### PR TITLE
Don't show Mapbox token input when map provider is Mapkit

### DIFF
--- a/projects/plugins/jetpack/changelog/add-map-block-mapkit-remove-token-input
+++ b/projects/plugins/jetpack/changelog/add-map-block-mapkit-remove-token-input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Remove the Mapbox API key box, when the mapping provider isn't Mapbox

--- a/projects/plugins/jetpack/extensions/blocks/map/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/controls.js
@@ -27,6 +27,7 @@ export default ( {
 	removeAPIKey,
 	updateAPIKey,
 	setPointVisibility,
+	mapProvider,
 } ) => {
 	const updateAlignment = value => {
 		setAttributes( { align: value } );
@@ -165,40 +166,42 @@ export default ( {
 					/>
 				</PanelBody>
 			) : null }
-			<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
-				<TextControl
-					help={
-						'wpcom' === state.apiKeySource && (
-							<>
-								{ __( 'You can optionally enter your own access token.', 'jetpack' ) }{ ' ' }
-								<ExternalLink href="https://account.mapbox.com/access-tokens/">
-									{ __( 'Find it on Mapbox', 'jetpack' ) }
-								</ExternalLink>
-							</>
-						)
-					}
-					label={ __( 'Mapbox Access Token', 'jetpack' ) }
-					value={ state.apiKeyControl }
-					onChange={ value => setState( { apiKeyControl: value } ) }
-				/>
-				<ButtonGroup>
-					<Button
-						type="button"
-						onClick={ updateAPIKey }
-						disabled={ ! state.apiKeyControl || state.apiKeyControl === state.apiKey }
-					>
-						{ __( 'Update Token', 'jetpack' ) }
-					</Button>
-					<Button
-						type="button"
-						onClick={ removeAPIKey }
-						disabled={ 'wpcom' === state.apiKeySource }
-						variant="secondary"
-					>
-						{ __( 'Remove Token', 'jetpack' ) }
-					</Button>
-				</ButtonGroup>
-			</PanelBody>
+			{ mapProvider === 'mapbox' ? (
+				<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
+					<TextControl
+						help={
+							'wpcom' === state.apiKeySource && (
+								<>
+									{ __( 'You can optionally enter your own access token.', 'jetpack' ) }{ ' ' }
+									<ExternalLink href="https://account.mapbox.com/access-tokens/">
+										{ __( 'Find it on Mapbox', 'jetpack' ) }
+									</ExternalLink>
+								</>
+							)
+						}
+						label={ __( 'Mapbox Access Token', 'jetpack' ) }
+						value={ state.apiKeyControl }
+						onChange={ value => setState( { apiKeyControl: value } ) }
+					/>
+					<ButtonGroup>
+						<Button
+							type="button"
+							onClick={ updateAPIKey }
+							disabled={ ! state.apiKeyControl || state.apiKeyControl === state.apiKey }
+						>
+							{ __( 'Update Token', 'jetpack' ) }
+						</Button>
+						<Button
+							type="button"
+							onClick={ removeAPIKey }
+							disabled={ 'wpcom' === state.apiKeySource }
+							variant="secondary"
+						>
+							{ __( 'Remove Token', 'jetpack' ) }
+						</Button>
+					</ButtonGroup>
+				</PanelBody>
+			) : null }
 		</>
 	);
 };

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.js
@@ -19,6 +19,7 @@ import Controls from './controls';
 import { getCoordinates } from './get-coordinates.js';
 import previewPlaceholder from './map-preview.jpg';
 import { settings } from './settings.js';
+import getMapProvider from './utils/get-map-provider';
 
 const API_STATE_LOADING = 0;
 const API_STATE_FAILURE = 1;
@@ -221,6 +222,9 @@ class MapEdit extends Component {
 			apiState,
 			apiRequestOutstanding,
 		} = this.state;
+
+		const mapProvider = getMapProvider();
+
 		const inspectorControls = (
 			<>
 				<BlockControls>
@@ -231,6 +235,7 @@ class MapEdit extends Component {
 						setPointVisibility={ this.setPointVisibility }
 						context="toolbar"
 						mapRef={ this.mapRef }
+						mapProvider={ mapProvider }
 					/>
 				</BlockControls>
 				<InspectorControls>
@@ -244,6 +249,7 @@ class MapEdit extends Component {
 						minHeight={ MIN_HEIGHT }
 						removeAPIKey={ this.removeAPIKey }
 						updateAPIKey={ this.updateAPIKey }
+						mapProvider={ mapProvider }
 					/>
 				</InspectorControls>
 			</>

--- a/projects/plugins/jetpack/extensions/blocks/map/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/test/controls.js
@@ -44,6 +44,7 @@ const defaultProps = {
 		apiRequestOutstanding: false,
 	},
 	setState: jest.fn(),
+	mapProvider: 'mapbox',
 };
 
 describe( 'Inspector controls', () => {
@@ -92,10 +93,15 @@ describe( 'Inspector controls', () => {
 	} );
 
 	describe( 'Mapbox access token panel', () => {
-		test( 'mapbox access token input shows correctly', () => {
+		test( 'mapbox access token input shows correctly when mapProvider is mapbox', () => {
 			render( <MapControls { ...defaultProps } /> );
-
 			expect( screen.getByText( 'Mapbox Access Token' ) ).toBeInTheDocument();
+		} );
+
+		test( "mapbox access token input doesn't show when mapProvider is mapkit", () => {
+			const props = { ...defaultProps, mapProvider: 'mapkit' };
+			render( <MapControls { ...props } /> );
+			expect( screen.queryByText( 'Mapbox Access Token' ) ).not.toBeInTheDocument();
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73647

## Proposed changes:
This PR hides the block setting section where you can enter a Mapbox key, when you're not using Mapbox as the map provider.

<img width="331" alt="CleanShot 2023-03-06 at 13 49 29@2x" src="https://user-images.githubusercontent.com/528287/223115035-446ec635-5e2b-4e68-bcfa-df43c443db87.png">

It also introduces a new prop passed to `controls.js` named `mapProvider`. This property gets filled when rendering the controls. By passing this in higher up, we can better test this logic.

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Apply this PR
2. Add a post/page, and append `?mapkit` to the URL
3. Add a map block
4. Click it to load the block settings on the right
5. You should not see a `Mapbox access token` section
6. Repeat without `?mapkit` in the URL
7. You should now see the `Mapbox access token` section

You can ignore that Mapkit isn't used to render the map. That functionality is in another PR.



