### PR TITLE
Stats: add momentjs as dependency odyssey

### DIFF
--- a/projects/packages/stats-admin/changelog/update-add-momentjs-as-dependency-odyssey
+++ b/projects/packages/stats-admin/changelog/update-add-momentjs-as-dependency-odyssey
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add momentjs dependency for Odyssey Stats

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.6.2",
+	"version": "0.6.3-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -26,7 +26,7 @@ class Dashboard {
 	/**
 	 * We bump the asset version when the Jetpack back end is not compatible anymore.
 	 */
-	const ODYSSEY_STATS_VERSION                = 'v1.0.1';
+	const ODYSSEY_STATS_VERSION                = 'v1';
 	const ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY = 'odyssey_stats_admin_asset_cache_buster';
 
 	/**

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -20,13 +20,13 @@ use Jetpack_Options;
  */
 class Dashboard {
 	// This is a fixed list @see https://github.com/Automattic/wp-calypso/pull/71442/
-	const JS_DEPENDENCIES                 = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning' );
+	const JS_DEPENDENCIES                 = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
 	const ODYSSEY_CDN_URL                 = 'https://widgets.wp.com/odyssey-stats/%s/%s';
 	const OPT_OUT_NEW_STATS_FEATURE_CLASS = 'opt-out-new-stats';
 	/**
 	 * We bump the asset version when the Jetpack back end is not compatible anymore.
 	 */
-	const ODYSSEY_STATS_VERSION                = 'v1';
+	const ODYSSEY_STATS_VERSION                = 'v1.0.1';
 	const ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY = 'odyssey_stats_admin_asset_cache_buster';
 
 	/**

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.6.2';
+	const VERSION = '0.6.3-alpha';
 
 	/**
 	 * Singleton Main instance.


### PR DESCRIPTION
## Proposed changes:
The PR adds moment.js explicitly as dependency for Odyssey scripts. Moment.js is now loaded as a dependency of dependencies.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

- Ensure Odyssey Stats works on JN sites