### PR TITLE
CRM: Onboarding wizard get updates opt-in

### DIFF
--- a/projects/plugins/crm/admin/activation/welcome-to-jpcrm.php
+++ b/projects/plugins/crm/admin/activation/welcome-to-jpcrm.php
@@ -457,7 +457,7 @@ $settings      = $zbs->settings->getAll();
 				</p>
 
 				<div class='clear'></div>
-				<div class='yespls'><p style="text-align: center;margin-top: 6px;"><?php esc_html_e( 'Get updates', 'zero-bs-crm' ); ?> <input type="checkbox" id="zbs_sub" value="zbs_sub" checked='checked'/></p></div>
+				<div class='yespls'><p style="text-align: center;margin-top: 6px;"><?php esc_html_e( 'Get updates', 'zero-bs-crm' ); ?> <input type="checkbox" id="zbs_sub" value="zbs_sub"/></p></div>
 
 
 

--- a/projects/plugins/crm/changelog/fix-crm-onboarding-wizard-change-updates-to-opt-in
+++ b/projects/plugins/crm/changelog/fix-crm-onboarding-wizard-change-updates-to-opt-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Get updates (mailing list) changed from opt-out to opt-in in the onboarding wizard.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR makes the Get Updates, suggested by the onboarding wizard, be opt-in instead of opt-out.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
https://github.com/Automattic/zero-bs-crm/issues/2899

## Testing instructions:

* Open the CRM for the first time to trigger the Onboarding Wizard
* Alternatively, delete the row containing `zbs_wizard_run` in the `option_name` field from the `wp_options` table.
* Go to step 4 of the Onboarding Wizard

In `trunk` the checkbox for the `Get updates` is checked by default
In `fix/crm-onboarding-wizard-change-tracking-to-opt-in`  the checkbox for the `Usage Tracking` is unchecked by default.

