### PR TITLE
Forms: Fix fatal errors on sites using old AMP versions

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-forms-legacy-amp-sites
+++ b/projects/plugins/jetpack/changelog/fix-forms-legacy-amp-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix fatal error on sites using old AMP versions

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -389,7 +389,6 @@ class Grunion_Contact_Form_Plugin {
 		wp_register_style( 'grunion.css', GRUNION_PLUGIN_URL . 'css/grunion.css', array(), JETPACK__VERSION );
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
-		self::enqueue_contact_forms_style_script();
 		self::register_contact_form_blocks();
 	}
 
@@ -530,6 +529,8 @@ class Grunion_Contact_Form_Plugin {
 				esc_html__( 'Submit a form.', 'jetpack' )
 			);
 		}
+
+		self::enqueue_contact_forms_style_script();
 
 		return Grunion_Contact_Form::parse( $atts, do_blocks( $content ) );
 	}


### PR DESCRIPTION
## Proposed changes:
* Fix fatal errors on sites using old AMP versions: p1678736148583249-slack-CBG1CP4EN

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Make sure you have and old (`< 2.0.1`) AMP version installed and active
* You should now be able to create, publish and visualize posts without fatal errors