### PR TITLE
CRM: Changing escape function for API generated activity

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -552,7 +552,7 @@ if (jQuery('#bar-chart').length){
 				<div class='date'><img class='ui avatar img img-rounded' alt='<?php esc_attr_e( 'Contact Image', 'zero-bs-crm' ); ?>' src='<?php echo esc_url( $avatar ); ?>'/></div>
 				<div class='content text'>
 				<span class='header'><?php echo esc_html( $logmetatype ); ?><span class='when'> (<?php echo esc_html( $diff . __( ' ago', 'zero-bs-crm' ) ); ?>)</span><span class='who'><?php echo esc_html( $logauthor ); ?></span></span>
-				<div class='description'><?php echo esc_html( $logmetashot ); ?><br/></div>
+				<div class='description'><?php echo wp_kses( $logmetashot, array( 'i' => array( 'class' => array() ) ) ); ?><br/></div>
 				</div>
 			</div>
 						<?php

--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -552,7 +552,7 @@ if (jQuery('#bar-chart').length){
 				<div class='date'><img class='ui avatar img img-rounded' alt='<?php esc_attr_e( 'Contact Image', 'zero-bs-crm' ); ?>' src='<?php echo esc_url( $avatar ); ?>'/></div>
 				<div class='content text'>
 				<span class='header'><?php echo esc_html( $logmetatype ); ?><span class='when'> (<?php echo esc_html( $diff . __( ' ago', 'zero-bs-crm' ) ); ?>)</span><span class='who'><?php echo esc_html( $logauthor ); ?></span></span>
-				<div class='description'><?php echo wp_kses( $logmetashot, array( 'i' => array( 'class' => array() ) ) ); ?><br/></div>
+				<div class='description'><?php echo wp_kses( $logmetashot, array( 'i' => array( 'class' => true ) ) ); ?><br/></div>
 				</div>
 			</div>
 						<?php

--- a/projects/plugins/crm/changelog/fix-crm-activity-api-html-i-tag
+++ b/projects/plugins/crm/changelog/fix-crm-activity-api-html-i-tag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+CRM: change escape function for API generated activity

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -417,7 +417,7 @@ function zeroBSCRM_html_contactTimeline($contactID=-1,$logs=false,$contactObj=fa
 						<div>
 							<?php
 							if ( isset( $log['shortdesc'] ) ) {
-								echo esc_html( $log['shortdesc'] );
+								echo wp_kses( $log['shortdesc'], array( 'i' => array( 'class' => true ) ) );
 							}
 							if ( !empty( $log['author'] ) ) {
 								echo ' &mdash; ' . esc_html( $log['author'] );
@@ -799,7 +799,23 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
                          	if (isset($log['type'])) echo esc_html( $log['type'] ); 
                          }
                          ?></h3>
-                        <p><?php if (isset($log['shortdesc'])) echo esc_html( $log['shortdesc'] ); ?><?php if (isset($log['author'])) echo " &mdash; " . esc_html( $log['author'] ) ?><?php if (isset($log['nicetime'])) echo ' &mdash; <i class="clock icon"></i>' . esc_html( $log['nicetime'] ) ?></p>
+						<p>
+						<?php
+						if ( isset( $log['shortdesc'] ) ) {
+							echo wp_kses( $log['shortdesc'], array( 'i' => array( 'class' => true ) ) );
+							?>
+							<?php
+							if ( isset( $log['author'] ) ) {
+								echo ' &mdash; ' . esc_html( $log['author'] );
+							}
+							?>
+							<?php
+							if ( isset( $log['nicetime'] ) ) {
+								echo ' &mdash; <i class="clock icon"></i>' . esc_html( $log['nicetime'] );
+							}
+						}
+						?>
+						</p>
                     </div>
                 </li>
                 <?php $i++; } ?>

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -803,13 +803,9 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
 						<?php
 						if ( isset( $log['shortdesc'] ) ) {
 							echo wp_kses( $log['shortdesc'], array( 'i' => array( 'class' => true ) ) );
-							?>
-							<?php
 							if ( isset( $log['author'] ) ) {
 								echo ' &mdash; ' . esc_html( $log['author'] );
 							}
-							?>
-							<?php
 							if ( isset( $log['nicetime'] ) ) {
 								echo ' &mdash; <i class="clock icon"></i>' . esc_html( $log['nicetime'] );
 							}


### PR DESCRIPTION
* In CRM 5.5.0 a change was introduced ([from this PR](https://github.com/Automattic/zero-bs-crm/pull/2712/)) that also escaped the short description string that is output when an activity (such as creating a new customer) is generated via API.
* The string in question [is created here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/crm/api/create_customer.php#L129), and the original issue reported on the dashboard activity feed is due to the escaping added [on this line.](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/crm/admin/dashboard/main.page.php#L555 )

## Proposed changes:

* This PR changes how that specific string is escaped, everywhere that the short description string could be output when an activity is created via the API. This was not only the dashboard activity feed, but also the activity feed on API-created individual contact pages. It also includes the activity feed for companies though that is not a documented API (those changes untested). It does not include the output for pinned logs because API-generated logs cannot be pinned.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2838  

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test without the changes in this PR applied, set up a test site using CRM 5.5.0 higher.
* To test an API action, make sure you have the API connector enabled and have an API key and secret. You could then run a command like the below to create a customer:
```
curl -XPOST -H --head "Content-type: application/json" -d '{
"fname": "APIgenerated",
"lname": "ExamplePerson",
"email": "apigeneratedperson@jetpackcrmtestapi.com"
}' 'https://yoursitehere.com/zbs_api/create_customer?api_key={yourkeyhere}&api_secret={yourkeyhere}'
```
* Once a customer has been successfully created, check the activity feed in the dashboard ( `/wp-admin/admin.php?page=zerobscrm-dash` ), and then on the new contacts page ( `/wp-admin/admin.php?page=zbs-add-edit&action=view&zbstype=contact&zbsid={thenewIDnumber}` ).
* You should notice the HTML being output ungenerated, as `<i class="fa fa-random"></i>`.
* Using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, repeat the above steps. On the dashboard and individual contact page activity feeds you should see the API connector icon instead of the ungenerated HTML.

Before (dashboard):

<img width="466" alt="Screenshot 2023-02-24 at 9 15 05 am" src="https://user-images.githubusercontent.com/16754605/221139598-5207ba27-a51f-4086-8d3b-ffda57486967.png">


Before (contact page):

<img width="466" alt="Screenshot 2023-02-24 at 9 12 51 am" src="https://user-images.githubusercontent.com/16754605/221139147-ef980d93-dfbc-432f-851a-7c4806ed5b1c.png">


After (dashboard):

<img width="453" alt="Screenshot 2023-02-24 at 9 13 44 am" src="https://user-images.githubusercontent.com/16754605/221139387-08465f07-e62e-4d1f-a15b-c226b2dc76e9.png">


After (contact page):

<img width="458" alt="Screenshot 2023-02-24 at 9 13 51 am" src="https://user-images.githubusercontent.com/16754605/221139409-3beb6340-5731-44b9-a629-54eb01f8ff9c.png">
