### PR TITLE
tools: Allow selecting more than one but not all plugins in create-release-branch.sh

### DIFF
--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -137,10 +137,10 @@ echo "==========="
 echo ""
 
 checking 'Usable version of bash'
-if [[ -n "${BASH_VERSINFO}" && -n "${BASH_VERSINFO[0]}" && ${BASH_VERSINFO[0]} -ge 4 ]]; then
+if [[ -n "${BASH_VERSINFO}" && -n "${BASH_VERSINFO[0]}" && ( ${BASH_VERSINFO[0]} -gt 4 || ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -ge 3 ) ]]; then
 	success "ok (version $BASH_VERSION)"
 else
-	failure "too old" '' "Bash at $BASH is $BASH_VERSION. Version 4 or later is required." "If you're on Mac OS, you can install an updated version of bash with ${CS}brew install bash${CE}"
+	failure "too old" '' "Bash at $BASH is $BASH_VERSION. Version 4.3 or later is required." "If you're on Mac OS, you can install an updated version of bash with ${CS}brew install bash${CE}"
 fi
 
 checking "Standard tools are available"

--- a/tools/includes/check-osx-bash-version.sh
+++ b/tools/includes/check-osx-bash-version.sh
@@ -4,12 +4,12 @@
 # like the one above, because poor OS X users will have the new bash at
 # /usr/local/bin/bash instead of /bin/bash like the rest of the world expects.
 
-if [[ -z "${BASH_VERSINFO}" || -z "${BASH_VERSINFO[0]}" || ${BASH_VERSINFO[0]} -lt 4 ]]; then
+if [[ -z "${BASH_VERSINFO}" || -z "${BASH_VERSINFO[0]}" || ${BASH_VERSINFO[0]} -lt 4 || ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -lt 3 ]]; then
 	. "$(dirname "$BASH_SOURCE[0]")/chalk-lite.sh"
 
 	[[ "$BASH_VERSION" ]] && V=" You have $BASH_VERSION." || V=
 	error <<-EOM
-		This script requires Bash version >= 4.$V
+		This script requires Bash version >= 4.3.$V
 
 		If you're on Mac OS, you can install an updated version of bash with
 		  brew install bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Turns out this is something we're going to be doing a lot, releasing Jetpack and mu-wpcom-plugin but not Backup or Social. So now we can either list multiple plugins on the command line or be prompted for each candidate plugin if only one is supplied.

Also, update the bash version check to require 4.3 (released 9 years ago) instead of just 4.0, as this uses "unset" which was introduced in that version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1676923763746739-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `tools/check-plugin-monorepo-deps.sh jetpack` should do all four plugins.
* `tools/check-plugin-monorepo-deps.sh plugins/jetpack` should prompt, and do whichever you specify.
* `tools/check-plugin-monorepo-deps.sh plugins/jetpack 123.456` should prompt, and (if you select only Jetpack) should make a release branch for version 123.456.
* `tools/check-plugin-monorepo-deps.sh plugins/jetpack plugins/mu-wpcom-plugin` should do just those two.
* `tools/check-plugin-monorepo-deps.sh plugins/jetpack plugins/mu-wpcom-plugin 123.456` should do just those two, and ignore the version number.
* `tools/check-plugin-monorepo-deps.sh plugins/beta` should do just that plugin without prompting.
* `tools/check-plugin-monorepo-deps.sh plugins/jetpack plugins/beta` should report an error.
