### PR TITLE
E2E: Temporarily disable Gutenberg subscribe block test

### DIFF
--- a/projects/plugins/jetpack/changelog/disable-subscribe-block-e2e
+++ b/projects/plugins/jetpack/changelog/disable-subscribe-block-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Temp disable Gutenberg subscribe block test until #29113 is fixed

--- a/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/blocks/free-blocks.test.js
@@ -177,7 +177,8 @@ test.describe( 'Site editor', () => {
 			await siteEditor.clearCustomizations();
 		} );
 	} );
-
+	/*
+	* TODO: Re-enable once the site editor is ready for e2e tests #29113.
 	test( 'Subscribe block in site editor', async ( { page } ) => {
 		await prerequisitesBuilder( page ).withActiveModules( [ 'subscriptions' ] ).build();
 		const block = new SubscribeBlock( null, page );
@@ -199,4 +200,5 @@ test.describe( 'Site editor', () => {
 			).toBeTruthy();
 		} );
 	} );
+	 */
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

It's being worked on in #29113 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Temporarily disable the gutenberg e2e test for subscribe block. The new Gutenberg version changed how to get into the site editor. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1677143018334769-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Green checks on the gutenberg e2e tests. 