### PR TITLE
VideoPress: pick and convert core/video VideoPress instances also from inner blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-pick-all-v6-instances-of-post
+++ b/projects/plugins/jetpack/changelog/update-videopress-pick-all-v6-instances-of-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: pick core/video VideoPess instances also from inner blocks

--- a/projects/plugins/jetpack/changelog/update-videopress-pick-all-v6-instances-of-post
+++ b/projects/plugins/jetpack/changelog/update-videopress-pick-all-v6-instances-of-post
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-VideoPress: pick core/video VideoPess instances also from inner blocks
+VideoPress: pick and convert core/video VideoPress instances also from inner blocks

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/components/transform-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/components/transform-control/index.js
@@ -61,9 +61,15 @@ const getAllCoreVideoVideoPressVideoBlocks = ( blocks = [], root = false, level 
 /**
  * React component that renders a block conversion control
  *
+ * @param {object} props            - Component props
+ * @param {string} props.clientId   - Block client ID
+ * @param {object} props.attributes - Block attributes
  * @returns {ReactElement} Transform panel component.
  */
-export default function TransformControl() {
+export default function TransformControl( {
+	clientId: currentBlockClientId,
+	attributes: currentBlockAttributes,
+} ) {
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId() );
 
 	const { getBlocks } = useSelect( blockEditorStore );
@@ -74,6 +80,15 @@ export default function TransformControl() {
 		const allV5Instances = getAllCoreVideoVideoPressVideoBlocks( getBlocks(), true );
 		if ( ! allV5Instances?.length ) {
 			return;
+		}
+
+		// Ensure the current block is included in the list.
+		if ( ! allV5Instances.find( block => block.clientId === currentBlockClientId ) ) {
+			allV5Instances.push( {
+				clientId: currentBlockClientId,
+				name: 'core/video',
+				currentBlockAttributes,
+			} );
 		}
 
 		allV5Instances.forEach( block => {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/components/transform-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/components/transform-control/index.js
@@ -22,14 +22,14 @@ const videoPressVideoBlocks = { instances: [] };
 
 // eslint-disable-next-line jsdoc/require-returns-check
 /**
- * Recursively get all VideoPress blocks
+ * Recursively get all core/video VideoPress (aka v5) block instances
  *
  * @param {Array} blocks - Array of blocks
  * @param {boolean} root - Whether it is the root block
  * @param {number} level - Nesting level in the block tree
- * @returns {Array} - Array of VideoPress blocks
+ * @returns {Array}        Array of VideoPress blocks
  */
-const getAllVideoPressVideoBlocks = ( blocks = [], root = false, level = 0 ) => {
+const getAllCoreVideoVideoPressVideoBlocks = ( blocks = [], root = false, level = 0 ) => {
 	if ( root ) {
 		// Clear the instances when it's called from the root block
 		videoPressVideoBlocks.instances = [];
@@ -37,7 +37,7 @@ const getAllVideoPressVideoBlocks = ( blocks = [], root = false, level = 0 ) => 
 
 	blocks.forEach( block => {
 		if ( block.innerBlocks.length ) {
-			getAllVideoPressVideoBlocks( block.innerBlocks, false, level + 1 );
+			getAllCoreVideoVideoPressVideoBlocks( block.innerBlocks, false, level + 1 );
 			return;
 		}
 
@@ -69,12 +69,12 @@ export default function TransformControl() {
 	const { tracks } = useAnalytics();
 
 	const handleTransformAll = () => {
-		const allV6Instances = getAllVideoPressVideoBlocks( getBlocks(), true );
-		if ( ! allV6Instances?.length ) {
+		const allV5Instances = getAllCoreVideoVideoPressVideoBlocks( getBlocks(), true );
+		if ( ! allV5Instances?.length ) {
 			return;
 		}
 
-		allV6Instances.forEach( block => {
+		allV5Instances.forEach( block => {
 			const { clientId, name, attributes } = block;
 			if ( name === 'core/video' && isVideoPressBlockBasedOnAttributes( attributes ) ) {
 				replaceBlock( clientId, createBlock( 'videopress/video', attributes ) );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/components/transform-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/components/transform-control/index.js
@@ -31,12 +31,13 @@ const videoPressVideoBlocks = { instances: [] };
  */
 const getAllCoreVideoVideoPressVideoBlocks = ( blocks = [], root = false, level = 0 ) => {
 	if ( root ) {
-		// Clear the instances when it's called from the root block
+		// Clear the instances when it's called from the root block.
 		videoPressVideoBlocks.instances = [];
 	}
 
 	blocks.forEach( block => {
 		if ( block.innerBlocks.length ) {
+			// Recursively call increasing the nesting level.
 			getAllCoreVideoVideoPressVideoBlocks( block.innerBlocks, false, level + 1 );
 			return;
 		}
@@ -48,8 +49,9 @@ const getAllCoreVideoVideoPressVideoBlocks = ( blocks = [], root = false, level 
 	} );
 
 	/*
-	 * Level zero is the forst call,
-	 * but is the last of the recursive calls.
+	 * Level zero is the first call,
+	 * but also is the last of the recursive calls.
+	 * Return the collected block instances when it's the last one.
 	 */
 	if ( level === 0 ) {
 		return videoPressVideoBlocks.instances;

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/edit.js
@@ -18,7 +18,7 @@ const withV6TransformEdit = createHigherOrderComponent( BlockEdit => props => {
 	return (
 		<>
 			<InspectorControls>
-				<TransformControl />
+				<TransformControl clientId={ props.clientId } attributes={ props.attributes } />
 			</InspectorControls>
 
 			<BlockEdit { ...props } />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: pick and convert core/video VideoPress instances also from inner blocks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a blocks composition by using Column blocks
* Add several core/video VideoPress block instances (v5). Put some instances at the top level, nest other. Try to set different nesting levels
* Select one of the v5 instances
* Click on the `Transform blocks to VideoPress` button
* Confirm all instances are transformed to v6
* Test with different clients

before | after
------|------
<img width="352" alt="image" src="https://user-images.githubusercontent.com/77539/223468891-63e37f4f-4986-464f-8d20-62e6933eb76a.png"> | <img width="351" alt="image" src="https://user-images.githubusercontent.com/77539/223469042-e5804de5-6d47-4e41-ad55-6c25355562ac.png">


https://user-images.githubusercontent.com/77539/223474194-a7728d3b-b13e-4c3b-ad57-6f703836bc0e.mov

