### PR TITLE
Make Jetpack Forms dashboard use the "Feedback" menu item in WP Admin

### DIFF
--- a/projects/packages/forms/changelog/replace-feedback-menu-with-forms-dashboard
+++ b/projects/packages/forms/changelog/replace-feedback-menu-with-forms-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Forms dashboard now replaces the "Feedback" menu entry in WP Admin.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -22,18 +22,7 @@ class Jetpack_Forms {
 	public static function load_contact_form() {
 		Util::init();
 
-		if (
-			is_admin()
-			/**
-			 * Enable the new Jetpack Forms dashboard.
-			 *
-			 * @module contact-form
-			 * @since 0.3.0
-			 *
-			 * @param bool false Should the new Jetpack Forms dashboard be enabled? Default to false.
-			 */
-			&& apply_filters( 'jetpack_forms_dashboard_enable', false )
-		) {
+		if ( is_admin() && self::is_feedback_dashboard_enabled() ) {
 			$dashboard = new Dashboard();
 			$dashboard->init();
 		}
@@ -52,5 +41,22 @@ class Jetpack_Forms {
 	 */
 	public static function plugin_url() {
 		return plugin_dir_url( __FILE__ );
+	}
+
+	/**
+	 * Returns true if the feedback dashboard is enabled.
+	 *
+	 * @return boolean
+	 */
+	public static function is_feedback_dashboard_enabled() {
+		/**
+		 * Enable the new Jetpack Forms dashboard.
+		 *
+		 * @module contact-form
+		 * @since 0.3.0
+		 *
+		 * @param bool false Should the new Jetpack Forms dashboard be enabled? Default to false.
+		 */
+		return apply_filters( 'jetpack_forms_dashboard_enable', false );
 	}
 }

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Forms\Dashboard;
 
-use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 
 /**
@@ -16,9 +15,8 @@ use Automattic\Jetpack\Assets;
 class Dashboard {
 
 	/**
-	 * Priority for the dashboard menu
-	 * For Jetpack sites: Jetpack uses 998 and 'Admin_Menu' uses 1000, so we need to use 999.
-	 * For simple site: the value is overriden in a child class with value 100000 to wait for all menus to be registered.
+	 * Priority for the dashboard menu.
+	 * Needs to be high enough for us to be able to unregister the default edit.php menu item.
 	 *
 	 * @var int
 	 */
@@ -38,7 +36,7 @@ class Dashboard {
 	 * @param string $hook The current admin page.
 	 */
 	public function load_admin_scripts( $hook ) {
-		if ( 'jetpack_page_jetpack-forms' !== $hook ) {
+		if ( 'toplevel_page_jetpack-forms' !== $hook ) {
 			return;
 		}
 
@@ -69,13 +67,16 @@ class Dashboard {
 	 * Register the dashboard admin submenu.
 	 */
 	public function add_admin_submenu() {
-		Admin_Menu::add_menu(
-			__( 'Jetpack Forms', 'jetpack-forms' ),
-			_x( 'Jetpack Forms', 'product name shown in menu', 'jetpack-forms' ),
+		remove_menu_page( 'feedback' );
+
+		add_menu_page(
+			__( 'Form Responses', 'jetpack-forms' ),
+			_x( 'Feedback', 'post type name shown in menu', 'jetpack-forms' ),
 			'read',
 			'jetpack-forms',
 			array( $this, 'render_dashboard' ),
-			100
+			'dashicons-feedback',
+			25 // Places 'Feedback' under 'Comments' in the menu
 		);
 	}
 

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -1,4 +1,4 @@
-body.jetpack_page_jetpack-forms {
+body.toplevel_page_jetpack-forms {
 	background-color: #fff;
 
 	#wpcontent {

--- a/projects/plugins/jetpack/changelog/replace-feedback-menu-with-forms-dashboard
+++ b/projects/plugins/jetpack/changelog/replace-feedback-menu-with-forms-dashboard
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This is an internal change at the moment.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This patch updates the WP Admin sidebar configuration so the JP Forms dashboard replaces the existing "Feedback" entry.  
At the same time, the old feedback admin page can still be accessed under `/wp-admin/edit.php?post_type=feedback`, which is intentional until we've reached full feature parity and the old interface can be deprecated.

In the short-term, we'll likely add a link or possibly a user meta setting allowing users to choose what interface they prefer to interact with. It'll be a separate PR as we're still figuring that out.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pcsBup-Pl-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable the new dashboard with these filters:

```
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
add_filter( 'jetpack_forms_dashboard_enable', '__return_true' );
```

- Verify that when the dashboard is enabled, the "Feedback" top-level sidebar item links to the new dashboard and not the default WP Admin interface for feedback.
- The default feedback admin should still be available when accessing the URL manually: `/wp-admin/edit.php?post_type=feedback`.