### PR TITLE
Fix/discount for first month trials

### DIFF
--- a/projects/js-packages/components/changelog/add-pricing-utils
+++ b/projects/js-packages/components/changelog/add-pricing-utils
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+JS Components: add pricing-utils folder to store pricing-related helper functions.

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -20,6 +20,7 @@ export { default as JetpackVaultPressBackupLogo } from './components/jetpack-vau
 export { default as JetpackVideoPressLogo } from './components/jetpack-videopress-logo';
 export { default as getRedirectUrl } from './tools/jp-redirect';
 export { default as getProductCheckoutUrl } from './tools/get-product-checkout-url';
+export { isFirstMonthTrial } from './tools/pricing-utils';
 export { default as AutomatticBylineLogo } from './components/automattic-byline-logo';
 export { default as JetpackFooter } from './components/jetpack-footer';
 export { default as Spinner } from './components/spinner';

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.27.8-alpha",
+	"version": "0.28.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/components/tools/pricing-utils/README.md
+++ b/projects/js-packages/components/tools/pricing-utils/README.md
@@ -1,0 +1,16 @@
+# Pricing Utils
+
+This is a helper folder that contains util functions related to pricing (e.g. Intro Offers) and can be extended to include other methods.
+
+## Usage
+
+### isFirstMonthTrial
+
+```jsx
+import { isFirstMonthTrial } from '@automattic/jetpack-components';
+isFirstMonthTrial( introOffer );
+```
+
+#### introOffer (required)
+
+An Intro Offer object returned by the API. It must contain an `interval_unit` and `interval_count` for the function to check if it's a first month trial or not. It returns `true` if `interval_unit` is `'month'` **and** `interval_count` is `1`, all other combinations return `false`.

--- a/projects/js-packages/components/tools/pricing-utils/index.ts
+++ b/projects/js-packages/components/tools/pricing-utils/index.ts
@@ -1,0 +1,11 @@
+import { IntroOffer } from './types';
+
+/**
+ * Returns whether an Introductory Offer is a first month trial
+ *
+ * @param {IntroOffer} introOffer - an intro offer object
+ * @returns {boolean}               Whether it's a first month trial or not
+ */
+export function isFirstMonthTrial( introOffer: IntroOffer ): boolean {
+	return introOffer?.interval_count === 1 && introOffer?.interval_unit === 'month';
+}

--- a/projects/js-packages/components/tools/pricing-utils/test/index.ts
+++ b/projects/js-packages/components/tools/pricing-utils/test/index.ts
@@ -1,0 +1,39 @@
+import { isFirstMonthTrial } from '..';
+import { IntroOffer } from './../types';
+
+const trialIntroOffer: IntroOffer = {
+	product_id: 0,
+	product_slug: 'test_product',
+	currency_code: 'USD',
+	formatted_price: '$10',
+	original_price: 10,
+	raw_price: 1,
+	discount_percentage: 90,
+	ineligible_reason: null,
+	interval_unit: 'month',
+	interval_count: 1,
+};
+
+describe( 'isFirstMonthTrial', () => {
+	it( 'returns true if interval_unit is "month" and interval_count is 1', () => {
+		expect( isFirstMonthTrial( trialIntroOffer ) ).toBe( true );
+	} );
+
+	it( 'returns false if interval_unit is not "month"', () => {
+		const introOffer: IntroOffer = {
+			...trialIntroOffer,
+			interval_unit: 'year',
+		};
+
+		expect( isFirstMonthTrial( introOffer ) ).toBe( false );
+	} );
+
+	it( "returns false if interval_unit not 'month' but interval_count isn't 1", () => {
+		const introOffer: IntroOffer = {
+			...trialIntroOffer,
+			interval_count: 3,
+		};
+
+		expect( isFirstMonthTrial( introOffer ) ).toBe( false );
+	} );
+} );

--- a/projects/js-packages/components/tools/pricing-utils/types.ts
+++ b/projects/js-packages/components/tools/pricing-utils/types.ts
@@ -1,0 +1,12 @@
+export interface IntroOffer {
+	product_id: number;
+	product_slug: string;
+	currency_code: string;
+	formatted_price: string;
+	original_price: number;
+	raw_price: number;
+	discount_percentage: number;
+	ineligible_reason: string[] | null;
+	interval_unit: string;
+	interval_count: number;
+}

--- a/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/index.jsx
@@ -1,4 +1,5 @@
 import { getCurrencyObject } from '@automattic/format-currency';
+import { isFirstMonthTrial } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Button from 'components/button';
@@ -42,17 +43,21 @@ const ProductCardUpsellComponent = ( {
 	const { discount } = discountData;
 	const hasDiscount = useMemo( () => isCouponValid( discountData ), [ discountData ] );
 
-	const { original_price: introOriginalPrice, raw_price: introRawPrice } = useMemo(
+	const introOffer = useMemo(
 		() => introOffers.find( ( { product_slug } ) => product_slug === slug ) || {},
 		[ slug, introOffers ]
 	);
+	const { original_price: introOriginalPrice, raw_price: introRawPrice } = introOffer;
 	// introOriginalPrice is the price per year before introductory offer. Defaults to `cost`
 	// (which is cost per month) if there's no such offer available.
 	const initialPrice = introOriginalPrice || cost * 12;
 	// introRawPrice is the price after introductory offer, but before any other discount.
 	const introPrice = introRawPrice || initialPrice;
-	// Apply special discount.
-	const finalPrice = hasDiscount && discount ? introPrice * ( 1 - discount / 100 ) : introPrice;
+	// Apply special discount if there's a discount and is not a first month trial.
+	const finalPrice =
+		! isFirstMonthTrial( introOffer ) && hasDiscount && discount
+			? introPrice * ( 1 - discount / 100 )
+			: introPrice;
 
 	// Compute total discount, including introductory offer (if it exists) and special discount.
 	const totalDiscount = initialPrice

--- a/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/index.jsx
@@ -53,11 +53,10 @@ const ProductCardUpsellComponent = ( {
 	const initialPrice = introOriginalPrice || cost * 12;
 	// introRawPrice is the price after introductory offer, but before any other discount.
 	const introPrice = introRawPrice || initialPrice;
+	const isTrial = isFirstMonthTrial( introOffer );
 	// Apply special discount if there's a discount and is not a first month trial.
 	const finalPrice =
-		! isFirstMonthTrial( introOffer ) && hasDiscount && discount
-			? introPrice * ( 1 - discount / 100 )
-			: introPrice;
+		! isTrial && hasDiscount && discount ? introPrice * ( 1 - discount / 100 ) : introPrice;
 
 	// Compute total discount, including introductory offer (if it exists) and special discount.
 	const totalDiscount = initialPrice
@@ -73,6 +72,14 @@ const ProductCardUpsellComponent = ( {
 		finalPrice,
 		currency,
 	] );
+
+	const checkoutUrl = new URL( upgradeUrl );
+
+	// Remove the coupon code from the URL if it's a trial.
+	// This is mostly to avoid confusion since the UI won't show the discount either
+	if ( isTrial ) {
+		checkoutUrl.searchParams.delete( 'coupon' );
+	}
 
 	const header = isRecommended && (
 		<RecommendedHeader className="jp-recommendations-product-card-upsell__header" />
@@ -130,7 +137,7 @@ const ProductCardUpsellComponent = ( {
 				className="jp-recommendations-product-card-upsell__cta-button"
 				primary={ ! isRecommended }
 				rna
-				href={ upgradeUrl }
+				href={ checkoutUrl.toString() }
 				onClick={ onClick }
 				target="_blank"
 				rel="noopener noreferrer"

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/style.scss
@@ -41,11 +41,6 @@
 			margin-bottom: 0;
 		}
 	}
-
-	.jp-recommendations-product-card-upsell,
-	.jp-recommendations-product-card-upsell__padding {
-		height: 100%;
-	}
 }
 
 .jp-recommendations-product-suggestion__money-back-guarantee {

--- a/projects/plugins/jetpack/changelog/fix-discount-for-first-month-trials
+++ b/projects/plugins/jetpack/changelog/fix-discount-for-first-month-trials
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Recommendations: avoid applying the coupon code from the Assistant on product with trial prices.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1201210512993648-as-120384786539956 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new JS package in `pricing-utils` for helper functions related to pricing
* Update the Product Upsell Card to not apply discounts to first month trials (i.e. $1 trials)
* Remove the coupon query param from the URL before proceeding to checkout
* Fix the CSS to display the money-back guarantee text that was hidden behind the cards in the previous versions

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1201210512993648-as-1203847865399516

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Note: to test this, you'll need a coupon that is generated when you go through the recommendations. The easiest way to do that is creating a new site instead of testing locally.
* Spin up an Atomic Ephemeral site with `jetpack-beta` installed
* Visit `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack`
* Switch to this feature branch: `fix/discount-for-first-month-trials`
* Visit you Jetpack Dashboard, and connect to WordPress.com
* When you get back to the recommendations screen, visit `/wp-admin/admin.php?page=jetpack#/recommendations/product-suggestions`
* Confirm that Security has a 10% discount but VaultPress Backup doesn't (it should be the $1 trial price)
* Make sure it matches the screenshot below

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/5714212/221025797-a29dfa81-a794-4aa6-bc67-f8389e03cbbc.png">

