### PR TITLE
[Boost] Add changelog file for Safari lazy-load fix

### DIFF
--- a/projects/plugins/boost/changelog/fix-safari-lazy-load
+++ b/projects/plugins/boost/changelog/fix-safari-lazy-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed images sometimes failing to Lazy-load in Safari

--- a/projects/plugins/boost/changelog/fix-safari-lazy-load
+++ b/projects/plugins/boost/changelog/fix-safari-lazy-load
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed images sometimes failing to Lazy-load in Safari
+Fixed images sometimes failing to Lazy-load in Safari.


### PR DESCRIPTION
Over in https://github.com/Automattic/jetpack/pull/29243, I fixed lazy loading in Safari. We want it noted in the changelog for the next Boost release - so this PR adds it to the changelog files dir.

## Proposed changes:
* Add a changelog entry for the safari lazy load fix.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
n/a