### PR TITLE
Update billing language to fit intro offers

### DIFF
--- a/projects/packages/backup/changelog/update-billing-language-to-fit-intro-offers
+++ b/projects/packages/backup/changelog/update-billing-language-to-fit-intro-offers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update billing language

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -357,7 +357,7 @@ const NoBackupCapabilities = () => {
 		introOffer?.interval_unit === 'month' && introOffer?.interval_count === 1
 			? sprintf(
 					// translators: %s is the regular monthly price
-					__( 'trial for the first month, then $%s/month', 'jetpack-backup-pkg' ),
+					__( 'trial for the first month, then $%s /month', 'jetpack-backup-pkg' ),
 					price
 			  )
 			: __(

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -13,7 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement, useState, useEffect, useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import useAnalytics from '../hooks/useAnalytics';
 import useCapabilities from '../hooks/useCapabilities';
 import useConnection from '../hooks/useConnection';
@@ -355,7 +355,11 @@ const NoBackupCapabilities = () => {
 	);
 	const priceDetails =
 		introOffer?.interval_unit === 'month' && introOffer?.interval_count === 1
-			? __( 'for the first month, billed yearly', 'jetpack-backup-pkg' )
+			? sprintf(
+					// translators: %s is the regular monthly price
+					__( 'trial for the first month, then $%s/month', 'jetpack-backup-pkg' ),
+					price
+			  )
 			: __(
 					'per month, billed yearly',
 					'jetpack-backup-pkg',

--- a/projects/packages/backup/src/js/components/Admin.js
+++ b/projects/packages/backup/src/js/components/Admin.js
@@ -357,7 +357,7 @@ const NoBackupCapabilities = () => {
 		introOffer?.interval_unit === 'month' && introOffer?.interval_count === 1
 			? sprintf(
 					// translators: %s is the regular monthly price
-					__( 'trial for the first month, then $%s /month', 'jetpack-backup-pkg' ),
+					__( 'trial for the first month, then $%s /month, billed yearly', 'jetpack-backup-pkg' ),
 					price
 			  )
 			: __(

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -150,7 +150,7 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 		introductoryOffer?.intervalUnit === 'month' && introductoryOffer?.intervalCount === 1
 			? sprintf(
 					// translators: %s is the monthly price for a product
-					__( 'trial for the first month, then $%s/month', 'jetpack-my-jetpack' ),
+					__( 'trial for the first month, then $%s /month', 'jetpack-my-jetpack' ),
 					price
 			  )
 			: __(

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -150,7 +150,7 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 		introductoryOffer?.intervalUnit === 'month' && introductoryOffer?.intervalCount === 1
 			? sprintf(
 					// translators: %s is the monthly price for a product
-					__( 'trial for the first month, then $%s /month', 'jetpack-my-jetpack' ),
+					__( 'trial for the first month, then $%s /month, billed yearly', 'jetpack-my-jetpack' ),
 					price
 			  )
 			: __(

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -148,7 +148,11 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 
 	const priceDescription =
 		introductoryOffer?.intervalUnit === 'month' && introductoryOffer?.intervalCount === 1
-			? __( 'for the first month, billed yearly', 'jetpack-my-jetpack' )
+			? sprintf(
+					// translators: %s is the monthly price for a product
+					__( 'trial for the first month, then $%s/month', 'jetpack-my-jetpack' ),
+					price
+			  )
 			: __(
 					'/month, paid yearly',
 					'jetpack-my-jetpack',

--- a/projects/packages/my-jetpack/changelog/update-billing-language-to-fit-intro-offers
+++ b/projects/packages/my-jetpack/changelog/update-billing-language-to-fit-intro-offers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update billing language

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.7.11",
+	"version": "2.7.12-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.7.11';
+	const PACKAGE_VERSION = '2.7.12-alpha';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/plugins/social/changelog/update-billing-language-to-fit-intro-offers
+++ b/projects/plugins/social/changelog/update-billing-language-to-fit-intro-offers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update billing language

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -108,7 +108,7 @@ const PricingPage = () => {
 						offPrice={ firstMonthIntroOffer }
 						legend={ sprintf(
 							// translators: %s is the regular monthly price
-							__( 'trial for the first month, then $%s /month', 'jetpack-social' ),
+							__( 'trial for the first month, then $%s /month, billed yearly', 'jetpack-social' ),
 							monthlyAdvancedPrice
 						) }
 						currency="USD"

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -9,7 +9,7 @@ import {
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { STORE_ID } from '../../store';
 import styles from './styles.module.scss';
@@ -31,6 +31,10 @@ const PricingPage = () => {
 		};
 		updateOptions( newOption );
 	}, [ updateOptions ] );
+
+	const firstMonthIntroOffer = 1;
+	const monthlyBasicPrice = 10;
+	const monthlyAdvancedPrice = 15;
 
 	const UNLIMITED_SHARES_TABLE_ITEM = (
 		<PricingTableItem
@@ -99,9 +103,13 @@ const PricingPage = () => {
 			<PricingTableColumn primary>
 				<PricingTableHeader>
 					<ProductPrice
-						price={ 30 }
-						offPrice={ 1 }
-						legend={ __( 'for the first month, billed yearly', 'jetpack-social' ) }
+						price={ monthlyAdvancedPrice }
+						offPrice={ firstMonthIntroOffer }
+						legend={ sprintf(
+							// translators: %s is the regular monthly price
+							__( 'trial for the first month, then $%s/month', 'jetpack-social' ),
+							monthlyAdvancedPrice
+						) }
 						currency="USD"
 						hidePriceFraction
 					/>
@@ -129,9 +137,13 @@ const PricingPage = () => {
 			<PricingTableColumn primary>
 				<PricingTableHeader>
 					<ProductPrice
-						price={ 10 }
-						offPrice={ 1 }
-						legend={ __( 'for the first month, billed yearly', 'jetpack-social' ) }
+						price={ monthlyBasicPrice }
+						offPrice={ firstMonthIntroOffer }
+						legend={ sprintf(
+							// translators: %s is the regular monthly price
+							__( 'trial for the first month, then $%s/month', 'jetpack-social' ),
+							monthlyBasicPrice
+						) }
 						currency="USD"
 						hidePriceFraction
 					/>

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -32,6 +32,7 @@ const PricingPage = () => {
 		updateOptions( newOption );
 	}, [ updateOptions ] );
 
+	// todo: pull pricing from wpcom
 	const firstMonthIntroOffer = 1;
 	const monthlyBasicPrice = 10;
 	const monthlyAdvancedPrice = 15;

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -101,7 +101,7 @@ const PricingPage = () => {
 					<ProductPrice
 						price={ 30 }
 						offPrice={ 1 }
-						legend={ __( '/month, billed yearly', 'jetpack-social' ) }
+						legend={ __( 'for the first month, billed yearly', 'jetpack-social' ) }
 						currency="USD"
 						hidePriceFraction
 					/>
@@ -131,7 +131,7 @@ const PricingPage = () => {
 					<ProductPrice
 						price={ 10 }
 						offPrice={ 1 }
-						legend={ __( '/month, billed yearly', 'jetpack-social' ) }
+						legend={ __( 'for the first month, billed yearly', 'jetpack-social' ) }
 						currency="USD"
 						hidePriceFraction
 					/>

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -142,7 +142,7 @@ const PricingPage = () => {
 						offPrice={ firstMonthIntroOffer }
 						legend={ sprintf(
 							// translators: %s is the regular monthly price
-							__( 'trial for the first month, then $%s /month', 'jetpack-social' ),
+							__( 'trial for the first month, then $%s /month, billed yearly', 'jetpack-social' ),
 							monthlyBasicPrice
 						) }
 						currency="USD"

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -108,7 +108,7 @@ const PricingPage = () => {
 						offPrice={ firstMonthIntroOffer }
 						legend={ sprintf(
 							// translators: %s is the regular monthly price
-							__( 'trial for the first month, then $%s/month', 'jetpack-social' ),
+							__( 'trial for the first month, then $%s /month', 'jetpack-social' ),
 							monthlyAdvancedPrice
 						) }
 						currency="USD"
@@ -142,7 +142,7 @@ const PricingPage = () => {
 						offPrice={ firstMonthIntroOffer }
 						legend={ sprintf(
 							// translators: %s is the regular monthly price
-							__( 'trial for the first month, then $%s/month', 'jetpack-social' ),
+							__( 'trial for the first month, then $%s /month', 'jetpack-social' ),
 							monthlyBasicPrice
 						) }
 						currency="USD"


### PR DESCRIPTION
Updates billing language to be more clear about how the $1 first month trials work

Fixes #

## Proposed changes:
Update billing language from `for the first month, billed yearly` to `trial for the first month, then ${price} /month, billed yearly`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Context: p1675799264369889-slack-C03V4PXKUGP

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Checkout these changes
2. Start up your local environment
3. Without a Jetpack VaultPress Backup plan, go to `/wp-admin/admin.php?page=jetpack-backup` and ensure the billing language is correct
![image](https://user-images.githubusercontent.com/65001528/220986427-806a41e0-8229-4dea-a094-5875cfa5e524.png)
4. Without a Jetpack Social plan, go to `/wp-admin/admin.php?page=jetpack-social` and ensure the billing language is correct. ( The social advance price was also updated here to match the pricing page )
![image](https://user-images.githubusercontent.com/65001528/220986314-9e1cb842-5c0e-492d-8129-5eacc5451303.png)
5. Go to `/wp-admin/admin.php?page=my-jetpack#/add-backup` and ensure the billing language is correct 
![image](https://user-images.githubusercontent.com/65001528/220986602-74387f6a-46f6-462a-b111-e6b1d986ffba.png)
