### PR TITLE
Add/jitm install hooks for videopress and protect

### DIFF
--- a/projects/packages/jitm/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/packages/jitm/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add sideload capability for protect and videopress plugins

--- a/projects/packages/jitm/composer.json
+++ b/projects/packages/jitm/composer.json
@@ -63,7 +63,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.3.x-dev"
+			"dev-trunk": "2.4.x-dev"
 		}
 	}
 }

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.3.0';
+	const PACKAGE_VERSION = '2.4.0-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -239,7 +239,7 @@ class Post_Connection_JITM extends JITM {
 	}
 
 	/**
-	 * A special filter used in the CTA of a JITM offering to install the Jetpack Protect plugin.
+	 * A special filter used in the CTA of a JITM offering to install the Jetpack VideoPress plugin.
 	 *
 	 * @return string The new CTA
 	 */
@@ -256,7 +256,7 @@ class Post_Connection_JITM extends JITM {
 	}
 
 	/**
-	 * A special filter used in the CTA of a JITM offering to activate the Jetpack Protect plugin.
+	 * A special filter used in the CTA of a JITM offering to activate the Jetpack VideoPress plugin.
 	 *
 	 * @return string The new CTA
 	 */

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -205,6 +205,74 @@ class Post_Connection_JITM extends JITM {
 	}
 
 	/**
+	 * A special filter used in the CTA of a JITM offering to install the Jetpack Protect plugin.
+	 *
+	 * @return string The new CTA
+	 */
+	public static function jitm_jetpack_protect_install() {
+		return wp_nonce_url(
+			add_query_arg(
+				array(
+					'jetpack-protect-action' => 'install',
+				),
+				admin_url( 'admin.php?page=jetpack' )
+			),
+			'jetpack-protect-install'
+		);
+	}
+
+	/**
+	 * A special filter used in the CTA of a JITM offering to activate the Jetpack Protect plugin.
+	 *
+	 * @return string The new CTA
+	 */
+	public static function jitm_jetpack_protect_activate() {
+		return wp_nonce_url(
+			add_query_arg(
+				array(
+					'jetpack-protect-action' => 'activate',
+				),
+				admin_url( 'admin.php?page=jetpack' )
+			),
+			'jetpack-protect-install'
+		);
+	}
+
+	/**
+	 * A special filter used in the CTA of a JITM offering to install the Jetpack Protect plugin.
+	 *
+	 * @return string The new CTA
+	 */
+	public static function jitm_jetpack_videopress_install() {
+		return wp_nonce_url(
+			add_query_arg(
+				array(
+					'jetpack-videopress-action' => 'install',
+				),
+				admin_url( 'admin.php?page=jetpack' )
+			),
+			'jetpack-videopress-install'
+		);
+	}
+
+	/**
+	 * A special filter used in the CTA of a JITM offering to activate the Jetpack Protect plugin.
+	 *
+	 * @return string The new CTA
+	 */
+	public static function jitm_jetpack_videopress_activate() {
+		return wp_nonce_url(
+			add_query_arg(
+				array(
+					'jetpack-videopress-action' => 'activate',
+				),
+				admin_url( 'admin.php?page=jetpack' )
+			),
+			'jetpack-videopress-install'
+		);
+	}
+
+	/**
 	 * Dismisses a JITM feature class so that it will no longer be shown.
 	 *
 	 * @param string $id The id of the JITM that was dismissed.
@@ -250,6 +318,14 @@ class Post_Connection_JITM extends JITM {
 		// Jetpack Boost.
 		add_filter( 'jitm_jetpack_boost_install', array( $this, 'jitm_jetpack_boost_install' ) );
 		add_filter( 'jitm_jetpack_boost_activate', array( $this, 'jitm_jetpack_boost_activate' ) );
+
+		// Jetpack Protect.
+		add_filter( 'jitm_jetpack_protect_install', array( $this, 'jitm_jetpack_protect_install' ) );
+		add_filter( 'jitm_jetpack_protect_activate', array( $this, 'jitm_jetpack_protect_activate' ) );
+
+		// Jetpack VideoPress
+		add_filter( 'jitm_jetpack_videopress_install', array( $this, 'jitm_jetpack_videopress_install' ) );
+		add_filter( 'jitm_jetpack_videopress_activate', array( $this, 'jitm_jetpack_videopress_activate' ) );
 
 		$user = wp_get_current_user();
 

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -88,7 +88,7 @@ jQuery( document ).ready( function ( $ ) {
 					envelope.id +
 					'" ' +
 					( ajaxAction ? 'data-ajax-action="' + ajaxAction + '"' : '' ) +
-					( envelope.CTA.waiting.length ? 'data-cta-waiting="'+ envelope.CTA.waiting +'"' : '' ) +
+					( envelope.CTA.waiting && envelope.CTA.waiting.length ? 'data-cta-waiting="'+ envelope.CTA.waiting +'"' : '' ) +
 					'>' +
 					envelope.CTA.message +
 					'</a>';

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -70,8 +70,6 @@ jQuery( document ).ready( function ( $ ) {
 
 				var ajaxAction = envelope.CTA.ajax_action;
 
-				console.log(envelope);
-
 				html += '<div class="jitm-banner__action">';
 				html +=
 					'<a href="' +

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -70,6 +70,8 @@ jQuery( document ).ready( function ( $ ) {
 
 				var ajaxAction = envelope.CTA.ajax_action;
 
+				console.log(envelope);
+
 				html += '<div class="jitm-banner__action">';
 				html +=
 					'<a href="' +
@@ -88,6 +90,7 @@ jQuery( document ).ready( function ( $ ) {
 					envelope.id +
 					'" ' +
 					( ajaxAction ? 'data-ajax-action="' + ajaxAction + '"' : '' ) +
+					( envelope.CTA.waiting.length ? 'data-cta-waiting="'+ envelope.CTA.waiting +'"' : '' ) +
 					'>' +
 					envelope.CTA.message +
 					'</a>';
@@ -192,6 +195,15 @@ jQuery( document ).ready( function ( $ ) {
 					$template.fadeOut( 'slow' );
 				}, 2000 );
 			} );
+		} );
+
+		// If the CTA has some "waiting" text, update it after the button is clicked on
+		$template.find( '.jitm-button[data-cta-waiting]' ).on( 'click', function ( e ) {
+			var button       = $( this ),
+				waiting_text = button.attr('data-cta-waiting');
+
+			button.attr( 'disabled', true );
+			button.text( waiting_text );
 		} );
 
 		// Handle CTA ajax actions.

--- a/projects/plugins/backup/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/plugins/backup/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -625,7 +625,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "3fb97bc8e8e95a5f305c9e8065d9f070555cb0b4"
+                "reference": "105032dde377f2fc13db12c5829c89e4b12f860e"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -654,7 +654,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/plugins/boost/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -471,7 +471,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "3fb97bc8e8e95a5f305c9e8065d9f070555cb0b4"
+                "reference": "105032dde377f2fc13db12c5829c89e4b12f860e"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -500,7 +500,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/3rd-party/3rd-party.php
+++ b/projects/plugins/jetpack/3rd-party/3rd-party.php
@@ -27,6 +27,8 @@ function load_3rd_party() {
 		'creative-mail.php',
 		'jetpack-backup.php',
 		'jetpack-boost.php',
+		'jetpack-protect.php',
+		'jetpack-videopress.php',
 		'debug-bar.php',
 		'class-domain-mapping.php',
 		'crowdsignal.php',

--- a/projects/plugins/jetpack/3rd-party/jetpack-protect.php
+++ b/projects/plugins/jetpack/3rd-party/jetpack-protect.php
@@ -70,12 +70,7 @@ function try_install() {
  */
 function install_and_activate() {
 	$result = Plugins_Installer::install_and_activate_plugin( PLUGIN_SLUG );
-
-	if ( is_wp_error( $result ) ) {
-		return false;
-	} else {
-		return true;
-	}
+	return ! is_wp_error( $result );
 }
 
 /**

--- a/projects/plugins/jetpack/3rd-party/jetpack-protect.php
+++ b/projects/plugins/jetpack/3rd-party/jetpack-protect.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Compatibility functions for the Jetpack Protect plugin.
+ * https://wordpress.org/plugins/jetpack-protect/
+ *
+ * @since 11.9
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Jetpack_Protect;
+
+use Automattic\Jetpack\Plugins_Installer;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const PLUGIN_SLUG = 'jetpack-protect';
+const PLUGIN_FILE = 'jetpack-protect/jetpack-protect.php';
+
+add_action( 'admin_notices', __NAMESPACE__ . '\error_notice' );
+add_action( 'admin_init', __NAMESPACE__ . '\try_install' );
+
+/**
+ * Verify the intent to install Jetpack Protect, and kick off installation.
+ *
+ * This works in tandem with a JITM set up in the JITM package.
+ */
+function try_install() {
+	if ( ! isset( $_GET['jetpack-protect-action'] ) ) {
+		return;
+	}
+
+	check_admin_referer( 'jetpack-protect-install' );
+
+	$result = false;
+	// If the plugin install fails, redirect to plugin install page pre-populated with jetpack-protect search term.
+	$redirect_on_error = admin_url( 'plugin-install.php?s=jetpack-protect&tab=search&type=term' );
+
+	// Attempt to install and activate the plugin.
+	if ( current_user_can( 'activate_plugins' ) ) {
+		switch ( $_GET['jetpack-protect-action'] ) {
+			case 'install':
+				$result = install_and_activate();
+				break;
+			case 'activate':
+				$result = activate();
+				break;
+		}
+	}
+
+	if ( $result ) {
+		/** This action is already documented in _inc/lib/class.core-rest-api-endpoints.php */
+		do_action( 'jetpack_activated_plugin', PLUGIN_FILE, 'jitm' );
+		$redirect = admin_url( 'admin.php?page=jetpack-protect' );
+	} else {
+		$redirect = add_query_arg( 'jetpack-protect-install-error', true, $redirect_on_error );
+	}
+
+	wp_safe_redirect( $redirect );
+
+	exit;
+}
+
+/**
+ * Install and activate the Jetpack Protect plugin.
+ *
+ * @return bool result of installation
+ */
+function install_and_activate() {
+	$result = Plugins_Installer::install_and_activate_plugin( PLUGIN_SLUG );
+
+	if ( is_wp_error( $result ) ) {
+		return false;
+	} else {
+		return true;
+	}
+}
+
+/**
+ * Activate the Jetpack Protect plugin.
+ *
+ * @return bool result of activation
+ */
+function activate() {
+	$result = activate_plugin( PLUGIN_FILE );
+
+	// Activate_plugin() returns null on success.
+	return $result === null;
+}
+
+/**
+ * Notify the user that the installation of Jetpack Protect failed.
+ */
+function error_notice() {
+	if ( empty( $_GET['jetpack-protect-install-error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+
+	?>
+	<div class="notice notice-error is-dismissible">
+		<p><?php esc_html_e( 'There was an error installing Jetpack Protect. Please try again.', 'jetpack' ); ?></p>
+	</div>
+	<?php
+}

--- a/projects/plugins/jetpack/3rd-party/jetpack-videopress.php
+++ b/projects/plugins/jetpack/3rd-party/jetpack-videopress.php
@@ -70,12 +70,7 @@ function try_install() {
  */
 function install_and_activate() {
 	$result = Plugins_Installer::install_and_activate_plugin( PLUGIN_SLUG );
-
-	if ( is_wp_error( $result ) ) {
-		return false;
-	} else {
-		return true;
-	}
+	return ! is_wp_error( $result );
 }
 
 /**

--- a/projects/plugins/jetpack/3rd-party/jetpack-videopress.php
+++ b/projects/plugins/jetpack/3rd-party/jetpack-videopress.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Compatibility functions for the Jetpack VideoPress plugin.
+ * https://wordpress.org/plugins/jetpack-videopress/
+ *
+ * @since 11.9
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Jetpack_VideoPress;
+
+use Automattic\Jetpack\Plugins_Installer;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const PLUGIN_SLUG = 'jetpack-videopress';
+const PLUGIN_FILE = 'jetpack-videopress/jetpack-videopress.php';
+
+add_action( 'admin_notices', __NAMESPACE__ . '\error_notice' );
+add_action( 'admin_init', __NAMESPACE__ . '\try_install' );
+
+/**
+ * Verify the intent to install Jetpack VideoPress, and kick off installation.
+ *
+ * This works in tandem with a JITM set up in the JITM package.
+ */
+function try_install() {
+	if ( ! isset( $_GET['jetpack-videopress-action'] ) ) {
+		return;
+	}
+
+	check_admin_referer( 'jetpack-videopress-install' );
+
+	$result = false;
+	// If the plugin install fails, redirect to plugin install page pre-populated with jetpack-videopress search term.
+	$redirect_on_error = admin_url( 'plugin-install.php?s=jetpack-videopress&tab=search&type=term' );
+
+	// Attempt to install and activate the plugin.
+	if ( current_user_can( 'activate_plugins' ) ) {
+		switch ( $_GET['jetpack-videopress-action'] ) {
+			case 'install':
+				$result = install_and_activate();
+				break;
+			case 'activate':
+				$result = activate();
+				break;
+		}
+	}
+
+	if ( $result ) {
+		/** This action is already documented in _inc/lib/class.core-rest-api-endpoints.php */
+		do_action( 'jetpack_activated_plugin', PLUGIN_FILE, 'jitm' );
+		$redirect = admin_url( 'admin.php?page=jetpack-videopress' );
+	} else {
+		$redirect = add_query_arg( 'jetpack-videopress-install-error', true, $redirect_on_error );
+	}
+
+	wp_safe_redirect( $redirect );
+
+	exit;
+}
+
+/**
+ * Install and activate the Jetpack VideoPress plugin.
+ *
+ * @return bool result of installation
+ */
+function install_and_activate() {
+	$result = Plugins_Installer::install_and_activate_plugin( PLUGIN_SLUG );
+
+	if ( is_wp_error( $result ) ) {
+		return false;
+	} else {
+		return true;
+	}
+}
+
+/**
+ * Activate the Jetpack VideoPress plugin.
+ *
+ * @return bool result of activation
+ */
+function activate() {
+	$result = activate_plugin( PLUGIN_FILE );
+
+	// Activate_plugin() returns null on success.
+	return $result === null;
+}
+
+/**
+ * Notify the user that the installation of Jetpack VideoPress failed.
+ */
+function error_notice() {
+	if ( empty( $_GET['jetpack-videopress-install-error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+
+	?>
+	<div class="notice notice-error is-dismissible">
+		<p><?php esc_html_e( 'There was an error installing Jetpack VideoPress. Please try again.', 'jetpack' ); ?></p>
+	</div>
+	<?php
+}

--- a/projects/plugins/jetpack/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/plugins/jetpack/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add sideload capability for protect and videopress plugins

--- a/projects/plugins/jetpack/changelog/add-jitm-install-hooks-for-videopress-and-protect#2
+++ b/projects/plugins/jetpack/changelog/add-jitm-install-hooks-for-videopress-and-protect#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1129,7 +1129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "3fb97bc8e8e95a5f305c9e8065d9f070555cb0b4"
+                "reference": "105032dde377f2fc13db12c5829c89e4b12f860e"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1158,7 +1158,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/migration/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/plugins/migration/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -543,7 +543,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "3fb97bc8e8e95a5f305c9e8065d9f070555cb0b4"
+                "reference": "105032dde377f2fc13db12c5829c89e4b12f860e"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -572,7 +572,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/plugins/protect/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -543,7 +543,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "3fb97bc8e8e95a5f305c9e8065d9f070555cb0b4"
+                "reference": "105032dde377f2fc13db12c5829c89e4b12f860e"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -572,7 +572,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/plugins/search/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -543,7 +543,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "3fb97bc8e8e95a5f305c9e8065d9f070555cb0b4"
+                "reference": "105032dde377f2fc13db12c5829c89e4b12f860e"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -572,7 +572,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/plugins/social/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -543,7 +543,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "3fb97bc8e8e95a5f305c9e8065d9f070555cb0b4"
+                "reference": "105032dde377f2fc13db12c5829c89e4b12f860e"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -572,7 +572,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/plugins/starter-plugin/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -543,7 +543,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "3fb97bc8e8e95a5f305c9e8065d9f070555cb0b4"
+                "reference": "105032dde377f2fc13db12c5829c89e4b12f860e"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -572,7 +572,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-jitm-install-hooks-for-videopress-and-protect
+++ b/projects/plugins/videopress/changelog/add-jitm-install-hooks-for-videopress-and-protect
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -543,7 +543,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "3fb97bc8e8e95a5f305c9e8065d9f070555cb0b4"
+                "reference": "105032dde377f2fc13db12c5829c89e4b12f860e"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -572,7 +572,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds the ability to sideload Protect and VideoPress plugins from a JITM

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your testing environment
* You will need to test with D102624-code and follow the instructions there
* For the Protect and VideoPress JITMs that you are testing, clicking the "Install" buttons should install & activate the respective plugin and redirect you to the wp-admin page for that plugin
* Note that you will need to un-install the Protect/ VideoPress plugins between test runs as the JITMs won't show if their respective plugin is already installed.