### PR TITLE
Protect: Display "All threats" instead of "All 1 threats"

### DIFF
--- a/projects/plugins/protect/changelog/fix-all-1-threats-title
+++ b/projects/plugins/protect/changelog/fix-all-1-threats-title
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed awkward phrasing in a title, no significant changes.
+
+

--- a/projects/plugins/protect/src/js/components/threats-list/index.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/index.jsx
@@ -41,8 +41,11 @@ const ThreatsList = () => {
 	const getTitle = useCallback( () => {
 		switch ( selected ) {
 			case 'all':
+				if ( list.length === 1 ) {
+					return __( 'All threats', 'jetpack-protect' );
+				}
 				return sprintf(
-					/* translators: Translates to Update to. %1$s: Name. %2$s: Fixed version */
+					/* translators: placeholder is the amount of threats found on the site. */
 					__( 'All %s threats', 'jetpack-protect' ),
 					list.length
 				);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When there is only one threat, adjusts title from "All 1 threats" to just display "All threats".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1204084997189614

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* N/A