### PR TITLE
Forms: Include display none to Form style probe styles

### DIFF
--- a/projects/packages/forms/changelog/update-form-style-probe-display
+++ b/projects/packages/forms/changelog/update-form-style-probe-display
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Include display:none to Form style probe styles

--- a/projects/packages/forms/src/contact-form/js/form-styles.js
+++ b/projects/packages/forms/src/contact-form/js/form-styles.js
@@ -30,7 +30,7 @@ function handleFormStyles() {
 function generateStyleVariables( selector, outputSelector = 'body' ) {
 	const STYLE_PROBE_CLASS = 'contact-form__style-probe';
 	const STYLE_PROBE_STYLE =
-		'position: absolute; z-index: -1; width: 1px; height: 1px; visibility: hidden';
+		'position: absolute; z-index: -1; width: 1px; height: 1px; visibility: hidden; display: none';
 	const HTML = `
 		<div class="contact-form" style="">
 			<div class="wp-block-button is-style-outline">

--- a/projects/plugins/jetpack/changelog/update-form-style-probe-display
+++ b/projects/plugins/jetpack/changelog/update-form-style-probe-display
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Include display:none to Form style probe styles

--- a/projects/plugins/jetpack/modules/contact-form/js/form-styles.js
+++ b/projects/plugins/jetpack/modules/contact-form/js/form-styles.js
@@ -30,7 +30,7 @@ function handleFormStyles() {
 function generateStyleVariables( selector, outputSelector = 'body' ) {
 	const STYLE_PROBE_CLASS = 'contact-form__style-probe';
 	const STYLE_PROBE_STYLE =
-		'position: absolute; z-index: -1; width: 1px; height: 1px; visibility: hidden';
+		'position: absolute; z-index: -1; width: 1px; height: 1px; visibility: hidden; display: none';
 	const HTML = `
 		<div class="contact-form" style="">
 			<div class="wp-block-button is-style-outline">


### PR DESCRIPTION
Fixes #28635

## Proposed changes:

* Include `display: none` to Form style probe styles

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Create a Post and add a Form block
* Open the browser devTools and search for `contact-form__style-probe`
* Check if the element now has `display: none` in its styles
* Make sure to check both, the editor and the public view

