### PR TITLE
Inline critical styles and remove the blur effect from the form blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-form-blur
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-blur
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix styles and remove blur loading effect from form blocks

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -560,15 +560,3 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-below .grunion-field-wrap .below-label__label {
 	margin-left: var(--jetpack--contact-form--border-size);
 }
-
-.wp-block-jetpack-contact-form-container {
-	filter: blur(10px);
-}
-
-.contact-form-styles-loaded .wp-block-jetpack-contact-form-container,
-html[amp] body .wp-block-jetpack-contact-form-container,
-html[amp-version] body .wp-block-jetpack-contact-form-container,
-html[class*='amphtml'] body .wp-block-jetpack-contact-form-container
-{
-	filter: blur(0px);
-}

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -389,6 +389,8 @@ class Grunion_Contact_Form_Plugin {
 		wp_register_style( 'grunion.css', GRUNION_PLUGIN_URL . 'css/grunion.css', array(), JETPACK__VERSION );
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
+		wp_register_style( 'jetpack-forms-block-style-variations', false, array(), JETPACK__VERSION );
+
 		self::enqueue_contact_forms_style_script();
 		self::register_contact_form_blocks();
 	}
@@ -4388,12 +4390,104 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Enqueues the inline styles for form block style variations.
+	 */
+	public function enqueue_block_variation_styles() {
+		static $loaded = false;
+
+		if ( $loaded ) {
+			return;
+		}
+
+		wp_enqueue_style( 'jetpack-forms-block-style-variations' );
+		$loaded = true;
+
+		wp_add_inline_style(
+			'jetpack-forms-block-style-variations',
+			<<<CSS
+.contact-form .is-style-outlined .grunion-field-wrap:not(.grunion-field-checkbox-wrap):not(.grunion-field-consent-wrap),
+.contact-form .is-style-animated .grunion-field-wrap:not(.grunion-field-checkbox-wrap):not(.grunion-field-consent-wrap) {
+	--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+	position: relative;
+	display: flex;
+	flex-direction: row-reverse;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label {
+	position: absolute;
+	right: 0;
+	left: 0;
+	width: 100%;
+	max-width: 100%;
+	height: 100%;
+	display: flex;
+	box-sizing: border-box;
+	text-align: left;
+	pointer-events: none;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__leading {
+	width: var(--notch-width);
+	border-radius: var(--jetpack--contact-form--border-radius);
+	border: var(--jetpack--contact-form--border);
+	border-color: var(--jetpack--contact-form--border-color);
+	border-style: var(--jetpack--contact-form--border-style);
+	border-width: var(--jetpack--contact-form--border-size);
+	border-right: none;
+	border-top-right-radius: unset;
+	border-bottom-right-radius: unset;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__notch {
+	border-radius: unset;
+	border: var(--jetpack--contact-form--border);
+	border-color: var(--jetpack--contact-form--border-color);
+	border-style: var(--jetpack--contact-form--border-style);
+	border-width: var(--jetpack--contact-form--border-size);
+	padding: 0 4px;
+	transition: border 150ms linear;
+}
+
+/*
+For some reason, when keeping the rule below together with the above selector,
+on production builds, the attributes are being reordered, causing side-effects
+*/
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__notch {
+	border-left: none;
+	border-right: none;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap.no-label .notched-label__notch {
+	padding: 0;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__label {
+	position: relative;
+	top: 50%;
+	transform: translateY(-50%);
+	pointer-events: none;
+	will-change: transform;
+	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	margin: 0;
+	font-weight: 300;
+}
+
+.contact-form .is-style-outlined .grunion-field-textarea-wrap .notched-label .notched-label__label {
+	top: var(--jetpack--contact-form--input-padding-top, 16px);
+}
+CSS
+		);
+	}
+
+	/**
 	 * Outputs the HTML for this form field
 	 *
 	 * @return string HTML
 	 */
 	public function render() {
 		global $current_user, $user_identity;
+
+		self::enqueue_block_variation_styles();
 
 		$field_id            = $this->get_attribute( 'id' );
 		$field_type          = $this->maybe_override_type();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

This PR should help fix the issue with shifting form layouts when using outlined or animated style variations, by loading the necessary CSS inline, separately from our main CSS file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Create a post with a contact form or forms.
- Test for either style variation: default, outlined and animated.
- Publish the post.
- When you view the public post, the contact form blocks should no longer be blurred while they're loading.
- While the page is loading, the form inputs and labels should also 'not shift violently.

