### PR TITLE
Editors: Refactor Jetpack Redirect for Launchpad modal

### DIFF
--- a/projects/plugins/jetpack/changelog/add-launchpad_modal_redirect
+++ b/projects/plugins/jetpack/changelog/add-launchpad_modal_redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+refactor redirect url

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -46,10 +46,10 @@ export const settings = {
 		const prevHasNeverPublishedPostOption = useRef( hasNeverPublishedPostOption );
 
 		const siteFragment = getSiteFragment();
-		const launchPadUrl = getRedirectUrl( `wpcom-launchpad-setup-${ siteIntentOption }`, {
+		const launchPadUrl = getRedirectUrl( 'wpcom-launchpad-setup', {
+			path: siteIntentOption,
 			query: `siteSlug=${ siteFragment }`,
 		} );
-
 		const { tracks } = useAnalytics();
 
 		const recordTracksEvent = eventName =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/72615

## Proposed changes:
Refactor the Jetpack Redirect to use dynamic `[path]` so we only need a single redirect.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
• Run `bin/jetpack-downloader test jetpack add/launchpad_modal_redirect` to sync this branch to your sandbox
• Sandbox `public-api.wordpress.com` and a Launchpad-enabled site
• Make a change in the Site or Post editor
• Once the Launchpad modal appears, click the "Next Steps" button
• Confirm you get redirected to Launchpad

