### PR TITLE
Jetpack Search: fix CSS for wc products

### DIFF
--- a/projects/packages/search/changelog/fix-search-products-css
+++ b/projects/packages/search/changelog/fix-search-products-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix CSS for products in search results

--- a/projects/packages/search/src/instant-search/components/search-result-product.jsx
+++ b/projects/packages/search/src/instant-search/components/search-result-product.jsx
@@ -56,7 +56,7 @@ class SearchResultProduct extends Component {
 					getCategories()
 						.map( cat => 'jetpack-instant-search__search-result-category--' + cleanForSlug( cat ) )
 						.join( ' ' ),
-				].join( '' ) }
+				].join( ' ' ) }
 			>
 				<a
 					className="jetpack-instant-search__search-result-product-img-link"


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/8094

This change fixes CSS classes for WooCommerce product results. There was a space missing in https://github.com/Automattic/jetpack/pull/28816.

Before:

![Screenshot 2023-02-23 at 07 14 04](https://user-images.githubusercontent.com/6437642/220837715-8385edca-5716-488d-827f-644f7b64fcda.png)

After:

![image](https://user-images.githubusercontent.com/6437642/220837784-44aa0f9b-213a-4936-9b52-5004426ab154.png)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

I first confirmed the bug, and then used this branch to confirm it's fixed:

1. Create a Jurassic Ninja site with Jetpack Search license and installed WooCommerce and Jetpack Beta plugins.
2. First, go to bleeding edge Jetpack to confirm the bug.
3. Add at least 2 products with images, Test 1 and Test 2
4. Search for Test. If you don't see any product results yet, you can reindex site using Jetpack Debugger to speed it up, and/or disable and reenable search in Jetpack Search dashboard.
5. The search results for products are a bit jumbled and unaligned.
6. Now go to Jetpack Beta and choose this feature branch (fix/search products css).
7. Confirm that now, search results are displayed correctly.



