### PR TITLE
VideoPress: remove style.scss file

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-remove-style-file
+++ b/projects/packages/videopress/changelog/update-videopress-remove-style-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+VideoPress: remove unused style.scss file from video block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -300,7 +300,7 @@ export default function VideoPressEdit( {
 	] );
 
 	const { className: blockMainClassName, ...blockProps } = useBlockProps( {
-		className: 'wp-block-jetpack-videopress',
+		className: 'wp-block-jetpack-videopress wp-block-video',
 	} );
 
 	// Setting video media process

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.native.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.native.ts
@@ -11,7 +11,6 @@ import { VideoPressIcon as icon } from './components/icons';
 import Edit from './edit';
 import save from './save';
 import transforms from './transforms';
-import './style.scss';
 
 export const { name, title, description, attributes } = metadata;
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
@@ -12,7 +12,6 @@ import Edit from './edit';
 import save from './save';
 import transforms from './transforms';
 import videoPressBlockExampleImage from './videopress-block-example-image.jpg';
-import './style.scss';
 
 export const { name, title, description, attributes } = metadata;
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -1,7 +1,0 @@
-@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
-
-.wp-block-jetpack-videopress {
-	figcaption {
-		@include caption-style-theme();
-	}
-}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -4,11 +4,6 @@
 import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import './style.scss';
-
 domReady( function () {
 	// eslint-disable-next-line no-console
 	console.log( __( 'VideoPress init', 'jetpack-videopress-pkg' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# branched off from https://github.com/Automattic/jetpack/pull/29226~

Janitorial PR removes the `style.scss` file since it's almost empty. The only styles that are defined are about the Caption section, which is not properly aligned with core. Instead of setting the styles, I opt to add the `wp-block-video` CSS class to inherit its styles.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: remove style.scss file

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build the assets. Everything should be ok.
* Go to the block editor
* Create/edit a VideoPress video block
* Add caption to the block
* Create a v5 block
* Compare the caption
* Confirm it look pretty similar
* Save the block
* Check it in the front-end
* ...

