### PR TITLE
Remove `Default Image` option from SIG panel

### DIFF
--- a/projects/js-packages/publicize-components/changelog/remove-sig-default-image
+++ b/projects/js-packages/publicize-components/changelog/remove-sig-default-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed default image for SIG as it's not used yet

--- a/projects/js-packages/publicize-components/src/components/social-image-generator/panel/index.js
+++ b/projects/js-packages/publicize-components/src/components/social-image-generator/panel/index.js
@@ -43,15 +43,9 @@ const SocialImageGeneratorPanel = ( { prePublish = false } ) => {
 							value: 'featured',
 						},
 						{ label: __( 'Custom Image', 'jetpack' ), value: 'custom' },
-						{ label: __( 'Default Image', 'jetpack' ), value: 'default' },
 						{ label: __( 'No Image', 'jetpack' ), value: 'none' },
 					] }
 					onChange={ setImageType }
-					help={
-						imageType === 'default'
-							? __( 'You can change the default image by clicking the Edit link below.', 'jetpack' )
-							: null
-					}
 				/>
 
 				{ imageType === 'custom' && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This small change removes the default image option from the SIG panel, as it's not used yet for the MVP.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1677593334180309/1677590659.798069-slack-C02JJ910CNL

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add the SIG blog sticker to your blog with `add_blog_sticker( 'publicize-social-image-generator', true, null, <blog_id>);`
* Check that the `Default image` option is not there anymore, and the panel works as before