### PR TITLE
Backup: Update days of saved backups link to use ExternalLink

### DIFF
--- a/projects/packages/backup/changelog/update-backup-retention-external-link
+++ b/projects/packages/backup/changelog/update-backup-retention-external-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update days of saved backups link to use external link instead of plain link.

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-details/index.jsx
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-details/index.jsx
@@ -1,5 +1,6 @@
 import './style.scss';
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -27,10 +28,8 @@ const StorageUsageDetails = ( { storageUsed, storageLimit } ) => {
 						daysOfBackupsSaved === 1 ? singularDaysOfBackupLabel : pluralDaysOfBackupLabel,
 						{
 							a: (
-								<a
-									href={ getRedirectUrl( 'backup-plugin-activity-log-rewind', { site: domain } ) }
-									target="_blank"
-									rel="noreferrer"
+								<ExternalLink
+									href={ getRedirectUrl( 'backup-plugin-storage-backups-saved', { site: domain } ) }
 								/>
 							),
 						}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update `X days of saved backups link` to use ExternalLink
* Update redirect source to `backup-plugin-storage-backups-saved` that is now pointing to Jetpack Cloud settings page. 

### Screenshots

![image](https://user-images.githubusercontent.com/1488641/221015473-f20fc5f5-bdcd-4185-88ed-26d3c1b5d896.png)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1677088016170539-slack-C04J59E8W57

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a Jurassic Ninja site with Jetpack Beta, using Backup branch `update/backup-retention-external-link` with a backup plan like Jetpack Backup (1 GB or 10 GB).
* Navigate to Jetpack -> VautlPress Backup
* Once the first backup completes, you should see the main page of the plugin, including the storage meter.
* Below the stoarge meter you should see the `X days of saved backups` link:
  * Ensure it points to `https://cloud.jetpack.com/settings/site_slug`
  * Ensure it has the external link icon