### PR TITLE
Fixes tests for Sync posts delete event type.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-test-sync-posts-delete-event-type
+++ b/projects/plugins/jetpack/changelog/fix-test-sync-posts-delete-event-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Test fix: adapted the Sync test to WordPress Core changes in post deletion mechanics.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -134,7 +134,11 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		wp_delete_post( $this->post->ID, true );
 
 		$this->sender->do_sync();
-		$event = $this->server_event_storage->get_most_recent_event();
+
+		// Only getting the deleted_post event types because the latest might be
+		// an option update for post counts.
+		// @see https://core.trac.wordpress.org/changeset/55419/trunk
+		$event = $this->server_event_storage->get_most_recent_event( 'deleted_post' );
 
 		$this->assertEquals( 'deleted_post', $event->action );
 		$this->assertEquals( $this->post->ID, $event->args[0] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Jetpack Monorepo tests on WordPress trunk.

## Proposed changes:
* Added an event type for Sync event lookup to avoid it being overrun by the option update that follows it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Run PHPUnit
```bash
cd ~/workspace/jetpack/projects/plugins/jetpack
WP_DEVELOP_DIR=~/workspace/wordpress-develop/tests/phpunit/ ./vendor/bin/phpunit -c ./tests/php.multisite.xml --filter=test_delete_post_syncs_event
```
* Make sure the test passes.

