### PR TITLE
Update/remove default subscription options duplication

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-default-subscription-options-duplication
+++ b/projects/plugins/jetpack/changelog/update-remove-default-subscription-options-duplication
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Reading Settings: Remove duplication of defining default subscription_options

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -376,8 +376,7 @@ class Jetpack_Subscriptions {
 
 		register_setting(
 			'reading',
-			'subscription_options',
-			array( $this, 'validate_settings' )
+			'subscription_options'
 		);
 
 		add_settings_section(
@@ -525,31 +524,6 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
-	 * Validate settings for the Subscriptions module.
-	 *
-	 * @param array $settings Settings to be validated.
-	 */
-	public function validate_settings( $settings ) {
-		global $allowedposttags;
-
-		$default = $this->get_default_settings();
-
-		// Blog Follow.
-		$settings['invitation'] = trim( wp_kses( $settings['invitation'], $allowedposttags ) );
-		if ( empty( $settings['invitation'] ) ) {
-			$settings['invitation'] = $default['invitation'];
-		}
-
-		// Comments Follow (single post).
-		$settings['comment_follow'] = trim( wp_kses( $settings['comment_follow'], $allowedposttags ) );
-		if ( empty( $settings['comment_follow'] ) ) {
-			$settings['comment_follow'] = $default['comment_follow'];
-		}
-
-		return $settings;
-	}
-
-	/**
 	 * HTML output helper for Reading section.
 	 */
 	public function reading_section() {
@@ -577,24 +551,10 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
-	 * Get default settings for the Subscriptions module.
-	 */
-	public function get_default_settings() {
-		$site_url    = get_home_url();
-		$display_url = preg_replace( '(^https?://)', '', untrailingslashit( $site_url ) );
-
-		return array(
-			/* translators: Both %1$s and %2$s is site address */
-			'invitation'     => sprintf( __( "Howdy,\nYou recently subscribed to <a href='%1\$s'>%2\$s</a> and we need to verify the email you provided. Once you confirm below, you'll be able to receive and read new posts.\n\nIf you believe this is an error, ignore this message and nothing more will happen.", 'jetpack' ), $site_url, $display_url ),
-			'comment_follow' => __( "Howdy.\n\nYou recently followed one of my posts. This means you will receive an email when new comments are posted.\n\nTo activate, click confirm below. If you believe this is an error, ignore this message and we'll never bother you again.", 'jetpack' ),
-		);
-	}
-
-	/**
 	 * Reeturn merged `subscription_options` option with module default settings.
 	 */
 	public function get_settings() {
-		return wp_parse_args( (array) get_option( 'subscription_options' ), $this->get_default_settings() );
+		return get_option( 'subscription_options' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -1052,3 +1052,31 @@ function subscription_options_fallback( $default, $option, $passed_default ) {
 }
 
 add_filter( 'default_option_subscription_options', 'subscription_options_fallback', 10, 3 );
+
+/**
+ * Validate settings for the Subscriptions module.
+ *
+ * @param array $settings Settings to be validated.
+ */
+function sanitize_subscription_options( $settings ) {
+	global $allowedposttags;
+
+	$default = subscription_options_fallback( null, 'subscription_options', false );
+
+	// Blog Follow.
+	$settings['invitation'] = trim( wp_kses( $settings['invitation'], $allowedposttags ) );
+	if ( empty( $settings['invitation'] ) ) {
+		$settings['invitation'] = $default['invitation'];
+	}
+
+	// Comments Follow (single post).
+	$settings['comment_follow'] = trim( wp_kses( $settings['comment_follow'], $allowedposttags ) );
+	if ( empty( $settings['comment_follow'] ) ) {
+		$settings['comment_follow'] = $default['comment_follow'];
+	}
+
+	return $settings;
+}
+
+add_filter( 'sanitize_option_subscription_options', 'sanitize_subscription_options', 10, 3 );
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/72013

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove duplication of defining the value for a site's default `subscription_options`
* Add the `sanitize_option_subscription_options` so that the "old" option sanitization is still kept

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Testing on Simple sites:
* Apply this PR to your sandbox
* Sandbox `public-api.wordpress.com`
* Go to https://wordpress.com/settings/reading and select your test site where you had not modified the **Confirmation email message** and the **Comment follow email message** fields the in the past
* Ensure the expected default values for the **Confirmation email message** and the **Comment follow email message** fields are displayed
* Ensure there is no errors in your sandbox PHP logs

### Testing on WoA:
* Apply this PR to your test WoA site
* Go to https://wordpress.com/settings/reading and select the test WoA site (ensure you had not modified the **Confirmation email message** and the **Comment follow email message** fields in the past, otherwise you can reset them via CLI)
* Ensure the expected default values for the **Confirmation email message** and the **Comment follow email message** fields are displayed
* Ensure there is no errors in your WoA site's PHP logs
* Then test setting the values to some other value and ensure there is no errors in your WoA site's PHP logs