### PR TITLE
CRM: Composer update - adding back wp-svn-autopublish

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-svn-autopublish
+++ b/projects/plugins/crm/changelog/add-crm-svn-autopublish
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Adding back a composer.json entry to allow svn auto publishing.
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -69,6 +69,7 @@
 			"link-template": "https://github.com/Automattic/zero-bs-crm/compare/v${old}...v${new}"
 		},
 		"release-branch-prefix": "crm",
-		"wp-plugin-slug": "zero-bs-crm"
+		"wp-plugin-slug": "zero-bs-crm",
+		"wp-svn-autopublish": true
 	}
 }

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e27168b59f27ffa476536c99520a818",
+    "content-hash": "24f536561a8925140e8018ae09a0b33e",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",


### PR DESCRIPTION


## Proposed changes:

* For the initial Github-only release this one line was removed from composer.json here: https://github.com/Automattic/jetpack/pull/28942 This PR adds it back , so that future releases made via Github will auto publish to WordPress.org via SVN.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* No testing, just proof-reading to make sure the added line matches what was here originally: https://github.com/Automattic/jetpack/pull/28942/files

