### PR TITLE
 VideoPress: remove uploading image for video poster when uploading video

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-remove-poster-from-imgage-when-uploading-video
+++ b/projects/packages/videopress/changelog/update-videopress-remove-poster-from-imgage-when-uploading-video
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+VideoPress: remove uploading image for video poster when uploading video

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -41,7 +41,7 @@ export function PosterDropdown( {
 	const replacePosterLabel = __( 'Replace Poster Image', 'jetpack-videopress-pkg' );
 
 	const buttonRef = useRef< HTMLButtonElement >( null );
-	const videoRatio = Number( attributes?.videoRatio ) / 100 || 16 / 9;
+	const videoRatio = Number( attributes?.videoRatio ) / 100 || 9 / 16;
 
 	const [ buttonImageHeight, setButtonImageHeight ] = useState( 140 );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-editor.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-editor.js
@@ -3,7 +3,7 @@
  */
 import { MediaUpload } from '@wordpress/block-editor';
 import { Button, BaseControl } from '@wordpress/components';
-import { createInterpolateElement, useRef } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -74,31 +74,9 @@ const PosterActions = ( { hasPoster, onSelectPoster, onRemovePoster } ) => {
 
 	return (
 		<span className="uploading-editor__scrubber-help">
-			{ createInterpolateElement(
-				__(
-					'This is how the video will look. Use the slider to choose a poster or <a>select a custom one</a>.',
-					'jetpack-videopress-pkg'
-				),
-				{
-					a: (
-						<MediaUpload
-							title={ __( 'Select Poster Image', 'jetpack-videopress-pkg' ) }
-							onSelect={ onSelectPoster }
-							allowedTypes={ VIDEO_POSTER_ALLOWED_MEDIA_TYPES }
-							render={ ( { open } ) => (
-								<a
-									className="uploading-editor__upload-link"
-									onClick={ open }
-									onKeyDown={ open }
-									role="button"
-									tabIndex={ 0 }
-								>
-									{ __( 'select a custom one', 'jetpack-videopress-pkg' ) }
-								</a>
-							) }
-						/>
-					),
-				}
+			{ __(
+				'This is how the video will look. Use the slider to choose a poster image.',
+				'jetpack-videopress-pkg'
 			) }
 		</span>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR removes the ability to set the poster by selecting a static image when the video is uploaded, considering that it's doable from the sidebar and toolbar once the video uploads.

Fixes https://github.com/Automattic/jetpack/issues/29175

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  VideoPress: remove uploading image for video poster when uploading video

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Block editor
* Create a new VideoPress video block
* Upload a new file
* Confirm it's possible to set the poster only by picking an iframe from the video
* Confirm that, once the video uploads, it's possible to set the poster from the block sidebar and toolbar.
