### PR TITLE
VideoPress: add fineAdjusment to TimestampControl component

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-timestamp-control
+++ b/projects/packages/videopress/changelog/update-videopress-timestamp-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add fineAdjusment to TimestampControl component

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -3,8 +3,7 @@
  */
 // eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 import { __experimentalNumberControl as NumberControl, RangeControl } from '@wordpress/components';
-import { useDebounce } from '@wordpress/compose';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import classnames from 'classnames';
 /**
  * Internal dependencies
@@ -172,14 +171,16 @@ export const TimestampControl = ( {
 	onDebounceChange,
 	wait = 1000,
 }: TimestampControlProps ): React.ReactElement => {
-	const debouncedOnChangeHandler = onDebounceChange ? useDebounce( onDebounceChange, wait ) : null;
+	const debounceTimer = useRef< NodeJS.Timeout >();
 
 	const onChangeHandler = useCallback(
 		( newValue: number ) => {
-			debouncedOnChangeHandler && debouncedOnChangeHandler( newValue );
+			clearTimeout( debounceTimer?.current );
+
 			onChange?.( newValue );
+			debounceTimer.current = setTimeout( onDebounceChange.bind( null, newValue ), wait );
 		},
-		[ onChange, debouncedOnChangeHandler ]
+		[ onChange ]
 	);
 
 	return (

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -170,6 +170,7 @@ export const TimestampControl = ( {
 	onChange,
 	onDebounceChange,
 	wait = 1000,
+	fineAdjustment = 50,
 }: TimestampControlProps ): React.ReactElement => {
 	const debounceTimer = useRef< NodeJS.Timeout >();
 
@@ -190,7 +191,7 @@ export const TimestampControl = ( {
 			<RangeControl
 				className={ styles[ 'timestamp-range-control' ] }
 				min={ 0 }
-				step={ 0.1 }
+				step={ fineAdjustment }
 				initialPosition={ value }
 				value={ value }
 				max={ max }

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -177,7 +177,7 @@ export const TimestampControl = ( {
 	const onChangeHandler = useCallback(
 		( newValue: number ) => {
 			debouncedOnChangeHandler && debouncedOnChangeHandler( newValue );
-			onChange( newValue );
+			onChange?.( newValue );
 		},
 		[ onChange, debouncedOnChangeHandler ]
 	);
@@ -187,7 +187,7 @@ export const TimestampControl = ( {
 			<TimestampInput max={ max } value={ value } onChange={ onChangeHandler } />
 
 			<RangeControl
-				className={ styles[ 'timestamp-control-range' ] }
+				className={ styles[ 'timestamp-range-control' ] }
 				min={ 0 }
 				step={ 0.1 }
 				initialPosition={ value }

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
@@ -48,3 +48,10 @@ Time, in milliseconds, that the `onDebounceChange` function will be debounced.
 
 Maximum time value, in milliseconds, expected by the component.
 Also, if it's bigger than one hour, the hour input will be rendered into the Timestamp Input component.
+
+### fineAdjustment
+
+- type: `number`
+- default: `50`
+
+Time, in milliseconds, for every step of the Range control.

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
@@ -41,6 +41,7 @@ _default.args = {
 	max: 3600 * 1000 * 2, // 2 hours
 	value: 236 * 1000, // 3:56
 	wait: 100,
+	fineAdjustment: 50,
 	onChange: ( newTime: number ) => {
 		console.log( { newTime } ); // eslint-disable-line no-console
 	},

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -14,6 +14,10 @@
 
 	.timestamp-control-input {
 		width: 24px;
+		margin-bottom: 0;
+		&:last-child{
+			margin-bottom: 0;
+		}
 	}
 
 	:global {
@@ -32,8 +36,11 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
+	margin-bottom: 8px;
 
-	.timestamp-control-range {
+	.timestamp-range-control,
+	.timestamp-range-control:last-child {
+		margin-bottom: 0;
 		flex-grow: 2;
 
 		:global .components-base-control__field {

--- a/projects/packages/videopress/src/client/components/timestamp-control/types.ts
+++ b/projects/packages/videopress/src/client/components/timestamp-control/types.ts
@@ -1,6 +1,7 @@
 export type TimestampInputProps = {
 	value: number;
 	max?: number;
+	fineAdjustment?: number;
 	onChange?: ( ms: number ) => void;
 };
 

--- a/projects/packages/videopress/src/client/components/timestamp-control/types.ts
+++ b/projects/packages/videopress/src/client/components/timestamp-control/types.ts
@@ -1,10 +1,10 @@
 export type TimestampInputProps = {
 	value: number;
 	max?: number;
-	onChange: ( ms: number ) => void;
+	onChange?: ( ms: number ) => void;
 };
 
 export type TimestampControlProps = TimestampInputProps & {
-	wait: number;
-	onDebounceChange: ( ms: number ) => void;
+	wait?: number;
+	onDebounceChange?: ( ms: number ) => void;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR continues with the Timestamp control implementation. Here:

* Add `fineAdjustment` prop
* Tweak style to fix correctly in the block editor (follow-up PRs coming on)
* Add its own debounce handling. useDebounce() has some issues when the app tries to trigger the `onChange()` event and also the `onDebounceEvent()`.

Part of https://github.com/Automattic/jetpack/issues/29278

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add fineAdjusment to TimestampControl component

### Other information:

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Test with storybook

```cli
cd projects/js-packages/storybook
```

```cli
pnpm run storybook:dev
```

* Search the TimestampControl story
* Play with the story
* To test the fineAdjustment control:
  1. Show the addons panel
  2. Set the fine adjustment (50ms ad default)
  3. Focus on the range control
  4. Type UP/DOWN and LEFT/RIGHT
  5. Confirm the time changes according to the typing

https://user-images.githubusercontent.com/77539/224736476-e396a0c9-f8b0-486d-9e1a-a5ac026217bc.mov

