### PR TITLE
Ensure presentation container is always added

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-shortcode-rendering
+++ b/projects/plugins/jetpack/changelog/fix-shortcode-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Presentation shortcode: always add presentation container

--- a/projects/plugins/jetpack/modules/shortcodes/presentations.php
+++ b/projects/plugins/jetpack/modules/shortcodes/presentations.php
@@ -249,26 +249,23 @@ if ( ! class_exists( 'Presentations' ) ) :
 			$out .= "<p class='not-supported-msg' style='display: inherit; padding: 25%; text-align: center;'>";
 			$out .= __( 'This slideshow could not be started. Try refreshing the page or viewing it in another browser.', 'jetpack' ) . '</p>';
 
-			// Bail out unless the scripts were added.
-			if ( $this->scripts_and_style_included ) {
-				$out .= sprintf(
-					'<div class="presentation" duration="%s" data-autoplay="%s" style="%s">',
-					esc_attr( $duration ),
-					esc_attr( $autoplay ),
-					esc_attr( $style )
-				);
-				$out .= "<div class='nav-arrow-left'></div>";
-				$out .= "<div class='nav-arrow-right'></div>";
-				$out .= "<div class='nav-fullscreen-button'></div>";
+			$out .= sprintf(
+				'<div class="presentation" duration="%s" data-autoplay="%s" style="%s">',
+				esc_attr( $duration ),
+				esc_attr( $autoplay ),
+				esc_attr( $style )
+			);
+			$out .= "<div class='nav-arrow-left'></div>";
+			$out .= "<div class='nav-arrow-right'></div>";
+			$out .= "<div class='nav-fullscreen-button'></div>";
 
-				if ( $autoplay ) {
-					$out .= '<div class="autoplay-overlay" style="display: none;"><p class="overlay-msg">';
-					$out .= __( 'Click to autoplay the presentation!', 'jetpack' );
-					$out .= '</p></div>';
-				}
-
-				$out .= do_shortcode( $content );
+			if ( $autoplay ) {
+				$out .= '<div class="autoplay-overlay" style="display: none;"><p class="overlay-msg">';
+				$out .= __( 'Click to autoplay the presentation!', 'jetpack' );
+				$out .= '</p></div>';
 			}
+
+			$out .= do_shortcode( $content );
 
 			$out .= '</section>';
 


### PR DESCRIPTION
The presentation shortcode fails to render properly for block themes.

In this scenario `add_scripts` is not called before `presentation_shortcode` even though is added with priority 1 ( `add_action( 'wp_head', array( $this, 'add_scripts' ), 1 )` )
This leaves the `scripts_and_style_included` to the initial `false` value and the required html for the presentation is not added.

With this patch I just removed the check for this value in `presentation_shortcode`.
Continuing to add the presentation html doesn't break anything or bring any visual change so its pretty safe in my opinion, since there is `display: none` applied to them.

Fixes: 107-gh-Automattic/wpsupport3

## Proposed changes:
* Remove `scripts_and_style_included` and ensure that presentation elements are always added

## Does this pull request change what data or activity we track or use?
My PR adds the presentation container without a check and doesn't affect data or activity that we track.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
- Sync this branch or use patch D102221
- Edit your host file to make the following sites pointing to your sandbox: kpapazov095.wordpress.com, en.support.wordpress.com, wordpress.com
- Checkout the following urls and make sure the presentation is rendered. Note for the sandbox wordpress site you will get certificate errors for some of the requests. To fix this open one of the failing requests from the network tab in a new tab and write "thisisunsafe".
https://wordpress.com/support/presentations/?theme=a8c/wpsupport2
pepCCm-7-p2
https://wordpress.com/support/presentations
<img width="669" alt="Screenshot 2023-02-21 at 15 19 42" src="https://user-images.githubusercontent.com/7000684/220385751-42672aa3-a030-4ae8-b4c1-b6310a35c735.png">
- Disable JS in your browser and check if the nodes added with this patch don't create issues
<img width="1563" alt="Screenshot 2023-02-21 at 15 20 21" src="https://user-images.githubusercontent.com/7000684/220385917-ac79e9c8-2143-4684-9e26-27a8c9e5537f.png">
- With no sandboxing the presentation shortcode is broken for the block theme urls:
pepCCm-7-p2
https://wordpress.com/support/presentations
