### PR TITLE
[AI] Keep the block displayed after saving if not finished

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-paragraph-issue-with-error
+++ b/projects/plugins/jetpack/changelog/fix-ai-paragraph-issue-with-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Handle Ai-paragraph when errored or not filed

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
@@ -7,16 +7,8 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
-	needsMoreCharacters: {
+	wasNotCompletedWhenSaved: {
 		type: 'boolean',
-		default: false,
-	},
-	showRetry: {
-		type: 'boolean',
-		default: false,
-	},
-	errorMessage: {
-		type: 'string',
-		default: '',
+		default: true,
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
@@ -7,4 +7,16 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+	needsMoreCharacters: {
+		type: 'boolean',
+		default: false,
+	},
+	showRetry: {
+		type: 'boolean',
+		default: false,
+	},
+	errorMessage: {
+		type: 'string',
+		default: '',
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/attributes.js
@@ -9,6 +9,6 @@ export default {
 	},
 	wasNotCompletedWhenSaved: {
 		type: 'boolean',
-		default: true,
+		default: false,
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -102,15 +102,24 @@ function ShowLittleByLittle( { html, showAnimation, onAnimationDone } ) {
 export default function Edit( { attributes, setAttributes, clientId } ) {
 	const [ isLoadingCompletion, setIsLoadingCompletion ] = useState( false );
 	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
-	const [ needsMoreCharacters, setNeedsMoreCharacters ] = useState( false );
-	const [ showRetry, setShowRetry ] = useState( false );
-	const [ errorMessage, setErrorMessage ] = useState( false );
+	const [ needsMoreCharacters, setNeedsMoreCharacters ] = useState( attributes.needsMoreCharacters );
+	const [ showRetry, setShowRetry ] = useState( attributes.showRetry );
+	const [ errorMessage, setErrorMessage ] = useState( attributes.errorMessage );
 	const { tracks } = useAnalytics();
 
 	// Let's grab post data so that we can do something smart.
 	const currentPostTitle = useSelect( select =>
 		select( 'core/editor' ).getEditedPostAttribute( 'title' )
 	);
+
+	// We update the attributes as side effect from the state change.
+	useEffect( ()=>{
+		setAttributes( {
+			errorMessage: errorMessage ,
+			needsMoreCharacters: needsMoreCharacters,
+			showRetry: showRetry
+		} );
+	}, [ errorMessage, needsMoreCharacters, showRetry ] );
 
 	let loading = false;
 	const categories =

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -92,6 +92,9 @@ export const settings = {
 	example: {
 		attributes: {
 			animationDone: false,
+			needsMoreCharacters: false,
+			showRetry: false,
+			errorMessage: false,
 			content: __( "I'm afraid I can't do that, Dave.", 'jetpack' ),
 		},
 	},

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -72,6 +72,8 @@ export const settings = {
 	},
 	edit,
 	save: attrs => {
+		attrs.attributes.wasNotCompletedWhenSaved = attrs.attributes.content === '';
+
 		const blockProps = useBlockProps.save();
 		return <RawHTML { ...blockProps }>{ attrs.attributes.content }</RawHTML>;
 	},

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -72,10 +72,11 @@ export const settings = {
 	},
 	edit,
 	save: attrs => {
-		attrs.attributes.wasNotCompletedWhenSaved = attrs.attributes.content === '';
+		const content = attrs.attributes.content;
+		attrs.attributes.wasNotCompletedWhenSaved = !! content;
 
 		const blockProps = useBlockProps.save();
-		return <RawHTML { ...blockProps }>{ attrs.attributes.content }</RawHTML>;
+		return <RawHTML { ...blockProps }>{ content }</RawHTML>;
 	},
 	attributes,
 	transforms: {

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -92,9 +92,7 @@ export const settings = {
 	example: {
 		attributes: {
 			animationDone: false,
-			needsMoreCharacters: false,
-			showRetry: false,
-			errorMessage: false,
+			wasNotCompletedWhenSaved: false,
 			content: __( "I'm afraid I can't do that, Dave.", 'jetpack' ),
 		},
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/29381

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added an attribute `wasNotCompletedWhenSaved` on the block that will prevent the blog to disappear after saving, and can be completed later
* It was made somewhat future-proof (I had an intermediate solution that was quite brittle) 

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
* Sandbox your favorite site to test open AI blocks
* Checkout this branch
* Build this branch locally with `jetpack watch plugins/jetpack`
* Deploy this to your sandbox with you rsync alias `jetpack rsync jetpack YOUR_ALIAS`
* Test to make sure the blocks behaves as usual
_For the following, either use rsync or just modify directly on your sandbox_
* Add this line in `_inc/lib/class-jetpack-ai-helper.php` to make `get_gpt_completion()` return early
```
return new WP_Error( 'dev_mode', __( 'Jetpack AI - testing error.', 'jetpack' ) );
```
* Deploy with `jetpack rsync jetpack YOUR_ALIAS`

Now you should see this behaviour:
* Open a new Open-AI block
* The endpoint should fail with
<img width="200" alt="Screenshot 2023-03-09 at 17 46 13" src="https://user-images.githubusercontent.com/790558/224001265-73ffb7ed-0e01-4656-8640-bb2fe6bc1c61.png">

* Save and reload the page and you should see:
<img width="200" alt="Screenshot 2023-03-09 at 17 46 52" src="https://user-images.githubusercontent.com/790558/224001371-72da4c94-6b3c-4ed5-90a8-22a971639e32.png">

Removing the PHP line should resume normal activity


