### PR TITLE
Repo gardening: fix unwanted issues in Kitkat notification task

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-kitkat-message-emoji
+++ b/projects/github-actions/repo-gardening/changelog/fix-kitkat-message-emoji
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use correct emoji in Kitkat notifications

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -150,7 +150,7 @@ async function notifyKitKat( payload, octokit ) {
 		debug(
 			`notify-kitkat: Found a [Pri] High label on issue #${ number }. Sending in Slack message.`
 		);
-		const message = `:bug_police: New High priority bug! Please take a moment to triage this bug.`;
+		const message = `:bug-police: New High priority bug! Please take a moment to triage this bug.`;
 		const slackMessageFormat = formatSlackMessage( payload, channel, message );
 		await sendSlackMessage( message, channel, slackToken, payload, slackMessageFormat );
 	}
@@ -161,7 +161,7 @@ async function notifyKitKat( payload, octokit ) {
 		debug(
 			`notify-kitkat: Found a [Pri] BLOCKER label on issue #${ number }. Sending in Slack message.`
 		);
-		const message = `:bug_police: New Blocker bug!  Please take a moment to triage this bug.`;
+		const message = `:bug-police: New Blocker bug!  Please take a moment to triage this bug.`;
 		const slackMessageFormat = formatSlackMessage( payload, channel, message );
 		await sendSlackMessage( message, channel, slackToken, payload, slackMessageFormat );
 	}

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -139,7 +139,7 @@ async function notifyKitKat( payload, octokit ) {
 
 	// Only proceed if the issue is stil open.
 	if ( 'open' !== state ) {
-		debug( `notify-kitkat: Issue #${ number } is already closed. Aborting.` );
+		debug( `notify-kitkat: Issue #${ number } is state '${ state }'. Aborting.` );
 		return;
 	}
 

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -119,7 +119,7 @@ function formatSlackMessage( payload, channel, message ) {
  */
 async function notifyKitKat( payload, octokit ) {
 	const {
-		issue: { number },
+		issue: { number, state },
 		repository,
 	} = payload;
 	const { owner, name: repo } = repository;
@@ -134,6 +134,12 @@ async function notifyKitKat( payload, octokit ) {
 	const channel = getInput( 'slack_kitkat_channel' );
 	if ( ! channel ) {
 		setFailed( 'notify-kitkat: Input slack_kitkat_channel is required but missing. Aborting.' );
+		return;
+	}
+
+	// Only proceed if the issue is stil open.
+	if ( 'open' !== state ) {
+		debug( `notify-kitkat: Issue #${ number } is already closed. Aborting.` );
 		return;
 	}
 


### PR DESCRIPTION
This is a follow-up to #28904

## Proposed changes:

- The message needs to use the correct emoji. See p1678046287029219-slack-CQD1HH4MA for an example.
- We should not trigger the message when an issue gets labeled after it's been closed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test; type in `:bug_police:` vs. `:bug-police:` in Slack.
