### PR TITLE
Map block: add `getMapProvider` function

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/map/utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/utils/index.js
@@ -1,0 +1,10 @@
+import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+
+const getMapProvider = () => {
+	if ( isAtomicSite() || isSimpleSite() || window.location.search.includes( 'mapkit' ) ) {
+		return 'mapkit';
+	}
+	return 'mapbox';
+};
+
+export { getMapProvider };


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/73714

## Proposed changes:
* This PR introduces a helper function that returns "mapkit" when on Simple/Atomic and "mapbox" otherwise.

It still includes a way to force the usage of Mapkit when adding a `?mapkit` query parameter. This [will be removed](https://github.com/Automattic/wp-calypso/issues/73715) later on. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
I think a simple code review should be fine for this one. It's not used by any code ATM.
