### PR TITLE
Tiny PR: Fix cookie consent default content and CSS

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-cookie-consent-block
+++ b/projects/plugins/jetpack/changelog/fix-cookie-consent-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Pre-escape the ampersand in the default content of the cookie consent block

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/attributes.js
@@ -6,7 +6,7 @@ export default {
 		source: 'html',
 		selector: 'p',
 		default: __(
-			'Privacy & Cookies: This site uses cookies. By continuing to use this website, you agree to their use. To find out more, including how to control cookies, see here: <a href=https://automattic.com/cookies/>Cookie Policy</a>.',
+			'Privacy &amp; Cookies: This site uses cookies. By continuing to use this website, you agree to their use. To find out more, including how to control cookies, see here: <a href="https://automattic.com/cookies/">Cookie Policy</a>.',
 			'jetpack'
 		),
 	},

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/common.scss
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/common.scss
@@ -2,8 +2,6 @@
 .wp-block-jetpack-cookie-consent {
 	position: fixed;
 	bottom: 50px;
-	transition: opacity 1s ease-in-out;
-	animation: cookie-consent-slide-in 0.5s ease-in-out;
 	z-index: 50001;
 	display: flex;
 	justify-content: space-between;

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/style.scss
@@ -1,6 +1,9 @@
 @import './common';
 
 .wp-block-jetpack-cookie-consent:not([role='document']) {
+	transition: opacity 0.2s ease-in-out;
+	animation: cookie-consent-slide-in 0.2s ease-in-out;
+
 	span {
 		display: none;
 	}
@@ -12,10 +15,12 @@
 	@keyframes cookie-consent-slide-in {
 		from {
 			opacity: 0;
+			transform: translateY(10px);
 		}
 
 		to {
 			opacity: 1;
+			transform: translateY(0);
 		}
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/style.scss
@@ -15,12 +15,10 @@
 	@keyframes cookie-consent-slide-in {
 		from {
 			opacity: 0;
-			transform: translateY(10px);
 		}
 
 		to {
 			opacity: 1;
-			transform: translateY(0);
 		}
 	}
 


### PR DESCRIPTION
Follow up to https://github.com/Automattic/jetpack/pull/29197.


## Proposed changes:
1. The `save` function was creating different content across sessions (save the block, refresh the page, and it will be broken). This PR fixes that by creating the same content.
2. This lowers the transition period from 1s to 0.2s because we got feedback that it's too long and I agree.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- Please follow the same steps [here](https://github.com/Automattic/jetpack/pull/29197#:~:text=Testing%20instructions%3A). 
- Make sure the block renders well after you save and refresh the editor.

