### PR TITLE
Jetpack Boost: Fix Undefined array key "post"

### DIFF
--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -31,7 +31,7 @@ class Environment_Change_Detector {
 
 	public function handle_post_change( $post_id, $post ) {
 		$post_types = get_post_types( array( 'name' => $post->post_type ), 'objects' );
-		if ( empty( $post_types ) || $post_types['post']->public !== true ) {
+		if ( empty( $post_types ) || ! isset( $post_types['post'] ) || $post_types['post']->public !== true ) {
 			return;
 		}
 

--- a/projects/plugins/boost/changelog/boost-fix-php-environment-warning
+++ b/projects/plugins/boost/changelog/boost-fix-php-environment-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Undefined array key "post" warning


### PR DESCRIPTION
Fixes #29094

## Proposed changes:
In the environment change detector class, Boost generates a warning when trying to figure out the visibility status of the saved post, this fixes that.


### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
Follow instructions from #29094:

1. On a site with Boost active and connected and debug log turned on, visit the Editor wp-admin/site-editor.php?
2. Make a change and save it..
3. Expect to see the PHP warning in the logs