### PR TITLE
VideoPress: prevent post saving while the video preview is not loaded

### DIFF
--- a/projects/packages/videopress/changelog/add-lock-saving-before-video-preview
+++ b/projects/packages/videopress/changelog/add-lock-saving-before-video-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: prevent post saving while video previews on VideoPress block are being loaded.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -12,6 +12,7 @@ import { createBlock } from '@wordpress/blocks';
 import { Spinner, Placeholder, Button, withNotices, ToolbarButton } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreEditorStore } from '@wordpress/editor';
 import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { caption as captionIcon } from '@wordpress/icons';
@@ -173,6 +174,27 @@ export default function VideoPressEdit( {
 		},
 		[ videoPressUrl ]
 	);
+
+	const {
+		lockPostSaving,
+		unlockPostSaving,
+		lockPostAutosaving,
+		unlockPostAutosaving,
+	} = useDispatch( coreEditorStore );
+
+	// Locks the post saving while the video preview is being loaded
+	useEffect( () => {
+		const postSavingLockName = `videopress-loading-preview-${ guid }`;
+		if ( isRequestingEmbedPreview ) {
+			debug( 'Locking the post save action: ' + postSavingLockName );
+			lockPostSaving( postSavingLockName );
+			lockPostAutosaving( postSavingLockName );
+		} else {
+			debug( 'Unlocking the post save action: ' + postSavingLockName );
+			unlockPostSaving( postSavingLockName );
+			unlockPostAutosaving( postSavingLockName );
+		}
+	}, [ isRequestingEmbedPreview ] );
 
 	// Pick video properties from preview.
 	const { html: previewHtml, scripts, width: previewWidth, height: previewHeight } = preview;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28727.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses post saving lock and autosaving lock to prevent the post from being saved before the video preview is fully loaded
* This will avoid the `{{unknown}}` entry for the oembed preview cache

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the development console of the browser
* Insert a new VideoPress block
* Upload a new video on the block and click on the "Done"
* Notice that the Publish/Update button gets disabled while the block is loading the preview of the video
* Notice that the buttons are active again when the preview is achieved
* On the development console, notice the lines talking about the lock:

<img width="438" alt="Screen Shot 2023-03-07 at 12 06 13" src="https://user-images.githubusercontent.com/6760046/223462100-1ad9f349-59fe-465e-a5cd-7850b2c86123.png">

* Additionally, try to replicate the issue described on #28727; you should not be able to replicate the bug