### PR TITLE
Stats: Fix JSON decoding the wrong varible while parsing the response body

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-decoding-wrong-varible
+++ b/projects/packages/stats-admin/changelog/fix-decoding-wrong-varible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: fix broken request_as_blog_cached

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -497,26 +497,27 @@ class REST_Controller {
 		$cache_key = 'STATS_REST_RESP_' . md5( implode( '|', array( $path, $version, wp_json_encode( $args ), wp_json_encode( $body ), $base_api_path ) ) );
 
 		if ( $use_cache ) {
-			$response_body = get_transient( $cache_key );
-			if ( false !== $response_body ) {
-				return json_decode( $response_body, true );
+			$response_body_content = get_transient( $cache_key );
+			if ( false !== $response_body_content ) {
+				return json_decode( $response_body_content, true );
 			}
 		}
 
-		$response              = Client::wpcom_json_api_request_as_blog(
+		$response = Client::wpcom_json_api_request_as_blog(
 			$path,
 			$version,
 			$args,
 			$body,
 			$base_api_path
 		);
-		$response_code         = wp_remote_retrieve_response_code( $response );
-		$response_body_content = wp_remote_retrieve_body( $response );
-		$response_body         = json_decode( $response_body, true );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
+
+		$response_code         = wp_remote_retrieve_response_code( $response );
+		$response_body_content = wp_remote_retrieve_body( $response );
+		$response_body         = json_decode( $response_body_content, true );
 
 		if ( 200 !== $response_code ) {
 			return $this->get_wp_error( $response_body, $response_code );


### PR DESCRIPTION
## Proposed changes:
The PR fixes the issue `$response_body` is used by mistake, where it should be `$response_body_content`. The bug leads to empty response on first requests.

The error sipped my self-review, because ngrok sometime doesn't relay certain requests properly and as a result, which I thought was the culprit.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Open Ads tab on a site
* Ensure there's on first load
* Switch period
* Ensure data loads okay

<img width="1286" alt="image" src="https://user-images.githubusercontent.com/1425433/219247685-51fce5b2-c92e-42ac-aa8b-190b244579bd.png">

