### PR TITLE
Forms: Fields Sidebar adjustments

### DIFF
--- a/projects/packages/forms/changelog/update-form-fields-sidebar
+++ b/projects/packages/forms/changelog/update-form-fields-sidebar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Move field width settings and remove placeholder field from MC/SC fields

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -27,6 +27,7 @@ const JetpackFieldControls = ( {
 	id,
 	placeholder,
 	placeholderField = 'placeholder',
+	hidePlaceholder,
 	required,
 	setAttributes,
 	width,
@@ -94,17 +95,18 @@ const JetpackFieldControls = ( {
 						onChange={ value => setAttributes( { required: value } ) }
 						help={ __( 'You can edit the "required" label in the editor', 'jetpack-forms' ) }
 					/>
-
-					<TextControl
-						label={ __( 'Placeholder text', 'jetpack-forms' ) }
-						value={ placeholder }
-						onChange={ value => setAttributes( { [ placeholderField ]: value } ) }
-						help={ __(
-							'Show visitors an example of the type of content expected. Otherwise, leave blank.',
-							'jetpack-forms'
-						) }
-					/>
-
+					{ ! hidePlaceholder && (
+						<TextControl
+							label={ __( 'Placeholder text', 'jetpack-forms' ) }
+							value={ placeholder }
+							onChange={ value => setAttributes( { [ placeholderField ]: value } ) }
+							help={ __(
+								'Show visitors an example of the type of content expected. Otherwise, leave blank.',
+								'jetpack-forms'
+							) }
+						/>
+					) }
+					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 					<ToggleControl
 						label={ __( 'Sync fields style', 'jetpack-forms' ) }
 						checked={ attributes.shareFieldAttributes }
@@ -118,7 +120,6 @@ const JetpackFieldControls = ( {
 					colorSettings={ colorSettings }
 				/>
 				<PanelBody title={ __( 'Input Field Styles', 'jetpack-forms' ) } initialOpen={ false }>
-					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 					<BaseControl>
 						<FontSizePicker
 							withReset={ true }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
@@ -130,6 +130,7 @@ function JetpackFieldMultiple( props ) {
 				setAttributes={ setAttributes }
 				type={ type }
 				width={ width }
+				hidePlaceholder
 			/>
 		</>
 	);

--- a/projects/plugins/jetpack/changelog/update-form-fields-sidebar
+++ b/projects/plugins/jetpack/changelog/update-form-fields-sidebar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Move field width settings and remove placeholder field from MC/SC fields

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
@@ -27,6 +27,7 @@ const JetpackFieldControls = ( {
 	id,
 	placeholder,
 	placeholderField = 'placeholder',
+	hidePlaceholder,
 	required,
 	setAttributes,
 	width,
@@ -94,17 +95,18 @@ const JetpackFieldControls = ( {
 						onChange={ value => setAttributes( { required: value } ) }
 						help={ __( 'You can edit the "required" label in the editor', 'jetpack' ) }
 					/>
-
-					<TextControl
-						label={ __( 'Placeholder text', 'jetpack' ) }
-						value={ placeholder }
-						onChange={ value => setAttributes( { [ placeholderField ]: value } ) }
-						help={ __(
-							'Show visitors an example of the type of content expected. Otherwise, leave blank.',
-							'jetpack'
-						) }
-					/>
-
+					{ ! hidePlaceholder && (
+						<TextControl
+							label={ __( 'Placeholder text', 'jetpack' ) }
+							value={ placeholder }
+							onChange={ value => setAttributes( { [ placeholderField ]: value } ) }
+							help={ __(
+								'Show visitors an example of the type of content expected. Otherwise, leave blank.',
+								'jetpack'
+							) }
+						/>
+					) }
+					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 					<ToggleControl
 						label={ __( 'Sync fields style', 'jetpack' ) }
 						checked={ attributes.shareFieldAttributes }
@@ -118,7 +120,6 @@ const JetpackFieldControls = ( {
 					colorSettings={ colorSettings }
 				/>
 				<PanelBody title={ __( 'Input Field Styles', 'jetpack' ) } initialOpen={ false }>
-					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 					<BaseControl>
 						<FontSizePicker
 							withReset={ true }

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-multiple.js
@@ -130,6 +130,7 @@ function JetpackFieldMultiple( props ) {
 				setAttributes={ setAttributes }
 				type={ type }
 				width={ width }
+				hidePlaceholder
 			/>
 		</>
 	);


### PR DESCRIPTION
Fixes #29254

## Proposed changes:

* Move the Form fields `Field Width` setting in the Sidebar to the `Field Settings` section. (ref: p8oabR-16e-p2#comment-7109)
* Remove the `Placeholder` field from the Multiple Choice and Single Choice fields (ref: p8oabR-16e-p2#comment-7097)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Create a post and add a Form block
* Check the fields Sidebar and confirm if the `Field Width` setting is inside the `Field Settings` section
* Add a Multiple Choice and a Single Choice field to the form and check if the `Placeholder` setting was removed
*