### PR TITLE
VideoPress: Add download button to video details page

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-dashboard-download
+++ b/projects/packages/videopress/changelog/add-videopress-dashboard-download
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add download button to video details page

--- a/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
@@ -4,7 +4,7 @@
 import { Button } from '@automattic/jetpack-components';
 import { Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { moreVertical, media, trash } from '@wordpress/icons';
+import { moreVertical, media, trash, download } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useCallback, useState } from 'react';
 /**
@@ -26,7 +26,7 @@ const VideoDetailsActions = ( {
 	const [ showDeleteModal, setShowDeleteModal ] = useState( false );
 
 	const {
-		data: { guid },
+		data: { guid, url },
 		deleteVideo,
 	} = useVideo( videoId );
 
@@ -69,6 +69,18 @@ const VideoDetailsActions = ( {
 							onClick={ onClose }
 						>
 							{ __( 'Add to new post', 'jetpack-videopress-pkg' ) }
+						</Button>
+						<Button
+							weight="regular"
+							fullWidth
+							variant="tertiary"
+							icon={ download }
+							href={ url }
+							target="_blank"
+							disabled={ disabled }
+							onClick={ onClose }
+						>
+							{ __( 'Download file', 'jetpack-videopress-pkg' ) }
 						</Button>
 						<hr className={ styles.separator } />
 						<Button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29400

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a download button to the actions dropdown menu in the video details page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the video details page of any video in the VideoPress dashboard
* At the top right corner, click on the actions menu
* Check that there is a download button
* Click the download button
* Check that another tab opens with the downloadable video

![2023-03-09_16-38-29](https://user-images.githubusercontent.com/8486249/224135825-4c35b538-ea86-4e9b-ae7a-00cc0050b037.png)
