### PR TITLE
Paid newsletters fix access levels

### DIFF
--- a/projects/plugins/jetpack/changelog/paid-newsletters-fix-access-levels
+++ b/projects/plugins/jetpack/changelog/paid-newsletters-fix-access-levels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Paid newsletters access panel would disappear on posts that have been previously published. This fixes the issue.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -16,9 +16,23 @@ import './panel.scss';
 import { META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS } from './constants';
 import { NewsletterAccess, accessOptions } from './settings';
 import { isNewsletterFeatureEnabled } from './utils';
+
+function renderAccessLevelSelectorPanel( setPostMeta, accessLevel ) {
+	if ( ! isNewsletterFeatureEnabled() ) {
+		return false;
+	}
+
+	return (
+		<PluginDocumentSettingPanel title={ __( 'Newsletter', 'jetpack' ) }>
+			<NewsletterAccess setPostMeta={ setPostMeta } accessLevel={ accessLevel } />
+		</PluginDocumentSettingPanel>
+	);
+}
+
 export default function SubscribePanels() {
 	const [ subscriberCount, setSubscriberCount ] = useState( null );
-	const [ postMeta = [], setPostMeta ] = useEntityProp( 'postType', 'post', 'meta' );
+	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
+	const [ postMeta = [], setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
 
 	const accessLevel =
 		postMeta[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ] ?? Object.keys( accessOptions )[ 0 ];
@@ -31,27 +45,29 @@ export default function SubscribePanels() {
 		} );
 	}, [] );
 
-	// Only show this for posts for now (subscriptions are only available on posts).
-	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const postWasEverPublished = useSelect(
 		select =>
 			select( editorStore ).getEditedPostAttribute( 'meta' )?.jetpack_post_was_ever_published,
 		[]
 	);
 
-	if ( 'post' !== postType ) {
-		return null;
-	}
-
-	// Subscriptions will not be triggered for a post that was already published in the past
-	if ( postWasEverPublished ) {
-		return null;
-	}
-
 	// Subscriptions will not be triggered on private sites (on WordPress.com simple and WoA),
 	// nor on sites that have not been launched yet.
 	if ( isPrivateSite() || isComingSoon() ) {
 		return null;
+	}
+
+	// Subscriptions are only available for posts. Additionally, we will allow access level selector for pages.
+	// TODO: Make it available for pages later.
+	if ( postType !== 'post' ) {
+		return null;
+	}
+
+	// Subscriptions will not be triggered for a post that was already published in the past and the email was sent.
+	// We still need to render the access level selector, as historical posts need a way to edit their access level for people visiting them on the web.
+	// TODO: Additionally, pages also can be protected. They will not send an email, but can be a resource that needs the acces selector.
+	if ( postWasEverPublished ) {
+		return renderAccessLevelSelectorPanel( setPostMeta, accessLevel );
 	}
 
 	// Do not show any panels when we have no info about the subscriber count, or it is too low.
@@ -65,12 +81,7 @@ export default function SubscribePanels() {
 	const showNotices = Number.isFinite( subscriberCount ) && subscriberCount > 0;
 	return (
 		<>
-			{ isNewsletterFeatureEnabled() && (
-				<PluginDocumentSettingPanel title={ __( 'Newsletter', 'jetpack' ) }>
-					<NewsletterAccess setPostMeta={ setPostMeta } accessLevel={ accessLevel } />
-				</PluginDocumentSettingPanel>
-			) }
-
+			{ renderAccessLevelSelectorPanel( setPostMeta, accessLevel ) }
 			<PluginPrePublishPanel
 				className="jetpack-subscribe-pre-publish-panel"
 				initialOpen

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -17,9 +17,9 @@ import { META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS } from './constants';
 import { NewsletterAccess, accessOptions } from './settings';
 import { isNewsletterFeatureEnabled } from './utils';
 
-function renderAccessLevelSelectorPanel( setPostMeta, accessLevel ) {
+function AccessLevelSelectorPanel( { setPostMeta, accessLevel } ) {
 	if ( ! isNewsletterFeatureEnabled() ) {
-		return false;
+		return null;
 	}
 
 	return (
@@ -67,7 +67,7 @@ export default function SubscribePanels() {
 	// We still need to render the access level selector, as historical posts need a way to edit their access level for people visiting them on the web.
 	// TODO: Additionally, pages also can be protected. They will not send an email, but can be a resource that needs the acces selector.
 	if ( postWasEverPublished ) {
-		return renderAccessLevelSelectorPanel( setPostMeta, accessLevel );
+		return <AccessLevelSelectorPanel setPostMeta={ setPostMeta } accessLevel={ accessLevel } />;
 	}
 
 	// Do not show any panels when we have no info about the subscriber count, or it is too low.
@@ -81,7 +81,7 @@ export default function SubscribePanels() {
 	const showNotices = Number.isFinite( subscriberCount ) && subscriberCount > 0;
 	return (
 		<>
-			{ renderAccessLevelSelectorPanel( setPostMeta, accessLevel ) }
+			<AccessLevelSelectorPanel setPostMeta={ setPostMeta } accessLevel={ accessLevel } />
 			<PluginPrePublishPanel
 				className="jetpack-subscribe-pre-publish-panel"
 				initialOpen

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -65,7 +65,6 @@ export function NewsletterAccess( { accessLevel, setPostMeta, withModal = true }
 		accessLevel = Object.keys( accessOptions )[ 0 ];
 	}
 	const accessLabel = accessOptions[ accessLevel ]?.label;
-
 	return (
 		<PostVisibilityCheck
 			render={ ( { canEdit } ) => (
@@ -104,7 +103,10 @@ export function NewsletterAccess( { accessLevel, setPostMeta, withModal = true }
 												help={ __( 'Control how this newsletter is viewed.', 'jetpack' ) }
 												onClose={ onClose }
 											/>
-											<NewsletterAccessChoices onChange={ setPostMeta } />
+											<NewsletterAccessChoices
+												accessLevel={ accessLevel }
+												onChange={ setPostMeta }
+											/>
 										</div>
 									) }
 								/>


### PR DESCRIPTION
This fixes issues 

- Fixes #29205 - access panel selector would disappear on previously published posts
- Also fixes the issue where the select panel would not show the selected option


## Does this pull request change what data or activity we track or use?

NO

## Testing instructions:


- Get a site with payments configured - you can use `membershipsandbox1.wordpress.com`
- Sandbox public-api, site domain, and store
- Create a post, publish it and reload the editor
- See the newsletter access there


