### PR TITLE
Search: Fix returning URL when site has valid purchase

### DIFF
--- a/projects/packages/search/changelog/fix-redirection-when-site-has-valid-purchase
+++ b/projects/packages/search/changelog/fix-redirection-when-site-has-valid-purchase
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Dashboard: fix wrong return URL when site already has a valid subscription

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.33.2",
+	"version": "0.33.3-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.33.2';
+	const VERSION = '0.33.3-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -63,7 +63,7 @@ export default function SearchModuleControl( {
 } ) {
 	const adminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl(), [] );
 	const { isUserConnected } = useConnection( {
-		redirectUri: `${ adminUrl }admin.php?page=jetpack-search`,
+		redirectUri: `admin.php?page=jetpack-search`,
 		from: 'jetpack-search',
 	} );
 	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -63,7 +63,7 @@ export default function SearchModuleControl( {
 } ) {
 	const adminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl(), [] );
 	const { isUserConnected } = useConnection( {
-		redirectUri: `admin.php?page=jetpack-search`,
+		redirectUri: 'admin.php?page=jetpack-search',
 		from: 'jetpack-search',
 	} );
 	const isWpcom = useSelect( select => select( STORE_ID ).isWpcom(), [] );

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
@@ -56,7 +56,8 @@ export default function UpsellPage( { isLoading = false } ) {
 		hasCheckoutStarted: hasCheckoutStartedPaid,
 	} = useProductCheckoutWorkflow( {
 		productSlug: 'jetpack_search',
-		redirectUrl: `${ adminUrl }admin.php?page=jetpack-search&just_upgraded=1`,
+		adminUrl,
+		redirectUri: `admin.php?page=jetpack-search&just_upgraded=1`,
 		siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 		from: 'jetpack-search',
 		siteSuffix: domain,
@@ -68,7 +69,8 @@ export default function UpsellPage( { isLoading = false } ) {
 		hasCheckoutStarted: hasCheckoutStartedFree,
 	} = useProductCheckoutWorkflow( {
 		productSlug: 'jetpack_search_free',
-		redirectUrl: `${ adminUrl }admin.php?page=jetpack-search`,
+		adminUrl,
+		redirectUri: `admin.php?page=jetpack-search`,
 		siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 		from: 'jetpack-search',
 		siteSuffix: domain,

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page.jsx
@@ -57,7 +57,7 @@ export default function UpsellPage( { isLoading = false } ) {
 	} = useProductCheckoutWorkflow( {
 		productSlug: 'jetpack_search',
 		adminUrl,
-		redirectUri: `admin.php?page=jetpack-search&just_upgraded=1`,
+		redirectUri: 'admin.php?page=jetpack-search&just_upgraded=1',
 		siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 		from: 'jetpack-search',
 		siteSuffix: domain,
@@ -70,7 +70,7 @@ export default function UpsellPage( { isLoading = false } ) {
 	} = useProductCheckoutWorkflow( {
 		productSlug: 'jetpack_search_free',
 		adminUrl,
-		redirectUri: `admin.php?page=jetpack-search`,
+		redirectUri: 'admin.php?page=jetpack-search',
 		siteProductAvailabilityHandler: checkSiteHasSearchProduct,
 		from: 'jetpack-search',
 		siteSuffix: domain,

--- a/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
+++ b/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
@@ -19,7 +19,8 @@ const {
  *
  * @param {object} props              - The props passed to the hook.
  * @param {string} props.productSlug  - The WordPress product slug.
- * @param {string} props.redirectUrl  - The URI to redirect to after checkout.
+ * @param {string} props.adminUrl     - The base URL of WP-Admin.
+ * @param {string} props.redirectUri  - The URI to redirect to after checkout.
  * @param {string} [props.siteSuffix] - The site suffix.
  * @param {Function} props.siteProductAvailabilityHandler - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
  * @param {Function} props.from       - The plugin slug initiated the flow.
@@ -28,7 +29,8 @@ const {
  */
 export default function useProductCheckoutWorkflow( {
 	productSlug,
-	redirectUrl,
+	adminUrl,
+	redirectUri,
 	siteSuffix = defaultSiteSuffix,
 	siteProductAvailabilityHandler = null,
 	from,
@@ -38,7 +40,7 @@ export default function useProductCheckoutWorkflow( {
 	const { registerSite } = useDispatch( CONNECTION_STORE_ID );
 
 	const { isUserConnected, isRegistered, handleConnectUser } = useConnection( {
-		redirectUri: redirectUrl,
+		redirectUri,
 		from,
 	} );
 
@@ -57,7 +59,7 @@ export default function useProductCheckoutWorkflow( {
 	const checkoutProductUrl = getProductCheckoutUrl(
 		productSlug,
 		siteSuffix,
-		redirectUrl,
+		adminUrl + redirectUri,
 		isUserConnected || isWpcom
 	);
 
@@ -91,7 +93,7 @@ export default function useProductCheckoutWorkflow( {
 			return handleAfterRegistration();
 		}
 
-		registerSite( { registrationNonce, redirectUri: redirectUrl } ).then( handleAfterRegistration );
+		registerSite( { registrationNonce, redirectUri } ).then( handleAfterRegistration );
 	};
 
 	// Initialize/Setup the REST API.


### PR DESCRIPTION
Fixes #29376 
Fixes #27892 

## Proposed changes:
The PR changes to use relative admin URL for returning URI, which would be prefixed by the backend, and fixes the issue when the site has a valid subscription, it doesn't return to a valid URL.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Install only search and get the paid plan
* Open Search Dashboard `/wp-admin/admin.php?page=jetpack-search`
* Ensure you could purchase a Free or Paid plan
* Ensure it returns to the Search Dashboard after purchase
* Go to My Jetpack and disconnect Jetpack
* Go back to Search Dashboard, it should show the pricing table again
* On the pricing table, choose either plan again
* It should take you to authentication, so authenticate Jetpack to establish a user connection
* Ensure the site/user connects okay
* Ensure it returns to Search Dashboard

Note: it's best to test on a simple site as well.

