### PR TITLE
VideoPress: set video URL based on the video privacy

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-change-link-to-video-when-private
+++ b/projects/packages/videopress/changelog/update-videopress-change-link-to-video-when-private
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: set video video URL based on the video privacy

--- a/projects/packages/videopress/changelog/update-videopress-change-link-to-video-when-private
+++ b/projects/packages/videopress/changelog/update-videopress-change-link-to-video-when-private
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-VideoPress: set video video URL based on the video privacy
+VideoPress: set video URL based on the video privacy

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -184,7 +184,6 @@ const EditVideoDetails = () => {
 		filename,
 		uploadDate,
 		url,
-		videoPressURL,
 		width,
 		height,
 		title,
@@ -193,6 +192,7 @@ const EditVideoDetails = () => {
 		privacySetting,
 		allowDownload,
 		displayEmbed,
+		isPrivate,
 		// Playback Token
 		isFetchingPlaybackToken,
 		// Page State/Actions
@@ -322,9 +322,10 @@ const EditVideoDetails = () => {
 							<VideoDetails
 								filename={ filename ?? '' }
 								uploadDate={ uploadDate ?? '' }
-								src={ videoPressURL ?? '' }
 								shortcode={ shortcode ?? '' }
 								loading={ isFetchingData }
+								guid={ guid }
+								isPrivate={ isPrivate }
 							/>
 							<div className={ styles[ 'side-fields' ] }>
 								{ isFetchingData ? (

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -113,8 +113,6 @@ export default () => {
 
 	const { playbackToken, isFetchingPlaybackToken } = usePlaybackToken( video );
 
-	const videoPressURL = `https://videopress.com/v/${ video?.guid }`;
-
 	const [ libraryAttachment, setLibraryAttachment ] = useState( null );
 	const [ posterImageSource, setPosterImageSource ] = useState<
 		'default' | 'video' | 'upload' | null
@@ -298,7 +296,6 @@ export default () => {
 		...video,
 		...formData, // formData is the local representation of the video
 		filename,
-		videoPressURL,
 		hasChanges,
 		posterImageSource,
 		libraryAttachment,

--- a/projects/packages/videopress/src/client/admin/components/video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details/index.tsx
@@ -4,6 +4,7 @@
 import { Text } from '@automattic/jetpack-components';
 import { gmdateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
+import { getVideoUrlBasedOnPrivacy } from '../../../lib/url';
 /**
  * Internal dependencies
  */
@@ -14,18 +15,25 @@ import { VideoDetailsProps } from './types';
 
 const VideoDetails = ( {
 	filename,
-	src,
 	uploadDate,
 	shortcode,
 	loading = false,
+	guid,
+	isPrivate,
 }: VideoDetailsProps ) => {
 	const formattedDate = uploadDate?.length ? gmdateI18n( 'F j, Y', uploadDate ) : false;
+
+	const videoLinkUrl = getVideoUrlBasedOnPrivacy( guid, isPrivate );
 
 	return (
 		<div className={ styles.details }>
 			<div>
 				<Text variant="body-small">{ __( 'Link to video', 'jetpack-videopress-pkg' ) }</Text>
-				{ loading ? <Placeholder height={ 36 } /> : <ClipboardButtonInput value={ src } /> }
+				{ loading ? (
+					<Placeholder height={ 36 } />
+				) : (
+					<ClipboardButtonInput value={ videoLinkUrl } />
+				) }
 			</div>
 
 			<div>

--- a/projects/packages/videopress/src/client/admin/components/video-details/stories/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details/stories/index.tsx
@@ -16,6 +16,8 @@ const VideoDetailsTemplate: ComponentStory< typeof VideoDetails > = VideoDetails
 
 export const Default = VideoDetailsTemplate.bind( {} );
 Default.args = {
+	guid: 'ezoR6kzb',
 	filename: 'video-thumbnail.png',
 	src: 'https://videos.files.wordpress.com/fx123456B/video-thumbnail.mov',
+	isPrivate: false,
 };

--- a/projects/packages/videopress/src/client/admin/components/video-details/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-details/types.ts
@@ -1,4 +1,11 @@
+import type { VideoGUID } from '../../../block-editor/blocks/video/types';
+
 export type VideoDetailsProps = {
+	/**
+	 * VideoPress GUID.
+	 */
+	guid?: VideoGUID;
+
 	/**
 	 * Video filename.
 	 */
@@ -7,7 +14,7 @@ export type VideoDetailsProps = {
 	/**
 	 * Video source file URL.
 	 */
-	src: string;
+	src?: string;
 
 	/**
 	 * VideoPress embed shortcode.
@@ -23,4 +30,6 @@ export type VideoDetailsProps = {
 	 * Loading mode
 	 */
 	loading?: boolean;
+
+	isPrivate?: boolean;
 };

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -141,3 +141,19 @@ export function buildVideoPressURL(
 export const removeFileNameExtension = ( name: string ) => {
 	return name.replace( /\.[^/.]+$/, '' );
 };
+
+/**
+ * Return the VideoPress video URL
+ * based on the privacy of the video.
+ *
+ * @param {VideoGUID} guid    - The VideoPress GUID.
+ * @param {boolean} isPrivate - Whether the video is private or not.
+ * @returns {string}            VideoPress URL.
+ */
+export function getVideoUrlBasedOnPrivacy( guid: VideoGUID, isPrivate: boolean ) {
+	if ( isPrivate ) {
+		return `https://video.wordpress.com/v/${ guid }`;
+	}
+
+	return `https://videopress.com/v/${ guid }`;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR switches the video URL exposed in the Video detail page based on its privacy:

* Public video: `https://videopress.com/v/<guid>`
* Private video: `https://video.wordpress.com/v/<guid>`

Follow-up of https://github.com/Automattic/jetpack/pull/29370

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: set video URL based on the video privacy

### Other information:

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test with Storybook

* Run storybook
* Test how the URL change based on the video privacy

https://user-images.githubusercontent.com/77539/224050677-d9aef878-43fe-428d-9310-50c5df873a6a.mov

### Test with the dashboard

* Go to the Video detail page
* Confirm that the URL changes correctly depending on the video's privacy.

<img width="729" alt="Screen Shot 2023-03-09 at 11 14 00" src="https://user-images.githubusercontent.com/77539/224051769-53e42ed2-e540-49b5-876f-9483b44bed90.png">
