### PR TITLE
Kitkat escalations: use a different label to mark escalation

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-kitkat-escalation
+++ b/projects/github-actions/repo-gardening/changelog/update-kitkat-escalation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Kitkat escalation task: change the name of the label applied to escalated issues.

--- a/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/notify-kitkat/index.js
@@ -36,7 +36,7 @@ async function hasBlockerPrioLabel( octokit, owner, repo, number ) {
 }
 
 /**
- * Check for a Kitkat Input Requested label on an issue.
+ * Check for a label showing that it was already escalated.
  *
  * @param {GitHub} octokit - Initialized Octokit REST client.
  * @param {string} owner   - Repository owner.
@@ -46,8 +46,11 @@ async function hasBlockerPrioLabel( octokit, owner, repo, number ) {
  */
 async function hasKitkatSignalLabel( octokit, owner, repo, number ) {
 	const labels = await getLabels( octokit, owner, repo, number );
-	// We're only interested in the Escalated to Kitkat label.
-	return labels.includes( '[Status] Escalated to Kitkat' );
+
+	// Does the list of labels includes the "[Status] Escalated" or "[Status] Escalated to Kitkat" label?
+	return (
+		labels.includes( '[Status] Escalated' ) || labels.includes( '[Status] Escalated to Kitkat' )
+	);
 }
 
 /**
@@ -178,7 +181,7 @@ async function notifyKitKat( payload, octokit ) {
 			owner: ownerLogin,
 			repo,
 			issue_number: number,
-			labels: [ '[Status] Escalated to Kitkat' ],
+			labels: [ '[Status] Escalated' ],
 		} );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

Let's use a different label to mark when a high/blocker issue has triggered an notification for the Kitkat team. In this PR, I changed the label to "[Status] Escalated".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1678437798494039/1678382956.120699-slack-CQD1HH4MA

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here, this will be active when merged.
