### PR TITLE
Writing prompts: use block to indicate answering a prompt

### DIFF
--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -55,6 +55,7 @@ add_action( 'wp_insert_post', 'jetpack_setup_blogging_prompt_response' );
  * @param WP_Post $post       Post object.
  */
 function jetpack_mark_if_post_answers_blogging_prompt( $new_status, $old_status, $post ) {
+	// Make sure we are publishing a post, and it's not already published.
 	if ( 'post' !== $post->post_type || 'publish' !== $new_status || 'publish' === $old_status ) {
 		return;
 	}
@@ -64,7 +65,7 @@ function jetpack_mark_if_post_answers_blogging_prompt( $new_status, $old_status,
 		if ( 'jetpack/blogging-prompt' === $block['blockName'] ) {
 			$prompt_id = $block['attrs']['promptId'];
 
-			if ( $prompt_id ) {
+			if ( $prompt_id && count( $blocks ) > 1 ) {
 				update_post_meta( $post->ID, '_jetpack_blogging_prompt_key', $prompt_id );
 				break;
 			}

--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -63,7 +63,7 @@ function jetpack_mark_if_post_answers_blogging_prompt( $new_status, $old_status,
 	$blocks = parse_blocks( $post->post_content );
 	foreach ( $blocks as $block ) {
 		if ( 'jetpack/blogging-prompt' === $block['blockName'] ) {
-			$prompt_id      = isset( $block['attrs']['promptId'] ) ? $block['attrs']['promptId'] : null;
+			$prompt_id      = isset( $block['attrs']['promptId'] ) ? absint( $block['attrs']['promptId'] ) : null;
 			$has_prompt_tag = has_tag( 'dailyprompt', $post ) || ( $prompt_id && has_tag( "dailyprompt-{$prompt_id}", $post ) );
 
 			if ( $prompt_id && $has_prompt_tag && count( $blocks ) > 1 ) {

--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -48,7 +48,7 @@ function jetpack_setup_blogging_prompt_response( $post_id ) {
 add_action( 'wp_insert_post', 'jetpack_setup_blogging_prompt_response' );
 
 /**
- * Add a meta value to posts that answer a blogging prompt, when published.
+ * When a published posts answers a blogging prompt, store the prompt id in the post meta.
  *
  * @param string  $new_status New post status.
  * @param string  $old_status Old post status.
@@ -68,8 +68,9 @@ function jetpack_mark_if_post_answers_blogging_prompt( $new_status, $old_status,
 
 			if ( $prompt_id && $has_prompt_tag && count( $blocks ) > 1 ) {
 				update_post_meta( $post->ID, '_jetpack_blogging_prompt_key', $prompt_id );
-				break;
 			}
+
+			break;
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -63,9 +63,10 @@ function jetpack_mark_if_post_answers_blogging_prompt( $new_status, $old_status,
 	$blocks = parse_blocks( $post->post_content );
 	foreach ( $blocks as $block ) {
 		if ( 'jetpack/blogging-prompt' === $block['blockName'] ) {
-			$prompt_id = isset( $block['attrs']['promptId'] ) ? $block['attrs']['promptId'] : null;
+			$prompt_id      = isset( $block['attrs']['promptId'] ) ? $block['attrs']['promptId'] : null;
+			$has_prompt_tag = has_tag( 'dailyprompt', $post ) || ( $prompt_id && has_tag( "dailyprompt-{$prompt_id}", $post ) );
 
-			if ( $prompt_id && count( $blocks ) > 1 ) {
+			if ( $prompt_id && $has_prompt_tag && count( $blocks ) > 1 ) {
 				update_post_meta( $post->ID, '_jetpack_blogging_prompt_key', $prompt_id );
 				break;
 			}

--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -48,6 +48,32 @@ function jetpack_setup_blogging_prompt_response( $post_id ) {
 add_action( 'wp_insert_post', 'jetpack_setup_blogging_prompt_response' );
 
 /**
+ * Add a meta value to posts when publishd that answer a blogging prompt.
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Old post status.
+ * @param WP_Post $post       Post object.
+ */
+function jetpack_mark_if_post_answers_blogging_prompt( $new_status, $old_status, $post ) {
+	if ( 'post' !== $post->post_type || 'publish' !== $new_status || 'publish' === $old_status ) {
+		return;
+	}
+
+	$blocks = parse_blocks( $post->post_content );
+	foreach ( $blocks as $block ) {
+		if ( 'jetpack/blogging-prompt' === $block['blockName'] ) {
+			$prompt_id = $block['attrs']['promptId'];
+
+			if ( $prompt_id ) {
+				update_post_meta( $post->ID, '_jetpack_blogging_prompt_key', $prompt_id );
+				break;
+			}
+		}
+	}
+}
+add_action( 'transition_post_status', 'jetpack_mark_if_post_answers_blogging_prompt', 10, 3 );
+
+/**
  * Utility functions.
  */
 

--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -48,7 +48,7 @@ function jetpack_setup_blogging_prompt_response( $post_id ) {
 add_action( 'wp_insert_post', 'jetpack_setup_blogging_prompt_response' );
 
 /**
- * Add a meta value to posts when publishd that answer a blogging prompt.
+ * Add a meta value to posts that answer a blogging prompt, when published.
  *
  * @param string  $new_status New post status.
  * @param string  $old_status Old post status.
@@ -63,7 +63,7 @@ function jetpack_mark_if_post_answers_blogging_prompt( $new_status, $old_status,
 	$blocks = parse_blocks( $post->post_content );
 	foreach ( $blocks as $block ) {
 		if ( 'jetpack/blogging-prompt' === $block['blockName'] ) {
-			$prompt_id = $block['attrs']['promptId'];
+			$prompt_id = isset( $block['attrs']['promptId'] ) ? $block['attrs']['promptId'] : null;
 
 			if ( $prompt_id && count( $blocks ) > 1 ) {
 				update_post_meta( $post->ID, '_jetpack_blogging_prompt_key', $prompt_id );

--- a/projects/plugins/jetpack/changelog/update-blogging-prompt-answer-marked
+++ b/projects/plugins/jetpack/changelog/update-blogging-prompt-answer-marked
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Writing prompts: marks prompt as answered when using a writing prompt block

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/attributes.js
@@ -27,4 +27,8 @@ export default {
 		type: 'boolean',
 		default: true,
 	},
+	tagsAdded: {
+		type: 'boolean',
+		default: false,
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/blogging-prompt.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/blogging-prompt.php
@@ -21,10 +21,12 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	Blocks::jetpack_register_block(
-		BLOCK_NAME,
-		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
-	);
+	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_connection_ready() ) {
+		Blocks::jetpack_register_block(
+			BLOCK_NAME,
+			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+		);
+	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/blogging-prompt.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/blogging-prompt.php
@@ -21,7 +21,7 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_connection_ready() ) {
+	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || \Jetpack::is_connection_ready() ) {
 		Blocks::jetpack_register_block(
 			BLOCK_NAME,
 			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
@@ -117,6 +117,18 @@ function BloggingPromptsBetaEdit( { attributes, noticeOperations, noticeUI, setA
 		</>
 	);
 
+	const { answerCount, gravatars, prompt, promptId, showLabel, showResponses } = attributes;
+
+	const blockProps = useBlockProps( { className: 'jetpack-blogging-prompts' } );
+
+	const onShowLabelChange = newValue => {
+		setAttributes( { showLabel: newValue } );
+	};
+
+	const onShowResponsesChange = newValue => {
+		setAttributes( { showResponses: newValue } );
+	};
+
 	return (
 		<div { ...blockProps }>
 			{ noticeUI }

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
@@ -117,18 +117,6 @@ function BloggingPromptsBetaEdit( { attributes, noticeOperations, noticeUI, setA
 		</>
 	);
 
-	const { answerCount, gravatars, prompt, promptId, showLabel, showResponses } = attributes;
-
-	const blockProps = useBlockProps( { className: 'jetpack-blogging-prompts' } );
-
-	const onShowLabelChange = newValue => {
-		setAttributes( { showLabel: newValue } );
-	};
-
-	const onShowResponsesChange = newValue => {
-		setAttributes( { showResponses: newValue } );
-	};
-
 	return (
 		<div { ...blockProps }>
 			{ noticeUI }

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
@@ -92,7 +92,7 @@ function BloggingPromptsBetaEdit( { attributes, noticeOperations, noticeUI, setA
 
 			<div className="jetpack-blogging-prompts__prompt">{ prompt }</div>
 
-			{ showResponses && (
+			{ showResponses && promptId && (
 				<div className="jetpack-blogging-prompts__answers">
 					{ gravatars &&
 						gravatars.slice( 0, 3 ).map( ( { url } ) => {

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
@@ -1,8 +1,41 @@
-/**
- * Internal dependencies
- */
 import registerJetpackBlock from '../../shared/register-jetpack-block';
 import { name, settings } from '.';
 import './style.scss';
 
 registerJetpackBlock( name, settings );
+
+// function addTagsOnBlockInsert() {
+// 	const { getBlocks: getBlockList } = wp.data.select( 'core/editor' );
+
+// 	// Get current blocks client ids
+// 	let blockList = getBlockList().map( block => block.clientId );
+
+// 	wp.data.subscribe( () => {
+// 		// Get new blocks client ids
+// 		const newBlockList = getBlockList().map( block => block.clientId );
+// 		console.log( getBlockList() );
+
+// 		// Compare lengths
+// 		const blockListChanged = newBlockList.length !== blockList.length;
+
+// 		if ( ! blockListChanged ) {
+// 			return;
+// 		}
+
+// 		// Block Added
+// 		if ( newBlockList > blockList ) {
+// 			// Get added blocks
+// 			const added = newBlockList.filter( x => ! blockList.includes( x ) );
+// 			console.log( 'added', added );
+// 		} else if ( newBlockList < blockList ) {
+// 			// Get removed blocks
+// 			const removed = blockList.filter( x => ! newBlockList.includes( x ) );
+// 			console.log( 'removed', removed );
+// 		}
+
+// 		// Update current block list with the new blocks for further comparison
+// 		blockList = newBlockList;
+// 	} );
+// }
+
+// addTagsOnBlockInsert();

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
@@ -3,39 +3,3 @@ import { name, settings } from '.';
 import './style.scss';
 
 registerJetpackBlock( name, settings );
-
-// function addTagsOnBlockInsert() {
-// 	const { getBlocks: getBlockList } = wp.data.select( 'core/editor' );
-
-// 	// Get current blocks client ids
-// 	let blockList = getBlockList().map( block => block.clientId );
-
-// 	wp.data.subscribe( () => {
-// 		// Get new blocks client ids
-// 		const newBlockList = getBlockList().map( block => block.clientId );
-// 		console.log( getBlockList() );
-
-// 		// Compare lengths
-// 		const blockListChanged = newBlockList.length !== blockList.length;
-
-// 		if ( ! blockListChanged ) {
-// 			return;
-// 		}
-
-// 		// Block Added
-// 		if ( newBlockList > blockList ) {
-// 			// Get added blocks
-// 			const added = newBlockList.filter( x => ! blockList.includes( x ) );
-// 			console.log( 'added', added );
-// 		} else if ( newBlockList < blockList ) {
-// 			// Get removed blocks
-// 			const removed = blockList.filter( x => ! newBlockList.includes( x ) );
-// 			console.log( 'removed', removed );
-// 		}
-
-// 		// Update current block list with the new blocks for further comparison
-// 		blockList = newBlockList;
-// 	} );
-// }
-
-// addTagsOnBlockInsert();

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/save.js
@@ -15,7 +15,7 @@ function BloggingPromptsSave( { attributes } ) {
 				</div>
 			) }
 			<div className="jetpack-blogging-prompts__prompt">{ prompt }</div>
-			{ showResponses && (
+			{ showResponses && promptId && (
 				<div className="jetpack-blogging-prompts__answers">
 					{ gravatars.map( ( { url } ) => {
 						return (

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/use-prompt-tags.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/use-prompt-tags.js
@@ -1,0 +1,70 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { escapeHTML } from '@wordpress/escape-html';
+// Tries to create a tag or fetch it if it already exists.
+// @link https://github.com/WordPress/gutenberg/blob/98b58d9042eda7590659c6cce2cf7916ba99aaa1/packages/editor/src/components/post-taxonomies/flat-term-selector.js#L55
+function findOrCreateTag( tagName ) {
+	const escapedTagName = escapeHTML( tagName );
+
+	return apiFetch( {
+		path: `/wp/v2/tags`,
+		method: 'POST',
+		data: { name: escapedTagName },
+	} ).catch( error => {
+		if ( error.code !== 'term_exists' ) {
+			return Promise.reject( error );
+		}
+
+		return Promise.resolve( {
+			id: error.data.term_id,
+			name: tagName,
+		} );
+	} );
+}
+
+export function usePromptTags( promptId, tagsAdded, setAttributes ) {
+	const { editPost } = useDispatch( 'core/editor' );
+
+	// Get the tags for the post.
+	const { tags, tagIds, tagsHaveResolved } = useSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getEntityRecords, hasFinishedResolution } = select( 'core' );
+		const _termIds = getEditedPostAttribute( 'tags' );
+
+		const query = {
+			_fields: 'id,name',
+			context: 'view',
+			include: _termIds?.join( ',' ),
+			per_page: -1,
+		};
+
+		return {
+			tagIds: _termIds,
+			tags: _termIds && _termIds.length ? getEntityRecords( 'taxonomy', 'post_tag', query ) : [],
+			tagsHaveResolved:
+				_termIds && _termIds.length
+					? hasFinishedResolution( 'getEntityRecords', [ 'taxonomy', 'post_tag', query ] )
+					: true,
+		};
+	}, [] );
+
+	// Add the related prompt tags, if they haven't been added already.
+	useEffect( () => {
+		if ( tagsAdded || ! tagsHaveResolved || ! promptId || ! Array.isArray( tags ) ) {
+			return;
+		}
+
+		if ( ! tags.some( tag => tag.name && 'dailyprompt' === tag.name ) ) {
+			findOrCreateTag( 'dailyprompt' ).then( tag => {
+				editPost( { tags: [ ...tagIds, tag.id ] } );
+			} );
+		} else if ( ! tags.some( tag => tag.name && `dailyprompt-${ promptId }` === tag.name ) ) {
+			findOrCreateTag( `dailyprompt-${ promptId }` ).then( tag => {
+				editPost( { tags: [ ...tagIds, tag.id ] } );
+			} );
+		} else {
+			setAttributes( { tagsAdded: true } );
+		}
+	}, [ editPost, promptId, setAttributes, tagsAdded, tagsHaveResolved, tags, tagIds ] );
+}


### PR DESCRIPTION
## Proposed changes:

Checks posts when published and adds meta if they use a blogging prompt block.

Follow up to #29189 and related writing prompt block work, currently requires setting up the related API changes to test.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Project: pe7F0s-uo-p2

Additional discussion: pe7F0s-Dk-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Set up your wpcom sandbox for testing by applying Jepack trunk to your sandbox with `bin/jetpack-downloader test jetpack trunk`
- Set the JETPACK__SANDBOX_DOMAIN constant to your wpcom sandbox host, using a define statement on your development site, or Settings > Jetpack Constants on your jurassic.ninja site.
- Make sure your site is connected to WP.com
- Create a post without a writing prompt block and publish it. You should not see the `_jetpack_blogging_prompt_key` post meta added.
- Create another post, add the writing prompts block with at least one other block, and publish it. You should see the `_jetpack_blogging_prompt_key` post meta added with the correct prompt id.
- Create another post, adding the writing prompts block with at least one other block. You should see the `dailyprompt` and `dailyprompt-{prompt_id}` tags added. Remove one tag, then publish. You should see the `_jetpack_blogging_prompt_key` post meta added with the correct prompt id.
- Create another post, adding the writing prompts block with at least one other block. Remove both tags. You should **not** see the `_jetpack_blogging_prompt_key` post meta added.