### PR TITLE
Stats Admin: allow showing opt-in notice  30 days after Odyssey is disabled

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-opt-in-stats-notice-30days
+++ b/projects/packages/stats-admin/changelog/fix-opt-in-stats-notice-30days
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Stats Admin: Opt-in notice should be shown a month after the customer has opted out of Odyssey Stats.

--- a/projects/packages/stats-admin/changelog/fix-opt-in-stats-notice-30days
+++ b/projects/packages/stats-admin/changelog/fix-opt-in-stats-notice-30days
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: fixed
 
 Stats Admin: Opt-in notice should be shown a month after the customer has opted out of Odyssey Stats.

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -60,7 +60,7 @@ class Notices {
 		return array(
 			// Show Opt-in notice 30 days after the new stats being disabled.
 			self::OPT_IN_NEW_STATS_NOTICE_ID   => ! $new_stats_enabled
-				&& Stats_Options::get_option( 'odyssey_stats_changed_at' ) > time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
+				&& Stats_Options::get_option( 'odyssey_stats_changed_at' ) < time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
 				&& ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
 
 			// Show feedback notice after 3 views of the new stats.

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -22,8 +22,9 @@ class Notices {
 	const NOTICE_STATUS_DISMISSED = 'dismissed';
 	const NOTICE_STATUS_POSTPONED = 'postponed';
 
-	const VIEWS_TO_SHOW_FEEDBACK = 3;
-	const POSTPONE_FEEDBACK_DAYS = 30;
+	const VIEWS_TO_SHOW_FEEDBACK      = 3;
+	const POSTPONE_FEEDBACK_DAYS      = 30;
+	const POSTPONE_OPT_IN_NOTICE_DAYS = 30;
 
 	/**
 	 * Update the notice status.
@@ -57,9 +58,20 @@ class Notices {
 		$stats_views       = $this->get_new_stats_views();
 
 		return array(
-			self::OPT_IN_NEW_STATS_NOTICE_ID   => ! $new_stats_enabled && ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
-			self::NEW_STATS_FEEDBACK_NOTICE_ID => $new_stats_enabled && $stats_views >= self::VIEWS_TO_SHOW_FEEDBACK && ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ),
-			self::OPT_OUT_NEW_STATS_NOTICE_ID  => $new_stats_enabled && $stats_views < self::VIEWS_TO_SHOW_FEEDBACK && ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ),
+			// Show Opt-in notice 30 days after the new stats being disabled.
+			self::OPT_IN_NEW_STATS_NOTICE_ID   => ! $new_stats_enabled
+				&& Stats_Options::get_option( 'odyssey_stats_changed_at' ) > time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
+				&& ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
+
+			// Show feedback notice after 3 views of the new stats.
+			self::NEW_STATS_FEEDBACK_NOTICE_ID => $new_stats_enabled
+				&& $stats_views >= self::VIEWS_TO_SHOW_FEEDBACK
+				&& ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ),
+
+			// Show opt-out notice before 3 views of the new stats, where 3 is included.
+			self::OPT_OUT_NEW_STATS_NOTICE_ID  => $new_stats_enabled
+				&& $stats_views < self::VIEWS_TO_SHOW_FEEDBACK
+				&& ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ),
 		);
 	}
 

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -54,13 +54,14 @@ class Notices {
 	 * @return array
 	 */
 	public function get_notices_to_show() {
-		$new_stats_enabled = Stats_Options::get_option( 'enable_odyssey_stats' );
-		$stats_views       = $this->get_new_stats_views();
+		$new_stats_enabled        = Stats_Options::get_option( 'enable_odyssey_stats' );
+		$stats_views              = $this->get_new_stats_views();
+		$odyssey_stats_changed_at = intval( Stats_Options::get_option( 'odyssey_stats_changed_at' ) );
 
 		return array(
 			// Show Opt-in notice 30 days after the new stats being disabled.
 			self::OPT_IN_NEW_STATS_NOTICE_ID   => ! $new_stats_enabled
-				&& Stats_Options::get_option( 'odyssey_stats_changed_at' ) < time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
+				&& $odyssey_stats_changed_at < time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
 				&& ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
 
 			// Show feedback notice after 3 views of the new stats.

--- a/projects/packages/stats-admin/tests/php/test-stats-notices.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-notices.php
@@ -101,6 +101,7 @@ class Test_Notices extends Stats_Test_Case {
 	 */
 	public function test_opt_in_new_stats_notice_show() {
 		Stats_Options::set_option( 'enable_odyssey_stats', false );
+		Stats_Options::set_option( 'odyssey_stats_changed_at', time() - 31 * DAY_IN_SECONDS );
 		$this->assertTrue( self::$notices->get_notices_to_show()['opt_in_new_stats'] );
 	}
 


### PR DESCRIPTION
## Proposed changes:
The PR is spun off https://github.com/Automattic/jetpack/pull/28828, which adds 30-day wait time for Opt-in notice to show as described in https://github.com/Automattic/jetpack/issues/28729.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Ensure all tests pass
