### PR TITLE
Admin Page: use external link icon for jetpack app link in card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/apps-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/apps-card/index.jsx
@@ -1,5 +1,6 @@
 import { imagePath } from 'constants/urls';
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
@@ -78,11 +79,9 @@ class AppsCard extends React.Component {
 					),
 					{
 						a: (
-							<a
+							<ExternalLink
 								className="jp-apps-card__link"
 								href={ getRedirectUrl( 'jetpack-plugin-dashboard-apps-card' ) }
-								rel="noopener noreferrer"
-								target="_blank"
 								onClick={ this.trackAppLinkClick }
 							/>
 						),

--- a/projects/plugins/jetpack/changelog/fix-external-link-jetpack-app-card
+++ b/projects/plugins/jetpack/changelog/fix-external-link-jetpack-app-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin Page: update link in Jetpack App card to include external link icon.


### PR DESCRIPTION
Fixes #29047

## Proposed changes:

Let's use an external link icon since the link opens in a new window.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

On a free, connected Jetpack site, go to Jetpack > Dashboard and scroll down to the bottom of the page. Ensure the jetpack app link is followed by an external icon icon.

<img width="561" alt="image" src="https://user-images.githubusercontent.com/426388/220169704-e5ef3443-70cd-46ac-ad68-17bdffe28b8a.png">


