### PR TITLE
Default to the default mapCenter defined in settings.js

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-map-block-mapkit-default-latlng
+++ b/projects/plugins/jetpack/changelog/fix-map-block-mapkit-default-latlng
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Support latitude & longitude next to lat/lng

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
@@ -12,10 +12,6 @@ import {
 } from '../../mapkit-utils';
 import { MapkitContext } from '../context';
 
-const DEFAULT_LATITUDE = 37.7577;
-const DEFAULT_LONGITUDE = -122.4376;
-const DEFAULT_CAMERA_DISTANCE = convertZoomLevelToCameraDistance( 13, DEFAULT_LATITUDE );
-
 const useMapkit = () => {
 	return useContext( MapkitContext );
 };
@@ -88,13 +84,12 @@ const useMapkitCenter = ( center, setCenter ) => {
 		if ( ! mapkit || ! map || ! memoizedCenter.current ) {
 			return;
 		}
-		if (
-			typeof memoizedCenter.current.lat === 'undefined' ||
-			typeof memoizedCenter.current.lng === 'undefined'
-		) {
-			map.center = new mapkit.Coordinate( DEFAULT_LATITUDE, DEFAULT_LONGITUDE );
-		} else {
-			map.center = new mapkit.Coordinate( memoizedCenter.current.lat, memoizedCenter.current.lng );
+
+		const lat = memoizedCenter.current?.lat ?? memoizedCenter.current?.latitude;
+		const lng = memoizedCenter.current?.lng ?? memoizedCenter.current?.longitude;
+
+		if ( typeof lat === 'number' && typeof lng === 'number' ) {
+			map.center = new mapkit.Coordinate( lat, lng );
 		}
 	}, [ mapkit, map, memoizedCenter ] );
 
@@ -146,13 +141,15 @@ const useMapkitZoom = ( zoom, setZoom ) => {
 	useEffect( () => {
 		if ( mapkit && map ) {
 			if ( points && points.length <= 1 ) {
+				const defaultCameraDistance = convertZoomLevelToCameraDistance( 13, map.center.latitude );
+
 				if ( zoom ) {
 					const cameraDistance = convertZoomLevelToCameraDistance( zoom, map.center.latitude );
 					if ( cameraDistance !== map.cameraDistance ) {
 						map.cameraDistance = cameraDistance;
 					}
-				} else if ( DEFAULT_CAMERA_DISTANCE !== map.cameraDistance ) {
-					map.cameraDistance = DEFAULT_CAMERA_DISTANCE;
+				} else if ( defaultCameraDistance !== map.cameraDistance ) {
+					map.cameraDistance = defaultCameraDistance;
 				}
 				// Zooming and scrolling are enabled when there are 0 or 1 points.
 				map.isZoomEnabled = true;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74191

## Proposed changes:

The Map component once used an object `{ latitude, longitude } ` to define the mapCenter. Later this changed to `{ lat, lng }`. This PR adds support for both formats, and this allows the mapCenter that's defined inside `settings.js` to be honored.
 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add this PR
2. Add a new post/page
3. Force the loading of Mapkit by entering this in your browser's console & reloading= `document.cookie = "map_provider=mapkit; path=/;";`
4. Add a new Map block. The center should be in San Francisco

<img width="838" alt="CleanShot 2023-03-09 at 14 06 04@2x" src="https://user-images.githubusercontent.com/528287/224032178-d04599b0-6afd-4b97-b9de-8460e02e8f1c.png">

