### PR TITLE
Shortcodes: remove jQuery from Crowdsignal

### DIFF
--- a/projects/plugins/jetpack/_inc/crowdsignal-shortcode.js
+++ b/projects/plugins/jetpack/_inc/crowdsignal-shortcode.js
@@ -1,18 +1,22 @@
-( function ( d, c, j ) {
-	var crowdsignal_shortcode_options;
+( function ( w, d, c, j ) {
 	if (
-		crowdsignal_shortcode_options &&
-		crowdsignal_shortcode_options.script_url &&
+		w.crowdsignal_shortcode_options &&
+		w.crowdsignal_shortcode_options.script_url &&
 		! d.getElementById( j )
 	) {
 		var pd = d.createElement( c ),
 			s;
 		pd.id = j;
 		pd.async = true;
-		pd.src = crowdsignal_shortcode_options.script_url;
+		pd.src = w.crowdsignal_shortcode_options.script_url;
 		s = d.getElementsByTagName( c )[ 0 ];
 		s.parentNode.insertBefore( pd, s );
-	} else if ( typeof jQuery !== 'undefined' ) {
-		jQuery( d.body ).trigger( 'pd-script-load' );
+	} else {
+		// In environments where jQuery is present, dispatch with jQuery.
+		if ( typeof w.jQuery !== 'undefined' ) {
+			w.jQuery( d.body ).trigger( 'pd-script-load' );
+		} else {
+			d.body.dispatchEvent( new Event( 'pd-script-load' ) );
+		}
 	}
-} )( document, 'script', 'pd-polldaddy-loader' );
+} )( window, document, 'script', 'pd-polldaddy-loader' );

--- a/projects/plugins/jetpack/changelog/update-remove-jquery-from-crowdsignal-shortcodes
+++ b/projects/plugins/jetpack/changelog/update-remove-jquery-from-crowdsignal-shortcodes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Shortcodes: removed jQuery dependency from Crowdsignal shortcodes

--- a/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
+++ b/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
@@ -57,7 +57,6 @@ if (
 			add_shortcode( 'polldaddy', array( $this, 'polldaddy_shortcode' ) );
 
 			add_filter( 'pre_kses', array( $this, 'crowdsignal_embed_to_shortcode' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'check_infinite' ) );
 			add_action( 'infinite_scroll_render', array( $this, 'crowdsignal_shortcode_infinite' ), 11 );
 		}
 
@@ -68,7 +67,7 @@ if (
 			wp_register_script(
 				'crowdsignal-shortcode',
 				Assets::get_file_url_for_environment( '_inc/build/crowdsignal-shortcode.min.js', '_inc/crowdsignal-shortcode.js' ),
-				array( 'jquery' ),
+				array(),
 				JETPACK__VERSION,
 				true
 			);
@@ -685,19 +684,6 @@ if (
 				}
 			}
 			self::$scripts = false;
-		}
-
-		/**
-		 * If the theme uses infinite scroll, include jquery at the start
-		 */
-		public function check_infinite() {
-			if (
-				current_theme_supports( 'infinite-scroll' )
-				&& class_exists( 'The_Neverending_Home_Page' )
-				&& The_Neverending_Home_Page::archive_supports_infinity()
-			) {
-				wp_enqueue_script( 'jquery' );
-			}
 		}
 
 		/**

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -58,7 +58,6 @@
 	"projects/plugins/jetpack/_inc/jetpack-deactivate-dialog.js",
 	"projects/plugins/jetpack/_inc/jetpack-modules.js",
 	"projects/plugins/jetpack/_inc/lib/debugger/jetpack-debugger-site-health.js",
-	"projects/plugins/jetpack/_inc/polldaddy-shortcode.js",
 	"projects/plugins/jetpack/_inc/twitter-timeline.js",
 	"projects/plugins/jetpack/extensions/blocks/donations/edit.js",
 	"projects/plugins/jetpack/extensions/blocks/eventbrite/index.js",


### PR DESCRIPTION
One of the Crowdsignal shortcode scripts still used jQuery, which was forcing the enqueueing of the library on infinite scroll themes, so that it would be ready once a poll was loaded.

This PR rewrites the script in vanilla JS, removing the jQuery dependency altogether. It also fixes a bug in `crowdsignal-shortcode.js`.

## Proposed changes:
* Rewrite `polldaddy-shortcode.js` in vanilla JS
* Fix logic bug in `crowdsignal-shortcode.js` that prevented it from ever loading the script defined in `crowdsignal_shortcode_options` (if present)

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None, this is a simple enhancement.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- Set up your site with a jQuery-less theme like `twentytwentyone`
- Enable infinite scrolling
- Create a page with a Crowdsignal shortcode for a poll
- While logged out, load the page in your browser, with devtools open
- Ensure that jQuery does not load
- Ensure that the poll loads correctly
- Load `/` or any other infinite scrolling page for your site
- If necessary, scroll until the post with the poll loads
- Ensure that jQuery does not load
- Ensure that the poll loads correctly

You can also repeat the steps above for a theme that does use jQuery, in order to ensure that things don't break there.