### PR TITLE
CRM: Making sure id is included in a tag inclusion

### DIFF
--- a/projects/plugins/crm/admin/settings/tax.page.php
+++ b/projects/plugins/crm/admin/settings/tax.page.php
@@ -138,9 +138,28 @@ if ( isset( $sbupdated ) ) {
 					<div class="ui info icon message">
 						<div class="content">
 							<div class="header"><?php esc_html_e( 'No Tax Rates', 'zero-bs-crm' ); ?></div>
-							<p><?php echo wp_kses( sprintf( __( 'There are no tax rates defined yet. Do you want to <a href="%s" id="zbs-new-add-tax-rate">create one</a>?', 'zero-bs-crm' ), '#' ), $zbs->acceptable_restricted_html ); ?></p>
+							<p>
+							<p>
+								<?php
+									echo sprintf(
+										wp_kses(
+											/* Translators: placeholder is an anchor, which gets changed via Javascript elsewhere to create new tax rate entry fields. */
+											__(
+												'There are no tax rates defined yet. Do you want to <a href="%s" id="zbs-new-add-tax-rate">create one</a>?',
+												'zero-bs-crm'
+											),
+											array(
+												'a' => array(
+													'href' => array(),
+													'id'   => array(),
+												),
+											)
+										),
+										'#'
+									);
+									?>
+							</p>
 						</div>
-					</div>
 				</td>
 			</tr>
 

--- a/projects/plugins/crm/admin/settings/tax.page.php
+++ b/projects/plugins/crm/admin/settings/tax.page.php
@@ -139,28 +139,27 @@ if ( isset( $sbupdated ) ) {
 						<div class="content">
 							<div class="header"><?php esc_html_e( 'No Tax Rates', 'zero-bs-crm' ); ?></div>
 							<p>
-								<p>
-									<?php
-										echo sprintf(
-											wp_kses(
-												/* Translators: placeholder is an anchor, which gets changed via Javascript elsewhere to create new tax rate entry fields. */
-												__(
-													'There are no tax rates defined yet. Do you want to <a href="%s" id="zbs-new-add-tax-rate">create one</a>?',
-													'zero-bs-crm'
-												),
-												array(
-													'a' => array(
-														'href' => array(),
-														'id'   => array(),
-													),
-												)
+								<?php
+									echo sprintf(
+										wp_kses(
+											/* Translators: placeholder is an anchor, which gets changed via Javascript elsewhere to create new tax rate entry fields. */
+											__(
+												'There are no tax rates defined yet. Do you want to <a href="%s" id="zbs-new-add-tax-rate">create one</a>?',
+												'zero-bs-crm'
 											),
-											'#'
-										);
-										?>
-								</p>
+											array(
+												'a' => array(
+													'href' => array(),
+													'id'   => array(),
+												),
+											)
+										),
+										'#'
+									);
+									?>
 							</p>
 						</div>
+					</div>
 				</td>
 			</tr>
 

--- a/projects/plugins/crm/admin/settings/tax.page.php
+++ b/projects/plugins/crm/admin/settings/tax.page.php
@@ -147,12 +147,7 @@ if ( isset( $sbupdated ) ) {
 												'There are no tax rates defined yet. Do you want to <a href="%s" id="zbs-new-add-tax-rate">create one</a>?',
 												'zero-bs-crm'
 											),
-											array(
-												'a' => array(
-													'href' => array(),
-													'id'   => array(),
-												),
-											)
+											$zbs->acceptable_restricted_html
 										),
 										'#'
 									);

--- a/projects/plugins/crm/admin/settings/tax.page.php
+++ b/projects/plugins/crm/admin/settings/tax.page.php
@@ -139,25 +139,26 @@ if ( isset( $sbupdated ) ) {
 						<div class="content">
 							<div class="header"><?php esc_html_e( 'No Tax Rates', 'zero-bs-crm' ); ?></div>
 							<p>
-							<p>
-								<?php
-									echo sprintf(
-										wp_kses(
-											/* Translators: placeholder is an anchor, which gets changed via Javascript elsewhere to create new tax rate entry fields. */
-											__(
-												'There are no tax rates defined yet. Do you want to <a href="%s" id="zbs-new-add-tax-rate">create one</a>?',
-												'zero-bs-crm'
-											),
-											array(
-												'a' => array(
-													'href' => array(),
-													'id'   => array(),
+								<p>
+									<?php
+										echo sprintf(
+											wp_kses(
+												/* Translators: placeholder is an anchor, which gets changed via Javascript elsewhere to create new tax rate entry fields. */
+												__(
+													'There are no tax rates defined yet. Do you want to <a href="%s" id="zbs-new-add-tax-rate">create one</a>?',
+													'zero-bs-crm'
 												),
-											)
-										),
-										'#'
-									);
-									?>
+												array(
+													'a' => array(
+														'href' => array(),
+														'id'   => array(),
+													),
+												)
+											),
+											'#'
+										);
+										?>
+								</p>
 							</p>
 						</div>
 				</td>

--- a/projects/plugins/crm/changelog/fix-crm-tax-settings-link
+++ b/projects/plugins/crm/changelog/fix-crm-tax-settings-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: fix tax rate creation link on tax rate settings page.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -456,6 +456,7 @@ final class ZeroBSCRM {
 		'a'          => array(
 			'href'  => array(),
 			'title' => array(),
+			'id'    => array(),
 		),
 		'br'         => array(),
 		'em'         => array(),


### PR DESCRIPTION
## Proposed changes:

* This PR fixes the issue with the 'create one' link not working on the tax settings page (when there are no tax rates added). The issue was that the extra parameter for the `a` tag (`id`), was not included in `$zbs->acceptable_restricted_html` . 
* ~We could add to the `$acceptable_restricted_html` array in `includes/ZeroBSCRM.Core.php`, but without knowing what else that impacts I opted to just add this via `wp_kses` directly~ (now added to the `$acceptable_restricted_html` array - [see this thread](https://github.com/Automattic/jetpack/pull/29209#discussion_r1120990683)).
* I also cleaned up ([reference](https://codex.wordpress.org/I18n_for_WordPress_Developers#HTM)) the way the translatable string was written.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2752

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, visit the CRM Settings > tax: `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=tax`.
* Make sure there are no tax rates added - if there are remove them. There is [currently a bug](https://github.com/Automattic/zero-bs-crm/issues/2753) affecting the last remaining tax field from what I've noticed (if there are more they appear to get deleted ok) meaning it might not get removed - if you encounter that find the value of the remaining tax field via the browser inspector, and add the following code somewhere on `tax.page.php`, the refresh the page - `zeroBSCRM_taxRates_deleteTaxRate( array( 'id' => {add your tax field value here } ) );`
* Click on 'create one' in the sentence 'There are no tax rates defined yet. Do you want to create one?', and two fields should appear to allow you to add a name and rate for a new tax rate. 
* This behaviour should be the same as when you click the plus icon on this same settings page:

<img width="1019" alt="Screenshot 2023-02-28 at 4 25 39 pm" src="https://user-images.githubusercontent.com/16754605/221915274-06d660c6-e087-4f9b-ac7a-afeb600a5477.png">
