### PR TITLE
Add import package media endpoints

### DIFF
--- a/projects/packages/import/changelog/update-add-import-media-endpoint
+++ b/projects/packages/import/changelog/update-add-import-media-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the `/jetpack/v4/import/media/*` endpoints.

--- a/projects/packages/import/composer.json
+++ b/projects/packages/import/composer.json
@@ -51,7 +51,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.1.x-dev"
+			"dev-trunk": "0.2.x-dev"
 		},
 		"textdomain": "jetpack-import",
 		"version-constants": {

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-import",
-	"version": "0.1.0",
+	"version": "0.2.0-alpha",
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
 	"bugs": {

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.1.0';
+	const PACKAGE_VERSION = '0.2.0-alpha';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -67,6 +67,7 @@ class Main {
 		$routes = array(
 			'categories' => new Endpoints\Category(),
 			'comments'   => new Endpoints\Comment(),
+			'media'      => new Endpoints\Attachment(),
 			'pages'      => new Endpoints\Page(),
 			'posts'      => new Endpoints\Post(),
 			'tags'       => new Endpoints\Tag(),

--- a/projects/packages/import/src/endpoints/class-attachment.php
+++ b/projects/packages/import/src/endpoints/class-attachment.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Attachments REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+/**
+ * Class Attachment
+ */
+class Attachment extends \WP_REST_Attachments_Controller {
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import;
+
+	/**
+	 * Whether the controller supports batching. Default false.
+	 *
+	 * @var false
+	 */
+	protected $allow_batch = false;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'attachment' );
+
+		// @see add_term_meta
+		$this->import_id_meta_type = 'post';
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @see WP_REST_Terms_Controller::register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::$rest_namespace,
+			'/' . $this->rest_base,
+			$this->get_route_options()
+		);
+
+		register_rest_route(
+			self::$rest_namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)/post-process',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'post_process_item' ),
+				'permission_callback' => array( $this, 'import_permissions_callback' ),
+				'args'                => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the attachment.', 'jetpack-import' ),
+						'type'        => 'integer',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Performs post processing on an attachment.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
+	 */
+	public function post_process_item( $request ) {
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+
+		\wp_update_image_subsizes( $request['id'] );
+		$request['context'] = 'edit';
+
+		return $this->prepare_item_for_response( \get_post( $request['id'] ), $request );
+	}
+}

--- a/projects/packages/import/src/endpoints/class-attachment.php
+++ b/projects/packages/import/src/endpoints/class-attachment.php
@@ -75,9 +75,14 @@ class Attachment extends \WP_REST_Attachments_Controller {
 				'callback'            => array( $this, 'post_process_item' ),
 				'permission_callback' => array( $this, 'import_permissions_callback' ),
 				'args'                => array(
-					'id' => array(
+					'id'     => array(
 						'description' => __( 'Unique identifier for the attachment.', 'jetpack-import' ),
 						'type'        => 'integer',
+					),
+					'action' => array(
+						'type'     => 'string',
+						'enum'     => array( 'create-image-subsizes' ),
+						'required' => true,
 					),
 				),
 			)

--- a/projects/packages/import/src/endpoints/class-category.php
+++ b/projects/packages/import/src/endpoints/class-category.php
@@ -18,6 +18,13 @@ class Category extends \WP_REST_Terms_Controller {
 	use Import;
 
 	/**
+	 * Whether the controller supports batching. Default true.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/projects/packages/import/src/endpoints/class-comment.php
+++ b/projects/packages/import/src/endpoints/class-comment.php
@@ -18,6 +18,13 @@ class Comment extends \WP_REST_Comments_Controller {
 	use Import;
 
 	/**
+	 * Whether the controller supports batching.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/projects/packages/import/src/endpoints/class-page.php
+++ b/projects/packages/import/src/endpoints/class-page.php
@@ -20,6 +20,19 @@ class Page extends Post {
 	}
 
 	/**
+	 * Adds the schema from additional fields to a schema array.
+	 *
+	 * The type of object is inferred from the passed schema.
+	 *
+	 * @param array $schema Schema array.
+	 * @return array Modified Schema array.
+	 */
+	public function add_additional_fields_schema( $schema ) {
+		// Add the import unique ID to the schema.
+		return $this->add_unique_identifier_to_schema( $schema );
+	}
+
+	/**
 	 * Creates a single page.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -22,6 +22,13 @@ class Post extends \WP_REST_Posts_Controller {
 	use Import;
 
 	/**
+	 * Whether the controller supports batching.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $post_type Post type.

--- a/projects/packages/import/src/endpoints/class-tag.php
+++ b/projects/packages/import/src/endpoints/class-tag.php
@@ -18,6 +18,13 @@ class Tag extends \WP_REST_Terms_Controller {
 	use Import;
 
 	/**
+	 * Whether the controller supports batching. Default true.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/projects/packages/import/src/endpoints/trait-import.php
+++ b/projects/packages/import/src/endpoints/trait-import.php
@@ -62,15 +62,16 @@ trait Import {
 	 * Adds the unique identifier to the schema array.
 	 *
 	 * @param array $schema Schema array.
+	 * @param bool  $required Whether the field is required.
 	 * @return array Modified Schema array.
 	 */
-	protected function add_unique_identifier_to_schema( $schema ) {
+	protected function add_unique_identifier_to_schema( $schema, $required = true ) {
 		// Add the import unique ID to the schema.
 		$schema['properties'][ $this->import_id_field_name ] = array(
 			'description' => __( 'Jetpack Import unique identifier for the term.', 'jetpack-import' ),
 			'type'        => 'integer',
 			'context'     => array( 'view', 'embed', 'edit' ),
-			'required'    => true,
+			'required'    => $required,
 		);
 
 		return $schema;
@@ -89,10 +90,11 @@ trait Import {
 			return $response;
 		}
 
-		$data = $response->get_data();
+		$data   = $response->get_data();
+		$status = $response->get_status();
 
-		// Skip if the resource has not been added.
-		if ( $response->get_status() !== 201 ) {
+		// Skip if the resource has not been added or modified.
+		if ( ! ( $data === 200 || $data === 201 ) ) {
 			return $response;
 		}
 

--- a/projects/packages/import/src/endpoints/trait-import.php
+++ b/projects/packages/import/src/endpoints/trait-import.php
@@ -94,7 +94,7 @@ trait Import {
 		$status = $response->get_status();
 
 		// Skip if the resource has not been added or modified.
-		if ( ! ( $data === 200 || $data === 201 ) ) {
+		if ( ! ( $status === 200 || $status === 201 ) ) {
 			return $response;
 		}
 

--- a/projects/packages/import/src/endpoints/trait-import.php
+++ b/projects/packages/import/src/endpoints/trait-import.php
@@ -158,7 +158,7 @@ trait Import {
 				'permission_callback' => array( $this, 'import_permissions_callback' ),
 				'args'                => $this->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
 			),
-			'allow_batch' => array( 'v1' => true ),
+			'allow_batch' => $this->allow_batch,
 			'schema'      => array( $this, 'get_public_item_schema' ),
 		);
 	}

--- a/projects/plugins/jetpack/changelog/update-add-import-media-endpoint
+++ b/projects/plugins/jetpack/changelog/update-add-import-media-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1065,7 +1065,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/import",
-                "reference": "dbd1e38ec065af14ccfc194b72d170f1aa90209a"
+                "reference": "37125a5f15779eea6046766a6a78b12d9de6b810"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev"
@@ -1083,7 +1083,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 },
                 "textdomain": "jetpack-import",
                 "version-constants": {


### PR DESCRIPTION
This PR adds new media endpoints to the Unified Importer package for the **Unified Importers i2**.

@see pcmemI-1Lp-p2
Fixes #29079

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `/jetpack/v4/import/media` endpoint
* Add `/jetpack/v4/import/media/post-process` endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See D103075-code