### PR TITLE
Blocks: introduce new way to declare custom descriptions for blocks.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-block-descriptions
+++ b/projects/plugins/jetpack/changelog/update-block-descriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: allow passing a custom description when registering a block, to display a custom description below the default one.

--- a/projects/plugins/jetpack/extensions/blocks/ai-image/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-image/editor.js
@@ -1,4 +1,4 @@
 import registerJetpackBlock from '../../shared/register-jetpack-block';
-import { name, settings } from '.';
+import { name, settings, customDescription } from '.';
 
-registerJetpackBlock( name, settings );
+registerJetpackBlock( name, settings, [], true, customDescription );

--- a/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
@@ -1,6 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
@@ -16,24 +15,9 @@ export const title = __( 'AI Image (Experimental)', 'jetpack' );
 export const settings = {
 	apiVersion: 2,
 	title,
-	description: (
-		<Fragment>
-			<p>
-				{ __(
-					'Automatically generate an illustration for your post, powered by AI magic.',
-					'jetpack'
-				) }
-			</p>
-			<p>
-				{ __(
-					'We are experimenting with this feature and can tweak or remove it at any point.',
-					'jetpack'
-				) }
-			</p>
-			<ExternalLink href={ getRedirectUrl( 'jetpack_ai_feedback' ) }>
-				{ __( 'Share your feedback.', 'jetpack' ) }
-			</ExternalLink>
-		</Fragment>
+	description: __(
+		'Automatically generate an illustration for your post, powered by AI magic.',
+		'jetpack'
 	),
 	icon: {
 		src: 'superhero',
@@ -79,3 +63,17 @@ export const settings = {
 		},
 	},
 };
+
+export const customDescription = (
+	<>
+		<p>
+			{ __(
+				'We are experimenting with this feature and can tweak or remove it at any point.',
+				'jetpack'
+			) }
+		</p>
+		<ExternalLink href={ getRedirectUrl( 'jetpack_ai_feedback' ) }>
+			{ __( 'Share your feedback.', 'jetpack' ) }
+		</ExternalLink>
+	</>
+);

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/editor.js
@@ -1,4 +1,4 @@
 import registerJetpackBlock from '../../shared/register-jetpack-block';
-import { name, settings } from '.';
+import { name, settings, customDescription } from '.';
 
-registerJetpackBlock( name, settings );
+registerJetpackBlock( name, settings, [], true, customDescription );

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/index.js
@@ -1,6 +1,5 @@
 import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { ExternalLink, Path, SVG } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import { DEFAULT_CURRENCY } from './constants';
@@ -28,22 +27,10 @@ const supportLink =
 
 export const settings = {
 	title: __( 'Pay with PayPal', 'jetpack' ),
-
-	description: (
-		<Fragment>
-			<p>
-				{ __(
-					'Lets you add credit and debit card payment buttons with minimal setup.',
-					'jetpack'
-				) }
-			</p>
-			<p>
-				{ __( 'Good for collecting donations or payments for products and services.', 'jetpack' ) }
-			</p>
-			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
-		</Fragment>
+	description: __(
+		'Lets you add credit and debit card payment buttons with minimal setup.',
+		'jetpack'
 	),
-
 	icon: {
 		src: icon,
 		foreground: getIconColor(),
@@ -184,3 +171,12 @@ export const settings = {
 
 	deprecated: [ deprecatedV1, deprecatedV2 ],
 };
+
+export const customDescription = (
+	<>
+		<p>
+			{ __( 'Good for collecting donations or payments for products and services.', 'jetpack' ) }
+		</p>
+		<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
+	</>
+);


### PR DESCRIPTION
Fixes #26792

## Proposed changess

> **Warning**
> This is just a POC. It's not perfect, and has issues as I discussed here: https://github.com/Automattic/jetpack/issues/26792#issuecomment-1462590616
> Ideally we should find a better solution.

This PR introduces a new custom description parameter we can pass when registering a Jetpack block. If we pass such a parameter, a new panel is created in the block sidebar to display the custom description.

![](https://user-images.githubusercontent.com/426388/224124324-b364cbe3-0044-4c90-a27c-f9f665351242.png)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See #26792
See #27795

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Check out this branch on a site running WP 6.2 Beta.
* See that the block descriptions for the blocks modified in this PR are still appearing in the sidebar.

