### PR TITLE
Sharing: force height of icons in Firefox

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-icon-height-firefox
+++ b/projects/plugins/jetpack/changelog/fix-sharing-icon-height-firefox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: avoid distored sharing icons in Firefox when using the Icon-only button style.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -568,6 +568,7 @@ body .sd-social-icon .sd-content li.share-custom a span {
 	height: auto;
 	margin-bottom: 0;
 	max-width: 32px;
+	max-height: 32px;
 }
 
 .sd-social-icon .sd-content ul li[class*='share-'] a.sd-button>span,


### PR DESCRIPTION
> **Warning**
> This may not be necessary, since #29090 also appears to address this issue in some cases. I'm not sure whether we'd still want to go ahead with that extra change.

## Proposed changes:

This is a follow-up to #28961. We want to make sure **all the button styles** look good in **all the browsers**.

**before**

<img width="321" alt="image" src="https://user-images.githubusercontent.com/426388/220972395-0d83bd48-d155-46f6-8f23-17d2d2955ad5.png">

**after**

<img width="350" alt="image" src="https://user-images.githubusercontent.com/426388/220972524-0e4d3554-f7c9-40f1-86a6-e1cfa6ed94fa.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1677169341944769-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No 

## Testing instructions:

* Start with a site that's connected to WordPress.com, where you have enabled sharing buttons under Jetpack > Settings > Sharing
* Under Settings > Sharing, choose the icon-only button style
* Ensure the icons look good in the frontend, on all browsers.
* Also check the look of the icons when choosing different button styles.
