### PR TITLE
VideoPress: Move privacy properties from media_details to jetpack_videopress field on media endpoint response

### DIFF
--- a/projects/packages/videopress/changelog/update-move-properties-to-videopress-field-on-media-response
+++ b/projects/packages/videopress/changelog/update-move-properties-to-videopress-field-on-media-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Move is_private and private_enabled_for_site fields to the jetpack_videopress property on the media endpoint response.

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -334,12 +334,12 @@ class Data {
 				$display_embed        = $jetpack_videopress['display_embed'];
 				$privacy_setting      = $jetpack_videopress['privacy_setting'];
 				$needs_playback_token = $jetpack_videopress['needs_playback_token'];
+				$is_private           = $jetpack_videopress['is_private'];
 
 				$original      = $videopress_media_details['original'];
 				$poster        = ( ! $needs_playback_token ) ? $videopress_media_details['poster'] : null;
 				$upload_date   = $videopress_media_details['upload_date'];
 				$duration      = $videopress_media_details['duration'];
-				$is_private    = $videopress_media_details['is_private'];
 				$file_url_base = $videopress_media_details['file_url_base'];
 				$finished      = $videopress_media_details['finished'];
 				$files         = $videopress_media_details['files'];

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -222,11 +222,11 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 			$caption     = $info->caption;
 		}
 
-		$video_privacy_setting          = ! isset( $info->privacy_setting ) ? \VIDEOPRESS_PRIVACY::SITE_DEFAULT : intval( $info->privacy_setting );
-		$all_videos_are_private_on_site = Data::get_videopress_videos_private_for_site();
+		$video_privacy_setting    = ! isset( $info->privacy_setting ) ? \VIDEOPRESS_PRIVACY::SITE_DEFAULT : intval( $info->privacy_setting );
+		$private_enabled_for_site = Data::get_videopress_videos_private_for_site();
 
 		// decide if the video needs a playback token based on the site privacy setting as well as the video privacy setting
-		$video_needs_playback_token = $all_videos_are_private_on_site ? true : ( $video_privacy_setting === \VIDEOPRESS_PRIVACY::IS_PRIVATE );
+		$video_needs_playback_token = $private_enabled_for_site ? true : ( $video_privacy_setting === \VIDEOPRESS_PRIVACY::IS_PRIVATE );
 
 		return array(
 			'title'                    => $title,
@@ -240,8 +240,8 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 				isset( $info->display_embed ) && $info->display_embed ? 1 : 0,
 			'privacy_setting'          => $video_privacy_setting,
 			'needs_playback_token'     => $video_needs_playback_token,
-			'is_private'               => $this->is_video_private( $video_privacy_setting, Data::get_videopress_videos_private_for_site() ),
-			'private_enabled_for_site' => Data::get_videopress_videos_private_for_site(),
+			'is_private'               => $this->is_video_private( $video_privacy_setting, $private_enabled_for_site ),
+			'private_enabled_for_site' => $private_enabled_for_site,
 		);
 	}
 

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -224,9 +224,10 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 
 		$video_privacy_setting    = ! isset( $info->privacy_setting ) ? \VIDEOPRESS_PRIVACY::SITE_DEFAULT : intval( $info->privacy_setting );
 		$private_enabled_for_site = Data::get_videopress_videos_private_for_site();
+		$is_private               = $this->video_is_private( $video_privacy_setting, $private_enabled_for_site );
 
-		// decide if the video needs a playback token based on the site privacy setting as well as the video privacy setting
-		$video_needs_playback_token = $private_enabled_for_site ? true : ( $video_privacy_setting === \VIDEOPRESS_PRIVACY::IS_PRIVATE );
+		// The video needs a playback token if it's private for any reason (video privacy setting or site default privacy setting)
+		$video_needs_playback_token = $is_private;
 
 		return array(
 			'title'                    => $title,
@@ -240,7 +241,7 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 				isset( $info->display_embed ) && $info->display_embed ? 1 : 0,
 			'privacy_setting'          => $video_privacy_setting,
 			'needs_playback_token'     => $video_needs_playback_token,
-			'is_private'               => $this->video_is_private( $video_privacy_setting, $private_enabled_for_site ),
+			'is_private'               => $is_private,
 			'private_enabled_for_site' => $private_enabled_for_site,
 		);
 	}

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -229,17 +229,19 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 		$video_needs_playback_token = $all_videos_are_private_on_site ? true : ( $video_privacy_setting === \VIDEOPRESS_PRIVACY::IS_PRIVATE );
 
 		return array(
-			'title'                => $title,
-			'description'          => $description,
-			'caption'              => $caption,
-			'guid'                 => $info->guid,
-			'rating'               => $info->rating,
-			'allow_download'       =>
+			'title'                    => $title,
+			'description'              => $description,
+			'caption'                  => $caption,
+			'guid'                     => $info->guid,
+			'rating'                   => $info->rating,
+			'allow_download'           =>
 				isset( $info->allow_download ) && $info->allow_download ? 1 : 0,
-			'display_embed'        =>
+			'display_embed'            =>
 				isset( $info->display_embed ) && $info->display_embed ? 1 : 0,
-			'privacy_setting'      => $video_privacy_setting,
-			'needs_playback_token' => $video_needs_playback_token,
+			'privacy_setting'          => $video_privacy_setting,
+			'needs_playback_token'     => $video_needs_playback_token,
+			'is_private'               => $this->is_video_private( $video_privacy_setting, Data::get_videopress_videos_private_for_site() ),
+			'private_enabled_for_site' => Data::get_videopress_videos_private_for_site(),
 		);
 	}
 
@@ -269,6 +271,26 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Determines if a video is private based on the video privacy
+	 * setting and the site default privacy setting.
+	 *
+	 * @param int  $video_privacy_setting The privacy setting for the video.
+	 * @param bool $private_enabled_for_site Flag stating if the default video privacy is private.
+	 *
+	 * @return bool
+	 */
+	private function is_video_private( $video_privacy_setting, $private_enabled_for_site ) {
+		if ( $video_privacy_setting === \VIDEOPRESS_PRIVACY::IS_PUBLIC ) {
+			return false;
+		}
+		if ( $video_privacy_setting === \VIDEOPRESS_PRIVACY::IS_PRIVATE ) {
+			return true;
+		}
+
+		return $private_enabled_for_site;
 	}
 }
 

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -240,7 +240,7 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 				isset( $info->display_embed ) && $info->display_embed ? 1 : 0,
 			'privacy_setting'          => $video_privacy_setting,
 			'needs_playback_token'     => $video_needs_playback_token,
-			'is_private'               => $this->is_video_private( $video_privacy_setting, $private_enabled_for_site ),
+			'is_private'               => $this->video_is_private( $video_privacy_setting, $private_enabled_for_site ),
 			'private_enabled_for_site' => $private_enabled_for_site,
 		);
 	}
@@ -282,7 +282,7 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 	 *
 	 * @return bool
 	 */
-	private function is_video_private( $video_privacy_setting, $private_enabled_for_site ) {
+	private function video_is_private( $video_privacy_setting, $private_enabled_for_site ) {
 		if ( $video_privacy_setting === \VIDEOPRESS_PRIVACY::IS_PUBLIC ) {
 			return false;
 		}

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -119,6 +119,15 @@ export type OriginalVideoPressVideo = {
 		 * VideoPress site privacy setting into account.
 		 */
 		needs_playback_token?: boolean;
+		/**
+		 * If the video is private, considering the video and the site
+		 * privacy settings.
+		 */
+		is_private?: boolean;
+		/**
+		 * If the site video default privacy setting is private.
+		 */
+		private_enabled_for_site?: boolean;
 	};
 	/**
 	 * Video source URL
@@ -145,7 +154,7 @@ export type VideoPressVideo = {
 	url: OriginalVideoPressVideo[ 'media_details' ][ 'videopress' ][ 'original' ];
 	uploadDate: OriginalVideoPressVideo[ 'media_details' ][ 'videopress' ][ 'upload_date' ];
 	duration: OriginalVideoPressVideo[ 'media_details' ][ 'videopress' ][ 'duration' ];
-	isPrivate?: OriginalVideoPressVideo[ 'media_details' ][ 'videopress' ][ 'is_private' ];
+	isPrivate?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'is_private' ];
 	posterImage?: OriginalVideoPressVideo[ 'media_details' ][ 'videopress' ][ 'poster' ];
 	allowDownload?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'allow_download' ];
 	displayEmbed?: OriginalVideoPressVideo[ 'jetpack_videopress' ][ 'display_embed' ];

--- a/projects/packages/videopress/src/client/state/utils/map-videos.ts
+++ b/projects/packages/videopress/src/client/state/utils/map-videos.ts
@@ -25,6 +25,7 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		display_embed: displayEmbed,
 		privacy_setting: privacySetting,
 		needs_playback_token: needsPlaybackToken,
+		is_private: isPrivate,
 	} = jetpackVideoPress;
 
 	const {
@@ -32,7 +33,6 @@ export const mapVideoFromWPV2MediaEndpoint = (
 		poster,
 		upload_date: uploadDate,
 		duration,
-		is_private: isPrivate,
 		file_url_base: fileURLBase,
 		finished,
 		files = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29388.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves the `is_private` and `private_enabled_for_site` fields from `media_details` (where they are just read from the post meta) to `jetpack_videopress` (where we can calculate them)
* Updates the code that uses the `wp/v2/media` endpoint to look for these fields on the new location
* Fixes the `needs_playback_token` flag logic; it considered that all videos were private on a site with "private" as the default privacy setting, which is wrong

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on Jetpack and WoA sites
* Make sure you have at least one video uploaded to your test site
* Click on the "Edit video details" button for the video
* On the new page, get 2 pieces of information for your video
   * The attachment ID (media ID) for your video
   * The video GUID (VideoPress GUID) for your video

<img width="800" alt="Screen Shot 2023-03-09 at 17 46 05" src="https://user-images.githubusercontent.com/6760046/224153847-68f82de7-f32d-4c97-8a1f-bbdd215ac803.png">

### Testing the API response

* Open the [WordPress API Console](https://developer.wordpress.com/docs/api/console/); we are going to make two API requests to compare the results of both
* Do a GET request to the `WP REST API` `wp/v2` `/sites/your-test-site.com/media/ID` endpoint; use your test site and media ID on the request:

<img width="500" alt="Screen Shot 2023-03-09 at 17 51 21" src="https://user-images.githubusercontent.com/6760046/224155249-ce059fca-20ac-41a9-a6d9-7eb76c51f871.png">

* This is the "local" media endpoint for your site and is the endpoint we are fixing on this PR; note that the result now contains two new fields under the `jetpack_videopress` property that were not there before (`is_private` and `private_enabled_for_site`); notice the value for these fields

* Do a GET request to the `WP.COM API` `v1.1` `/videos/GUID` endpoint; use the VideoPress GUID on the request; we are not changing the code for it, so there is not need to apply this change to your sandbox and no need to sandbox the request;

<img width="400" alt="Screen Shot 2023-03-09 at 17 55 32" src="https://user-images.githubusercontent.com/6760046/224155766-45a5aeb4-3348-4c7e-8a82-a1d9b2d31cfb.png">

* Look for the `is_private` and `private_enabled_for_site` fields; notice the value for theses fields
* Compare the values for `is_private` and `private_enabled_for_site` on the first and second requests; they should be the same no matter the video privacy settings and the site default video privacy setting; to make sure, play with the value of the privacy of the video and the site

### Testing the initial state and client request results

* Go back to the VideoPress dashboard and click the "Edit video details" button again
* Open up the developer console on the browser and inspect the value of the `jetpackVideoPressInitialState.initialState.videos.items` variable
* Pick one video from the list to test using the `WP.COM API` `v1.1` `/videos/GUID` endpoint; the `is_private` field returned on the endpoint response needs to have the same value of `isPrivate` on the variable ispected on the console:

<img width="300" alt="Screen Shot 2023-03-09 at 18 08 27" src="https://user-images.githubusercontent.com/6760046/224158606-01357267-765a-4aad-bb90-e8778693aff9.png">

<img width="300" alt="Screen Shot 2023-03-09 at 18 09 29" src="https://user-images.githubusercontent.com/6760046/224158622-e9f79abb-103b-473a-a648-b8065bf9d780.png">

* Do the same thing on for the Redux state on the browser; inspect the state for the `videopress/media` store, looking for the `root.videos.items` variable; the `isPrivate` property on any of the videos should have the same value returned on a `WP.COM API` `v1.1` `/videos/GUID` request for the video:

<img width="300" alt="Screen Shot 2023-03-09 at 18 13 16" src="https://user-images.githubusercontent.com/6760046/224160672-81462881-c7b6-454c-9c14-cecd6c308e7e.png">
 