### PR TITLE
Remove Jetpack submenu under Settings in Calypso on Atomic sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-remove-settings-jetpack-submenu-atomic
+++ b/projects/plugins/jetpack/changelog/fix-remove-settings-jetpack-submenu-atomic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+bugfix

--- a/projects/plugins/jetpack/changelog/fix-remove-settings-jetpack-submenu-atomic
+++ b/projects/plugins/jetpack/changelog/fix-remove-settings-jetpack-submenu-atomic
@@ -1,3 +1,3 @@
-Significance: minor
+Significance: patch
 Type: bugfix
 Comment: Remove Jetpack submenu under Settings in Calypso on Atomic sites

--- a/projects/plugins/jetpack/changelog/fix-remove-settings-jetpack-submenu-atomic
+++ b/projects/plugins/jetpack/changelog/fix-remove-settings-jetpack-submenu-atomic
@@ -1,4 +1,3 @@
 Significance: minor
 Type: bugfix
-
-bugfix
+Comment: Remove Jetpack submenu under Settings in Calypso on Atomic sites

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -355,13 +355,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 11 );
 
-		if (
-			function_exists( 'wpcom_site_has_feature' ) &&
-			wpcom_site_has_feature( \WPCOM_Features::ATOMIC )
-		) {
-			add_submenu_page( 'options-general.php', esc_attr__( 'Jetpack', 'jetpack' ), __( 'Jetpack', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain, null, 12 );
-		}
-
 		// Page Optimize is active by default on all Atomic sites and registers a Settings > Performance submenu which
 		// would conflict with our own Settings > Performance that links to Calypso, so we hide it it since the Calypso
 		// performance settings already have a link to Page Optimize settings page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [#72983](https://github.com/Automattic/wp-calypso/issues/72983)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR removes the Jetpack submenu that appears under the Settings menu in Calypso on Atomic sites.  The slug this menu points to `settings/jetpack/{SiteSlug}` links to the Jetpack credentials settings page. Atomic credentials are managed and this link is not necessary.

A corresponding PR is forthcoming and will aim to display a notice for users who manually navigate to this slug as to prevent any confusion. 

## Before
<img width="427" alt="image" src="https://user-images.githubusercontent.com/65082164/222632828-7a4e98c3-4306-495d-9eea-91390ce02232.png">


## After

<img width="423" alt="image" src="https://user-images.githubusercontent.com/65082164/222632870-27fc6a93-760e-4278-bdac-6730d06f4fc8.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9F6qB-bqe-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

## Testing on Atomic on WPCOM
* Create an Atomic dev blog if you don't already have one as per p9o2xV-1r2-p2
* Upload the affected file to an Atomic dev blog in Jetpack's plugin directory and navigate to Calypso to ensure that the menu item no longer appears.
* You can push the same file on your WPCOM sandbox and confirm that this doesn't affect Simple sites (it shouldn't because this file only affects nav unification on Atomic)
* This file does not affect Jetpack sites