### PR TITLE
VideoPress: Fix video URL available to copying in video details page

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-copy-url
+++ b/projects/packages/videopress/changelog/update-videopress-copy-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix video URL available to copying in video details page

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -176,6 +176,7 @@ const EditVideoDetails = () => {
 		filename,
 		uploadDate,
 		url,
+		videoPressURL,
 		width,
 		height,
 		title,
@@ -311,7 +312,7 @@ const EditVideoDetails = () => {
 							<VideoDetails
 								filename={ filename ?? '' }
 								uploadDate={ uploadDate ?? '' }
-								src={ url ?? '' }
+								src={ videoPressURL ?? '' }
 								shortcode={ shortcode ?? '' }
 								loading={ isBusy }
 							/>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -111,6 +111,8 @@ export default () => {
 
 	const { playbackToken, isFetchingPlaybackToken } = usePlaybackToken( video );
 
+	const videoPressURL = `https://videopress.com/v/${ video?.guid }`;
+
 	const [ libraryAttachment, setLibraryAttachment ] = useState( null );
 	const [ posterImageSource, setPosterImageSource ] = useState<
 		'default' | 'video' | 'upload' | null
@@ -293,6 +295,7 @@ export default () => {
 		isFetchingPlaybackToken,
 		...video,
 		...formData, // formData is the local representation of the video
+		videoPressURL,
 		hasChanges,
 		posterImageSource,
 		libraryAttachment,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29239

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `videoPressURL` to the `useEditDetails` hook

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard and upload a video if there is none
* Go to the details page of a video
* Check that the URL available to copying now points to the VideoPress player instead of the downloadable video
* Check that the frame as poster image feature keeps working as normal

Before | After
-|-
![2023-03-08_16-34-08](https://user-images.githubusercontent.com/8486249/223825526-7776f5ad-0dca-4d51-b4d5-530b01c5a1a9.png) | ![2023-03-08_16-22-45](https://user-images.githubusercontent.com/8486249/223824514-2a469d6b-66e9-43ee-9b70-a7c0a0a567ab.png)

Before | After
-|-
![2023-03-08_16-34-44](https://user-images.githubusercontent.com/8486249/223826550-1166bf3c-6633-4cd4-8023-0caed2b5e0d6.png) | ![2023-03-08_16-32-26](https://user-images.githubusercontent.com/8486249/223826573-222fec35-7aea-4176-addf-b6ced9d73662.png)
