### PR TITLE
Change VideoPress plugin versioning from SemVer to WordPress

### DIFF
--- a/projects/plugins/videopress/changelog/modify-videopress-plugin-versioning
+++ b/projects/plugins/videopress/changelog/modify-videopress-plugin-versioning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -45,6 +45,9 @@
 		"mirror-repo": "Automattic/jetpack-videopress-plugin",
 		"autorelease": true,
 		"autotagger": true,
+		"changelogger": {
+			"versioning": "wordpress"
+		},
 		"release-branch-prefix": "videopress",
 		"beta-plugin-slug": "jetpack-videopress",
 		"wp-plugin-slug": "jetpack-videopress",
@@ -56,6 +59,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_4_1_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_videopressⓥ1_5_alpha"
 	}
 }

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "faefaedb6a3045f6d773302b27fc511a",
+    "content-hash": "52723a4da57d238ae83d20657ef5a5e9",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VideoPress
  * Plugin URI: https://wordpress.org/plugins/jetpack-videopress
  * Description: High quality, ad-free video.
- * Version: 1.4.1-alpha
+ * Version: 1.5-alpha
  * Author: Automattic - Jetpack Video team
  * Author URI: https://jetpack.com/videopress/
  * License: GPLv2 or later


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Change [versioning setting](https://github.com/Automattic/jetpack-changelogger#configuration) for the VideoPress standalone plugin so it uses WordPress versioning instead of SemVer.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1677228438833339-slack-C03TA48NSUX
pdWQjU-fo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack release plugins/videopress changelog` and choose a stable version. 
* Check  the`/plugins/videopress/jetpack-videopress.php` file:

| Expected version with this change | Expected version without this change |
|  :---:   |  :---:   |
| **1.5** |  **1.4.1** |

