### PR TITLE
CRM: Consistent naming for Tasks

### DIFF
--- a/projects/plugins/crm/admin/settings/general.page.php
+++ b/projects/plugins/crm/admin/settings/general.page.php
@@ -49,7 +49,7 @@ $autoLoggers = array(
 	),
 	array(
 		'fieldname' => 'autolog_event_new',
-		'title'     => 'Event Creation',
+		'title'     => 'Task Creation',
 	),
 	array(
 		'fieldname' => 'autolog_clientportal_new',

--- a/projects/plugins/crm/admin/tags/tag-manager.page.php
+++ b/projects/plugins/crm/admin/tags/tag-manager.page.php
@@ -136,8 +136,8 @@ function zeroBSCRM_pages_admin_tags() {
 				array(
 					'objTypeID'  => ZBS_TYPE_EVENT,
 					'objType'    => 'event',
-					'singular'   => __( 'Event', 'zero-bs-crm' ),
-					'plural'     => __( 'Events', 'zero-bs-crm' ),
+					'singular'   => __( 'Task', 'zero-bs-crm' ),
+					'plural'     => __( 'Tasks', 'zero-bs-crm' ),
 					'langLabels' => array(),
 					'extraBoxes' => '',
 				)

--- a/projects/plugins/crm/changelog/fix-crm-consistent-naming-for-tasks
+++ b/projects/plugins/crm/changelog/fix-crm-consistent-naming-for-tasks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Corrected text where tasks where being referred to as events

--- a/projects/plugins/crm/html/templates/eventnotification.html
+++ b/projects/plugins/crm/html/templates/eventnotification.html
@@ -1,4 +1,4 @@
-<h3 style="text-align:center;font-size: 1.5em;margin-top: 0em;margin-bottom: 2em;">Your Event is starting soon</h3>
+<h3 style="text-align:center;font-size: 1.5em;margin-top: 0em;margin-bottom: 2em;">Your scheduled Task is starting soon</h3>
 <div style="text-align:center;font-size: 1.5em;margin-top: 0em;margin-bottom: 2em;">##TASK-TITLE##</div>
 <br/>
 ##TASK-BODY##

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -175,7 +175,7 @@ function zeroBSCRM_update_edit_form() {
 
 /*
 ======================================================
-	/ Edit Post Messages (i.e. "Post Updated => Event Updated")
+	/ Edit Post Messages (i.e. "Post Updated => Task Updated")
 	/ See: http://ryanwelcher.com/2014/10/change-wordpress-post-updated-messages/
 	====================================================== */
 
@@ -193,7 +193,7 @@ function zeroBSCRM_post_updated_messages( $messages ) {
 		3  => __( 'Custom field deleted.', 'zero-bs-crm' ),
 		4  => __( 'Task updated.', 'zero-bs-crm' ),
 		/* translators: %s: date and time of the revision */
-		5  => isset( $_GET['revision'] ) ? sprintf( __( 'Event restored to revision from %s', 'zero-bs-crm' ), wp_post_revision_title( (int) sanitize_text_field( $_GET['revision'] ), false ) ) : false,
+		5  => isset( $_GET['revision'] ) ? sprintf( __( 'Task restored to revision from %s', 'zero-bs-crm' ), wp_post_revision_title( (int) sanitize_text_field( $_GET['revision'] ), false ) ) : false, // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		6  => __( 'Task saved.', 'zero-bs-crm' ),
 		7  => __( 'Task saved.', 'zero-bs-crm' ),
 		8  => __( 'Task submitted.', 'zero-bs-crm' ),
@@ -2507,7 +2507,7 @@ function zeroBSCRM_html_deletion() {
 
 		// } Fill out
 		$delType = __( 'Task', 'zero-bs-crm' );
-		$delStr  = 'Event ID: ' . $delID;
+		$delStr  = 'Task ID: ' . $delID; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -2666,7 +2666,7 @@ final class ZeroBSCRM {
 							break;
 
 						case 'event':
-							$objType = __( 'Event', 'zero-bs-crm' );
+							$objType = __( 'Task', 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 							break;
 
 						case 'form':

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL2.Mail.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL2.Mail.php
@@ -453,7 +453,7 @@ function zeroBSCRM_populateEmailTemplateList() {
 	$bcc      = '';
 
 	// } The email stuff...
-	$subject = __( 'Your Event starts soon', 'zero-bs-crm' );
+	$subject = __( 'Your scheduled Task starts soon', 'zero-bs-crm' );
 	$content = zeroBSCRM_mail_retrieveDefaultBodyTemplate( 'eventnotification' );
 
 	// BRUTAL DELETE old one (avoids dupes)

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -1659,7 +1659,7 @@ function zeroBSCRM_mergeCustomers($dominantID=-1,$slaveID=-1){
 
                                 // for events, we just "switch" the meta val :)
                                 zeroBSCRM_changeEventCustomer($event['id'],$dominantID);
-                                $changes[] = __('Assigned event from secondary record onto main record',"zero-bs-crm").' (#'.$event['id'].').';
+											$changes[] = __( 'Assigned task from secondary record onto main record', 'zero-bs-crm' ) . ' (#' . $event['id'] . ').';
                                 
 
    						}

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -183,23 +183,26 @@ class zbsDAL {
             ZBS_TYPE_QUOTETEMPLATE => 'zerobs_quo_template',
     );
 
-    // retrieve via DAL->typeStr(1)
-    private $typeNames = array(
-
-            ZBS_TYPE_CONTACT =>         array('Contact','Contacts'),
-            ZBS_TYPE_COMPANY =>         array('Company','Companies'),
-            ZBS_TYPE_QUOTE =>           array('Quote','Quotes'),
-            ZBS_TYPE_INVOICE =>         array('Invoice','Invoices'),
-            ZBS_TYPE_TRANSACTION =>     array('Transaction','Transactions'),
-            ZBS_TYPE_EVENT =>           array('Event','Events'),
-            ZBS_TYPE_FORM =>            array('Form','Forms'),
-            ZBS_TYPE_SEGMENT =>         array('Segment','Segments'),
-            ZBS_TYPE_LOG =>             array('Log','Logs'),
-            ZBS_TYPE_LINEITEM =>        array('Line Item','Line Items'),
-            ZBS_TYPE_EVENTREMINDER =>   array('Event Reminder','Event Reminders'),
-            ZBS_TYPE_QUOTETEMPLATE =>   array('Quote Template','Quote Templates'),
-            ZBS_TYPE_ADDRESS =>         array('Address','Addresses')
-    );
+	/**
+	 * Retrieve via DAL->typeStr(1).
+	 *
+	 * @var array
+	 */
+	private $typeNames = array( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+		ZBS_TYPE_CONTACT       => array( 'Contact', 'Contacts' ),
+		ZBS_TYPE_COMPANY       => array( 'Company', 'Companies' ),
+		ZBS_TYPE_QUOTE         => array( 'Quote', 'Quotes' ),
+		ZBS_TYPE_INVOICE       => array( 'Invoice', 'Invoices' ),
+		ZBS_TYPE_TRANSACTION   => array( 'Transaction', 'Transactions' ),
+		ZBS_TYPE_EVENT         => array( 'Task', 'Tasks' ),
+		ZBS_TYPE_FORM          => array( 'Form', 'Forms' ),
+		ZBS_TYPE_SEGMENT       => array( 'Segment', 'Segments' ),
+		ZBS_TYPE_LOG           => array( 'Log', 'Logs' ),
+		ZBS_TYPE_LINEITEM      => array( 'Line Item', 'Line Items' ),
+		ZBS_TYPE_EVENTREMINDER => array( 'Task Reminder', 'Task Reminders' ),
+		ZBS_TYPE_QUOTETEMPLATE => array( 'Quote Template', 'Quote Templates' ),
+		ZBS_TYPE_ADDRESS       => array( 'Address', 'Addresses' ),
+	);
 
     // List View refs
     private $listViewRefs = array(

--- a/projects/plugins/crm/includes/ZeroBSCRM.Delete.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Delete.php
@@ -396,10 +396,16 @@ class zeroBSCRM_Delete{
 
                                                         case ZBS_TYPE_CONTACT:
                                                         case ZBS_TYPE_COMPANY:
-                                                            ?><p><?php esc_html_e('Shall I also delete the associated Contacts, Invoices, Quotes, Transactions and Events?','zero-bs-crm'); echo '<br>'; esc_html_e('(This cannot be undone!)',"zero-bs-crm"); ?></p><?php
-                                                            break;
-
-                                                    } ?>
+														?>
+														<?php
+															echo '<p>';
+															esc_html_e( 'Shall I also delete the associated Contacts, Invoices, Quotes, Transactions, and Tasks?', 'zero-bs-crm' );
+															echo '<br>';
+															esc_html_e( '(This cannot be undone!)', 'zero-bs-crm' );
+															echo '</p>';
+															break;
+												}
+												?>
                                                     <p>
                                                         <select name="zbs-delete-kill-children">
                                                             <option value="no"><?php esc_html_e('No, leave them',"zero-bs-crm"); ?></option>

--- a/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
@@ -795,7 +795,7 @@
 
 					#} Add log
 					$newLogID = zeroBS_addUpdateLog($zbsNoteAgainstPostID,-1,-1,array(
-						'type' => 'Event Created',
+						'type'      => 'Task Created',
 						'shortdesc' => $noteShortDesc,
 						'longdesc' => $note_long_description
 					),'zerobs_customer');

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.CompletedEvents.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.CompletedEvents.php
@@ -28,17 +28,16 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 
 class zeroBSCRM_Events_List_Complete extends WP_List_Table {
 
-    /** Class constructor */
-    public function __construct() {
-
-        parent::__construct( array(
-            'singular' => __( 'Event', 'zero-bs-crm' ), //singular name of the listed records
-            'plural'   => __( 'Events', 'zero-bs-crm' ), //plural name of the listed records
-            'ajax'     => false //does this table support ajax?
-        ) );
-
-    }
-
+	/** Class constructor */
+	public function __construct() {
+		parent::__construct(
+			array(
+				'singular' => __( 'Task', 'zero-bs-crm' ),
+				'plural'   => __( 'Tasks', 'zero-bs-crm' ),
+				'ajax'     => false,
+			)
+		);
+	}
 
     /**
      * Retrieve bookings data from the database
@@ -335,7 +334,7 @@ function zeroBSCRM_render_eventslistcomplete_page(){
 
     $option = 'per_page';
     $args   = array(
-        'label'   => 'Completed Events',
+		'label'   => 'Completed Tasks',
         'default' => 10,
         'option'  => 'events_per_page'
     );

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
@@ -60,7 +60,7 @@ function zeroBSCRM_render_customerslist_page(){
                 'statusnotupdated' => __('Could not update statuses!',"zero-bs-crm"),
  
                 // bulk actions - contact deleting
-                'andthese' => __('Shall I also delete the associated Invoices, Quotes, Transactions and Events?',"zero-bs-crm"),
+				'andthese'             => __( 'Shall I also delete the associated Invoices, Quotes, Transactions and, Tasks?', 'zero-bs-crm' ),
                 'contactsdeleted' => __('Your contact(s) have been deleted.',"zero-bs-crm"),
                 'notcontactsdeleted' => __('Your contact(s) could not be deleted.',"zero-bs-crm"),
 
@@ -121,7 +121,7 @@ function zeroBSCRM_render_companyslist_page(){
                 'export' => __('Export',"zero-bs-crm"),
 
                 // bulk actions - company deleting
-                'andthese' => __('Shall I also delete the associated Contacts, Invoices, Quotes, Transactions and Events? (This cannot be undone!)',"zero-bs-crm"),                
+				'andthese'           => __( 'Shall I also delete the associated Contacts, Invoices, Quotes, Transactions, and Tasks? (This cannot be undone!)', 'zero-bs-crm' ),
                 'companysdeleted' => __('Your company(s) have been deleted.',"zero-bs-crm"),
                 'notcompanysdeleted' => __('Your company(s) could not be deleted.',"zero-bs-crm"),
 
@@ -167,7 +167,7 @@ function zeroBSCRM_render_quoteslist_page(){
 
 
                 // bulk actions - quote deleting
-                'andthese' => __('Shall I also delete the associated Invoices, Quotes, Transactions and Events?',"zero-bs-crm"),
+				'andthese'                 => __( 'Shall I also delete the associated Invoices, Quotes, Transactions, and Tasks?', 'zero-bs-crm' ),
                 'quotesdeleted' => __('Your quote(s) have been deleted.',"zero-bs-crm"),
                 'notquotesdeleted' => __('Your quote(s) could not be deleted.',"zero-bs-crm"),
 
@@ -583,8 +583,8 @@ function zeroBSCRM_render_eventslist_page(){
     $list = new zeroBSCRM_list(array(
 
             'objType'       => 'event',
-            'singular'      => __('Event',"zero-bs-crm"),
-            'plural'        => __('Events',"zero-bs-crm"),
+		'singular'        => __( 'Task', 'zero-bs-crm' ),
+		'plural'          => __( 'Tasks', 'zero-bs-crm' ),
             'tag'           => '',
             'postType'      => 'zerobs_event',
             'postPage'      => 'manage-events-list',
@@ -600,12 +600,12 @@ function zeroBSCRM_render_eventslist_page(){
                 'markincomplete' => __('Mark Task(s) Incomplete',"zero-bs-crm"),
 
                 // bulk actions - event actions
-                'eventsdeleted' => __( 'Your Event(s) have been deleted.',"zero-bs-crm"),
-                'noteventsdeleted' => __( 'Your Event(s) could not be deleted.',"zero-bs-crm"),            
-                'areyousureeventscompleted' => __( 'Are you sure you want to mark these events as completed?', "zero-bs-crm" ),
-                'areyousureeventsincomplete' => __( 'Are you sure you want to mark these events as incomplete?', "zero-bs-crm" ),
-                'eventsmarked' => __( 'Your Event(s) have been updated.', "zero-bs-crm" ),
-                'noteventsmarked' => __( 'Your Event(s) could not be updated.', "zero-bs-crm" ),
+				'eventsdeleted'              => __( 'Your Task(s) have been deleted.', 'zero-bs-crm' ),
+				'noteventsdeleted'           => __( 'Your Task(s) could not be deleted.', 'zero-bs-crm' ),
+				'areyousureeventscompleted'  => __( 'Are you sure you want to mark these tasks as completed?', 'zero-bs-crm' ),
+				'areyousureeventsincomplete' => __( 'Are you sure you want to mark these tasks as incomplete?', 'zero-bs-crm' ),
+				'eventsmarked'               => __( 'Your Task(s) have been updated.', 'zero-bs-crm' ),
+				'noteventsmarked'            => __( 'Your Task(s) could not be updated.', 'zero-bs-crm' ),
 
             ),
             'bulkActions'   => array('addtag','removetag','delete','markcomplete','markincomplete'), // 'export' - possible but needs tidy /wp-admin/admin.php?page=zbs-export-tools&zbstype=event            

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
@@ -60,7 +60,7 @@ function zeroBSCRM_render_customerslist_page(){
                 'statusnotupdated' => __('Could not update statuses!',"zero-bs-crm"),
  
                 // bulk actions - contact deleting
-				'andthese'             => __( 'Shall I also delete the associated Invoices, Quotes, Transactions and, Tasks?', 'zero-bs-crm' ),
+				'andthese'             => __( 'Shall I also delete the associated Invoices, Quotes, Transactions, and Tasks?', 'zero-bs-crm' ),
                 'contactsdeleted' => __('Your contact(s) have been deleted.',"zero-bs-crm"),
                 'notcontactsdeleted' => __('Your contact(s) could not be deleted.',"zero-bs-crm"),
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -355,7 +355,7 @@
 
             ?><div class="zbs-generic-save-wrap">
 
-                    <div class="ui medium dividing header"><i class="save icon"></i> <?php esc_html_e('Event Actions','zero-bs-crm'); ?></div>
+				<div class="ui medium dividing header"><i class="save icon"></i> <?php esc_html_e( 'Task Actions', 'zero-bs-crm' ); ?></div>
 
             <?php
 
@@ -402,7 +402,7 @@
 
                     <div class="zbs-event-actions-bottom zbs-objedit-actions-bottom">
 
-                        <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Update","zero-bs-crm"); ?> <?php esc_html_e("Event","zero-bs-crm"); ?></button>
+							<button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Task', 'zero-bs-crm' ); ?></button>
 
                         <?php
 
@@ -425,7 +425,7 @@
 
                     // NEW Event ?>
 
-                    <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Save","zero-bs-crm"); ?> <?php esc_html_e("Event","zero-bs-crm"); ?></button>
+						<button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e( 'Save', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Task', 'zero-bs-crm' ); ?></button>
 
                  <?php
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Logs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Logs.php
@@ -66,7 +66,7 @@
                     'updated'=> array("locked" => true,"label" => __("Updated","zero-bs-crm"), "ico" => "fa-pencil-square-o"),
                     'quote_created'=> array("locked" => true,"label" => __("Quote Created","zero-bs-crm"), "ico" => "fa-plus-circle"),                    
                     'invoice_created'=> array("locked" => true,"label" => __("Invoice Created","zero-bs-crm"), "ico" => "fa-plus-circle"),
-                    'event_created'=> array("locked" => true,"label" => __("Event Created","zero-bs-crm"), "ico" => "fa-calendar"),
+			'event_created' => array('locked' => true, 'label' => __( 'Task Created', 'zero-bs-crm' ), 'ico' => 'fa-calendar' ), // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound, WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
                     'task_created'=> array("locked" => true,"label" => __("Task Created","zero-bs-crm"), "ico" => "fa-calendar"),
                     'transaction_created'=> array("locked" => true,"label" => __("Transaction Created","zero-bs-crm"), "ico" => "fa-credit-card"),
                     'transaction_updated'=> array("locked" => true,"label" => __("Transaction Updated","zero-bs-crm"), "ico" => "fa-credit-card"),

--- a/projects/plugins/crm/includes/jpcrm-mail-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-mail-templating.php
@@ -213,8 +213,8 @@ function zeroBSCRM_mailTemplate_emailPreview($templateID=-1){
 		// event
 		if ( $templateID == 5 ){
 
-			$replacements['task-title'] = __('Example Event #101','zero-bs-crm');
-			$replacements['task-link'] = '<div style="text-align:center;margin:1em;margin-top:2em">'.zeroBSCRM_mailTemplate_emailSafeButton(admin_url(),__('View Event','zero-bs-crm')).'</div>';
+			$replacements['task-title'] = __( 'Example Task #101', 'zero-bs-crm' );
+			$replacements['task-link']  = '<div style="text-align:center;margin:1em;margin-top:2em">' . zeroBSCRM_mailTemplate_emailSafeButton( admin_url(), __( 'View Task', 'zero-bs-crm' ) ) . '</div>';
 
 	        // replace vars
 	        $html = $placeholder_templating->replace_placeholders( array( 'global', 'event' ), $html, $replacements );
@@ -864,15 +864,15 @@ function zeroBSCRM_Event_generateNotificationHTML( $return = true, $email = fals
 		$eventURL = jpcrm_esc_link( 'edit', $event['id'], ZBS_TYPE_EVENT );
 		$eventHTML = '<p>' . nl2br( $event['desc'] ) . '</p>';
 		$eventHTML .= '<hr /><p style="text-align:center">';
-		$eventHTML .= __( 'Your event starts at ', 'zero-bs-crm' ) . '<strong>' . $event['start_date'] . '</strong><br/>';
+		$eventHTML .= __( 'Your task starts at ', 'zero-bs-crm' ) . '<strong>' . $event['start_date'] . '</strong><br/>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		// $eventHTML .= __( 'to: ', 'zero-bs-crm' ) . $event['end_date'];
 		$eventHTML .= '</p><hr />';
 
 		// replacements
-		$replacements['title'] = __( 'Your Event is starting soon', 'zero-bs-crm' );
-		$replacements['task-title'] = '<h2>' . $event['title'] . '</h2>';
-		$replacements['task-desc'] = $eventHTML;
-		$replacements['task-link-button'] = '<div style="text-align:center;margin:1em;margin-top:2em">' . __( 'You can view your event at the following URL: ', 'zero-bs-crm' ) . '<br />' . zeroBSCRM_mailTemplate_emailSafeButton( $eventURL, __( 'View Event', 'zero-bs-crm' ) ) . '</div>';
+		$replacements['title']            = __( 'Your Task is starting soon', 'zero-bs-crm' );
+		$replacements['task-title']       = '<h2>' . $event['title'] . '</h2>';
+		$replacements['task-desc']        = $eventHTML; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$replacements['task-link-button'] = '<div style="text-align:center;margin:1em;margin-top:2em">' . __( 'You can view your task at the following URL: ', 'zero-bs-crm' ) . '<br />' . zeroBSCRM_mailTemplate_emailSafeButton( $eventURL, __( 'View Task', 'zero-bs-crm' ) ) . '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		// replacements
 		$html = $placeholder_templating->replace_placeholders( array( 'global', 'event', 'contact', 'company' ), $html, $replacements, array( ZBS_TYPE_EVENT => $event ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR makes the naming consistent for Tasks. In some places Tasks were referred to as Events, this has been changed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/zero-bs-crm/issues/2761

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to 'Your Tasks' (`wp-admin/admin.php?page=manage-events&zbsowner=1`).
* Add a new task (`wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=event`)
* Edit a task (`wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=event&zbsid=1`)
* Take a look at a contact's tasks (`wp-admin/admin.php?page=zbs-add-edit&action=view&zbstype=contact&zbsid=1`)
* Edit said contact (`wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact&zbsid=1`)

In `trunk` you will notice that Tasks are sometimes referred to as Events
In `fix/crm-consistent-naming-for-tasks` Tasks are only referred to as Tasks


