### PR TITLE
CRM: using correct title slugs for edit and new form pages

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-edit-add-form-title
+++ b/projects/plugins/crm/changelog/fix-crm-edit-add-form-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: swapping edit and new form titles to correctly reflect page.

--- a/projects/plugins/crm/includes/class-learn-menu.php
+++ b/projects/plugins/crm/includes/class-learn-menu.php
@@ -291,10 +291,10 @@ class Learn_Menu {
 		}
 
 		// Forms
-		if ( zeroBSCRM_is_form_new_page() ){
-			$slug = 'editform';
-		} elseif ( zeroBSCRM_is_form_edit_page() ){
+		if ( zeroBSCRM_is_form_new_page() ) {
 			$slug = 'formnew';
+		} elseif ( zeroBSCRM_is_form_edit_page() ) {
+			$slug = 'editform';
 		}
 
 		// profile page


### PR DESCRIPTION


## Proposed changes:

* This PR switches the slugs for new form pages and edit form pages, which had been mixed up. The result is that when adding a new form the page title now says 'New Form' instead of 'Edit Form', and similarly the edit form page now says 'Edit Form' instead of 'New Form'.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2759

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To replicate the issue, on a site running a recent CRM version add a new form by clicking 'Add New' from the forms page: `wp-admin/admin.php?page=manage-forms`. The page title will say 'Edit Form'.
* Edit an existing form from the forms page, and the page title will say 'New Form'.
* To test this fix, using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, add a new form from the forms page and the page title should now say 'New Form' (and the 'New Form' button should disappear).
* Edit an existing form from the forms page. The page title should now say 'Edit Form' and include a 'New Form' button.

*New form page before:*

<img width="1242" alt="Screenshot 2023-03-03 at 9 52 14 am" src="https://user-images.githubusercontent.com/16754605/222689038-f438fe6f-951e-4e45-984d-a38b79cdd130.png">


*New form page after:*

<img width="1256" alt="Screenshot 2023-03-03 at 9 50 52 am" src="https://user-images.githubusercontent.com/16754605/222688967-bc0273ba-686e-4603-b871-a94fd95a9202.png">


*Edit form page before:*

<img width="1242" alt="Screenshot 2023-03-03 at 9 51 27 am" src="https://user-images.githubusercontent.com/16754605/222688862-fe8e1c47-89cf-4dfe-ab87-4b6bd3fa67bf.png">

*Edit form page after:*

<img width="1235" alt="Screenshot 2023-03-03 at 9 51 03 am" src="https://user-images.githubusercontent.com/16754605/222688941-a75d6459-046d-4845-8657-f6197ae15f4e.png">
