### PR TITLE
Social: Update copy which prompts the user to upgrade from the free plans. 

### DIFF
--- a/projects/js-packages/components/changelog/update-social-upgrade-copy
+++ b/projects/js-packages/components/changelog/update-social-upgrade-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated css for the ContextualUpgradeTrigger and added a prop to it. 

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
@@ -12,7 +12,7 @@ const ContextualUpgradeTrigger: React.FC< CutBaseProps > = ( {
 	href,
 	openInNewTab = false,
 	className,
-	tooltipText = null,
+	tooltipText = '',
 } ) => {
 	const Tag = href !== undefined ? 'a' : 'button';
 	const tagProps =
@@ -23,16 +23,16 @@ const ContextualUpgradeTrigger: React.FC< CutBaseProps > = ( {
 			<div>
 				<Tag { ...tagProps }>
 					<Text>
-						{ description }{ ' ' }
+						{ description }
 						{ tooltipText && (
-							<span className="tooltip">
+							<>
 								<Tooltip position="middle center" text={ tooltipText }>
 									<span>
 										<Icon icon={ info } size={ 12 } />
 									</span>
 								</Tooltip>
-							</span>
-						) }{ ' ' }
+							</>
+						) }
 					</Text>
 					<Text className={ styles.cta }>{ cta }</Text>
 				</Tag>

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
@@ -1,10 +1,10 @@
-import { Icon, arrowRight } from '@wordpress/icons';
+import { Tooltip } from '@wordpress/components';
+import { Icon, arrowRight, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import Text from '../text';
 import styles from './style.module.scss';
 import { CutBaseProps } from './types';
 import type React from 'react';
-
 const ContextualUpgradeTrigger: React.FC< CutBaseProps > = ( {
 	description,
 	cta,
@@ -12,6 +12,7 @@ const ContextualUpgradeTrigger: React.FC< CutBaseProps > = ( {
 	href,
 	openInNewTab = false,
 	className,
+	tooltipText = null,
 } ) => {
 	const Tag = href !== undefined ? 'a' : 'button';
 	const tagProps =
@@ -20,8 +21,19 @@ const ContextualUpgradeTrigger: React.FC< CutBaseProps > = ( {
 	return (
 		<div className={ classnames( styles.cut, className ) }>
 			<div>
-				<Text>{ description }</Text>
 				<Tag { ...tagProps }>
+					<Text>
+						{ description }{ ' ' }
+						{ tooltipText && (
+							<span className="tooltip">
+								<Tooltip position="middle center" text={ tooltipText }>
+									<span>
+										<Icon icon={ info } size={ 12 } />
+									</span>
+								</Tooltip>
+							</span>
+						) }{ ' ' }
+					</Text>
 					<Text className={ styles.cta }>{ cta }</Text>
 				</Tag>
 			</div>

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
@@ -12,7 +12,21 @@
 	position: relative;
 	color: var(--jp-gray-80);
 
-	button,
+	button {
+		all: unset;
+		color: var(--jp-gray-80);
+		cursor: pointer;
+
+		&::after {
+			content: '';
+			position: absolute;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 100%;
+		}
+	}
+
 	a {
 		text-decoration: none;
 		color: var(--jp-gray-80);

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
@@ -30,7 +30,7 @@
 	a {
 		text-decoration: none;
 		color: var(--jp-gray-80);
-		cursor: pointer !important;
+		cursor: pointer;
 
 		&::after {
 			position: absolute;

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
@@ -14,22 +14,19 @@
 
 	button,
 	a {
-		all: unset;
+		text-decoration: none;
 		color: var(--jp-gray-80);
-		cursor: pointer;
+		cursor: pointer !important;
 
 		&::after {
-			content: '';
+			//content: '';
 			position: absolute;
 			top: 0;
 			left: 0;
 			width: 100%;
 			height: 100%;
+			cursor: pointer;
 		}
-	}
-
-	&:focus-within {
-		border-color: var( --jp-black );
 	}
 
 	&:focus-within,

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/style.module.scss
@@ -19,7 +19,6 @@
 		cursor: pointer !important;
 
 		&::after {
-			//content: '';
 			position: absolute;
 			top: 0;
 			left: 0;

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/types.ts
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/types.ts
@@ -5,4 +5,5 @@ export type CutBaseProps = {
 	href?: string;
 	openInNewTab?: boolean;
 	onClick?: () => void;
+	tooltipText?: string;
 };

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.30.0",
+	"version": "0.29.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.29.0-alpha",
+	"version": "0.31.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/plugins/social/changelog/update-social-upgrade-copy
+++ b/projects/plugins/social/changelog/update-social-upgrade-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated css for the ContextualUpgradeTrigger and added a prop to it. 

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -78,6 +78,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_8_1_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ1_9_0_alpha"
 	}
 }

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 1.8.1-alpha
+ * Version: 1.9.0-alpha
  * Author: Automattic - Jetpack Social team
  * Author URI: https://jetpack.com/social/
  * License: GPLv2 or later

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -77,10 +77,11 @@ const Header = () => {
 					{ isShareLimitEnabled && ! hasPaidPlan ? (
 						<>
 							<ShareCounter value={ sharesCount } max={ 30 } />
+
 							<ContextualUpgradeTrigger
 								className={ styles.cut }
 								description={ __(
-									'Keep sharing all your posts to social media',
+									'Unlock unlimited shares and advanced posting options',
 									'jetpack-social'
 								) }
 								cta={ __( 'Get a Jetpack Social Plan', 'jetpack-social' ) }
@@ -88,6 +89,7 @@ const Header = () => {
 									site: siteSuffix,
 									query: 'redirect_to=' + window.location.href,
 								} ) }
+								tooltipText={ __( 'Share as a post', 'jetpack-social' ) }
 							/>
 						</>
 					) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # 1203876111187910-as-1203884651474282

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updated the CSS rules in the `ContextualUpgradeTrigger` component and changed the text copy. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdrWKz-I8-p2#comment-1050

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Boot up a new JN site on this branch with Social and Protect plugins. Boot up a trunk site on this branch with Social and Protect plugins
* Make sure you have the free plans on both and compare the behaviour of the upgrade box by hovering over them. You will also see the information icon in this branch. Hover over it to see the upgrade copy.  

Before

<img width="703" alt="Screenshot 2023-03-01 at 19 02 00" src="https://user-images.githubusercontent.com/6594561/222153284-79f221d1-61fa-4b5e-88c8-7fe2ea599fb8.png">

After

<img width="697" alt="Screenshot 2023-03-01 at 18 15 01" src="https://user-images.githubusercontent.com/6594561/222143047-59db8651-8ac2-4d8d-8f5e-781716272564.png">
<img width="714" alt="Screenshot 2023-03-01 at 18 58 52" src="https://user-images.githubusercontent.com/6594561/222153123-191d9669-ac62-4e2e-bf98-68a3a52459f1.png">


* Testing the component in another plugin: Install Jetpack Protect on your JN site and make sure the upgrade copy looks the same. 


Before and After:

<img width="641" alt="Screenshot 2023-03-01 at 18 59 40" src="https://user-images.githubusercontent.com/6594561/222153077-0d6f8255-ead7-4a31-b360-63e65f900977.png">
is is to ensure that our changes to the `ContextualUpgradeTrigger` component didn't break anything. 

