### PR TITLE
CRM: Alphabetizing extensions and highlighting featured Woo extensions on extensions page.

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-extensions-page-featured
+++ b/projects/plugins/crm/changelog/update-crm-extensions-page-featured
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+CRM: highlight popular Woo extensions on extensions page, plus alphabetize results

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -2166,38 +2166,29 @@ function zeroBSCRM_html_extensions() {
 			$top_woo_extension_slugs = array( 'advanced-segments', 'sales-dashboard', 'automations', 'client-portal-pro', 'csv-importer-pro', 'wordpress-utilities' );
 			$extensions_to_display   = array();
 			$top_woo_extensions      = array();
+			$has_woosync             = zeroBSCRM_isExtensionInstalled( 'woo-sync' );
 
 			// We want to prioritize the top 5 Woo modules in the list if 'woosync' is active, but otherwise alphabetize everything.
 			foreach ( $extensions->paid as $extension ) {
 
-				if ( in_array( $extension->slug, $top_woo_extension_slugs, true ) && zeroBSCRM_isExtensionInstalled( 'woo-sync' ) ) {
+				if ( $has_woosync && in_array( $extension->slug, $top_woo_extension_slugs, true ) ) {
 					$top_woo_extensions[] = $extension;
-					usort(
-						$top_woo_extensions,
-						function (
-						$str1,
-						$str2
-						) {
-							return strcasecmp( $str1->name, $str2->name );
-						}
-					);
-				} else {
-					$extensions_to_display[] = $extension;
-					usort(
-						$extensions_to_display,
-						function (
-						$str1,
-						$str2
-						) {
-							return strcasecmp( $str1->name, $str2->name );
-						}
-					);
+					continue;
 				}
+				$extensions_to_display[] = $extension;
 			}
 
-			if ( zeroBSCRM_isExtensionInstalled( 'woo-sync' ) ) {
-				$extensions_to_display = array_merge( $top_woo_extensions, $extensions_to_display );
-			}
+			usort(
+				$extensions_to_display,
+				function (
+				$str1,
+				$str2
+				) {
+					return strcasecmp( $str1->name, $str2->name );
+				}
+			);
+
+			$extensions_to_display = array_merge( $top_woo_extensions, $extensions_to_display );
 
 			foreach ( $extensions_to_display as $extension ) {
 				// hide bundles

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -2162,8 +2162,44 @@ function zeroBSCRM_html_extensions() {
 		$count     = 0;
 		$idsToHide = array( 17121, 17119 );
 		if ( is_array( $extensions->paid ) ) {
+
+			$top_woo_extension_slugs = array( 'advanced-segments', 'sales-dashboard', 'automations', 'client-portal-pro', 'csv-importer-pro', 'wordpress-utilities' );
+			$extensions_to_display   = array();
+			$top_woo_extensions      = array();
+
+			// We want to prioritize the top 5 Woo modules in the list if 'woosync' is active, but otherwise alphabetize everything.
 			foreach ( $extensions->paid as $extension ) {
 
+				if ( in_array( $extension->slug, $top_woo_extension_slugs, true ) && zeroBSCRM_isExtensionInstalled( 'woo-sync' ) ) {
+					$top_woo_extensions[] = $extension;
+					usort(
+						$top_woo_extensions,
+						function (
+						$str1,
+						$str2
+						) {
+							return strcmp( $str1->name, $str2->name );
+						}
+					);
+				} else {
+					$extensions_to_display[] = $extension;
+					usort(
+						$extensions_to_display,
+						function (
+						$str1,
+						$str2
+						) {
+							return strcmp( $str1->name, $str2->name );
+						}
+					);
+				}
+			}
+
+			if ( zeroBSCRM_isExtensionInstalled( 'woo-sync' ) ) {
+				$extensions_to_display = array_merge( $top_woo_extensions, $extensions_to_display );
+			}
+
+			foreach ( $extensions_to_display as $extension ) {
 				// hide bundles
 				if ( ! in_array( $extension->id, $idsToHide ) ) {
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -2178,7 +2178,7 @@ function zeroBSCRM_html_extensions() {
 						$str1,
 						$str2
 						) {
-							return strcmp( $str1->name, $str2->name );
+							return strcasecmp( $str1->name, $str2->name );
 						}
 					);
 				} else {
@@ -2189,7 +2189,7 @@ function zeroBSCRM_html_extensions() {
 						$str1,
 						$str2
 						) {
-							return strcmp( $str1->name, $str2->name );
+							return strcasecmp( $str1->name, $str2->name );
 						}
 					);
 				}

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -2178,6 +2178,18 @@ function zeroBSCRM_html_extensions() {
 				$extensions_to_display[] = $extension;
 			}
 
+			if ( count( $top_woo_extensions ) !== 0 ) {
+				usort(
+					$top_woo_extensions,
+					function (
+					$str1,
+					$str2
+					) {
+						return strcasecmp( $str1->name, $str2->name );
+					}
+				);
+			}
+
 			usort(
 				$extensions_to_display,
 				function (


### PR DESCRIPTION
## Proposed changes:

* This PR runs one additional loop through the list of paid extensions in order to create a new array with just the top 6 Woo extensions (alphabetized), and at the same time create another new array with all the extensions (alphabetized). That second array includes all extensions if the Woo Sync feature is not active, and all but those Woo extensions otherwise.
* After looping through all extensions, if the Woo Sync feature is active then the Woo extension array is added to the beginning of the ‘everything else’ array. 
* The result is a list of extensions on the extensions page - `wp-admin/admin.php?page=zerobscrm-extensions`- which includes alphabetized top Woo extensions if Woo sync is active, with the remaining extensions following (also alphabetized). If Woo Sync is not active on the site, then the entire extensions list that is displayed is alphabetized.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/1953
p1677500616546899-slack-CTXBP902X

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, visit the extensions page: `wp-admin/admin.php?page=zerobscrm-extensions`.
* If Woo Sync is active (`/wp-admin/admin.php?page=zerobscrm-modules`), the first 6 results should be 'Advanced Segments', 'Automations', 'Client Portal Pro, 'CSV Importer PRO', then 'Sales Dashboard' and 'WordPress Utilities'. Following that, the remaining extensions should be alphabetized.
* If Woo Sync is disabled , the results should all be alphabetized and the top 5 Woo extensions  included amongst the alphabetized results.