### PR TITLE
Add util functions to convert from/between Mapbox zoom levels & Mapkit camera distance

### DIFF
--- a/projects/plugins/jetpack/changelog/add-map-block-mapkit-zoom-conversion
+++ b/projects/plugins/jetpack/changelog/add-map-block-mapkit-zoom-conversion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Adds util functions for mapkit that allow converting zoom levels to camera distance, and back

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit-utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit-utils/index.js
@@ -10,13 +10,8 @@ function convertZoomLevelToCameraDistance( zoomLevel, latitude ) {
 }
 
 function convertCameraDistanceToZoomLevel( cameraDistance, latitude ) {
-	let metersPerPixel = getMetersPerPixel( latitude );
-	let zoomLevel = -1;
-	while ( metersPerPixel > cameraDistance / 512 ) {
-		metersPerPixel /= 2;
-		zoomLevel++;
-	}
-	return zoomLevel;
+	const altitude = cameraDistance / getMetersPerPixel( latitude );
+	return Math.log2( 512 / ( altitude / 0.5 ) );
 }
 
 export { convertZoomLevelToCameraDistance, convertCameraDistanceToZoomLevel };

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit-utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit-utils/index.js
@@ -1,0 +1,22 @@
+const earthRadius = 6.371e6;
+
+function getMetersPerPixel( latitude ) {
+	return Math.abs( ( earthRadius * Math.cos( ( latitude * Math.PI ) / 180 ) * 2 * Math.PI ) / 256 );
+}
+
+function convertZoomLevelToCameraDistance( zoomLevel, latitude ) {
+	const altitude = ( 512 / Math.pow( 2, zoomLevel ) ) * 0.5; // altitude in pixels
+	return altitude * getMetersPerPixel( latitude );
+}
+
+function convertCameraDistanceToZoomLevel( cameraDistance, latitude ) {
+	let metersPerPixel = getMetersPerPixel( latitude );
+	let zoomLevel = -1;
+	while ( metersPerPixel > cameraDistance / 512 ) {
+		metersPerPixel /= 2;
+		zoomLevel++;
+	}
+	return zoomLevel;
+}
+
+export { convertZoomLevelToCameraDistance, convertCameraDistanceToZoomLevel };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/73644


## Proposed changes:
This PR provides helper functions that allow converting between Mapbox zoom levels, and Mapkit camera distance, and back.

The conversion is not 100% perfect, since it needs to account for many variables (latitude and especially map projection - which is probably not the same between Mapbox & Mapkit), but in my testing I've found it to be close enough. Especially when looking at this table provided by Mapbox:

At zoom level | You can see
-- | --
0 | The Earth
3 | A continent
4 | Large islands
6 | Large rivers
10 | Large roads
15 | Buildings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
This PR is hard to test, I've made a [Codepen](https://codepen.io/timbroddin/pen/eYLZVyz) that shows a Mapbox and Mapkit map, that sync their zoom (using the function from this PR) & region. 

You can play around with this, taking in regards the acceptance criteria (the table) above. Besides that, I think a quick code review should be enough.

<img width="1669" alt="CleanShot 2023-02-22 at 11 48 27@2x" src="https://user-images.githubusercontent.com/528287/220598562-489d7aca-05d9-4159-bd68-19b2b3aca359.png">


