### PR TITLE
[Super Cache] Add missing changelog entry.

### DIFF
--- a/projects/plugins/super-cache/CHANGELOG.md
+++ b/projects/plugins/super-cache/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed undefined PHP variable when trying to delete a protected folder. [#28524]
+- Fixed deprecation warnings on PHP 8.1+. [#28959]
 
 ## [1.9.3-beta] - 2023-01-23
 ### Added

--- a/projects/plugins/super-cache/changelog/super-cache-add-missing-changelogs
+++ b/projects/plugins/super-cache/changelog/super-cache-add-missing-changelogs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Added a missing changelog entry. It would be silly to add a changelog file for this. :)
+
+

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -278,6 +278,7 @@ Your theme is probably responsive which means it resizes the page to suit whatev
 
 #### Fixed
 - Fixed undefined PHP variable when trying to delete a protected folder.
+- Fixed deprecation warnings on PHP 8.1+.
 
 --------
 


### PR DESCRIPTION
When prepping the 1.9.4 release, I missed an important changelog line somehow. This adds it.

## Proposed changes:
* Add a missing changelog entry for 1.9.4.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
n/a