### PR TITLE
Update sharing button height from 34px to 32px

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-button-height
+++ b/projects/plugins/jetpack/changelog/fix-sharing-button-height
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Update sharing button height from 34px to 32px

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
@@ -87,7 +87,7 @@ body.settings_page_sharing ul.services-hidden {
 	font-weight: 500;
 	line-height: 23px;
 	margin: 0 8px 8px 0;
-	padding: 4px 11px 5px 9px;
+	padding: 3px 11px 4px 9px;
 	border-radius: 4px;
 	background: #fff;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.12);

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -98,7 +98,7 @@ body.highlander-dark h3.sd-title:before {
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.12);
 	text-shadow: none;
 	line-height: 23px;
-	padding: 5px 11px 4px 9px;
+	padding: 4px 11px 3px 9px;
 }
 
 .sd-social-official .sd-content ul li a.sd-button,


### PR DESCRIPTION
## Description

We just made some updates to the sharing button styles. This morning I noticed that the updated buttons are 34px in height. They should be 32px. I didn’t take into account that the box-shadow adds 2 px. This PR adjusts the height to 32px, else these sharing buttons will be a different height than the like, reply, follow conversation buttons and avatars also present at the bottom of most posts.

### Before

![image](https://user-images.githubusercontent.com/5634774/222759387-f8204d21-8c9f-4a6d-b295-e5cd9bc4081d.png)

### After

<img width="871" alt="CleanShot 2023-03-03 at 10 22 50@2x" src="https://user-images.githubusercontent.com/5634774/222759342-ac6ebe25-7940-47d7-8a6f-c2f3fffc1c5f.png">

## Jetpack product discussion
p8oabR-16e-p2#comment-7132

## Does this pull request change what data or activity we track or use?
Nope.

## Testing instructions:
1) Follow instructions to [set up JP locally](https://github.com/Automattic/jetpack/blob/trunk/docs/quick-start.md) (with jurassic.tube proxy), or use jurassic ninja
2) Make sure sharing buttons are enabled in `/wp-admin/admin.php?page=jetpack#/sharing`
3) Add sharing buttons in `/marketing/sharing-buttons/{SITE_URL}` and set them to "Icon & text" or "Text only"
4) View height of buttons on front-end of your test site