### PR TITLE
[RNMobile] Add MVP for VideoPress block v5

### DIFF
--- a/projects/plugins/jetpack/changelog/rnmobile-support-videopress-v5
+++ b/projects/plugins/jetpack/changelog/rnmobile-support-videopress-v5
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Expand native implementation of VideoPress block v5.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit-common-settings.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit-common-settings.native.js
@@ -1,0 +1,93 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { ToggleControl, SelectControl } from '@wordpress/components';
+import { useMemo, useCallback, Platform } from '@wordpress/element';
+
+const options = [
+	{ value: 'auto', label: __( 'Auto' ) },
+	{ value: 'metadata', label: __( 'Metadata' ) },
+	{ value: 'none', label: _x( 'None', 'Preload value' ) },
+];
+
+const VideoSettings = ( { setAttributes, attributes } ) => {
+	const { autoplay, controls, loop, muted, playsInline, preload } =
+		attributes;
+
+	const autoPlayHelpText = __(
+		'Autoplay may cause usability issues for some users.'
+	);
+	const getAutoplayHelp = Platform.select( {
+		web: useCallback( ( checked ) => {
+			return checked ? autoPlayHelpText : null;
+		}, [] ),
+		native: autoPlayHelpText,
+	} );
+
+	const toggleFactory = useMemo( () => {
+		const toggleAttribute = ( attribute ) => {
+			return ( newValue ) => {
+				setAttributes( { [ attribute ]: newValue } );
+			};
+		};
+
+		return {
+			autoplay: toggleAttribute( 'autoplay' ),
+			loop: toggleAttribute( 'loop' ),
+			muted: toggleAttribute( 'muted' ),
+			controls: toggleAttribute( 'controls' ),
+			playsInline: toggleAttribute( 'playsInline' ),
+		};
+	}, [] );
+
+	const onChangePreload = useCallback( ( value ) => {
+		setAttributes( { preload: value } );
+	}, [] );
+
+	return (
+		<>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Autoplay' ) }
+				onChange={ toggleFactory.autoplay }
+				checked={ !! autoplay }
+				help={ getAutoplayHelp }
+			/>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Loop' ) }
+				onChange={ toggleFactory.loop }
+				checked={ !! loop }
+			/>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Muted' ) }
+				onChange={ toggleFactory.muted }
+				checked={ !! muted }
+			/>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Playback controls' ) }
+				onChange={ toggleFactory.controls }
+				checked={ !! controls }
+			/>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Play inline' ) }
+				onChange={ toggleFactory.playsInline }
+				checked={ !! playsInline }
+			/>
+			<SelectControl
+				__nextHasNoMarginBottom
+				label={ __( 'Preload' ) }
+				value={ preload }
+				onChange={ onChangePreload }
+				options={ options }
+				hideCancelButton={ true }
+			/>
+		</>
+	);
+};
+
+export default VideoSettings;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit-common-settings.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit-common-settings.native.js
@@ -1,33 +1,30 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
 import { ToggleControl, SelectControl } from '@wordpress/components';
 import { useMemo, useCallback, Platform } from '@wordpress/element';
+import { __, _x } from '@wordpress/i18n';
 
 const options = [
-	{ value: 'auto', label: __( 'Auto' ) },
-	{ value: 'metadata', label: __( 'Metadata' ) },
-	{ value: 'none', label: _x( 'None', 'Preload value' ) },
+	{ value: 'auto', label: __( 'Auto', 'jetpack' ) },
+	{ value: 'metadata', label: __( 'Metadata', 'jetpack' ) },
+	{ value: 'none', label: _x( 'None', 'Preload value', 'jetpack' ) },
 ];
 
 const VideoSettings = ( { setAttributes, attributes } ) => {
-	const { autoplay, controls, loop, muted, playsInline, preload } =
-		attributes;
+	const { autoplay, controls, loop, muted, playsInline, preload } = attributes;
 
-	const autoPlayHelpText = __(
-		'Autoplay may cause usability issues for some users.'
-	);
+	const autoPlayHelpText = __( 'Autoplay may cause usability issues for some users.', 'jetpack' );
 	const getAutoplayHelp = Platform.select( {
-		web: useCallback( ( checked ) => {
+		web: useCallback( checked => {
 			return checked ? autoPlayHelpText : null;
 		}, [] ),
 		native: autoPlayHelpText,
 	} );
 
 	const toggleFactory = useMemo( () => {
-		const toggleAttribute = ( attribute ) => {
-			return ( newValue ) => {
+		const toggleAttribute = attribute => {
+			return newValue => {
 				setAttributes( { [ attribute ]: newValue } );
 			};
 		};
@@ -41,7 +38,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 		};
 	}, [] );
 
-	const onChangePreload = useCallback( ( value ) => {
+	const onChangePreload = useCallback( value => {
 		setAttributes( { preload: value } );
 	}, [] );
 
@@ -49,38 +46,38 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 		<>
 			<ToggleControl
 				__nextHasNoMarginBottom
-				label={ __( 'Autoplay' ) }
+				label={ __( 'Autoplay', 'jetpack' ) }
 				onChange={ toggleFactory.autoplay }
 				checked={ !! autoplay }
 				help={ getAutoplayHelp }
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom
-				label={ __( 'Loop' ) }
+				label={ __( 'Loop', 'jetpack' ) }
 				onChange={ toggleFactory.loop }
 				checked={ !! loop }
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom
-				label={ __( 'Muted' ) }
+				label={ __( 'Muted', 'jetpack' ) }
 				onChange={ toggleFactory.muted }
 				checked={ !! muted }
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom
-				label={ __( 'Playback controls' ) }
+				label={ __( 'Playback controls', 'jetpack' ) }
 				onChange={ toggleFactory.controls }
 				checked={ !! controls }
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom
-				label={ __( 'Play inline' ) }
+				label={ __( 'Play inline', 'jetpack' ) }
 				onChange={ toggleFactory.playsInline }
 				checked={ !! playsInline }
 			/>
 			<SelectControl
 				__nextHasNoMarginBottom
-				label={ __( 'Preload' ) }
+				label={ __( 'Preload', 'jetpack' ) }
 				value={ preload }
 				onChange={ onChangePreload }
 				options={ options }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit-common-settings.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit-common-settings.native.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { ToggleControl, SelectControl } from '@wordpress/components';
-import { useMemo, useCallback, Platform } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 
 const options = [
@@ -13,14 +13,6 @@ const options = [
 
 const VideoSettings = ( { setAttributes, attributes } ) => {
 	const { autoplay, controls, loop, muted, playsInline, preload } = attributes;
-
-	const autoPlayHelpText = __( 'Autoplay may cause usability issues for some users.', 'jetpack' );
-	const getAutoplayHelp = Platform.select( {
-		web: useCallback( checked => {
-			return checked ? autoPlayHelpText : null;
-		}, [] ),
-		native: autoPlayHelpText,
-	} );
 
 	const toggleFactory = useMemo( () => {
 		const toggleAttribute = attribute => {
@@ -36,11 +28,14 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 			controls: toggleAttribute( 'controls' ),
 			playsInline: toggleAttribute( 'playsInline' ),
 		};
-	}, [] );
+	}, [ setAttributes ] );
 
-	const onChangePreload = useCallback( value => {
-		setAttributes( { preload: value } );
-	}, [] );
+	const onChangePreload = useCallback(
+		value => {
+			setAttributes( { preload: value } );
+		},
+		[ setAttributes ]
+	);
 
 	return (
 		<>
@@ -49,7 +44,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 				label={ __( 'Autoplay', 'jetpack' ) }
 				onChange={ toggleFactory.autoplay }
 				checked={ !! autoplay }
-				help={ getAutoplayHelp }
+				help={ __( 'Autoplay may cause usability issues for some users.', 'jetpack' ) }
 			/>
 			<ToggleControl
 				__nextHasNoMarginBottom

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
@@ -1,0 +1,403 @@
+/**
+ * External dependencies
+ */
+import { View, TouchableWithoutFeedback, Text } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import {
+	mediaUploadSync,
+	requestImageFailedRetryDialog,
+	requestImageUploadCancelDialog,
+} from '@wordpress/react-native-bridge';
+import {
+	Icon,
+	ToolbarButton,
+	ToolbarGroup,
+	PanelBody,
+} from '@wordpress/components';
+import { withPreferredColorScheme, compose } from '@wordpress/compose';
+import {
+	BlockCaption,
+	MediaPlaceholder,
+	MediaUpload,
+	MediaUploadProgress,
+	MEDIA_TYPE_VIDEO,
+	BlockControls,
+	VIDEO_ASPECT_RATIO,
+	VideoPlayer,
+	InspectorControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { __, sprintf } from '@wordpress/i18n';
+import { isURL, getProtocol } from '@wordpress/url';
+import { doAction, hasAction } from '@wordpress/hooks';
+import { video as SvgIcon, replace } from '@wordpress/icons';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { createUpgradedEmbedBlock } from '../embed/util';
+import style from './style.scss';
+import SvgIconRetry from './icon-retry';
+import VideoCommonSettings from './edit-common-settings';
+
+const ICON_TYPE = {
+	PLACEHOLDER: 'placeholder',
+	RETRY: 'retry',
+	UPLOAD: 'upload',
+};
+
+class VideoEdit extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isCaptionSelected: false,
+			videoContainerHeight: 0,
+		};
+
+		this.mediaUploadStateReset = this.mediaUploadStateReset.bind( this );
+		this.onSelectMediaUploadOption =
+			this.onSelectMediaUploadOption.bind( this );
+		this.onSelectURL = this.onSelectURL.bind( this );
+		this.finishMediaUploadWithSuccess =
+			this.finishMediaUploadWithSuccess.bind( this );
+		this.finishMediaUploadWithFailure =
+			this.finishMediaUploadWithFailure.bind( this );
+		this.updateMediaProgress = this.updateMediaProgress.bind( this );
+		this.onVideoPressed = this.onVideoPressed.bind( this );
+		this.onVideoContanerLayout = this.onVideoContanerLayout.bind( this );
+		this.onFocusCaption = this.onFocusCaption.bind( this );
+	}
+
+	componentDidMount() {
+		const { attributes } = this.props;
+		if ( attributes.id && getProtocol( attributes.src ) === 'file:' ) {
+			mediaUploadSync();
+		}
+	}
+
+	componentWillUnmount() {
+		// This action will only exist if the user pressed the trash button on the block holder.
+		if (
+			hasAction( 'blocks.onRemoveBlockCheckUpload' ) &&
+			this.state.isUploadInProgress
+		) {
+			doAction(
+				'blocks.onRemoveBlockCheckUpload',
+				this.props.attributes.id
+			);
+		}
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		// Avoid a UI flicker in the toolbar by insuring that isCaptionSelected
+		// is updated immediately any time the isSelected prop becomes false.
+		return {
+			isCaptionSelected: props.isSelected && state.isCaptionSelected,
+		};
+	}
+
+	onVideoPressed() {
+		const { attributes } = this.props;
+
+		if ( this.state.isUploadInProgress ) {
+			requestImageUploadCancelDialog( attributes.id );
+		} else if (
+			attributes.id &&
+			getProtocol( attributes.src ) === 'file:'
+		) {
+			requestImageFailedRetryDialog( attributes.id );
+		}
+
+		this.setState( {
+			isCaptionSelected: false,
+		} );
+	}
+
+	onFocusCaption() {
+		if ( ! this.state.isCaptionSelected ) {
+			this.setState( { isCaptionSelected: true } );
+		}
+	}
+
+	updateMediaProgress( payload ) {
+		const { setAttributes } = this.props;
+		if ( payload.mediaUrl ) {
+			setAttributes( { url: payload.mediaUrl } );
+		}
+		if ( ! this.state.isUploadInProgress ) {
+			this.setState( { isUploadInProgress: true } );
+		}
+	}
+
+	finishMediaUploadWithSuccess( payload ) {
+		const { setAttributes } = this.props;
+		setAttributes( { src: payload.mediaUrl, id: payload.mediaServerId } );
+		this.setState( { isUploadInProgress: false } );
+	}
+
+	finishMediaUploadWithFailure( payload ) {
+		const { setAttributes } = this.props;
+		setAttributes( { id: payload.mediaId } );
+		this.setState( { isUploadInProgress: false } );
+	}
+
+	mediaUploadStateReset() {
+		const { setAttributes } = this.props;
+		setAttributes( { id: null, src: null } );
+		this.setState( { isUploadInProgress: false } );
+	}
+
+	onSelectMediaUploadOption( { id, url } ) {
+		const { setAttributes } = this.props;
+		setAttributes( { id, src: url } );
+	}
+
+	onSelectURL( url ) {
+		const { createErrorNotice, onReplace, setAttributes } = this.props;
+
+		if ( isURL( url ) ) {
+			// Check if there's an embed block that handles this URL.
+			const embedBlock = createUpgradedEmbedBlock( {
+				attributes: { url },
+			} );
+			if ( undefined !== embedBlock ) {
+				onReplace( embedBlock );
+				return;
+			}
+
+			setAttributes( { id: url, src: url } );
+		} else {
+			createErrorNotice( __( 'Invalid URL.' ) );
+		}
+	}
+
+	onVideoContanerLayout( event ) {
+		const { width } = event.nativeEvent.layout;
+		const height = width / VIDEO_ASPECT_RATIO;
+		if ( height !== this.state.videoContainerHeight ) {
+			this.setState( { videoContainerHeight: height } );
+		}
+	}
+
+	getIcon( iconType ) {
+		let iconStyle;
+		switch ( iconType ) {
+			case ICON_TYPE.RETRY:
+				return <Icon icon={ SvgIconRetry } { ...style.icon } />;
+			case ICON_TYPE.PLACEHOLDER:
+				iconStyle = this.props.getStylesFromColorScheme(
+					style.icon,
+					style.iconDark
+				);
+				break;
+			case ICON_TYPE.UPLOAD:
+				iconStyle = this.props.getStylesFromColorScheme(
+					style.iconUploading,
+					style.iconUploadingDark
+				);
+				break;
+		}
+
+		return <Icon icon={ SvgIcon } { ...iconStyle } />;
+	}
+
+	render() {
+		const { setAttributes, attributes, isSelected, wasBlockJustInserted } =
+			this.props;
+		const { id, src } = attributes;
+		const { videoContainerHeight } = this.state;
+
+		const toolbarEditButton = (
+			<MediaUpload
+				allowedTypes={ [ MEDIA_TYPE_VIDEO ] }
+				isReplacingMedia={ true }
+				onSelect={ this.onSelectMediaUploadOption }
+				onSelectURL={ this.onSelectURL }
+				render={ ( { open, getMediaOptions } ) => {
+					return (
+						<ToolbarGroup>
+							{ getMediaOptions() }
+							<ToolbarButton
+								label={ __( 'Edit video' ) }
+								icon={ replace }
+								onClick={ open }
+							/>
+						</ToolbarGroup>
+					);
+				} }
+			></MediaUpload>
+		);
+
+		if ( ! id ) {
+			return (
+				<View style={ { flex: 1 } }>
+					<MediaPlaceholder
+						allowedTypes={ [ MEDIA_TYPE_VIDEO ] }
+						onSelect={ this.onSelectMediaUploadOption }
+						onSelectURL={ this.onSelectURL }
+						icon={ this.getIcon( ICON_TYPE.PLACEHOLDER ) }
+						onFocus={ this.props.onFocus }
+						autoOpenMediaUpload={
+							isSelected && wasBlockJustInserted
+						}
+					/>
+				</View>
+			);
+		}
+
+		return (
+			<TouchableWithoutFeedback
+				accessible={ ! isSelected }
+				onPress={ this.onVideoPressed }
+				disabled={ ! isSelected }
+			>
+				<View style={ { flex: 1 } }>
+					{ ! this.state.isCaptionSelected && (
+						<BlockControls>{ toolbarEditButton }</BlockControls>
+					) }
+					{ isSelected && (
+						<InspectorControls>
+							<PanelBody title={ __( 'Settings' ) }>
+								<VideoCommonSettings
+									setAttributes={ setAttributes }
+									attributes={ attributes }
+								/>
+							</PanelBody>
+						</InspectorControls>
+					) }
+					<MediaUploadProgress
+						mediaId={ id }
+						onFinishMediaUploadWithSuccess={
+							this.finishMediaUploadWithSuccess
+						}
+						onFinishMediaUploadWithFailure={
+							this.finishMediaUploadWithFailure
+						}
+						onUpdateMediaProgress={ this.updateMediaProgress }
+						onMediaUploadStateReset={ this.mediaUploadStateReset }
+						renderContent={ ( {
+							isUploadInProgress,
+							isUploadFailed,
+							retryMessage,
+						} ) => {
+							const showVideo =
+								isURL( src ) &&
+								! isUploadInProgress &&
+								! isUploadFailed;
+							const icon = this.getIcon(
+								isUploadFailed
+									? ICON_TYPE.RETRY
+									: ICON_TYPE.UPLOAD
+							);
+							const styleIconContainer = isUploadFailed
+								? style.modalIconRetry
+								: style.modalIcon;
+
+							const iconContainer = (
+								<View style={ styleIconContainer }>
+									{ icon }
+								</View>
+							);
+
+							const videoStyle = {
+								height: videoContainerHeight,
+								...style.video,
+							};
+
+							const containerStyle =
+								showVideo && isSelected
+									? style.containerFocused
+									: style.container;
+
+							return (
+								<View
+									onLayout={ this.onVideoContanerLayout }
+									style={ containerStyle }
+								>
+									{ showVideo && (
+										<View style={ style.videoContainer }>
+											<VideoPlayer
+												isSelected={
+													isSelected &&
+													! this.state
+														.isCaptionSelected
+												}
+												style={ videoStyle }
+												source={ { uri: src } }
+												paused={ true }
+											/>
+										</View>
+									) }
+									{ ! showVideo && (
+										<View
+											style={ {
+												height: videoContainerHeight,
+												width: '100%',
+												...this.props.getStylesFromColorScheme(
+													style.placeholderContainer,
+													style.placeholderContainerDark
+												),
+											} }
+										>
+											{ videoContainerHeight > 0 &&
+												iconContainer }
+											{ isUploadFailed && (
+												<Text
+													style={
+														style.uploadFailedText
+													}
+												>
+													{ retryMessage }
+												</Text>
+											) }
+										</View>
+									) }
+								</View>
+							);
+						} }
+					/>
+					<BlockCaption
+						accessible={ true }
+						accessibilityLabelCreator={ ( caption ) =>
+							! caption
+								? /* translators: accessibility text. Empty video caption. */
+								  __( 'Video caption. Empty' )
+								: sprintf(
+										/* translators: accessibility text. %s: video caption. */
+										__( 'Video caption. %s' ),
+										caption
+								  )
+						}
+						clientId={ this.props.clientId }
+						isSelected={ this.state.isCaptionSelected }
+						onFocus={ this.onFocusCaption }
+						onBlur={ this.props.onBlur } // Always assign onBlur as props.
+						insertBlocksAfter={ this.props.insertBlocksAfter }
+					/>
+				</View>
+			</TouchableWithoutFeedback>
+		);
+	}
+}
+
+export default compose( [
+	withSelect( ( select, { clientId } ) => ( {
+		wasBlockJustInserted: select( blockEditorStore ).wasBlockJustInserted(
+			clientId,
+			'inserter_menu'
+		),
+	} ) ),
+	withDispatch( ( dispatch ) => {
+		const { createErrorNotice } = dispatch( noticesStore );
+
+		return { createErrorNotice };
+	} ),
+	withPreferredColorScheme,
+] )( VideoEdit );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
@@ -1,24 +1,6 @@
 /**
- * External dependencies
- */
-import { View, TouchableWithoutFeedback, Text } from 'react-native';
-
-/**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import {
-	mediaUploadSync,
-	requestImageFailedRetryDialog,
-	requestImageUploadCancelDialog,
-} from '@wordpress/react-native-bridge';
-import {
-	Icon,
-	ToolbarButton,
-	ToolbarGroup,
-	PanelBody,
-} from '@wordpress/components';
-import { withPreferredColorScheme, compose } from '@wordpress/compose';
 import {
 	BlockCaption,
 	MediaPlaceholder,
@@ -31,20 +13,31 @@ import {
 	InspectorControls,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { __, sprintf } from '@wordpress/i18n';
-import { isURL, getProtocol } from '@wordpress/url';
-import { doAction, hasAction } from '@wordpress/hooks';
-import { video as SvgIcon, replace } from '@wordpress/icons';
+import { Icon, ToolbarButton, ToolbarGroup, PanelBody } from '@wordpress/components';
+import { withPreferredColorScheme, compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { Component } from '@wordpress/element';
+import { doAction, hasAction } from '@wordpress/hooks';
+import { __, sprintf } from '@wordpress/i18n';
+import { video as SvgIcon, replace } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-
+import {
+	mediaUploadSync,
+	requestImageFailedRetryDialog,
+	requestImageUploadCancelDialog,
+} from '@wordpress/react-native-bridge';
+import { isURL, getProtocol } from '@wordpress/url';
+/**
+ * External dependencies
+ */
+import { View, TouchableWithoutFeedback, Text } from 'react-native';
 /**
  * Internal dependencies
  */
 import { createUpgradedEmbedBlock } from '../embed/util';
-import style from './style.scss';
-import SvgIconRetry from './icon-retry';
 import VideoCommonSettings from './edit-common-settings';
+import SvgIconRetry from './icon-retry';
+import style from './style.scss';
 
 const ICON_TYPE = {
 	PLACEHOLDER: 'placeholder',
@@ -62,13 +55,10 @@ class VideoEdit extends Component {
 		};
 
 		this.mediaUploadStateReset = this.mediaUploadStateReset.bind( this );
-		this.onSelectMediaUploadOption =
-			this.onSelectMediaUploadOption.bind( this );
+		this.onSelectMediaUploadOption = this.onSelectMediaUploadOption.bind( this );
 		this.onSelectURL = this.onSelectURL.bind( this );
-		this.finishMediaUploadWithSuccess =
-			this.finishMediaUploadWithSuccess.bind( this );
-		this.finishMediaUploadWithFailure =
-			this.finishMediaUploadWithFailure.bind( this );
+		this.finishMediaUploadWithSuccess = this.finishMediaUploadWithSuccess.bind( this );
+		this.finishMediaUploadWithFailure = this.finishMediaUploadWithFailure.bind( this );
 		this.updateMediaProgress = this.updateMediaProgress.bind( this );
 		this.onVideoPressed = this.onVideoPressed.bind( this );
 		this.onVideoContanerLayout = this.onVideoContanerLayout.bind( this );
@@ -84,14 +74,8 @@ class VideoEdit extends Component {
 
 	componentWillUnmount() {
 		// This action will only exist if the user pressed the trash button on the block holder.
-		if (
-			hasAction( 'blocks.onRemoveBlockCheckUpload' ) &&
-			this.state.isUploadInProgress
-		) {
-			doAction(
-				'blocks.onRemoveBlockCheckUpload',
-				this.props.attributes.id
-			);
+		if ( hasAction( 'blocks.onRemoveBlockCheckUpload' ) && this.state.isUploadInProgress ) {
+			doAction( 'blocks.onRemoveBlockCheckUpload', this.props.attributes.id );
 		}
 	}
 
@@ -108,10 +92,7 @@ class VideoEdit extends Component {
 
 		if ( this.state.isUploadInProgress ) {
 			requestImageUploadCancelDialog( attributes.id );
-		} else if (
-			attributes.id &&
-			getProtocol( attributes.src ) === 'file:'
-		) {
+		} else if ( attributes.id && getProtocol( attributes.src ) === 'file:' ) {
 			requestImageFailedRetryDialog( attributes.id );
 		}
 
@@ -174,7 +155,7 @@ class VideoEdit extends Component {
 
 			setAttributes( { id: url, src: url } );
 		} else {
-			createErrorNotice( __( 'Invalid URL.' ) );
+			createErrorNotice( __( 'Invalid URL.', 'jetpack' ) );
 		}
 	}
 
@@ -192,10 +173,7 @@ class VideoEdit extends Component {
 			case ICON_TYPE.RETRY:
 				return <Icon icon={ SvgIconRetry } { ...style.icon } />;
 			case ICON_TYPE.PLACEHOLDER:
-				iconStyle = this.props.getStylesFromColorScheme(
-					style.icon,
-					style.iconDark
-				);
+				iconStyle = this.props.getStylesFromColorScheme( style.icon, style.iconDark );
 				break;
 			case ICON_TYPE.UPLOAD:
 				iconStyle = this.props.getStylesFromColorScheme(
@@ -209,8 +187,7 @@ class VideoEdit extends Component {
 	}
 
 	render() {
-		const { setAttributes, attributes, isSelected, wasBlockJustInserted } =
-			this.props;
+		const { setAttributes, attributes, isSelected, wasBlockJustInserted } = this.props;
 		const { id, src } = attributes;
 		const { videoContainerHeight } = this.state;
 
@@ -225,7 +202,7 @@ class VideoEdit extends Component {
 						<ToolbarGroup>
 							{ getMediaOptions() }
 							<ToolbarButton
-								label={ __( 'Edit video' ) }
+								label={ __( 'Edit video', 'jetpack' ) }
 								icon={ replace }
 								onClick={ open }
 							/>
@@ -244,9 +221,7 @@ class VideoEdit extends Component {
 						onSelectURL={ this.onSelectURL }
 						icon={ this.getIcon( ICON_TYPE.PLACEHOLDER ) }
 						onFocus={ this.props.onFocus }
-						autoOpenMediaUpload={
-							isSelected && wasBlockJustInserted
-						}
+						autoOpenMediaUpload={ isSelected && wasBlockJustInserted }
 					/>
 				</View>
 			);
@@ -259,52 +234,26 @@ class VideoEdit extends Component {
 				disabled={ ! isSelected }
 			>
 				<View style={ { flex: 1 } }>
-					{ ! this.state.isCaptionSelected && (
-						<BlockControls>{ toolbarEditButton }</BlockControls>
-					) }
+					{ ! this.state.isCaptionSelected && <BlockControls>{ toolbarEditButton }</BlockControls> }
 					{ isSelected && (
 						<InspectorControls>
-							<PanelBody title={ __( 'Settings' ) }>
-								<VideoCommonSettings
-									setAttributes={ setAttributes }
-									attributes={ attributes }
-								/>
+							<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+								<VideoCommonSettings setAttributes={ setAttributes } attributes={ attributes } />
 							</PanelBody>
 						</InspectorControls>
 					) }
 					<MediaUploadProgress
 						mediaId={ id }
-						onFinishMediaUploadWithSuccess={
-							this.finishMediaUploadWithSuccess
-						}
-						onFinishMediaUploadWithFailure={
-							this.finishMediaUploadWithFailure
-						}
+						onFinishMediaUploadWithSuccess={ this.finishMediaUploadWithSuccess }
+						onFinishMediaUploadWithFailure={ this.finishMediaUploadWithFailure }
 						onUpdateMediaProgress={ this.updateMediaProgress }
 						onMediaUploadStateReset={ this.mediaUploadStateReset }
-						renderContent={ ( {
-							isUploadInProgress,
-							isUploadFailed,
-							retryMessage,
-						} ) => {
-							const showVideo =
-								isURL( src ) &&
-								! isUploadInProgress &&
-								! isUploadFailed;
-							const icon = this.getIcon(
-								isUploadFailed
-									? ICON_TYPE.RETRY
-									: ICON_TYPE.UPLOAD
-							);
-							const styleIconContainer = isUploadFailed
-								? style.modalIconRetry
-								: style.modalIcon;
+						renderContent={ ( { isUploadInProgress, isUploadFailed, retryMessage } ) => {
+							const showVideo = isURL( src ) && ! isUploadInProgress && ! isUploadFailed;
+							const icon = this.getIcon( isUploadFailed ? ICON_TYPE.RETRY : ICON_TYPE.UPLOAD );
+							const styleIconContainer = isUploadFailed ? style.modalIconRetry : style.modalIcon;
 
-							const iconContainer = (
-								<View style={ styleIconContainer }>
-									{ icon }
-								</View>
-							);
+							const iconContainer = <View style={ styleIconContainer }>{ icon }</View>;
 
 							const videoStyle = {
 								height: videoContainerHeight,
@@ -312,23 +261,14 @@ class VideoEdit extends Component {
 							};
 
 							const containerStyle =
-								showVideo && isSelected
-									? style.containerFocused
-									: style.container;
+								showVideo && isSelected ? style.containerFocused : style.container;
 
 							return (
-								<View
-									onLayout={ this.onVideoContanerLayout }
-									style={ containerStyle }
-								>
+								<View onLayout={ this.onVideoContanerLayout } style={ containerStyle }>
 									{ showVideo && (
 										<View style={ style.videoContainer }>
 											<VideoPlayer
-												isSelected={
-													isSelected &&
-													! this.state
-														.isCaptionSelected
-												}
+												isSelected={ isSelected && ! this.state.isCaptionSelected }
 												style={ videoStyle }
 												source={ { uri: src } }
 												paused={ true }
@@ -346,16 +286,9 @@ class VideoEdit extends Component {
 												),
 											} }
 										>
-											{ videoContainerHeight > 0 &&
-												iconContainer }
+											{ videoContainerHeight > 0 && iconContainer }
 											{ isUploadFailed && (
-												<Text
-													style={
-														style.uploadFailedText
-													}
-												>
-													{ retryMessage }
-												</Text>
+												<Text style={ style.uploadFailedText }>{ retryMessage }</Text>
 											) }
 										</View>
 									) }
@@ -365,13 +298,13 @@ class VideoEdit extends Component {
 					/>
 					<BlockCaption
 						accessible={ true }
-						accessibilityLabelCreator={ ( caption ) =>
+						accessibilityLabelCreator={ caption =>
 							! caption
 								? /* translators: accessibility text. Empty video caption. */
-								  __( 'Video caption. Empty' )
+								  __( 'Video caption. Empty', 'jetpack' )
 								: sprintf(
 										/* translators: accessibility text. %s: video caption. */
-										__( 'Video caption. %s' ),
+										__( 'Video caption. %s', 'jetpack' ),
 										caption
 								  )
 						}
@@ -394,7 +327,7 @@ export default compose( [
 			'inserter_menu'
 		),
 	} ) ),
-	withDispatch( ( dispatch ) => {
+	withDispatch( dispatch => {
 		const { createErrorNotice } = dispatch( noticesStore );
 
 		return { createErrorNotice };

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import {
 	BlockCaption,
 	MediaPlaceholder,
@@ -14,7 +15,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { Icon, ToolbarButton, ToolbarGroup, PanelBody } from '@wordpress/components';
-import { withPreferredColorScheme, compose } from '@wordpress/compose';
+import { withPreferredColorScheme, compose, createHigherOrderComponent } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
 import { doAction, hasAction } from '@wordpress/hooks';
@@ -26,7 +27,7 @@ import {
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
 } from '@wordpress/react-native-bridge';
-import { isURL, getProtocol } from '@wordpress/url';
+import { isURL, getProtocol, addQueryArgs } from '@wordpress/url';
 /**
  * External dependencies
  */
@@ -34,10 +35,10 @@ import { View, TouchableWithoutFeedback, Text } from 'react-native';
 /**
  * Internal dependencies
  */
-import { createUpgradedEmbedBlock } from '../embed/util';
 import VideoCommonSettings from './edit-common-settings';
 import SvgIconRetry from './icon-retry';
 import style from './style.scss';
+import { pickGUIDFromUrl } from './utils';
 
 const ICON_TYPE = {
 	PLACEHOLDER: 'placeholder',
@@ -45,13 +46,17 @@ const ICON_TYPE = {
 	UPLOAD: 'upload',
 };
 
-class VideoEdit extends Component {
+class VideoPressEdit extends Component {
 	constructor( props ) {
 		super( props );
 
 		this.state = {
 			isCaptionSelected: false,
 			videoContainerHeight: 0,
+			isUploadInProgress: false,
+			isUploadFailed: false,
+			isLoadingMetadata: false,
+			metadata: {},
 		};
 
 		this.mediaUploadStateReset = this.mediaUploadStateReset.bind( this );
@@ -65,10 +70,19 @@ class VideoEdit extends Component {
 		this.onFocusCaption = this.onFocusCaption.bind( this );
 	}
 
-	componentDidMount() {
+	async componentDidMount() {
 		const { attributes } = this.props;
+		const { guid } = attributes;
 		if ( attributes.id && getProtocol( attributes.src ) === 'file:' ) {
 			mediaUploadSync();
+		}
+
+		// Try to infer the VideoPress ID from the source upon component mount.
+		// If the ID already exists, fetch the metadata to get the video URL.
+		if ( ! guid ) {
+			await this.setGuid();
+		} else {
+			await this.fetchMetadata( guid );
 		}
 	}
 
@@ -80,11 +94,37 @@ class VideoEdit extends Component {
 	}
 
 	static getDerivedStateFromProps( props, state ) {
-		// Avoid a UI flicker in the toolbar by insuring that isCaptionSelected
-		// is updated immediately any time the isSelected prop becomes false.
 		return {
+			// Avoid a UI flicker in the toolbar by insuring that isCaptionSelected
+			// is updated immediately any time the isSelected prop becomes false.
 			isCaptionSelected: props.isSelected && state.isCaptionSelected,
+			// Reset metadata when "guid" attribute is not defined.
+			metadata: props.attributes?.guid ? state.metadata : {},
 		};
+	}
+
+	async setGuid( value ) {
+		const { setAttributes, attributes } = this.props;
+		const { src } = attributes;
+		// If no value is passed, we try to extract the VideoPress ID from the source.
+		const guid = value ?? pickGUIDFromUrl( src ) ?? undefined;
+		setAttributes( { guid } );
+		if ( guid ) {
+			await this.fetchMetadata( guid );
+		}
+	}
+
+	async fetchMetadata( guid ) {
+		this.setState( { isLoadingMetadata: true } );
+		await apiFetch( { path: `/wp/v2/media/videos/${ guid }` } )
+			.then( metadata => {
+				this.setState( { metadata, isLoadingMetadata: false } );
+			} )
+			.catch( () => {
+				// eslint-disable-next-line no-console
+				console.error( `Couldn't fetch metadata of VideoPress video with ID = ${ guid }` );
+				this.setState( { isLoadingMetadata: false } );
+			} );
 	}
 
 	onVideoPressed() {
@@ -119,8 +159,11 @@ class VideoEdit extends Component {
 
 	finishMediaUploadWithSuccess( payload ) {
 		const { setAttributes } = this.props;
-		setAttributes( { src: payload.mediaUrl, id: payload.mediaServerId } );
+		const { mediaUrl, mediaServerId, metadata = {} } = payload;
+		const { videopressGUID } = metadata;
+		setAttributes( { src: mediaUrl, id: mediaServerId } );
 		this.setState( { isUploadInProgress: false } );
+		this.setGuid( videopressGUID );
 	}
 
 	finishMediaUploadWithFailure( payload ) {
@@ -131,28 +174,22 @@ class VideoEdit extends Component {
 
 	mediaUploadStateReset() {
 		const { setAttributes } = this.props;
-		setAttributes( { id: null, src: null } );
+		setAttributes( { id: null, src: null, guid: null } );
 		this.setState( { isUploadInProgress: false } );
 	}
 
-	onSelectMediaUploadOption( { id, url } ) {
+	onSelectMediaUploadOption( payload ) {
 		const { setAttributes } = this.props;
+		const { id, url, metadata = {} } = payload;
+		const { videopressGUID } = metadata;
 		setAttributes( { id, src: url } );
+		this.setGuid( videopressGUID );
 	}
 
 	onSelectURL( url ) {
-		const { createErrorNotice, onReplace, setAttributes } = this.props;
+		const { createErrorNotice, setAttributes } = this.props;
 
 		if ( isURL( url ) ) {
-			// Check if there's an embed block that handles this URL.
-			const embedBlock = createUpgradedEmbedBlock( {
-				attributes: { url },
-			} );
-			if ( undefined !== embedBlock ) {
-				onReplace( embedBlock );
-				return;
-			}
-
 			setAttributes( { id: url, src: url } );
 		} else {
 			createErrorNotice( __( 'Invalid URL.', 'jetpack' ) );
@@ -186,10 +223,26 @@ class VideoEdit extends Component {
 		return <Icon icon={ SvgIcon } { ...iconStyle } />;
 	}
 
+	getVideoURL() {
+		const { attributes } = this.props;
+		const { src } = attributes;
+		const { metadata = {} } = this.state;
+		const { originalURL, token } = metadata;
+		if ( originalURL ) {
+			return token ? addQueryArgs( originalURL, { metadata_token: token } ) : originalURL;
+		}
+		return src;
+	}
+
 	render() {
 		const { setAttributes, attributes, isSelected, wasBlockJustInserted } = this.props;
-		const { id, src } = attributes;
-		const { videoContainerHeight } = this.state;
+		const { id } = attributes;
+		const {
+			isLoadingMetadata,
+			isUploadInProgress,
+			isUploadFailed,
+			videoContainerHeight,
+		} = this.state;
 
 		const toolbarEditButton = (
 			<MediaUpload
@@ -248,8 +301,13 @@ class VideoEdit extends Component {
 						onFinishMediaUploadWithFailure={ this.finishMediaUploadWithFailure }
 						onUpdateMediaProgress={ this.updateMediaProgress }
 						onMediaUploadStateReset={ this.mediaUploadStateReset }
-						renderContent={ ( { isUploadInProgress, isUploadFailed, retryMessage } ) => {
-							const showVideo = isURL( src ) && ! isUploadInProgress && ! isUploadFailed;
+						renderContent={ ( { retryMessage } ) => {
+							const videoURL = this.getVideoURL();
+							const showVideo =
+								isURL( videoURL ) &&
+								! isUploadInProgress &&
+								! isUploadFailed &&
+								! isLoadingMetadata;
 							const icon = this.getIcon( isUploadFailed ? ICON_TYPE.RETRY : ICON_TYPE.UPLOAD );
 							const styleIconContainer = isUploadFailed ? style.modalIconRetry : style.modalIcon;
 
@@ -270,7 +328,7 @@ class VideoEdit extends Component {
 											<VideoPlayer
 												isSelected={ isSelected && ! this.state.isCaptionSelected }
 												style={ videoStyle }
-												source={ { uri: src } }
+												source={ { uri: videoURL } }
 												paused={ true }
 											/>
 										</View>
@@ -299,9 +357,8 @@ class VideoEdit extends Component {
 					<BlockCaption
 						accessible={ true }
 						accessibilityLabelCreator={ caption =>
-							! caption
-								? /* translators: accessibility text. Empty video caption. */
-								  __( 'Video caption. Empty', 'jetpack' )
+							! caption /* translators: accessibility text. Empty video caption. */
+								? __( 'Video caption. Empty', 'jetpack' )
 								: sprintf(
 										/* translators: accessibility text. %s: video caption. */
 										__( 'Video caption. %s', 'jetpack' ),
@@ -320,17 +377,21 @@ class VideoEdit extends Component {
 	}
 }
 
-export default compose( [
-	withSelect( ( select, { clientId } ) => ( {
-		wasBlockJustInserted: select( blockEditorStore ).wasBlockJustInserted(
-			clientId,
-			'inserter_menu'
-		),
-	} ) ),
-	withDispatch( dispatch => {
-		const { createErrorNotice } = dispatch( noticesStore );
+export default CoreVideoEdit =>
+	compose( [
+		withSelect( ( select, { clientId } ) => ( {
+			wasBlockJustInserted: select( blockEditorStore ).wasBlockJustInserted(
+				clientId,
+				'inserter_menu'
+			),
+		} ) ),
+		withDispatch( dispatch => {
+			const { createErrorNotice } = dispatch( noticesStore );
 
-		return { createErrorNotice };
-	} ),
-	withPreferredColorScheme,
-] )( VideoEdit );
+			return { createErrorNotice };
+		} ),
+		withPreferredColorScheme,
+		createHigherOrderComponent( WrappedComponent => props => {
+			return <WrappedComponent originalEdit={ CoreVideoEdit } { ...props } />;
+		} ),
+	] )( VideoPressEdit );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.native.js
@@ -31,7 +31,7 @@ import { isURL, getProtocol, addQueryArgs } from '@wordpress/url';
 /**
  * External dependencies
  */
-import { View, TouchableWithoutFeedback, Text } from 'react-native';
+import { ActivityIndicator, View, TouchableWithoutFeedback, Text } from 'react-native';
 /**
  * Internal dependencies
  */
@@ -344,7 +344,8 @@ class VideoPressEdit extends Component {
 												),
 											} }
 										>
-											{ videoContainerHeight > 0 && iconContainer }
+											{ videoContainerHeight > 0 &&
+												( isLoadingMetadata ? <ActivityIndicator /> : iconContainer ) }
 											{ isUploadFailed && (
 												<Text style={ style.uploadFailedText }>{ retryMessage }</Text>
 											) }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/icon-retry.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/icon-retry.native.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
+		<Path d="M0 0h24v24H0z" fill="none" />
+	</SVG>
+);

--- a/projects/plugins/jetpack/extensions/blocks/videopress/style.native.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/style.native.scss
@@ -1,0 +1,80 @@
+// @format
+
+.video {
+	width: 100%;
+}
+
+.videoContainer {
+	flex: 1;
+	background-color: #000;
+}
+
+.placeholderContainer {
+	flex: 1;
+	justify-content: center;
+	align-items: center;
+	background-color: $gray-light;
+}
+
+.placeholderContainerDark {
+	background-color: $gray-90;
+}
+
+.placeholderIcon {
+	justify-content: center;
+	align-items: center;
+	fill: $gray-dark;
+	background-color: $gray-lighten-30;
+}
+
+.uploadFailedText {
+	color: $gray-dark;
+	font-size: 14;
+	margin-top: 5;
+	text-align: center;
+}
+
+.modalIcon {
+	width: 40px;
+	height: 40px;
+	justify-content: center;
+	align-items: center;
+}
+
+.modalIconRetry {
+	width: 80px;
+	height: 80px;
+	justify-content: center;
+	align-items: center;
+}
+
+.container {
+	flex: 1;
+}
+
+.containerFocused {
+	flex: 1;
+	border-color: $blue-medium;
+	border-width: 2px;
+	border-style: solid;
+}
+
+.icon {
+	fill: $gray-dark;
+	width: 100%;
+	height: 100%;
+}
+
+.iconDark {
+	fill: $white;
+}
+
+.iconUploading {
+	fill: $gray-lighten-20;
+	width: 100%;
+	height: 100%;
+}
+
+.iconUploadingDark {
+	fill: $gray-70;
+}

--- a/projects/plugins/jetpack/extensions/blocks/videopress/style.native.scss
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/style.native.scss
@@ -1,5 +1,3 @@
-// @format
-
 .video {
 	width: 100%;
 }
@@ -18,13 +16,6 @@
 
 .placeholderContainerDark {
 	background-color: $gray-90;
-}
-
-.placeholderIcon {
-	justify-content: center;
-	align-items: center;
-	fill: $gray-dark;
-	background-color: $gray-lighten-30;
 }
 
 .uploadFailedText {


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20237

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5497.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The idea of this PR is to support VideoPress block v5 to address https://github.com/wordpress-mobile/gutenberg-mobile/issues/5497 by reusing as much as possible the current implementation of the core Video block. Since the issue only affects iOS, this version will only be enabled on iOS for now. On Android, we'll keep using the core Video block.

The main changes introduced in this PR are:
- https://github.com/Automattic/jetpack/pull/29256/commits/e8506634adee979a360a87f0efc32b144a3d9bf0: Enable v5 only on iOS.
- https://github.com/Automattic/jetpack/pull/29256/commits/bd0ecccbf0595d87b303472687a92fc03f5688a0: Copy the logic of core Video block.
- https://github.com/Automattic/jetpack/pull/29256/commits/2ad6c42ff85ce511ff27d153fd00b2fe7d835dba, https://github.com/Automattic/jetpack/pull/29256/commits/bcb1cc8bf309480b611f6187716a2cf912f8d152: Apply fixes to solve ESLint issues.
- https://github.com/Automattic/jetpack/pull/29256/commits/8473c456318d34f70396b7b4c2ed991666f5e052: **Apply changes to the Video block and implement the VideoPress metadata fetch to allow playing private videos:**
    * Set the attribute `guid` (i.e. VideoPress video ID) based if it can be inferred from the URL in `src` attribute. This is done upon block mounting or when the `src` attributes changes. The idea behind this logic is to automatically migrate from the core Video block format to VideoPress when using a VideoPress URL.
    * Fetch VideoPress video metadata to retrieve the token required for playing private videos. This will add the `metadata_token` query parameter in the video URL.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Part of the testing requires to check the HTML produced by the block. Here are examples of the block's HTML by version:

**Video block V5 - (Simple site/Self-hosted) [🍎 iOS]:**
```
<!-- wp:video {"guid":"<VIDEOPRESS_GUID>","id":<MEDIA_ID>,"videoPressTracks":[],"videoPressClassNames":"wp-block-embed is-type-video is-provider-videopress"} -->
<figure class="wp-block-video wp-block-embed is-type-video is-provider-videopress">
    <div class="wp-block-embed__wrapper">
        https://videopress.com/v/<VIDEOPRESS_GUID>?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
    </div>
</figure>
<!-- /wp:video -->
```

**Core Video block - Simple site [🤖 Android]:**
```
<!-- wp:video {"id":<MEDIA_ID>} -->
<figure class="wp-block-video"><video controls
        src="https://videos.files.wordpress.com/<VIDEOPRESS_GUID/<FILENAME>"></video></figure>
<!-- /wp:video -->
```

**Core Video block - Self-hosted [🍎 iOS/ 🤖 Android]:**
```
<!-- wp:video {"id":<MEDIA_ID>} -->
<figure class="wp-block-video"><video controls src="https://<SITE_HOST>/wp-content/uploads/2023/03/<FILE_NAME>"></video></figure>
<!-- /wp:video -->
```

### 1 - Simple sites
**Preparation:**
Since the PR addresses the issue with private videos, we need to ensure to test using private videos.

1. Go to a Simple site.
2. Set the site visibility to Private.

**NOTE:** Alternatively, a public site can be used by changing the privacy of videos to Private after upload.

#### 1.1 - 🍎 iOS - v5

**Upload within the editor:**
1. Open/create a post.
2. Add a Video block.
3. Upload a video from the local device.
4. Wait for the upload to finish.
5. Observe that the video is added to the block and can be played.
6. Switch to HTML mode and observe that the block's HTML matches the format ***Video block V5*** referenced above.
7. Preview the post and observe that video can be played using the VideoPress player.

**Upload outside the editor:**
1. Open/create a post.
2. Add a Video block.
3. Upload a video from the local device.
4. Before the upload finish, leave the editor and save the post.
5. Wait for the upload to finish in the Post list screen.
6. Open the post again.
7. Observe that the video is added to the block and can be played.
8. Switch to HTML mode and observe that the block's HTML matches the format ***Video block V5*** referenced above.
9. Preview the post and observe that video can be played using the VideoPress player.

**Take a video:**
1. Open/create a post.
2. Add a Video block.
3. Take a video and upload it.
4. Wait for the upload to finish.
5. Observe that the video is added to the block and can be played.
6. Switch to HTML mode and observe that the block's HTML matches the format ***Video block V5*** referenced above.
7. Preview the post and observe that video can be played using the VideoPress player.

**Insert from Media library:**
1. Open/create a post.
2. Add a Video block.
3. Insert a video from the Media library.
4. Observe that the video is added to the block and can be played.
5. Switch to HTML mode and observe that the block's HTML matches the format ***Video block V5*** referenced above.
6. Preview the post and observe that video can be played using the VideoPress player.

**Replace video:**
1. Follow one of the above test cases to add a Video block.
2. Replace the video with a different source.
3. Observe that the video is added to the block and can be played.
4. Switch to HTML mode and observe that the block's HTML matches the format ***Video block V5*** referenced above.
5. Preview the post and observe that video can be played using the VideoPress player.

**Transform block:**
1. Follow one of the above test cases to add a Video block.
2. Transform the block to:
   - Columns
   - Cover _(Video source should point to the attachment URL)_
   - File _(File URL should point to the attachment URL)_
   - Group
   - Media & Text _(Video source should point to the attachment URL)_
3. Observe that the block transforms as expected.
4. Switch to HTML mode and observe that the block's HTML matches the block transform.

**NOTE:** When the post is saved, the `src` attribute is removed from the block. This means that transforming the block into Cover/File/Media & Text will result in an empty block.

#### 1.2 - 🤖 Android - core Video block

Follow the same test cases of iOS, but after adding the video check follow these steps:
- Switch to HTML mode and observe that the block's HTML matches the format ***Core Video block - Simple site*** referenced above.
- Observe that the video can be played using the native video player.

### 2 - Self-hosted sites with Jetpack

**Preparation - attachment and VideoPress videos:**
Once VideoPress is enabled, all video uploads will use VideoPress. In order to test the block, it's important to also use videos uploaded to the site.
1. Go to the Media screen.
5. Upload a video.

**Preparation - private videos:**
Similar to Simple site, we need to ensure to test using private videos. However, since self-hosted sites can't be private, we need to enable video privacy:

1. Create a self-hosted site (e.g. Jurassic ninja site)
2. Connect the site to Jetpack.
6. Go to "Jetpack -> My Jetpack" and enable VideoPress.
7. Go to "Jetpack -> VideoPress" and enable Video Privacy by checking "Settings - Video Privacy: Restrict views to members of this site".

**NOTE:** Alternatively, the video privacy can be changed on each video via editing video details after upload.

#### 2.1 - 🍎 iOS - v5

**NOTE:** Free users can only have one video in VideoPress, so keep this in mind when testing. In case you already uploaded a video, you can delete it and upload a new one. Alternatively, you can purchase the VideoPress plan to have unlimited uploads.

**Upload within the editor - success:**
1. Follow the same steps as "Simple sites - Upload within the editor".

**Upload within the editor - error:**
1. After already uploading a video.
2. Follow the same steps as "Simple sites - Upload within the editor".
3. Observe that the video is not uploaded and an error is shown.

**Upload outside the editor - success:**
1. Follow the same steps as "Simple sites - Upload outside the editor".

**Upload outside the editor - error:**
1. After already uploading a video.
2. Follow the same steps as "Simple sites - Upload outside the editor".
3. Observe that the video is not uploaded and an error is shown.

**Take a video:**
1. Follow the same steps as "Simple sites - Take a video".

**Insert from Media library - VideoPress video:**
1. Open/create a post.
2. Add a Video block.
3. Insert a video from the Media library. **Select a video that was uploaded to VideoPress.**
4. Observe that the video is added to the block and can be played.
8. Switch to HTML mode and observe that the block's HTML matches the format ***Video block V5*** referenced above.
9. Preview the post and observe that video can be played using the VideoPress player.

**Insert from Media library - Attachment:**
1. Upload a video via the Media screen.
2. Open/create a post.
3. Add a Video block.
4. Insert a video from the Media library. **Select a video that was uploaded to the site, not VideoPress.**
5. Observe that the video is added to the block and can be played.
6. Switch to HTML mode and observe that the block's HTML matches the format ***Core Video block - Self-hosted*** referenced above.
10. Preview the post and observe that video can be played using the native player.

**Replace video:**
1. Follow one of the above test cases to add a Video block.
2. Replace the video with a different source.
3. Observe that the video is added to the block and can be played.
4. Switch to HTML mode and observe that the block's HTML matches the format ***Video block V5*/Core Video block - Self-hosted*** referenced above, depending on the video selected.
5. Preview the post and observe that video can be played using the VideoPress/native player, depending on the video selected.

**Transform block:**
1. Follow the same steps as "Simple sites - Transform block".

#### 2.2 - 🤖 Android - core Video block

Follow the same test cases of iOS, but after adding the video check follow these steps:
- Switch to HTML mode and observe that the block's HTML matches the format *Core Video block - Simple site* referenced above.
- Observe that the video can be played using the native video player.

### 3 - Self-hosted sites without Jetpack

VideoPress is only available with Jetpack, so in all test cases we should check that the block's format is *Core Video block - Self-hosted*.

