### PR TITLE
Make the "message sent" tracks event go through Grunion record_tracks_event()

### DIFF
--- a/projects/packages/forms/changelog/fix-use_record_tracks_event
+++ b/projects/packages/forms/changelog/fix-use_record_tracks_event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Forms: Use Grunion record_tracks_event() to record these "sent emails" events too

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -272,7 +272,6 @@ class Util {
 		/*
 		 * Event details.
 		 */
-		$event_user  = wp_get_current_user();
 		$event_name  = 'contact_form_block_message_sent';
 		$event_props = array(
 			'entry_permalink' => esc_url( $all_values['entry_permalink'] ),
@@ -297,33 +296,8 @@ class Util {
 			$event_props['no_post'] = 1;
 		}
 
-		/*
-		 * Record event.
-		 * We use different libs on wpcom and Jetpack.
-		 */
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$event_name             = 'wpcom_' . $event_name;
-			$event_props['blog_id'] = get_current_blog_id();
-			// If the form was sent by a logged out visitor, record event with blog owner.
-			if ( empty( $event_user->ID ) ) {
-				$event_user_id = wpcom_get_blog_owner( $event_props['blog_id'] );
-				$event_user    = get_userdata( $event_user_id );
-			}
-
-			require_lib( 'tracks/client' );
-			tracks_record_event( $event_user, $event_name, $event_props );
-		} else {
-			// If the form was sent by a logged out visitor, record event with Jetpack master user.
-			if ( empty( $event_user->ID ) ) {
-				$master_user_id = \Jetpack_Options::get_option( 'master_user' );
-				if ( ! empty( $master_user_id ) ) {
-					$event_user = get_userdata( $master_user_id );
-				}
-			}
-
-			$tracking = new \Automattic\Jetpack\Tracking();
-			$tracking->record_user_event( $event_name, $event_props, $event_user );
-		}
+		$grunion = \Automattic\Jetpack\Forms\ContactForm\Grunion_Contact_Form_Plugin::init();
+		$grunion->record_tracks_event( $event_name, $event_props );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-use_record_tracks_event
+++ b/projects/plugins/jetpack/changelog/fix-use_record_tracks_event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Forms: Use Grunion record_tracks_event() to record these "sent emails" events too

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -5219,7 +5219,6 @@ function jetpack_tracks_record_grunion_pre_message_sent( $post_id, $all_values, 
 	/*
 	 * Event details.
 	 */
-	$event_user  = wp_get_current_user();
 	$event_name  = 'contact_form_block_message_sent';
 	$event_props = array(
 		'entry_permalink' => esc_url( $all_values['entry_permalink'] ),
@@ -5244,32 +5243,7 @@ function jetpack_tracks_record_grunion_pre_message_sent( $post_id, $all_values, 
 		$event_props['no_post'] = 1;
 	}
 
-	/*
-	 * Record event.
-	 * We use different libs on wpcom and Jetpack.
-	 */
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$event_name             = 'wpcom_' . $event_name;
-		$event_props['blog_id'] = get_current_blog_id();
-		// If the form was sent by a logged out visitor, record event with blog owner.
-		if ( empty( $event_user->ID ) ) {
-			$event_user_id = wpcom_get_blog_owner( $event_props['blog_id'] );
-			$event_user    = get_userdata( $event_user_id );
-		}
-
-		require_lib( 'tracks/client' );
-		tracks_record_event( $event_user, $event_name, $event_props );
-	} else {
-		// If the form was sent by a logged out visitor, record event with Jetpack master user.
-		if ( empty( $event_user->ID ) ) {
-			$master_user_id = Jetpack_Options::get_option( 'master_user' );
-			if ( ! empty( $master_user_id ) ) {
-				$event_user = get_userdata( $master_user_id );
-			}
-		}
-
-		$tracking = new Automattic\Jetpack\Tracking();
-		$tracking->record_user_event( $event_name, $event_props, $event_user );
-	}
+	$grunion = \Automattic\Jetpack\Forms\ContactForm\Grunion_Contact_Form_Plugin::init();
+	$grunion->record_tracks_event( $event_name, $event_props );
 }
 add_action( 'grunion_pre_message_sent', 'jetpack_tracks_record_grunion_pre_message_sent', 12, 3 );


### PR DESCRIPTION
This PR depends on #29102 being merged first as that is where record_tracks_event() is defined.

Grunion contact form has had a tracks event fired when emails were sent after a response was made. The PR mentioned above adds a general purpose recording function to the Grunion class and this PR forces the message sent code to use it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pcsBup-S8-p2#comment-362

## Testing instructions:
Apply patch.
Create a post with a contact form in it.
Fill in the contact form and submit it.
Look up the contact_form_block_message_sent stat for your event.
