### PR TITLE
Forms: Introduce Buttons variation for the MC/SC field

### DIFF
--- a/projects/plugins/jetpack/changelog/update-mc-sc-fields-style-variations
+++ b/projects/plugins/jetpack/changelog/update-mc-sc-fields-style-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Introduce Buttons variation for the Multiple Choice and Single Choice fields

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/child-blocks.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/child-blocks.js
@@ -237,6 +237,7 @@ const editMultiField = type => props => {
 
 	return (
 		<JetpackFieldMultiple
+			className={ props.className }
 			clientId={ props.clientId }
 			label={ getFieldLabel( props ) }
 			required={ props.attributes.required }
@@ -609,6 +610,10 @@ export const childBlocks = [
 					default: 'Choose several options',
 				},
 			},
+			styles: [
+				{ name: 'list', label: 'List', isDefault: true },
+				{ name: 'button', label: 'Button' },
+			],
 			deprecated: [ multiFieldV1( 'checkbox' ) ],
 		},
 	},
@@ -639,6 +644,10 @@ export const childBlocks = [
 					default: 'Choose one option',
 				},
 			},
+			styles: [
+				{ name: 'list', label: 'List', isDefault: true },
+				{ name: 'button', label: 'Button' },
+			],
 			deprecated: [ multiFieldV1( 'radio' ) ],
 		},
 	},

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-controls.js
@@ -30,6 +30,7 @@ const JetpackFieldControls = ( {
 	hidePlaceholder,
 	required,
 	setAttributes,
+	type,
 	width,
 } ) => {
 	const setNumberAttribute = ( key, parse = parseInt ) => value => {
@@ -40,6 +41,13 @@ const JetpackFieldControls = ( {
 		} );
 	};
 
+	const inputColorLabel = [ 'radio', 'checkbox' ].includes( type )
+		? __( 'Option Text', 'jetpack' )
+		: __( 'Field Text', 'jetpack' );
+	const backgroundColorLabel = [ 'radio', 'checkbox' ].includes( type )
+		? __( 'Background', 'jetpack' )
+		: __( 'Field Background', 'jetpack' );
+
 	const colorSettings = [
 		{
 			value: attributes.labelColor,
@@ -49,12 +57,12 @@ const JetpackFieldControls = ( {
 		{
 			value: attributes.inputColor,
 			onChange: value => setAttributes( { inputColor: value } ),
-			label: __( 'Field Text', 'jetpack' ),
+			label: inputColorLabel,
 		},
 		{
 			value: attributes.fieldBackgroundColor,
 			onChange: value => setAttributes( { fieldBackgroundColor: value } ),
-			label: __( 'Field Background', 'jetpack' ),
+			label: backgroundColorLabel,
 		},
 		{
 			value: attributes.borderColor,

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-multiple.js
@@ -12,6 +12,7 @@ const ALLOWED_BLOCKS = [ 'jetpack/field-option' ];
 
 function JetpackFieldMultiple( props ) {
 	const {
+		className,
 		clientId,
 		id,
 		type,
@@ -34,7 +35,7 @@ function JetpackFieldMultiple( props ) {
 		[ clientId ]
 	);
 
-	const classes = classnames( 'jetpack-field jetpack-field-multiple', {
+	const classes = classnames( className, 'jetpack-field jetpack-field-multiple', {
 		'is-selected': isSelected,
 		'has-placeholder': ( options && options.length ) || innerBlocks.length,
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-option.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/components/jetpack-field-option.js
@@ -2,6 +2,7 @@ import { RichText } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { first } from 'lodash';
 import { useParentAttributes } from '../util/use-parent-attributes';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
@@ -23,6 +24,8 @@ export const JetpackFieldOptionEdit = props => {
 
 	const type = name.replace( 'jetpack/field-option-', '' );
 
+	const classes = classnames( 'jetpack-field-option', `field-option-${ type }` );
+
 	const handleSplit = label =>
 		createBlock( name, {
 			...attributes,
@@ -39,7 +42,7 @@ export const JetpackFieldOptionEdit = props => {
 	};
 
 	return (
-		<div className="jetpack-field-option">
+		<div className={ classes } style={ optionStyle }>
 			<input type={ type } className="jetpack-option__type" tabIndex="-1" />
 			<RichText
 				allowedFormats={ [] }
@@ -53,7 +56,6 @@ export const JetpackFieldOptionEdit = props => {
 				preserveWhiteSpace={ false }
 				withoutInteractiveFormatting
 				value={ attributes.label }
-				style={ optionStyle }
 			/>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -326,6 +326,34 @@
 	}
 
 	&.jetpack-field-multiple {
+		&.is-style-button {
+			.block-editor-block-list__layout {
+				display: flex;
+				flex-direction: column;
+				align-items: flex-start;
+				gap: 12px;
+			}
+
+			.jetpack-field-option {
+				color: var(--jetpack--contact-form--button-text-color);
+				border: var(--jetpack--contact-form--button-border);
+				border-color: currentColor;
+				border-radius: var(--jetpack--contact-form--button-border-radius);
+				padding: var(--jetpack--contact-form--button-padding);
+				line-height: var(--jetpack--contact-form--button-line-height);
+
+				&.field-option-radio {
+					position: relative;
+					flex-direction: row-reverse;
+					gap: 16px;
+
+					.jetpack-option__type {
+						display: none;
+					}
+				}
+			}
+		}
+
 		.jetpack-field-multiple__add-option {
 			margin: 0;
 			padding: 0;

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/util/form-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/util/form-styles.js
@@ -18,9 +18,12 @@ window.jetpackForms.generateStyleVariables = function ( selector ) {
 	const STYLE_PROBE_STYLE =
 		'position: absolute; z-index: -1; width: 1px; height: 1px; visibility: hidden';
 	const HTML = `
-			<div class="contact-form" style="">
+			<div class="contact-form">
+				<div class="wp-block-button">
+					<div class="wp-block-button__link btn-primary">Test</div>
+				</div>
 				<div class="wp-block-button is-style-outline">
-					<div class="wp-block-button__link">Test</div>
+					<div class="wp-block-button__link btn-outline">Test</div>
 				</div>
 				<div class="jetpack-field">
 					<input class="jetpack-field__input" type="text">
@@ -43,12 +46,21 @@ window.jetpackForms.generateStyleVariables = function ( selector ) {
 	const container = _document.querySelector( selector );
 	container.appendChild( styleProbe );
 
-	const buttonNode = styleProbe.querySelector( '.wp-block-button__link' );
+	const buttonPrimaryNode = styleProbe.querySelector( '.btn-primary' );
+	const buttonOutlineNode = styleProbe.querySelector( '.btn-outline' );
 	const inputNode = styleProbe.querySelector( 'input[type="text"]' );
 
 	const backgroundColor = window.jetpackForms.getBackgroundColor( bodyNode );
 	const inputBackground = window.jetpackForms.getBackgroundColor( inputNode );
-	const primaryColor = window.getComputedStyle( buttonNode ).borderColor;
+	const primaryColor = window.getComputedStyle( buttonPrimaryNode ).backgroundColor;
+
+	const {
+		border: buttonBorder,
+		borderRadius: buttonBorderRadius,
+		color: buttonTextColor,
+		padding: buttonPadding,
+		lineHeight: buttonLineHeight,
+	} = window.getComputedStyle( buttonOutlineNode );
 
 	const {
 		color: textColor,
@@ -83,5 +95,10 @@ window.jetpackForms.generateStyleVariables = function ( selector ) {
 		'--jetpack--contact-form--font-size': fontSize,
 		'--jetpack--contact-form--font-family': fontFamily,
 		'--jetpack--contact-form--line-height': lineHeight,
+		'--jetpack--contact-form--button-padding': buttonPadding,
+		'--jetpack--contact-form--button-border': buttonBorder,
+		'--jetpack--contact-form--button-border-radius': buttonBorderRadius,
+		'--jetpack--contact-form--button-text-color': buttonTextColor,
+		'--jetpack--contact-form--button-line-height': buttonLineHeight,
 	};
 };

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -109,6 +109,7 @@
 .contact-form .grunion-radio-options {
 	display: flex;
 	flex-direction: column;
+	align-items: flex-start;
 	gap: 12px;
 }
 
@@ -592,4 +593,52 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .is-style-below .grunion-field-wrap .below-label__label {
 	margin-left: var(--jetpack--contact-form--border-size);
+}
+
+.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .grunion-checkbox-multiple-label,
+.grunion-field-radio-wrap.is-style-button-wrap .grunion-radio-label {
+	color: var(--jetpack--contact-form--button-text-color);
+	border: var(--jetpack--contact-form--button-border);
+	border-color: currentColor;
+	border-radius: var(--jetpack--contact-form--button-border-radius);
+	padding: var(--jetpack--contact-form--button-padding);
+	line-height: var(--jetpack--contact-form--button-line-height);
+	cursor: pointer;
+}
+
+.grunion-field-radio-wrap.is-style-button-wrap .grunion-radio-label {
+	position: relative;
+	flex-direction: row-reverse;
+	gap: 16px;
+}
+
+.grunion-field-radio-wrap.is-style-button-wrap .grunion-field.radio {
+	position: absolute;
+	width: auto;
+	visibility: hidden;
+	display: flex;
+	align-items: center;
+	margin: 0;
+	color: inherit;
+}
+
+.grunion-field-radio-wrap.is-style-button-wrap .grunion-field.radio:checked {
+	position: relative;
+}
+
+.grunion-field-radio-wrap.is-style-button-wrap .grunion-field.radio::after {
+	width: 10px;
+	height: 16px;
+	content: ' ';
+	display: block;
+	border: var(--jetpack--contact-form--button-border);
+	border-color: currentColor;
+	border-top: none;
+	border-left: none;
+	transform: rotate(45deg) skew(5deg, 5deg);
+	margin-top: -10px;
+}
+
+.grunion-field-radio-wrap.is-style-button-wrap .grunion-field.radio:checked::after {
+	visibility: visible;
 }


### PR DESCRIPTION
## Proposed changes:

* Introduces the Buttons variation for the Multiple Choice and Single Choice fields

![image](https://user-images.githubusercontent.com/7811225/224368808-1b94155c-b57d-4025-8f9b-6e59e573fcaa.png)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pcsBup-TA-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Create a post and add a Form block
* Add a Multiple Choice and a Single Choice field
* Change the style variation to `Button` and play with the block
* Check if everything works well on the editor and on the published page