### PR TITLE
Jetpack-mu-wpcom: Check if function exists before loading endpoints

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-defensive-loader-function
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-defensive-loader-function
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check for existence of wpcom_rest_api_v2_load_plugin function before loading wpcom endpoints.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "1.1.0",
+	"version": "1.1.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -70,6 +70,10 @@ class Jetpack_Mu_Wpcom {
 	 * Load WP REST API plugins for wpcom
 	 */
 	public static function load_wpcom_rest_api_endpoints() {
+
+		if ( ! function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
+			return;
+		}
 		// We don't use `wpcom_rest_api_v2_load_plugin_files` because it operates inconsisently.
 		$plugins = glob( __DIR__ . '/features/wpcom-endpoints/*.php' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -70,10 +70,10 @@ class Jetpack_Mu_Wpcom {
 	 * Load WP REST API plugins for wpcom
 	 */
 	public static function load_wpcom_rest_api_endpoints() {
-
 		if ( ! function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
 			return;
 		}
+
 		// We don't use `wpcom_rest_api_v2_load_plugin_files` because it operates inconsisently.
 		$plugins = glob( __DIR__ . '/features/wpcom-endpoints/*.php' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '1.1.0';
+	const PACKAGE_VERSION = '1.1.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add some defensiveness to check if a function we need exists before loading the wpcom endpoints.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1678381106882829/1678374795.923169-slack-C01U2KGS2PQ
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Dunno, see if the CI checks on wpcomsh pass when we do a release?