### PR TITLE
My Jetpack: Fix button to add bundle in product interstitial component

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -187,7 +187,7 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 	function ProductIcon( { slug: iconSlug } ) {
 		const ProIcon = getIconBySlug( iconSlug );
 		if ( ! ProIcon ) {
-			return () => null;
+			return null;
 		}
 
 		return (

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -59,8 +59,15 @@ export default function ProductInterstitial( {
 
 	const clickHandler = useCallback(
 		checkout => {
-			activate().finally( () => {
+			const activateOrCheckout = () => ( bundle ? Promise.resolve() : activate() );
+
+			activateOrCheckout().finally( () => {
 				const product = select( STORE_ID ).getProduct( slug );
+				if ( bundle ) {
+					// Get straight to the checkout page.
+					checkout?.();
+					return;
+				}
 				const postActivationUrl = product?.postActivationUrl;
 				const hasRequiredPlan = product?.hasRequiredPlan;
 				const isFree = product?.pricingForUi?.isFree;
@@ -79,7 +86,7 @@ export default function ProductInterstitial( {
 				checkout?.();
 			} );
 		},
-		[ navigateToMyJetpackOverviewPage, activate, slug ]
+		[ navigateToMyJetpackOverviewPage, activate, bundle, slug ]
 	);
 
 	const onClickGoBack = useCallback( () => {

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -113,8 +113,9 @@ export default function ProductInterstitial( {
 						<Col sm={ 4 } md={ 4 } lg={ 5 } className={ styles.imageContainer }>
 							{ bundle ? (
 								<ProductDetailCard
-									slug="security"
+									slug={ bundle }
 									trackButtonClick={ trackBundleClick }
+									onClick={ installsPlugin ? clickHandler : undefined }
 									className={ isUpgradableByBundle ? styles.container : null }
 								/>
 							) : (

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -115,7 +115,7 @@ export default function ProductInterstitial( {
 								<ProductDetailCard
 									slug={ bundle }
 									trackButtonClick={ trackBundleClick }
-									onClick={ installsPlugin ? clickHandler : undefined }
+									onClick={ clickHandler }
 									className={ isUpgradableByBundle ? styles.container : null }
 								/>
 							) : (

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-add-security
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-add-security
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix button to add bundle in product interstitial component

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.7.10",
+	"version": "2.7.11-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.7.10';
+	const PACKAGE_VERSION = '2.7.11-alpha';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-add-security
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-add-security
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Version bump
+
+

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -56,6 +56,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_4_0"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_4_1_alpha"
 	}
 }

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VideoPress
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
- * Version: 1.4.0
+ * Version: 1.4.1-alpha
  * Author: Automattic - Jetpack Video team
  * Author URI: https://jetpack.com/videopress/
  * License: GPLv2 or later


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28983

This was observed in https://github.com/Automattic/jetpack/pull/27615/#issuecomment-1333582689 which we didn't tackle before merging. cc @renatoagds 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the button to add a bundle in the product interstitial page by adding an `onClick` prop

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1676485057759749-slack-C02TQF5VAJD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the product interstitial page for `Scan` (`wp-admin/admin.php?page=my-jetpack#/add-scan`)
* Click on `Add Jetpack Scan`
* Check that you are redirected to the checkout page of the `Jetpack Scan Daily` plan
* Remove the plan from the cart and go back to the previous page
* Click on `Add Security`
![2023-02-15_17-04-43](https://user-images.githubusercontent.com/8486249/219143059-4967aa50-c991-409f-81d6-35b4a3a80090.png)
* Check that you are redirected to the checkout page of the `Jetpack Security (10GB)` plan
 * Go to the product interstitial page for `Anti-Spam` (`wp-admin/admin.php?page=my-jetpack#/add-anti-spam`)
* Click on `Add Jetpack Anti-Spam`
* Check that you are redirected to the Akismet connectioni page
*  Go back to the product interstitial page for `Anti-Spam` (`wp-admin/admin.php?page=my-jetpack#/add-anti-spam`)
* Click on `Add Security` 
  ![image](https://user-images.githubusercontent.com/746152/219215479-408a9306-ce2a-4797-9434-a3141a749932.png)
* Check that you are redirected to the checkout page of the `Jetpack Security (10GB)` plan