### PR TITLE
Replace links with Jetpack redirect service for migration plugin

### DIFF
--- a/projects/plugins/migration/changelog/update-migration-doc-link
+++ b/projects/plugins/migration/changelog/update-migration-doc-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update doc link for migration plugin

--- a/projects/plugins/migration/src/js/components/constants.ts
+++ b/projects/plugins/migration/src/js/components/constants.ts
@@ -1,2 +1,0 @@
-export const MIGRATION_HANDLER_ROUTE =
-	'https://wordpress.com/setup/import-focused/migrationHandler';

--- a/projects/plugins/migration/src/js/components/migration/index.tsx
+++ b/projects/plugins/migration/src/js/components/migration/index.tsx
@@ -5,7 +5,6 @@ import { Button, Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
-import { MIGRATION_HANDLER_ROUTE } from '../constants';
 import { WordPressLogo, ExternalLink } from '../illustrations';
 import migrationImage1 from './../../../../images/migration-1.png';
 import type React from 'react';
@@ -121,7 +120,9 @@ export function Migration( props: Props ) {
 					isPrimary={ true }
 					isBusy={ buttonIsLoading }
 					disabled={ buttonIsLoading }
-					href={ `${ MIGRATION_HANDLER_ROUTE }?from=${ sourceSiteSlug }` }
+					href={ getRedirectUrl( 'wpcom-migration-handler-route', {
+						query: `from=${ sourceSiteSlug }`,
+					} ) }
 					onClick={ onGetStartedClick }
 				>
 					{ __( 'Get started', 'wpcom-migration' ) }
@@ -129,9 +130,7 @@ export function Migration( props: Props ) {
 				<Button
 					isSecondary={ true }
 					target={ '_blank' }
-					href={ getRedirectUrl(
-						'https://wordpress.com/support/import-using-wordpress-migration/'
-					) }
+					href={ getRedirectUrl( 'wpcom-migration-doc-link' ) }
 				>
 					{ createInterpolateElement( __( 'Learn more <ExternalLink />', 'wpcom-migration' ), {
 						ExternalLink: <ExternalLink size={ 20 } />,
@@ -148,10 +147,7 @@ export function Migration( props: Props ) {
 					__( 'Do you need help? <Button>Contact us.</Button>', 'wpcom-migration' ),
 					{
 						Button: (
-							<Button
-								href={ getRedirectUrl( 'https://wordpress.com/support/help-support-options/' ) }
-								target={ '_blank' }
-							/>
+							<Button href={ getRedirectUrl( 'wpcom-migration-contact-us' ) } target={ '_blank' } />
 						),
 					}
 				) }

--- a/projects/plugins/migration/src/js/components/migration/index.tsx
+++ b/projects/plugins/migration/src/js/components/migration/index.tsx
@@ -130,7 +130,7 @@ export function Migration( props: Props ) {
 					isSecondary={ true }
 					target={ '_blank' }
 					href={ getRedirectUrl(
-						'https://wordpress.com/support/import/import-an-entire-wordpress-site/'
+						'https://wordpress.com/support/import-using-wordpress-migration/'
 					) }
 				>
 					{ createInterpolateElement( __( 'Learn more <ExternalLink />', 'wpcom-migration' ), {

--- a/projects/plugins/migration/src/js/components/migration/progress.tsx
+++ b/projects/plugins/migration/src/js/components/migration/progress.tsx
@@ -6,7 +6,6 @@ import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect, useCallback } from 'react';
-import { MIGRATION_HANDLER_ROUTE } from '../constants';
 import { WordPressLogo } from '../illustrations';
 import migrationImage2 from './../../../../images/migration-2.png';
 import './styles.module.scss';
@@ -55,7 +54,9 @@ export function MigrationProgress( props: Props ) {
 				<Button
 					isSecondary={ true }
 					target={ '_blank' }
-					href={ `${ MIGRATION_HANDLER_ROUTE }?from=${ sourceSiteSlug }` }
+					href={ getRedirectUrl( 'wpcom-migration-handler-route', {
+						query: `from=${ sourceSiteSlug }`,
+					} ) }
 					onClick={ onCheckProgressClick }
 				>
 					{ __( 'Check your migration progress', 'wpcom-migration' ) }
@@ -66,10 +67,7 @@ export function MigrationProgress( props: Props ) {
 					__( 'Do you need help? <Button>Contact us.</Button>', 'wpcom-migration' ),
 					{
 						Button: (
-							<Button
-								href={ getRedirectUrl( 'https://wordpress.com/support/help-support-options/' ) }
-								target={ '_blank' }
-							/>
+							<Button href={ getRedirectUrl( 'wpcom-migration-contact-us' ) } target={ '_blank' } />
 						),
 					}
 				) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29128 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace all the static links in the plugin with the Jetpack redirect manager.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a [JN site](https://jurassic.ninja/create/?jetpack-beta&branches.wpcom-migration=update/migration-doc-link&wp-debug-log) and navigate to Move to WordPress.com
* Click on the Learn more link and see if it brings you to `https://wordpress.com/support/import-using-wordpress-migration/`
* The doc is still in draft now and will be live on March 1st
* Click on `Contact us`, `Get Started`, `Check your migration progress` buttons to see if they get linked correctly like it was.

