### PR TITLE
VideoPress: propagate custom CSS from VideoPress video block to core/embed when transforming block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-handle-css-classes-when-transforming-embed-block
+++ b/projects/packages/videopress/changelog/update-videopress-handle-css-classes-when-transforming-embed-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: propagate custom CSS from VideoPress video block to core/embed when transforming block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -6,12 +6,14 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { buildVideoPressURL, pickGUIDFromUrl } from '../../../../lib/url';
+import { CoreEmbedVideoPressVariationBlockAttributes, VideoBlockAttributes } from '../types';
 
 const transformFromCoreEmbed = {
 	type: 'block',
 	blocks: [ 'core/embed' ],
-	isMatch: attrs => attrs.providerNameSlug === 'videopress' && pickGUIDFromUrl( attrs?.url ),
-	transform: attrs => {
+	isMatch: ( attrs: CoreEmbedVideoPressVariationBlockAttributes ) =>
+		attrs.providerNameSlug === 'videopress' && pickGUIDFromUrl( attrs?.url ),
+	transform: ( attrs: CoreEmbedVideoPressVariationBlockAttributes ) => {
 		const { url: src, providerNameSlug } = attrs;
 		const guid = pickGUIDFromUrl( src );
 
@@ -38,8 +40,8 @@ const transformFromCoreEmbed = {
 const transformToCoreEmbed = {
 	type: 'block',
 	blocks: [ 'core/embed' ],
-	isMatch: attrs => attrs?.src || attrs?.guid,
-	transform: attrs => {
+	isMatch: ( attrs: VideoBlockAttributes ) => attrs?.src || attrs?.guid,
+	transform: ( attrs: VideoBlockAttributes ) => {
 		const { guid, src: srcFromAttr } = attrs;
 
 		// Build the source (URL) in case it isn't defined.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -76,7 +76,7 @@ const transformToCoreEmbed = {
 			const { className: embedClassName } = getBlockAttributes( clientId ) || {};
 			const updatedClassName = classnames( className, embedClassName );
 			updateBlockAttributes( clientId, { className: updatedClassName } );
-		}, 0 );
+		}, 100 );
 
 		return block;
 	},

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -58,6 +58,20 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	className?: string;
 };
 
+export type CoreEmbedBlockAttributes = {
+	className: string;
+	allowResponsive: boolean;
+	providerNameSlug: string;
+	responsive: boolean;
+	type: string;
+	url: string;
+};
+
+export type CoreEmbedVideoPressVariationBlockAttributes = CoreEmbedBlockAttributes & {
+	providerNameSlug: 'videopress';
+	type: 'video';
+};
+
 export type VideoBlockSetAttributesProps = ( attributes: VideoBlockAttributes ) => void;
 
 export type VideoControlProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28953

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: propagate custom CSS from VideoPress video block to core/embed when transforming block

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a VideoPress video block
* Set the video
* Add a custom class
* Transform to `core/embed` block
* Confirm the custom class is there
* Transform to v6. 
* Confirm the class is there.


https://user-images.githubusercontent.com/77539/219798203-421dd726-49d2-4793-8ea8-d971365f24c8.mov


