### PR TITLE
Jetpack: register VideoPress video block based on the filtered extensions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-register-videopress-video-based-on-filtered-extensions
+++ b/projects/plugins/jetpack/changelog/update-videopress-register-videopress-video-based-on-filtered-extensions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack: register VideoPress video block based on the filtered extensions

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -412,7 +412,7 @@ class Jetpack_Gutenberg {
 	 *
 	 * @return array A list of block and plugins and their availability status.
 	 */
-	public function get_extensions() {
+	public static function get_extensions() {
 		return self::$extensions;
 	}
 

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -406,6 +406,17 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
+	 * Return the list of extensions that are available.
+	 *
+	 * @since 11.9
+	 *
+	 * @return array A list of block and plugins and their availability status.
+	 */
+	public function get_extensions() {
+		return self::$extensions;
+	}
+
+	/**
 	 * Check if an extension/block is already registered
 	 *
 	 * @since 7.2

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -21,11 +21,11 @@ add_action(
 add_action(
 	'init',
 	function () {
-		$availability                = \Jetpack_Gutenberg::get_availability();
-		$is_videopress_video_enabled = isset( $availability['videopress/video'] ) && $availability['videopress/video']['available'];
+		$extensions                            = \Jetpack_Gutenberg::get_extensions();
+		$is_videopress_video_extension_enabled = in_array( 'videopress/video', $extensions, true );
 
 		if (
-			$is_videopress_video_enabled &&
+			$is_videopress_video_extension_enabled &&
 			method_exists( 'Automattic\Jetpack\VideoPress\Initializer', 'register_videopress_video_block' )
 		) {
 			VideoPress_Pkg_Initializer::register_videopress_video_block();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a `get_extensions()` method to the `Jetpack_Gutenberg` class to get access to these data.
The extensions list provided by it can be filtered, meaning that if an extension is defined as beta, it's possible to redefine its value using one of the available filters.

This PR uses this method to register, or not, the VideoPress video block.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: register VideoPress video block based on the filtered extensions #29207

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and Activate the Jetpack plugin (Jetpack and Atomic sites)
* Activate VideoPress module (Jetpack and Atomic sites)

<img width="500" alt="image" src="https://user-images.githubusercontent.com/77539/220638323-865e250e-b384-4ff5-b0f5-8b5d6205a9c5.png">

* Confirm the VideoPress video block `v6` is available only when [the beta extension](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/jetpack/extensions#beta-extensions) is enabled in the testing site
* Test in Jetpack, Atomic, and Simple sites

* Install and Activate the VideoPress Standalone plugin 
* Confirm `v6` is available for Jetpack and Atomic sites

