### PR TITLE
VideoPress: Update isPrivate field on state when video privacy changes

### DIFF
--- a/projects/packages/videopress/changelog/update-set-is-private-after-video-privacy-update
+++ b/projects/packages/videopress/changelog/update-set-is-private-after-video-privacy-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Update isPrivate video property on state after privacy changes.

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -52,8 +52,10 @@ import {
 	WP_REST_API_VIDEOPRESS_SETTINGS_ENDPOINT,
 	UPDATE_PAGINATION_AFTER_DELETE,
 	FLUSH_DELETED_VIDEOS,
+	UPDATE_VIDEO_IS_PRIVATE,
 } from './constants';
 import { mapVideoFromWPV2MediaEndpoint } from './utils/map-videos';
+import { videoIsPrivate } from './utils/video-is-private';
 
 /**
  * Utility function to pool the video data until poster is ready.
@@ -180,6 +182,13 @@ const updateVideoPrivacy = ( id, level ) => async ( { dispatch, select, resolveS
 			// @todo: implement error handling / UI
 			return;
 		}
+
+		// determine if video is private and update the state for it
+		const { videoPressVideosPrivateForSite } = select.getVideoPressSettings();
+		dispatch.updateVideoIsPrivate(
+			id,
+			videoIsPrivate( privacySetting, videoPressVideosPrivateForSite )
+		);
 
 		return dispatch( { type: UPDATE_VIDEO_PRIVACY, id, privacySetting } );
 	} catch ( error ) {
@@ -447,6 +456,10 @@ const updateVideoPressSettings = settings => async ( { dispatch } ) => {
 	}
 };
 
+const updateVideoIsPrivate = ( id, isPrivate ) => {
+	return { type: UPDATE_VIDEO_IS_PRIVATE, id, isPrivate };
+};
+
 const dismissFirstVideoPopover = () => {
 	return { type: DISMISS_FIRST_VIDEO_POPOVER };
 };
@@ -494,6 +507,8 @@ const actions = {
 
 	setVideoPressSettings,
 	updateVideoPressSettings,
+
+	updateVideoIsPrivate,
 };
 
 export { actions as default };

--- a/projects/packages/videopress/src/client/state/constants.js
+++ b/projects/packages/videopress/src/client/state/constants.js
@@ -63,6 +63,8 @@ export const UPDATE_VIDEO_POSTER = 'UPDATE_VIDEO_POSTER';
 
 export const SET_VIDEOPRESS_SETTINGS = 'SET_VIDEOPRESS_SETTINGS';
 
+export const UPDATE_VIDEO_IS_PRIVATE = 'UPDATE_VIDEO_IS_PRIVATE';
+
 /*
  * Accepted file extensions
  */

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -43,6 +43,7 @@ import {
 	DISMISS_FIRST_VIDEO_POPOVER,
 	FLUSH_DELETED_VIDEOS,
 	UPDATE_PAGINATION_AFTER_DELETE,
+	UPDATE_VIDEO_IS_PRIVATE,
 } from './constants';
 
 /**
@@ -220,6 +221,27 @@ const videos = ( state, action ) => {
 						},
 					},
 				},
+			};
+		}
+
+		case UPDATE_VIDEO_IS_PRIVATE: {
+			const { id, isPrivate } = action;
+			const items = [ ...( state.items ?? [] ) ];
+			const videoIndex = items.findIndex( item => item.id === id );
+
+			if ( videoIndex < 0 ) {
+				return state;
+			}
+
+			// Set isPrivate on video state
+			items[ videoIndex ] = {
+				...items[ videoIndex ],
+				isPrivate,
+			};
+
+			return {
+				...state,
+				items,
 			};
 		}
 

--- a/projects/packages/videopress/src/client/state/utils/video-is-private.ts
+++ b/projects/packages/videopress/src/client/state/utils/video-is-private.ts
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import { PrivacySettingProp } from '../../types';
+import {
+	VIDEO_PRIVACY_LEVELS,
+	VIDEO_PRIVACY_LEVEL_PUBLIC,
+	VIDEO_PRIVACY_LEVEL_PRIVATE,
+} from '../constants';
+
+/**
+ * Determines if a video is private taking into account the video
+ * privacy setting and the site default privacy setting.
+ *
+ * @param {PrivacySettingProp} privacySetting - The privacy setting for the video
+ * @param {boolean} privateEnabledForSite - The site default privacy setting, if it's private or not
+ * @returns {boolean} - true if the video is private, false otherwise
+ */
+export const videoIsPrivate = (
+	privacySetting: PrivacySettingProp,
+	privateEnabledForSite: boolean
+): boolean => {
+	if ( VIDEO_PRIVACY_LEVELS[ privacySetting ] === VIDEO_PRIVACY_LEVEL_PUBLIC ) {
+		return false;
+	}
+
+	if ( VIDEO_PRIVACY_LEVELS[ privacySetting ] === VIDEO_PRIVACY_LEVEL_PRIVATE ) {
+		return true;
+	}
+
+	return privateEnabledForSite;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a follow-up to #29404. @dhasilva noticed that the `isPrivate` field was not changing on the local state after a privacy change, so now we are fixing it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Dispatch a new action to update the video `isPrivate` field after a privacy change is made to the video

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Jetpack > VideoPress` to see your list of videos
* Click the `Edit video details` button of some video
* We are going to inspect the Redux state of the application, so open up the Redux debugger and select the `videopress/media` store:

<img width="800" alt="Screen Shot 2023-03-10 at 15 46 21" src="https://user-images.githubusercontent.com/6760046/224400066-140cc47b-192a-4e98-8c91-dfea4d245ab6.png">

* On the state data, check the value for the `isPrivate` field for the video that you are editing; the videos are stored on `root > videos > items`

<img width="800" alt="Screen Shot 2023-03-10 at 15 50 44" src="https://user-images.githubusercontent.com/6760046/224400957-80279605-c06b-4587-ae8e-f3ac6c1fe8c8.png">

* Check that it has the correct value for the current privacy setting of the video (refer to the table below to make sure of the value)
* Change the video privacy setting, save the changes by clicking `Save changes` and check the state again, assuring that `isPrivate` contains the right value (again, refer to the table below)
* Notice that an `UPDATE_VIDEO_IS_PRIVATE` action is being fired everytime a privacy setting change is saved:

<img width="350" alt="Screen Shot 2023-03-10 at 15 58 58" src="https://user-images.githubusercontent.com/6760046/224403170-0ef9aedd-5773-4e13-aeec-956aa38a0cfc.png">

* Test it for Jetpack and WoA sites

### `isPrivate` expected values according to the privacy settings

| Video privacy setting  | Site default privacy setting for videos | `isPrivate` value |
| ------------- | ------------- | ------------- |
| Public | Any value | `false`  |
| Private | Any value | `true`  |
| Site Default | Public (unchecked toggle) | `false` |
| Site Default | Private (checked toggle) | `true` |