### PR TITLE
Fix viewer lists for List User API

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-users-include-viewer
+++ b/projects/plugins/jetpack/changelog/fix-users-include-viewer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix a bug in list user endpoint when include_viewers is true


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1701

## Proposed changes:
This makes sure that the List Users API endpoint returns the correct number of viewers. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
There is a good discussion here: pcmemI-1NC-p2 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Merge the WP.com diff below
- Go to [API console](https://developer.wordpress.com/docs/api/console/)
- Make sure that the endpoint returns correct results for every edge case.

<img width="947" alt="CleanShot 2023-02-21 at 16 39 06@2x" src="https://user-images.githubusercontent.com/533/220329125-ba474ba9-ad27-40a4-8e7c-b26fac2175d9.png">


Known issue: search still only works with the first page. This is documented in the API for now, and we can think about improving this once we consider an ElasticSearch-based solution.
