### PR TITLE
Sharing: fix display of icon-only display option

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-icon-margin
+++ b/projects/plugins/jetpack/changelog/fix-sharing-icon-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: fix display issues when choosing the Icon-only option.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -128,6 +128,12 @@ body.highlander-dark h3.sd-title:before {
 	margin-left: 6px;
 }
 
+/* Icon Only */
+.sd-social-icon .sd-content ul li a.sd-button>span {
+	margin-left: 0;
+}
+
+/* Text Only */
 .sd-social-text .sd-content ul li a.sd-button span {
 	margin-left: 3px;
 }


### PR DESCRIPTION
Fixes #29083

## Proposed changes:

> **Note**
> The problem is already fixed on WordPress.com simple and WoA. You consequently must test this on Jetpack only.

Following #28961, we have to make an adjustment to the look of sharing options when picking the icon-only option.

**Before**

<img width="268" alt="image" src="https://user-images.githubusercontent.com/426388/220591079-cf85620a-7aa0-4f3f-ab9a-8c80f8d1da62.png">

**After**

<img width="311" alt="image" src="https://user-images.githubusercontent.com/426388/220591288-5e89fe60-c7dd-4f75-922c-0146d202fa39.png">

### Other information:

- WoA hotfix: 1275-gh-wpcomsh
- WordPress.com Simple hotfix: D102406-code

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Go to Jetpack > Settings > Sharing
* Switch between the different button styles, and ensure they all look good on the frontend.
