### PR TITLE
Jetpack: log when transform from video block v5 to v6

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-log-v5-v6-transform
+++ b/projects/plugins/jetpack/changelog/update-jetpack-log-v5-v6-transform
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack: log when transforming from video block v5 to v6

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import analytics from '@automattic/jetpack-analytics';
 import {
 	isAtomicSite,
 	isSimpleSite,
@@ -13,8 +14,8 @@ import { parse } from '@wordpress/block-serialization-default-parser';
 import { createBlock, getBlockType } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useDispatch } from '@wordpress/data';
-import { mediaUpload } from '@wordpress/editor';
+import { useDispatch, select } from '@wordpress/data';
+import { mediaUpload, store as editorStore } from '@wordpress/editor';
 import { useContext, useEffect } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
@@ -447,7 +448,16 @@ function addVideoPressCoreVideoTransform( settings, name ) {
 						const guidFromSrc = pickGUIDFromUrl( src );
 						return guid || guidFromSrc;
 					},
-					transform: attrs => createBlock( 'videopress/video', attrs ),
+					transform: attrs => {
+						const postId = select( editorStore ).getCurrentPostId();
+						analytics?.tracks?.recordEvent(
+							'jetpack_editor_videopress_block_manual_transform_click',
+							{
+								post_id: postId,
+							}
+						);
+						return createBlock( 'videopress/video', attrs );
+					},
 				},
 			],
 			to: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: log when transforming from video block v5 to v6

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes, it tracks the `jetpack_editor_videopress_block_manual_transform_click` event when the user transform a video block v5 te the new VideoPress video block, from the transform block tool.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Activate Jetpack plugin / activate VideoPress module
* Go to the block editor
* Set debug() scope with `dops:analytics`:

```
localStorage.setItem( 'debug', 'dops:analytics*' )
```

* Hard refresh
* Create a new v5 instance.
* Open the block toolbar
* Transform the block by using the transform tool
* Confirm the app logs one event for every block transformed.

<img width="733" alt="Screen Shot 2023-02-21 at 15 42 00" src="https://user-images.githubusercontent.com/77539/220431975-55d949c8-0786-4b18-9032-797bc820f033.png">

* Confirm the `t` gif image is loaded

<img width="855" alt="image" src="https://user-images.githubusercontent.com/77539/220432052-07b409f2-eaf0-47ed-a4cc-eba01834af3b.png">


