### PR TITLE
Jetpack Boost: Add error handling capabilities to DS Client

### DIFF
--- a/projects/js-packages/svelte-data-sync-client/README.md
+++ b/projects/js-packages/svelte-data-sync-client/README.md
@@ -82,7 +82,7 @@ Every created Data Sync Client Store will also have an `.endpoints` property tha
 ```ts
 // favorites.ts
 const result = await favorites.enabled.endpoints.GET();
-const result = await favorites.enabled.endpoints.POST( true );;
+const result = await favorites.enabled.endpoints.POST(true);
 ```
 
 Note that the endpoint methods are type-safe too, so you can't pass a value that doesn't match the schema. If you do, errors will be thrown.
@@ -92,10 +92,10 @@ If you need to interact with the REST API endpoints directly, you can use the [A
 ```ts
 const api = new API();
 // API Must be initialized with a nonce, otherwise WordPress REST API will return a 403 error.
-api.initialize( 'jetpack_favorites', window.jetpack_favorites.rest_api.nonce );
+api.initialize('jetpack_favorites', window.jetpack_favorites.rest_api.nonce);
 
 // Send a request to any endpoint:
-const result = await api.request( 'GET', 'foobar', "<endpoint-nonce>");
+const result = await api.request('GET', 'foobar', '<endpoint-nonce>');
 ```
 
 To dive in deeper, have a look at [API](./src/API.ts) and [Endpoint](./src/Endpoint.ts) source files.
@@ -122,7 +122,7 @@ export const favorites = {
 };
 ```
 
-And use the stores in Svelte. 
+And use the stores in Svelte.
 
 ```svelte
 <div class="posts">
@@ -158,6 +158,32 @@ You can view the available properties of the error object in the [SyncedStoreErr
 {/if}
 ```
 
+#### Global Error Store
+
+`initializeClient()` also returns a global error store that can be used to display errors from all stores.
+
+It uses `derived()` under the hood, so it will only update when the error store of any of the stores changes.
+
+For example, assuming
+
+```svelte
+<script>
+	// Import the client that was setup using `initializeClient()`
+	import { favoritesClient } from './favorites.ts'
+	const globalErrors = favoritesClient.globalErrorStore();
+</script>
+
+<div class="error-area">
+	{#if $globalErrors.length > 0}
+		{#each $globalErrors as error}
+			<div class="error">
+				<h1>Error</h1>
+				<p>{error.message}</p>
+			</div>
+		{/each}
+	{/if}
+</div>
+```
 
 ## Security
 

--- a/projects/js-packages/svelte-data-sync-client/README.md
+++ b/projects/js-packages/svelte-data-sync-client/README.md
@@ -133,6 +133,31 @@ And use the stores in Svelte.
 </div>
 ```
 
+### Error Handling
+
+Values are synced with the REST API asynchronously and Synced Store is going to attempt to automatically retry 3 times before giving up and reverting the UI value to the last known value.
+
+After 3 attempts have failed, Synced Store will [add the error to the error store](https://github.com/Automattic/jetpack/blob/981d325c76ceaa4e46ee00751307850d8b0bb947/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts#L136-L146).
+
+The error store can be used to display an error message to the user.
+
+You can view the available properties of the error object in the [SyncedStoreError](./src/types.ts#L46) type.
+
+```svelte
+<script>
+	const posts = client.createAsyncStore('posts', z.array(favorite_post_schema));
+	const errors = posts.errors;
+</script>
+
+{#if $errors.length > 0}
+	{@const error = $errors[0]}
+	<div class="error">
+		<h1>Error</h1>
+		<p>{error.message}</p>
+	</div>
+{/if}
+```
+
 
 ## Security
 

--- a/projects/js-packages/svelte-data-sync-client/changelog/boost-update-data-sync-error-handling
+++ b/projects/js-packages/svelte-data-sync-client/changelog/boost-update-data-sync-error-handling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added an error store to help track errors that happen during syncing.

--- a/projects/js-packages/svelte-data-sync-client/src/API.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/API.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { ApiError } from './ApiError';
 import { JSONSchema } from './utils';
 export type RequestParams = string | JSONSchema;
 export type RequestMethods = 'GET' | 'POST' | 'DELETE';
@@ -71,8 +72,7 @@ export class API {
 
 		const result = await fetch( url, args );
 		if ( ! result.ok ) {
-			console.error( 'Failed to fetch', url, result );
-			throw new Error( `Failed to "${ method }" to ${ url }. Received ${ result.status }` );
+			throw new ApiError( url, result.status, result.statusText );
 		}
 
 		let data;
@@ -81,6 +81,7 @@ export class API {
 			data = JSON.parse( text );
 		} catch ( e ) {
 			console.error( 'Failed to parse the response\n', { url, text, result, error: e } );
+			throw new ApiError( url, 'json_parse_error', 'Failed to parse the response' );
 		}
 
 		/**
@@ -91,8 +92,8 @@ export class API {
 		 * @see https://github.com/WordPress/wordpress-develop/blob/28f10e4af559c9b4dbbd1768feff0bae575d5e78/src/wp-includes/rest-api/class-wp-rest-request.php#L701
 		 */
 		if ( ! data || data.JSON === undefined ) {
-			console.error( 'Failed to parse the response\n', { url, text, result } );
-			throw new Error( `Failed to "${ method }" to ${ url }. Received ${ result.status }` );
+			console.error( 'JSON response is empty.\n', { url, text, result } );
+			throw new ApiError( url, 'json_empty', 'JSON response is empty' );
 		}
 
 		return data.JSON;

--- a/projects/js-packages/svelte-data-sync-client/src/ApiError.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/ApiError.ts
@@ -1,0 +1,19 @@
+export class ApiError extends Error {
+	public name = 'ApiError';
+	constructor(
+		public location: string,
+		public status: number | 'failed_to_sync' | 'json_parse_error' | 'json_empty' | 'schema_error',
+		public message: string
+	) {
+		super( message );
+
+		/**
+		 * This makes `foo instanceof ApiError` work.
+		 * To make instanceof work correctly
+		 * set the prototype explicitly.
+		 *
+		 * @see https://stackoverflow.com/a/41102306/1015046
+		 */
+		Object.setPrototypeOf( this, ApiError.prototype );
+	}
+}

--- a/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
@@ -1,19 +1,28 @@
 import deepEqual from 'deep-equal';
-import { writable } from 'svelte/store';
+import { Writable, writable } from 'svelte/store';
+import { ApiError } from './ApiError';
+import {
+	Pending,
+	SyncedStoreInterface,
+	SyncedWritable,
+	SyncedStoreCallback,
+	SyncedStoreError,
+} from './types';
 import { sleep } from './utils';
-import type { Pending, SyncedStoreInterface, SyncedWritable, SyncedStoreCallback } from './types';
+
 /*
  * A custom Svelte Store that's used to indicate if a value is being synced.
  */
 export class SyncedStore< T > {
 	private store: SyncedWritable< T >;
+	private errorStore: Writable< SyncedStoreError< T >[] >;
 	private pending: Pending;
-	private failedToSync = Symbol( 'failedToSync' );
 	private updateCallback?: SyncedStoreCallback< T >;
 	private abortController: AbortController;
 
 	constructor( initialValue?: T ) {
 		this.store = this.createStore( initialValue );
+		this.errorStore = writable< SyncedStoreError< T >[] >( [] );
 		this.pending = this.createPendingStore();
 	}
 
@@ -71,18 +80,28 @@ export class SyncedStore< T > {
 		this.updateCallback = callback;
 	}
 
-	private async synchronize( value: T ): Promise< T | typeof this.failedToSync > {
+	private async synchronize( value: T ): Promise< T | ApiError > {
 		if ( ! this.updateCallback ) {
 			return value;
 		}
-		const result = await this.updateCallback( value, this.abortController.signal );
 
-		// Success is only when the updateCallback result matches the value.
-		if ( this.equals( result, value ) ) {
-			return result ? result : value;
+		try {
+			const result = await this.updateCallback( value, this.abortController.signal );
+
+			// Success is only when the updateCallback result matches the value.
+			if ( this.equals( result, value ) ) {
+				return result ? result : value;
+			}
+		} catch ( error ) {
+			if ( error instanceof ApiError || error.name === 'ApiError' ) {
+				return error as ApiError;
+			}
+
+			// Rethrow the error if it's not an ApiError.
+			throw error;
 		}
 
-		return this.failedToSync;
+		return new ApiError( 'SyncedStore::synchronize', 'failed_to_sync', 'Failed to sync' );
 	}
 
 	private async abortableSynchronize( prevValue: T, value: T, retry = 0 ) {
@@ -102,7 +121,7 @@ export class SyncedStore< T > {
 			return;
 		}
 
-		if ( result === this.failedToSync ) {
+		if ( result instanceof ApiError ) {
 			if ( retry < 3 ) {
 				// Wait a second before retrying.
 				await sleep( 1000 );
@@ -112,7 +131,17 @@ export class SyncedStore< T > {
 				this.abortableSynchronize( prevValue, value, retry + 1 );
 				return;
 			}
-
+			this.errorStore.update( errors => {
+				errors.push( {
+					time: Date.now(),
+					previousValue: prevValue,
+					value,
+					location: result.location,
+					status: result.status,
+					message: result.message,
+				} );
+				return errors;
+			} );
 			this.store.override( prevValue );
 		}
 

--- a/projects/js-packages/svelte-data-sync-client/src/initializeClient.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/initializeClient.ts
@@ -92,7 +92,16 @@ export function initializeClient( namespace: string ) {
 	const api = setupRestApi( namespace );
 	const errorStores = [];
 
-	function createAsyncStore< T extends z.ZodSchema >( valueName: string, schema: T ) {
+	type AsyncStoreOptions = {
+		// If this is set to true, the store won't be added to the global error store.
+		hideFromGlobalErrors?: boolean;
+	};
+
+	function createAsyncStore< T extends z.ZodSchema >(
+		valueName: string,
+		schema: T,
+		opts: AsyncStoreOptions = {}
+	) {
 		// Get the value from window and validate it with the schema.
 		const { nonce, value } = getValidatedValue( namespace, valueName, schema );
 
@@ -128,8 +137,10 @@ export function initializeClient( namespace: string ) {
 			...store,
 		};
 
-		// Keep track of all the error stores
-		errorStores.push( client.errors );
+		if ( opts.hideFromGlobalErrors !== true ) {
+			// Keep track of all the error stores that don't opt out.
+			errorStores.push( client.errors );
+		}
 
 		return client;
 	}

--- a/projects/js-packages/svelte-data-sync-client/src/initializeClient.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/initializeClient.ts
@@ -95,7 +95,7 @@ export function initializeClient( namespace: string ) {
 		const { nonce, value } = getValidatedValue( namespace, valueName, schema );
 
 		// Setup the Svelte Store and the API Endpoint for this value
-		const store = new SyncedStore< z.infer< T > >( value );
+		const syncedStore = new SyncedStore< z.infer< T > >( value );
 		const endpoint = new API_Endpoint< z.infer< T > >( api, valueName, schema );
 
 		/**
@@ -114,15 +114,16 @@ export function initializeClient( namespace: string ) {
 		 *	} );
 		 */
 		endpoint.nonce = nonce;
-		store.setCallback( endpoint.POST );
 
 		// The client doesn't need the whole store object.
 		// Only expose selected public methods:
-		const storeInterface = store.getPublicInterface();
+		const client = syncedStore.getPublicInterface();
+
+		client.setCallback( endpoint.POST );
 
 		return {
 			endpoint,
-			...storeInterface,
+			...client,
 		};
 	}
 	return {

--- a/projects/js-packages/svelte-data-sync-client/src/types.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/types.ts
@@ -41,3 +41,12 @@ export interface Pending {
 export type SyncedWritable< T > = Writable< T > & {
 	override: ( value: T ) => void;
 };
+
+export type SyncedStoreError< T > = {
+	time: number;
+	status: number | string;
+	message: string;
+	location: string;
+	value: T;
+	previousValue: T;
+};

--- a/projects/js-packages/svelte-data-sync-client/src/types.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/types.ts
@@ -14,6 +14,7 @@ export type SyncedStoreCallback< T > = ( value: T, abortSignal?: AbortSignal ) =
 export type SyncedStoreInterface< T > = {
 	store: SyncedWritable< T >;
 	pending: Readable< boolean >;
+	errors: Readable< SyncedStoreError< T >[] >;
 	setCallback: ( callback: SyncedStoreCallback< T > ) => void;
 };
 


### PR DESCRIPTION
This is going to enable us to significantly improve error handling in our dash and move https://github.com/Automattic/boost-cloud/issues/218 forward.

Values are synced with the REST API asynchronously and Synced Store is going to attempt to automatically retry 3 times before giving up and reverting the UI value to the last known value.

After 3 attempts have failed, Synced Store will [add the error to the error store](https://github.com/Automattic/jetpack/blob/981d325c76ceaa4e46ee00751307850d8b0bb947/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts#L136-L146).

The error store can be used to display an error message to the user.

You can view the available properties of the error object in the [SyncedStoreError](./src/types.ts#L46) type.

```svelte
<script>
	const posts = client.createAsyncStore('posts', z.array(favorite_post_schema));
	const errors = posts.errors;
</script>

{#if $errors.length > 0}
	{@const error = $errors[0]}
	<div class="error">
		<h1>Error</h1>
		<p>{error.message}</p>
	</div>
{/if}
```

#### Global Error Store

`initializeClient()` also returns a global error store that can be used to display errors from all stores.

It uses `derived()` under the hood, so it will only update when the error store of any of the stores changes.

For example, assuming

```svelte
<script>
	// Import the client that was setup using `initializeClient()`
	import { favoritesClient } from './favorites.ts'
	const globalErrors = favoritesClient.globalErrorStore();
</script>

<div class="error-area">
	{#if $globalErrors.length > 0}
		{#each $globalErrors as error}
			<div class="error">
				<h1>Error</h1>
				<p>{error.message}</p>
			</div>
		{/each}
	{/if}
</div>
```

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:

1. Apply the patch
2. Create a new store that doesn't exist or use an existing one that has errors in it
3. Trigger store updates that you know will cause errors

This is what I used:

```ts

/*
 * Data Sync Stores
 */
export const suggestRegenerateDS = client.createAsyncStore(
	'critical_css_suggest_regenerate',
	z.coerce.boolean().catch( false ),
	{ hideFromGlobalErrors: true }
);
suggestRegenerateDS.errors.subscribe( errors => {
	if ( errors.length ) {
		console.error( 'Error syncing critical_css_suggest_regenerate', errors[0].message );
	}
} );
window.suggest = suggestRegenerateDS;
const globalErrors = client.globalErrorStore();
globalErrors.subscribe( errors => {
	console.log( 'Global errors', errors );
} );

```