### PR TITLE
Removing awkward spacer after every 2nd button in "More" button overlay

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-more-modal-spacing
+++ b/projects/plugins/jetpack/changelog/fix-more-modal-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Removing awkward spacer after every second button within the sharing more button overlay

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -1179,10 +1179,6 @@ function sharing_display( $text = '', $echo = false ) {
 					$sharing_content .= $service->get_display( $post );
 					$sharing_content .= '</li>';
 
-					if ( ( $count % 2 ) === 0 ) {
-						$sharing_content .= '<li class="share-end"></li>';
-					}
-
 					++$count;
 				}
 


### PR DESCRIPTION
## Description

We just made some updates to the sharing button styles. In testing we found an awkward gap between the buttons in the "More" button overlay. 

Candidly, I'm not sure why we were intentionally adding a spacer after every even numbered link within the "More" button overlay, but I went ahead and removed this code.

### Before

<img width="676" alt="before" src="https://user-images.githubusercontent.com/5634774/222172190-56a0ba01-1d4c-404b-a53e-d0908b498e6b.png">

### After

<img width="657" alt="after" src="https://user-images.githubusercontent.com/5634774/222172163-283c37c6-6731-4a54-b0fa-e2595bd3d052.png">

## Jetpack product discussion
p8oabR-16e-p2#comment-7075

## Does this pull request change what data or activity we track or use?
Nope.

## Testing instructions:
- Make sure sharing buttons are enabled in `/wp-admin/admin.php?page=jetpack#/sharing`
- Add at least 3 options to the "More" button in `/marketing/sharing-buttons/{SITE_URL}`
- Preview a post on the front-end of your site