### PR TITLE
Fix/forms inbox search

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-inbox-search
+++ b/projects/packages/forms/changelog/fix-forms-inbox-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fix search by invalidating resolution on the selector

--- a/projects/packages/forms/src/dashboard/inbox/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/index.js
@@ -13,7 +13,7 @@ import InboxList from './list';
 import InboxResponse from './response';
 import './style.scss';
 
-const RESPONSES_FETCH_LIMIT = 5;
+const RESPONSES_FETCH_LIMIT = 20;
 
 const Inbox = () => {
 	const [ currentResponseId, setCurrentResponseId ] = useState( -1 );

--- a/projects/packages/forms/src/dashboard/inbox/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/index.js
@@ -3,7 +3,7 @@ import {
 	__experimentalInputControl as InputControl, // eslint-disable-line wpcalypso/no-unsafe-wp-apis
 	SelectControl,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { first, includes, map } from 'lodash';
@@ -11,23 +11,31 @@ import Layout from '../components/layout';
 import { STORE_NAME } from '../state';
 import InboxList from './list';
 import InboxResponse from './response';
-
 import './style.scss';
+
+const RESPONSES_FETCH_LIMIT = 5;
 
 const Inbox = () => {
 	const [ currentResponseId, setCurrentResponseId ] = useState( -1 );
 	const [ searchText, setSearchText ] = useState( '' );
+	const [ currentPage, setCurrentPage ] = useState( 1 );
+	const [ searchTerm, setSearchTerm ] = useState( searchText );
 
+	const { invalidateResolution } = useDispatch( STORE_NAME );
 	const [ loading, responses, total ] = useSelect(
 		select => {
 			const stateSelector = select( STORE_NAME );
 			return [
 				stateSelector.isFetchingResponses(),
-				stateSelector.getResponses( searchText ),
+				stateSelector.getResponses(
+					searchTerm,
+					RESPONSES_FETCH_LIMIT,
+					( currentPage - 1 ) * RESPONSES_FETCH_LIMIT
+				),
 				stateSelector.getTotalResponses(),
 			];
 		},
-		[ searchText ]
+		[ searchTerm ]
 	);
 
 	useEffect( () => {
@@ -38,15 +46,22 @@ const Inbox = () => {
 		setCurrentResponseId( responses[ 0 ].id );
 	}, [ responses, currentResponseId ] );
 
-	const handleLoadMore = useCallback( () => {
-		// this only needs to change the offset for the query
-	}, [] );
+	useEffect( () => {
+		invalidateResolution( 'getResponses', [
+			searchTerm,
+			RESPONSES_FETCH_LIMIT,
+			( currentPage - 1 ) * RESPONSES_FETCH_LIMIT,
+		] );
+	}, [ searchTerm, currentPage, invalidateResolution ] );
 
-	const handleSearch = useCallback( event => {
-		event.preventDefault();
-		// this only needs to actually set a searchText (called differently) so we put as dependency on the useSelect
-		// currently the search is being triggered every time searchText changes
-	}, [] );
+	const handleSearch = useCallback(
+		event => {
+			event.preventDefault();
+			setSearchTerm( searchText );
+			setCurrentPage( 1 );
+		},
+		[ searchText ]
+	);
 
 	const numberOfResponses = sprintf(
 		/* translators: %s: Number of responses. */
@@ -80,9 +95,12 @@ const Inbox = () => {
 						currentResponseId={ currentResponseId }
 						hasMore={ responses.length < total }
 						loading={ loading }
-						onLoadMore={ handleLoadMore }
 						onSelectionChange={ setCurrentResponseId }
 						responses={ responses }
+						currentPage={ currentPage }
+						setCurrentPage={ setCurrentPage }
+						total={ total }
+						pages={ Math.ceil( total / RESPONSES_FETCH_LIMIT ) }
 					/>
 				</div>
 

--- a/projects/packages/forms/src/dashboard/inbox/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/index.js
@@ -35,7 +35,7 @@ const Inbox = () => {
 				stateSelector.getTotalResponses(),
 			];
 		},
-		[ searchTerm ]
+		[ searchTerm, currentPage ]
 	);
 
 	useEffect( () => {

--- a/projects/packages/forms/src/dashboard/inbox/list.js
+++ b/projects/packages/forms/src/dashboard/inbox/list.js
@@ -1,4 +1,3 @@
-import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PageNavigation from '../components/page-navigation';
 import Table from '../components/table';
@@ -18,9 +17,7 @@ const COLUMNS = [
 	},
 ];
 
-const InboxList = ( { responses, onSelectionChange } ) => {
-	const [ currentPage, setCurrentPage ] = useState( 1 );
-
+const InboxList = ( { responses, onSelectionChange, currentPage, setCurrentPage, pages } ) => {
 	return (
 		<>
 			<Table
@@ -32,7 +29,7 @@ const InboxList = ( { responses, onSelectionChange } ) => {
 
 			<PageNavigation
 				currentPage={ currentPage }
-				pages={ 10 }
+				pages={ pages }
 				onSelectPage={ setCurrentPage }
 				expandedRange={ 2 }
 			/>

--- a/projects/packages/forms/src/dashboard/state/selectors.js
+++ b/projects/packages/forms/src/dashboard/state/selectors.js
@@ -8,11 +8,12 @@ export const isFetchingResponses = state => state.loading;
 
 export const getResponses = state =>
 	map( state.responses, response => {
-		response.date = dateI18n( 'F j, Y', response.date );
-		response.source = response.entry_title;
-		response.name =
-			response.author_name || response.author_email || response.author_url || response.ip;
-		return response;
+		return {
+			...response,
+			date: dateI18n( 'F j, Y', response.date ),
+			source: response.entry_title,
+			name: response.author_name || response.author_email || response.author_url || response.ip,
+		};
 	} );
 
 export const getTotalResponses = state => state.total;

--- a/projects/plugins/jetpack/changelog/fix-forms-inbox-search
+++ b/projects/plugins/jetpack/changelog/fix-forms-inbox-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix search by invalidating selector

--- a/projects/plugins/jetpack/changelog/fix-forms-inbox-search
+++ b/projects/plugins/jetpack/changelog/fix-forms-inbox-search
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix search by invalidating selector


### PR DESCRIPTION
This PR addresses an issue with the Form Responses Inbox search and paging. It does so by invalidating the selector resolution on any of the params currently defining the request: `searchTerm` and `currentPage`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1677701062226519-slack-C01CSBEN0QZ
p1677777900393659-slack-C01CSBEN0QZ

## Does this pull request change what data or activity we track or use?


## Testing instructions:
Enable the package and new wp-admin page by adding these lines on modules/contact-form.php, near the top
```php
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
add_filter( 'jetpack_forms_dashboard_enable', '__return_true' );
```

Navigate to http://localhost/wp-admin/admin.php?page=jetpack-forms and use the search box. Searching for one term and then going back to empty string should work as expected.