### PR TITLE
CRM: Dashboard activity - display default avatar when contact image mode set to none.

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -620,12 +620,13 @@ if (jQuery('#bar-chart').length){
 				<tbody>
 					<?php
 					foreach ( $latest_cust as $cust ) {
-						// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- to be refactored.
-						$avatar = ( isset( $cust ) && isset( $cust['id'] ) ) ? $zbs->DAL->contacts->getContactAvatar( $cust['id'] ) : '';
-						$fname  = ( isset( $cust ) && isset( $cust['fname'] ) ) ? $cust['fname'] : '';
-						$lname  = ( isset( $cust ) && isset( $cust['lname'] ) ) ? $cust['lname'] : '';
-						$status = ( isset( $cust ) && isset( $cust['status'] ) ) ? $cust['status'] : '';
-						// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						// phpcs:disable WordPress.NamingConventions.ValidVariableName -- to be refactored.
+						$contactAvatar = $zbs->DAL->contacts->getContactAvatar( $cust['id'] );
+						$avatar        = ( isset( $cust ) && isset( $cust['id'] ) ) ? ( $contactAvatar ? $contactAvatar : zeroBSCRM_getDefaultContactAvatar() ) : '';
+						$fname         = ( isset( $cust ) && isset( $cust['fname'] ) ) ? $cust['fname'] : '';
+						$lname         = ( isset( $cust ) && isset( $cust['lname'] ) ) ? $cust['lname'] : '';
+						$status        = ( isset( $cust ) && isset( $cust['status'] ) ) ? $cust['status'] : '';
+						// phpcs:enable WordPress.NamingConventions.ValidVariableName
 						if ( empty( $status ) ) {
 							$status = __( 'None', 'zero-bs-crm' );
 						}

--- a/projects/plugins/crm/changelog/fix-crm-contact-image-mode-none
+++ b/projects/plugins/crm/changelog/fix-crm-contact-image-mode-none
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: show default avatar under activity, when contact image mode set to none.


### PR DESCRIPTION
* In CRM 5.5.2 a change was shipped that resulted in broken images showing in place of default avatars under the activity feed on the CRM dashboard, when the contact image mode was set to none.
* The [Github issue reporting this regression](https://github.com/Automattic/zero-bs-crm/issues/2841) also reported another issue - no avatars were displaying under 'View all' on the Contacts page when the contact image mode was set to none either. However, that has been the case since CRM 2.7 when contact image mode was introduced, so in this PR I'm not treating that as an issue to be fixed but rather it would be an enhancement if we took that route. That said there is an alternative solution to what I've suggested below, and that will 'fix' both issues. That solution would be to `return zeroBSCRM_getDefaultContactAvatar()` on line 4647 of `includes/ZeroBSCRM.Dal3.Obj.Contacts.php` instead of an empty string : https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php#L4647 

## Proposed changes:

* In this PR, in `admin/dashboard/main.page.php`, a check is added for an empty string where there should be an avatar. If that exists, then a default avatar is added in it's place.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2841

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test without applying the changes in this PR, on a test site with 5.5.2, 5.5.3 or 5.5.4-alpha, visit the Contacts page and 'Add New' contacts if there aren't any: `wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact`.
* On the CRM Settings page - `wp-admin/admin.php?page=zerobscrm-plugin-settings` - set Contact Image mode to 'none'.
* Visit the CRM dashboard, and scroll down to the activity feed. You should see a broken image and the alt text 'Contact Image'.
* Using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, repeat the above steps. On the dashboard you should see a default avatar instead of broken images and alt text.
* Make sure the other image modes aren't affected by this change (Gravatar and Custom Images).

Before:

<img width="865" alt="Screenshot 2023-02-21 at 10 23 08 am" src="https://user-images.githubusercontent.com/16754605/220318383-4b1966ec-e40a-4beb-8f75-c15052716c0d.png">


After:
<img width="1030" alt="Screenshot 2023-02-20 at 4 39 35 pm" src="https://user-images.githubusercontent.com/16754605/220317034-154cd7c9-05b1-4369-ba3d-bc8b260a023a.png">
