### PR TITLE
CRM: Change from Customer ID to Contact ID in the Contact Edit page

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-contact-edit-page-customer-id-to-contact-id
+++ b/projects/plugins/crm/changelog/fix-crm-contact-edit-page-customer-id-to-contact-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed wrong naming from Customer ID to Contact ID in the Edit Contact page

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -271,7 +271,7 @@
                     # ... further hacked
 
                     if ($zbsShowID == "1" && isset($contact['id']) && !empty($contact['id'])) { ?>
-                    <tr class="wh-large"><th><label><?php esc_html_e('Customer',"zero-bs-crm");?> ID:</label></th>
+	<tr class="wh-large"><th><label><?php esc_html_e( 'Contact', 'zero-bs-crm' ); ?> ID:</label></th>
                     <td class="zbs-field-id">
                         #<?php if (isset($contact['id'])) echo esc_html( $contact['id'] ); ?>
                     </td></tr>

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -271,7 +271,7 @@
                     # ... further hacked
 
                     if ($zbsShowID == "1" && isset($contact['id']) && !empty($contact['id'])) { ?>
-	<tr class="wh-large"><th><label><?php esc_html_e( 'Contact', 'zero-bs-crm' ); ?> ID:</label></th>
+							<tr class="wh-large"><th><label><?php esc_html_e( 'Contact', 'zero-bs-crm' ); ?> ID:</label></th>
                     <td class="zbs-field-id">
                         #<?php if (isset($contact['id'])) echo esc_html( $contact['id'] ); ?>
                     </td></tr>

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -271,7 +271,7 @@
                     # ... further hacked
 
                     if ($zbsShowID == "1" && isset($contact['id']) && !empty($contact['id'])) { ?>
-							<tr class="wh-large"><th><label><?php esc_html_e( 'Contact', 'zero-bs-crm' ); ?> ID:</label></th>
+							<tr class="wh-large"><th><label><?php esc_html_e( 'Contact ID', 'zero-bs-crm' ); ?>:</label></th>
                     <td class="zbs-field-id">
                         #<?php if (isset($contact['id'])) echo esc_html( $contact['id'] ); ?>
                     </td></tr>


### PR DESCRIPTION
## Proposed changes:
* This PR changes the string 'Customer ID' to 'Contact ID' in the Edit Contact page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/zero-bs-crm/issues/2788

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the edit page for a existing Contact (e.g. `wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact&zbsid=8`).

In `trunk` you will find the field `Customer ID`
In `fix/crm-contact-edit-page-customer-id-to-contact-id` the field was renamed to `Contact ID`


