### PR TITLE
Fix Pinterest button JS Error and adjust marginRight instead of width

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-pinterest-official-button
+++ b/projects/plugins/jetpack/changelog/fix-pinterest-official-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix JS Error and adjust marginRight of Pinterest official button instead of width

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -2572,8 +2572,10 @@ class Share_Pinterest extends Sharing_Source {
 						var shares = document.querySelectorAll( 'li.share-pinterest' );
 						for ( var i = 0; i < shares.length; i++ ) {
 							var share = shares[ i ];
-							if ( share.querySelector( 'a span:visible' ) ) {
-								share.style.width = '80px';
+							var countComputedStyle = window.getComputedStyle(share.querySelector( 'a span' ));
+							if ( countComputedStyle.display === 'block' ) {
+								var countWidth = parseInt( countComputedStyle.width, 10 );
+								share.style.marginRight = countWidth + 11 + 'px';
 							}
 						}
 					}

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -2572,10 +2572,13 @@ class Share_Pinterest extends Sharing_Source {
 						var shares = document.querySelectorAll( 'li.share-pinterest' );
 						for ( var i = 0; i < shares.length; i++ ) {
 							var share = shares[ i ];
-							var countComputedStyle = window.getComputedStyle(share.querySelector( 'a span' ));
-							if ( countComputedStyle.display === 'block' ) {
-								var countWidth = parseInt( countComputedStyle.width, 10 );
-								share.style.marginRight = countWidth + 11 + 'px';
+							var countElement = share.querySelector( 'a span' );
+							if (countElement) {
+								var countComputedStyle = window.getComputedStyle(countElement);
+								if ( countComputedStyle.display === 'block' ) {
+									var countWidth = parseInt( countComputedStyle.width, 10 );
+									share.style.marginRight = countWidth + 11 + 'px';
+								}
 							}
 						}
 					}


### PR DESCRIPTION
## Description

We just made some updates to the sharing button styles. In testing we found that the "official" Pinterest button was causing a JS error. Furthermore, the code causing the error was increasing the width of the Pinterest button vs. adding margin right to account for the the count span tag.

### Before

![before](https://user-images.githubusercontent.com/5634774/222734196-8d41c863-53f8-47d3-a749-00470e6d82bb.png)

### After

![CleanShot 2023-03-03 at 08 40 23](https://user-images.githubusercontent.com/5634774/222734719-f89336ee-7a1d-41b6-b958-d612f3da2652.gif)

## Jetpack product discussion
p8oabR-16e-p2#comment-7108

## Does this pull request change what data or activity we track or use?
Nope.

## Testing instructions:
This is a tad tricky to test since this PR must get merged to WP.com before it will work.

1) Make sure sharing buttons are enabled in `/wp-admin/admin.php?page=jetpack#/sharing`
2) Add Pinterest sharing button in `/marketing/sharing-buttons/{SITE_URL}`
3) Comment out this CSS (which was already removed in a separate PR)

![CleanShot 2023-03-03 at 08 42 08@2x](https://user-images.githubusercontent.com/5634774/222735131-7dcefb1a-06ec-4d38-bf04-cb18c5c7887a.png)

4) Paste the following into your console:

```
var shares = document.querySelectorAll( 'li.share-pinterest' );
for ( var i = 0; i < shares.length; i++ ) {
	var share = shares[ i ];
        var countComputedStyle = window.getComputedStyle(share.querySelector( 'a span' ));
	if ( countComputedStyle.display === 'block' ) {
		var countWidth = parseInt( countComputedStyle.width, 10 );
		share.style.marginRight = countWidth + 11 + 'px';
	}
}
```