### PR TITLE
CRM: Edit description for company name in onboarding wizard.

### DIFF
--- a/projects/plugins/crm/admin/activation/welcome-to-jpcrm.php
+++ b/projects/plugins/crm/admin/activation/welcome-to-jpcrm.php
@@ -106,7 +106,7 @@ $settings      = $zbs->settings->getAll();
 				<div class="wizopt">
 
 					<label><?php esc_html_e( jpcrm_label_company() . ' Name / CRM Name:', 'zero-bs-crm' ); ?></label>
-					<p style="margin-bottom:0"><?php esc_html_e( "This name will be shown at the top left of your CRM (as shown below). E.g. 'Widget Co CRM'", 'zero-bs-crm' ); ?></p>
+					<p style="margin-bottom:0"><?php esc_html_e( "This name will be shown at the top left of your CRM. E.g. 'Widget Co CRM'", 'zero-bs-crm' ); ?></p>
 					<div style="width:90%;">
 						<div style="width:50%;float:left">
 							<input class='form-control' type="text" name="zbs_crm_name" id='zbs_crm_name' value="" placeholder="<?php esc_html_e( 'Name of your CRM (e.g Jetpack CRM)', 'zero-bs-crm' ); ?>" style="width:90%" onchange="zbs_crm_name_change();"/>

--- a/projects/plugins/crm/changelog/update-crm-onboarding-wizard-company-name-explanation
+++ b/projects/plugins/crm/changelog/update-crm-onboarding-wizard-company-name-explanation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+CRM: change onboarding wizard company name description to remove 'as shown below'


### PR DESCRIPTION


## Proposed changes:

* This PR follows on from https://github.com/Automattic/jetpack/pull/29171 and edits the description on the first page of the onboarding wizard to remove the 'as seen below' which is no longer relevant (related to the company name).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2975

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Follow the testing instructions as per this PR - https://github.com/Automattic/jetpack/pull/29171 - but for this PR.
* The company name description should no longer show 'as shown below':

How it should now look:

<img width="648" alt="Screenshot 2023-03-01 at 9 36 21 am" src="https://user-images.githubusercontent.com/16754605/222102174-c0feb37a-e819-4824-bf3f-4d2bbfe50c37.png">


