### PR TITLE
Updated /posts endpoint to sort by their views

### DIFF
--- a/projects/plugins/jetpack/changelog/update-posts-endpoing-tto-sort-by-views
+++ b/projects/plugins/jetpack/changelog/update-posts-endpoing-tto-sort-by-views
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Updated /posts endpoint to sort by views

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -223,7 +223,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 
 		$formatted_top_posts = array();
 
-		if ( isset( $args['order_by'] ) && 'views' === $args['order_by'] ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && isset( $args['order_by'] ) && 'views' === $args['order_by'] ) {
 			$date      = gmdate( 'Y-m-d' );
 			$days      = 30;
 			$max_posts = isset( $args['number'] ) ? $args['number'] : 20;
@@ -448,7 +448,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 					foreach ( $wp_query->posts as $post_ID ) {
 						$the_post = $this->get_post_by( 'ID', $post_ID, $args['context'] );
 						if ( $the_post && ! is_wp_error( $the_post ) ) {
-							if ( isset( $args['order_by'] ) && 'views' === $args['order_by'] ) {
+							if ( defined( 'IS_WPCOM' ) && IS_WPCOM && isset( $args['order_by'] ) && 'views' === $args['order_by'] ) {
 								$post_views = array_filter(
 									$formatted_top_posts,
 									function ( $value ) use ( $post_ID ) {
@@ -506,7 +506,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			}
 		}
 
-		if ( isset( $args['order_by'] ) && 'views' === $args['order_by'] ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && isset( $args['order_by'] ) && 'views' === $args['order_by'] ) {
 			usort(
 				$return['posts'],
 				function ( $item1, $item2 ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -228,16 +228,16 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			$days      = 30;
 			$max_posts = isset( $args['number'] ) ? $args['number'] : 20;
 
-			$stats_history_query = stats_get_daily_history( false, $blog_id, 'postviews', 'post_id', $date, $days, '', $max_posts, true );
+			$stats_history_query = stats_get_daily_history( false, $blog_id, 'postviews', 'post_id', $date, $days, '', $max_posts + 1, true );
 			$top_posts_data      = array_shift( $stats_history_query );
 
 			if ( $top_posts_data ) {
 				get_posts( array( 'include' => join( ', ', array_keys( $top_posts_data ) ) ) );
 				foreach ( $top_posts_data as $id => $views ) {
-					$is_homepage_stat = ( 0 == $id );
+					$is_homepage_stat = ( 0 === $id );
 					$post             = get_post( $id );
 
-					if ( ! $is_homepage_stat && ( empty( $post ) || 'publish' != $post->post_status || 'attachment' == $post->post_type ) ) {
+					if ( ! $is_homepage_stat && ( empty( $post ) || 'publish' !== $post->post_status || 'attachment' === $post->post_type ) ) {
 						continue;
 					}
 
@@ -452,7 +452,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 								$post_views = array_filter(
 									$formatted_top_posts,
 									function ( $value ) use ( $post_ID ) {
-										return $value['post_id'] == $post_ID;
+										return $value['post_id'] === $post_ID;
 									},
 									ARRAY_FILTER_USE_BOTH
 								);
@@ -510,7 +510,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			usort(
 				$return['posts'],
 				function ( $item1, $item2 ) {
-					if ( $item1['views'] == $item2['views'] ) {
+					if ( $item1['views'] === $item2['views'] ) {
 						return 0;
 					}
 					return $item1['views'] > $item2['views'] ? -1 : 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1442-gh-Automattic/dotcom-forge

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We're adding the ability to sort posts by their views, so we can easily show the most relevant posts in our frontend: 1442-gh-Automattic/dotcom-forge

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this code to your sandbox. You can use the `Connecting to your Sandbox` notes at: pdWQjU-77-p2#example-use-case
* Apply [these changes](https://github.com/Automattic/wp-calypso/pull/73623) to your local calypso
* Access a popular site you have and make sure we're listing posts and pages by their views at the top of /advertising items
* Tip: Comment [these lines](https://github.com/Automattic/wp-calypso/blob/update/filter-advertising-by-views-v2/client/my-sites/promote-post/main.tsx#L122-L143) and access any private site from automattic that have more views, like the explorers p2.

Note: You can also test it by using the https://developer.wordpress.com/docs/api/console/ and WPCOM API 1.1 with the URL `/sites/site-id/posts?order_by=views`