### PR TITLE
Widget Visibility: switch to shared Analytics implementation.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-widget-visibility-tracks
+++ b/projects/plugins/jetpack/changelog/update-widget-visibility-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Widget Visibility: switch to shared Analytics implementation.

--- a/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
+++ b/projects/plugins/jetpack/modules/widget-visibility/editor/index.jsx
@@ -1,11 +1,10 @@
-import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import { isSimpleSite, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { InspectorAdvancedControls } from '@wordpress/block-editor'; // eslint-disable-line import/no-unresolved
 import { BaseControl, Button, SelectControl, ToggleControl } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { Fragment, useCallback, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import analytics from '../../../_inc/client/lib/analytics';
 
 /* global widget_conditions_data */
 /* eslint-disable react/react-in-jsx-scope */
@@ -226,6 +225,8 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 		const conditions = useMemo( () => attributes.conditions || {}, [ attributes ] );
 		const rules = useMemo( () => conditions.rules || [], [ conditions ] );
 
+		const { tracks } = useAnalytics();
+
 		// Is this block the top-most level block in a widget?.
 		const isTopLevelWidgetBlock = useSelect(
 			select => {
@@ -241,14 +242,14 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 		);
 
 		const toggleMatchAll = useCallback( () => {
-			analytics.tracks.recordEvent( 'jetpack_widget_visibility_toggle_match_all_click' );
+			tracks.recordEvent( 'jetpack_widget_visibility_toggle_match_all_click' );
 			setAttributes( {
 				conditions: {
 					...maybeAddDefaultConditions( conditions ),
 					match_all: conditions.match_all === '0' ? '1' : '0',
 				},
 			} );
-		}, [ setAttributes, conditions ] );
+		}, [ tracks, setAttributes, conditions ] );
 
 		const setAction = useCallback(
 			value =>
@@ -262,19 +263,19 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 		);
 		const addNewRule = useCallback( () => {
 			const newRules = [ ...rules, { major: '', minor: '' } ];
-			analytics.tracks.recordEvent( 'jetpack_widget_visibility_add_new_rule_click' );
+			tracks.recordEvent( 'jetpack_widget_visibility_add_new_rule_click' );
 			setAttributes( {
 				conditions: {
 					...maybeAddDefaultConditions( conditions ),
 					rules: newRules,
 				},
 			} );
-		}, [ setAttributes, conditions, rules ] );
+		}, [ rules, tracks, setAttributes, conditions ] );
 
 		const deleteRule = useCallback(
 			i => {
 				const newRules = [ ...rules.slice( 0, i ), ...rules.slice( i + 1 ) ];
-				analytics.tracks.recordEvent( 'jetpack_widget_visibility_delete_rule_click' );
+				tracks.recordEvent( 'jetpack_widget_visibility_delete_rule_click' );
 				setAttributes( {
 					conditions: {
 						...maybeAddDefaultConditions( conditions ),
@@ -282,12 +283,12 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 					},
 				} );
 			},
-			[ setAttributes, conditions, rules ]
+			[ rules, tracks, setAttributes, conditions ]
 		);
 
 		const setMajor = useCallback(
 			( i, majorValue ) => {
-				analytics.tracks.recordEvent( 'jetpack_widget_visibility_set_major_rule_click' );
+				tracks.recordEvent( 'jetpack_widget_visibility_set_major_rule_click' );
 				// When changing majors, also change the minor to the first available option
 				let minorValue = '';
 				if (
@@ -310,12 +311,12 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 					},
 				} );
 			},
-			[ setAttributes, conditions, rules ]
+			[ tracks, rules, setAttributes, conditions ]
 		);
 
 		const setMinor = useCallback(
 			( i, value ) => {
-				analytics.tracks.recordEvent( 'jetpack_widget_visibility_set_minor_rule_click' );
+				tracks.recordEvent( 'jetpack_widget_visibility_set_minor_rule_click' );
 				// Don't allow section headings to be set
 				if ( value && value.includes( '__HEADER__' ) ) {
 					return;
@@ -332,7 +333,7 @@ const visibilityAdvancedControls = createHigherOrderComponent(
 					},
 				} );
 			},
-			[ setAttributes, conditions, rules ]
+			[ tracks, rules, setAttributes, conditions ]
 		);
 
 		let mainRender = null;


### PR DESCRIPTION
Fixes #25113

## Proposed changes:

No functional changes here; we just move from calling the Analytics implementation from the React dashboard codebase to our newer shared analytics utility.

See #27937

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* No

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Turn on Widget Visibility: `jetpack docker wp jetpack module activate widget-visibility`
* Switch to a theme that supports widgets, Twenty Sixteen for example: `jetpack docker wp theme install twentysixteen && jetpack docker wp theme activate twentysixteen`
* Open wp-admin.
* In the browser js console, type in `localStorage.setItem( 'debug', 'dops:analytics*' );`
* Go to Appearance > Customize > Widgets
* Add a new Paragraph block in one of the widget areas.
* In the block's tolbar, click "Show more settings"
* In the block's settings panel, scroll down and open the Advanced area.
* Add a new widget visibility rule, and check that you see the events logged in your browser console.

<img width="933" alt="Screenshot 2023-02-27 at 17 46 22" src="https://user-images.githubusercontent.com/426388/221628245-04216b79-61e2-4e62-a42b-fe55889fa4a5.png">

