### PR TITLE
VideoPress: add player-bridge. Update player loading state

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-player-bridge
+++ b/projects/packages/videopress/changelog/update-videopress-add-player-bridge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add player-bridget. Update player loading state

--- a/projects/packages/videopress/changelog/update-videopress-add-player-bridge
+++ b/projects/packages/videopress/changelog/update-videopress-add-player-bridge
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-VideoPress: add player-bridget. Update player loading state
+VideoPress: add player-bridge. Update player loading state

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.10.12",
+	"version": "0.10.13-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -160,6 +160,7 @@ class Block_Editor_Extensions {
 			'isVideoPressModuleActive'    => Status::is_jetpack_plugin_and_videopress_module_active(),
 			'isStandaloneActive'          => Status::is_standalone_plugin_active(),
 			'imagesURLBase'               => plugin_dir_url( __DIR__ ) . 'build/images/',
+			'playerBridgeUrl'             => plugins_url( '../build/lib/player-bridge.js', __FILE__ ),
 		);
 
 		// Expose initital state of site connection

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.10.12';
+	const PACKAGE_VERSION = '0.10.13-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
@@ -30,6 +30,10 @@ if ( window.videopressAjax ) {
 	);
 }
 
+if ( window?.videoPressEditorState?.playerBridgeUrl ) {
+	globalScripts.push( window.videoPressEditorState.playerBridgeUrl );
+}
+
 // Define a debug instance for block bridge.
 window.debugBridgeInstance = debugFactory( 'jetpack:vp-block:bridge' );
 
@@ -133,24 +137,29 @@ export default function VideoPressPlayer( {
 
 	/*
 	 * Callback state handler for the video player
-	 * tied to the `onVideoPressLoadingState` event,
+	 * tied to the `message` event,
 	 * provided by the videopress player through the bridge.
 	 */
-	const onVideoLoadingStateHandler = useCallback( ( { detail } ) => {
-		setIsVideoPlayerLoaded( detail?.state === 'loaded' );
+	const onVideoLoadingStateHandler = useCallback( ev => {
+		const eventName = ev?.data?.event;
+		if ( ! eventName || eventName !== 'videopress_loading_state' ) {
+			return;
+		}
+
+		const playerLoadingState = ev?.data?.state;
+		setIsVideoPlayerLoaded( playerLoadingState === 'loaded' );
 	}, [] );
 
-	// Listen to the `onVideoPressLoadingState` event.
+	// Listen to the `message` event.
 	useEffect( () => {
 		if ( ! window ) {
 			return;
 		}
 
-		window.addEventListener( 'onVideoPressLoadingState', onVideoLoadingStateHandler );
+		window.addEventListener( 'message', onVideoLoadingStateHandler );
 
-		return () =>
-			window?.removeEventListener( 'onVideoPressLoadingState', onVideoLoadingStateHandler );
-	}, [ onVideoLoadingStateHandler, window, html ] );
+		return () => window?.removeEventListener( 'message', onVideoLoadingStateHandler );
+	}, [ onVideoLoadingStateHandler ] );
 
 	useEffect( () => {
 		if ( isRequestingEmbedPreview ) {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-player/index.js
@@ -6,10 +6,6 @@ import { ResizableBox, SandBox } from '@wordpress/components';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
-/**
- * Internal dependencies
- */
-import vpBlockBridge from '../../scripts/vp-block-bridge';
 
 // Global scripts array to be run in the Sandbox context.
 const globalScripts = [];
@@ -36,9 +32,6 @@ if ( window.videopressAjax ) {
 
 // Define a debug instance for block bridge.
 window.debugBridgeInstance = debugFactory( 'jetpack:vp-block:bridge' );
-
-// Load VideoPressBlock bridge script.
-globalScripts.push( vpBlockBridge );
 
 /**
  * VideoPlayer react component

--- a/projects/packages/videopress/src/client/block-editor/global.d.ts
+++ b/projects/packages/videopress/src/client/block-editor/global.d.ts
@@ -12,6 +12,7 @@ declare global {
 			isStandaloneActive: '' | '1';
 			jetpackVideoPressSettingUrl: string;
 			imagesURLBase: string;
+			playerBridgeUrl: string;
 		};
 
 		JP_CONNECTION_INITIAL_STATE: {

--- a/projects/packages/videopress/src/client/lib/player-bridge/Readme.md
+++ b/projects/packages/videopress/src/client/lib/player-bridge/Readme.md
@@ -1,0 +1,3 @@
+# Player Bridge
+
+Bridge to communicate player with the block editor.

--- a/projects/packages/videopress/src/client/lib/player-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/player-bridge/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Types
+ */
+import type { VideoGUID } from '../../block-editor/blocks/video/types';
+
+type Origin = 'https://videopress.com' | 'https://video.wordpress.com';
+
+const VIDEOPRESS_ALLOWED_LISTENING_EVENTS = [
+	'videopress_playing',
+	'videopress_pause',
+	'videopress_seeking',
+	'videopress_resize',
+	'videopress_volumechange',
+	'videopress_ended',
+	'videopress_timeupdate',
+	'videopress_durationchange',
+	'videopress_progress',
+	'videopress_loading_state',
+	'videopress_toggle_fullscreen',
+] as const;
+
+type PlayerBrigeEventProps = {
+	event: typeof VIDEOPRESS_ALLOWED_LISTENING_EVENTS[ number ];
+	id: VideoGUID;
+	origin: Origin;
+};
+
+/**
+ * Function handler to dialog between
+ * the client (player) and the app (editor)
+ *
+ * @param {object} event - The event object
+ */
+export async function playerBridgeHandler(
+	event: MessageEvent< PlayerBrigeEventProps >
+): Promise< void > {
+	const { data = { event: null } } = event || {};
+	const { event: eventName } = data;
+
+	// Propagate only allowed events.
+	if ( ! VIDEOPRESS_ALLOWED_LISTENING_EVENTS.includes( eventName ) ) {
+		return;
+	}
+
+	// Propagate only allowed origins.
+	const allowed_origins: Array< Origin > = [
+		'https://videopress.com',
+		'https://video.wordpress.com',
+	];
+
+	if ( -1 === allowed_origins.indexOf( event.origin as Origin ) ) {
+		return;
+	}
+
+	window.top.postMessage( event.data, '*' );
+}
+
+( function () {
+	window.addEventListener( 'message', playerBridgeHandler );
+} )();

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -10,6 +10,8 @@ module.exports = [
 			'block-editor/blocks/video/view': './src/client/block-editor/blocks/video/view.ts',
 
 			'lib/token-bridge': './src/client/lib/token-bridge/index.ts',
+			'lib/player-bridge': './src/client/lib/player-bridge/index.ts',
+
 			'lib/videopress-token-bridge': './src/client/lib/videopress-token-bridge.js',
 
 			// VideoPress dashboard page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/28310

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add player-bridget. Update player loading state

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Building and loading s scripts

* Locally, restart your compiling process.
* Confirm the app creates a new `./build/lib/player-bridge` set of files (`.js`, `.js.map`, `.php`)
* Go to the block editor
* Open the console
* Confirm the file URL of the bridge is exposed in the `videoPressEditorState` global var

<img width="547" alt="Screen Shot 2023-02-21 at 08 56 47" src="https://user-images.githubusercontent.com/77539/220338629-79b550f3-54c1-411d-889b-805d3e03ff86.png">

* Open the network tab of your browser
* Filter by player-bridge
* Confirm the file is loaded

<img width="538" alt="Screen Shot 2023-02-21 at 08 56 10" src="https://user-images.githubusercontent.com/77539/220338638-0fdb0eed-2bc2-485b-8196-06fc659c08a9.png">

The app cancels the first load when the iFrame is rendered. Something that we can try to handle in a better way in a follow-up
* Confirm the app (block editor) detects when the video has been loaded by listening to the `videopress_loading_state` event.


https://user-images.githubusercontent.com/77539/220341468-02d8b710-96f5-49b7-8d66-6b8e1bca6582.mov