### PR TITLE
E2E: Fix connection tests

### DIFF
--- a/tools/e2e-commons/flows/jetpack-connect.js
+++ b/tools/e2e-commons/flows/jetpack-connect.js
@@ -4,11 +4,13 @@ import {
 	JetpackPage,
 	JetpackMyPlanPage,
 	RecommendationsPage,
+	JetpackDashboardPage,
 } from '../pages/wp-admin/index.js';
 import {
 	AuthorizePage,
 	PickAPlanPage,
 	CheckoutPage,
+	CompletePage,
 	ThankYouPage,
 	LoginPage,
 } from '../pages/wpcom/index.js';
@@ -25,9 +27,10 @@ export async function doClassicConnection( page, plan = 'free' ) {
 	await ( await AuthorizePage.init( page ) ).approve();
 
 	if ( plan === 'free' ) {
-		await ( await PickAPlanPage.init( page ) ).select( 'free' );
-		await RecommendationsPage.init( page );
+		await ( await CompletePage.init( page ) ).select( 'free' );
+		await JetpackDashboardPage.init( page );
 	} else {
+		await ( await CompletePage.init( page ) ).viewProducts();
 		await ( await PickAPlanPage.init( page ) ).select( plan );
 		await ( await CheckoutPage.init( page ) ).processPurchase( cardCredentials );
 		await ( await ThankYouPage.init( page ) ).waitForSetupAndProceed();

--- a/tools/e2e-commons/pages/wpcom/complete-plan.js
+++ b/tools/e2e-commons/pages/wpcom/complete-plan.js
@@ -4,7 +4,7 @@ import logger from '../../logger.cjs';
 export default class CompletePage extends WpPage {
 	constructor( page ) {
 		super( page, {
-			expectedSelectors: [ 'div.jetpack-complete-page__main' ],
+			expectedSelectors: [ 'main.jetpack-complete-page__main' ],
 			explicitWaitMS: 40000,
 		} );
 	}

--- a/tools/e2e-commons/pages/wpcom/complete-plan.js
+++ b/tools/e2e-commons/pages/wpcom/complete-plan.js
@@ -1,0 +1,27 @@
+import WpPage from '../wp-page.js';
+import logger from '../../logger.cjs';
+
+export default class CompletePage extends WpPage {
+	constructor( page ) {
+		super( page, {
+			expectedSelectors: [ 'div.jetpack-complete-page__main' ],
+			explicitWaitMS: 40000,
+		} );
+	}
+
+	async viewProducts() {
+		const viewProductsButton = '.view-all-products-link a';
+		await this.click( viewProductsButton );
+	}
+
+	async select( product = 'free' ) {
+		switch ( product ) {
+			case 'free':
+				const freePlanButton = '.jetpack-complete-page__start-free-button a';
+				await this.click( freePlanButton );
+				break;
+			default:
+				logger.error( `Selecting plan '${ product }' is not implemented! Add it yourself?` );
+		}
+	}
+}

--- a/tools/e2e-commons/pages/wpcom/complete-plan.js
+++ b/tools/e2e-commons/pages/wpcom/complete-plan.js
@@ -10,14 +10,14 @@ export default class CompletePage extends WpPage {
 	}
 
 	async viewProducts() {
-		const viewProductsButton = '.view-all-products-link a';
+		const viewProductsButton = 'a.view-all-products-link';
 		await this.click( viewProductsButton );
 	}
 
 	async select( product = 'free' ) {
 		switch ( product ) {
 			case 'free':
-				const freePlanButton = '.jetpack-complete-page__start-free-button a';
+				const freePlanButton = 'a.jetpack-complete-page__start-free-button';
 				await this.click( freePlanButton );
 				break;
 			default:

--- a/tools/e2e-commons/pages/wpcom/index.js
+++ b/tools/e2e-commons/pages/wpcom/index.js
@@ -1,5 +1,6 @@
 export { default as AuthorizePage } from './authorize.js';
 export { default as CheckoutPage } from './checkout.js';
+export { default as CompletePage } from './complete-plan.js';
 export { default as ConnectionsPage } from './connections.js';
 export { default as HomePage } from './home.js';
 export { default as LoginPage } from './login.js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The connection E2E is failing because of changes made to the default flow in p1HpG7-jYo-p2, which is landing by default on the complete page. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- New "Page" object for Complete. 
- Updates the "free" flow to hit the "free" button on Complete page
- Updates the "free" flow to redirect back to the main Jetpack dashboard (changed behavior)
- Update the other "product" flows to first hit the "view all products" link on the complete page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Flow changed as part of p1HpG7-jYo-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Green tests. 
See tests passing on https://github.com/Automattic/jetpack/pull/29287, where it changes the Jetpack plugin to trigger the full connection tests. 