### PR TITLE
Fix Backup Versioning

### DIFF
--- a/projects/plugins/backup/changelog/fix-backup-versioning
+++ b/projects/plugins/backup/changelog/fix-backup-versioning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes the plugin's versioning so it actually uses WordPress versioning

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -46,11 +46,11 @@
 		"autotagger": {
 			"v": false
 		},
+		"changelogger": {
+			"versioning": "wordpress"
+		},
 		"release-branch-prefix": "jetpack",
 		"wp-plugin-slug": "jetpack-backup",
 		"wp-svn-autopublish": true
-	},
-	"changelogger": {
-		"versioning": "wordpress"
 	}
 }

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -34,7 +34,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ1_4_5_alpha",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ1_5_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17713a49a048dad36b8a2cec52db481f",
+    "content-hash": "ca94c69eb8cb04e34a717469b0851cd6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VaultPress Backup
  * Plugin URI: https://jetpack.com/jetpack-backup
  * Description: Easily restore or download a backup of your site from a specific moment in time.
- * Version: 1.4.5-alpha
+ * Version: 1.5-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backup tried to switch to WP style versioning in #21405, but the changelog object was added in the wrong place.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1677169905330119/1677168942.424469-slack-CBG1CP4EN
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Run `jetpack release plugins/backup changelog` and choose a stable version. Does it release 1.5?