### PR TITLE
Better handling inbox loading state and empty results

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-inbox-empty-results
+++ b/projects/packages/forms/changelog/fix-forms-inbox-empty-results
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Better handling for loading state and empty results

--- a/projects/packages/forms/src/dashboard/inbox/list.js
+++ b/projects/packages/forms/src/dashboard/inbox/list.js
@@ -26,6 +26,7 @@ const InboxList = ( {
 	responses,
 	setCurrentPage,
 	setCurrentResponseId,
+	loading,
 } ) => {
 	const tableItems = useMemo(
 		() =>
@@ -37,8 +38,23 @@ const InboxList = ( {
 		[ currentResponseId, responses, setCurrentResponseId ]
 	);
 
+	if ( loading ) {
+		return (
+			<Table
+				className="jp-forms__inbox-list"
+				columns={ [ { key: 'empty', label: 'Loading...' } ] }
+				items={ [] }
+			/>
+		);
+	}
 	if ( responses.length === 0 ) {
-		return null;
+		return (
+			<Table
+				className="jp-forms__inbox-list"
+				columns={ [ { key: 'empty', label: 'No results found' } ] }
+				items={ [] }
+			/>
+		);
 	}
 
 	return (

--- a/projects/packages/forms/src/dashboard/inbox/list.js
+++ b/projects/packages/forms/src/dashboard/inbox/list.js
@@ -42,7 +42,7 @@ const InboxList = ( {
 		return (
 			<Table
 				className="jp-forms__inbox-list"
-				columns={ [ { key: 'empty', label: 'Loading...' } ] }
+				columns={ [ { key: 'empty', label: __( 'Loading…', 'jetpack-forms' ) } ] }
 				items={ [] }
 			/>
 		);
@@ -51,7 +51,7 @@ const InboxList = ( {
 		return (
 			<Table
 				className="jp-forms__inbox-list"
-				columns={ [ { key: 'empty', label: 'No results found' } ] }
+				columns={ [ { key: 'empty', label: __( 'No results found', 'jetpack-forms' ) } ] }
 				items={ [] }
 			/>
 		);

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -99,6 +99,7 @@
 
 .jp-forms__inbox-list.jp-forms__table {
 	display: table;
+	min-height: unset;
 
 	@media (max-width: 480px) {
 		border-left-width: 0;

--- a/projects/plugins/jetpack/changelog/fix-forms-inbox-empty-results
+++ b/projects/plugins/jetpack/changelog/fix-forms-inbox-empty-results
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Better handling for loading state and empty results


### PR DESCRIPTION
## Proposed changes:
This PR adds little fixes for better handling loading state of the table and empty results.

<img width="676" alt="image" src="https://user-images.githubusercontent.com/157240/224038446-eeadc433-c9e2-4381-bc17-c602a463dc76.png">

<img width="673" alt="image" src="https://user-images.githubusercontent.com/157240/224038545-f9a17cf2-78b0-4989-a3bb-f8b105fde1bb.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Checkout and watch it load responses to see the "loading" state. Search for something that won't return anything and see the empty results table