### PR TITLE
[Boost] Exclude Defer JS in the customizer preview

### DIFF
--- a/projects/plugins/boost/app/features/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/features/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -114,6 +114,11 @@ class Render_Blocking_JS implements Feature {
 			return;
 		}
 
+		// Disable in customizer previews
+		if ( is_customize_preview() ) {
+			return;
+		}
+
 		// Disable in feeds, AJAX, Cron, XML.
 		if ( is_feed() || wp_doing_ajax() || wp_doing_cron() || wp_is_xml_request() ) {
 			return;

--- a/projects/plugins/boost/changelog/boost-exclude-defer-js-in-customizer
+++ b/projects/plugins/boost/changelog/boost-exclude-defer-js-in-customizer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Turn off Deferred JS in the customizer preview, fixing compatibility with some page builders


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/8093

Some pagebuilders add custom code to the customizer, which breaks with Defer JS. This PR fixes the issue by turning off Deferred JS in the customizer preview.

## Proposed changes:
* Turn off Deferred JS in the customizer preview

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Use a pagebuilder like Colibri and a theme like Hugo WP
* Visit the Customizer page, and check that the customizer works correctly with this patch.