### PR TITLE
Jetpack: change how to register VideoPress video block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-vieopress-register-v6
+++ b/projects/plugins/jetpack/changelog/update-vieopress-register-v6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: tidy registering VideoPress video block

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -9,29 +9,26 @@ namespace Automattic\Jetpack\Extensions\VideoPress_Video;
 
 use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Pkg_Initializer;
 
-add_action(
-	'init',
-	function () {
-		$is_video_extension_available    = in_array( 'videopress/video', \Jetpack_Gutenberg::get_available_extensions(), true );
-		$is_chapters_extension_available = in_array( 'videopress/video-chapters', \Jetpack_Gutenberg::get_available_extensions(), true );
-
-		$is_some_extension_available = $is_video_extension_available || $is_chapters_extension_available;
-		$is_proxied                  = function_exists( 'wpcom_is_proxied_request' ) ? wpcom_is_proxied_request() : false;
-
-		if ( ! $is_some_extension_available && ! $is_proxied ) {
-			return;
-		}
-
-		if ( method_exists( 'Automattic\Jetpack\VideoPress\Initializer', 'register_videopress_video_block' ) ) {
-			VideoPress_Pkg_Initializer::register_videopress_video_block();
-		}
-	}
-);
-
 // Set the videopress/video block availability, depending on the site plan.
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
 		\Jetpack_Gutenberg::set_availability_for_plan( 'videopress/video' );
+	}
+);
+
+// Register the videopress/video block.
+add_action(
+	'init',
+	function () {
+		$availability               = \Jetpack_Gutenberg::get_availability();
+		$is_videopress_video_enable = isset( $availability['videopress/video'] ) && $availability['videopress/video']['available'];
+
+		if (
+			$is_videopress_video_enable &&
+			method_exists( 'Automattic\Jetpack\VideoPress\Initializer', 'register_videopress_video_block' )
+		) {
+			VideoPress_Pkg_Initializer::register_videopress_video_block();
+		}
 	}
 );

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -22,7 +22,7 @@ add_action(
 	'init',
 	function () {
 		$availability               = \Jetpack_Gutenberg::get_availability();
-		$is_videopress_video_enable = isset( $availability['videopress/video'] ) && $availability['videopress/video']['available'];
+		$is_videopress_video_enabled = isset( $availability['videopress/video'] ) && $availability['videopress/video']['available'];
 
 		if (
 			$is_videopress_video_enable &&

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -21,7 +21,7 @@ add_action(
 add_action(
 	'init',
 	function () {
-		$availability               = \Jetpack_Gutenberg::get_availability();
+		$availability                = \Jetpack_Gutenberg::get_availability();
 		$is_videopress_video_enabled = isset( $availability['videopress/video'] ) && $availability['videopress/video']['available'];
 
 		if (

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -25,7 +25,7 @@ add_action(
 		$is_videopress_video_enabled = isset( $availability['videopress/video'] ) && $availability['videopress/video']['available'];
 
 		if (
-			$is_videopress_video_enable &&
+			$is_videopress_video_enabled &&
 			method_exists( 'Automattic\Jetpack\VideoPress\Initializer', 'register_videopress_video_block' )
 		) {
 			VideoPress_Pkg_Initializer::register_videopress_video_block();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR changes the way to check whether the `videopress/video` extension is _beta_ or not, registering the VideoPress video block according to it.

Also, it cleans code about the video chapters feature that is not used anymore.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: tidy registering VideoPress video block

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and Activate the Jetpack plugin (Jetpack and Atomic sites)
* Activate VideoPress module (Jetpack and Atomic sites)

<img width="500" alt="image" src="https://user-images.githubusercontent.com/77539/220638323-865e250e-b384-4ff5-b0f5-8b5d6205a9c5.png">

* Confirm the VideoPress video block `v6` is available only when [the beta extension](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/jetpack/extensions#beta-extensions) is enabled in the testing site
* Test in Jetpack, Atomic, and Simple sites

* Install and Activate the VideoPress Standalone plugin 
* Confirm `v6` is available for Jetpack and Atomic sites


