### PR TITLE
Odyssey: Remove Calypso recommendations from legacy stats page

### DIFF
--- a/projects/plugins/jetpack/changelog/update-odyssey-stats-remove-legacy-nudges
+++ b/projects/plugins/jetpack/changelog/update-odyssey-stats-remove-legacy-nudges
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Remove NewDash nudges in legacy stats

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -478,16 +478,11 @@ function jetpack_admin_ui_stats_report_page_wrapper() {
  * @param bool $main_chart_only (default: false) Main Chart Only.
  */
 function stats_reports_page( $main_chart_only = false ) {
-	// TODO: Replace or remove "View stats on WordPress.com right now" link.
-	// Probably makes more sense to advertise Odyssey here.
-	// TODO: Remove DIV with debug tools. (currently hidden for easier testing)
-
 	if ( isset( $_GET['dashboard'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return stats_dashboard_widget_content();
 	}
 
-	$blog_id   = Stats_Options::get_option( 'blog_id' );
-	$stats_url = Redirect::get_url( 'calypso-stats' );
+	$blog_id = Stats_Options::get_option( 'blog_id' );
 
 	if ( ! $main_chart_only && ! isset( $_GET['noheader'] ) && empty( $_GET['nojs'] ) && empty( $_COOKIE['stnojs'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$nojs_url = add_query_arg( 'nojs', '1' );
@@ -527,7 +522,6 @@ function stats_reports_page( $main_chart_only = false ) {
 		</div>
 		<div id="stats-loading-wrap" class="wrap">
 		<p class="hide-if-no-js"><img width="32" height="32" alt="<?php esc_attr_e( 'Loading&hellip;', 'jetpack' ); ?>" src="<?php echo esc_url( $static_url ); ?>" /></p>
-		<p style="font-size: 11pt; margin: 0;"><a href="<?php echo esc_url( $stats_url ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'View stats on WordPress.com right now', 'jetpack' ); ?></a></p>
 		<p class="hide-if-js"><?php esc_html_e( 'Jetpack Stats work better with JavaScript enabled.', 'jetpack' ); ?><br />
 		<a href="<?php echo esc_url( $nojs_url ); ?>"><?php esc_html_e( 'View Jetpack Stats without JavaScript', 'jetpack' ); ?></a>.</p>
 		</div>

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -35,9 +35,10 @@ if ( defined( 'STATS_DASHBOARD_SERVER' ) ) {
 define( 'STATS_DASHBOARD_SERVER', 'dashboard.wordpress.com' );
 
 /**
- * Stats content marker.
+ * Stats content markers.
  * Used to test for content vs script when parsing server-generated HTML.
  */
+const STATS_BODY_MARKER    = '<div id="statchart"';
 const STATS_CONTENT_MARKER = '<div class="gotonewdash">';
 
 add_action( 'jetpack_modules_loaded', 'stats_load' );
@@ -729,9 +730,7 @@ function stats_parse_header_section( $html ) {
  * @return string
  */
 function stats_parse_content_section( $html ) {
-	// TODO: Skip past gotonewdash DIV.
-	// Doesn't make sense to push users to Calypso once Odyssey is ready.
-	$body = strstr( $html, STATS_CONTENT_MARKER );
+	$body = strstr( $html, STATS_BODY_MARKER );
 	// Enforce a string result instead of string|false.
 	if ( $body === false ) {
 		return '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29112.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Now that Odyssey Stats is shipping and we have an upgrade notice in place, we should favour that over pushing people to Calypso. This PR removes the two prompts that link out to WordPress.com.

**Previous Behaviour:**

https://user-images.githubusercontent.com/40267301/220867443-630abc56-16eb-412c-9b2f-0b9ac9c3dede.mp4

**Updated Behaviour:**

https://user-images.githubusercontent.com/40267301/220867523-c14180b9-8f75-4495-b58a-d8b240803d64.mp4

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure Odyssey Stats are disabled.
* Visit Jetpack → Stats.
* Confirm the prompt during loading is no longer visible.
* Confirm the prompt after loading is no longer visible.

