### PR TITLE
Fix Lazy Loading in Safari

### DIFF
--- a/projects/packages/lazy-images/changelog/fix-safari-lazy-loading
+++ b/projects/packages/lazy-images/changelog/fix-safari-lazy-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix lazy-load images in Safari

--- a/projects/packages/lazy-images/src/js/lazy-images.js
+++ b/projects/packages/lazy-images/src/js/lazy-images.js
@@ -180,6 +180,13 @@ const jetpackLazyImagesModule = function () {
 			image.addEventListener( 'error', loadedImage, { once: true } );
 		}
 
+		// Hack for Safari: it does not respect srcset changes for img tags outside
+		// of <figure> tags. So, we need to force Safari to re-parse that bit of HTML.
+		if ( 'undefined' !== typeof safari ) {
+			// eslint-disable-next-line no-self-assign
+			image.outerHTML = image.outerHTML;
+		}
+
 		// Fire an event so that third-party code can perform actions after an image is loaded.
 		try {
 			lazyLoadedImageEvent = new Event( 'jetpack-lazy-loaded-image', {


### PR DESCRIPTION
Fixes #23553

Images were not loading in Safari, because it doesn't always respect changes to srcset attributes made by JavaScript. In order to work around the problem, assigning `outerHTML` over itself forces Safari to rethink the HTML image element, which fixes the issue.

## Proposed changes:
* Add a Safari-specific hack to fix lazy loading.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Create a Woocommrce store, add a product with a product image
* Browse the store in Safari. Reload the page lots, you will eventually see one or more image fail to load without this patch - but load successfully with this patch.