### PR TITLE
Forms: Fix Multiple Choice field styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-twenty-twenty-styles
+++ b/projects/plugins/jetpack/changelog/fix-twenty-twenty-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Improve Multiple Choice Field styles

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -44,7 +44,7 @@
 	height: 200px;
 }
 
-.contact-form .grunion-field {
+.contact-form :where(.grunion-field[type="text"], .grunion-field.textarea) {
 	padding-left: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
 	padding-right: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
 }
@@ -59,11 +59,14 @@
 	min-width: 150px;
 }
 
-.contact-form input[type='radio'],
-.contact-form input[type='checkbox'] {
+.contact-form :where(input[type='radio'], input[type='checkbox']) {
 	width: 1rem;
 	height: 1rem;
 	float: none;
+}
+
+.contact-form input[type='radio'],
+.contact-form input[type='checkbox'] {
 	margin: 0 0.75rem 0 0;
 }
 
@@ -340,6 +343,12 @@
 	padding: 0;
 	line-height: normal;
 	box-shadow: 0 2px 6px rgb(0 0 0 / 5%);
+	list-style: none;
+	margin: 0;
+}
+
+.contact-form .contact-form-dropdown__menu .ui-menu-item {
+	margin: 0;
 }
 
 .contact-form .contact-form-dropdown__menu .ui-menu {
@@ -377,7 +386,7 @@
 .contact-form .is-style-animated .grunion-field-wrap .grunion-radio-options
 {
 	padding: var(--jetpack--contact-form--input-padding, 16px);
-	padding-top: calc(var(--jetpack--contact-form--input-padding, 16px) + 4px);
+	padding-top: calc(var(--jetpack--contact-form--input-padding-top, 16px) + 4px);
 	flex-grow: 1;
 }
 


### PR DESCRIPTION
## Proposed changes:
* Adjust Multiple Choice field styles on theme Twenty Twenty (p8oabR-16e-p2#comment-7141)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p8oabR-16e-p2#comment-7141

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* On a site with the theme Twenty Twenty, create a post and add a Form block
* Include a Multiple Choice field
* Publish the page and check if the checkbox style was improved in the published page