### PR TITLE
CRM: PHP error with empty values in Address Custom Field (Date)

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-2978-php-error-empty-addr-custom-field
+++ b/projects/plugins/crm/changelog/fix-crm-2978-php-error-empty-addr-custom-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contacts: PHP error using empty values for Address Custom Field (Date)

--- a/projects/plugins/crm/includes/jpcrm-localisation.php
+++ b/projects/plugins/crm/includes/jpcrm-localisation.php
@@ -18,6 +18,9 @@ if ( ! defined( 'ZEROBSCRM_PATH' ) ) exit;
  */
 function jpcrm_uts_to_datetime_str( $timestamp, $format=false ) {
 
+	if ( $timestamp === '' ) {
+		return false;
+	}
 	// default to WP format
 	if ( !$format ) {
 		$format = get_option('date_format') . ' ' . get_option('time_format');


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/2978

## Proposed changes:
This PR fixes an issue in any contact when the user sets an Address Custom Field (Date), and it has an empty value in the contact, provoking a PHP error because DateTime expects an integer instead of an empty value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
- Add a new Address Custom Field, type Date. Save.
- Go to a contact edit or any section related to Contacts: (Dashboard, Contact list...)
- **In trunk,** you will get the PHP error
![image](https://user-images.githubusercontent.com/9832440/222427804-b24e6db2-be20-43ed-bcba-43f3dd4d8c16.png)
- **In this branch,** You can normally work, without any error. Leaving the field empty or setting any date.


