### PR TITLE
CRM: Composer and version updates in prep for the next release

### DIFF
--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -5,7 +5,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.5.4-alpha] - 2023-02-15
+## [5.5.4-a.1] - 2023-02-15
 ### Added
 - adds the necessary migration to move all files that were inside the zbscrm-store folder with a flat struture to the new jpcrm-storage folder that uses a hierarchical structure [#28350]
 - Copy tests from old repo. [#28354]
@@ -59,4 +59,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved: Security around phone numbers viewing
 - Improved: Added a migration to remove outdated AKA lines
 
-[5.5.4-alpha]: https://github.com/Automattic/zero-bs-crm/compare/v5.5.3...v5.5.4-alpha
+[5.5.4-a.1]: https://github.com/Automattic/zero-bs-crm/compare/v5.5.3...v5.5.4-a.1

--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -59,4 +59,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved: Security around phone numbers viewing
 - Improved: Added a migration to remove outdated AKA lines
 
-[5.5.4-a.1]: https://github.com/Automattic/zero-bs-crm/compare/v5.5.3...v5.5.4-a.1
+[5.5.4-a.1]: https://github.com/Automattic/jetpack-crm/compare/v5.5.3...v5.5.4-a.1

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 5.5.5-alpha
+ * Version: 5.5.4-a.2
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/init-release-cycle#2
+++ b/projects/plugins/crm/changelog/init-release-cycle#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 5.5.4-a.2
+
+

--- a/projects/plugins/crm/changelog/update-crm-next-alpha-version
+++ b/projects/plugins/crm/changelog/update-crm-next-alpha-version
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -65,8 +65,9 @@
 		},
 		"autorelease": true,
 		"mirror-repo": "Automattic/jetpack-crm",
+		"dev-releases": true,
 		"changelogger": {
-			"link-template": "https://github.com/Automattic/zero-bs-crm/compare/v${old}...v${new}"
+			"link-template": "https://github.com/Automattic/jetpack-crm/compare/v${old}...v${new}"
 		},
 		"release-branch-prefix": "crm",
 		"wp-plugin-slug": "zero-bs-crm"

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -37,7 +37,7 @@
 		"platform": {
 			"php": "7.3"
 		},
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_5_5_alpha",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_5_4_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
@@ -70,6 +70,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-crm/compare/v${old}...v${new}"
 		},
 		"release-branch-prefix": "crm",
-		"wp-plugin-slug": "zero-bs-crm"
+		"wp-plugin-slug": "zero-bs-crm",
+		"wp-svn-autopublish": true
 	}
 }

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e27168b59f27ffa476536c99520a818",
+    "content-hash": "e4211adecf939624fad89bc9151c2017",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "5.5.5-alpha",
+	"version": "5.5.4-a.2",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",


### PR DESCRIPTION
## Proposed changes:

* This PR includes composer.json plus version changes throughout to better prepare CRM for the next release - 5.5.4. That includes changing the 'current' version from 5.5.5-alpha to 5.5.4-a.2 to fit in with what our tooling currently expects of alphas (due to the alpha release that went out early this week in Github).
* To enable this, composer.json changes included setting dev-releases to true. 
* Additional composer.json changes in prep for the next release include re-enabling wp-svn-autopublish, and correcting the changelogger comparison link.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* More information about the versioning change here: p1676472566113319-slack-C04J4UG3FLG

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* The main test here is that the PR checks should all pass. But please also proof-read the changes in composer.json to check for accuracy (spelling, for example) too. For comparison with another standalone plugin, this is the [Social composer.json](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/social/composer.json) file.