### PR TITLE
Add support for Mapkit geocoding

### DIFF
--- a/projects/plugins/jetpack/changelog/add-map-block-mapkit-geocoder
+++ b/projects/plugins/jetpack/changelog/add-map-block-mapkit-geocoder
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add Mapkit geocoder for use on WPCOM.

--- a/projects/plugins/jetpack/extensions/blocks/map/location-search/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/location-search/index.js
@@ -1,101 +1,12 @@
-import { BaseControl, TextControl } from '@wordpress/components';
-import { Component, createRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import Lookup from '../lookup';
+import { getMapProvider } from '../utils';
+import MapboxLocationSearch from './mapbox';
+import MapkitLocationSearch from './mapkit';
 
-const placeholderText = __( 'Add a marker…', 'jetpack' );
-
-export class LocationSearch extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.textRef = createRef();
-		this.containerRef = createRef();
-		this.state = {
-			isEmpty: true,
-		};
-		this.autocompleter = {
-			name: 'placeSearch',
-			options: this.search,
-			isDebounced: true,
-			getOptionLabel: option => <span>{ option.place_name }</span>,
-			getOptionKeywords: option => [ option.place_name ],
-			getOptionCompletion: this.getOptionCompletion,
-		};
-	}
-	componentDidMount() {
-		setTimeout( () => {
-			this.containerRef.current.querySelector( 'input' ).focus();
-		}, 50 );
-	}
-	getOptionCompletion = option => {
-		const { value } = option;
-		const point = {
-			placeTitle: value.text,
-			title: value.text,
-			caption: value.place_name,
-			id: value.id,
-			coordinates: {
-				longitude: value.geometry.coordinates[ 0 ],
-				latitude: value.geometry.coordinates[ 1 ],
-			},
-		};
-		this.props.onAddPoint( point );
-		return value.text;
-	};
-
-	search = value => {
-		const { apiKey, onError } = this.props;
-		const url =
-			'https://api.mapbox.com/geocoding/v5/mapbox.places/' +
-			encodeURI( value ) +
-			'.json?access_token=' +
-			apiKey;
-		return new Promise( function ( resolve, reject ) {
-			const xhr = new XMLHttpRequest();
-			xhr.open( 'GET', url );
-			xhr.onload = function () {
-				if ( xhr.status === 200 ) {
-					const res = JSON.parse( xhr.responseText );
-					resolve( res.features );
-				} else {
-					const res = JSON.parse( xhr.responseText );
-					onError( res.statusText, res.responseJSON.message );
-					reject( new Error( 'Mapbox Places Error' ) );
-				}
-			};
-			xhr.send();
-		} );
-	};
-	onReset = () => {
-		this.textRef.current.value = null;
-	};
-	render() {
-		const { label } = this.props;
-		return (
-			<div ref={ this.containerRef }>
-				<BaseControl label={ label } className="components-location-search">
-					<Lookup completer={ this.autocompleter } onReset={ this.onReset }>
-						{ ( { isExpanded, listBoxId, activeId, onChange, onKeyDown } ) => (
-							<TextControl
-								placeholder={ placeholderText }
-								ref={ this.textRef }
-								onChange={ onChange }
-								aria-expanded={ isExpanded }
-								aria-owns={ listBoxId }
-								aria-activedescendant={ activeId }
-								onKeyDown={ onKeyDown }
-							/>
-						) }
-					</Lookup>
-				</BaseControl>
-			</div>
-		);
-	}
-}
-
-LocationSearch.defaultProps = {
-	onError: () => {},
+const LocationSearch = props => {
+	const provider = getMapProvider();
+	const LocationSearchComponent =
+		provider === 'mapbox' ? MapboxLocationSearch : MapkitLocationSearch;
+	return <LocationSearchComponent { ...props } />;
 };
 
 export default LocationSearch;

--- a/projects/plugins/jetpack/extensions/blocks/map/location-search/mapbox.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/location-search/mapbox.js
@@ -1,0 +1,101 @@
+import { BaseControl, TextControl } from '@wordpress/components';
+import { Component, createRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import Lookup from '../lookup';
+
+const placeholderText = __( 'Add a marker…', 'jetpack' );
+
+export class MapboxLocationSearch extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.textRef = createRef();
+		this.containerRef = createRef();
+		this.state = {
+			isEmpty: true,
+		};
+		this.autocompleter = {
+			name: 'placeSearch',
+			options: this.search,
+			isDebounced: true,
+			getOptionLabel: option => <span>{ option.place_name }</span>,
+			getOptionKeywords: option => [ option.place_name ],
+			getOptionCompletion: this.getOptionCompletion,
+		};
+	}
+	componentDidMount() {
+		setTimeout( () => {
+			this.containerRef.current.querySelector( 'input' ).focus();
+		}, 50 );
+	}
+	getOptionCompletion = option => {
+		const { value } = option;
+		const point = {
+			placeTitle: value.text,
+			title: value.text,
+			caption: value.place_name,
+			id: value.id,
+			coordinates: {
+				longitude: value.geometry.coordinates[ 0 ],
+				latitude: value.geometry.coordinates[ 1 ],
+			},
+		};
+		this.props.onAddPoint( point );
+		return value.text;
+	};
+
+	search = value => {
+		const { apiKey, onError } = this.props;
+		const url =
+			'https://api.mapbox.com/geocoding/v5/mapbox.places/' +
+			encodeURI( value ) +
+			'.json?access_token=' +
+			apiKey;
+		return new Promise( function ( resolve, reject ) {
+			const xhr = new XMLHttpRequest();
+			xhr.open( 'GET', url );
+			xhr.onload = function () {
+				if ( xhr.status === 200 ) {
+					const res = JSON.parse( xhr.responseText );
+					resolve( res.features );
+				} else {
+					const res = JSON.parse( xhr.responseText );
+					onError( res.statusText, res.responseJSON.message );
+					reject( new Error( 'Mapbox Places Error' ) );
+				}
+			};
+			xhr.send();
+		} );
+	};
+	onReset = () => {
+		this.textRef.current.value = null;
+	};
+	render() {
+		const { label } = this.props;
+		return (
+			<div ref={ this.containerRef }>
+				<BaseControl label={ label } className="components-location-search">
+					<Lookup completer={ this.autocompleter } onReset={ this.onReset }>
+						{ ( { isExpanded, listBoxId, activeId, onChange, onKeyDown } ) => (
+							<TextControl
+								placeholder={ placeholderText }
+								ref={ this.textRef }
+								onChange={ onChange }
+								aria-expanded={ isExpanded }
+								aria-owns={ listBoxId }
+								aria-activedescendant={ activeId }
+								onKeyDown={ onKeyDown }
+							/>
+						) }
+					</Lookup>
+				</BaseControl>
+			</div>
+		);
+	}
+}
+
+MapboxLocationSearch.defaultProps = {
+	onError: () => {},
+};
+
+export default MapboxLocationSearch;

--- a/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
@@ -1,0 +1,92 @@
+import { BaseControl, TextControl } from '@wordpress/components';
+import { useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import Lookup from '../lookup';
+import { useMapKitSetup } from '../mapkit/hooks';
+
+const placeholderText = __( 'Add a marker…', 'jetpack' );
+
+const MapkitLocationSearch = ( { label, onAddPoint } ) => {
+	const containerRef = useRef();
+	const textRef = useRef();
+	const { mapkit } = useMapKitSetup( containerRef );
+
+	const autocompleter = {
+		name: 'placeSearch',
+		options: value => {
+			return new Promise( function ( resolve, reject ) {
+				const search = new mapkit.Search( {
+					getsUserLocation: true,
+				} );
+				search.autocomplete( value, ( err, results ) => {
+					if ( err ) {
+						reject( err );
+						return;
+					}
+					// filter out results from Yelp etc
+					const filtered = results?.results.filter(
+						result =>
+							result.dependentLocalities === undefined || result.dependentLocalities?.length === 0
+					);
+
+					// add placeName
+					const withPlaceName = filtered.map( result => ( {
+						...result,
+						placeName: result.displayLines?.join( ', ' ),
+					} ) );
+
+					resolve( withPlaceName );
+				} );
+			} );
+		},
+		isDebounced: true,
+		getOptionLabel: option => {
+			return <span>{ option.placeName }</span>;
+		},
+		getOptionKeywords: option => [ option.placeName ],
+		getOptionCompletion: option => {
+			const { value } = option;
+			const point = {
+				placeTitle: value.placeName,
+				title: value.placeName,
+				caption: value.placeName,
+				coordinates: {
+					longitude: value.coordinate.longitude,
+					latitude: value.coordinate.latitude,
+				},
+			};
+			onAddPoint( point );
+			return value.placeName;
+		},
+	};
+
+	const onReset = () => {
+		textRef.current.value = '';
+	};
+
+	useEffect( () => {
+		textRef.current.focus();
+	}, [ textRef ] );
+
+	return (
+		<div ref={ containerRef }>
+			<BaseControl label={ label } className="components-location-search">
+				<Lookup completer={ autocompleter } onReset={ onReset }>
+					{ ( { isExpanded, listBoxId, activeId, onChange, onKeyDown } ) => (
+						<TextControl
+							placeholder={ placeholderText }
+							ref={ textRef }
+							onChange={ onChange }
+							aria-expanded={ isExpanded }
+							aria-owns={ listBoxId }
+							aria-activedescendant={ activeId }
+							onKeyDown={ onKeyDown }
+						/>
+					) }
+				</Lookup>
+			</BaseControl>
+		</div>
+	);
+};
+
+export default MapkitLocationSearch;

--- a/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
@@ -65,8 +65,10 @@ const MapkitLocationSearch = ( { label, onAddPoint } ) => {
 	};
 
 	useEffect( () => {
-		textRef.current.focus();
-	}, [ textRef ] );
+		setTimeout( () => {
+			containerRef.current.querySelector( 'input' ).focus();
+		}, 50 );
+	}, [] );
 
 	return (
 		<div ref={ containerRef }>

--- a/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
@@ -13,21 +13,19 @@ const MapkitLocationSearch = ( { label, onAddPoint } ) => {
 
 	const autocompleter = {
 		name: 'placeSearch',
-		options: value => {
+		options: async value => {
 			return new Promise( function ( resolve, reject ) {
 				const search = new mapkit.Search( {
 					getsUserLocation: true,
+					includePointsOfInterest: false,
 				} );
 				search.autocomplete( value, ( err, results ) => {
 					if ( err ) {
 						reject( err );
 						return;
 					}
-					// filter out results from Yelp etc
-					const filtered = results?.results.filter(
-						result =>
-							result.dependentLocalities === undefined || result.dependentLocalities?.length === 0
-					);
+					// filter out results without coordinates
+					const filtered = results?.results.filter( result => result.coordinate );
 
 					// add placeName
 					const withPlaceName = filtered.map( result => ( {

--- a/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
@@ -16,7 +16,6 @@ const MapkitLocationSearch = ( { label, onAddPoint } ) => {
 		options: async value => {
 			return new Promise( function ( resolve, reject ) {
 				const search = new mapkit.Search( {
-					getsUserLocation: true,
 					includePointsOfInterest: false,
 				} );
 				search.autocomplete( value, ( err, results ) => {

--- a/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/location-search/mapkit.js
@@ -24,7 +24,7 @@ const MapkitLocationSearch = ( { label, onAddPoint } ) => {
 						return;
 					}
 					// filter out results without coordinates
-					const filtered = results?.results.filter( result => result.coordinate );
+					const filtered = results?.results.filter( result => result.coordinate ) ?? [];
 
 					// add placeName
 					const withPlaceName = filtered.map( result => ( {

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
@@ -1,0 +1,79 @@
+import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
+import { select } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { getLoadContext, waitForObject } from '../../../../shared/block-editor-asset-loader';
+
+// mapRef can be a ref to the element that will render the map
+// or a ref to the element that will be on the page when the map is rendered.
+// It is only used here to determine the document and window to use.
+const useMapKitSetup = mapRef => {
+	const [ loaded, setLoaded ] = useState( false );
+	const [ error, setError ] = useState( false );
+	const [ mapkit, setMapkit ] = useState( null );
+
+	useEffect( () => {
+		const blog_id = select( CONNECTION_STORE_ID ).getBlogId();
+
+		const loadLibrary = async () => {
+			return new Promise( resolve => {
+				const { currentDoc } = getLoadContext( mapRef.current );
+				const element = currentDoc.createElement( 'script' );
+				element.addEventListener(
+					'load',
+					() => {
+						const { currentWindow } = getLoadContext( mapRef.current );
+						waitForObject( currentWindow, 'mapkit' ).then( mapkitObj => {
+							setMapkit( mapkitObj );
+							resolve( mapkitObj );
+						} );
+					},
+					{ once: true }
+				);
+				element.src = 'https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js';
+				//element['data-libraries'] = 'services,full-map,geojson';
+				element.crossOrigin = 'anonymous';
+				currentDoc.head.appendChild( element );
+			} );
+		};
+
+		const fetchKey = async mapkitObj => {
+			return new Promise( resolve => {
+				mapkitObj.init( {
+					authorizationCallback: done => {
+						fetch( `https://public-api.wordpress.com/wpcom/v2/sites/${ blog_id }/mapkit` )
+							.then( response => {
+								if ( response.status === 200 ) {
+									return response.json();
+								}
+								setError( 'Mapkit API error' );
+							} )
+							.then( data => {
+								done( data.wpcom_mapkit_access_token );
+								resolve();
+							} );
+					},
+				} );
+			} );
+		};
+
+		if ( mapRef.current ) {
+			const { currentWindow } = getLoadContext( mapRef.current );
+
+			// if mapkit is already loaded, reuse it.
+			if ( currentWindow.mapkit ) {
+				setMapkit( currentWindow.mapkit );
+				setLoaded( true );
+			} else {
+				loadLibrary().then( mapkitObj => {
+					fetchKey( mapkitObj ).then( () => {
+						setLoaded( true );
+					} );
+				} );
+			}
+		}
+	}, [ mapRef ] );
+
+	return { loaded, error, mapkit };
+};
+
+export { useMapKitSetup };

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
@@ -34,7 +34,7 @@ const useMapKitSetup = mapRef => {
 			} );
 		};
 
-		const fetchKey = async mapkitObj => {
+		const fetchKey = mapkitObj => {
 			return new Promise( resolve => {
 				mapkitObj.init( {
 					authorizationCallback: async done => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73650

## Proposed changes:
This PR adds support for geocoding through the Mapkit API.

It also adds a hook called `useMapKitSetup` that takes care of loading the Mapkit library (when it's not yet loaded). 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Apply this diff to your sandbox & sandbox public-api.wordpress.com: D101694-code

1. Build the Jetpack plugin
2. Create a post/page with a map
3. Append `&mapkit` to the URL to force it to use Mapkit for geocoding
4. Add a marker, confirm that results get loaded when typing, and that clicking a result adds a marker on the map.

<img width="828" alt="CleanShot 2023-02-23 at 14 39 41@2x" src="https://user-images.githubusercontent.com/528287/220923247-5dd0f9c0-a933-48ee-a349-da3453cfec1c.png">
