### PR TITLE
Custom CSS: use slug to link to Custom CSS settings

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-custom-css-direct-link
+++ b/projects/plugins/jetpack/changelog/fix-custom-css-direct-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Custom CSS: ensure the link to enable Custom CSS works in all languages.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -177,7 +177,7 @@ class Jetpack_Admin {
 	 */
 	public static function theme_enhancements_redirect() {
 		wp_safe_redirect(
-			'admin.php?page=jetpack#/writing?term=Custom%20CSS'
+			'admin.php?page=jetpack#/writing?term=custom-css'
 		);
 		exit;
 	}


### PR DESCRIPTION
Fixes #29184

## Proposed changes:

Using a slug instead of a search term ensures that the link will work in all languages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Switch your site language to French.
* Ensure the Custom CSS feature is disabled on your site: `jetpack docker wp jetpack module deactivate custom-css`
* Load wp-admin
* Click on Apparence > CSS Additionnel
* Ensure you are redirected to the Jetpack > Settings > Writing screen, with the Custom CSS card displayed.
