### PR TITLE
Geocode the address attribute if it's present

### DIFF
--- a/projects/plugins/jetpack/changelog/add-map-block-mapkit-address-attribute
+++ b/projects/plugins/jetpack/changelog/add-map-block-mapkit-address-attribute
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Mapkit support for the address attribute

--- a/projects/plugins/jetpack/extensions/blocks/map/component/mapbox.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/component/mapbox.js
@@ -382,6 +382,7 @@ MapBoxComponent.defaultProps = {
 	markerColor: 'red',
 	apiKey: null,
 	mapCenter: {},
+	address: null,
 };
 
 export default MapBoxComponent;

--- a/projects/plugins/jetpack/extensions/blocks/map/component/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/component/mapkit.js
@@ -11,6 +11,7 @@ import {
 	useMapkitOnMapTap,
 	useMapkitZoom,
 	useMapkitPoints,
+	useMapkitAddressLookup,
 } from '../mapkit/hooks';
 import { createCalloutElementCallback } from '../mapkit-utils';
 import InfoWindow from './info-window';
@@ -53,11 +54,13 @@ const MapkitComponent = forwardRef( ( props, mapRef ) => {
 
 const MapkitHelpers = memo(
 	( {
+		address,
 		mapCenter,
 		mapStyle,
 		zoom,
 		onSetMapCenter,
 		onSetZoom,
+		onSetPoints,
 		points,
 		markerColor,
 		onMarkerClick,
@@ -73,6 +76,7 @@ const MapkitHelpers = memo(
 		} = useMapkit();
 		// Save these in a ref to prevent unwanted rerenders
 		const onMarkerClickRef = useRef( onMarkerClick );
+		const onSetPointsRef = useRef( onSetPoints );
 
 		const onSelect = useCallback(
 			marker => {
@@ -104,6 +108,8 @@ const MapkitHelpers = memo(
 				map.setCenterAnimated( previousCenter );
 			}
 		} );
+
+		useMapkitAddressLookup( address, onSetPointsRef );
 		return null;
 	}
 );
@@ -119,6 +125,7 @@ MapkitComponent.defaultProps = {
 	onError: () => {},
 	markerColor: 'red',
 	mapCenter: {},
+	address: null,
 };
 
 export default MapkitComponent;

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.js
@@ -232,6 +232,7 @@ class MapEdit extends Component {
 			onResizeStart,
 		} = this.props;
 		const {
+			address,
 			mapDetails,
 			points,
 			zoom,
@@ -350,6 +351,7 @@ class MapEdit extends Component {
 						<div className="wp-block-jetpack-map__map_wrapper">
 							<Map
 								ref={ this.mapRef }
+								address={ address }
 								scrollToZoom={ allowScrollToZoom }
 								showFullscreenButton={ showFullscreenButton }
 								mapStyle={ mapStyle || 'default' }

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
@@ -235,6 +235,37 @@ const useMapkitOnMapTap = onMapTap => {
 	}, [ loaded, map, previousCenter, onMapTapRef ] );
 };
 
+const useMapkitAddressLookup = ( address, onSetPointsRef ) => {
+	const { mapkit, map } = useMapkit();
+
+	useEffect( () => {
+		if ( mapkit && map && address?.length ) {
+			const geocoder = new mapkit.Geocoder();
+			geocoder.lookup( address, ( error, data ) => {
+				if ( data?.results?.length ) {
+					const place = data.results[ 0 ];
+					const title = place.formattedAddress;
+					const point = {
+						placeTitle: title,
+						title: title,
+						caption: title,
+						coordinates: {
+							longitude: place.coordinate.longitude,
+							latitude: place.coordinate.latitude,
+						},
+						// mapkit doesn't give us an id, so we'll make one containing the place name and coordinates
+						id: `${ title } ${ Number( place.coordinate.latitude ).toFixed( 2 ) } ${ Number(
+							place.coordinate.longitude
+						).toFixed( 2 ) }`,
+					};
+
+					onSetPointsRef.current( [ point ] );
+				}
+			} );
+		}
+	}, [ mapkit, map, address, onSetPointsRef ] );
+};
+
 export {
 	useMapkit,
 	useMapkitSetup,
@@ -245,4 +276,5 @@ export {
 	useMapkitPoints,
 	useMapkitOnMapLoad,
 	useMapkitOnMapTap,
+	useMapkitAddressLookup,
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74281

## Proposed changes:
In an old version of the Map block, there was support for having an address attribute. Having this would geocode this address and place a point on the map. This would only happen in the editor.

This PR adds support for this old behavior. 

There's a pitfall. You can delete the point, but the next time you edit the page again it will reappear. This seems to be the behavior that's also present in Mapbox. I'm leaving it as is, because this attribute has been deprecated and a workaround would take some time.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Apply this PR
2. Add a new page or post
3. Make sure Mapkit is forced by setting the cookie and reloading: `document.cookie = "map_provider=mapkit; path=/;"`
4. Switch to code editor and add this code. Note the address.
5. It should add a marker in Brussels

```
<!-- wp:jetpack/map {"address": "Brussels, Belgium", "mapCenter":{"lat":37.7577,"lng":-122.43759999999999}} -->
<div class="wp-block-jetpack-map" data-map-style="default" data-map-details="true" data-points="[]" data-zoom="13" data-map-center="{&quot;lat&quot;:37.7577,&quot;lng&quot;:-122.43759999999999}" data-marker-color="red" data-show-fullscreen-button="true"></div>
<!-- /wp:jetpack/map -->
```

<img width="763" alt="CleanShot 2023-03-09 at 16 45 19@2x" src="https://user-images.githubusercontent.com/528287/224076912-fc2123ba-fe53-4615-be44-e2132ae646a2.png">
