### PR TITLE
Related Posts: Add block suport for fontFamily controls

### DIFF
--- a/projects/plugins/jetpack/changelog/add-related-posts-block-font-family-support
+++ b/projects/plugins/jetpack/changelog/add-related-posts-block-font-family-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add block support for font family in Related Posts block

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/index.js
@@ -66,6 +66,7 @@ export const settings = {
 			padding: true,
 		},
 		typography: {
+			__experimentalFontFamily: true,
 			fontSize: true,
 			lineHeight: true,
 		},


### PR DESCRIPTION
Adds support for fontFamily controls to the Related Posts block

<img width="1404" alt="image" src="https://user-images.githubusercontent.com/746152/220641259-55c62feb-836e-4a87-9fce-eec281cf8fd6.png">

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `{ supports: typography: { __experimentalFontFamily: true } }`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:
* On a connected jetpack site, enable Related posts
* Create a post, add the Related posts block
* Expect to see Typography -> Font Family controls
