### PR TITLE
Change forms inbox default responses per page

### DIFF
--- a/projects/packages/forms/changelog/change-forms-inbox-max-responses
+++ b/projects/packages/forms/changelog/change-forms-inbox-max-responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Change default entries per page on responses inbox

--- a/projects/packages/forms/src/dashboard/inbox/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/index.js
@@ -12,7 +12,7 @@ import InboxList from './list';
 import InboxResponse from './response';
 import './style.scss';
 
-const RESPONSES_FETCH_LIMIT = 20;
+const RESPONSES_FETCH_LIMIT = 10;
 
 const Inbox = () => {
 	const [ currentResponseId, setCurrentResponseId ] = useState( -1 );

--- a/projects/plugins/jetpack/changelog/change-forms-inbox-max-responses
+++ b/projects/plugins/jetpack/changelog/change-forms-inbox-max-responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Change default entries per page on responses inbox


### PR DESCRIPTION

## Proposed changes:
Minor/wee change: this PR changes the default number of responses per page (hence how many we fetch from backend) from 20 to 10

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Well, checkout and see how many responses you get to see per page at /wp-admin/admin.php?page=jetpack-forms