### PR TITLE
Prepare Super Cache for the next dev cycle

### DIFF
--- a/projects/plugins/super-cache/CHANGELOG.md
+++ b/projects/plugins/super-cache/CHANGELOG.md
@@ -5,6 +5,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.4-beta] - 2023-02-28
+### Added
+- Added new filter which controls cache clearing on post edit. [#28556]
+- Added a check to ensure preload cronjobs exist when updating preload settings. [#28545]
+
+### Changed
+- Updated contributors list. [#28891]
+
+### Fixed
+- Fixed undefined PHP variable when trying to delete a protected folder. [#28524]
+
 ## [1.9.3-beta] - 2023-01-23
 ### Added
 - Added new filters to set mod_expires rules and HTTP headers in the cache htaccess file. [#28031]
@@ -635,6 +646,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Misc fixes
 
+[1.9.4-beta]: https://github.com/Automattic/wp-super-cache/compare/v1.9.3-beta...v1.9.4-beta
 [1.9.3-beta]: https://github.com/Automattic/wp-super-cache/compare/v1.9.2-beta...v1.9.3-beta
 [1.9.2-beta]: https://github.com/Automattic/wp-super-cache/compare/v1.9.1...v1.9.2-beta
 [1.9.1]: https://github.com/Automattic/wp-super-cache/compare/v1.9.0...v1.9.1

--- a/projects/plugins/super-cache/changelog/fix-deprecation-warning-php-8-1
+++ b/projects/plugins/super-cache/changelog/fix-deprecation-warning-php-8-1
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed PHP 8.1 deprecation notice
-
-

--- a/projects/plugins/super-cache/changelog/fix-super-cache-undefined-variable
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-undefined-variable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix undefined PHP variable when trying to delete a protected folder.

--- a/projects/plugins/super-cache/changelog/init-release-cycle
+++ b/projects/plugins/super-cache/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 1.9.5-alpha
+
+

--- a/projects/plugins/super-cache/changelog/init-release-cycle
+++ b/projects/plugins/super-cache/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Init 1.9.4-alpha
-
-

--- a/projects/plugins/super-cache/changelog/remove-remnants-of-automated-code-coverage
+++ b/projects/plugins/super-cache/changelog/remove-remnants-of-automated-code-coverage
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `test-coverage` scripts and other remnants of automated code coverage.
-
-

--- a/projects/plugins/super-cache/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/super-cache/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/super-cache/changelog/super-cache-fix-schedule
+++ b/projects/plugins/super-cache/changelog/super-cache-fix-schedule
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Reassert scheduled cron-job whenever the interval setting is updated

--- a/projects/plugins/super-cache/changelog/super-cache-post-edit-hook
+++ b/projects/plugins/super-cache/changelog/super-cache-post-edit-hook
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added a filter to allow users to control post-editing cache-clearing behavior

--- a/projects/plugins/super-cache/changelog/update-boost-super-cache-contributors-list
+++ b/projects/plugins/super-cache/changelog/update-boost-super-cache-contributors-list
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update contributors list.

--- a/projects/plugins/super-cache/changelog/update-node-to-v18
+++ b/projects/plugins/super-cache/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -51,6 +51,6 @@
 		"wp-svn-autopublish": true
 	},
 	"config": {
-		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_9_4_alpha"
+		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_9_4_beta"
 	}
 }

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -51,6 +51,6 @@
 		"wp-svn-autopublish": true
 	},
 	"config": {
-		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_9_4_beta"
+		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_9_5_alpha"
 	}
 }

--- a/projects/plugins/super-cache/package.json
+++ b/projects/plugins/super-cache/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-super-cache",
-	"version": "1.9.4-alpha",
+	"version": "1.9.4-beta",
 	"description": "A very fast caching engine for WordPress that produces static html files.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/super-cache/package.json
+++ b/projects/plugins/super-cache/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-super-cache",
-	"version": "1.9.4-beta",
+	"version": "1.9.5-alpha",
 	"description": "A very fast caching engine for WordPress that produces static html files.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -4,7 +4,7 @@ Tags: performance, caching, wp-cache, wp-super-cache, cache
 Requires at least: 5.9
 Requires PHP: 5.6
 Tested up to: 6.1
-Stable tag: 1.9.2
+Stable tag: 1.9.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -268,13 +268,16 @@ Your theme is probably responsive which means it resizes the page to suit whatev
 
 
 == Changelog ==
-### 1.9.3-beta - 2023-01-23
+### 1.9.4-beta - 2023-02-28
 #### Added
-- Added new filters to set mod_expires rules and HTTP headers in the cache htaccess file.
+- Added new filter which controls cache clearing on post edit.
+- Added a check to ensure preload cronjobs exist when updating preload settings.
+
+#### Changed
+- Updated contributors list.
 
 #### Fixed
-- Fixed an issue that caused wp-config.php file permissions to change.
-- Fixed missing missing action 'wp_cache_cleared' when clearing the cache on post update.
+- Fixed undefined PHP variable when trying to delete a protected folder.
 
 --------
 

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Super Cache
  * Plugin URI: https://wordpress.org/plugins/wp-super-cache/
  * Description: Very fast caching plugin for WordPress.
- * Version: 1.9.4-alpha
+ * Version: 1.9.4-beta
  * Author: Automattic
  * Author URI: https://automattic.com/
  * License: GPL2+

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Super Cache
  * Plugin URI: https://wordpress.org/plugins/wp-super-cache/
  * Description: Very fast caching plugin for WordPress.
- * Version: 1.9.4-beta
+ * Version: 1.9.5-alpha
  * Author: Automattic
  * Author URI: https://automattic.com/
  * License: GPL2+


### PR DESCRIPTION
Bump versions, etc for super cache to prep for the next dev cycle.

## Proposed changes:
* Bump versions, etc for super cache to prep for the next dev cycle.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
n/a

## Testing instructions:
* Read the changes.