### PR TITLE
Related Posts: Add block support in server block renderer

### DIFF
--- a/projects/plugins/jetpack/changelog/add-related-posts-block-font-family-support-server-render
+++ b/projects/plugins/jetpack/changelog/add-related-posts-block-font-family-support-server-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add block support for font family in Related Posts block server block renderer

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -138,8 +138,9 @@ class Jetpack_RelatedPosts {
 						'padding' => true,
 					),
 					'typography' => array(
-						'fontSize'   => true,
-						'lineHeight' => true,
+						'__experimentalFontFamily' => true,
+						'fontSize'                 => true,
+						'lineHeight'               => true,
 					),
 					'align'      => array( 'wide', 'full' ),
 				),


### PR DESCRIPTION
Follow up to #29097

As we're also registering the block with PHP and declaring its support, `__experimentalFontFamily` was missing here. 

Fixes https://github.com/Automattic/jetpack/pull/29097#issuecomment-1440823523

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `__experimentalFontFamily` to the supports array in the PHP block registration

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a connected jetpack site, enable Related posts
* Create a post, add the Related posts block
* Update the font with the control Typography -> Font Family controls
* Save the post.
* Visit the post
* Confirm the Related block headings font is updated

