### PR TITLE
CRM: OAuth page critical error

### DIFF
--- a/projects/plugins/crm/admin/settings/oauth-connections.page.php
+++ b/projects/plugins/crm/admin/settings/oauth-connections.page.php
@@ -92,7 +92,7 @@ if ( isset( $_GET['edit-provider'] ) && $zbs->oauth->legitimate_provider( $_GET[
 								case 'config-no-connect':
 									// just connect button
 									?>
-									<button type="button" class="jpcrm-open-popup-href ui tiny green button" data-href="<?php echo esc_url( $zbs->oauth->get_callback_url( $provider_key ) ); ?>" data-title="<?php esc_url_e( 'Connect to CRM', 'zero-bs-crm' ); ?>" data-width="600" data-height="600"><i class="plug icon"></i> <?php esc_html_e( 'Connect', 'zero-bs-crm' ); ?></button>
+									<button type="button" class="jpcrm-open-popup-href ui tiny green button" data-href="<?php echo esc_url( $zbs->oauth->get_callback_url( $provider_key ) ); ?>" data-title="<?php esc_attr_e( 'Connect to CRM', 'zero-bs-crm' ); ?>" data-width="600" data-height="600"><i class="plug icon"></i> <?php esc_html_e( 'Connect', 'zero-bs-crm' ); ?></button>
 									<?php
 
 									break;
@@ -101,7 +101,7 @@ if ( isset( $_GET['edit-provider'] ) && $zbs->oauth->legitimate_provider( $_GET[
 									// reconnect + disconnect buttons
 									?>
 									<div class="ui tiny buttons">
-										<button type="button" class="jpcrm-open-popup-href ui tiny green button" data-href="<?php echo esc_url( $zbs->oauth->get_callback_url( $provider_key ) ); ?>" data-title="<?php esc_att_e( 'Connect to CRM', 'zero-bs-crm' ); ?>" data-width="600" data-height="600"><i class="sync icon"></i> <?php esc_html_e( 'Reconnect', 'zero-bs-crm' ); ?></button>                                        
+										<button type="button" class="jpcrm-open-popup-href ui tiny green button" data-href="<?php echo esc_url( $zbs->oauth->get_callback_url( $provider_key ) ); ?>" data-title="<?php esc_attr_e( 'Connect to CRM', 'zero-bs-crm' ); ?>" data-width="600" data-height="600"><i class="sync icon"></i> <?php esc_html_e( 'Reconnect', 'zero-bs-crm' ); ?></button>                                        
 										<a href="<?php echo esc_url( wp_nonce_url( '?page=' . $zbs->slugs['settings'] . '&tab=oauth&disconnect=' . $provider_key, 'disconnect_oauth' ) ); ?>" class="ui tiny orange button"><i class="stop icon"></i> <?php esc_html_e( 'Disconnect', 'zero-bs-crm' ); ?></a>
 									</div>
 									<hr>

--- a/projects/plugins/crm/changelog/crm-oauth-page-critical-error
+++ b/projects/plugins/crm/changelog/crm-oauth-page-critical-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+OAuth connections page no longer shows critical error after saving credentials


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes the critical error shown after saving OAuth credentials in the settings page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/zero-bs-crm/issues/2886

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings -> OAuth Connections (`wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=oauth`)
* Save any Client ID and Client Secret (this can be dummy data)
* Go back to the OAuth Connections page (`wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=oauth`)

In `trunk` a critical error is shown:
https://user-images.githubusercontent.com/16754605/218505599-a5e8498e-d366-4291-88ae-fc48ee1b47f9.png

In `fix/crm-oauth-page-critical-error`, everything works as expected:
![image](https://user-images.githubusercontent.com/37049295/220202318-75d599a1-5151-4910-8b8a-2e0a2858ec4a.png)


