### PR TITLE
Added space bar press to improve "More" button a11y

### DIFF
--- a/projects/plugins/jetpack/changelog/enhancement-more-button-a11y
+++ b/projects/plugins/jetpack/changelog/enhancement-more-button-a11y
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added space bar as an option to open "More" button overlay

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.js
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.js
@@ -195,7 +195,7 @@
 		}
 	};
 
-	MoreButton.prototype.nonHoverOpen = function ( event ) {
+	MoreButton.prototype.nonHoverOpen = function () {
 		clearTimeout( this.openTimer );
 		clearTimeout( this.closeTimer );
 

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.js
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.js
@@ -195,6 +195,19 @@
 		}
 	};
 
+	MoreButton.prototype.nonHoverOpen = function ( event ) {
+		clearTimeout( this.openTimer );
+		clearTimeout( this.closeTimer );
+
+		if ( this.recentlyOpenedByHover ) {
+			this.recentlyOpenedByHover = false;
+			clearTimeout( this.hoverOpenTimer );
+			this.open();
+		} else {
+			this.toggle();
+		}
+	};
+
 	MoreButton.prototype.resetCloseTimer = function () {
 		clearTimeout( this.closeTimer );
 		this.closeTimer = setTimeout( this.close.bind( this ), MoreButton.hoverCloseDelay );
@@ -206,15 +219,16 @@
 			event.stopPropagation();
 
 			this.openedBy = 'click';
-			clearTimeout( this.openTimer );
-			clearTimeout( this.closeTimer );
+			this.nonHoverOpen();
+		}.bind( this );
 
-			if ( this.recentlyOpenedByHover ) {
-				this.recentlyOpenedByHover = false;
-				clearTimeout( this.hoverOpenTimer );
-				this.open();
-			} else {
-				this.toggle();
+		this.buttonKeydown = function ( event ) {
+			if ( event.keyCode === 13 || event.keyCode === 32 ) {
+				event.preventDefault();
+				event.stopPropagation();
+
+				this.openedBy = 'keydown';
+				this.nonHoverOpen();
 			}
 		}.bind( this );
 
@@ -260,6 +274,7 @@
 		}.bind( this );
 
 		this.button.addEventListener( 'click', this.buttonClick );
+		this.button.addEventListener( 'keydown', this.buttonKeydown );
 		document.addEventListener( 'click', this.documentClick );
 
 		if ( document.ontouchstart === undefined ) {


### PR DESCRIPTION
## Description

We just made some updates to the sharing button styles. In testing we found that the more button does not open when navigating via the keyboard and the space bar is pressed. 

### Before

![before](https://user-images.githubusercontent.com/5634774/222197631-4cff9c28-5573-4a83-9f91-44575ba8c261.gif)

### After

![after](https://user-images.githubusercontent.com/5634774/222197660-3ef05927-a09e-4b8f-a464-239e0cfab839.gif)

## Jetpack product discussion
p8oabR-16e-p2#comment-7077

## Does this pull request change what data or activity we track or use?
Nope.

## Testing instructions:
- Make sure sharing buttons are enabled in `/wp-admin/admin.php?page=jetpack#/sharing`
- Add at least one sharing option to the "More" button in `/marketing/sharing-buttons/{SITE_URL}`
- Preview a post on the front-end of your site
- Tab to the "More" button and press the space bar