### PR TITLE
CRM: Cleaning up PHPCS comments in ZeroBSCRM.FormatHelpers.php

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-remove-phpcsdisable-leftover
+++ b/projects/plugins/crm/changelog/fix-crm-remove-phpcsdisable-leftover
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removing phpcs comments
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1148,7 +1148,6 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 	    return $start_d . ' - ' . $end_d;
 	}
 
-	// phpcs:disable
 /* ======================================================
   /	Tasks
    ====================================================== */
@@ -1960,4 +1959,3 @@ function zeroBSCRM_outputEmailHistory($userID = -1){
    		return $migrationName;
    		
    }
-// phpcs: enable


### PR DESCRIPTION
## Proposed changes:

* This PR removes one phpcs:disable comment and one phpcs:enable comment from ZeroBSCRM.FormatHelpers.php, leftovers from this PR: https://github.com/Automattic/jetpack/pull/28956

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* PHPCS checks should pass for this PR.

