### PR TITLE
Forms: fix permission check in Responses endpoint

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-endpoint-permissions
+++ b/projects/packages/forms/changelog/fix-forms-endpoint-permissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms Responses endpoint: fix permission check.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.6.0",
+	"version": "0.6.1-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.6.0';
+	const PACKAGE_VERSION = '0.6.1-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -39,10 +39,10 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base . '/responses',
 			array(
-				'methods'           => WP_REST_Server::READABLE,
-				'callback'          => array( $this, 'get_responses' ),
-				'permissions_check' => array( $this, 'get_responses_permission_check' ),
-				'args'              => array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_responses' ),
+				'permission_callback' => array( $this, 'get_responses_permission_check' ),
+				'args'                => array(
 					'limit'   => array(
 						'default'  => 20,
 						'type'     => 'integer',


### PR DESCRIPTION
## Proposed changes:

* This is a follow-up to #29043. When registering the endpoint, we used the wrong parameter to define permissions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Start by enabling the new Forms interface, by adding the following to a functionality plugin:

```php
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
add_filter( 'jetpack_forms_dashboard_enable', '__return_true' );
```

Then, before you check out this branch:

1. Go to `https://yoursite.com/wp-json/wpcom/v2/forms/responses`
2. View responses, even though you are not authenticated.
3. Check out this branch, and reload the page above.
4. Get a permission error.
5. In wp-admin, go to the Feedback menu.
6. In your browser console, fetch responses and check that they are all returned: `wp.apiFetch({path: '/wpcom/v2/forms/responses'}).then(r=>console.log(r))`

