### PR TITLE
Fix broken Tumblr button inside "More" button overlay

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-more-tumblr-button
+++ b/projects/plugins/jetpack/changelog/fix-more-tumblr-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix broken Tumblr button inside "More" button overlay

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -454,6 +454,11 @@ body .sd-content ul li.share-custom.no-icon a span {
 	min-width: 55px;
 }
 
+.sd-social-official .sd-content .share-tumblr iframe {
+	max-width: 53px;
+	width: unset;
+}
+
 body .sd-social-official li.share-print ,
 body .sd-social-official li.share-email a,
 body .sd-social-official li.share-custom a,


### PR DESCRIPTION
## Description

We just made some updates to the sharing button styles. In testing we found that the "official" Tumblr button is cut off prematurely within the "More" button overlay. 

### Related

Normally I wouldn't feel super comfortable assigning such a specific `max-width` value to a button like this, but I proceeded for the following reasons:

- I tested this change in Chrome, FireFox, and Safari.
- The use of `display:block` within the iframe (outside of what I can control with CSS) seems to be affecting the full width styles that we're seeing.
- I tested switching my language to Spanish and while some of the buttons do update with translated text, the Tumblr button does not. Here's a preview:

<img width="611" alt="CleanShot 2023-03-01 at 10 15 31@2x" src="https://user-images.githubusercontent.com/5634774/222182042-5fa443a7-ac3c-4fb6-b734-462209aa5014.png">

Again, this is not ideal. It's a bit fragile, especially if we ever plan to add translations. I am definitely open to alternate ways to approach this.

### Before

<img width="626" alt="before" src="https://user-images.githubusercontent.com/5634774/222179810-397ce253-1aa1-49a1-ac15-38a7bec859c8.png">

### After

<img width="631" alt="after" src="https://user-images.githubusercontent.com/5634774/222179793-d31e2fee-0a5b-4b9d-a8fa-db6c07e84c23.png">

## Jetpack product discussion
p8oabR-16e-p2#comment-7076

## Does this pull request change what data or activity we track or use?
Nope.

## Testing instructions:
- Make sure sharing buttons are enabled in `/wp-admin/admin.php?page=jetpack#/sharing`
- Add Tumblr to the "More" button in `/marketing/sharing-buttons/{SITE_URL}`
- Preview a post on the front-end of your site