### PR TITLE
General: enabled automated plugin releases for Migration

### DIFF
--- a/projects/plugins/migration/changelog/update-migration-enable-autoupdates
+++ b/projects/plugins/migration/changelog/update-migration-enable-autoupdates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+General: enable automated plugin releases.

--- a/projects/plugins/migration/composer.json
+++ b/projects/plugins/migration/composer.json
@@ -59,9 +59,14 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
+		"autorelease": true,
+		"autotagger": {
+			"v": false
+		},
 		"mirror-repo": "Automattic/wpcom-migration",
 		"release-branch-prefix": "migration",
-		"wp-plugin-slug": "wpcom-migration"
+		"wp-plugin-slug": "wpcom-migration",
+		"wp-svn-autopublish": true
 	},
 	"config": {
 		"allow-plugins": {

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ddcdf6c42199ee2e81f1e3125bff4f1",
+    "content-hash": "1fd3765ca177131d6455d3228f5260a2",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",


### PR DESCRIPTION
## Proposed changes:

Let's allow automatically updating this plugin. The other required elements for this to happen were already implemented in the mirror repo.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* See p1676624117708979-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here yet.
