### PR TITLE
Implement RWD navigation for feedback dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-feedback-response-rwd-navigation
+++ b/projects/packages/forms/changelog/update-feedback-response-rwd-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Implement RWD navigation for feedback dashboard

--- a/projects/packages/forms/src/dashboard/components/layout/index.js
+++ b/projects/packages/forms/src/dashboard/components/layout/index.js
@@ -1,12 +1,15 @@
 import { JetpackFooter } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import JetpackFormsLogo from '../logo';
 
 import './style.scss';
 
-const Layout = ( { children, title, subtitle } ) => {
+const Layout = ( { children, className, title, subtitle } ) => {
+	const classes = classnames( 'jp-forms__layout', className );
+
 	return (
-		<div className="jp-forms__layout">
+		<div className={ classes }>
 			<JetpackFormsLogo />
 
 			<div className="jp-forms__layout-header">

--- a/projects/packages/forms/src/dashboard/components/table/item.js
+++ b/projects/packages/forms/src/dashboard/components/table/item.js
@@ -30,7 +30,7 @@ const TableItem = ( { columns, item, isSelected, onSelectChange } ) => {
 
 			{ map( columns, ( { additionalClassNames, component, getProps, key } ) => {
 				let Wrapper = Fragment;
-				let props = [];
+				let props = {};
 
 				if ( component ) {
 					Wrapper = component;

--- a/projects/packages/forms/src/dashboard/components/table/style.scss
+++ b/projects/packages/forms/src/dashboard/components/table/style.scss
@@ -34,7 +34,6 @@
 	text-align: left;
 	transition: background-color .1s ease-out, opacity .1s ease-out;
 	vertical-align: middle;
-	white-space: nowrap;
 
 	// Max-width is required on all columns for text-overflow: ellipsis; to work on any.
 	// Hence setting this here to a conservatively high number.

--- a/projects/packages/forms/src/dashboard/inbox/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/index.js
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/jetpack-components';
 import {
 	Button,
 	__experimentalInputControl as InputControl, // eslint-disable-line wpcalypso/no-unsafe-wp-apis
@@ -5,7 +6,7 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { find, includes, map } from 'lodash';
 import Layout from '../components/layout';
@@ -21,6 +22,7 @@ const Inbox = () => {
 	const [ searchText, setSearchText ] = useState( '' );
 	const [ currentPage, setCurrentPage ] = useState( 1 );
 	const [ searchTerm, setSearchTerm ] = useState( searchText );
+	const [ view, setView ] = useState( 'list' );
 
 	const { invalidateResolution } = useDispatch( STORE_NAME );
 	const [ loading, responses, total ] = useSelect(
@@ -64,18 +66,33 @@ const Inbox = () => {
 		[ searchText ]
 	);
 
-	const numberOfResponses = sprintf(
-		/* translators: %s: Number of responses. */
-		_n( '%s response', '%s responses', total, 'jetpack-forms' ),
-		total
-	);
+	const selectResponse = useCallback( id => {
+		setCurrentResponseId( id );
+		setView( 'response' );
+	}, [] );
 
-	const contentClasses = classnames( 'jp-forms__inbox-content', {
-		'show-response': currentResponseId >= 0,
+	const handleGoBack = useCallback( event => {
+		event.preventDefault();
+		setView( 'list' );
+	}, [] );
+
+	const classes = classnames( 'jp-forms__inbox', {
+		'is-response-view': view === 'response',
 	} );
 
+	const title = (
+		<>
+			<span className="title">{ __( 'Responses', 'jetpack-forms' ) }</span>
+			{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */ }
+			<a className="back-button" onClick={ handleGoBack }>
+				<Gridicon icon="arrow-left" />
+				{ __( 'View all responses', 'jetpack-forms' ) }
+			</a>
+		</>
+	);
+
 	return (
-		<Layout title={ __( 'Responses', 'jetpack-forms' ) } subtitle={ numberOfResponses }>
+		<Layout title={ title } className={ classes }>
 			<div className="jp-forms__actions">
 				<form className="jp-forms__actions-form">
 					<SelectControl
@@ -95,12 +112,12 @@ const Inbox = () => {
 				</form>
 			</div>
 
-			<div className={ contentClasses }>
+			<div className="jp-forms__inbox-content">
 				<div className="jp-forms__inbox-content-column">
 					<InboxList
 						currentResponseId={ currentResponseId }
-						setCurrentResponseId={ setCurrentResponseId }
 						loading={ loading }
+						setCurrentResponseId={ selectResponse }
 						responses={ responses }
 						currentPage={ currentPage }
 						setCurrentPage={ setCurrentPage }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -1,11 +1,43 @@
+.jp-forms__inbox {
+	 a.back-button {
+	 	align-items: center;
+	 	color: #2C3338;
+		display: none;
+		font-size: 14px;
+	}
+
+	@media (min-width: 1025px) {
+		a.back-button {
+			display: none !important;
+		}
+
+		span.title {
+			display: inline-flex !important;
+		}
+	}
+
+	&.is-response-view {
+		span.title {
+			display: none;
+		}
+
+		a.back-button {
+			display: inline-flex;
+		}
+	}
+}
+
 .jp-forms__inbox-content {
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: row;
-	gap: 24px;
+	gap: 0;
 	padding: 32px 0;
+	position: relative;
+	width: 100%;
 
-	@media (min-width: 481px) {
+	@media (min-width: 1025px) {
+		gap: 24px;
 		padding-left: 64px;
 		padding-right: 64px;
 	}
@@ -14,17 +46,37 @@
 .jp-forms__inbox-content-column {
 	align-items: center;
 	box-sizing: border-box;
-	display: flex;
-	flex: 3;
 	flex-direction: column;
 	min-width: 0;
+	width: 100%;
+
+	&:first-child {
+		display: flex;
+	}
 
 	&:last-child {
 		display: none;
-		flex: 2;
+	}
 
-		@media (min-width: 1025px) {
-			display: flex;
+	.jp-forms__inbox.is-response-view &:first-child {
+		display: none;
+	}
+
+	.jp-forms__inbox.is-response-view &:last-child {
+		display: flex;
+	}
+
+	@media (min-width: 481px) and (max-width: 1025px) {
+		padding-left: 64px;
+		padding-right: 64px;
+	}
+
+	@media (min-width: 1025px) {
+		display: flex !important;
+		flex: 3;
+		width: auto;
+
+		&:last-child {
 			flex: 2;
 		}
 	}
@@ -57,6 +109,17 @@
 	@media (max-width: 660px) {
 		.jp-forms__table-cell.is-source {
 			display: none;
+		}
+	}
+
+	@media (max-width: 1024px) {
+		.jp-forms__table-item.is-active {
+			background-color: #fff;
+			color: inherit;
+
+			&:nth-child(even) {
+				background-color: #f9f9f6;
+			}
 		}
 	}
 
@@ -189,6 +252,14 @@
 	display: flex;
 	flex-direction: row;
 	padding: 20px 64px;
+
+	.jp-forms__inbox.is-response-view & {
+		display: none;
+
+		@media (min-width: 1025px) {
+			display: flex;
+		}
+	}
 
 	button {
 		margin: 0 5px;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -17,6 +17,7 @@
 	display: flex;
 	flex: 3;
 	flex-direction: column;
+	min-width: 0;
 
 	&:last-child {
 		display: none;
@@ -53,11 +54,32 @@
 		border-radius: 0;
 	}
 
+	@media (max-width: 660px) {
+		.jp-forms__table-cell.is-source {
+			display: none;
+		}
+	}
+
+	.jp-forms__table-cell {
+		white-space: nowrap;
+	}
+
 	.jp-forms__table-cell.is-name,
 	.jp-forms__table-cell.is-source {
 		overflow: hidden;
 		text-overflow: ellipsis;
-		white-space: nowrap;
+	}
+
+	.jp-forms__table-cell.is-source {
+		@media (min-width: 1025px) and (max-width: 1440px) {
+			max-width: 130px;
+		}
+
+		max-width: 350px;
+	}
+
+	.jp-forms__table-cell.is-name {
+		max-width: 100px;
 		width: 100%;
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-feedback-response-rwd-navigation
+++ b/projects/plugins/jetpack/changelog/update-feedback-response-rwd-navigation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Change doesn't affect the plugin.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This adds the mobile navigation and interaction set for the feedback dashboard view. The view should now toggle correctly between the list and response views on narrower screens.

This PR also attempts to address the RWD style issues around the table.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pcsBup-Pl-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Enable the jetpack forms package and the new dashboard before testing with:

```
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
add_filter( 'jetpack_forms_dashboard_enable', '__return_true' );
```

- Go to `/wp-admin/admin.php?page=jetpack-forms`
- Make sure your viewport width is 1024px or less, to trigger the single column view.
- When on the single column view, the list should never highlight the currently selected response.
- Clicking on a response in the list should switch the view to the response view.
- The header in the response view should display a `'view all responses' link.
- Clicking 'view all responses' should bring you back to the list view.
