### PR TITLE
Fix: Search & Stats Admin unit tests without internet

### DIFF
--- a/projects/packages/search/changelog/fix-unit-test-without-internet
+++ b/projects/packages/search/changelog/fix-unit-test-without-internet
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed unit tests without internet

--- a/projects/packages/search/tests/php/class-test-case.php
+++ b/projects/packages/search/tests/php/class-test-case.php
@@ -63,7 +63,7 @@ class Test_Case extends TestCase {
 		wp_set_current_user( 0 );
 
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
-		add_filter( 'http_response', array( $this, 'plan_http_response_fixture' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'plan_http_response_fixture' ), 10, 3 );
 	}
 
 	/**
@@ -78,7 +78,7 @@ class Test_Case extends TestCase {
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
 
-		remove_filter( 'http_response', array( $this, 'plan_http_response_fixture' ) );
+		remove_filter( 'pre_http_request', array( $this, 'plan_http_response_fixture' ) );
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ) );
 	}
 

--- a/projects/packages/stats-admin/changelog/fix-unit-test-without-internet
+++ b/projects/packages/stats-admin/changelog/fix-unit-test-without-internet
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed unit tests without internet

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.6.0",
+	"version": "0.6.1-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -18,7 +18,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.6.0';
+	const VERSION = '0.6.1-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/tests/php/class-test-case.php
+++ b/projects/packages/stats-admin/tests/php/class-test-case.php
@@ -59,7 +59,7 @@ class Test_Case extends TestCase {
 		wp_set_current_user( 0 );
 
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
-		add_filter( 'http_response', array( $this, 'plan_http_response_fixture' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'plan_http_response_fixture' ), 10, 3 );
 	}
 
 	/**
@@ -74,7 +74,7 @@ class Test_Case extends TestCase {
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
 
-		remove_filter( 'http_response', array( $this, 'plan_http_response_fixture' ) );
+		remove_filter( 'pre_http_request', array( $this, 'plan_http_response_fixture' ) );
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ) );
 	}
 


### PR DESCRIPTION
## Proposed changes:
The PR proposes to hook `pre_http_request` instead of `http_response` to avoid test failures without internet.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1676076247409879-slack-C034JEXD1RD
p1676470210545469-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Go you local Jetpack dev env
* Disconnect network
* `cd path/to/jetpack/projects/packages/stats-admin && composer test-php`
* `cd path/to/jetpack/projects/packages/search && composer test-php`
* Enusre tests pass