### PR TITLE
CRM: Fix potential XSS attack in tax settings page

### DIFF
--- a/projects/plugins/crm/admin/settings/tax.page.php
+++ b/projects/plugins/crm/admin/settings/tax.page.php
@@ -264,13 +264,13 @@ if ( isset( $sbupdated ) ) {
 
 			html += '<tr class="zbs-taxtable-line">';
 			html += '<td>';
-			html += '<input type="hidden" name="jpcrm-taxtable-line[ids][]" value="' + thisID + '" />';
-			html += '<div class="ui fluid input"><input type="text" class="winput form-control" name="jpcrm-taxtable-line[names][]" value="' + namestr + '" placeholder="' + window.zeroBSCRMJS_taxTableLang.defaultTaxName + '" /></div>';
+			html += '<input type="hidden" name="jpcrm-taxtable-line[ids][]" value="' + jpcrm.esc_attr( thisID ) + '" />';
+			html += '<div class="ui fluid input"><input type="text" class="winput form-control" name="jpcrm-taxtable-line[names][]" value="' + jpcrm.esc_attr( namestr ) + '" placeholder="' + jpcrm.esc_attr( window.zeroBSCRMJS_taxTableLang.defaultTaxName ) + '" /></div>';
 			html += '</td>';
 			html += '<td>';
 			html += '<div class="ui right labeled input">';
-			html += '<input type="text" class="winput form-control numbersOnly zbs-dc" name="jpcrm-taxtable-line[rates][]" value="' + rateval + '" placeholder="' + window.zeroBSCRMJS_taxTableLang.defaultTaxPerc + '"  />';
-			html += '<div class="ui basic label">' + window.zeroBSCRMJS_taxTableLang.percSymbol + '</div></div>';
+			html += '<input type="text" class="winput form-control numbersOnly zbs-dc" name="jpcrm-taxtable-line[rates][]" value="' + jpcrm.esc_attr( rateval ) + '" placeholder="' + jpcrm.esc_attr( window.zeroBSCRMJS_taxTableLang.defaultTaxPerc ) + '"  />';
+			html += '<div class="ui basic label">' + jpcrm.esc_html( window.zeroBSCRMJS_taxTableLang.percSymbol ) + '</div></div>';
 			html += '</td>';
 			html += '<td class="wmid">';
 			html += '<button type="button" class="ui icon button zbs-taxtable-remove-rate"><i class="close icon"></i></button>';

--- a/projects/plugins/crm/changelog/fix-crm-xss-attack-in-tax-rate
+++ b/projects/plugins/crm/changelog/fix-crm-xss-attack-in-tax-rate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed potential XSS in the Tax Settings page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes a potential XSS in the Tax settings page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/zero-bs-crm/issues/2746

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Tax Settings page ('/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=tax')
* Add a tax with the following name: `test"onmouseover=alert(1) x="y`
* Save it
* Move the mouse over the tax name input

In `trunk`, an alert will be shown.
In `fix/crm-xss-attack-in-tax-rate`, the field will be properly escaped, and now alert will be shown.

