### PR TITLE
Clean up misleading comments

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dependency-comment
+++ b/projects/packages/forms/changelog/fix-forms-dependency-comment
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comments only change.
+
+

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -66,12 +66,12 @@ class Dashboard {
 				'in_footer'    => true,
 				'textdomain'   => 'jetpack-forms',
 				'enqueue'      => true,
-				'dependencies' => array( 'wp-api-fetch' ), // this here just for testing, remove when done (apiFetch will be on build)
+				'dependencies' => array( 'wp-api-fetch' ),
 			)
 		);
 
 		$api_root = defined( 'IS_WPCOM' ) && IS_WPCOM
-			? sprintf( '/wpcom/v2/sites/%s/', esc_url_raw( rest_url() ) ) // should we include full URL here (public-api.wordpress.com)?
+			? sprintf( '/wpcom/v2/sites/%s/', esc_url_raw( rest_url() ) )
 			: '/wp-json/wpcom/v2/';
 
 		wp_add_inline_script(

--- a/projects/plugins/jetpack/changelog/fix-forms-dependency-comment
+++ b/projects/plugins/jetpack/changelog/fix-forms-dependency-comment
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Comments only.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR removes some misleading comments so we don't accidentally feel like we need to act upon them in the future.
See d104408-code for more context.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
-

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

No testing required.

