### PR TITLE
jetpack-mu-wpcom: fix undefined is_plugin_active fatal on wpcom

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-is-plugin-active
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-is-plugin-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix undefined is_plugin_active fatal on wpcom.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -49,6 +49,9 @@ class Jetpack_Mu_Wpcom {
 		 * On WoA sites, users may be using non-symlinked older versions of the FSE plugin.
 		 * If they are, check the active version to avoid redeclaration errors.
 		 */
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 		$invalid_fse_version_active = is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) && version_compare( get_plugin_data( WP_PLUGIN_DIR . '/full-site-editing/full-site-editing-plugin.php' )['Version'], '3.56084', '<' );
 		if ( $invalid_fse_version_active ) {
 			return;


### PR DESCRIPTION
## Proposed changes:

Fix the following fatal on wpcom that surfaced from #28932

```
PHP Fatal error:  Uncaught Error: Call to undefined function Automattic\Jetpack\is_plugin_active() in ...jetpack-mu-wpcom-plugin/production/vendor/automattic/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php:52
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal: p1677262859532259/1677260163.446909-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Test the newly built `mu-wpcom-plugin` on your sandbox and make sure there is no fatal:

> bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/mu-wpcom-is-plugin-active
