### PR TITLE
Fix import hierarchies

### DIFF
--- a/projects/packages/import/changelog/fix-import-hierarchies
+++ b/projects/packages/import/changelog/fix-import-hierarchies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed various imported resources hierarchies

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.1.1-alpha';
+	const PACKAGE_VERSION = '0.1.0-alpha';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.1-alpha';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/import/src/endpoints/class-category.php
+++ b/projects/packages/import/src/endpoints/class-category.php
@@ -64,7 +64,7 @@ class Category extends \WP_REST_Terms_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
-		if ( isset( $request['parent'] ) ) {
+		if ( ! empty( $request['parent'] ) ) {
 			$parent = get_term_by( 'slug', $request['parent'], 'category' );
 
 			// Overwrite the parent ID with the parent term ID found using the slug.
@@ -74,29 +74,5 @@ class Category extends \WP_REST_Terms_Controller {
 		$response = parent::create_item( $request );
 
 		return $this->add_import_id_metadata( $request, $response );
-	}
-
-	/**
-	 * Update the category parent ID.
-	 *
-	 * @param int $resource_id      The resource ID.
-	 * @param int $parent_import_id The parent ID.
-	 * @return bool True if updated.
-	 */
-	protected function update_parent_id( $resource_id, $parent_import_id ) {
-		$categories = \get_categories( $this->get_import_db_query( $parent_import_id ) );
-
-		if ( is_array( $categories ) && count( $categories ) === 1 ) {
-			$parent_id = $categories[0];
-
-			return (bool) \wp_update_category(
-				array(
-					'cat_ID'          => $resource_id,
-					'category_parent' => $parent_id,
-				)
-			);
-		}
-
-		return false;
 	}
 }

--- a/projects/packages/import/src/endpoints/class-page.php
+++ b/projects/packages/import/src/endpoints/class-page.php
@@ -20,26 +20,21 @@ class Page extends Post {
 	}
 
 	/**
-	 * Update the post parent ID.
+	 * Creates a single page.
 	 *
-	 * @param int $resource_id      The resource ID.
-	 * @param int $parent_import_id The parent ID.
-	 * @return bool True if updated.
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
-	protected function update_parent_id( $resource_id, $parent_import_id ) {
-		$pages = \get_pages( $this->get_import_db_query( $parent_import_id ) );
+	public function create_item( $request ) {
+		if ( ! empty( $request['parent'] ) ) {
+			$pages = \get_pages( $this->get_import_db_query( $request['parent'] ) );
 
-		if ( is_array( $pages ) && count( $pages ) === 1 ) {
-			$parent_id = $pages[0]->ID;
-
-			return (bool) \wp_update_post(
-				array(
-					'ID'          => $resource_id,
-					'post_parent' => $parent_id,
-				)
-			);
+			// Overwrite the page parent page ID.
+			$request['parent'] = is_array( $pages ) && count( $pages ) ? $pages[0]->ID : 0;
 		}
 
-		return false;
+		$response = parent::create_item( $request );
+
+		return $this->add_import_id_metadata( $request, $response );
 	}
 }

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -64,7 +64,7 @@ class Post extends \WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Creates a single post / page.
+	 * Creates a single post.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -130,29 +130,5 @@ class Post extends \WP_REST_Posts_Controller {
 			// Flush away any invalid terms.
 			return array();
 		}
-	}
-
-	/**
-	 * Update the post parent ID.
-	 *
-	 * @param int $resource_id      The resource ID.
-	 * @param int $parent_import_id The parent ID.
-	 * @return bool True if updated.
-	 */
-	protected function update_parent_id( $resource_id, $parent_import_id ) {
-		$posts = \get_posts( $this->get_import_db_query( $parent_import_id ) );
-
-		if ( is_array( $posts ) && count( $posts ) === 1 ) {
-			$parent_id = $posts[0];
-
-			return (bool) \wp_update_post(
-				array(
-					'ID'          => $resource_id,
-					'post_parent' => $parent_id,
-				)
-			);
-		}
-
-		return false;
 	}
 }

--- a/projects/packages/import/src/endpoints/class-tag.php
+++ b/projects/packages/import/src/endpoints/class-tag.php
@@ -39,23 +39,4 @@ class Tag extends \WP_REST_Terms_Controller {
 			$this->get_route_options()
 		);
 	}
-
-	/**
-	 * Update the tag parent ID.
-	 *
-	 * @param int $resource_id      The resource ID.
-	 * @param int $parent_import_id The parent ID.
-	 * @return bool True if updated.
-	 */
-	protected function update_parent_id( $resource_id, $parent_import_id ) {
-		$terms = \get_terms( $this->get_import_db_query( $parent_import_id ) );
-
-		if ( is_array( $terms ) && count( $terms ) === 1 ) {
-			$parent_id = $terms[0];
-
-			return (bool) \wp_update_term( $resource_id, $this->import_id_meta_type, array( 'parent' => $parent_id ) );
-		}
-
-		return false;
-	}
 }

--- a/projects/packages/import/src/endpoints/trait-import.php
+++ b/projects/packages/import/src/endpoints/trait-import.php
@@ -99,12 +99,6 @@ trait Import {
 		// Add the import unique ID to the resource metadata.
 		\add_metadata( $this->import_id_meta_type, $data['id'], $this->import_id_field_name, $request[ $this->import_id_field_name ], true );
 
-		// If the resource has a parent.
-		if ( $request[ $this->import_id_field_name ] !== 0 ) {
-			// Update the parent.
-			$this->update_parent_id( $data['id'], $request[ $this->import_id_field_name ] );
-		}
-
 		return $response;
 	}
 
@@ -168,13 +162,4 @@ trait Import {
 			'schema'      => array( $this, 'get_public_item_schema' ),
 		);
 	}
-
-	/**
-	 * Update the resource parent ID.
-	 *
-	 * @param int $resource_id      The resource ID.
-	 * @param int $parent_import_id The parent ID.
-	 * @return bool True if updated.
-	 */
-	abstract protected function update_parent_id( $resource_id, $parent_import_id );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
In this PR, various import issues have been fixed. During the import procedure, every single resource has a specific ID found in the WXR file, which must then be changed with the new one.

Important: this fix follows D101865-code

These are the hierarchies that are guaranteed to exist:

1. Categories parent-child
2. Comments parent-child
3. Comments parent post
4. Pages parent-child

Related to https://github.com/Automattic/dotcom-forge/issues/1688
See pcmemI-1ro-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update all the WXR IDs with the local ones before processing the resource
* Remove all the post-update parent ID
* Add the correct comments parent post

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Detailed instructions can be found here: pcmemI-1LC-p2
2. Unzip the file attached to this PR and use it

This must be the exact final status of the test blog:

1. Two posts called "Example post" and "Example post 2".
    - The first one must have "Parent category", "Child category 2" and "Uncategorized" as categories and "Tag 1", "Tag 2" and "Tag 3" as tags
    - The second one must have "Parent category" and no tags
2. There must be five categories:
    - Parent category -> Child category -> Category 2 -> Child category 2
    - Uncategorized
3. Three tags:
     - "Tag 1"
     - "Tag 2"
     - "Tag 3"
5. "Example post" must be four comments, three of them must reply one after another

[hierarchy-test.xml.zip](https://github.com/Automattic/jetpack/files/10761838/hierarchy-test.xml.zip)