### PR TITLE
Jetpack Forms: Add tracking of Google Sheets exports of responses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           name: jetpack-build
       - name: Extract build archive
-        run: tar --xz -xvvf build.tar.xz
+        run: tar --xz -xvvf build.tar.xz build
 
       - name: Prepare plugin zips
         id: prepare
@@ -290,7 +290,7 @@ jobs:
           name: jetpack-build
         timeout-minutes: 2  # 2022-03-15: Successful runs normally take a few seconds, but on occasion they've been taking 60+ recently.
       - name: Extract build archive
-        run: tar --xz -xvvf build.tar.xz
+        run: tar --xz -xvvf build.tar.xz build
         timeout-minutes: 1  # 2021-01-18: Successful runs seem to take a few seconds
 
       - name: Wait for prior instances of the workflow to finish

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -14,6 +14,11 @@ env:
   COMPOSER_ROOT_VERSION: "dev-trunk"
   SUMMARY: Post-Build run [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for Build run [#${{ github.event.workflow_run.id }}](${{ github.event.workflow_run.html_url }})
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
 # Note the job logic here is a bit unusual. That's because this workflow is triggered by `workflow_run`, and so is not shown on the PR by default.
 # Instead we have to manually report back, including where we could normally just skip or let a failure be handled.
 #  - If the "Build" job failed, we need to set our status as failed too (build_failed).
@@ -256,7 +261,7 @@ jobs:
           done
           [[ ! -e "artifact.zip" ]] && { echo "::error::Failed to download artifact."; exit 1; }
           unzip artifact.zip
-          tar --xz -xvvf build.tar.xz
+          tar --xz -xvvf build.tar.xz build
 
       - name: Setup WordPress
         run: trunk/.github/files/test-plugin-update/setup.sh

--- a/projects/js-packages/components/changelog/add-arrow-icons
+++ b/projects/js-packages/components/changelog/add-arrow-icons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added arrow-left and arrow-right icons to the Gridicon component

--- a/projects/js-packages/components/changelog/add-pricing-utils
+++ b/projects/js-packages/components/changelog/add-pricing-utils
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+JS Components: add pricing-utils folder to store pricing-related helper functions.

--- a/projects/js-packages/components/components/gridicon/index.tsx
+++ b/projects/js-packages/components/components/gridicon/index.tsx
@@ -19,6 +19,8 @@ class Gridicon extends Component< GridiconProps > {
 
 	needsOffset( icon, size ) {
 		const iconNeedsOffset = [
+			'gridicons-arrow-left',
+			'gridicons-arrow-right',
 			'gridicons-calendar',
 			'gridicons-cart',
 			'gridicons-folder',
@@ -46,6 +48,10 @@ class Gridicon extends Component< GridiconProps > {
 				return '';
 			case 'gridicons-audio':
 				return __( 'Has audio.', 'jetpack' );
+			case 'gridicons-arrow-left':
+				return __( 'Arrow left', 'jetpack' );
+			case 'gridicons-arrow-right':
+				return __( 'Arrow right', 'jetpack' );
 			case 'gridicons-calendar':
 				return __( 'Is an event.', 'jetpack' );
 			case 'gridicons-cart':
@@ -89,6 +95,18 @@ class Gridicon extends Component< GridiconProps > {
 				return (
 					<g>
 						<path d="M8 4v10.184C7.686 14.072 7.353 14 7 14c-1.657 0-3 1.343-3 3s1.343 3 3 3 3-1.343 3-3V7h7v4.184c-.314-.112-.647-.184-1-.184-1.657 0-3 1.343-3 3s1.343 3 3 3 3-1.343 3-3V4H8z" />
+					</g>
+				);
+			case 'gridicons-arrow-left':
+				return (
+					<g>
+						<path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+					</g>
+				);
+			case 'gridicons-arrow-right':
+				return (
+					<g>
+						<path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z" />
 					</g>
 				);
 			case 'gridicons-block':

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -20,6 +20,7 @@ export { default as JetpackVaultPressBackupLogo } from './components/jetpack-vau
 export { default as JetpackVideoPressLogo } from './components/jetpack-videopress-logo';
 export { default as getRedirectUrl } from './tools/jp-redirect';
 export { default as getProductCheckoutUrl } from './tools/get-product-checkout-url';
+export { isFirstMonthTrial } from './tools/pricing-utils';
 export { default as AutomatticBylineLogo } from './components/automattic-byline-logo';
 export { default as JetpackFooter } from './components/jetpack-footer';
 export { default as Spinner } from './components/spinner';

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.27.8-alpha",
+	"version": "0.28.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/components/tools/pricing-utils/README.md
+++ b/projects/js-packages/components/tools/pricing-utils/README.md
@@ -1,0 +1,16 @@
+# Pricing Utils
+
+This is a helper folder that contains util functions related to pricing (e.g. Intro Offers) and can be extended to include other methods.
+
+## Usage
+
+### isFirstMonthTrial
+
+```jsx
+import { isFirstMonthTrial } from '@automattic/jetpack-components';
+isFirstMonthTrial( introOffer );
+```
+
+#### introOffer (required)
+
+An Intro Offer object returned by the API. It must contain an `interval_unit` and `interval_count` for the function to check if it's a first month trial or not. It returns `true` if `interval_unit` is `'month'` **and** `interval_count` is `1`, all other combinations return `false`.

--- a/projects/js-packages/components/tools/pricing-utils/index.ts
+++ b/projects/js-packages/components/tools/pricing-utils/index.ts
@@ -1,0 +1,11 @@
+import { IntroOffer } from './types';
+
+/**
+ * Returns whether an Introductory Offer is a first month trial
+ *
+ * @param {IntroOffer} introOffer - an intro offer object
+ * @returns {boolean}               Whether it's a first month trial or not
+ */
+export function isFirstMonthTrial( introOffer: IntroOffer ): boolean {
+	return introOffer?.interval_count === 1 && introOffer?.interval_unit === 'month';
+}

--- a/projects/js-packages/components/tools/pricing-utils/test/index.ts
+++ b/projects/js-packages/components/tools/pricing-utils/test/index.ts
@@ -1,0 +1,39 @@
+import { isFirstMonthTrial } from '..';
+import { IntroOffer } from './../types';
+
+const trialIntroOffer: IntroOffer = {
+	product_id: 0,
+	product_slug: 'test_product',
+	currency_code: 'USD',
+	formatted_price: '$10',
+	original_price: 10,
+	raw_price: 1,
+	discount_percentage: 90,
+	ineligible_reason: null,
+	interval_unit: 'month',
+	interval_count: 1,
+};
+
+describe( 'isFirstMonthTrial', () => {
+	it( 'returns true if interval_unit is "month" and interval_count is 1', () => {
+		expect( isFirstMonthTrial( trialIntroOffer ) ).toBe( true );
+	} );
+
+	it( 'returns false if interval_unit is not "month"', () => {
+		const introOffer: IntroOffer = {
+			...trialIntroOffer,
+			interval_unit: 'year',
+		};
+
+		expect( isFirstMonthTrial( introOffer ) ).toBe( false );
+	} );
+
+	it( "returns false if interval_unit not 'month' but interval_count isn't 1", () => {
+		const introOffer: IntroOffer = {
+			...trialIntroOffer,
+			interval_count: 3,
+		};
+
+		expect( isFirstMonthTrial( introOffer ) ).toBe( false );
+	} );
+} );

--- a/projects/js-packages/components/tools/pricing-utils/types.ts
+++ b/projects/js-packages/components/tools/pricing-utils/types.ts
@@ -1,0 +1,12 @@
+export interface IntroOffer {
+	product_id: number;
+	product_slug: string;
+	currency_code: string;
+	formatted_price: string;
+	original_price: number;
+	raw_price: number;
+	discount_percentage: number;
+	ineligible_reason: string[] | null;
+	interval_unit: string;
+	interval_count: number;
+}

--- a/projects/js-packages/publicize-components/changelog/remove-sig-default-image
+++ b/projects/js-packages/publicize-components/changelog/remove-sig-default-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed default image for SIG as it's not used yet

--- a/projects/js-packages/publicize-components/src/components/social-image-generator/panel/index.js
+++ b/projects/js-packages/publicize-components/src/components/social-image-generator/panel/index.js
@@ -43,15 +43,9 @@ const SocialImageGeneratorPanel = ( { prePublish = false } ) => {
 							value: 'featured',
 						},
 						{ label: __( 'Custom Image', 'jetpack' ), value: 'custom' },
-						{ label: __( 'Default Image', 'jetpack' ), value: 'default' },
 						{ label: __( 'No Image', 'jetpack' ), value: 'none' },
 					] }
 					onChange={ setImageType }
-					help={
-						imageType === 'default'
-							? __( 'You can change the default image by clicking the Edit link below.', 'jetpack' )
-							: null
-					}
 				/>
 
 				{ imageType === 'custom' && (

--- a/projects/packages/forms/changelog/add-jetpack-forms-dashboard-page-navigation
+++ b/projects/packages/forms/changelog/add-jetpack-forms-dashboard-page-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added a page navigation component for the new feedback dashboard

--- a/projects/packages/forms/changelog/add-tracking_form_exports
+++ b/projects/packages/forms/changelog/add-tracking_form_exports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Forms: Add tracking of Google Sheets exports

--- a/projects/packages/forms/changelog/replace-feedback-menu-with-forms-dashboard
+++ b/projects/packages/forms/changelog/replace-feedback-menu-with-forms-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Forms dashboard now replaces the "Feedback" menu entry in WP Admin.

--- a/projects/packages/forms/changelog/update-form-field-padding
+++ b/projects/packages/forms/changelog/update-form-field-padding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Increase form fields padding based on user-defined border-radius

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -22,18 +22,7 @@ class Jetpack_Forms {
 	public static function load_contact_form() {
 		Util::init();
 
-		if (
-			is_admin()
-			/**
-			 * Enable the new Jetpack Forms dashboard.
-			 *
-			 * @module contact-form
-			 * @since 0.3.0
-			 *
-			 * @param bool false Should the new Jetpack Forms dashboard be enabled? Default to false.
-			 */
-			&& apply_filters( 'jetpack_forms_dashboard_enable', false )
-		) {
+		if ( is_admin() && self::is_feedback_dashboard_enabled() ) {
 			$dashboard = new Dashboard();
 			$dashboard->init();
 		}
@@ -52,5 +41,22 @@ class Jetpack_Forms {
 	 */
 	public static function plugin_url() {
 		return plugin_dir_url( __FILE__ );
+	}
+
+	/**
+	 * Returns true if the feedback dashboard is enabled.
+	 *
+	 * @return boolean
+	 */
+	public static function is_feedback_dashboard_enabled() {
+		/**
+		 * Enable the new Jetpack Forms dashboard.
+		 *
+		 * @module contact-form
+		 * @since 0.3.0
+		 *
+		 * @param bool false Should the new Jetpack Forms dashboard be enabled? Default to false.
+		 */
+		return apply_filters( 'jetpack_forms_dashboard_enable', false );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -223,6 +223,8 @@ class Admin {
 
 		$sheet = Google_Drive::create_sheet( $user_id, $spreadsheet_title, $sheet_data );
 
+		$grunion->record_tracks_event( 'forms_export_responses', array( 'format' => 'gsheets' ) );
+
 		wp_send_json(
 			array(
 				'success' => ! is_wp_error( $sheet ),

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Forms\Dashboard;
 
-use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 
 /**
@@ -16,9 +15,8 @@ use Automattic\Jetpack\Assets;
 class Dashboard {
 
 	/**
-	 * Priority for the dashboard menu
-	 * For Jetpack sites: Jetpack uses 998 and 'Admin_Menu' uses 1000, so we need to use 999.
-	 * For simple site: the value is overriden in a child class with value 100000 to wait for all menus to be registered.
+	 * Priority for the dashboard menu.
+	 * Needs to be high enough for us to be able to unregister the default edit.php menu item.
 	 *
 	 * @var int
 	 */
@@ -38,7 +36,7 @@ class Dashboard {
 	 * @param string $hook The current admin page.
 	 */
 	public function load_admin_scripts( $hook ) {
-		if ( 'jetpack_page_jetpack-forms' !== $hook ) {
+		if ( 'toplevel_page_jetpack-forms' !== $hook ) {
 			return;
 		}
 
@@ -69,13 +67,16 @@ class Dashboard {
 	 * Register the dashboard admin submenu.
 	 */
 	public function add_admin_submenu() {
-		Admin_Menu::add_menu(
-			__( 'Jetpack Forms', 'jetpack-forms' ),
-			_x( 'Jetpack Forms', 'product name shown in menu', 'jetpack-forms' ),
+		remove_menu_page( 'feedback' );
+
+		add_menu_page(
+			__( 'Form Responses', 'jetpack-forms' ),
+			_x( 'Feedback', 'post type name shown in menu', 'jetpack-forms' ),
 			'read',
 			'jetpack-forms',
 			array( $this, 'render_dashboard' ),
-			100
+			'dashicons-feedback',
+			25 // Places 'Feedback' under 'Comments' in the menu
 		);
 	}
 

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -1,4 +1,4 @@
-body.jetpack_page_jetpack-forms {
+body.toplevel_page_jetpack-forms {
 	background-color: #fff;
 
 	#wpcontent {

--- a/projects/packages/forms/src/dashboard/components/page-navigation/index.js
+++ b/projects/packages/forms/src/dashboard/components/page-navigation/index.js
@@ -1,0 +1,77 @@
+import { Gridicon } from '@automattic/jetpack-components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { filter, flatten, map, range } from 'lodash';
+import PageNumber from './page-number';
+
+import './style.scss';
+
+const PageNavigation = ( { currentPage, expandedRange = 3, onSelectPage, pages } ) => {
+	const goToPrevious = useCallback( () => onSelectPage( currentPage - 1 ), [
+		currentPage,
+		onSelectPage,
+	] );
+	const goToNext = useCallback( () => onSelectPage( currentPage + 1 ), [
+		currentPage,
+		onSelectPage,
+	] );
+
+	const currentRange = range(
+		Math.max( 0, currentPage - expandedRange + 1 ),
+		Math.min( pages, currentPage + expandedRange - 1 ) + 1
+	);
+	const totalRange = filter(
+		flatten( [
+			expandedRange < currentPage && 1,
+			expandedRange + 1 < currentPage && ( currentPage === expandedRange + 2 ? 2 : Infinity ),
+			currentRange,
+			currentPage < pages - expandedRange &&
+				( currentPage === pages - expandedRange ? pages - 1 : Infinity ),
+			currentPage < pages - expandedRange + 1 && pages,
+		] )
+	);
+
+	return (
+		<div className="jp-forms__page-navigation">
+			<button
+				disabled={ currentPage === 1 }
+				className="jp-forms__page-navigation-button"
+				onClick={ goToPrevious }
+			>
+				<Gridicon icon="arrow-left" size={ 18 } />
+				{ __( 'Previous', 'jetpack-forms' ) }
+			</button>
+
+			{ map( totalRange, ( n, index ) =>
+				! isFinite( n ) ? (
+					<button
+						key={ `placeholder-${ index }` }
+						className="jp-forms__page-navigation-placeholder"
+						disabled
+					>
+						…
+					</button>
+				) : (
+					<PageNumber
+						key={ n }
+						className="jp-forms__page-navigation-button"
+						active={ n === currentPage }
+						page={ n }
+						onSelect={ onSelectPage }
+					/>
+				)
+			) }
+
+			<button
+				disabled={ currentPage === pages }
+				className="jp-forms__page-navigation-button"
+				onClick={ goToNext }
+			>
+				{ __( 'Next', 'jetpack-forms' ) }
+				<Gridicon icon="arrow-right" size={ 18 } />
+			</button>
+		</div>
+	);
+};
+
+export default PageNavigation;

--- a/projects/packages/forms/src/dashboard/components/page-navigation/page-number.js
+++ b/projects/packages/forms/src/dashboard/components/page-navigation/page-number.js
@@ -1,0 +1,18 @@
+import { useCallback } from '@wordpress/element';
+import classNames from 'classnames';
+
+const PageNumber = ( { active, className, page, onSelect } ) => {
+	const buttonClass = classNames( 'jp-forms__page-navigation-page-number', className, {
+		'is-active': active,
+	} );
+
+	const selectPage = useCallback( () => onSelect( page ), [ page, onSelect ] );
+
+	return (
+		<button className={ buttonClass } onClick={ selectPage }>
+			{ page }
+		</button>
+	);
+};
+
+export default PageNumber;

--- a/projects/packages/forms/src/dashboard/components/page-navigation/style.scss
+++ b/projects/packages/forms/src/dashboard/components/page-navigation/style.scss
@@ -1,0 +1,55 @@
+.jp-forms__page-navigation {
+	background-color: #fff;
+	border: 1px solid #dcdcde;
+	border-radius: 3px;
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: row;
+	height: 36px;
+	justify-content: center;
+	padding: 0;
+	width: fit-content;
+}
+
+.jp-forms__page-navigation-button,
+.jp-forms__page-navigation-button:hover,
+.jp-forms__page-navigation-placeholder:hover,
+.jp-forms__page-navigation-placeholder {
+	background: transparent;
+	border: 0;
+	box-sizing: border-box;
+	color: #101517;
+	cursor: pointer;
+	display: inline-flex;
+	font-weight: bold;
+	font-size: 13px;
+	height: 34px;
+	line-height: 18px;
+	text-align: center;
+	padding: 8px 12px;
+
+	&.is-active {
+		background-color: #101517;
+		color: #fff;
+	}
+
+	&:disabled {
+		cursor: default;
+
+		&:first-child, &:last-child {
+			color: #dcdcde;
+		}
+	}
+
+	.gridicon {
+		display: inline-flex;
+
+		&.gridicons-arrow-left {
+			margin-right: 3px;
+		}
+
+		&.gridicons-arrow-right {
+			margin-left: 3px;
+		}
+	}
+}

--- a/projects/packages/forms/src/dashboard/inbox/list.js
+++ b/projects/packages/forms/src/dashboard/inbox/list.js
@@ -1,5 +1,7 @@
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { noop } from 'lodash';
+import PageNavigation from '../components/page-navigation';
 import Table from '../components/table';
 
 const COLUMNS = [
@@ -51,6 +53,8 @@ const DATA = [
 ];
 
 const InboxList = () => {
+	const [ currentPage, setCurrentPage ] = useState( 1 );
+
 	return (
 		<>
 			<Table
@@ -58,6 +62,13 @@ const InboxList = () => {
 				columns={ COLUMNS }
 				items={ DATA }
 				onSelectionChange={ noop }
+			/>
+
+			<PageNavigation
+				currentPage={ currentPage }
+				pages={ 10 }
+				onSelectPage={ setCurrentPage }
+				expandedRange={ 2 }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -12,8 +12,11 @@
 }
 
 .jp-forms__inbox-content-column {
+	align-items: center;
 	box-sizing: border-box;
+	display: flex;
 	flex: 3;
+	flex-direction: column;
 
 	&:last-child {
 		display: none;
@@ -23,6 +26,10 @@
 			display: flex;
 			flex: 2;
 		}
+	}
+
+	.jp-forms__page-navigation {
+		margin: 16px 0;
 	}
 }
 

--- a/projects/packages/ip/changelog/add-get-ip-addresses-from-string-method
+++ b/projects/packages/ip/changelog/add-get-ip-addresses-from-string-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a utility function to extract an array of IP addresses from a given string.

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -167,4 +167,80 @@ class Utils {
 		return false;
 	}
 
+	/**
+	 * Extracts IP addresses from a given string.
+	 *
+	 * We allow for both, one IP per line or comma-; semicolon; or whitespace-separated lists. This also validates the IP addresses
+	 * and only returns the ones that look valid. IP ranges using the "-" character are also supported.
+	 *
+	 * @param string $ips List of ips - example: "8.8.8.8\n4.4.4.4,2.2.2.2;1.1.1.1 9.9.9.9,5555.5555.5555.5555,1.1.1.10-1.1.1.20".
+	 * @return array List of valid IP addresses. - example based on input example: array('8.8.8.8', '4.4.4.4', '2.2.2.2', '1.1.1.1', '9.9.9.9', '1.1.1.10-1.1.1.20')
+	 */
+	public static function get_ip_addresses_from_string( $ips ) {
+		$ips = (string) $ips;
+		$ips = preg_split( '/[\s,;]/', $ips );
+
+		$result = array();
+
+		foreach ( $ips as $ip ) {
+			// Validate both IP values from the range.
+			$range = explode( '-', $ip );
+			if ( count( $range ) === 2 ) {
+				if ( self::validate_ip_range( $range[0], $range[1] ) ) {
+					$result[] = $ip;
+				}
+				continue;
+			}
+
+			// Validate the single IP value.
+			if ( filter_var( $ip, FILTER_VALIDATE_IP ) !== false ) {
+				$result[] = $ip;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Validates the low and high IP addresses of a range.
+	 *
+	 * NOTE: servers that do not support inet_pton cannot support ipv6.
+	 *
+	 * @param string $range_low  Low IP address.
+	 * @param string $range_high High IP address.
+	 * @return bool True if the range is valid, false otherwise.
+	 */
+	public static function validate_ip_range( $range_low, $range_high ) {
+		// Validate that both IP addresses are valid.
+		if ( ! filter_var( $range_low, FILTER_VALIDATE_IP ) || ! filter_var( $range_high, FILTER_VALIDATE_IP ) ) {
+			return false;
+		}
+
+		// Validate that the $range_low is lower or equal to $range_high.
+		if ( function_exists( 'inet_pton' ) ) {
+			// The inet_pton will give us binary string of an ipv4 or ipv6.
+			// We can then use strcmp to see if the address is in range.
+			$ip_low  = inet_pton( $range_low );
+			$ip_high = inet_pton( $range_high );
+			if ( false === $ip_low || false === $ip_high ) {
+				return false;
+			}
+			if ( strcmp( $ip_low, $ip_high ) > 0 ) {
+				return false;
+			}
+		} else {
+			// The ip2long will give us an integer of an ipv4 address only. it will produce FALSE for ipv6.
+			$ip_low  = ip2long( $range_low );
+			$ip_high = ip2long( $range_high );
+			if ( false === $ip_low || false === $ip_high ) {
+				return false;
+			}
+			if ( $ip_low > $ip_high ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 }

--- a/projects/packages/ip/tests/php/test-utils.php
+++ b/projects/packages/ip/tests/php/test-utils.php
@@ -305,4 +305,55 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 		$this->assertFalse( Utils::ip_address_is_in_range( $out_range_ip, $range_low, $range_high ) );
 	}
 
+	/**
+	 * Test `get_ip_addresses_from_string`.
+	 * Covers IPv4 and IPv6 addresses, including ranges, concatenated with various delimiters.
+	 *
+	 * @covers ::get_ip_addresses_from_string
+	 */
+	public function test_get_ip_addresses_from_string() {
+		$ip_string =
+			// IPv4.
+			"1.1.1.1\n2.2.2.2,3.3.3.3;4.4.4.4 5.5.5.5-6.6.6.6\n" .
+			// IPv6.
+			"2001:db8::1\n2001:db8::2,2001:db8::3;2001:db8::4 2001:db8::5-2001:db8::6\n" .
+			// Invalid IP addresses.
+			'hello world - 1.2.3:4,9999:9999:9999.9999:9999:9999:9999';
+
+		$expected = array(
+			'1.1.1.1',
+			'2.2.2.2',
+			'3.3.3.3',
+			'4.4.4.4',
+			'5.5.5.5-6.6.6.6',
+			'2001:db8::1',
+			'2001:db8::2',
+			'2001:db8::3',
+			'2001:db8::4',
+			'2001:db8::5-2001:db8::6',
+		);
+
+		$this->assertEquals( $expected, Utils::get_ip_addresses_from_string( $ip_string ) );
+	}
+
+	/**
+	 * Test `validate_ip_range`.
+	 *
+	 * @covers ::validate_ip_range
+	 */
+	public function test_validate_ip_range() {
+		// Valid range.
+		$this->assertTrue( Utils::validate_ip_range( '1.1.1.1', '2.2.2.2' ) );
+		$this->assertTrue( Utils::validate_ip_range( '2001:db8::1', '2001:db8::2' ) );
+
+		// Invalid ranges.
+		$this->assertFalse( Utils::validate_ip_range( '2.2.2.2', '1.1.1.1' ) );
+		$this->assertFalse( Utils::validate_ip_range( '2001:db8::2', '2001:db8::1' ) );
+		$this->assertFalse( Utils::validate_ip_range( '1.1.1', '2.2.2.2' ) );
+
+		// Ranges with the same low and high address are still considered valid.
+		$this->assertTrue( Utils::validate_ip_range( '1.1.1.1', '1.1.1.1' ) );
+		$this->assertTrue( Utils::validate_ip_range( '2001:db8::1', '2001:db8::1' ) );
+	}
+
 }

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-is-plugin-active
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-is-plugin-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix undefined is_plugin_active fatal on wpcom.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -49,6 +49,9 @@ class Jetpack_Mu_Wpcom {
 		 * On WoA sites, users may be using non-symlinked older versions of the FSE plugin.
 		 * If they are, check the active version to avoid redeclaration errors.
 		 */
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
 		$invalid_fse_version_active = is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) && version_compare( get_plugin_data( WP_PLUGIN_DIR . '/full-site-editing/full-site-editing-plugin.php' )['Version'], '3.56084', '<' );
 		if ( $invalid_fse_version_active ) {
 			return;

--- a/projects/packages/videopress/changelog/update-videopress-remove-poster-from-imgage-when-uploading-video
+++ b/projects/packages/videopress/changelog/update-videopress-remove-poster-from-imgage-when-uploading-video
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+VideoPress: remove uploading image for video poster when uploading video

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -41,7 +41,7 @@ export function PosterDropdown( {
 	const replacePosterLabel = __( 'Replace Poster Image', 'jetpack-videopress-pkg' );
 
 	const buttonRef = useRef< HTMLButtonElement >( null );
-	const videoRatio = Number( attributes?.videoRatio ) / 100 || 16 / 9;
+	const videoRatio = Number( attributes?.videoRatio ) / 100 || 9 / 16;
 
 	const [ buttonImageHeight, setButtonImageHeight ] = useState( 140 );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-editor.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-editor.js
@@ -3,7 +3,7 @@
  */
 import { MediaUpload } from '@wordpress/block-editor';
 import { Button, BaseControl } from '@wordpress/components';
-import { createInterpolateElement, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -74,31 +74,9 @@ const PosterActions = ( { hasPoster, onSelectPoster, onRemovePoster } ) => {
 
 	return (
 		<span className="uploading-editor__scrubber-help">
-			{ createInterpolateElement(
-				__(
-					'This is how the video will look. Use the slider to choose a poster or <a>select a custom one</a>.',
-					'jetpack-videopress-pkg'
-				),
-				{
-					a: (
-						<MediaUpload
-							title={ __( 'Select Poster Image', 'jetpack-videopress-pkg' ) }
-							onSelect={ onSelectPoster }
-							allowedTypes={ VIDEO_POSTER_ALLOWED_MEDIA_TYPES }
-							render={ ( { open } ) => (
-								<a
-									className="uploading-editor__upload-link"
-									onClick={ open }
-									onKeyDown={ open }
-									role="button"
-									tabIndex={ 0 }
-								>
-									{ __( 'select a custom one', 'jetpack-videopress-pkg' ) }
-								</a>
-							) }
-						/>
-					),
-				}
+			{ __(
+				'This is how the video will look. Use the slider to choose a poster image.',
+				'jetpack-videopress-pkg'
 			) }
 		</span>
 	);

--- a/projects/packages/waf/changelog/add-ip-range-support
+++ b/projects/packages/waf/changelog/add-ip-range-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added support for IP ranges in allow and block lists.

--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -6,6 +6,7 @@
 	"require": {
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-ip": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"wikimedia/aho-corasick": "^1.0"
 	},
@@ -56,7 +57,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.9.x-dev"
+			"dev-trunk": "0.10.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\IP\Utils as IP_Utils;
 use Jetpack_Options;
 use WP_Error;
 
@@ -260,28 +261,6 @@ class Waf_Rules_Manager {
 	}
 
 	/**
-	 * We allow for both, one IP per line or comma-; semicolon; or whitespace-separated lists. This also validates the IP addresses
-	 * and only returns the ones that look valid.
-	 *
-	 * @param string $ips List of ips - example: "8.8.8.8\n4.4.4.4,2.2.2.2;1.1.1.1 9.9.9.9,5555.5555.5555.5555".
-	 * @return array List of valid IP addresses. - example based on input example: array('8.8.8.8', '4.4.4.4', '2.2.2.2', '1.1.1.1', '9.9.9.9')
-	 */
-	public static function ip_option_to_array( $ips ) {
-		$ips = (string) $ips;
-		$ips = preg_split( '/[\s,;]/', $ips );
-
-		$result = array();
-
-		foreach ( $ips as $ip ) {
-			if ( filter_var( $ip, FILTER_VALIDATE_IP ) !== false ) {
-				$result[] = $ip;
-			}
-		}
-
-		return $result;
-	}
-
-	/**
 	 * Generates the rules.php script
 	 *
 	 * @throws \Exception If filesystem is not available.
@@ -309,8 +288,8 @@ class Waf_Rules_Manager {
 			$wp_filesystem->mkdir( dirname( $block_ip_file_path ) );
 		}
 
-		$allow_list = self::ip_option_to_array( get_option( self::IP_ALLOW_LIST_OPTION_NAME ) );
-		$block_list = self::ip_option_to_array( get_option( self::IP_BLOCK_LIST_OPTION_NAME ) );
+		$allow_list = IP_Utils::get_ip_addresses_from_string( get_option( self::IP_ALLOW_LIST_OPTION_NAME ) );
+		$block_list = IP_Utils::get_ip_addresses_from_string( get_option( self::IP_BLOCK_LIST_OPTION_NAME ) );
 
 		$allow_rules_content = '';
 		// phpcs:disable WordPress.PHP.DevelopmentFunctions

--- a/projects/packages/waf/src/class-waf-stats.php
+++ b/projects/packages/waf/src/class-waf-stats.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Waf;
 
+use Automattic\Jetpack\IP\Utils as IP_Utils;
+
 /**
  * Retrieves WAF stats.
  */
@@ -24,7 +26,7 @@ class Waf_Stats {
 			return 0;
 		}
 
-		$results = Waf_Rules_Manager::ip_option_to_array( $ip_allow_list );
+		$results = IP_Utils::get_ip_addresses_from_string( $ip_allow_list );
 
 		return count( $results );
 	}
@@ -41,7 +43,7 @@ class Waf_Stats {
 			return 0;
 		}
 
-		$results = Waf_Rules_Manager::ip_option_to_array( $ip_block_list );
+		$results = IP_Utils::get_ip_addresses_from_string( $ip_block_list );
 
 		return count( $results );
 	}

--- a/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/index.jsx
@@ -1,4 +1,5 @@
 import { getCurrencyObject } from '@automattic/format-currency';
+import { isFirstMonthTrial } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Button from 'components/button';
@@ -42,17 +43,20 @@ const ProductCardUpsellComponent = ( {
 	const { discount } = discountData;
 	const hasDiscount = useMemo( () => isCouponValid( discountData ), [ discountData ] );
 
-	const { original_price: introOriginalPrice, raw_price: introRawPrice } = useMemo(
+	const introOffer = useMemo(
 		() => introOffers.find( ( { product_slug } ) => product_slug === slug ) || {},
 		[ slug, introOffers ]
 	);
+	const { original_price: introOriginalPrice, raw_price: introRawPrice } = introOffer;
 	// introOriginalPrice is the price per year before introductory offer. Defaults to `cost`
 	// (which is cost per month) if there's no such offer available.
 	const initialPrice = introOriginalPrice || cost * 12;
 	// introRawPrice is the price after introductory offer, but before any other discount.
 	const introPrice = introRawPrice || initialPrice;
-	// Apply special discount.
-	const finalPrice = hasDiscount && discount ? introPrice * ( 1 - discount / 100 ) : introPrice;
+	const isTrial = isFirstMonthTrial( introOffer );
+	// Apply special discount if there's a discount and is not a first month trial.
+	const finalPrice =
+		! isTrial && hasDiscount && discount ? introPrice * ( 1 - discount / 100 ) : introPrice;
 
 	// Compute total discount, including introductory offer (if it exists) and special discount.
 	const totalDiscount = initialPrice
@@ -68,6 +72,14 @@ const ProductCardUpsellComponent = ( {
 		finalPrice,
 		currency,
 	] );
+
+	const checkoutUrl = new URL( upgradeUrl );
+
+	// Remove the coupon code from the URL if it's a trial.
+	// This is mostly to avoid confusion since the UI won't show the discount either
+	if ( isTrial ) {
+		checkoutUrl.searchParams.delete( 'coupon' );
+	}
 
 	const header = isRecommended && (
 		<RecommendedHeader className="jp-recommendations-product-card-upsell__header" />
@@ -125,7 +137,7 @@ const ProductCardUpsellComponent = ( {
 				className="jp-recommendations-product-card-upsell__cta-button"
 				primary={ ! isRecommended }
 				rna
-				href={ upgradeUrl }
+				href={ checkoutUrl.toString() }
 				onClick={ onClick }
 				target="_blank"
 				rel="noopener noreferrer"

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/style.scss
@@ -41,11 +41,6 @@
 			margin-bottom: 0;
 		}
 	}
-
-	.jp-recommendations-product-card-upsell,
-	.jp-recommendations-product-card-upsell__padding {
-		height: 100%;
-	}
 }
 
 .jp-recommendations-product-suggestion__money-back-guarantee {

--- a/projects/plugins/jetpack/changelog/add-jetpack-forms-dashboard-page-navigation
+++ b/projects/plugins/jetpack/changelog/add-jetpack-forms-dashboard-page-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+This change doesn't affect the plugin.

--- a/projects/plugins/jetpack/changelog/add-related-posts-block-font-family-support-server-render
+++ b/projects/plugins/jetpack/changelog/add-related-posts-block-font-family-support-server-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add block support for font family in Related Posts block server block renderer

--- a/projects/plugins/jetpack/changelog/add-rest-api-staging-site-attributes
+++ b/projects/plugins/jetpack/changelog/add-rest-api-staging-site-attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Adds `is_wpcom_staging_site`, `wpcom_production_blog_id`, and `wpcom_staging_blog_ids` attributes to the site object

--- a/projects/plugins/jetpack/changelog/add-tracking_of_gsheets_export#2
+++ b/projects/plugins/jetpack/changelog/add-tracking_of_gsheets_export#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/add-tracking_of_gsheets_export#2
+++ b/projects/plugins/jetpack/changelog/add-tracking_of_gsheets_export#2
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: Updated composer.lock.
+Comment: Jetpack Forms: Add tracking of Google Sheets exports
 
 

--- a/projects/plugins/jetpack/changelog/add-waf-ip-ranges
+++ b/projects/plugins/jetpack/changelog/add-waf-ip-ranges
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/fix-custom-css-direct-link
+++ b/projects/plugins/jetpack/changelog/fix-custom-css-direct-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Custom CSS: ensure the link to enable Custom CSS works in all languages.

--- a/projects/plugins/jetpack/changelog/fix-discount-for-first-month-trials
+++ b/projects/plugins/jetpack/changelog/fix-discount-for-first-month-trials
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Recommendations: avoid applying the coupon code from the Assistant on product with trial prices.

--- a/projects/plugins/jetpack/changelog/replace-feedback-menu-with-forms-dashboard
+++ b/projects/plugins/jetpack/changelog/replace-feedback-menu-with-forms-dashboard
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This is an internal change at the moment.
+
+

--- a/projects/plugins/jetpack/changelog/update-block-scaffold-update
+++ b/projects/plugins/jetpack/changelog/update-block-scaffold-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: update scaffolding.

--- a/projects/plugins/jetpack/changelog/update-form-field-padding
+++ b/projects/plugins/jetpack/changelog/update-form-field-padding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Increase form fields padding based on user-defined border-radius

--- a/projects/plugins/jetpack/changelog/update-form-field-padding#2
+++ b/projects/plugins/jetpack/changelog/update-form-field-padding#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/update-jetpack-to-test-11.9
+++ b/projects/plugins/jetpack/changelog/update-jetpack-to-test-11.9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack: update to-test.md for v11.9
+
+

--- a/projects/plugins/jetpack/changelog/update-launchpad-save-modal-selector-logic
+++ b/projects/plugins/jetpack/changelog/update-launchpad-save-modal-selector-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Consolidates selector logic in the launchpad save modal

--- a/projects/plugins/jetpack/changelog/update-odyssey-stats-remove-legacy-nudges
+++ b/projects/plugins/jetpack/changelog/update-odyssey-stats-remove-legacy-nudges
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Remove NewDash nudges in legacy stats

--- a/projects/plugins/jetpack/changelog/update-widget-visibility-tracks
+++ b/projects/plugins/jetpack/changelog/update-widget-visibility-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Widget Visibility: switch to shared Analytics implementation.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -177,7 +177,7 @@ class Jetpack_Admin {
 	 */
 	public static function theme_enhancements_redirect() {
 		wp_safe_redirect(
-			'admin.php?page=jetpack#/writing?term=Custom%20CSS'
+			'admin.php?page=jetpack#/writing?term=custom-css'
 		);
 		exit;
 	}

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -2010,7 +2010,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 					'title'            => $title,
 					'underscoredSlug'  => str_replace( '-', '_', $slug ),
 					'underscoredTitle' => str_replace( ' ', '_', $title ),
-					'jetpackVersion'   => substr( JETPACK__VERSION, 0, strpos( JETPACK__VERSION, '.' ) ) . '.x',
 				)
 			),
 			"$path/index.js"      => $this->render_block_file(

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1124,6 +1124,55 @@
             }
         },
         {
+            "name": "automattic/jetpack-ip",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/ip",
+                "reference": "7b9a848c16ddef248597636fbcf13f77b8637a6e"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "brain/monkey": "2.6.1",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-ip",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-ip/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-ip",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-utils.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities for working with IP addresses.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-jitm",
             "version": "dev-trunk",
             "dist": {
@@ -2304,11 +2353,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/waf",
-                "reference": "9e0055457442062de1b4b955db24a02b8191c8a4"
+                "reference": "c93147d884aff0f808231bf84618ecbdfbb153e8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "wikimedia/aho-corasick": "^1.0"
             },
@@ -2326,7 +2376,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -353,6 +353,13 @@
 	}
 }
 
+:where(:not(.contact-form)) > .jetpack-field {
+	.jetpack-field__input, .jetpack-field__textarea {
+		padding-left: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+		padding-right: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+	}
+}
+
 .jetpack-field-label__width {
 	.components-button-group {
 		display: block;

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -12,15 +12,13 @@ export const name = 'launchpad-save-modal';
 
 export const settings = {
 	render: function LaunchpadSaveModal() {
-		const isSavingSite = useSelect(
-			select => select( editorStore ).isSavingNonPostEntityChanges(),
-			[]
-		);
-		const isSavingPost = useSelect( select => select( editorStore ).isSavingPost(), [] );
-		const isPublishingPost = useSelect( select => select( editorStore ).isPublishingPost(), [] );
-		const isCurrentPostPublished = useSelect(
-			select => select( editorStore ).isCurrentPostPublished(),
-			[]
+		const { isSavingSite, isSavingPost, isPublishingPost, isCurrentPostPublished } = useSelect(
+			selector => ( {
+				isSavingSite: selector( editorStore ).isSavingNonPostEntityChanges(),
+				isSavingPost: selector( editorStore ).isSavingPost(),
+				isPublishingPost: selector( editorStore ).isPublishingPost(),
+				isCurrentPostPublished: selector( editorStore ).isCurrentPostPublished(),
+			} )
 		);
 
 		const prevIsSavingSite = usePrevious( isSavingSite );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -76,6 +76,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
 		'is_wpcom_atomic'             => '(bool) If the site is a WP.com Atomic one.',
+		'is_wpcom_staging_site'       => '(bool) If the site is a WP.com staging site.',
 		'user_interactions'           => '(array) An array of user interactions with a site.',
 	);
 
@@ -195,6 +196,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'blogging_prompts_settings',
 		'launchpad_screen',
 		'launchpad_checklist_tasks_statuses',
+		'wpcom_production_blog_id',
+		'wpcom_staging_blog_ids',
 	);
 
 	/**
@@ -557,6 +560,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'is_wpcom_atomic':
 				$response[ $key ] = $this->site->is_wpcom_atomic();
 				break;
+			case 'is_wpcom_staging_site':
+				$response[ $key ] = $this->site->is_wpcom_staging_site();
+				break;
 			case 'user_interactions':
 				$response[ $key ] = $this->site->get_user_interactions();
 				break;
@@ -852,6 +858,12 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'launchpad_checklist_tasks_statuses':
 					$options[ $key ] = $site->get_launchpad_checklist_tasks_statuses();
+					break;
+				case 'wpcom_production_blog_id':
+					$options[ $key ] = $site->get_wpcom_production_blog_id();
+					break;
+				case 'wpcom_staging_blog_ids':
+					$options[ $key ] = $site->get_wpcom_staging_blog_ids();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -1319,6 +1319,8 @@ class Grunion_Admin {
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-google-drive-helper.php';
 		$sheet = Jetpack_Google_Drive_Helper::create_sheet( $user_id, $spreadsheet_title, $sheet_data );
 
+		$grunion->record_tracks_event( 'forms_export_responses', array( 'format' => 'gsheets' ) );
+
 		wp_send_json(
 			array(
 				'success' => ! is_wp_error( $sheet ),

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -35,6 +35,11 @@
 	height: 200px;
 }
 
+.contact-form .grunion-field {
+	padding-left: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+	padding-right: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
+}
+
 .contact-form .grunion-field-wrap input,
 .contact-form .grunion-field-wrap textarea {
 	margin: 0;

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -138,8 +138,9 @@ class Jetpack_RelatedPosts {
 						'padding' => true,
 					),
 					'typography' => array(
-						'fontSize'   => true,
-						'lineHeight' => true,
+						'__experimentalFontFamily' => true,
+						'fontSize'                 => true,
+						'lineHeight'               => true,
 					),
 					'align'      => array( 'wide', 'full' ),
 				),

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -35,9 +35,10 @@ if ( defined( 'STATS_DASHBOARD_SERVER' ) ) {
 define( 'STATS_DASHBOARD_SERVER', 'dashboard.wordpress.com' );
 
 /**
- * Stats content marker.
+ * Stats content markers.
  * Used to test for content vs script when parsing server-generated HTML.
  */
+const STATS_BODY_MARKER    = '<div id="statchart"';
 const STATS_CONTENT_MARKER = '<div class="gotonewdash">';
 
 add_action( 'jetpack_modules_loaded', 'stats_load' );
@@ -477,16 +478,11 @@ function jetpack_admin_ui_stats_report_page_wrapper() {
  * @param bool $main_chart_only (default: false) Main Chart Only.
  */
 function stats_reports_page( $main_chart_only = false ) {
-	// TODO: Replace or remove "View stats on WordPress.com right now" link.
-	// Probably makes more sense to advertise Odyssey here.
-	// TODO: Remove DIV with debug tools. (currently hidden for easier testing)
-
 	if ( isset( $_GET['dashboard'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return stats_dashboard_widget_content();
 	}
 
-	$blog_id   = Stats_Options::get_option( 'blog_id' );
-	$stats_url = Redirect::get_url( 'calypso-stats' );
+	$blog_id = Stats_Options::get_option( 'blog_id' );
 
 	if ( ! $main_chart_only && ! isset( $_GET['noheader'] ) && empty( $_GET['nojs'] ) && empty( $_COOKIE['stnojs'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$nojs_url = add_query_arg( 'nojs', '1' );
@@ -526,7 +522,6 @@ function stats_reports_page( $main_chart_only = false ) {
 		</div>
 		<div id="stats-loading-wrap" class="wrap">
 		<p class="hide-if-no-js"><img width="32" height="32" alt="<?php esc_attr_e( 'Loading&hellip;', 'jetpack' ); ?>" src="<?php echo esc_url( $static_url ); ?>" /></p>
-		<p style="font-size: 11pt; margin: 0;"><a href="<?php echo esc_url( $stats_url ); ?>" rel="noopener noreferrer" target="_blank"><?php esc_html_e( 'View stats on WordPress.com right now', 'jetpack' ); ?></a></p>
 		<p class="hide-if-js"><?php esc_html_e( 'Jetpack Stats work better with JavaScript enabled.', 'jetpack' ); ?><br />
 		<a href="<?php echo esc_url( $nojs_url ); ?>"><?php esc_html_e( 'View Jetpack Stats without JavaScript', 'jetpack' ); ?></a>.</p>
 		</div>
@@ -729,9 +724,7 @@ function stats_parse_header_section( $html ) {
  * @return string
  */
 function stats_parse_content_section( $html ) {
-	// TODO: Skip past gotonewdash DIV.
-	// Doesn't make sense to push users to Calypso once Odyssey is ready.
-	$body = strstr( $html, STATS_CONTENT_MARKER );
+	$body = strstr( $html, STATS_BODY_MARKER );
 	// Enforce a string result instead of string|false.
 	if ( $body === false ) {
 		return '';

--- a/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
+++ b/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
@@ -1,11 +1,10 @@
-import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import { isSimpleSite, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { InspectorAdvancedControls } from '@wordpress/block-editor'; // eslint-disable-line import/no-unresolved
 import { BaseControl, Button, SelectControl, ToggleControl } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { Fragment, useCallback, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import analytics from '../../../_inc/client/lib/analytics';
 
 /* global widget_conditions_data */
 /* eslint-disable react/react-in-jsx-scope */
@@ -226,6 +225,8 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 		const conditions = useMemo( () => attributes.conditions || {}, [ attributes ] );
 		const rules = useMemo( () => conditions.rules || [], [ conditions ] );
 
+		const { tracks } = useAnalytics();
+
 		// Is this block the top-most level block in a widget?.
 		const isTopLevelWidgetBlock = useSelect(
 			select => {
@@ -241,14 +242,14 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 		);
 
 		const toggleMatchAll = useCallback( () => {
-			analytics.tracks.recordEvent( 'jetpack_widget_visibility_toggle_match_all_click' );
+			tracks.recordEvent( 'jetpack_widget_visibility_toggle_match_all_click' );
 			setAttributes( {
 				conditions: {
 					...maybeAddDefaultConditions( conditions ),
 					match_all: conditions.match_all === '0' ? '1' : '0',
 				},
 			} );
-		}, [ setAttributes, conditions ] );
+		}, [ tracks, setAttributes, conditions ] );
 
 		const setAction = useCallback(
 			value =>
@@ -262,19 +263,19 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 		);
 		const addNewRule = useCallback( () => {
 			const newRules = [ ...rules, { major: '', minor: '' } ];
-			analytics.tracks.recordEvent( 'jetpack_widget_visibility_add_new_rule_click' );
+			tracks.recordEvent( 'jetpack_widget_visibility_add_new_rule_click' );
 			setAttributes( {
 				conditions: {
 					...maybeAddDefaultConditions( conditions ),
 					rules: newRules,
 				},
 			} );
-		}, [ setAttributes, conditions, rules ] );
+		}, [ rules, tracks, setAttributes, conditions ] );
 
 		const deleteRule = useCallback(
 			i => {
 				const newRules = [ ...rules.slice( 0, i ), ...rules.slice( i + 1 ) ];
-				analytics.tracks.recordEvent( 'jetpack_widget_visibility_delete_rule_click' );
+				tracks.recordEvent( 'jetpack_widget_visibility_delete_rule_click' );
 				setAttributes( {
 					conditions: {
 						...maybeAddDefaultConditions( conditions ),
@@ -282,12 +283,12 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 					},
 				} );
 			},
-			[ setAttributes, conditions, rules ]
+			[ rules, tracks, setAttributes, conditions ]
 		);
 
 		const setMajor = useCallback(
 			( i, majorValue ) => {
-				analytics.tracks.recordEvent( 'jetpack_widget_visibility_set_major_rule_click' );
+				tracks.recordEvent( 'jetpack_widget_visibility_set_major_rule_click' );
 				// When changing majors, also change the minor to the first available option
 				let minorValue = '';
 				if (
@@ -310,12 +311,12 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 					},
 				} );
 			},
-			[ setAttributes, conditions, rules ]
+			[ tracks, rules, setAttributes, conditions ]
 		);
 
 		const setMinor = useCallback(
 			( i, value ) => {
-				analytics.tracks.recordEvent( 'jetpack_widget_visibility_set_minor_rule_click' );
+				tracks.recordEvent( 'jetpack_widget_visibility_set_minor_rule_click' );
 				// Don't allow section headings to be set
 				if ( value && value.includes( '__HEADER__' ) ) {
 					return;
@@ -332,7 +333,7 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 					},
 				} );
 			},
-			[ setAttributes, conditions, rules ]
+			[ tracks, rules, setAttributes, conditions ]
 		);
 
 		let mainRender = null;

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -477,6 +477,18 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Detect whether a site is WordPress.com Staging Site.
+	 *
+	 * @return bool
+	 */
+	public function is_wpcom_staging_site() {
+		if ( function_exists( 'has_blog_sticker' ) ) {
+			return has_blog_sticker( 'staging_site' );
+		}
+		return false;
+	}
+
+	/**
 	 * Detect whether a site is an automated transfer site and WooCommerce is active.
 	 *
 	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php.
@@ -1457,5 +1469,23 @@ abstract class SAL_Site {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Get site option for the production blog id (if is a WP.com Staging Site).
+	 *
+	 * @return string
+	 */
+	public function get_wpcom_production_blog_id() {
+		return get_option( 'wpcom_production_blog_id', '' );
+	}
+
+	/**
+	 * Get site option for the staging blog ids (if it has them)
+	 *
+	 * @return string
+	 */
+	public function get_wpcom_staging_blog_ids() {
+		return get_option( 'wpcom_staging_blog_ids', array() );
 	}
 }

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -1,4 +1,4 @@
-## Jetpack 11.8
+## Jetpack 11.9
 
 ### Before you start:
 
@@ -7,29 +7,38 @@
 
 ### Form Block
 
-The form block received updates for styling the input fields, to test:
+The Form block received several updates, to test:
 
-- Create a new test post and add a Form block.
-- When presented with the different form variation templates, make sure there aren't any design oddities with the updated icons.
-- Select the 'Contact Form' type for this example.
-- Click on one of the input fields in the inserted Form block, and in the sidebar for the block settings there should be 'Color' and 'Input Field Styles' sections.
-- Try adjusting some of the style settings for the input fields, saving, and make sure the published post looks okay on the frontend.
+- Create a new test post and add a Form block (contact form template will work).
+- Add a 'Multiple Choice (checkbox)' field with a few options to select from.
+- Add a 'Text Input Field' with some dummy 'Placeholder Text' in the sidebar settings. Then change the border-radius for the text field to a large value.
+	- While editing or viewing the form on the frontend, the placeholder text should remain visible even with a large border-radius set.
+- While still having the text input field selected, make sure the 'Sync fields style' is enabled. Then, change the background color or other style settings from the sidebar.
+- Add an additional text input field. This new field should retain the same style settings previously applied from the other text field.
+- On the frontend in a new private/guest browser window, submit a test form submission.
+	- You may notice the form having a brief blur while while it is loading, this is expected.
+- Check the form responses in 'Feedback > Form Responses' for the test submission. Make sure that the output looks ok and that you don't see an 'Array()' wrapped around the multiple choice checkbox field data.
 
-### Subscribe Block
+Related PRs: [28815](https://github.com/Automattic/jetpack/pull/28815), [28988](https://github.com/Automattic/jetpack/pull/28988), [28820](https://github.com/Automattic/jetpack/pull/28820), [28973](https://github.com/Automattic/jetpack/pull/28973)
 
-The Subscriptions module received several changes in this version, to test:
+### Sharing Buttons
 
-- On a Jetpack-connected test site, add a Subscribe block to a new post.
-  - Make sure Subscriptions are enabled first, via Jetpack -> Settings -> Discussion.
-- In the block settings sidebar, under Settings, there should be a toggle to include social followers in the count. Make sure the follower amounts match the subscribers and connected social followers, if there are any.
-- If you have a social network connected via the WordPress.com dashboard at Tools -> Marketing -> Connections, you can also test the social followers are included when publishing if the toggle is enabled.
-- Publish the post with your Subscribe block. Next, visit the published post and subscribe one of your email addresses to receive new post notifications.
-  - For the purposes of this test, make sure the email address is not connected to a WordPress.com account. If you are using Gmail, you can use the '+' symbol to create an alias such as 'example+20230130@gmail.com'
-  - Make sure to confirm the subscription by clicking the link in the confirmation email.
-- Publish another new post with some text content. Make sure the email address you subscribed receives the new post email notification.
+The Sharing buttons also received updates in this version, to test:
+
+- Verify that the sharing buttons are enabled in 'Jetpack > Settings > Sharing'.
+- Click on the 'Configure your sharing buttons' link.
+- Add some different sharing buttons including the new Mastadon button. Save those changes.
+- Have at least one blog post published, then visit a post on the frontend.
+- Make sure the sharing buttons are displayed as expected.
+	- Be sure to test the sharing buttons displayed on the frontend in a variety of different browsers and screen sizes.
+	- If you aren't seeing any sharing buttons at all, try disabling any adblock extensions.
+- Activate the 'Twenty Nineteen' theme on your site and check the sharing buttons on the frontend again, they should look the same.
+- Test additional sharing button settings such as 'official buttons' versus 'icon only' for example.
+
+Related PRs: [28874](https://github.com/Automattic/jetpack/pull/28874), [28694](https://github.com/Automattic/jetpack/pull/28694)
 
 ### And More!
 
-You can see a [full list of changes in this release here](https://github.com/Automattic/jetpack/blob/jetpack/branch-11.8/projects/plugins/jetpack/CHANGELOG.md). Please feel free to test any and all functionality mentioned! 
+You can see a [full list of changes in this release here](https://github.com/Automattic/jetpack/blob/jetpack/branch-11.9/projects/plugins/jetpack/CHANGELOG.md). Please feel free to test any and all functionality mentioned! 
 
 **Thank you for all your help!**

--- a/projects/plugins/jetpack/wp-cli-templates/block-edit-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-edit-js.mustache
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
 import { BlockIcon } from '@wordpress/block-editor';
 import { Placeholder, withNotices } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import icon from './icon';
 

--- a/projects/plugins/jetpack/wp-cli-templates/block-editor-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-editor-js.mustache
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import registerJetpackBlock from '../../shared/register-jetpack-block';
 import { name, settings } from '.';
 

--- a/projects/plugins/jetpack/wp-cli-templates/block-icon-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-icon-js.mustache
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { SVG, Path } from '@wordpress/components';
 
 export default (

--- a/projects/plugins/jetpack/wp-cli-templates/block-index-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-index-js.mustache
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import { __{{#hasKeywords}}, _x{{/hasKeywords}} } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { __{{#hasKeywords}}, _x{{/hasKeywords}} } from '@wordpress/i18n';
+import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
 import edit from './edit';
 import icon from './icon';
-import { getIconColor } from '../../shared/block-icons';
 
 /**
  * Style dependencies

--- a/projects/plugins/jetpack/wp-cli-templates/block-register-php.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-register-php.mustache
@@ -2,7 +2,7 @@
 /**
  * {{ title }} Block.
  *
- * @since {{ jetpackVersion }}
+ * @since $$next-version$$
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/migration/changelog/update-migration-doc-link
+++ b/projects/plugins/migration/changelog/update-migration-doc-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update doc link for migration plugin

--- a/projects/plugins/migration/src/js/components/constants.ts
+++ b/projects/plugins/migration/src/js/components/constants.ts
@@ -1,2 +1,0 @@
-export const MIGRATION_HANDLER_ROUTE =
-	'https://wordpress.com/setup/import-focused/migrationHandler';

--- a/projects/plugins/migration/src/js/components/migration/index.tsx
+++ b/projects/plugins/migration/src/js/components/migration/index.tsx
@@ -5,7 +5,6 @@ import { Button, Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
-import { MIGRATION_HANDLER_ROUTE } from '../constants';
 import { WordPressLogo, ExternalLink } from '../illustrations';
 import migrationImage1 from './../../../../images/migration-1.png';
 import type React from 'react';
@@ -121,7 +120,9 @@ export function Migration( props: Props ) {
 					isPrimary={ true }
 					isBusy={ buttonIsLoading }
 					disabled={ buttonIsLoading }
-					href={ `${ MIGRATION_HANDLER_ROUTE }?from=${ sourceSiteSlug }` }
+					href={ getRedirectUrl( 'wpcom-migration-handler-route', {
+						query: `from=${ sourceSiteSlug }`,
+					} ) }
 					onClick={ onGetStartedClick }
 				>
 					{ __( 'Get started', 'wpcom-migration' ) }
@@ -129,9 +130,7 @@ export function Migration( props: Props ) {
 				<Button
 					isSecondary={ true }
 					target={ '_blank' }
-					href={ getRedirectUrl(
-						'https://wordpress.com/support/import/import-an-entire-wordpress-site/'
-					) }
+					href={ getRedirectUrl( 'wpcom-migration-doc-link' ) }
 				>
 					{ createInterpolateElement( __( 'Learn more <ExternalLink />', 'wpcom-migration' ), {
 						ExternalLink: <ExternalLink size={ 20 } />,
@@ -148,10 +147,7 @@ export function Migration( props: Props ) {
 					__( 'Do you need help? <Button>Contact us.</Button>', 'wpcom-migration' ),
 					{
 						Button: (
-							<Button
-								href={ getRedirectUrl( 'https://wordpress.com/support/help-support-options/' ) }
-								target={ '_blank' }
-							/>
+							<Button href={ getRedirectUrl( 'wpcom-migration-contact-us' ) } target={ '_blank' } />
 						),
 					}
 				) }

--- a/projects/plugins/migration/src/js/components/migration/progress.tsx
+++ b/projects/plugins/migration/src/js/components/migration/progress.tsx
@@ -6,7 +6,6 @@ import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect, useCallback } from 'react';
-import { MIGRATION_HANDLER_ROUTE } from '../constants';
 import { WordPressLogo } from '../illustrations';
 import migrationImage2 from './../../../../images/migration-2.png';
 import './styles.module.scss';
@@ -55,7 +54,9 @@ export function MigrationProgress( props: Props ) {
 				<Button
 					isSecondary={ true }
 					target={ '_blank' }
-					href={ `${ MIGRATION_HANDLER_ROUTE }?from=${ sourceSiteSlug }` }
+					href={ getRedirectUrl( 'wpcom-migration-handler-route', {
+						query: `from=${ sourceSiteSlug }`,
+					} ) }
 					onClick={ onCheckProgressClick }
 				>
 					{ __( 'Check your migration progress', 'wpcom-migration' ) }
@@ -66,10 +67,7 @@ export function MigrationProgress( props: Props ) {
 					__( 'Do you need help? <Button>Contact us.</Button>', 'wpcom-migration' ),
 					{
 						Button: (
-							<Button
-								href={ getRedirectUrl( 'https://wordpress.com/support/help-support-options/' ) }
-								target={ '_blank' }
-							/>
+							<Button href={ getRedirectUrl( 'wpcom-migration-contact-us' ) } target={ '_blank' } />
 						),
 					}
 				) }

--- a/projects/plugins/protect/changelog/add-waf-ip-ranges
+++ b/projects/plugins/protect/changelog/add-waf-ip-ranges
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -538,6 +538,55 @@
             }
         },
         {
+            "name": "automattic/jetpack-ip",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/ip",
+                "reference": "7b9a848c16ddef248597636fbcf13f77b8637a6e"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "brain/monkey": "2.6.1",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-ip",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-ip/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-ip",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-utils.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities for working with IP addresses.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-jitm",
             "version": "dev-trunk",
             "dist": {
@@ -1283,11 +1332,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/waf",
-                "reference": "9e0055457442062de1b4b955db24a02b8191c8a4"
+                "reference": "c93147d884aff0f808231bf84618ecbdfbb153e8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "wikimedia/aho-corasick": "^1.0"
             },
@@ -1305,7 +1355,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 }
             },
             "autoload": {

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -190,10 +190,38 @@ export function getQuestions( type ) {
 	const jsPackageQuestions = [];
 	const pluginQuestions = [
 		{
+			type: 'list',
+			name: 'versioningMethod',
+			message: 'How do you want versioning to work for your plugin?',
+			choices: [
+				// Note: There's no actual reason for recommending either option. Neither method is
+				// objectively better. We're not going to actually have consistency, tooling is
+				// already pretty simple in this respect (and without mandatory consistency it can't
+				// be simplified anyway), cognitive load would need research to determine the extent
+				// to which it's an issue, and WordPress core explicitly doesn't take a side on it.
+				// It comes down to which way the developers actually working on the plugin think
+				// about versioning for it.
+				//
+				// But everyone else wants to make an arbitrary recommendation anyway, so 🤷.
+				{
+					name:
+						'WordPress-style ("recommended"): Like 1.2, with each non-bugfix release always incrementing by 0.1.',
+					checked: true,
+					value: 'wordpress',
+				},
+				{
+					name:
+						'Semver: Like 1.2.3, with the next version depending on what kinds of changes are included.',
+					checked: true,
+					value: 'semver',
+				},
+			],
+		},
+		{
 			type: 'input',
 			name: 'version',
 			message: "What is the plugin's starting version?:",
-			default: '0.1.0-alpha',
+			default: answers => ( answers.versioningMethod === 'semver' ? '0.1.0-alpha' : '0.0-alpha' ),
 		},
 		{
 			type: 'list',
@@ -243,6 +271,8 @@ export async function generateProject(
 		fileURLToPath( new URL( './', import.meta.url ) ),
 		`../../../projects/${ type }/${ answers.name }`
 	);
+	answers.project = project;
+	answers.projDir = projDir;
 
 	if ( 'plugin' === answers.type && 'starter' === answers.pluginTemplate ) {
 		return generatePluginFromStarter( projDir, answers );
@@ -356,6 +386,13 @@ async function generatePluginFromStarter( projDir, answers ) {
 		path.join( projDir, 'src/class-jetpack-starter-plugin.php' ),
 		path.join( projDir, 'src/class-jetpack-' + answers.name + '.php' )
 	);
+
+	// Update composer.json.
+	const composerJson = readComposerJson( answers.project );
+	composerJson.extra ||= {};
+	composerJson.extra.changelogger ||= {};
+	composerJson.extra.changelogger.versioning = answers.versioningMethod;
+	writeComposerJson( answers.project, composerJson, answers.projDir );
 }
 
 /**
@@ -526,6 +563,8 @@ async function createComposerJson( composerJson, answers ) {
 			composerJson.extra = composerJson.extra || {};
 			composerJson.extra[ 'release-branch-prefix' ] = answers.name;
 			composerJson.type = 'wordpress-plugin';
+			composerJson.extra.changelogger ||= {};
+			composerJson.extra.changelogger.versioning = answers.versioningMethod;
 			break;
 		case 'js-package':
 			composerJson.scripts = {


### PR DESCRIPTION
This is a dupe of #29119.

When responses are exported from WP-Admin->Feedback->Form Responses they can be exported to Google Sheets. This patch adds tracking of those actions.

It requires the record_tracks_event function from https://github.com/Automattic/jetpack/pull/29102.

Discussion: pcsBup-S8-p2
Testing instructions:

Wait for https://github.com/Automattic/jetpack/pull/29102 to be merged or grab record_tracks_event from it.
Create a form block in a post with /form.
Fill out the form and submit.
Go to WP-Admin->Feedback->Form Responses and export the response(s) to Google Sheets. You'll have to connect it first. If using Firefox containers you might have to do this bit in Chrome.
If an Automattician, look for the forms_export_responses tracking event. The format prop should be "gsheets"

## Does this pull request change what data or activity we track or use?

Yes, it tracks exports by Google Sheets from the Feedback Forms page.

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
