### PR TITLE
Remove Scan submenu from Jetpack menu in WP-Admin on Atomic sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-remove-scan-submenu-on-atomic
+++ b/projects/plugins/jetpack/changelog/fix-remove-scan-submenu-on-atomic
@@ -1,3 +1,3 @@
-Significance: minor
+Significance: patch
 Type: bugfix
 Comment: Remove Scan submenu from Jetpack menu in WP-Admin on Atomic sites when SSO is off

--- a/projects/plugins/jetpack/changelog/fix-remove-scan-submenu-on-atomic
+++ b/projects/plugins/jetpack/changelog/fix-remove-scan-submenu-on-atomic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+bugfix

--- a/projects/plugins/jetpack/changelog/fix-remove-scan-submenu-on-atomic
+++ b/projects/plugins/jetpack/changelog/fix-remove-scan-submenu-on-atomic
@@ -1,4 +1,3 @@
 Significance: minor
 Type: bugfix
-
-bugfix
+Comment: Remove Scan submenu from Jetpack menu in WP-Admin on Atomic sites when SSO is off

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Scan;
 
 use Automattic\Jetpack\My_Jetpack\Products\Backup;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status\Host;
 use Jetpack_Core_Json_Api_Endpoints;
 
 /**
@@ -135,12 +136,12 @@ class Admin_Sidebar_Link {
 	/**
 	 * Check if we should display the Scan menu item.
 	 *
-	 * It will only be displayed if site has Scan enabled and the stand-alone Protect plugin is not active, because it will have a menu item of its own.
+	 * It will only be displayed if site has Scan enabled, is not an Atomic site, and the stand-alone Protect plugin is not active, because it will have a menu item of its own.
 	 *
 	 * @return boolean
 	 */
 	private function should_show_scan() {
-		return $this->has_scan() && ! $this->has_protect_plugin();
+		return $this->has_scan() && ! $this->has_protect_plugin() && ! ( new Host() )->is_woa_site();
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/72982

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* WP-Admin on Atomic sites with SSO disabled will populate the `Scan` submenu in the Jetpack menu, linking to the Redirect URL `getRedirectUrl( 'calypso-scanner'`.
* Since Atomic sites are on managed hosting, the escalated Atomic team manages all security and there are no user facing Scan pages as on Jetpack sites with the Jetpack Security plan.
* As a result, when a user clicks the Scan submenu item, they are led to a 404 page

This PR will add the condition in the `should_show_scan()` to ensure that Atomic sites do not display the Scan submenu item in the Jetpack menu in WP-Admin

## Before
<img width="319" alt="Screen Shot 2023-03-02 at 9 12 23 PM" src="https://user-images.githubusercontent.com/65082164/222636969-b412037f-d198-4237-a8ff-2db31ff4214f.png">

## After
<img width="320" alt="Screen Shot 2023-03-02 at 9 12 09 PM" src="https://user-images.githubusercontent.com/65082164/222636988-7de5ffb2-ed79-4755-a4fb-7f92a65c2c8a.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9F6qB-bqe-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test on Atomic
* Create Atomic Dev blog as per p9o2xV-1r2-p2
* Upload the changed file to the corresponding Jetpack plugin folder on the WoA dev blog
* Toggle off SSO, and log into the wp-admin section of the site and ensure that the Scan submenu item does not appear under the Jetpack menu

### Test on self hosted
* Spin up a Jurassic Ninja site
* Log into WP-Admin and ensure that Scan does NOT appear as a submenu item under the Jetpack menu
* Add a Jetpack Security plan, ensure that Scan now appears in the Jetpack menu as a submenu item
* Upload the changed file to the corresponding Jetpack plugin folder on the Jurassic Ninja site
* Confirm that Scan still appears and is unaffected by this site

No testing should be necessary on WPCOM Simple sites nor Calypso on Atomic as the menu item does not appear there and does not affect nav unification