### PR TITLE
Stats Admin: move new stats toggling to package

### DIFF
--- a/projects/packages/stats-admin/changelog/update-move-new-stats-toggling-to-package
+++ b/projects/packages/stats-admin/changelog/update-move-new-stats-toggling-to-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: moved New Stats toggling logic to stats-admin

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.6.1",
+	"version": "0.6.2-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.6.1';
+	const VERSION = '0.6.2-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Stats_Admin;
 
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Stats\Options as Stats_Options;
+use Automattic\Jetpack\Tracking;
+
 /**
  * Stats Main class.
  *
@@ -48,5 +52,32 @@ class Main {
 	 */
 	private function __construct() {
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
+	}
+
+	/**
+	 * Update New Stats status.
+	 *
+	 * @param bool $status true to enable or false to disable.
+	 * @return bool
+	 */
+	public static function update_new_stats_status( $status ) {
+		$status = (bool) $status;
+
+		$stats_options = array(
+			'enable_odyssey_stats'     => $status,
+			'odyssey_stats_changed_at' => time(),
+		);
+		$updated       = Stats_Options::set_options( $stats_options );
+
+		// Track the event.
+		$event_name = 'calypso_stats_disabled';
+		if ( $status ) {
+			$event_name = 'calypso_stats_enabled';
+		}
+		$connection_manager = new Manager( 'jetpack' );
+		$tracking           = new Tracking( 'jetpack', $connection_manager );
+		$tracking->record_user_event( $event_name, array_merge( $stats_options, array( 'updated' => $updated ) ) );
+
+		return $updated;
 	}
 }

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -5,14 +5,11 @@
  * @package automattic/jetpack
  */
 
-use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\Plugins_Installer;
-use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
+use Automattic\Jetpack\Stats_Admin\Main as Stats_Admin_Main;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Tracking;
-
 /**
  * This is the base class for every Core API endpoint Jetpack uses.
  */
@@ -883,20 +880,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'enable_odyssey_stats':
-					$value         = (bool) $value;
-					$stats_options = array(
-						'enable_odyssey_stats'     => $value,
-						'odyssey_stats_changed_at' => time(),
-					);
-					$updated       = Stats_Options::set_options( $stats_options );
-					// Track the event.
-					$event_name = 'calypso_stats_disabled';
-					if ( $value ) {
-						$event_name = 'calypso_stats_enabled';
-					}
-					$connection_manager = new Manager( 'jetpack' );
-					$tracking           = new Tracking( 'jetpack', $connection_manager );
-					$tracking->record_user_event( $event_name, array_merge( $stats_options, array( 'updated' => $updated ) ) );
+					$updated = Stats_Admin_Main::update_new_stats_status( $value );
+
 					break;
 
 				case 'akismet_show_user_comments_approved':

--- a/projects/plugins/jetpack/changelog/update-move-new-stats-toggling-to-package
+++ b/projects/plugins/jetpack/changelog/update-move-new-stats-toggling-to-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Stats: moved New Stats toggling logic to stats-admin


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/pull/28828/files#r1112402849

## Proposed changes:
Moves the toggling function to package `stats-admin` for reuse in https://github.com/Automattic/jetpack/pull/28828.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Go to `/wp-admin/admin.php?page=jetpack#/traffic` and find section `Jetpack Stats`
* Toggle `Enable the new Jetpack Stats experience New`
* Ensure Odyssey Status enables / disables accordingly
