### PR TITLE
Forms: avoid fatals when submitting forms with new package

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-namespace-package
+++ b/projects/packages/forms/changelog/fix-contact-form-namespace-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid Fatal errors by calling method from the right class in the paackage.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -770,7 +770,7 @@ class Contact_Form_Plugin {
 			// end of copy-pasta from wp-includes/template-loader.php.
 
 			// Ensure 'block_template' attribute is added to any shortcodes in the template.
-			$template = grunion_contact_form_set_block_template_attribute( $template );
+			$template = Util::grunion_contact_form_set_block_template_attribute( $template );
 
 			// Process the block template to populate Grunion_Contact_Form::$last
 			get_the_block_template_html();


### PR DESCRIPTION
Follow-up from #28574

## Proposed changes:

When we copied files to the package, we introduced the Util class, but were still calling the `grunion_contact_form_set_block_template_attribute` from Jetpack itself, while it may not always be available.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Start by enabling the contact form from the package:
`add_filter( 'jetpack_contact_form_use_package', '__return_true' );`

1. Go to Jetpack > Settings and enable the contact form feature.
2. Go to Appearance > Themes and ensure you use a block theme like Twenty Twenty Three.
3. Go to Appearance > Site editor and add a form to a template on your site; you could add a simple form to the footer for example.
4. Save your changes
5. Access your site and try to submit data in that form.
6. The form should get submitted without any fatal errors.

