### PR TITLE
Allowing getting posts by ids in GET /posts response using include array

### DIFF
--- a/projects/plugins/jetpack/changelog/update-getting-posts-by-ids
+++ b/projects/plugins/jetpack/changelog/update-getting-posts-by-ids
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allowing getting posts by ids in GET /posts response using include array

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
@@ -41,6 +41,7 @@ new WPCOM_JSON_API_List_Posts_Endpoint(
 			'term'         => '(object:string) Specify comma-separated term slugs to search within, indexed by taxonomy slug.',
 			'type'         => "(string) Specify the post type. Defaults to 'post', use 'any' to query for both posts and pages. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
 			'parent_id'    => '(int) Returns only posts which are children of the specified post. Applies only to hierarchical post types.',
+			'include'      => '(array:int|int) Includes the specified post ID(s) in the response',
 			'exclude'      => '(array:int|int) Excludes the specified post ID(s) from the response',
 			'exclude_tree' => '(int) Excludes the specified post and all of its descendants from the response. Applies only to hierarchical post types.',
 			'status'       => array(
@@ -195,6 +196,10 @@ class WPCOM_JSON_API_List_Posts_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			$query['has_password'] = false;
 		}
 
+		if ( isset( $args['include'] ) ) {
+			$query['post__in'] = is_array( $args['include'] ) ? $args['include'] : array( (int) $args['include'] );
+		}
+
 		if ( isset( $args['meta_key'] ) ) {
 			$show = false;
 			if ( WPCOM_JSON_API_Metadata::is_public( $args['meta_key'] ) ) {
@@ -225,7 +230,7 @@ class WPCOM_JSON_API_List_Posts_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			is_array( $sticky )
 		) {
 			if ( $args['sticky'] ) {
-				$query['post__in'] = $sticky;
+				$query['post__in'] = isset( $args['include'] ) ? array_merge( $query['post__in'], $sticky ) : $sticky;
 			} else {
 				$query['post__not_in']        = $sticky;
 				$query['ignore_sticky_posts'] = 1;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -222,7 +222,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		}
 
 		if ( isset( $args['include'] ) ) {
-			$query['post__in'] = $args['include'];
+			$query['post__in'] = is_array( $args['include'] ) ? $args['include'] : array( (int) $args['include'] );
 		}
 
 		if ( isset( $args['meta_key'] ) ) {
@@ -256,7 +256,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		} elseif ( 'require' === $args['sticky'] ) {
 			$sticky = get_option( 'sticky_posts' );
 			if ( is_array( $sticky ) && ! empty( $sticky ) ) {
-				$query['post__in'] = $sticky;
+				$query['post__in'] = isset( $args['include'] ) ? array_merge( $query['post__in'], $sticky ) : $sticky;
 			} else {
 				// no sticky posts exist.
 				return array(

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -45,6 +45,7 @@ new WPCOM_JSON_API_List_Posts_v1_1_Endpoint(
 			'term'            => '(object:string) Specify comma-separated term slugs to search within, indexed by taxonomy slug.',
 			'type'            => "(string) Specify the post type. Defaults to 'post', use 'any' to query for both posts and pages. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
 			'parent_id'       => '(int) Returns only posts which are children of the specified post. Applies only to hierarchical post types.',
+			'include'         => '(array:int|int) Includes the specified post ID(s) in the response',
 			'exclude'         => '(array:int|int) Excludes the specified post ID(s) from the response',
 			'exclude_tree'    => '(int) Excludes the specified post and all of its descendants from the response. Applies only to hierarchical post types.',
 			'status'          => '(string) Comma-separated list of statuses for which to query, including any of: "publish", "private", "draft", "pending", "future", and "trash", or simply "any". Defaults to "publish"',
@@ -218,6 +219,10 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 
 		if ( ! is_user_logged_in() ) {
 			$query['has_password'] = false;
+		}
+
+		if ( isset( $args['include'] ) ) {
+			$query['post__in'] = $args['include'];
 		}
 
 		if ( isset( $args['meta_key'] ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -46,6 +46,7 @@ new WPCOM_JSON_API_List_Posts_v1_2_Endpoint(
 			'type'                  => "(string) Specify the post type. Defaults to 'post', use 'any' to query for both posts and pages. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
 			'exclude_private_types' => '(bool=false) Use this flag together with `type=any` to get only publicly accessible posts.',
 			'parent_id'             => '(int) Returns only posts which are children of the specified post. Applies only to hierarchical post types.',
+			'include'               => '(array:int|int) Includes the specified post ID(s) in the response',
 			'exclude'               => '(array:int|int) Excludes the specified post ID(s) from the response',
 			'exclude_tree'          => '(int) Excludes the specified post and all of its descendants from the response. Applies only to hierarchical post types.',
 			'status'                => '(string) Comma-separated list of statuses for which to query, including any of: "publish", "private", "draft", "pending", "future", and "trash", or simply "any". Defaults to "publish"',
@@ -187,6 +188,10 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 			$query['has_password'] = false;
 		}
 
+		if ( isset( $args['include'] ) ) {
+			$query['post__in'] = is_array( $args['include'] ) ? $args['include'] : array( (int) $args['include'] );
+		}
+
 		if ( isset( $args['meta_key'] ) ) {
 			$show = false;
 			if ( WPCOM_JSON_API_Metadata::is_public( $args['meta_key'] ) ) {
@@ -218,7 +223,7 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 		} elseif ( 'require' === $args['sticky'] ) {
 			$sticky = get_option( 'sticky_posts' );
 			if ( is_array( $sticky ) && ! empty( $sticky ) ) {
-				$query['post__in'] = $sticky;
+				$query['post__in'] = isset( $args['include'] ) ? array_merge( $query['post__in'], $sticky ) : $sticky;
 			} else {
 				// no sticky posts exist.
 				return array(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/73760

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We're adding the ability to get /posts by their IDs, so we can easily load a chunk of posts on Calypso

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this code to your sandbox. You can use the `Connecting to your Sandbox` notes at: pdWQjU-77-p2#example-use-case
* Apply [these changes](https://github.com/Automattic/wp-calypso/pull/73760) to your local calypso
* Access a popular site you have and make sure we're listing posts and pages by their views at the top of /advertising items
* Tip: Comment [these lines](https://github.com/Automattic/wp-calypso/blob/update/filter-advertising-by-views-v2/client/my-sites/promote-post/main.tsx#L122-L143) and access any private site from automattic that have more views, like the explorers p2.
* You should be able to see /advertising posts and note that we're loading a chunck of them by calling `https://public-api.wordpress.com/rest/v1.1/sites/163795312/posts?http_envelope=1&include%5B%5D=0&include%5B%5D=8671...`

We can also validate it directly by calling the API endpoint passing the posts_ids we want to load, example `/sites/163795312/posts?http_envelope=1&include[]=8671&include[]=9310&include[]=9794`:

<img width="881" alt="image" src="https://user-images.githubusercontent.com/1044309/221189403-1e785d80-f596-4743-95d4-176e1f9c4223.png">


