### PR TITLE
Subscriptions: start working on a new way to display block

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,6 +570,7 @@ importers:
       '@automattic/jetpack-connection': workspace:*
       '@babel/core': 7.20.12
       '@babel/preset-react': 7.18.6
+      '@wordpress/api-fetch': 6.23.0
       '@wordpress/compose': 6.3.0
       '@wordpress/element': 5.3.0
       '@wordpress/i18n': 4.26.0
@@ -580,6 +581,7 @@ importers:
     dependencies:
       '@automattic/jetpack-analytics': link:../analytics
       '@automattic/jetpack-connection': link:../connection
+      '@wordpress/api-fetch': 6.23.0
       '@wordpress/compose': 6.3.0_react@18.2.0
       '@wordpress/element': 5.3.0
       '@wordpress/i18n': 4.26.0

--- a/projects/js-packages/shared-extension-utils/changelog/update-subscriptions-inactive
+++ b/projects/js-packages/shared-extension-utils/changelog/update-subscriptions-inactive
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new utilitly to toggle Jetpack modules on and off.

--- a/projects/js-packages/shared-extension-utils/index.js
+++ b/projects/js-packages/shared-extension-utils/index.js
@@ -15,3 +15,4 @@ export {
 } from './src/plan-utils';
 export { default as isCurrentUserConnected } from './src/is-current-user-connected';
 export { default as useAnalytics } from './src/hooks/use-analytics';
+export { default as useModuleStatus } from './src/hooks/use-module-status';

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -17,6 +17,7 @@
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
+		"@wordpress/api-fetch": "6.23.0",
 		"@wordpress/compose": "6.3.0",
 		"@wordpress/element": "5.3.0",
 		"@wordpress/i18n": "4.26.0",

--- a/projects/js-packages/shared-extension-utils/src/hooks/use-module-status.js
+++ b/projects/js-packages/shared-extension-utils/src/hooks/use-module-status.js
@@ -1,0 +1,107 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+import { isSimpleSite } from '../site-type-utils';
+
+/**
+ * Fetch information about all Jetpack modules.
+ *
+ * @returns {Promise<object>} Details about all available modules on the site.
+ */
+async function fetchModules() {
+	try {
+		const result = await apiFetch( {
+			path: `/jetpack/v4/module/all`,
+			method: 'GET',
+		} );
+		return result;
+	} catch ( error ) {
+		return Promise.reject( error.message );
+	}
+}
+
+/**
+ * Update a Jetpack module's status.
+ *
+ * @param {*} name - The module's name.
+ * @param {*} toggle - New module status.
+ * @returns {Promise<boolean>} Promise that resolves to the new module status.
+ */
+async function changeStatus( name, toggle ) {
+	try {
+		const result = await apiFetch( {
+			path: `/jetpack/v4/module/${ name }/active`,
+			method: 'POST',
+			data: {
+				active: toggle,
+			},
+		} );
+		return result;
+	} catch ( error ) {
+		return Promise.reject( error.message );
+	}
+}
+
+/**
+ * Determine whethher a Jetpack module is active.
+ *
+ * @param {string} name - The module's name
+ * @returns {Promise<boolean>} Whether the module is active.
+ */
+async function isJetpackModuleActive( name ) {
+	// On WordPress.com Simple sites, all modules are always active.
+	if ( isSimpleSite() ) {
+		return true;
+	}
+
+	// Fetch module info.
+	const modulesInfo = await fetchModules();
+	if ( ! modulesInfo || ! modulesInfo.hasOwnProperty( name ) ) {
+		return false;
+	}
+
+	// Check if module is active.
+	return !! modulesInfo[ name ].activated;
+}
+
+/**
+ * Manage a Jetpack module's status (get and set).
+ *
+ * @param {string} name - The module's name.
+ * @returns {boolean} Whether the module is active.
+ */
+const useModuleStatus = name => {
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isModuleActive, setModuleStatus ] = useState( false );
+
+	// Get module status.
+	useEffect( () => {
+		if ( ! name ) {
+			return;
+		}
+
+		setIsLoading( true );
+
+		isJetpackModuleActive( name ).then( moduleStatus => {
+			setModuleStatus( moduleStatus );
+		} );
+
+		setIsLoading( false );
+	}, [ name ] );
+
+	// Update module status.
+	useEffect( () => {
+		if ( ! name || ! changeStatus ) {
+			return;
+		}
+
+		setIsLoading( true );
+		const newModuleStatus = changeStatus( name, ! isModuleActive );
+		setModuleStatus( newModuleStatus );
+
+		setIsLoading( false );
+	}, [ isModuleActive, name ] );
+
+	return { isLoading, isModuleActive, changeStatus };
+};
+
+export default useModuleStatus;

--- a/projects/plugins/jetpack/changelog/update-subscriptions-inactive
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-inactive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Subscriptions: make block available, even when the Subscriptions module is off.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -1,5 +1,9 @@
 import { JetpackLogo, numberFormat } from '@automattic/jetpack-components';
-import { isComingSoon, isPrivateSite } from '@automattic/jetpack-shared-extension-utils';
+import {
+	isComingSoon,
+	isPrivateSite,
+	useModuleStatus,
+} from '@automattic/jetpack-shared-extension-utils';
 import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import {
@@ -16,20 +20,27 @@ import './panel.scss';
 import { META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS } from './constants';
 import { NewsletterAccess, accessOptions } from './settings';
 import { isNewsletterFeatureEnabled } from './utils';
+import { name } from './';
+
 export default function SubscribePanels() {
 	const [ subscriberCount, setSubscriberCount ] = useState( null );
 	const [ postMeta = [], setPostMeta ] = useEntityProp( 'postType', 'post', 'meta' );
+	const { isModuleActive } = useModuleStatus( name );
 
 	const accessLevel =
 		postMeta[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ] ?? Object.keys( accessOptions )[ 0 ];
 
 	const [ followerCount, setFollowerCount ] = useState( null );
 	useEffect( () => {
+		if ( ! isModuleActive ) {
+			return;
+		}
+
 		getSubscriberCounts( counts => {
 			setSubscriberCount( counts.email_subscribers );
 			setFollowerCount( counts.social_followers );
 		} );
-	}, [] );
+	}, [ isModuleActive ] );
 
 	// Only show this for posts for now (subscriptions are only available on posts).
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -33,7 +33,7 @@ const DEFAULT_SPACING_VALUE       = 10;
 function register_block() {
 	if (
 		( defined( 'IS_WPCOM' ) && IS_WPCOM )
-		|| ( Jetpack::is_connection_ready() && Jetpack::is_module_active( 'subscriptions' ) && ! ( new Status() )->is_offline_mode() )
+		|| ( Jetpack::is_connection_ready() && ! ( new Status() )->is_offline_mode() )
 	) {
 		Blocks::jetpack_register_block(
 			BLOCK_NAME,
@@ -48,6 +48,14 @@ function register_block() {
 				),
 			)
 		);
+	}
+
+	/*
+	 * If the Subscriptions module is not active,
+	 * do not make any further changes on the site.
+	 */
+	if ( ! Jetpack::is_module_active( 'subscriptions' ) ) {
+		return;
 	}
 
 	if (
@@ -366,6 +374,11 @@ function get_element_styles_from_attributes( $attributes ) {
  * @return string
  */
 function render_block( $attributes ) {
+	// If the Subscriptions module is not active, don't render the block.
+	if ( ! Jetpack::is_module_active( 'subscriptions' ) ) {
+		return '';
+	}
+
 	// We only want the sites that have newsletter plans to be graced by this JavaScript and thickbox.
 	if ( has_newsletter_plans() ) {
 		// We only want the sites that have newsletter plans to be graced by this JavaScript and thickbox.


### PR DESCRIPTION
## Proposed changes:

This is a companion to #29044. It isn't tested, but aims to offer a way to toggle modules on and off from the block editor. This is based on discussion in p1676970563872519-slack-CDLH4C1UZ

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

see p1676970563872519-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Start with a site that's connected to WordPress.com, but where the subscriptions module is not active (check under Jetpack > Settings(
)
* Go to Posts > Add New
* Add a Subscribe block
