### PR TITLE
svn auto-publish: Correctly publish first version

### DIFF
--- a/.github/files/gh-wp-svn-autopublish/files/wp-svn-autopublish.sh
+++ b/.github/files/gh-wp-svn-autopublish/files/wp-svn-autopublish.sh
@@ -73,7 +73,11 @@ echo '::endgroup::'
 CHECK="$(svn diff trunk/readme.txt | grep '^[+-]Stable tag:' || true)"
 if [[ -n "$CHECK" ]]; then
 	LINE="$(grep --line-number --max-count=1 '^Stable tag:' trunk/readme.txt)"
-	if [[ -n "$LINE" ]]; then
+	if grep -q '^+' <<<"$CHECK" && ! grep -q '^-' <<<"$CHECK"; then
+		# On the initial commit, it seems there's no way to specify not to immediately have that commit served as the stable version.
+		# So just print a notice pointing that out in case anyone is looking and leave it as-is.
+		echo "::notice::This appears to be the initial release of the plugin, which will unavoidably set the stable tag to the version being released now."
+	elif [[ -n "$LINE" ]]; then
 		echo "::warning::Stable tag must be updated manually! Update would change it, attempting to undo the change.%0A%0A${CHECK/$'\n'/%0A}"
 		nl=$'\n'
 		patch -R trunk/readme.txt <<<"@@ -${LINE%%:*},1 +${LINE%%:*},1 @@$nl$CHECK"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Usually we leave the old version marked as stable, so humans can smoke-test before manually updating the tag. But in the case of the first commit there's no "old version", which causes our code that tries to keep the old version to break.

Since there seems to be no documented way say "no version is stable yet", it seems our best bet is to just let the version being auto-published be marked as stable for the initial commit.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1677681979406179-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷 I guess you could manually go through the steps of the script, using `-r` on the `svn checkout` and `svn up` commands to get the empty repo, until you get `CHECK` set and then verify that the change here will do the right thing.