### PR TITLE
VideoPress: set poster height in block sidebar based on video ratio

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-set-poster-preview-size-based-on-video-ratio
+++ b/projects/packages/videopress/changelog/update-videopress-set-poster-preview-size-based-on-video-ratio
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: set poster height in block sidebar based on video ratio

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -3,6 +3,7 @@
  */
 import { MediaUploadCheck, MediaUpload } from '@wordpress/block-editor';
 import { MenuItem, PanelBody, NavigableMenu, Dropdown, Button } from '@wordpress/components';
+import { useRef, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { linkOff, image as imageIcon } from '@wordpress/icons';
 /**
@@ -39,9 +40,24 @@ export function PosterDropdown( {
 	const selectPosterLabel = __( 'Select Poster Image', 'jetpack-videopress-pkg' );
 	const replacePosterLabel = __( 'Replace Poster Image', 'jetpack-videopress-pkg' );
 
-	const imageStyle = {
-		backgroundImage: poster ? `url(${ poster })` : undefined,
-	};
+	const buttonRef = useRef< HTMLButtonElement >( null );
+	const videoRatio = Number( attributes?.videoRatio ) / 100 || 16 / 9;
+
+	const [ buttonImageHeight, setButtonImageHeight ] = useState( 140 );
+
+	useEffect( () => {
+		if ( ! poster || ! buttonRef?.current ) {
+			return;
+		}
+
+		const { current: buttonElement } = buttonRef;
+		const buttonWidth = buttonElement.offsetWidth;
+		if ( ! buttonWidth ) {
+			return;
+		}
+
+		setButtonImageHeight( buttonWidth * videoRatio );
+	}, [ poster, buttonRef, videoRatio ] );
 
 	return (
 		<Dropdown
@@ -49,7 +65,11 @@ export function PosterDropdown( {
 			position="top left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
-					style={ imageStyle }
+					ref={ buttonRef }
+					style={ {
+						backgroundImage: poster ? `url(${ poster })` : undefined,
+						height: buttonImageHeight,
+					} }
 					className={ `poster-panel__button ${ poster ? 'has-poster' : '' }` }
 					variant="secondary"
 					onClick={ onToggle }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -39,13 +39,17 @@ export function PosterDropdown( {
 	const selectPosterLabel = __( 'Select Poster Image', 'jetpack-videopress-pkg' );
 	const replacePosterLabel = __( 'Replace Poster Image', 'jetpack-videopress-pkg' );
 
+	const imageStyle = {
+		backgroundImage: poster ? `url(${ poster })` : undefined,
+	};
+
 	return (
 		<Dropdown
 			contentClassName="poster-panel__dropdown"
 			position="top left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
-					style={ { backgroundImage: poster ? `url(${ poster })` : undefined } }
+					style={ imageStyle }
 					className={ `poster-panel__button ${ poster ? 'has-poster' : '' }` }
 					variant="secondary"
 					onClick={ onToggle }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
@@ -15,7 +15,8 @@ body.modal-open .poster-panel__dropdown {
 			display: block;
 			text-align: center;
 			border-radius: 2px;
-			min-height: 90px;
+			min-height: 140px;
+			max-height: 512px;
 			background-color: #fAfAfA;
 			background-size: cover;
 			background-position: center center;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR sets the height of the poster image in the block sidebar based on the video ratio to show a more accurate preview of how the poster will be shown in the video player context.

Fixes https://github.com/Automattic/jetpack/issues/28781

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: set poster height in block sidebar based on video ratio

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create to VideoPress video instances with different ratios.
* Set the video poster using the same image.
* Confirm the poster image shown in the sidebar changes it's height based on each video ratio.

For instance, with my testing videos:

Video | Poster | Height (dynamic)
-----|-----|------|
<img width="998" alt="image" src="https://user-images.githubusercontent.com/77539/221544513-5824a3bc-f5b2-449f-bfc0-d63c2d08ab9e.png"> | <img width="285" alt="image" src="https://user-images.githubusercontent.com/77539/221544584-09c8cf61-d29d-411e-b907-aa877f07dd6c.png"> | `234.77`
<img width="992" alt="image" src="https://user-images.githubusercontent.com/77539/221544722-e4470c61-38ac-4829-9451-574dfaa65dd6.png"> | <img width="288" alt="image" src="https://user-images.githubusercontent.com/77539/221544759-912974bf-30d4-4fcd-802a-d4e321479c04.png"> | `140`
