### PR TITLE
Blogging Prompts: avoid PHP notices when hitting API endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -299,16 +299,14 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 			),
 		);
 
-		$args['categories']         = $parent_args['categories'];
-		$args['categories_exclude'] = $parent_args['categories_exclude'];
-		$args['exclude']            = $parent_args['exclude'];
-		$args['include']            = $parent_args['include'];
-		$args['page']               = $parent_args['page'];
-		$args['per_page']           = $parent_args['per_page'];
-		$args['order']              = $parent_args['order'];
-		$args['order']['default']   = 'asc';
-		$args['orderby']            = $parent_args['orderby'];
-		$args['search']             = $parent_args['search'];
+		$args['exclude']          = $parent_args['exclude'];
+		$args['include']          = $parent_args['include'];
+		$args['page']             = $parent_args['page'];
+		$args['per_page']         = $parent_args['per_page'];
+		$args['order']            = $parent_args['order'];
+		$args['order']['default'] = 'asc';
+		$args['orderby']          = $parent_args['orderby'];
+		$args['search']           = $parent_args['search'];
 
 		return $args;
 	}

--- a/projects/plugins/jetpack/changelog/fix-notices-blogging-prompt
+++ b/projects/plugins/jetpack/changelog/fix-notices-blogging-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blogging Prompts: avoid PHP notices with non-existing REST query paarameters.


### PR DESCRIPTION
Follow-up from #29182

## Proposed changes:

The `categories` and `categories_exclude` query parameters do not seem to be used when we query our endpoint, and they do not seem to exist in Core:
https://github.com/WordPress/WordPress/blob/338b45ddba73c34ab1a80c8910e5a8d66fdd8df2/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L2767

As a result, we're seeing a lot of PHP notices since we've added the endpoint:

```
E_NOTICE: Undefined index: categories in /public_html/wp-content/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php:302
E_NOTICE: Undefined index: categories_exclude in /public_html/wp-content/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php:303
```

This should help.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* PT: pe7F0s-uo-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Try the instructions in #29349. The prompt should continue to work just like before.
