### PR TITLE
Plugins: backport release stale plugins after JP 11.9

### DIFF
--- a/projects/plugins/debug-helper/CHANGELOG.md
+++ b/projects/plugins/debug-helper/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2023-03-08
+### Added
+- Add "Cookie State Faker" tool. [#28371]
+- Add a button to set the current primary user. [#26562]
+- Added a helper module for Jetpack Scan. [#25641]
+- Added threat descriptions. [#25266]
+- Mocker tool: add runner to add rows in the WAF log DB table for blocked requests [#25645]
+- Replace "XML-RPC errors" with "connection errors", add error type ("xml-rpc" or "rest") to generated errors. [#25694]
+
+### Changed
+- Remove pre-defined prefix in the REST API tool. [#26521]
+- Updated package dependencies.
+- Updated Protect Helper to use newly added data source constant. [#26069]
+
+### Fixed
+- Prevented the threat tester from being identified as a threat due to containing the Akismet suspicious link URL. [#26192]
+
 ## [1.4.0] - 2022-07-06
 ### Added
 - Added the Autoloader debugger helper to the Debug tool. [#23726]
@@ -60,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial version.
 
+[1.5.0]: https://github.com/Automattic/jetpack-debug-helper/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/Automattic/jetpack-debug-helper/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/Automattic/jetpack-debug-helper/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Automattic/jetpack-debug-helper/compare/v1.1.0...v1.2.0

--- a/projects/plugins/debug-helper/changelog/add-debug-helper-scan-results
+++ b/projects/plugins/debug-helper/changelog/add-debug-helper-scan-results
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added a helper module for Jetpack Scan.

--- a/projects/plugins/debug-helper/changelog/add-debug-helper-set-primary-user
+++ b/projects/plugins/debug-helper/changelog/add-debug-helper-set-primary-user
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a button to set the current primary user.

--- a/projects/plugins/debug-helper/changelog/add-debug-helper-waf-mocker
+++ b/projects/plugins/debug-helper/changelog/add-debug-helper-waf-mocker
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Mocker tool: add runner to add rows in the WAF log DB table for blocked requests

--- a/projects/plugins/debug-helper/changelog/add-jetpack-debug-state
+++ b/projects/plugins/debug-helper/changelog/add-jetpack-debug-state
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add "Cookie State Faker" tool.

--- a/projects/plugins/debug-helper/changelog/add-protect-scan-api-data-source
+++ b/projects/plugins/debug-helper/changelog/add-protect-scan-api-data-source
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated Protect Helper to use newly added data source constant.

--- a/projects/plugins/debug-helper/changelog/add-protect-threat-descriptions
+++ b/projects/plugins/debug-helper/changelog/add-protect-threat-descriptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added threat descriptions.

--- a/projects/plugins/debug-helper/changelog/add-verify-rest-api-errors
+++ b/projects/plugins/debug-helper/changelog/add-verify-rest-api-errors
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Replace "XML-RPC errors" with "connection errors", add error type ("xml-rpc" or "rest") to generated errors.

--- a/projects/plugins/debug-helper/changelog/changelogger-merge
+++ b/projects/plugins/debug-helper/changelog/changelogger-merge
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Minor update to changelog package that supports git merge strategy. Should not affect shipped code.
-
-

--- a/projects/plugins/debug-helper/changelog/fix-debug-helper-suspicious-link-concat
+++ b/projects/plugins/debug-helper/changelog/fix-debug-helper-suspicious-link-concat
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Prevented the threat tester from being identified as a threat due to containing the Akismet suspicious link URL.

--- a/projects/plugins/debug-helper/changelog/remove-remnants-of-automated-code-coverage
+++ b/projects/plugins/debug-helper/changelog/remove-remnants-of-automated-code-coverage
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `test-coverage` scripts and other remnants of automated code coverage.
-
-

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#5
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#6
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#7
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#8
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#9
+++ b/projects/plugins/debug-helper/changelog/renovate-lock-file-maintenance#9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-major-symfony
+++ b/projects/plugins/debug-helper/changelog/renovate-major-symfony
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/plugins/debug-helper/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/debug-helper/changelog/update-build-action-version-handling
+++ b/projects/plugins/debug-helper/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/debug-helper/changelog/update-rest-api-tester-prefix
+++ b/projects/plugins/debug-helper/changelog/update-rest-api-tester-prefix
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Remove pre-defined prefix in the REST API tool.

--- a/projects/plugins/debug-helper/changelog/update-wpcs
+++ b/projects/plugins/debug-helper/changelog/update-wpcs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: PHPCS fixes for new WPCS sniffs. Should be no user-visible changes.
-
-

--- a/projects/plugins/debug-helper/changelog/update-wpcs-pre-phpcbf
+++ b/projects/plugins/debug-helper/changelog/update-wpcs-pre-phpcbf
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: PHPCS: Fix most auto-fixable sniffs coming in new WPCS snapshot. No user-visible change to the project.
-
-

--- a/projects/plugins/debug-helper/plugin.php
+++ b/projects/plugins/debug-helper/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Debug Tools
  * Description: Give me a Jetpack connection, and I'll break it every way possible.
  * Author: Automattic - Jetpack Crew
- * Version: 1.5.0-alpha
+ * Version: 1.5.0
  * Text Domain: jetpack
  *
  * @package automattic/jetpack-debug-helper.
@@ -33,7 +33,7 @@ define( 'JETPACK_DEBUG_HELPER_BASE_PLUGIN_FILE', __FILE__ );
  * The plugin version.
  * Increase that if you do any edits to ensure refreshing the cached assets.
  */
-define( 'JETPACK_DEBUG_HELPER_VERSION', '1.5.0-alpha' );
+define( 'JETPACK_DEBUG_HELPER_VERSION', '1.5.0' );
 
 /**
  * Include file names from the modules directory here.

--- a/projects/plugins/search/CHANGELOG.md
+++ b/projects/plugins/search/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2023-03-08
+### Changed
+- Remove `ci.targets` from package.json. Better scoping of e2e tests. [#28913]
+- Update playwright dependency. [#28094]
+- Updated package dependencies.
+
 ## [1.4.0] - 2022-12-12
 ### Added
 - Search: port Search plugin 1.3.1 changelog and plugin description [#27399]
@@ -115,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.1.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.0.0...1.1.0-beta
 [1.2.0-beta]: https://github.com/Automattic/jetpack-search-plugin/compare/1.1.0...1.2.0-beta
+[1.4.1]: https://github.com/Automattic/jetpack-search-plugin/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.3.1...1.4.0
 [1.3.1]: https://github.com/Automattic/jetpack-search-plugin/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/Automattic/jetpack-search-plugin/compare/1.2.0...1.3.0

--- a/projects/plugins/search/changelog/add-e2e-tiled-gallery-block-test
+++ b/projects/plugins/search/changelog/add-e2e-tiled-gallery-block-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update playwright dependency

--- a/projects/plugins/search/changelog/add-license-key-selector
+++ b/projects/plugins/search/changelog/add-license-key-selector
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-license-verification
+++ b/projects/plugins/search/changelog/add-license-verification
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/search/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-promoted-posts-post-publish-panel
+++ b/projects/plugins/search/changelog/add-promoted-posts-post-publish-panel
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-shared-get-blog-id
+++ b/projects/plugins/search/changelog/add-shared-get-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/search/changelog/add-status-private-coming-soon-site
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-store-enable-disable-time-for-odyssey
+++ b/projects/plugins/search/changelog/add-store-enable-disable-time-for-odyssey
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/add-woo-sync-whitelist
+++ b/projects/plugins/search/changelog/add-woo-sync-whitelist
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/changelogger-merge
+++ b/projects/plugins/search/changelog/changelogger-merge
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Minor update to changelog package that supports git merge strategy. Should not affect shipped code.
-
-

--- a/projects/plugins/search/changelog/e2e-better_scoping
+++ b/projects/plugins/search/changelog/e2e-better_scoping
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove `ci.targets` from package.json. Better scoping of e2e tests.

--- a/projects/plugins/search/changelog/init-release-cycle
+++ b/projects/plugins/search/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Init 1.5.0-alpha
-
-

--- a/projects/plugins/search/changelog/remove-placeholder-blogging-prompts
+++ b/projects/plugins/search/changelog/remove-placeholder-blogging-prompts
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: composer.lock file change
-
-

--- a/projects/plugins/search/changelog/remove-remnants-of-automated-code-coverage
+++ b/projects/plugins/search/changelog/remove-remnants-of-automated-code-coverage
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `test-coverage` scripts and other remnants of automated code coverage.
-
-

--- a/projects/plugins/search/changelog/renovate-automattic-wordbless-0.x
+++ b/projects/plugins/search/changelog/renovate-automattic-wordbless-0.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/renovate-composer-composer-2.x
+++ b/projects/plugins/search/changelog/renovate-composer-composer-2.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/renovate-eslint-packages
+++ b/projects/plugins/search/changelog/renovate-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix new eslint sniffs. Should be no change to the project itself.
-
-

--- a/projects/plugins/search/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/search/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/search/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/search/changelog/update-add-date-to-search-results
+++ b/projects/plugins/search/changelog/update-add-date-to-search-results
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-blaze-package-todos
+++ b/projects/plugins/search/changelog/update-blaze-package-todos
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-import-package
+++ b/projects/plugins/search/changelog/update-import-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-jitm-style
+++ b/projects/plugins/search/changelog/update-jitm-style
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-move-delete-connection-owner-notice
+++ b/projects/plugins/search/changelog/update-move-delete-connection-owner-notice
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-move-delete-connection-owner-notice#2
+++ b/projects/plugins/search/changelog/update-move-delete-connection-owner-notice#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/search/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/changelog/update-node-to-v18
+++ b/projects/plugins/search/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/plugins/search/changelog/update-search-add-category-classnames
+++ b/projects/plugins/search/changelog/update-search-add-category-classnames
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -64,7 +64,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_4_1_alpha",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ1_4_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: Easily add cloud-powered instant search and filters to your website or WooCommerce store with advanced algorithms that boost your search results based on traffic to your site.
- * Version: 1.4.1-alpha
+ * Version: 1.4.1
  * Author: Automattic - Jetpack Search team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.4.1-alpha' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '1.4.1' );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -4,7 +4,7 @@ Tags: search, filter, woocommerce search, ajax search, product search, free clou
 Requires at least: 6.0
 Requires PHP: 5.6
 Tested up to: 6.1
-Stable tag: 1.3.1
+Stable tag: 1.4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -122,13 +122,10 @@ If you are using the Jetpack Search free option, and you have more than 5000 rec
 5. Manage all of your Jetpack products, including Search, in a single place.
 
 == Changelog ==
-### 1.4.0 - 2022-12-12
-#### Added
-- Search: port Search plugin 1.3.1 changelog and plugin description
-
+### 1.4.1 - 2023-03-08
 #### Changed
-- My Jetpack: Requires connection only if needed
-- My Jetpack: Show My Jetpack even if site is disconnected
+- Remove `ci.targets` from package.json. Better scoping of e2e tests.
+- Update playwright dependency.
 - Updated package dependencies.
 
 == Testimonials ==

--- a/projects/plugins/starter-plugin/CHANGELOG.md
+++ b/projects/plugins/starter-plugin/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 - 2023-03-08
+### Added
+- Add support for JITMs to starter plugin [#25880]
+- E2E tests: use CI build artifacts in e2e tests [#26278]
+- My Jetpack includes JITMs [#22452]
+- Starter Plugin: Add basic JS and PHP test setup [#27729]
+- Use ThemeProvider when rendering Starter Plugin AdminPage [#25870]
+
+### Changed
+- Compatibility: WordPress 6.1 compatibility [#27084]
+- E2E tests: bump dependencies [#25725]
+- Updated package dependencies.
+- Update playwright dependency [#28094]
+- Update to React 18. [#28710]
+
+### Removed
+- E2E tests: removed deprecated Slack notification code [#26215]
+
+### Fixed
+- E2E tests: fixed pretest cleanup script not running [#25051]
+- Plugin activation: Only redirect when activating from Plugins page in the browser [#25711]
+
 ## 0.1.0 - 2022-07-06
 ### Added
 - Add activation and deactivation hooks. [#24250]

--- a/projects/plugins/starter-plugin/changelog/add-add-jitms-to-jetpack-social
+++ b/projects/plugins/starter-plugin/changelog/add-add-jitms-to-jetpack-social
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add support for JITMs to starter plugin

--- a/projects/plugins/starter-plugin/changelog/add-backup-disclaimer-text-to-product-card
+++ b/projects/plugins/starter-plugin/changelog/add-backup-disclaimer-text-to-product-card
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-connection-verified-errors-react-initial-state
+++ b/projects/plugins/starter-plugin/changelog/add-connection-verified-errors-react-initial-state
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-custom-taxonomy-slugs
+++ b/projects/plugins/starter-plugin/changelog/add-custom-taxonomy-slugs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-db-post-type-breakdown
+++ b/projects/plugins/starter-plugin/changelog/add-db-post-type-breakdown
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-e2e-tiled-gallery-block-test
+++ b/projects/plugins/starter-plugin/changelog/add-e2e-tiled-gallery-block-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update playwright dependency

--- a/projects/plugins/starter-plugin/changelog/add-free-search-product-support-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/add-free-search-product-support-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-icon_tooltip
+++ b/projects/plugins/starter-plugin/changelog/add-icon_tooltip
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-jetpack-connect-error-notice-react-component
+++ b/projects/plugins/starter-plugin/changelog/add-jetpack-connect-error-notice-react-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-jetpack-connection-errors-react-vars
+++ b/projects/plugins/starter-plugin/changelog/add-jetpack-connection-errors-react-vars
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-jetpack-connection-errors-react-vars#2
+++ b/projects/plugins/starter-plugin/changelog/add-jetpack-connection-errors-react-vars#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-jetpack-social-add-share-meter
+++ b/projects/plugins/starter-plugin/changelog/add-jetpack-social-add-share-meter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-jetpack-social-panel-save-attached-media
+++ b/projects/plugins/starter-plugin/changelog/add-jetpack-social-panel-save-attached-media
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-jitm-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/add-jitm-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-My Jetpack includes JITMs

--- a/projects/plugins/starter-plugin/changelog/add-license-key-selector
+++ b/projects/plugins/starter-plugin/changelog/add-license-key-selector
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-license-verification
+++ b/projects/plugins/starter-plugin/changelog/add-license-verification
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
+++ b/projects/plugins/starter-plugin/changelog/add-new-wpcom-subscription-emails-use-excerpt-option
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-pricing-table-component
+++ b/projects/plugins/starter-plugin/changelog/add-pricing-table-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-promoted-posts-post-publish-panel
+++ b/projects/plugins/starter-plugin/changelog/add-promoted-posts-post-publish-panel
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-reconnect-notice-restore
+++ b/projects/plugins/starter-plugin/changelog/add-reconnect-notice-restore
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-record-meter-donut-chart
+++ b/projects/plugins/starter-plugin/changelog/add-record-meter-donut-chart
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-scan-in-protect
+++ b/projects/plugins/starter-plugin/changelog/add-scan-in-protect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-scan-in-protect#2
+++ b/projects/plugins/starter-plugin/changelog/add-scan-in-protect#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-shared-get-blog-id
+++ b/projects/plugins/starter-plugin/changelog/add-shared-get-blog-id
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-starter-plugin-js-php-tests
+++ b/projects/plugins/starter-plugin/changelog/add-starter-plugin-js-php-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Starter Plugin: Add basic JS and PHP test setup

--- a/projects/plugins/starter-plugin/changelog/add-status-private-coming-soon-site
+++ b/projects/plugins/starter-plugin/changelog/add-status-private-coming-soon-site
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-super-cache-measurement
+++ b/projects/plugins/starter-plugin/changelog/add-super-cache-measurement
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-sync-request-full-response-logging
+++ b/projects/plugins/starter-plugin/changelog/add-sync-request-full-response-logging
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-sync-request-full-response-logging#2
+++ b/projects/plugins/starter-plugin/changelog/add-sync-request-full-response-logging#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-sync-sl-insta-media-to-blacklist
+++ b/projects/plugins/starter-plugin/changelog/add-sync-sl-insta-media-to-blacklist
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-upgrade-trigger-in-jetpack-social
+++ b/projects/plugins/starter-plugin/changelog/add-upgrade-trigger-in-jetpack-social
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-upgraded_tooltips
+++ b/projects/plugins/starter-plugin/changelog/add-upgraded_tooltips
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/add-verify-rest-api-errors
+++ b/projects/plugins/starter-plugin/changelog/add-verify-rest-api-errors
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-verify-rest-api-errors#2
+++ b/projects/plugins/starter-plugin/changelog/add-verify-rest-api-errors#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-woo-sync-whitelist
+++ b/projects/plugins/starter-plugin/changelog/add-woo-sync-whitelist
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-wpcom-platform
+++ b/projects/plugins/starter-plugin/changelog/add-wpcom-platform
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/bump-wp6.0-to-6.1
+++ b/projects/plugins/starter-plugin/changelog/bump-wp6.0-to-6.1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Compatibility: WordPress 6.1 compatibility

--- a/projects/plugins/starter-plugin/changelog/change-move-sharing-limits-to-publicize-package
+++ b/projects/plugins/starter-plugin/changelog/change-move-sharing-limits-to-publicize-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/changelogger-merge
+++ b/projects/plugins/starter-plugin/changelog/changelogger-merge
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Minor update to changelog package that supports git merge strategy. Should not affect shipped code.
-
-

--- a/projects/plugins/starter-plugin/changelog/e2e-bump-dependencies
+++ b/projects/plugins/starter-plugin/changelog/e2e-bump-dependencies
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-E2E tests: bump dependencies

--- a/projects/plugins/starter-plugin/changelog/e2e-fix-pre-scripts
+++ b/projects/plugins/starter-plugin/changelog/e2e-fix-pre-scripts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-E2E tests: fixed pretest cleanup script not running

--- a/projects/plugins/starter-plugin/changelog/e2e-slack-notifications-cleanup
+++ b/projects/plugins/starter-plugin/changelog/e2e-slack-notifications-cleanup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-E2E tests: removed deprecated Slack notification code

--- a/projects/plugins/starter-plugin/changelog/e2e-use-built-artefacts-in-ci
+++ b/projects/plugins/starter-plugin/changelog/e2e-use-built-artefacts-in-ci
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-E2E tests: use CI build artifacts in e2e tests

--- a/projects/plugins/starter-plugin/changelog/fix-check-intra-monorepo-deps-for-plugin-release-branches
+++ b/projects/plugins/starter-plugin/changelog/fix-check-intra-monorepo-deps-for-plugin-release-branches
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/fix-user-token-after-restore-error
+++ b/projects/plugins/starter-plugin/changelog/fix-user-token-after-restore-error
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/modify-backup-review-request-logic
+++ b/projects/plugins/starter-plugin/changelog/modify-backup-review-request-logic
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/modify-connection-react-component-connection-error-notice
+++ b/projects/plugins/starter-plugin/changelog/modify-connection-react-component-connection-error-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/modify-connection-react-component-connection-error-notice#2
+++ b/projects/plugins/starter-plugin/changelog/modify-connection-react-component-connection-error-notice#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/remove-connection-ui-package
+++ b/projects/plugins/starter-plugin/changelog/remove-connection-ui-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: This is a cleanup task
-
-

--- a/projects/plugins/starter-plugin/changelog/remove-placeholder-blogging-prompts
+++ b/projects/plugins/starter-plugin/changelog/remove-placeholder-blogging-prompts
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: composer.lock file change
-
-

--- a/projects/plugins/starter-plugin/changelog/remove-remnants-of-automated-code-coverage
+++ b/projects/plugins/starter-plugin/changelog/remove-remnants-of-automated-code-coverage
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `test-coverage` scripts and other remnants of automated code coverage.
-
-

--- a/projects/plugins/starter-plugin/changelog/renovate-automattic-wordbless-0.x
+++ b/projects/plugins/starter-plugin/changelog/renovate-automattic-wordbless-0.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#4
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#5
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#6
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#7
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-composer-composer-2.x
+++ b/projects/plugins/starter-plugin/changelog/renovate-composer-composer-2.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/renovate-concurrently-7.x
+++ b/projects/plugins/starter-plugin/changelog/renovate-concurrently-7.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-jest-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-jest-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-js-unit-testing-packages
+++ b/projects/plugins/starter-plugin/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-js-unit-testing-packages#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-js-unit-testing-packages#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#5
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#6
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#7
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#8
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#9
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-major-symfony
+++ b/projects/plugins/starter-plugin/changelog/renovate-major-symfony
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-playwright-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-playwright-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-renovatebot-github-action-34.x
+++ b/projects/plugins/starter-plugin/changelog/renovate-renovatebot-github-action-34.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Make "jetpack-e2e-commons" dep explicitly "workspace:*"
-
-

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#5
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#6
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#7
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#8
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/plugins/starter-plugin/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/sync-add-reset-endpoint
+++ b/projects/plugins/starter-plugin/changelog/sync-add-reset-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-auto-redirect-after-install-condition
+++ b/projects/plugins/starter-plugin/changelog/update-auto-redirect-after-install-condition
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-blaze-package-todos
+++ b/projects/plugins/starter-plugin/changelog/update-blaze-package-todos
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-build-action-version-handling
+++ b/projects/plugins/starter-plugin/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-components-apply-icon-button-styles
+++ b/projects/plugins/starter-plugin/changelog/update-components-apply-icon-button-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-connection-deprecated-method-cleanup
+++ b/projects/plugins/starter-plugin/changelog/update-connection-deprecated-method-cleanup
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-connection-deprecated-soft-disconnect-cleanup
+++ b/projects/plugins/starter-plugin/changelog/update-connection-deprecated-soft-disconnect-cleanup
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-connection-error-notice-redesign
+++ b/projects/plugins/starter-plugin/changelog/update-connection-error-notice-redesign
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-connection-error-notice-redesign#2
+++ b/projects/plugins/starter-plugin/changelog/update-connection-error-notice-redesign#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-connection-error-notice-redesign#3
+++ b/projects/plugins/starter-plugin/changelog/update-connection-error-notice-redesign#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-icon-tooltip-component
+++ b/projects/plugins/starter-plugin/changelog/update-icon-tooltip-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-import-package
+++ b/projects/plugins/starter-plugin/changelog/update-import-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-init-with-config-package
+++ b/projects/plugins/starter-plugin/changelog/update-init-with-config-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-integrate-stats-pkg-in-jetpack-plugin
+++ b/projects/plugins/starter-plugin/changelog/update-integrate-stats-pkg-in-jetpack-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-jitm-style
+++ b/projects/plugins/starter-plugin/changelog/update-jitm-style
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-move-delete-connection-owner-notice
+++ b/projects/plugins/starter-plugin/changelog/update-move-delete-connection-owner-notice
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-move-delete-connection-owner-notice#2
+++ b/projects/plugins/starter-plugin/changelog/update-move-delete-connection-owner-notice#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-move-restore-connection
+++ b/projects/plugins/starter-plugin/changelog/update-move-restore-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-move-restore-connection#2
+++ b/projects/plugins/starter-plugin/changelog/update-move-restore-connection#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-add-scroll-to-top
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-add-scroll-to-top
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-remove-videopress-hybrid
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-remove-videopress-hybrid
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-show-while-disconnected
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-show-while-disconnected
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-node-to-v18
+++ b/projects/plugins/starter-plugin/changelog/update-node-to-v18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update tooling node version to 18.13.0. Should be no change to the project.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-pnpm-7.5.0
+++ b/projects/plugins/starter-plugin/changelog/update-pnpm-7.5.0
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `.engines.pnpm` from `package.json`. It's not needed, as pnpm always checks the monorepo root `package.json` anyway. Further, `.engines` is stripped from the mirror repos.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-pricing-table-design
+++ b/projects/plugins/starter-plugin/changelog/update-pricing-table-design
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-react-18
+++ b/projects/plugins/starter-plugin/changelog/update-react-18
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update to React 18.

--- a/projects/plugins/starter-plugin/changelog/update-refactor_upgrade_tooltips
+++ b/projects/plugins/starter-plugin/changelog/update-refactor_upgrade_tooltips
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-search-require-only-site-connection
+++ b/projects/plugins/starter-plugin/changelog/update-search-require-only-site-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-search-support-woo-brands-plugin
+++ b/projects/plugins/starter-plugin/changelog/update-search-support-woo-brands-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-starter-plugin-activation
+++ b/projects/plugins/starter-plugin/changelog/update-starter-plugin-activation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Plugin activation: Only redirect when activating from Plugins page in the browser

--- a/projects/plugins/starter-plugin/changelog/update-starter-plugin-use-theme-provider
+++ b/projects/plugins/starter-plugin/changelog/update-starter-plugin-use-theme-provider
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Use ThemeProvider when rendering Starter Plugin AdminPage

--- a/projects/plugins/starter-plugin/changelog/update-sync-debug-info
+++ b/projects/plugins/starter-plugin/changelog/update-sync-debug-info
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-sync-minimal-config-add-updates-module
+++ b/projects/plugins/starter-plugin/changelog/update-sync-minimal-config-add-updates-module
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-wordbless
+++ b/projects/plugins/starter-plugin/changelog/update-wordbless
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated a dev dependency. No functional change.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-wordbless#2
+++ b/projects/plugins/starter-plugin/changelog/update-wordbless#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-wpcs-pre-phpcbf
+++ b/projects/plugins/starter-plugin/changelog/update-wpcs-pre-phpcbf
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: PHPCS: Fix most auto-fixable sniffs coming in new WPCS snapshot. No user-visible change to the project.
-
-

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -68,6 +68,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_starter_pluginⓥ0_2_0_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_starter_pluginⓥ0_2_0"
 	}
 }

--- a/projects/plugins/starter-plugin/jetpack-starter-plugin.php
+++ b/projects/plugins/starter-plugin/jetpack-starter-plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Starter Plugin
  * Plugin URI: https://wordpress.org/plugins/jetpack-starter-plugin
  * Description: plugin--description.
- * Version: 0.2.0-alpha
+ * Version: 0.2.0
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/vaultpress/CHANGELOG.md
+++ b/projects/plugins/vaultpress/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.3 - 2023-03-08
+### Changed
+- Add a note to README (visible in wordpress.org) that Jetpack VaultPress is deprecated. [#27465]
+- Compatibility: WordPress 6.1 compatibility [#27084]
+- Updated package dependencies.
+- Update README references from VaultPress to Jetpack VaultPress [#27412]
+
 ## 2.2.2 - 2022-07-06
 ### Changed
 - Build: do not ship PHPCS configuration file. [#22604]

--- a/projects/plugins/vaultpress/changelog/bump-wp6.0-to-6.1
+++ b/projects/plugins/vaultpress/changelog/bump-wp6.0-to-6.1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Compatibility: WordPress 6.1 compatibility

--- a/projects/plugins/vaultpress/changelog/changelogger-merge
+++ b/projects/plugins/vaultpress/changelog/changelogger-merge
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Minor update to changelog package that supports git merge strategy. Should not affect shipped code.
-
-

--- a/projects/plugins/vaultpress/changelog/fix-check-intra-monorepo-deps-for-plugin-release-branches
+++ b/projects/plugins/vaultpress/changelog/fix-check-intra-monorepo-deps-for-plugin-release-branches
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/remove-remnants-of-automated-code-coverage
+++ b/projects/plugins/vaultpress/changelog/remove-remnants-of-automated-code-coverage
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove `test-coverage` scripts and other remnants of automated code coverage.
-
-

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#5
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#6
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#7
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#7
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#8
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#9
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-major-symfony
+++ b/projects/plugins/vaultpress/changelog/renovate-major-symfony
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-yoast-phpunit-polyfills-1.x
+++ b/projects/plugins/vaultpress/changelog/renovate-yoast-phpunit-polyfills-1.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/update-build-action-version-handling
+++ b/projects/plugins/vaultpress/changelog/update-build-action-version-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/update-vp-plugin-depreciation-notice
+++ b/projects/plugins/vaultpress/changelog/update-vp-plugin-depreciation-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Add a note to README (visible in wordpress.org) that Jetpack VaultPress is deprecated.

--- a/projects/plugins/vaultpress/changelog/update-vp-plugin-rebranding-readme
+++ b/projects/plugins/vaultpress/changelog/update-vp-plugin-rebranding-readme
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update README references from VaultPress to Jetpack VaultPress

--- a/projects/plugins/vaultpress/changelog/update-wpcs-pre-phpcbf
+++ b/projects/plugins/vaultpress/changelog/update-wpcs-pre-phpcbf
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: PHPCS: Fix most auto-fixable sniffs coming in new WPCS snapshot. No user-visible change to the project.
-
-

--- a/projects/plugins/vaultpress/composer.json
+++ b/projects/plugins/vaultpress/composer.json
@@ -35,7 +35,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ2_2_3_alpha",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ2_2_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true
 		}

--- a/projects/plugins/vaultpress/readme.txt
+++ b/projects/plugins/vaultpress/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, annezazu, apokalyptik, bjorsch, briancolinger, dsmart,
 Tags: security, malware, virus, archive, back up, back ups, backup, backups, scanning, restore, wordpress backup, site backup, website backup
 Requires at least: 5.2
 Tested up to: 6.1
-Stable tag: 2.2.0
+Stable tag: 2.2.2
 Requires PHP: 5.6
 License: GPLv2
 
@@ -11,8 +11,8 @@ License: GPLv2
 
 == Description ==
 
-**Please note:** This plugin is no longer actively supported for new customers. 
-	
+**Please note:** This plugin is no longer actively supported for new customers.
+
 For the next generation of VaultPress technology, **we recommend** [Jetpack Security](https://jetpack.com/features/security/). It includes real-time backups, malware scanning, anti-spam comment protection, and a new Web Application Firewall (WAF) for ultimate WordPress site security.
 
 == Installation ==
@@ -29,16 +29,15 @@ View our full list of FAQs at [http://help.vaultpress.com/faq/](http://help.vaul
 
 = How many sites can I protect with VaultPress? =
 
-A Jetpack VaultPress subscription is for a single WordPress site. 
+A Jetpack VaultPress subscription is for a single WordPress site.
 
 == Changelog ==
-### 2.2.2 - 2022-07-06
+### 2.2.3 - 2023-03-08
 #### Changed
-- Build: do not ship PHPCS configuration file.
-- Janitorial: require a more recent version of WordPress now that WP 6.0 is coming out.
-- Renaming `master` references to `trunk`.
-- Updated composer.lock
+- Add a note to README (visible in wordpress.org) that Jetpack VaultPress is deprecated.
+- Compatibility: WordPress 6.1 compatibility
 - Updated package dependencies.
+- Update README references from VaultPress to Jetpack VaultPress
 
 --------
 

--- a/projects/plugins/vaultpress/vaultpress.php
+++ b/projects/plugins/vaultpress/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>. Activate, enter your registration key, and never worry again. <a href="http://vaultpress.com/help/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">Need some help?</a>
- * Version: 2.2.3-alpha
+ * Version: 2.2.3
  * Author: Automattic
  * Author URI: http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+
@@ -17,7 +17,7 @@
 defined( 'ABSPATH' ) || die();
 
 define( 'VAULTPRESS__MINIMUM_PHP_VERSION', '5.6' );
-define( 'VAULTPRESS__VERSION', '2.2.3-alpha' );
+define( 'VAULTPRESS__VERSION', '2.2.3' );
 define( 'VAULTPRESS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 /**


### PR DESCRIPTION
## Proposed changes:

Plugins: backport release stale plugins after JP 11.9

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread.