### PR TITLE
VideoPress: Remove storage meter for Atomic sites

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-remove-storage-meter-atomic
+++ b/projects/packages/videopress/changelog/update-videopress-remove-storage-meter-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+VideoPress: Remove storage meter for atomic sites

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.12.1",
+	"version": "0.12.2-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.12.1';
+	const PACKAGE_VERSION = '0.12.2-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/admin/components/video-storage-meter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-storage-meter/index.tsx
@@ -9,10 +9,15 @@ import filesize from 'filesize';
  * Internal dependencies
  */
 import { usePlan } from '../../hooks/use-plan';
+import { useVideoPressSettings } from '../../hooks/use-videopress-settings';
 import useVideos from '../../hooks/use-videos';
 import ProgressBar from '../progress-bar';
+import { SITE_TYPE_ATOMIC } from '../site-settings-section/constants';
 import styles from './style.module.scss';
-import { VideoStorageMeterProps } from './types';
+/**
+ * Types
+ */
+import type { VideoStorageMeterProps } from './types';
 import type React from 'react';
 
 /**
@@ -55,9 +60,16 @@ const VideoStorageMeter: React.FC< VideoStorageMeterProps > = ( {
 
 export const ConnectVideoStorageMeter = props => {
 	const { storageUsed, uploadedVideoCount } = useVideos();
+	const { features } = usePlan();
+	const { settings } = useVideoPressSettings();
+	const { siteType } = settings;
+
 	const total = 1000 * 1000 * 1000 * 1000;
 
-	const { features } = usePlan();
+	// Do not show storage meter if the site is an Atomic site.
+	if ( siteType === SITE_TYPE_ATOMIC ) {
+		return null;
+	}
 
 	// Do not show storage meter for unlimited storage plans.
 	if ( features?.isVideoPressUnlimitedSupported ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #27625

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Does not render the storage meter if the site is Atomic

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On a Jetpack site:
* Go to the VideoPress dashboard with at least one video uploaded.
* Check that nothing changes and the storage meter is displayed normally

On an Atomic site:
* Go to the VideoPress dashboard with at least one video uploaded.
* Check that the storage meter is not displayed anymore.

Jetpack | Atomic
-|-
![2023-03-13_17-29-55](https://user-images.githubusercontent.com/8486249/224825304-b0fa6024-904e-4c93-a883-1c8d49cfa9b3.png) | ![2023-03-13_17-30-34](https://user-images.githubusercontent.com/8486249/224825321-a784a989-636e-4b1f-9a67-43caf7a22d0a.png)
