### PR TITLE
Stats: Update layouts on legacy page.

### DIFF
--- a/projects/plugins/jetpack/changelog/stats-update-legacy-layouts
+++ b/projects/plugins/jetpack/changelog/stats-update-legacy-layouts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Updates the layout of the loading and "no JS" sections on the legacy Stats page.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -410,7 +410,7 @@ function stats_reports_css() {
 #stats-loading-wrap p {
 	text-align: center;
 	font-size: 2em;
-	margin: 7.5em 15px 0 0;
+	margin-bottom: 3em;
 	height: 64px;
 	line-height: 64px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29114.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Tweaks the margins around the loading spinner and the status notice shown when JS is disabled.

**Loading Spinner:**

<img width="883" alt="SCR-20230301-n5q" src="https://user-images.githubusercontent.com/40267301/222087747-31ad6792-e029-4177-8e1f-a5869df2939a.png">

**JS Disabled Status:**

<img width="883" alt="SCR-20230301-n5x" src="https://user-images.githubusercontent.com/40267301/222087806-e4cbc941-c42b-43cc-8ed0-39d770e2804b.png">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Make sure Odyssey Stats are disabled.
- Visit Jetpack → Stats.
- Confirm the large gap above the loading spinner is no longer there.
- Disable JS for the site. In Chrome, this can be done via the lock icon in the address bar → Site settings.
- Reload the stats page and confirm the notice matches the screenshot above. (no gap, second line of text visible)







