### PR TITLE
VideoPress: move the Playback Bar color panel into the colors panel group

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-organize-block-panels
+++ b/projects/packages/videopress/changelog/update-videopress-organize-block-panels
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-VideoPress: reorganize video block settings sidebar using tabs
+VideoPress: move the Playback Bar color panel into the colors panel group

--- a/projects/packages/videopress/changelog/update-videopress-organize-block-panels
+++ b/projects/packages/videopress/changelog/update-videopress-organize-block-panels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: reorganize video block settings sidebar using tabs

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/index.tsx
@@ -49,7 +49,16 @@ export default function ColorPanel( { clientId, attributes, setAttributes }: Vid
 		debouncedSetColors( colorToUpdate );
 	}, [] );
 
-	const resetStaticColors = useCallback( () => setAttributes( { useAverageColor: true } ), [] );
+	const resetStaticColors = useCallback( () => {
+		setColorsState( {} );
+
+		setAttributes( {
+			useAverageColor: true,
+			seekbarColor: '',
+			seekbarLoadingColor: '',
+			seekbarPlayedColor: '',
+		} );
+	}, [] );
 
 	return (
 		<ToolsPanelItem

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/index.tsx
@@ -3,6 +3,7 @@
  */
 import { PanelColorSettings } from '@wordpress/block-editor';
 import {
+	PanelRow,
 	ToggleControl,
 	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -52,6 +53,7 @@ export default function ColorPanel( { clientId, attributes, setAttributes }: Vid
 
 	return (
 		<ToolsPanelItem
+			className="videopress-playback-bar-colors-panel-item"
 			hasValue={ () => ! useAverageColor }
 			label={ __( 'Dynamic color', 'jetpack-videopress-pkg' ) }
 			resetAllFilter={ resetStaticColors }
@@ -59,6 +61,10 @@ export default function ColorPanel( { clientId, attributes, setAttributes }: Vid
 			panelId={ clientId }
 			onDeselect={ resetStaticColors }
 		>
+			<PanelRow className="videopress-color-panel__title">
+				{ __( 'Playback bar colors', 'jetpack-videopress-pkg' ) }
+			</PanelRow>
+
 			<ToggleControl
 				label={ __( 'Dynamic color', 'jetpack-videopress-pkg' ) }
 				help={

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/index.tsx
@@ -2,7 +2,11 @@
  *External dependencies
  */
 import { PanelColorSettings } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	ToggleControl,
+	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -24,7 +28,7 @@ import type React from 'react';
  * @param {VideoControlProps} props - Component props.
  * @returns {React.ReactElement}    Component template
  */
-export default function ColorPanel( { attributes, setAttributes }: VideoControlProps ) {
+export default function ColorPanel( { clientId, attributes, setAttributes }: VideoControlProps ) {
 	const { useAverageColor, seekbarColor, seekbarLoadingColor, seekbarPlayedColor } = attributes;
 
 	const initialColorState: VideoBlockColorAttributesProps = {
@@ -44,8 +48,17 @@ export default function ColorPanel( { attributes, setAttributes }: VideoControlP
 		debouncedSetColors( colorToUpdate );
 	}, [] );
 
+	const resetStaticColors = useCallback( () => setAttributes( { useAverageColor: true } ), [] );
+
 	return (
-		<PanelBody title={ __( 'Color', 'jetpack-videopress-pkg' ) } initialOpen={ false }>
+		<ToolsPanelItem
+			hasValue={ () => ! useAverageColor }
+			label={ __( 'Dynamic color', 'jetpack-videopress-pkg' ) }
+			resetAllFilter={ resetStaticColors }
+			isShownByDefault
+			panelId={ clientId }
+			onDeselect={ resetStaticColors }
+		>
 			<ToggleControl
 				label={ __( 'Dynamic color', 'jetpack-videopress-pkg' ) }
 				help={
@@ -94,6 +107,6 @@ export default function ColorPanel( { attributes, setAttributes }: VideoControlP
 					] }
 				/>
 			) }
-		</PanelBody>
+		</ToolsPanelItem>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/color-panel/style.scss
@@ -9,3 +9,20 @@
 	--spacing-base: 8px;
 	margin-top: var( --spacing-base );
 }
+
+.color-block-support-panel__inner-wrapper .videopress-playback-bar-colors-panel-item {
+	margin-top: 0; // clean up the margin-top from the color picker
+
+	.videopress-color-panel__title {
+		margin-bottom: 8px;
+	}
+}
+
+.videopress-color-panel__title {
+	min-height: 24px;
+	height: 24px;
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
+	text-transform: uppercase;
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -505,7 +505,7 @@ export default function VideoPressEdit( {
 				/>
 			</BlockControls>
 
-			<InspectorControls>
+			<InspectorControls group="settings">
 				<DetailsPanel
 					filename={ filename }
 					chapter={ chapter }
@@ -514,11 +514,19 @@ export default function VideoPressEdit( {
 					isRequestingVideoData={ isRequestingVideoData }
 					{ ...{ attributes, setAttributes } }
 				/>
+
 				<PlaybackPanel { ...{ attributes, setAttributes, isRequestingVideoData } } />
+
 				<PrivacyAndRatingPanel
 					{ ...{ attributes, setAttributes, isRequestingVideoData, privateEnabledForSite } }
 				/>
-				<ColorPanel { ...{ attributes, setAttributes, isRequestingVideoData } } />
+			</InspectorControls>
+
+			<InspectorControls group="color">
+				<ColorPanel
+					clientId={ clientId }
+					{ ...{ attributes, setAttributes, isRequestingVideoData } }
+				/>
 			</InspectorControls>
 
 			<ConnectBanner

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -505,7 +505,7 @@ export default function VideoPressEdit( {
 				/>
 			</BlockControls>
 
-			<InspectorControls group="settings">
+			<InspectorControls>
 				<DetailsPanel
 					filename={ filename }
 					chapter={ chapter }
@@ -522,7 +522,7 @@ export default function VideoPressEdit( {
 				/>
 			</InspectorControls>
 
-			<InspectorControls group="color">
+			<InspectorControls __experimentalGroup="color">
 				<ColorPanel
 					clientId={ clientId }
 					{ ...{ attributes, setAttributes, isRequestingVideoData } }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR moves the "Playback Bar color control" into the `colors` panel group.

It automatically will move the panel to the `style` settings for recent versions of Gutenberg and will keep the panel in the sidebar for the current version in WordPress core.


Fixes https://github.com/Automattic/jetpack/issues/28814

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: move the Playback Bar color panel into the colors panel group

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Ensure you test with the core version of Gutenberg (no Gutenbger plugin activated)
* Go to the block editor
* Add/edit a VideoPress video block
* Select the block
* Open the block settings sidebar
* Confirm the Colors group is there
* Confirm the Playback Bar colors panel is there

before | after
------|------
<img width="296" alt="image" src="https://user-images.githubusercontent.com/77539/220958133-237b38ad-7551-4f91-9eab-dcf0993762d9.png"> | <img width="285" alt="image" src="https://user-images.githubusercontent.com/77539/220952398-4b201295-c0e5-4c65-bbd4-83aa95d8db77.png">

* Confirm the `Dynamic color` item is disabled initially. It's because it's enabled by default.

<img width="285" alt="image" src="https://user-images.githubusercontent.com/77539/220953041-3faed60f-48e0-445a-b102-818ed4a6dd1c.png">

* Switch to static colors by clicking on the toggle control
* Set customs colors
* Confirm now the item allows resetting the settings by clicking on the `Dynamic color` option or the `Reset all` option.

<img width="284" alt="image" src="https://user-images.githubusercontent.com/77539/220953859-d208a416-e77c-4c6e-a614-9be130d024f8.png">

* Confirm that static colors are definitely cleaned. It doesn't happen when you toggle the control.

<img width="271" alt="image" src="https://user-images.githubusercontent.com/77539/220956856-e4bd5aac-ff38-4be7-88d9-43961ba3ae0d.png">

* Activate the Gutenberg plugin version to a new version
* Confirm the panel is rendered in the `Style` tab

<img width="377" alt="image" src="https://user-images.githubusercontent.com/77539/220957473-ac3e3366-8126-4757-96e6-702a5c265536.png">

* Confirm it behaves as expected