### PR TITLE
CRM: PHP notice on woo order draft status

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-php-notice-on-woo-order-draft-status
+++ b/projects/plugins/crm/changelog/fix-crm-php-notice-on-woo-order-draft-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+PHP notice when a WooCommerce order is in a Draft status

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -228,13 +228,14 @@ class Woo_Sync {
 	 */
 	public function get_woo_order_statuses() {
 		$woo_order_statuses = array(
-			'wcpending'    => __( 'Pending', 'zero-bs-crm' ),
-			'wcprocessing' => __( 'Processing', 'zero-bs-crm' ),
-			'wconhold'     => __( 'On hold', 'zero-bs-crm' ),
-			'wccompleted'  => __( 'Completed', 'zero-bs-crm' ),
-			'wccancelled'  => __( 'Cancelled', 'zero-bs-crm' ),
-			'wcrefunded'   => __( 'Refunded', 'zero-bs-crm' ),
-			'wcfailed'     => __( 'Failed', 'zero-bs-crm' ),
+			'wcpending'       => __( 'Pending', 'zero-bs-crm' ),
+			'wcprocessing'    => __( 'Processing', 'zero-bs-crm' ),
+			'wconhold'        => __( 'On hold', 'zero-bs-crm' ),
+			'wccompleted'     => __( 'Completed', 'zero-bs-crm' ),
+			'wccancelled'     => __( 'Cancelled', 'zero-bs-crm' ),
+			'wcrefunded'      => __( 'Refunded', 'zero-bs-crm' ),
+			'wcfailed'        => __( 'Failed', 'zero-bs-crm' ),
+			'wccheckoutdraft' => __( 'Draft', 'zero-bs-crm' ),
 		);
 		return apply_filters( 'zbs-woo-additional-status', $woo_order_statuses );
 	}
@@ -1531,13 +1532,14 @@ class Woo_Sync {
 		$setting_prefix = $this->get_woo_order_mapping_types()[ $crm_type ]['prefix'];
 
 		return array(
-			'completed'  => $setting_prefix . 'wccompleted',
-			'on-hold'    => $setting_prefix . 'wconhold',
-			'cancelled'  => $setting_prefix . 'wccancelled',
-			'processing' => $setting_prefix . 'wcprocessing',
-			'refunded'   => $setting_prefix . 'wcrefunded',
-			'failed'     => $setting_prefix . 'wcfailed',
-			'pending'    => $setting_prefix . 'wcpending',
+			'completed'      => $setting_prefix . 'wccompleted',
+			'on-hold'        => $setting_prefix . 'wconhold',
+			'cancelled'      => $setting_prefix . 'wccancelled',
+			'processing'     => $setting_prefix . 'wcprocessing',
+			'refunded'       => $setting_prefix . 'wcrefunded',
+			'failed'         => $setting_prefix . 'wcfailed',
+			'pending'        => $setting_prefix . 'wcpending',
+			'checkout-draft' => $setting_prefix . 'wccheckoutdraft',
 		);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/2965

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes a PHP notices when a WooCommerce order is in Draft status `checkout-draft`. This issue was provoking a continuos PHP notice in the user logs (on each cron execution). We were not mapping this valid status for WooCommerce orders.

`Notice:  Undefined index: checkout-draft in Automattic/jetpack/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php on line 1728`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Install WooComerce plugin
- Active WooSync module in your JPCRM installation
- Create a new order from your WooCommerce and set the status as `Draft`. The transaction will be in your JPCRM transactions section.

In trunk, you will get a PHP notice.
In this branch, you won't see any PHP notice.

