### PR TITLE
Jetpack: tweak MediaButton component

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-tweak-media-button
+++ b/projects/plugins/jetpack/changelog/update-jetpack-tweak-media-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: tweak MediaButton component

--- a/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
+++ b/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
@@ -411,12 +411,34 @@ $grid-size: 8px;
 	justify-content: space-between;
 }
 
+.jetpack-external-media-button-menu__dropdown {
+	width: 100%;
+
+	.jetpack-external-media-button-menu {
+		width: 100%;
+		flex-direction: row;
+		text-align: left;
+		padding-left: 12px;
+		padding-right: 12px;
+	
+		.jetpack-external-media-button-menu__label {
+			flex-grow: 2;
+		}
+	}
+}
+
 // Reset placeholder button margin.
 .components-placeholder__fieldset,
 .editor-post-featured-image {
 	.components-dropdown .jetpack-external-media-button-menu {
 		margin-right: 8px;
 		margin-bottom: 1em;
+		padding-left: 6px;
+		padding-right: 6px;
+
+		> svg {
+			display: none;
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
+++ b/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
@@ -431,6 +431,7 @@ $grid-size: 8px;
 .components-placeholder__fieldset,
 .editor-post-featured-image {
 	.components-dropdown .jetpack-external-media-button-menu {
+		width: auto;
 		margin-right: 8px;
 		margin-bottom: 1em;
 		padding-left: 6px;

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
@@ -56,9 +56,7 @@ function MediaButtonMenu( props ) {
 							aria-expanded={ isOpen }
 							onClick={ onToggle }
 						>
-							<div className="jetpack-external-media-button-menu__label">
-								{ props.label || label }
-							</div>
+							<div className="jetpack-external-media-button-menu__label">{ label }</div>
 							<Icon icon={ media } />
 						</Button>
 					);

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
@@ -1,6 +1,6 @@
 import { Button, MenuItem, MenuGroup, Dropdown, NavigableMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { media } from '@wordpress/icons';
+import { Icon, media } from '@wordpress/icons';
 import MediaSources from './media-sources';
 
 function MediaButtonMenu( props ) {
@@ -37,6 +37,7 @@ function MediaButtonMenu( props ) {
 		<>
 			<Dropdown
 				placement="bottom-start"
+				className="jetpack-external-media-button-menu__dropdown"
 				contentClassName="jetpack-external-media-button-menu__options"
 				renderToggle={ ( { isOpen, onToggle } ) => {
 					// override original button only when it's a simple button with text, or a featured image
@@ -55,7 +56,10 @@ function MediaButtonMenu( props ) {
 							aria-expanded={ isOpen }
 							onClick={ onToggle }
 						>
-							{ label }
+							<div className="jetpack-external-media-button-menu__label">
+								{ props.label || label }
+							</div>
+							<Icon icon={ media } />
 						</Button>
 					);
 				} }
@@ -63,7 +67,6 @@ function MediaButtonMenu( props ) {
 					<NavigableMenu aria-label={ label }>
 						<MenuGroup>
 							<MenuItem
-								icon={ media }
 								onClick={ () => {
 									onClose();
 									open();

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
@@ -65,6 +65,7 @@ function MediaButtonMenu( props ) {
 					<NavigableMenu aria-label={ label }>
 						<MenuGroup>
 							<MenuItem
+								icon={ media }
 								onClick={ () => {
 									onClose();
 									open();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR tweaks the `<MediaButton />` component:

* Stretch it and adjust the box model  to align it with other buttons in the same context (toolbar)
* Add a media icon
* Reset some styles in the MediaPlaceholder context

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: tweak MediaButton component

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a block that extends the media button: `core/image`, `core/cover`, etc...
* Confirm the Select image button looks consistent with the other buttons

<img width="680" alt="Screen Shot 2023-02-17 at 12 08 32" src="https://user-images.githubusercontent.com/77539/219692463-62347c17-2247-4813-b51d-42a76dd696db.png">

* Set the media image
* Open the toolbar
* Confirm the media button is properly aligned with the other buttons
* Confirm the button has the media icon

before | after
------|------
<img width="400" alt="image" src="https://user-images.githubusercontent.com/77539/219693103-c166597d-412d-4c67-9d5b-b566e8cc32de.png"> | <img width="415" alt="image" src="https://user-images.githubusercontent.com/77539/219692940-9a73cfef-37cf-4ae4-89cc-3743adb8c5e8.png">


