### PR TITLE
Staging sites: disable launchpad for staging sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-staging-sites-disable-launchpad
+++ b/projects/plugins/jetpack/changelog/update-staging-sites-disable-launchpad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Overrides launchpad_screen to `off` for staging sites `is_wpcom_staging_site`

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1453,6 +1453,9 @@ abstract class SAL_Site {
 	 * @return string
 	 */
 	public function get_launchpad_screen() {
+		if ( $this->is_wpcom_staging_site() ) {
+			return 'off';
+		}
 		return get_option( 'launchpad_screen' );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

- Fixes https://github.com/Automattic/dotcom-forge/issues/1942

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Override the `launchpad_screen` option to `off` for staging sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

