### PR TITLE
Launchpad: Avoid rendering launchpad modal above post publish modal

### DIFF
--- a/projects/plugins/jetpack/changelog/update-launchpad-save-modal-to-avoid-rendering-above-post-publish-modal
+++ b/projects/plugins/jetpack/changelog/update-launchpad-save-modal-to-avoid-rendering-above-post-publish-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Prevent launchpad modal from rendering on top of the first post published modal

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -17,6 +17,7 @@ export const settings = {
 			[]
 		);
 		const isSavingPost = useSelect( select => select( editorStore ).isSavingPost(), [] );
+		const isPublishingPost = useSelect( select => select( editorStore ).isPublishingPost(), [] );
 		const isCurrentPostPublished = useSelect(
 			select => select( editorStore ).isCurrentPostPublished(),
 			[]
@@ -24,6 +25,7 @@ export const settings = {
 
 		const prevIsSavingSite = usePrevious( isSavingSite );
 		const prevIsSavingPost = usePrevious( isSavingPost );
+		const prevIsPublishingPost = usePrevious( isPublishingPost );
 
 		// We use this state as a flag to manually handle the modal close on first post publish
 		const [ isInitialPostPublish, setIsInitialPostPublish ] = useState( false );
@@ -54,25 +56,25 @@ export const settings = {
 			} );
 
 		useEffect( () => {
+			// We want to prevent the launchpad modal from rendering on top of the first
+			// post published modal that exists in the editing toolkit. The following
+			// conditional is a stopgap solution for the time being, and the end goal is
+			// to migrate the first post published modal logic into jetpack, abstract code from
+			// both modals and their rendering behavior, and remove this solution afterwards.
 			if (
+				prevIsPublishingPost === true &&
+				isPublishingPost === false &&
+				prevHasNeverPublishedPostOption.current &&
+				siteIntentOption === 'write' &&
+				isInsidePostEditor
+			) {
+				setIsModalOpen( false );
+				prevHasNeverPublishedPostOption.current = '';
+				return;
+			} else if (
 				( prevIsSavingSite === true && isSavingSite === false ) ||
 				( prevIsSavingPost === true && isSavingPost === false )
 			) {
-				// We want to prevent the launchpad modal from rendering on top of the first
-				// post published modal that exists in the editing toolkit. The following
-				// conditional is a stopgap solution for the time being, and the end goal is
-				// to migrate the first post published modal logic into jetpack, abstract code from
-				// both modals and their rendering behavior, and remove this solution afterwards.
-				if (
-					siteIntentOption === 'write' &&
-					prevHasNeverPublishedPostOption.current &&
-					isInsidePostEditor
-				) {
-					setIsModalOpen( false );
-					prevHasNeverPublishedPostOption.current = '';
-					return;
-				}
-
 				setIsModalOpen( true );
 			}
 		}, [
@@ -82,6 +84,8 @@ export const settings = {
 			prevIsSavingPost,
 			siteIntentOption,
 			isInsidePostEditor,
+			isPublishingPost,
+			prevIsPublishingPost,
 		] );
 
 		useEffect( () => {

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -65,7 +65,7 @@ export const settings = {
 				// both modals and their rendering behavior, and remove this solution afterwards.
 				if (
 					siteIntentOption === 'write' &&
-					parseInt( prevHasNeverPublishedPostOption.current ) &&
+					prevHasNeverPublishedPostOption.current &&
 					isInsidePostEditor
 				) {
 					setIsModalOpen( false );

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/launchpad-save-modal.php
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/launchpad-save-modal.php
@@ -22,8 +22,8 @@ function add_launchpad_options() {
 	}
 
 	$launchpad_options = array(
-		'launchpadScreenOption' => get_option( 'launchpad_screen' ),
-		'siteIntentOption'      => get_option( 'site_intent' ),
+		'launchpadScreenOption'       => get_option( 'launchpad_screen' ),
+		'siteIntentOption'            => get_option( 'site_intent' ),
 		'hasNeverPublishedPostOption' => get_option( 'has_never_published_post' ),
 	);
 	wp_add_inline_script(

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/launchpad-save-modal.php
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/launchpad-save-modal.php
@@ -24,6 +24,7 @@ function add_launchpad_options() {
 	$launchpad_options = array(
 		'launchpadScreenOption' => get_option( 'launchpad_screen' ),
 		'siteIntentOption'      => get_option( 'site_intent' ),
+		'hasNeverPublishedPostOption' => get_option( 'has_never_published_post' ),
 	);
 	wp_add_inline_script(
 		'jetpack-blocks-editor',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/72803

## Estimated Time to Test / Review:
- Test -> Short / Med
- Review -> Short

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevents the launchpad modal from rendering if a first post hasn't been published yet ( to avoid rendering above the first post published modal )

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site through general onboarding https://wordpress.com/start
* Select `Write & Publish` as the site's goal
* Select any category
* Use any site title and tagline
* Before moving forward, sandbox your new site ( Don't forget to reset the DNS cache by forcing reconnection to autoproxxy or other means )
* Run in the terminal `bin/jetpack-downloader test jetpack update/launchpad-save-modal-to-avoid-rendering-above-post-publish-modal`
* Continue onboarding by clicking on the `Skip to dashboard` button
* When you land in the Launchpad, click on the `Edit site design` task
* Make changes in the site editor and save them
* VERIFY that the launchpad modal continues to behave as expected
* Navigate back to the Launchpad by clicking on the site editor back to dashboard button
* Click on the `Write your first post` task
* Edit the post's content
* Click on the "Save Draft" button
* Click on the publish button
* VERIFY that only one modal is shown
* VERIFY that the modal displays first post published text
* VERIFY that the `View post` button navigates to the post in the frontend
* VERIFY that subsequent saves in the post editor display the launchpad modal

https://user-images.githubusercontent.com/20927667/219204630-19b1203f-2dce-48aa-baf6-f42b3d995061.mov