### PR TITLE
Protect: remove example full path from UI

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-example-standalone
+++ b/projects/plugins/protect/changelog/fix-protect-example-standalone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin: remove example full path from example in UI

--- a/projects/plugins/protect/src/js/components/standalone-mode-modal/index.jsx
+++ b/projects/plugins/protect/src/js/components/standalone-mode-modal/index.jsx
@@ -20,7 +20,7 @@ const StandaloneModeModal = () => {
 					<Text variant={ 'body-small' }>
 						{ createInterpolateElement(
 							__(
-								'To ensure the firewall can best protect your site, please update: <mark>auto_prepend_file</mark> PHP directive to point to <mark>src/users/user66501445/public/wp-content/jetpack-waf/bootstrap.php</mark> Typically this is set either in an .htaccess file or in the global PHP configuration; contact your host for further assistance.',
+								'To ensure the firewall can best protect your site, please update: <mark>auto_prepend_file</mark> PHP directive to point to <mark>wp-content/jetpack-waf/bootstrap.php</mark> Typically this is set either in an .htaccess file or in the global PHP configuration; contact your host for further assistance.',
 								'jetpack-protect'
 							),
 							{


### PR DESCRIPTION
Fixes #29036

## Proposed changes:

- We do not have to be that specific in that example path.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to `/wp-admin/admin.php?page=jetpack-protect#/firewall`
* Click Learn more
* You should not see the full path anymore.
