### PR TITLE
Sharing: remove unused variable

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sharing-rm-count-var
+++ b/projects/plugins/jetpack/changelog/update-sharing-rm-count-var
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sharing: remove unused variable

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -1165,7 +1165,6 @@ function sharing_display( $text = '', $echo = false ) {
 					$sharing_content .= '<ul>';
 				}
 
-				$count = 1;
 				foreach ( $enabled['hidden'] as $service ) {
 					// Individual HTML for sharing service.
 					$klasses = array( 'share-' . $service->get_class() );
@@ -1178,8 +1177,6 @@ function sharing_display( $text = '', $echo = false ) {
 					$sharing_content .= '<li class="' . implode( ' ', $klasses ) . '">';
 					$sharing_content .= $service->get_display( $post );
 					$sharing_content .= '</li>';
-
-					++$count;
 				}
 
 				// End of wrapper.


### PR DESCRIPTION
## Proposed changes:

This is a follow-up to #29228

Since we've removed part of what was added in r27653-wpcom, we can now remove the rest.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Make sure sharing buttons are enabled in /wp-admin/admin.php?page=jetpack#/sharing
* Add at least 3 options to the "More" button in /marketing/sharing-buttons/{SITE_URL}
* Preview a post on the front-end of your site

