### PR TITLE
Update required-review config

### DIFF
--- a/.github/files/required-review.yaml
+++ b/.github/files/required-review.yaml
@@ -1,19 +1,12 @@
-# Jetpack Approvers need to review changes to the monorepo itself.
-- name: Monorepo itself
-  paths:
-   - '!projects/**'
-   - '!pnpm-lock.yaml'
-  teams:
-   - jetpack-approvers
-
 # Everyone who can approve anything can merge pnpm.lock and docs.
-- name: pnpm lockfile, composer files
+- name: lockfiles, plugin composer.json, changelogs, docs
   paths:
    - 'docs/**'
    - 'pnpm-lock.yaml'
-   - 'projects/plugins/*/composer.lock'
+   - 'projects/*/*/composer.lock'
    - 'projects/plugins/*/composer.json'
-   - 'projects/plugins/*/changelog/*'
+   - 'projects/*/*/changelog/*'
+  consume: true
   teams:
    # Unfortunately this list need to be maintaned manually...
    # yamato-backup-and-security is the group that consists of both yamato-scan and yamato-backup teams.
@@ -25,38 +18,43 @@
    - red
    - yamato-backup-and-security
 
-# Jetpack Approvers review the Jetpack plugin and all packages, except for those with specific team ownership.
-- name: Jetpack and packages
+# Jetpack Approvers need to review changes to the monorepo itself.
+- name: Monorepo itself
   paths:
-   - 'projects/packages/**'
-   - 'projects/plugins/jetpack/**'
-   # Exclude packages managed by other teams, which are covered by other blocks below.
-   - '!projects/js-packages/image-guide/**'
-   - '!projects/js-packages/svelte-data-sync-client/**'
-   - '!projects/packages/wp-js-data-sync/**'
-   - '!projects/packages/backup/**'
-   - '!projects/packages/import/**'
-   - '!projects/packages/forms/**'
-   - '!projects/packages/search/**'
-   - '!projects/packages/stats/**'
-   - '!projects/packages/stats-admin/**'
-   - '!projects/packages/publicize/**'
-   - '!projects/packages/waf/**'
-   - '!projects/plugins/*/composer.lock'
-   - '!projects/plugins/*/composer.json'
-   - '!projects/plugins/*/changelog/*'
+   - '!projects/**'
   teams:
    - jetpack-approvers
 
+# Jetpack Approvers review the Jetpack plugin.
+- name: Jetpack-the-plugin
+  paths:
+   - 'projects/plugins/jetpack/**'
+  teams:
+   - jetpack-approvers
+
+# Packages owned by Ground Control.
+- name: Ground Control packages
+  paths:
+   - 'projects/js-packages/babel-plugin-replace-textdomain/**'
+   - 'projects/js-packages/eslint-changed/**'
+   - 'projects/js-packages/eslint-config-target-es/**'
+   - 'projects/js-packages/i18n-check-webpack-plugin/**'
+   - 'projects/js-packages/i18n-loader-webpack-plugin/**'
+   - 'projects/js-packages/remove-asset-webpack-plugin/**'
+   - 'projects/js-packages/webpack-config/**'
+   - 'projects/packages/autoloader/**'
+   - 'projects/packages/changelogger/**'
+   - 'projects/packages/codesniffer/**'
+   - 'projects/packages/ignorefile/**'
+   - 'projects/packages/phpcs-filter/**'
+  teams:
+   - jetpack-approvers
 
 # The Avengers team reviews changes to the CRM plugin,
 # and can add dependencies to the monorepo's lock file.
 - name: CRM
   paths:
     - 'projects/plugins/crm/**'
-    - '!projects/plugins/*/composer.lock'
-    - '!projects/plugins/*/composer.json'
-    - '!projects/plugins/*/changelog/*'
   teams:
     - avengers
     - jetpack-approvers
@@ -67,9 +65,6 @@
   paths:
     - 'projects/packages/import/**'
     - 'projects/plugins/migration/**'
-    - '!projects/plugins/*/composer.lock'
-    - '!projects/plugins/*/composer.json'
-    - '!projects/plugins/*/changelog/*'
   teams:
     - caribou
     - jetpack-approvers
@@ -81,9 +76,6 @@
    - 'projects/packages/backup/**'
    - 'projects/plugins/vaultpress/**'
    - 'projects/plugins/backup/**'
-   - '!projects/plugins/*/composer.lock'
-   - '!projects/plugins/*/composer.json'
-   - '!projects/plugins/*/changelog/*'
   teams:
    - yamato-backup
    - jetpack-approvers
@@ -94,9 +86,6 @@
   paths:
     - 'projects/packages/waf/**'
     - 'projects/plugins/protect/**'
-    - '!projects/plugins/*/composer.lock'
-    - '!projects/plugins/*/composer.json'
-    - '!projects/plugins/*/changelog/*'
   teams:
     - yamato-scan
     - jetpack-approvers
@@ -110,9 +99,6 @@
    - 'projects/js-packages/image-guide/**'
    - 'projects/js-packages/svelte-data-sync-client/**'
    - 'projects/packages/wp-js-data-sync/**'
-   - '!projects/plugins/*/composer.lock'
-   - '!projects/plugins/*/composer.json'
-   - '!projects/plugins/*/changelog/*'
   teams:
    - heart-of-gold
    - jetpack-approvers
@@ -123,9 +109,6 @@
   paths:
    - 'projects/plugins/search/**'
    - 'projects/packages/search/**'
-   - '!projects/plugins/*/composer.lock'
-   - '!projects/plugins/*/composer.json'
-   - '!projects/plugins/*/changelog/*'
   teams:
    - red
    - jetpack-approvers
@@ -135,9 +118,6 @@
   paths:
    - 'projects/packages/stats/**'
    - 'projects/packages/stats-admin/**'
-   - '!projects/plugins/*/composer.lock'
-   - '!projects/plugins/*/composer.json'
-   - '!projects/plugins/*/changelog/*'
   teams:
    - red
    - jetpack-approvers
@@ -148,9 +128,6 @@
    - 'projects/plugins/social/**'
    - 'projects/packages/publicize/**'
    - 'projects/js-packages/publicize-components/**'
-   - '!projects/plugins/*/composer.lock'
-   - '!projects/plugins/*/composer.json'
-   - '!projects/plugins/*/changelog/*'
   teams:
    - jetpack-reach
    - jetpack-approvers
@@ -159,9 +136,6 @@
 - name: Forms
   paths:
     - 'projects/packages/forms/**'
-    - '!projects/plugins/*/composer.lock'
-    - '!projects/plugins/*/composer.json'
-    - '!projects/plugins/*/changelog/*'
   teams:
     - '@cgastrell'
     - '@ice9js'

--- a/projects/github-actions/required-review/README.md
+++ b/projects/github-actions/required-review/README.md
@@ -80,6 +80,12 @@ The requirements consist of an array of requirement objects. A requirement objec
 * `paths` is an array of path patterns, or the string "unmatched". If an array, the reviewers
   specified will be checked if any path in the array matches any path in the PR. If the string
   "unmatched", the reviewers are checked if any file in the PR has not been matched yet.
+* `consume` is a boolean, defaulting to false. If set, any paths that match this rule will be ignored
+  for all following rules.
+
+  This is intended for things like lockfiles or changelogs that you might want to allow everyone
+  to edit in any package in a monorepo, to avoid having to manually exclude these files in every
+  requirement for each different team owning some package.
 * `teams` is an array of strings that are GitHub team slugs in the organization or repository. A
   review is required from a member of any of these teams.
 
@@ -107,6 +113,23 @@ the "Docs" and "Front end" review requirements. If you wanted to avoid that, you
    - 'docs/**'
   teams:
    - documentation
+
+# Everyone can update lockfiles, even if later rules might otherwise match.
+- name: Lockfiles
+  paths:
+   - 'packages/*/composer.lock'
+   - '**.css'
+  consume: true
+  teams:
+   - everyone
+
+# The "Some package" team must approve anything in `packages/some-package/`.
+# Except for changes to `packages/some-package/composer.lock`, because the previous requirement consumed that path.
+- name: Some package
+  paths:
+   - 'packages/some-package/**'
+  teams:
+   - some-package-team
 
 # Any CSS and React .jsx files must be reviewed by a front-end developer AND by a designer,
 # OR by a member of the maintenance team.

--- a/projects/github-actions/required-review/changelog/add-required-review-consume-option
+++ b/projects/github-actions/required-review/changelog/add-required-review-consume-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added `consume` option for requirements.

--- a/projects/github-actions/required-review/src/main.js
+++ b/projects/github-actions/required-review/src/main.js
@@ -63,17 +63,19 @@ async function main() {
 		reviewers.forEach( r => core.info( r ) );
 		core.endGroup();
 
-		const paths = await require( './paths.js' )();
+		let paths = await require( './paths.js' )();
 		core.startGroup( `PR affects ${ paths.length } file(s)` );
 		paths.forEach( p => core.info( p ) );
 		core.endGroup();
 
-		const matchedPaths = [];
+		let matchedPaths = [];
 		let ok = true;
 		for ( let i = 0; i < requirements.length; i++ ) {
 			const r = requirements[ i ];
 			core.startGroup( `Checking requirement "${ r.name }"...` );
-			if ( ! r.appliesToPaths( paths, matchedPaths ) ) {
+			let applies;
+			( { applies, matchedPaths, paths } = r.appliesToPaths( paths, matchedPaths ) );
+			if ( ! applies ) {
 				core.endGroup();
 				core.info( `Requirement "${ r.name }" does not apply to any files in this PR.` );
 			} else if ( await r.isSatisfied( reviewers ) ) {

--- a/projects/github-actions/required-review/test.sh
+++ b/projects/github-actions/required-review/test.sh
@@ -19,7 +19,7 @@ function addenv {
 eval "$(
 	# Read defaults from action.yml
 	node -e 'console.log( JSON.stringify( require( "js-yaml" ).load( require( "fs" ).readFileSync( process.argv[1] ) ) ) );' "$BASE/projects/github-actions/required-review/action.yml" |
-		jq -r '.inputs | to_entries | .[] | select( .key != "token" and .value.default ) | [ "addenv INPUT_", ( .key | ascii_upcase | sub( " "; "_" ) ), " ", @sh "\(.value.default)" ] | join( "" )';
+		jq -r '.inputs | to_entries | .[] | select( .key != "token" and ( .value | has( "default" ) ) ) | [ "addenv INPUT_", ( .key | ascii_upcase | sub( " "; "_" ) ), " ", @sh "\(.value.default)" ] | join( "" )';
 
 	# Read values from .github/workflows/required-review.yml
 	node -e 'console.log( JSON.stringify( require( "js-yaml" ).load( require( "fs" ).readFileSync( process.argv[1] ) ) ) );' "$BASE/.github/workflows/required-review.yml" |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This makes the following changes:

* Taking advantage of the new `consume` option to DRY things out.
* Allow everyone to update `composer.lock` and `changelog/*` in all projects, not only plugins.
* Fix #28359, as written the "Monorepo itself" rule still applied to docs so only jetpack-approvers were actually allowed. This is done by leaving `docs/**` in the rule with `consume` set an moving "Monorepo itself" after.
* The "Jetpack and packages" rule now only covers Jetpack. A second rule covers those packages (and now js-packages too) that are maintained by Ground Control. All other packages are left to team rules or the catch-all at the end, so we don't have to exclude them anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* **Do not merge until after a new version of the required-review package containing #29317 has been released!**
* Use the test.sh script to run against various PRs, I guess.
