### PR TITLE
VideoPress: add Caption button to the VideoPress video block toolbar

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-video-caption
+++ b/projects/packages/videopress/changelog/update-videopress-video-caption
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add caption control to vidfeo block toolbar

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-import { RichText, BlockControls } from '@wordpress/block-editor';
-import { ResizableBox, SandBox, ToolbarButton } from '@wordpress/components';
+import { RichText } from '@wordpress/block-editor';
+import { ResizableBox, SandBox } from '@wordpress/components';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { caption as captionIcon } from '@wordpress/icons';
 /**
  * Types
  */
@@ -46,6 +45,7 @@ if ( window?.videoPressEditorState?.playerBridgeUrl ) {
  * @returns {React.ReactElement} Playback block sidebar panel
  */
 export default function Player( {
+	showCaption,
 	html,
 	isSelected,
 	attributes,
@@ -58,7 +58,6 @@ export default function Player( {
 	const videoWrapperRef = useRef< HTMLDivElement >();
 
 	const { maxWidth, caption, videoRatio } = attributes;
-	const [ showCaption, setShowCaption ] = useState( !! caption );
 
 	/*
 	 * Temporary height is used to set the height of the video
@@ -195,25 +194,8 @@ export default function Player( {
 			: 0;
 	}
 
-	const removeCaptionLabel = __( 'Remove caption', 'jetpack-videopress-pkg' );
-	const addCaptionLabel = __( 'Add caption', 'jetpack-videopress-pkg' );
-
 	return (
 		<figure ref={ mainWrapperRef } className="jetpack-videopress-player">
-			<BlockControls group="block">
-				<ToolbarButton
-					onClick={ () => {
-						setShowCaption( ! showCaption );
-						if ( showCaption && caption ) {
-							setAttributes( { caption: undefined } );
-						}
-					} }
-					icon={ captionIcon }
-					isPressed={ showCaption }
-					label={ showCaption ? removeCaptionLabel : addCaptionLabel }
-				/>
-			</BlockControls>
-
 			<ResizableBox
 				enable={ {
 					top: false,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { RichText } from '@wordpress/block-editor';
-import { ResizableBox, SandBox } from '@wordpress/components';
+import { RichText, BlockControls } from '@wordpress/block-editor';
+import { ResizableBox, SandBox, ToolbarButton } from '@wordpress/components';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { caption as captionIcon } from '@wordpress/icons';
 /**
  * Types
  */
@@ -55,7 +56,9 @@ export default function Player( {
 }: PlayerProps ): React.ReactElement {
 	const mainWrapperRef = useRef< HTMLDivElement >();
 	const videoWrapperRef = useRef< HTMLDivElement >();
+
 	const { maxWidth, caption, videoRatio } = attributes;
+	const [ showCaption, setShowCaption ] = useState( !! caption );
 
 	/*
 	 * Temporary height is used to set the height of the video
@@ -192,8 +195,25 @@ export default function Player( {
 			: 0;
 	}
 
+	const removeCaptionLabel = __( 'Remove caption', 'jetpack-videopress-pkg' );
+	const addCaptionLabel = __( 'Add caption', 'jetpack-videopress-pkg' );
+
 	return (
 		<figure ref={ mainWrapperRef } className="jetpack-videopress-player">
+			<BlockControls group="block">
+				<ToolbarButton
+					onClick={ () => {
+						setShowCaption( ! showCaption );
+						if ( showCaption && caption ) {
+							setAttributes( { caption: undefined } );
+						}
+					} }
+					icon={ captionIcon }
+					isPressed={ showCaption }
+					label={ showCaption ? removeCaptionLabel : addCaptionLabel }
+				/>
+			</BlockControls>
+
 			<ResizableBox
 				enable={ {
 					top: false,
@@ -228,7 +248,7 @@ export default function Player( {
 				</div>
 			</ResizableBox>
 
-			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
+			{ showCaption && ( ! RichText.isEmpty( caption ) || isSelected ) && (
 				<RichText
 					identifier="caption"
 					tagName="figcaption"

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -230,10 +230,12 @@ export default function Player( {
 
 			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 				<RichText
+					identifier="caption"
 					tagName="figcaption"
-					placeholder={ __( 'Write caption…', 'jetpack-videopress-pkg' ) }
+					aria-label={ __( 'Video caption text', 'jetpack-videopress-pkg' ) }
+					placeholder={ __( 'Add caption', 'jetpack-videopress-pkg' ) }
 					value={ caption }
-					onChange={ value => setAttributes( { caption: value } ) }
+					onChange={ ( value: string ) => setAttributes( { caption: value } ) }
 					inlineToolbar
 				/>
 			) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -187,6 +187,16 @@ export default function Player( {
 		paddingBottom?: number;
 	} = {};
 
+	// Focus the caption when we click to add one.
+	const captionRef = useCallback(
+		( node: HTMLElement ) => {
+			if ( node && ! caption ) {
+				node.focus();
+			}
+		},
+		[ caption ]
+	);
+
 	if ( videoPlayerTemporaryHeight !== 'auto' ) {
 		wrapperElementStyle.height = videoPlayerTemporaryHeight || 200;
 		wrapperElementStyle.paddingBottom = videoPlayerTemporaryHeight
@@ -239,6 +249,7 @@ export default function Player( {
 					value={ caption }
 					onChange={ ( value: string ) => setAttributes( { caption: value } ) }
 					inlineToolbar
+					ref={ captionRef }
 				/>
 			) }
 		</figure>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/types.ts
@@ -4,6 +4,7 @@
 import { VideoBlockAttributes } from '../../types';
 
 export type PlayerProps = {
+	showCaption: boolean;
 	html: string;
 	isSelected: boolean;
 	attributes: VideoBlockAttributes;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -9,11 +9,12 @@ import {
 	BlockControls,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { Spinner, Placeholder, Button, withNotices } from '@wordpress/components';
+import { Spinner, Placeholder, Button, withNotices, ToolbarButton } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { caption as captionIcon } from '@wordpress/icons';
 import classNames from 'classnames';
 import debugFactory from 'debug';
 /**
@@ -141,6 +142,8 @@ export default function VideoPressEdit( {
 
 	// Detect if the chapter file is auto-generated.
 	const chapter = tracks?.filter( track => track.kind === 'chapters' )?.[ 0 ];
+
+	const [ showCaption, setShowCaption ] = useState( !! caption );
 
 	const {
 		videoData,
@@ -438,6 +441,9 @@ export default function VideoPressEdit( {
 		);
 	}
 
+	const removeCaptionLabel = __( 'Remove caption', 'jetpack-videopress-pkg' );
+	const addCaptionLabel = __( 'Add caption', 'jetpack-videopress-pkg' );
+
 	// Show VideoPress player.
 	return (
 		<div
@@ -448,6 +454,18 @@ export default function VideoPressEdit( {
 			} ) }
 		>
 			<BlockControls group="block">
+				<ToolbarButton
+					onClick={ () => {
+						setShowCaption( ! showCaption );
+						if ( showCaption && caption ) {
+							setAttributes( { caption: undefined } );
+						}
+					} }
+					icon={ captionIcon }
+					isPressed={ showCaption }
+					label={ showCaption ? removeCaptionLabel : addCaptionLabel }
+				/>
+
 				<PosterImageBlockControl
 					attributes={ attributes }
 					setAttributes={ setAttributes }
@@ -555,6 +573,7 @@ export default function VideoPressEdit( {
 			/>
 
 			<Player
+				showCaption={ showCaption }
 				html={ html }
 				isRequestingEmbedPreview={ isRequestingEmbedPreview }
 				scripts={ scripts }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


~# branched off from https://github.com/Automattic/jetpack/pull/29226~

This PR adds a Caption button to the VideoPress video block toolbar, drawing the same behavior as the core Image video.

Fixes https://github.com/Automattic/jetpack/issues/27655

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add Caption button to the VideoPress video block toolbar

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add/edit a video block
* Confirm caption input is not shown by default

<img width="500" alt="Screen Shot 2023-03-01 at 14 03 49" src="https://user-images.githubusercontent.com/77539/222210831-b7373d98-56d6-44b3-930f-afab41cb5562.png">

* Confirm you see the new Caption button in the block toolbar
* Confirm caption input is not shown when the Caption button is not pressed 
* Confirm that it focuses the caption input when clicking on the button

<img width="500" alt="Screen Shot 2023-03-01 at 14 04 14" src="https://user-images.githubusercontent.com/77539/222210937-afcdcecb-25f2-475c-bb11-f72589b13a0a.png">

* Confirm you can add and save the caption
* Confirm that you can remove the caption by "impressing" the Caption button


https://user-images.githubusercontent.com/77539/222484211-01ed8478-d956-4235-9307-363ae2f249b4.mov

