### PR TITLE
Only show specific controls when mapprovider is mapbox

### DIFF
--- a/projects/plugins/jetpack/changelog/add-map-block-mapkit-hide-unimplemented-options
+++ b/projects/plugins/jetpack/changelog/add-map-block-mapkit-hide-unimplemented-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Hide Mapbox specific options when using Mapkit

--- a/projects/plugins/jetpack/extensions/blocks/map/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/controls.js
@@ -138,23 +138,29 @@ export default ( {
 					min={ 0 }
 					max={ 22 }
 				/>
-				<ToggleControl
-					label={ __( 'Show street names', 'jetpack' ) }
-					checked={ attributes.mapDetails }
-					onChange={ value => setAttributes( { mapDetails: value } ) }
-				/>
-				<ToggleControl
-					label={ __( 'Scroll to zoom', 'jetpack' ) }
-					help={ __( 'Allow the map to capture scrolling, and zoom in or out.', 'jetpack' ) }
-					checked={ attributes.scrollToZoom }
-					onChange={ value => setAttributes( { scrollToZoom: value } ) }
-				/>
-				<ToggleControl
-					label={ __( 'Show Fullscreen Button', 'jetpack' ) }
-					help={ __( 'Allow your visitors to display the map in fullscreen.', 'jetpack' ) }
-					checked={ attributes.showFullscreenButton }
-					onChange={ value => setAttributes( { showFullscreenButton: value } ) }
-				/>
+				{ mapProvider === 'mapbox' ? (
+					<ToggleControl
+						label={ __( 'Show street names', 'jetpack' ) }
+						checked={ attributes.mapDetails }
+						onChange={ value => setAttributes( { mapDetails: value } ) }
+					/>
+				) : null }
+				{ mapProvider === 'mapbox' ? (
+					<ToggleControl
+						label={ __( 'Scroll to zoom', 'jetpack' ) }
+						help={ __( 'Allow the map to capture scrolling, and zoom in or out.', 'jetpack' ) }
+						checked={ attributes.scrollToZoom }
+						onChange={ value => setAttributes( { scrollToZoom: value } ) }
+					/>
+				) : null }
+				{ mapProvider === 'mapbox' ? (
+					<ToggleControl
+						label={ __( 'Show Fullscreen Button', 'jetpack' ) }
+						help={ __( 'Allow your visitors to display the map in fullscreen.', 'jetpack' ) }
+						checked={ attributes.showFullscreenButton }
+						onChange={ value => setAttributes( { showFullscreenButton: value } ) }
+					/>
+				) : null }
 			</PanelBody>
 			{ attributes.points.length ? (
 				<PanelBody title={ __( 'Markers', 'jetpack' ) } initialOpen={ false }>

--- a/projects/plugins/jetpack/extensions/blocks/map/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/test/controls.js
@@ -73,22 +73,46 @@ describe( 'Inspector controls', () => {
 			expect( screen.getByText( 'Zoom level' ) ).toBeInTheDocument();
 		} );
 
-		test( 'street names toggle shows correctly', () => {
+		test( 'street names toggle shows correctly when mapProvider is mapbox', () => {
 			render( <MapControls { ...defaultProps } /> );
 
 			expect( screen.getByText( 'Show street names' ) ).toBeInTheDocument();
 		} );
 
-		test( 'scroll to zoom toggle shows correctly', () => {
+		test( "street names toggle shows doesn't show when mapProvider is mapkit", () => {
+			const props = { ...defaultProps, mapProvider: 'mapkit' };
+
+			render( <MapControls { ...props } /> );
+
+			expect( screen.queryByText( 'Show street names' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'scroll to zoom toggle shows correctly when mapProvider is mapbox', () => {
 			render( <MapControls { ...defaultProps } /> );
 
 			expect( screen.getByText( 'Scroll to zoom' ) ).toBeInTheDocument();
 		} );
 
-		test( 'show fullscreen button toggle shows correctly', () => {
+		test( "scroll to zoom toggle doesn't show when mapProvider is mapkit", () => {
+			const props = { ...defaultProps, mapProvider: 'mapkit' };
+
+			render( <MapControls { ...props } /> );
+
+			expect( screen.queryByText( 'Scroll to zoom' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'show fullscreen button toggle shows correctly when mapProvider is mapbox', () => {
 			render( <MapControls { ...defaultProps } /> );
 
 			expect( screen.getByText( 'Show Fullscreen Button' ) ).toBeInTheDocument();
+		} );
+
+		test( 'show fullscreen button toggle shows correctly', () => {
+			const props = { ...defaultProps, mapProvider: 'mapkit' };
+
+			render( <MapControls { ...props } /> );
+
+			expect( screen.queryByText( 'Show Fullscreen Button' ) ).not.toBeInTheDocument();
 		} );
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/73648

## Proposed changes:
This PR hides the options `Show street names`, `Scroll to zoom` and `Show fullscreen button` when the mapprovider is not Mapbox.

<img width="319" alt="CleanShot 2023-03-07 at 13 26 27@2x" src="https://user-images.githubusercontent.com/528287/223421729-6b1783e7-e549-4396-b5f9-b3a65ca31ef7.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Apply this PR
2. Add a post/page, and append ?mapkit to the URL
3. Add a map block
4. Click it to load the block settings on the right
5. You should not see `Show street names`, `Scroll to zoom` and `Show fullscreen button` 
6. Repeat without ?mapkit in the URL
7. You should now see `Show street names`, `Scroll to zoom` and `Show fullscreen button` 

You can ignore that Mapkit isn't used to render the map. That functionality is in another PR.