### PR TITLE
Jetpack: Auto-activate Subscriptions

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2541,14 +2541,20 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'stb_enabled'                          => array(
 				'description'       => esc_html__( "Show a <em>'follow blog'</em> option in the comment form", 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => 1,
+				// Keep the previous behaviour after updating subscription to autoactivate
+				// So we don't update the frontend for new users of Jetpack
+				// https://github.com/Automattic/jetpack/pull/29028
+			'default'               => jetpack_get_module_info( 'subscriptions' )['auto_activate'] === 'No' ? 1 : 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
 			'stc_enabled'                          => array(
 				'description'       => esc_html__( "Show a <em>'follow comments'</em> option in the comment form", 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => 1,
+				// Keep the previous behaviour after updating subscription to autoactivate
+				// So we don't update the frontend for new users of Jetpack
+				// https://github.com/Automattic/jetpack/pull/29028
+			'default'               => jetpack_get_module_info( 'subscriptions' )['auto_activate'] === 'No' ? 1 : 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),

--- a/projects/plugins/jetpack/changelog/update-jumpstart-subscriptions
+++ b/projects/plugins/jetpack/changelog/update-jumpstart-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Autoactivate Subscriptions

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -281,12 +281,12 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			) . '</p>';
 			return;
 		}
-
 		if ( in_array( 'subscriptions', Jetpack::get_active_modules(), true ) ) {
-			$stb_enabled = get_option( 'stb_enabled', 1 );
+			$default     = jetpack_get_module_info( 'subscriptions' )['auto_activate'] === 'No' ? 1 : 0;
+			$stb_enabled = get_option( 'stb_enabled', $default );
 			$stb_enabled = empty( $stb_enabled ) ? 0 : 1;
 
-			$stc_enabled = get_option( 'stc_enabled', 1 );
+			$stc_enabled = get_option( 'stc_enabled', $default );
 			$stc_enabled = empty( $stc_enabled ) ? 0 : 1;
 		} else {
 			$stb_enabled = 0;

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -415,11 +415,22 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
+	 * Returns the default value for the options stc_enabled and stb_enabled
+	 * that should be assumed depending on the Auto-activate status of the
+	 * subscriptions module.
+	 * We keep the previous behaviour after updating subscription to autoactivate
+	 * So we don't update the frontend for new users of Jetpack
+	 * https://github.com/Automattic/jetpack/pull/29028
+	 */
+	public function stc_stb_default_value() {
+		return jetpack_get_module_info( 'subscriptions' )['auto_activate'] === 'No' ? 1 : 0;
+	}
+
+	/**
 	 * Post Subscriptions Toggle.
 	 */
 	public function subscription_post_subscribe_setting() {
-
-		$stb_enabled = get_option( 'stb_enabled', 1 );
+		$stb_enabled = get_option( 'stb_enabled', $this->stc_stb_default_value() );
 		?>
 
 		<p class="description">
@@ -441,8 +452,7 @@ class Jetpack_Subscriptions {
 	 * Comments Subscriptions Toggle.
 	 */
 	public function subscription_comment_subscribe_setting() {
-
-		$stc_enabled = get_option( 'stc_enabled', 1 );
+		$stc_enabled = get_option( 'stc_enabled', $this->stc_stb_default_value() );
 		?>
 
 		<p class="description">
@@ -809,7 +819,7 @@ class Jetpack_Subscriptions {
 
 		$str = '';
 
-		if ( false === has_filter( 'comment_form', 'show_subscription_checkbox' ) && 1 === (int) get_option( 'stc_enabled', 1 ) && empty( $post->post_password ) && 'post' === get_post_type() ) {
+		if ( false === has_filter( 'comment_form', 'show_subscription_checkbox' ) && 1 === (int) get_option( 'stc_enabled', $this->stc_stb_default_value() ) && empty( $post->post_password ) && 'post' === get_post_type() ) {
 			// Subscribe to comments checkbox.
 			$str             .= '<p class="comment-subscription-form"><input type="checkbox" name="subscribe_comments" id="subscribe_comments" value="subscribe" style="width: auto; -moz-appearance: checkbox; -webkit-appearance: checkbox;"' . $comments_checked . ' /> ';
 			$comment_sub_text = __( 'Notify me of follow-up comments by email.', 'jetpack' );
@@ -828,7 +838,7 @@ class Jetpack_Subscriptions {
 			$str .= '</p>';
 		}
 
-		if ( 1 === (int) get_option( 'stb_enabled', 1 ) ) {
+		if ( 1 === (int) get_option( 'stb_enabled', $this->stc_stb_default_value() ) ) {
 			// Subscribe to blog checkbox.
 			$str          .= '<p class="comment-subscription-form"><input type="checkbox" name="subscribe_blog" id="subscribe_blog" value="subscribe" style="width: auto; -moz-appearance: checkbox; -webkit-appearance: checkbox;"' . $blog_checked . ' /> ';
 			$blog_sub_text = __( 'Notify me of new posts by email.', 'jetpack' );

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -7,7 +7,7 @@
  * First Introduced: 1.2
  * Requires Connection: Yes
  * Requires User Connection: Yes
- * Auto Activate: No
+ * Auto Activate: Yes
  * Module Tags: Social
  * Feature: Engagement
  * Additional Search Queries: subscriptions, subscription, email, follow, followers, subscribers, signup


### PR DESCRIPTION
Makes subscriptions enabled by default 

~I'm still deciding on whether these options should be set to false as they affect the frontend.~ Already tackled in https://github.com/Automattic/jetpack/commit/a91df30b716ad8687a563d4f9205514009797bea

Fixes #14621

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the header of modules/subscriptions.php to have `Auto-activate: yes`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a [JN site with this branch
](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=update/jumpstart-subscriptions&wp-debug-log)
* Create a post
* Connect Jetpack
* Attempt to add a Subscrible block. Confirm you can.
* Visit the frontend sample post and confirm the checkboxes for subscribing are not there



<table>
<tr>
	<td > 
<img width=700 alt="image" src="https://user-images.githubusercontent.com/746152/219734618-9c92fadc-3167-4e62-bbaa-a3c6692bce28.png">
	<td>
<img width=700 alt="image" src="https://user-images.githubusercontent.com/746152/219733211-68aa67bf-9c6d-43f6-b163-0d66bff92055.png">
</tr>
<tr>
	<td>Like this
	<td>Not like this
</table>

* Visit Jetpack Settings and confirm they're by default like this:
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/746152/219732955-dc2e903e-f5f9-4750-8d74-da908df4ef9b.png">




