### PR TITLE
tools: changelogger-release should ask if there are no changes

### DIFF
--- a/.github/files/renovate-post-upgrade.sh
+++ b/.github/files/renovate-post-upgrade.sh
@@ -48,21 +48,11 @@ for DIR in $(git -c core.quotepath=off diff --name-only HEAD | grep -E -v '(^|/)
 	echo "Adding change file for $SLUG"
 	cd "$DIR"
 
-	ARGS=()
-	ARGS=( add --filename="${CHANGEFILE}" --no-interaction --filename-auto-suffix --significance=patch )
-
-	CLTYPE="$(jq -r '.extra["changelogger-default-type"] // "changed"' composer.json)"
-	if [[ -n "$CLTYPE" ]]; then
-		ARGS+=( "--type=$CLTYPE" )
-	fi
-
-	ARGS+=( --entry="Updated package dependencies." )
-
 	CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
 	if [[ -d "$CHANGES_DIR" && "$(ls -- "$CHANGES_DIR")" ]]; then
-		changelogger "${ARGS[@]}"
+		changelogger_add 'Updated package dependencies.' '' --filename="${CHANGEFILE}" --filename-auto-suffix
 	else
-		changelogger "${ARGS[@]}"
+		changelogger_add 'Updated package dependencies.' '' --filename="${CHANGEFILE}" --filename-auto-suffix
 		echo "Updating version for $SLUG"
 		PRERELEASE=$(alpha_tag composer.json 0)
 		VER=$(changelogger version next --default-first-version --prerelease="$PRERELEASE") || { echo "$VER"; exit 1; }

--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -7,6 +7,7 @@ BASE=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 . "$BASE/tools/includes/chalk-lite.sh"
 . "$BASE/tools/includes/alpha-tag.sh"
 . "$BASE/tools/includes/changelogger.sh"
+. "$BASE/tools/includes/proceed_p.sh"
 
 # Print help and exit.
 function usage {
@@ -122,11 +123,12 @@ function releaseProject {
 	local CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
 	if [[ ! -d "$CHANGES_DIR" || -z "$(ls -- "$CHANGES_DIR")" ]]; then
 		if [[ -z "$FROM" ]]; then
-			info "Project $SLUG has no changes, skipping."
+			proceed_p "Project $SLUG has no changes." 'Do a release anyway?' || return
+			changelogger_add 'Internal updates.' '' --filename=force-a-release
 		else
 			debug "${I}Project $SLUG has no changes, skipping."
+			return
 		fi
-		return
 	fi
 
 	info "${I}Processing $SLUG..."

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -159,13 +159,7 @@ if $UPDATE; then
 		local OLDDIR=$PWD
 		cd "$BASE/projects/$SLUG"
 
-		local ARGS=()
-		ARGS=( add --no-interaction --significance=patch )
-		local CLTYPE="$(jq -r '.extra["changelogger-default-type"] // "changed"' composer.json)"
-		if [[ -n "$CLTYPE" ]]; then
-			ARGS+=( "--type=$CLTYPE" )
-		fi
-
+		local ARGS=( "$2" "$3" )
 		if [[ -n "$CL_FILENAME" ]]; then
 			ARGS+=( --filename="$CL_FILENAME" )
 		fi
@@ -173,13 +167,11 @@ if $UPDATE; then
 			ARGS+=( --filename-auto-suffix )
 		fi
 
-		ARGS+=( --entry="$2" --comment="$3" )
-
 		local CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
 		if [[ -d "$CHANGES_DIR" && "$(ls -- "$CHANGES_DIR")" ]]; then
-			changelogger "${ARGS[@]}"
+			changelogger_add "${ARGS[@]}"
 		else
-			changelogger "${ARGS[@]}"
+			changelogger_add "${ARGS[@]}"
 			info "Updating version for $SLUG"
 			local PRERELEASE=$(alpha_tag composer.json 0)
 			local VER=$(changelogger version next --default-first-version --prerelease=$PRERELEASE) || { error "$VER"; EXIT=1; cd "$OLDDIR"; return; }

--- a/tools/includes/changelogger.sh
+++ b/tools/includes/changelogger.sh
@@ -28,3 +28,28 @@ function changelogger {
 	init_changelogger > /dev/null
 	"$CLBASE/projects/packages/changelogger/bin/changelogger" "$@"
 }
+
+# Fetch the default changelogger type.
+#
+# Executes `changelogger add --no-interaction --significance=patch --type=... --entry="$1" --comment="$2"`.
+#
+# - $1: Changelog entry text.
+# - $2: Changelog comment text.
+# - $@: Any additional changelogger arguments to pass.
+function changelogger_add {
+	init_changelogger
+
+	local ARGS=( add --no-interaction --significance=patch --filename-auto-suffix --entry="$1" --comment="$2" )
+	shift 2
+
+	local CLTYPE="$(jq -r '.extra["changelogger-default-type"] // "changed"' composer.json)"
+	if [[ -n "$CLTYPE" ]]; then
+		ARGS+=( "--type=$CLTYPE" )
+	fi
+
+	if [[ $# -gt 0 ]]; then
+		ARGS+=( "$@" )
+	fi
+
+	changelogger "${ARGS[@]}"
+}

--- a/tools/project-version.sh
+++ b/tools/project-version.sh
@@ -248,16 +248,7 @@ done < <(jq -r '.extra["version-constants"] // {} | to_entries | .[] | .key + " 
 
 if $DO_CHANGELOG; then
 	cd "$BASE/projects/$SLUG"
-
-	ARGS=()
-	ARGS=( add --no-interaction --significance=patch --filename=init-release-cycle --filename-auto-suffix )
-	CLTYPE="$(jq -r '.extra["changelogger-default-type"] // "changed"' composer.json)"
-	if [[ -n "$CLTYPE" ]]; then
-		ARGS+=( "--type=$CLTYPE" )
-	fi
-	ARGS+=( --entry="" --comment="Init $VERSION" )
-	changelogger "${ARGS[@]}"
-
+	changelogger_add '' "Init $VERSION" --filename=init-release-cycle --filename-auto-suffix
 	cd "$BASE"
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When running `changelogger-release.sh` on a plugin, it may be that the plugin itself has no changes but packages it depends on do so we still want to do a release.

So, in the case that `changelogger-release.sh` finds nothing to do for its command line argument, have it ask the user whether they want to do a release anyway. If so, generate a change entry for "Internal updates" to be used in the changelog.

Also, instead of copy-pasing the same code for figuring out which `--type` to pass to changelogger for the 4th time, let's make a function to handle it and use that everywhere.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1678475150661779-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* For some project that currently has nothing except `.gitkeep` in `projects/$SLUG/changelog/`, run `tools/changelogger-release.sh`.
* Test the other scripts being modified here, make sure they still work as they did before.