### PR TITLE
required-review: Add `consume` option

### DIFF
--- a/projects/github-actions/required-review/README.md
+++ b/projects/github-actions/required-review/README.md
@@ -80,6 +80,12 @@ The requirements consist of an array of requirement objects. A requirement objec
 * `paths` is an array of path patterns, or the string "unmatched". If an array, the reviewers
   specified will be checked if any path in the array matches any path in the PR. If the string
   "unmatched", the reviewers are checked if any file in the PR has not been matched yet.
+* `consume` is a boolean, defaulting to false. If set, any paths that match this rule will be ignored
+  for all following rules.
+
+  This is intended for things like lockfiles or changelogs that you might want to allow everyone
+  to edit in any package in a monorepo, to avoid having to manually exclude these files in every
+  requirement for each different team owning some package.
 * `teams` is an array of strings that are GitHub team slugs in the organization or repository. A
   review is required from a member of any of these teams.
 
@@ -107,6 +113,23 @@ the "Docs" and "Front end" review requirements. If you wanted to avoid that, you
    - 'docs/**'
   teams:
    - documentation
+
+# Everyone can update lockfiles, even if later rules might otherwise match.
+- name: Lockfiles
+  paths:
+   - 'packages/*/composer.lock'
+   - '**.css'
+  consume: true
+  teams:
+   - everyone
+
+# The "Some package" team must approve anything in `packages/some-package/`.
+# Except for changes to `packages/some-package/composer.lock`, because the previous requirement consumed that path.
+- name: Some package
+  paths:
+   - 'packages/some-package/**'
+  teams:
+   - some-package-team
 
 # Any CSS and React .jsx files must be reviewed by a front-end developer AND by a designer,
 # OR by a member of the maintenance team.

--- a/projects/github-actions/required-review/changelog/add-required-review-consume-option
+++ b/projects/github-actions/required-review/changelog/add-required-review-consume-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added `consume` option for requirements.

--- a/projects/github-actions/required-review/package.json
+++ b/projects/github-actions/required-review/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "required-review",
-	"version": "3.0.2",
+	"version": "3.1.0-alpha",
 	"description": "Check that a Pull Request has reviews from required teams.",
 	"main": "index.js",
 	"author": "Automattic",

--- a/projects/github-actions/required-review/src/main.js
+++ b/projects/github-actions/required-review/src/main.js
@@ -63,17 +63,19 @@ async function main() {
 		reviewers.forEach( r => core.info( r ) );
 		core.endGroup();
 
-		const paths = await require( './paths.js' )();
+		let paths = await require( './paths.js' )();
 		core.startGroup( `PR affects ${ paths.length } file(s)` );
 		paths.forEach( p => core.info( p ) );
 		core.endGroup();
 
-		const matchedPaths = [];
+		let matchedPaths = [];
 		let ok = true;
 		for ( let i = 0; i < requirements.length; i++ ) {
 			const r = requirements[ i ];
 			core.startGroup( `Checking requirement "${ r.name }"...` );
-			if ( ! r.appliesToPaths( paths, matchedPaths ) ) {
+			let applies;
+			( { applies, matchedPaths, paths } = r.appliesToPaths( paths, matchedPaths ) );
+			if ( ! applies ) {
 				core.endGroup();
 				core.info( `Requirement "${ r.name }" does not apply to any files in this PR.` );
 			} else if ( await r.isSatisfied( reviewers ) ) {

--- a/projects/github-actions/required-review/test.sh
+++ b/projects/github-actions/required-review/test.sh
@@ -19,7 +19,7 @@ function addenv {
 eval "$(
 	# Read defaults from action.yml
 	node -e 'console.log( JSON.stringify( require( "js-yaml" ).load( require( "fs" ).readFileSync( process.argv[1] ) ) ) );' "$BASE/projects/github-actions/required-review/action.yml" |
-		jq -r '.inputs | to_entries | .[] | select( .key != "token" and .value.default ) | [ "addenv INPUT_", ( .key | ascii_upcase | sub( " "; "_" ) ), " ", @sh "\(.value.default)" ] | join( "" )';
+		jq -r '.inputs | to_entries | .[] | select( .key != "token" and ( .value | has( "default" ) ) ) | [ "addenv INPUT_", ( .key | ascii_upcase | sub( " "; "_" ) ), " ", @sh "\(.value.default)" ] | join( "" )';
 
 	# Read values from .github/workflows/required-review.yml
 	node -e 'console.log( JSON.stringify( require( "js-yaml" ).load( require( "fs" ).readFileSync( process.argv[1] ) ) ) );' "$BASE/.github/workflows/required-review.yml" |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the monorepo we have a bunch of projects owned by different teams. Everyone should be able to update lock files and changelog entries, which means that the rules for each team's projects has to exclude those files so only the "anyone can update these files" rule applies.

This adds a new rule option, `consume`. When set on a rule, any paths matching the rule will be ignored for all later rules in the file. This will allow us to not have to repeat these exclusions everywhere.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. Has been on my list for a long time, and the most recent update made me decide to finally do it.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the `test.sh` script to run against various PRs, I guess.
  * Probably would be good to test in combination with #29318 that adjusts the monorepo config to use the new option.
* Check added docs for typos and sense.