### PR TITLE
Introduce useMapkitSetup hook

### DIFF
--- a/projects/plugins/jetpack/changelog/add-map-block-mapkit-use-mapkit-setup
+++ b/projects/plugins/jetpack/changelog/add-map-block-mapkit-use-mapkit-setup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Adds useMapkitSetup hook

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
@@ -1,0 +1,79 @@
+import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
+import { select } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { getLoadContext, waitForObject } from '../../../../shared/block-editor-asset-loader';
+
+// mapRef can be a ref to the element that will render the map
+// or a ref to the element that will be on the page when the map is rendered.
+// It is only used here to determine the document and window to use.
+const useMapKitSetup = mapRef => {
+	const [ loaded, setLoaded ] = useState( false );
+	const [ error, setError ] = useState( false );
+	const [ mapkit, setMapkit ] = useState( null );
+
+	useEffect( () => {
+		const blog_id = select( CONNECTION_STORE_ID ).getBlogId();
+
+		const loadLibrary = async () => {
+			return new Promise( resolve => {
+				const { currentDoc } = getLoadContext( mapRef.current );
+				const element = currentDoc.createElement( 'script' );
+				element.addEventListener(
+					'load',
+					() => {
+						const { currentWindow } = getLoadContext( mapRef.current );
+						waitForObject( currentWindow, 'mapkit' ).then( mapkitObj => {
+							setMapkit( mapkitObj );
+							resolve( mapkitObj );
+						} );
+					},
+					{ once: true }
+				);
+				element.src = 'https://cdn.apple-mapkit.com/mk/5.x.x/mapkit.js';
+				//element['data-libraries'] = 'services,full-map,geojson';
+				element.crossOrigin = 'anonymous';
+				currentDoc.head.appendChild( element );
+			} );
+		};
+
+		const fetchKey = async mapkitObj => {
+			return new Promise( resolve => {
+				mapkitObj.init( {
+					authorizationCallback: done => {
+						fetch( `https://public-api.wordpress.com/wpcom/v2/sites/${ blog_id }/mapkit` )
+							.then( response => {
+								if ( response.status === 200 ) {
+									return response.json();
+								}
+								setError( 'Mapkit API error' );
+							} )
+							.then( data => {
+								done( data.wpcom_mapkit_access_token );
+								resolve();
+							} );
+					},
+				} );
+			} );
+		};
+
+		if ( mapRef.current ) {
+			const { currentWindow } = getLoadContext( mapRef.current );
+
+			// if mapkit is already loaded, reuse it.
+			if ( currentWindow.mapkit ) {
+				setMapkit( currentWindow.mapkit );
+				setLoaded( true );
+			} else {
+				loadLibrary().then( mapkitObj => {
+					fetchKey( mapkitObj ).then( () => {
+						setLoaded( true );
+					} );
+				} );
+			}
+		}
+	}, [ mapRef ] );
+
+	return { loaded, error, mapkit };
+};
+
+export { useMapKitSetup };

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
@@ -34,7 +34,7 @@ const useMapKitSetup = mapRef => {
 			} );
 		};
 
-		const fetchKey = async mapkitObj => {
+		const fetchKey = mapkitObj => {
 			return new Promise( resolve => {
 				mapkitObj.init( {
 					authorizationCallback: async done => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73754

## Proposed changes:
This adds a hook that can be used to load the Mapkit library & setup the API key.

Cherry-picked from this PR: https://github.com/Automattic/jetpack/pull/29120

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Since this is cherry-picked from the geocoder feature branch ([here](https://github.com/Automattic/jetpack/pull/29120 )), it might be easier to test that PR and check to see if the library loads correctly. 

You'll need to have this diff applied to your sandboxed `public-api.wordpress.com`: D101694-code