### PR TITLE
Writing Prompt block: prevent multiple requests when fetching prompts/tags

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blogging-prompt-multiple-requests
+++ b/projects/plugins/jetpack/changelog/fix-blogging-prompt-multiple-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Writing Prompt block: prevent multiple requests when fetching prompt or tags

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
@@ -1,13 +1,14 @@
 import apiFetch from '@wordpress/api-fetch';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Button, PanelBody, Spinner, ToggleControl, withNotices } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import './editor.scss';
 import icon from './icon';
 import { usePromptTags } from './use-prompt-tags';
 
 function BloggingPromptEdit( { attributes, noticeOperations, noticeUI, setAttributes } ) {
+	const fetchedPromptRef = useRef( false );
 	const [ isLoading, setLoading ] = useState( true );
 	const { gravatars, prompt, promptId, showLabel, showResponses, tagsAdded } = attributes;
 	const blockProps = useBlockProps( { className: 'jetpack-blogging-prompt' } );
@@ -19,8 +20,14 @@ function BloggingPromptEdit( { attributes, noticeOperations, noticeUI, setAttrib
 
 	// Fetch the prompt by id, if present, otherwise the get the prompt for today.
 	useEffect( () => {
+		// Only fetch the prompt once.
+		if ( fetchedPromptRef.current ) {
+			return;
+		}
+
 		const retryPrompt = () => {
 			setLoading( true );
+			fetchedPromptRef.current = false;
 			noticeOperations.removeAllNotices();
 		};
 
@@ -55,11 +62,6 @@ function BloggingPromptEdit( { attributes, noticeOperations, noticeUI, setAttrib
 			</>
 		);
 
-		// If not initially rendering the block, don't fetch new data.
-		if ( ! isLoading ) {
-			return;
-		}
-
 		let path = '/wpcom/v3/blogging-prompts';
 
 		if ( promptId ) {
@@ -74,6 +76,7 @@ function BloggingPromptEdit( { attributes, noticeOperations, noticeUI, setAttrib
 			path += `?after=--${ month }-${ day }&order=desc`;
 		}
 
+		fetchedPromptRef.current = true;
 		apiFetch( { path } )
 			.then( prompts => {
 				const promptData = promptId ? prompts : prompts[ 0 ];
@@ -94,7 +97,7 @@ function BloggingPromptEdit( { attributes, noticeOperations, noticeUI, setAttrib
 				noticeOperations.removeAllNotices();
 				noticeOperations.createErrorNotice( message );
 			} );
-	}, [ isLoading, noticeOperations, promptId, setAttributes, setLoading ] );
+	}, [ fetchedPromptRef, isLoading, noticeOperations, promptId, setAttributes, setLoading ] );
 
 	const onShowLabelChange = newValue => {
 		setAttributes( { showLabel: newValue } );

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
@@ -12,8 +12,10 @@ function BloggingPromptEdit( { attributes, noticeOperations, noticeUI, setAttrib
 	const { gravatars, prompt, promptId, showLabel, showResponses, tagsAdded } = attributes;
 	const blockProps = useBlockProps( { className: 'jetpack-blogging-prompt' } );
 
+	const setTagsAdded = state => setAttributes( { tagsAdded: state } );
+
 	// Add the prompt tags to the post, if they haven't already been added.
-	usePromptTags( promptId, tagsAdded, setAttributes );
+	usePromptTags( promptId, tagsAdded, setTagsAdded );
 
 	// Fetch the prompt by id, if present, otherwise the get the prompt for today.
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/use-prompt-tags.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/use-prompt-tags.js
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 
 // Tries to create a tag or fetch it if it already exists.
@@ -24,8 +24,12 @@ function findOrCreateTag( tagName ) {
 	} );
 }
 
-export function usePromptTags( promptId, tagsAdded, setAttributes ) {
+export function usePromptTags( promptId, tagsAdded, setTagsAdded ) {
 	const { editPost } = useDispatch( 'core/editor' );
+
+	// Track the status of requests to create or fetch tags.
+	// Statuses are 'not-started', 'pending', 'fulfilled', or 'rejected'.
+	const promptTagRequestStatus = useRef( 'not-started' );
 
 	// Get information about tags for the edited post.
 	const { postType, postsSupportTags, tags, tagIds, tagsHaveResolved } = useSelect( select => {
@@ -70,26 +74,47 @@ export function usePromptTags( promptId, tagsAdded, setAttributes ) {
 			return;
 		}
 
-		if ( ! tags.some( tag => tag.name && 'dailyprompt' === tag.name ) ) {
-			findOrCreateTag( 'dailyprompt' ).then( tag => {
-				editPost( { tags: [ ...tagIds, tag.id ] } );
-			} );
-		} else if ( ! tags.some( tag => tag.name && `dailyprompt-${ promptId }` === tag.name ) ) {
-			findOrCreateTag( `dailyprompt-${ promptId }` ).then( tag => {
-				editPost( { tags: [ ...tagIds, tag.id ] } );
-			} );
-		} else {
-			setAttributes( { tagsAdded: true } );
+		// Make sure we only try fetch prompt tag ids one time, even though the hook reruns on every component render.
+		if ( promptTagRequestStatus.current === 'not-started' ) {
+			// Add the prompt tags, if any are missing.
+			if (
+				! tags.some( t => t.name && t.name === 'dailyprompt' ) ||
+				! tags.some( t => t.name && t.name === `dailyprompt-${ promptId }` )
+			) {
+				promptTagRequestStatus.current = 'pending';
+
+				Promise.all( [
+					findOrCreateTag( 'dailyprompt' ),
+					findOrCreateTag( `dailyprompt-${ promptId }` ),
+				] )
+					.then( tagResponses => {
+						const promptTagIds = tagResponses.map( tagResponse => tagResponse.id );
+						editPost( { tags: [ ...tagIds, ...promptTagIds ] } );
+						promptTagRequestStatus.current = 'fulfilled';
+					} )
+					.catch( error => {
+						console.error( error ); // eslint-disable-line no-console
+						promptTagRequestStatus.current = 'rejected';
+					} );
+			} else {
+				// Otherwise mark the tag request as finished.
+				promptTagRequestStatus.current = 'fulfilled';
+			}
+		}
+
+		if ( promptTagRequestStatus.current === 'fulfilled' ) {
+			setTagsAdded( true );
 		}
 	}, [
 		editPost,
-		postType,
 		postsSupportTags,
+		postType,
 		promptId,
-		setAttributes,
-		tagsAdded,
-		tagsHaveResolved,
+		promptTagRequestStatus,
+		setTagsAdded,
 		tags,
 		tagIds,
+		tagsAdded,
+		tagsHaveResolved,
 	] );
 }


### PR DESCRIPTION
## Proposed changes:

Updates the useEffect hooks in the edit function of the Writing Prompt block to
- Not refetch the prompt from `/blogging-prompts/{prompt_id}` after setting today's prompt when inserting the block
- Make sure each prompt tag (`dailyprompt` and `dailyprompt-{prompt_id}`) is only fetched once, even when the component is re-rendered before the tag request completes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pe7F0s-uo-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Set up your wpcom sandbox for testing by applying the patch D102925-code and applying Jepack trunk to your sandbox with `bin/jetpack-downloader test jetpack trunk`.
- Set the JETPACK__SANDBOX_DOMAIN constant to your wpcom sandbox host, using a define statement on your development site, or Settings > Jetpack Constants on your jurassic.ninja site.
- Make sure your site is connected to WP.com (you will need to use local tunneling if using a local dev site PCYsg-GJ2-p2).
- Open the editor and open the network tab of your browser's development tools
- Insert a writing prompt block
- You should see only one request to fetch the prompt (`wpcom/v3/blogging-prompts?after=--03-08&order=desc&_locale=user`) and not a second request for the prompt by id (`wpcom/v3/blogging-prompts/:id`)
- You should only see 2 POST requests to `wp/v2/tags`, one for `dailyprompt` and one for `dailyprompt-{prompt_id}`