### PR TITLE
Forms: Update form-styles script to prevent blurred forms on slow loading pages

### DIFF
--- a/projects/packages/forms/changelog/update-form-styles-improvement
+++ b/projects/packages/forms/changelog/update-form-styles-improvement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update form-styles script to prevent blurred forms on slow loading pages

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -61,7 +61,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.4.x-dev"
+			"dev-trunk": "0.5.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.4.0",
+	"version": "0.5.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.4.0';
+	const PACKAGE_VERSION = '0.5.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/js/form-styles.js
+++ b/projects/packages/forms/src/contact-form/js/form-styles.js
@@ -1,16 +1,23 @@
-window.addEventListener( 'load', () => {
-	const FRONTEND_SELECTOR = '.wp-block-jetpack-contact-form-container';
-	const EDITOR_SELECTOR = '[data-type="jetpack/contact-form"]';
+const FRONTEND_SELECTOR = '.wp-block-jetpack-contact-form-container';
+const EDITOR_SELECTOR = '[data-type="jetpack/contact-form"]';
 
+const iframeCanvas = document.querySelector( 'iframe[name="editor-canvas"]' );
+const doc = iframeCanvas ? iframeCanvas.contentDocument : document;
+const bodyNode = doc.querySelector( 'body' );
+
+//Fallback in case of the page load event takes too long to fire up
+const fallbackTimer = setTimeout( () => {
+	handleFormStyles();
+}, 3000 );
+
+window.addEventListener( 'load', () => {
 	const observer = new MutationObserver( () => {
-		generateStyleVariables( FRONTEND_SELECTOR );
-		generateStyleVariables( EDITOR_SELECTOR );
+		handleFormStyles();
 	} );
 
 	//Make sure to execute at least once if not triggered by the observer
 	setTimeout( () => {
-		generateStyleVariables( FRONTEND_SELECTOR );
-		generateStyleVariables( EDITOR_SELECTOR );
+		handleFormStyles();
 
 		observer.observe( document.querySelector( 'body' ), {
 			childList: true,
@@ -18,6 +25,11 @@ window.addEventListener( 'load', () => {
 		} );
 	}, 100 );
 } );
+
+function handleFormStyles() {
+	generateStyleVariables( FRONTEND_SELECTOR );
+	generateStyleVariables( EDITOR_SELECTOR );
+}
 
 function generateStyleVariables( selector, outputSelector = 'body' ) {
 	const STYLE_PROBE_CLASS = 'contact-form__style-probe';
@@ -34,8 +46,10 @@ function generateStyleVariables( selector, outputSelector = 'body' ) {
 		</div>
 	`;
 
-	const iframeCanvas = document.querySelector( 'iframe[name="editor-canvas"]' );
-	const doc = iframeCanvas ? iframeCanvas.contentDocument : document;
+	setTimeout( () => {
+		clearTimeout( fallbackTimer );
+		bodyNode.classList.add( 'contact-form-styles-loaded' );
+	}, 200 );
 
 	if ( ! doc.querySelectorAll( selector ).length ) {
 		return;
@@ -64,7 +78,6 @@ function generateStyleVariables( selector, outputSelector = 'body' ) {
 	const container = doc.querySelector( selector );
 	container.appendChild( styleProbe );
 
-	const bodyNode = doc.querySelector( 'body' );
 	const buttonNode = styleProbe.querySelector( '.wp-block-button__link' );
 	const inputNode = styleProbe.querySelector( 'input[type="text"]' );
 
@@ -108,10 +121,6 @@ function generateStyleVariables( selector, outputSelector = 'body' ) {
 	outputContainer.style.setProperty( '--jetpack--contact-form--font-size', fontSize );
 	outputContainer.style.setProperty( '--jetpack--contact-form--font-family', fontFamily );
 	outputContainer.style.setProperty( '--jetpack--contact-form--line-height', lineHeight );
-
-	setTimeout( () => {
-		bodyNode.classList.add( 'contact-form-styles-loaded' );
-	}, 200 );
 }
 
 function getBackgroundColor( backgroundColorNode ) {

--- a/projects/plugins/jetpack/changelog/update-form-styles-improvement
+++ b/projects/plugins/jetpack/changelog/update-form-styles-improvement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update form-styles script to prevent blurred forms on slow loading pages

--- a/projects/plugins/jetpack/changelog/update-form-styles-improvement#2
+++ b/projects/plugins/jetpack/changelog/update-form-styles-improvement#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -919,7 +919,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "51b402cc8d32dd9f01032c34ef93293cc2904753"
+                "reference": "9da1f03bb949078304436c77f5b1229b286e1467"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -941,7 +941,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.4.x-dev"
+                    "dev-trunk": "0.5.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {

--- a/projects/plugins/jetpack/modules/contact-form/js/form-styles.js
+++ b/projects/plugins/jetpack/modules/contact-form/js/form-styles.js
@@ -1,16 +1,23 @@
-window.addEventListener( 'load', () => {
-	const FRONTEND_SELECTOR = '.wp-block-jetpack-contact-form-container';
-	const EDITOR_SELECTOR = '[data-type="jetpack/contact-form"]';
+const FRONTEND_SELECTOR = '.wp-block-jetpack-contact-form-container';
+const EDITOR_SELECTOR = '[data-type="jetpack/contact-form"]';
 
+const iframeCanvas = document.querySelector( 'iframe[name="editor-canvas"]' );
+const doc = iframeCanvas ? iframeCanvas.contentDocument : document;
+const bodyNode = doc.querySelector( 'body' );
+
+//Fallback in case the page load event takes to long to fire up
+const fallbackTimer = setTimeout( () => {
+	handleFormStyles();
+}, 3000 );
+
+window.addEventListener( 'load', () => {
 	const observer = new MutationObserver( () => {
-		generateStyleVariables( FRONTEND_SELECTOR );
-		generateStyleVariables( EDITOR_SELECTOR );
+		handleFormStyles();
 	} );
 
 	//Make sure to execute at least once if not triggered by the observer
 	setTimeout( () => {
-		generateStyleVariables( FRONTEND_SELECTOR );
-		generateStyleVariables( EDITOR_SELECTOR );
+		handleFormStyles();
 
 		observer.observe( document.querySelector( 'body' ), {
 			childList: true,
@@ -18,6 +25,11 @@ window.addEventListener( 'load', () => {
 		} );
 	}, 100 );
 } );
+
+function handleFormStyles() {
+	generateStyleVariables( FRONTEND_SELECTOR );
+	generateStyleVariables( EDITOR_SELECTOR );
+}
 
 function generateStyleVariables( selector, outputSelector = 'body' ) {
 	const STYLE_PROBE_CLASS = 'contact-form__style-probe';
@@ -34,8 +46,10 @@ function generateStyleVariables( selector, outputSelector = 'body' ) {
 		</div>
 	`;
 
-	const iframeCanvas = document.querySelector( 'iframe[name="editor-canvas"]' );
-	const doc = iframeCanvas ? iframeCanvas.contentDocument : document;
+	setTimeout( () => {
+		clearTimeout( fallbackTimer );
+		bodyNode.classList.add( 'contact-form-styles-loaded' );
+	}, 200 );
 
 	if ( ! doc.querySelectorAll( selector ).length ) {
 		return;
@@ -64,7 +78,6 @@ function generateStyleVariables( selector, outputSelector = 'body' ) {
 	const container = doc.querySelector( selector );
 	container.appendChild( styleProbe );
 
-	const bodyNode = doc.querySelector( 'body' );
 	const buttonNode = styleProbe.querySelector( '.wp-block-button__link' );
 	const inputNode = styleProbe.querySelector( 'input[type="text"]' );
 
@@ -108,10 +121,6 @@ function generateStyleVariables( selector, outputSelector = 'body' ) {
 	outputContainer.style.setProperty( '--jetpack--contact-form--font-size', fontSize );
 	outputContainer.style.setProperty( '--jetpack--contact-form--font-family', fontFamily );
 	outputContainer.style.setProperty( '--jetpack--contact-form--line-height', lineHeight );
-
-	setTimeout( () => {
-		bodyNode.classList.add( 'contact-form-styles-loaded' );
-	}, 200 );
 }
 
 function getBackgroundColor( backgroundColorNode ) {


### PR DESCRIPTION
## Proposed changes:

Before running, the form-styles script needs to make sure all the necessary CSS is already loaded.
Because of that, we're triggering the script based on the page `load` event.
Some of the users have very slow requests on their pages, and those requests are holding the  `load` event back.

This PR updates the form-styles script to prevent blurred forms on slow-loading pages by adding a timer to remove the blur effect if the page takes too long to finish loading.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

That's a bit tricky to test.
The ideal testing scenario is to have a page/post with a Form block with a slow request that will make the page take more than 3 seconds to finish loading.
After that time, the blur effect should be removed even with the page still loading.

During the development, I played with the timers and added logs to the console to check if the fallback timer was being executed.