### PR TITLE
VideoPress: fix requesting video data on Simple sites

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-requesting-video-data-on-simple-sites
+++ b/projects/packages/videopress/changelog/update-videopress-fix-requesting-video-data-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix requesting video data on Simple sites

--- a/projects/packages/videopress/src/client/lib/fetch-video-item/index.ts
+++ b/projects/packages/videopress/src/client/lib/fetch-video-item/index.ts
@@ -68,6 +68,7 @@ export async function fetchVideoItem( {
 		return await apiFetch( {
 			url: `https://public-api.wordpress.com/rest/v1.1/videos/${ guid }${ requestArgs }`,
 			credentials: 'omit',
+			global: true,
 		} );
 	} catch ( errorData ) {
 		debug( 'updating retry from', retries, 'to', retries + 1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue introduced when refactoring code here https://github.com/Automattic/jetpack/pull/29155. We forgot to set the requests global when calling the apiFetch() 

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix requesting video data on Simple sites

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with Simple sites
* Go to the block editor
* Create/edit a block instances

**before**
Some controls of the block sidebar are disabled

<img width="832" alt="Screen Shot 2023-03-02 at 16 59 45" src="https://user-images.githubusercontent.com/77539/222538961-2cf3f911-5f46-4e64-83d0-1253fbdff34a.png">

Also, you can try to catch the video request. When the `global` prop is not true, the endpoint will automatically add the site ID, getting a `404` because that endpoint doesn't exist.

<img width="889" alt="Screen Shot 2023-03-02 at 17 06 25" src="https://user-images.githubusercontent.com/77539/222540770-167166f1-7424-430f-ad23-a6f3e225364d.png">


**after**
teConfirm part of the block sidebar works as expected 



