### PR TITLE
[Boost] Catch changes to all post-types which affect the UI

### DIFF
--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -30,8 +30,22 @@ class Environment_Change_Detector {
 	}
 
 	public function handle_post_change( $post_id, $post ) {
-		$post_types = get_post_types( array( 'name' => $post->post_type ), 'objects' );
-		if ( empty( $post_types ) || ! isset( $post_types['post'] ) || $post_types['post']->public !== true ) {
+		// Ignore changes to any post which is not published.
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		// Ignore any chnages which do not impact any public post types.
+		$post_types      = get_post_types( array( 'name' => $post->post_type ), 'objects' );
+		$includes_public = false;
+		foreach ( $post_types as $post_type ) {
+			if ( $post_type->public ) {
+				$includes_public = true;
+				break;
+			}
+		}
+
+		if ( ! $includes_public ) {
 			return;
 		}
 

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -35,20 +35,13 @@ class Environment_Change_Detector {
 			return;
 		}
 
-		// Ignore any chnages which do not impact any public post types.
-		$post_types      = get_post_types( array( 'name' => $post->post_type ), 'objects' );
-		$includes_public = false;
-		foreach ( $post_types as $post_type ) {
-			if ( $post_type->public ) {
-				$includes_public = true;
-				break;
-			}
-		}
-
-		if ( ! $includes_public ) {
+		// Ignore changes to post types which do not affect the front-end UI
+		if ( ! $this->is_post_type_invalidating( $post->post_type ) ) {
+			error_log( 'not invalidating: ' . $post->post_type );
 			return;
 		}
 
+		error_log( 'act' );
 		$this->do_action( false, 'post_saved' );
 	}
 
@@ -68,5 +61,23 @@ class Environment_Change_Detector {
 	 */
 	public function do_action( $is_major_change, $change_type ) {
 		do_action( 'handle_environment_change', $is_major_change, $change_type );
+	}
+
+	/**
+	 * Given a post_type, return true if this post type affects the front end of
+	 * the site - i.e.: should cause cached optimizations to be invalidated.
+	 *
+	 * @param string $post_type The post type to check
+	 * @return bool             True if this post type affects the front end of the site.
+	 */
+	private function is_post_type_invalidating( $post_type ) {
+		// Special cases: items which are not viewable, but affect the UI.
+		if ( in_array( $post_type, array( 'wp_template', 'wp_template_part' ), true ) ) {
+			return true;
+		}
+
+		if ( is_post_type_viewable( $post_type ) ) {
+			return true;
+		}
 	}
 }

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -37,11 +37,9 @@ class Environment_Change_Detector {
 
 		// Ignore changes to post types which do not affect the front-end UI
 		if ( ! $this->is_post_type_invalidating( $post->post_type ) ) {
-			error_log( 'not invalidating: ' . $post->post_type );
 			return;
 		}
 
-		error_log( 'act' );
 		$this->do_action( false, 'post_saved' );
 	}
 

--- a/projects/plugins/boost/changelog/fix-react-to-all-visible-changes
+++ b/projects/plugins/boost/changelog/fix-react-to-all-visible-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure changes to visible posts / other post types which affect the ui get caught


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/pull/28714#issuecomment-1440100127

Our environment change detector was only checking for `post`s, not other post types - like `page`s or `template`s. This PR updates the way we filter post update actions to include any public-facing post_type, including ones that affect the UI (but are not considered viewable unto themselves), like templates and template parts.

## Proposed changes:
* Catch all post changes which may affect the UI.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Make sure your test site is using non-cloud / local CSS.
* Generate fresh CSS.
* Modify templates / template parts, ensure that the Boost dashboard says you need to regen.
* Regenerate fresh CSS to clear the notice.
* Modify posts, ensure that the Boost dashboard says you need to regen.