### PR TITLE
Staging Sites: Add staging site attributes to the site object

### DIFF
--- a/projects/plugins/jetpack/changelog/add-rest-api-staging-site-attributes
+++ b/projects/plugins/jetpack/changelog/add-rest-api-staging-site-attributes
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Adds `is_staging_site`, `wpcom_production_blog_id`, and `wpcom_staging_blog_ids` attributes to the site object
+Adds `is_wpcom_staging_site`, `wpcom_production_blog_id`, and `wpcom_staging_blog_ids` attributes to the site object

--- a/projects/plugins/jetpack/changelog/add-rest-api-staging-site-attributes
+++ b/projects/plugins/jetpack/changelog/add-rest-api-staging-site-attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Adds `is_staging_site`, `wpcom_production_blog_id`, and `wpcom_staging_blog_ids` attributes to the site object

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -76,6 +76,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
 		'is_wpcom_atomic'             => '(bool) If the site is a WP.com Atomic one.',
+		'is_staging_site'             => '(bool) If the site is a WP.com staging site.',
 		'user_interactions'           => '(array) An array of user interactions with a site.',
 	);
 
@@ -195,6 +196,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'blogging_prompts_settings',
 		'launchpad_screen',
 		'launchpad_checklist_tasks_statuses',
+		'wpcom_production_blog_id',
+		'wpcom_staging_blog_ids',
 	);
 
 	/**
@@ -557,6 +560,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'is_wpcom_atomic':
 				$response[ $key ] = $this->site->is_wpcom_atomic();
 				break;
+			case 'is_staging_site':
+				$response[ $key ] = $this->site->is_staging_site();
+				break;
 			case 'user_interactions':
 				$response[ $key ] = $this->site->get_user_interactions();
 				break;
@@ -852,6 +858,12 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'launchpad_checklist_tasks_statuses':
 					$options[ $key ] = $site->get_launchpad_checklist_tasks_statuses();
+					break;
+				case 'wpcom_production_blog_id':
+					$options[ $key ] = $site->get_wpcom_production_blog_id();
+					break;
+				case 'wpcom_staging_blog_ids':
+					$options[ $key ] = $site->get_wpcom_staging_blog_ids();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -76,7 +76,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
 		'is_wpcom_atomic'             => '(bool) If the site is a WP.com Atomic one.',
-		'is_staging_site'             => '(bool) If the site is a WP.com staging site.',
+		'is_wpcom_staging_site'       => '(bool) If the site is a WP.com staging site.',
 		'user_interactions'           => '(array) An array of user interactions with a site.',
 	);
 
@@ -560,8 +560,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'is_wpcom_atomic':
 				$response[ $key ] = $this->site->is_wpcom_atomic();
 				break;
-			case 'is_staging_site':
-				$response[ $key ] = $this->site->is_staging_site();
+			case 'is_wpcom_staging_site':
+				$response[ $key ] = $this->site->is_wpcom_staging_site();
 				break;
 			case 'user_interactions':
 				$response[ $key ] = $this->site->get_user_interactions();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -477,6 +477,18 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Detect whether a site is WordPress.com Staging Site.
+	 *
+	 * @return bool
+	 */
+	public function is_staging_site() {
+		if ( function_exists( 'has_blog_sticker' ) ) {
+			return has_blog_sticker( 'staging_site' );
+		}
+		return false;
+	}
+
+	/**
 	 * Detect whether a site is an automated transfer site and WooCommerce is active.
 	 *
 	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php.
@@ -1457,5 +1469,23 @@ abstract class SAL_Site {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Get site option for the production blog id (if is a WP.com Staging Site).
+	 *
+	 * @return string
+	 */
+	public function get_wpcom_production_blog_id() {
+		return get_option( 'wpcom_production_blog_id', '' );
+	}
+
+	/**
+	 * Get site option for the staging blog ids (if it has them)
+	 *
+	 * @return string
+	 */
+	public function get_wpcom_staging_blog_ids() {
+		return get_option( 'wpcom_staging_blog_ids', array() );
 	}
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -481,7 +481,7 @@ abstract class SAL_Site {
 	 *
 	 * @return bool
 	 */
-	public function is_staging_site() {
+	public function is_wpcom_staging_site() {
 		if ( function_exists( 'has_blog_sticker' ) ) {
 			return has_blog_sticker( 'staging_site' );
 		}


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1848
See https://github.com/Automattic/dotcom-forge/issues/1697

## Proposed changes:

Exposes `is_wpcom_staging_site`, `wpcom_production_blog_id`, and `wpcom_staging_blog_ids` attributes on the site object to drive various parts of the UI.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

N/A

## Testing instructions:

1. Apply this pull request to your sandbox.
2. Create a new WordPress.com Business site and take it Atomic.
3. In the wpcalypso environment or your local environment, visit 'Hosting Configuration' and click 'Add staging site'.
4. Check out https://github.com/Automattic/wp-calypso/pull/73855 in your local environment.
5. Inspect `SitesTableRow` on the Sites page to verify the data is pulled into your sites as expected (you should have a production and a staging site by this point).