### PR TITLE
Blocks: update scaffolding CLI commands

### DIFF
--- a/projects/plugins/jetpack/changelog/update-block-scaffold-update
+++ b/projects/plugins/jetpack/changelog/update-block-scaffold-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: update scaffolding.

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -2010,7 +2010,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 					'title'            => $title,
 					'underscoredSlug'  => str_replace( '-', '_', $slug ),
 					'underscoredTitle' => str_replace( ' ', '_', $title ),
-					'jetpackVersion'   => substr( JETPACK__VERSION, 0, strpos( JETPACK__VERSION, '.' ) ) . '.x',
 				)
 			),
 			"$path/index.js"      => $this->render_block_file(

--- a/projects/plugins/jetpack/wp-cli-templates/block-edit-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-edit-js.mustache
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
 import { BlockIcon } from '@wordpress/block-editor';
 import { Placeholder, withNotices } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import icon from './icon';
 

--- a/projects/plugins/jetpack/wp-cli-templates/block-editor-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-editor-js.mustache
@@ -1,6 +1,3 @@
-/**
- * Internal dependencies
- */
 import registerJetpackBlock from '../../shared/register-jetpack-block';
 import { name, settings } from '.';
 

--- a/projects/plugins/jetpack/wp-cli-templates/block-icon-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-icon-js.mustache
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import { SVG, Path } from '@wordpress/components';
 
 export default (

--- a/projects/plugins/jetpack/wp-cli-templates/block-index-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-index-js.mustache
@@ -1,17 +1,10 @@
-/**
- * External dependencies
- */
-import { __{{#hasKeywords}}, _x{{/hasKeywords}} } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { __{{#hasKeywords}}, _x{{/hasKeywords}} } from '@wordpress/i18n';
+import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
 import edit from './edit';
 import icon from './icon';
-import { getIconColor } from '../../shared/block-icons';
 
 /**
  * Style dependencies

--- a/projects/plugins/jetpack/wp-cli-templates/block-register-php.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-register-php.mustache
@@ -2,7 +2,7 @@
 /**
  * {{ title }} Block.
  *
- * @since {{ jetpackVersion }}
+ * @since $$next-version$$
  *
  * @package automattic/jetpack
  */


### PR DESCRIPTION
## Proposed changes:

- Remove comments and alphabetically order imports.
    - Comments are no longer required.
    - Imports that are not alphabetically ordered generate linting errors.
- Rely on `$$next-version$$` instead of only guessing a version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Run `jetpack docker wp jetpack scaffold block thing`
* Ensure it is properly generated.

