### PR TITLE
media summary: write to memo when no images found

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.media-summary.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-summary.php
@@ -96,6 +96,7 @@ class Jetpack_Media_Summary {
 			if ( $switched ) {
 				restore_current_blog();
 			}
+			self::$cache[ $cache_key ] = $return;
 			return $return;
 		}
 

--- a/projects/plugins/jetpack/changelog/update-media-summary-memo
+++ b/projects/plugins/jetpack/changelog/update-media-summary-memo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+media summary: write to memo when no images found


### PR DESCRIPTION
## Proposed changes:

* `Jetpack_Media_Summary::get()` runs up to 4 times on a single post.  It already has memoization, but it doesn't remember its results when it returns early. This adds the already-existing memoization to the early return path.
  * Originally added in #5938.

On my WPCOM sandbox this reduces the time spent in `jetpack_og_tags()` on a simple site with a few text posts from ~25ms to ~15ms (when viewing a single text post). 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a simple post with no images
* Visit that post's page and view source
* The code between the `<!-- Jetpack Open Graph Tags -->` and `<!-- End Jetpack Open Graph Tags -->` should appear the same before and after the change
  * The callers are `jetpack_open_graph_tags -> enhanced_og_image()`, `jetpack_open_graph_tags -> enhanced_og_video()`, and `jetpack_open_graph_tags -> enhanced_og_gallery()`

`./projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-summary.php` should also cover it (unsure how to run)