### PR TITLE
Admin Page: use external icons for external links in support card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/agencies-card/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/components/agencies-card/index.tsx
@@ -70,13 +70,13 @@ const AgenciesCard: FC< Props > = ( {
 				</Button>
 				<div className="jp-agencies-card__contact">
 					<h3 className="jp-agencies-card__header">
-						{ __( "Manage your clients' sites with ease", 'jetpack' ) }
+						{ __( 'Manage your clients’ sites with ease', 'jetpack' ) }
 					</h3>
 					<p className="jp-agencies-card__description">
 						{ sprintf(
 							/* translators: %s is the percentage discount the users get in the agencies portal */
 							__(
-								`Manage your clients' sites with ease and get a %s discount with the Jetpack licensing platform.`,
+								'Manage your clients’ sites with ease and get a %s discount with the Jetpack licensing platform.',
 								'jetpack'
 							),
 							`${ discountPercentage }%`

--- a/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
@@ -77,7 +77,7 @@ class SupportCard extends React.Component {
 			<div className={ classes }>
 				<Card className="jp-support-card__happiness">
 					<div className="jp-support-card__happiness-contact">
-						<h3 className="jp-support-card__header">{ __( "We're here to help", 'jetpack' ) }</h3>
+						<h3 className="jp-support-card__header">{ __( 'We’re here to help', 'jetpack' ) }</h3>
 						<p className="jp-support-card__description">
 							{ hasSupport
 								? sprintf(

--- a/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Button from 'components/button';
@@ -90,25 +91,27 @@ class SupportCard extends React.Component {
 								  ) }
 						</p>
 						<p className="jp-support-card__description">
-							<Button
-								onClick={ this.trackGettingStartedClick }
-								href={
-									this.props.isAtomicSite
-										? getRedirectUrl( 'calypso-help' )
-										: getRedirectUrl( 'jetpack-support-getting-started' )
-								}
-							>
-								{ __( 'Getting started with Jetpack', 'jetpack' ) }
+							<Button onClick={ this.trackGettingStartedClick }>
+								<ExternalLink
+									href={
+										this.props.isAtomicSite
+											? getRedirectUrl( 'calypso-help' )
+											: getRedirectUrl( 'jetpack-support-getting-started' )
+									}
+								>
+									{ __( 'Getting started with Jetpack', 'jetpack' ) }
+								</ExternalLink>
 							</Button>
-							<Button
-								onClick={ this.trackSearchClick }
-								href={
-									this.props.isAtomicSite
-										? getRedirectUrl( 'calypso-help' )
-										: getRedirectUrl( 'jetpack-support' )
-								}
-							>
-								{ __( 'Search our support site', 'jetpack' ) }
+							<Button onClick={ this.trackSearchClick }>
+								<ExternalLink
+									href={
+										this.props.isAtomicSite
+											? getRedirectUrl( 'calypso-help' )
+											: getRedirectUrl( 'jetpack-support' )
+									}
+								>
+									{ __( 'Search our support site', 'jetpack' ) }
+								</ExternalLink>
 							</Button>
 						</p>
 					</div>

--- a/projects/plugins/jetpack/changelog/fix-external-link-jetpack-support-card
+++ b/projects/plugins/jetpack/changelog/fix-external-link-jetpack-support-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin Page: use external icons for external links in support card.


### PR DESCRIPTION
## Proposed changes:

Let's use the external link icons when we're leading people away in new windows.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* On a connected Jetpack site, go to Jetpack > Dashboard and scroll down to the bottom of the page.
* Check the "We're here to help" section.
* There should now be an external icon in each button.
<img width="565" alt="image" src="https://user-images.githubusercontent.com/426388/220172998-cee7ff17-de5f-4a3d-add8-667f1008b00f.png">

