### PR TITLE
[Boost] Fix heading fonts sizes and weights on Premium sales pages

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/admin-style.scss
+++ b/projects/plugins/boost/app/assets/src/css/admin-style.scss
@@ -25,3 +25,4 @@
 @import 'components/snackbar';
 @import 'components/getting-started';
 @import 'components/icon-tooltip';
+@import 'components/pricing-table.scss';

--- a/projects/plugins/boost/app/assets/src/css/components/card.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/card.scss
@@ -19,6 +19,11 @@
 		}
 	}
 
+	.jb-card__summary {
+		font-size: 24px;
+		line-height: 32px;
+	}
+
 	.jp-components__pricing-card {
 		.jp-components__pricing-card__icon img {
 			width: 16px;

--- a/projects/plugins/boost/app/assets/src/css/components/pricing-table.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/pricing-table.scss
@@ -1,0 +1,6 @@
+.jb-pricing-table {
+	h2 {
+		font-size: 36px;
+		font-weight: 700;
+	}
+}

--- a/projects/plugins/boost/app/assets/src/css/components/pricing-table.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/pricing-table.scss
@@ -2,5 +2,6 @@
 	h2 {
 		font-size: 36px;
 		font-weight: 700;
+		line-height: 40px;
 	}
 }

--- a/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
@@ -9,6 +9,11 @@
 	display: flex;
 	flex-direction: column;
   	position: relative;
+
+	h1 {
+		font-size: 36px;
+		font-weight: 700;
+	}
 }
 
 .jb-feature-toggle__content h3:focus-visible, .jb-connection__title:focus-visible {

--- a/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
@@ -13,6 +13,7 @@
 	h1 {
 		font-size: 36px;
 		font-weight: 700;
+		line-height: 40px;
 	}
 }
 

--- a/projects/plugins/boost/changelog/fix-boost-upsell-headings
+++ b/projects/plugins/boost/changelog/fix-boost-upsell-headings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use correct font size and weight in upsell screens


### PR DESCRIPTION
See: p1HpG7-l29-p2
We were using the wrong font size and weight on pages around Boost. This PR fixes that.

## Proposed changes:
* Use correct font sizes and weights.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-l29-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Check the getting-started page
* Check the Boost benefits interstitial.

Screenshots:
![image](https://user-images.githubusercontent.com/1369626/224243943-8240e922-de4c-47b4-93fd-fc4c0b3c7d8c.png)

![image](https://user-images.githubusercontent.com/1369626/224243964-cf64f8dc-3393-40d2-9541-b947943e9415.png)

