### PR TITLE
Fix export bug: missing data/columns (A sort of Revert of  #28678)

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-export-bug-29429
+++ b/projects/packages/forms/changelog/fix-forms-export-bug-29429
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Rollback rename of columns/fields on export

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.8.x-dev"
+			"dev-trunk": "0.9.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.8.0",
+	"version": "0.9.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.8.0';
+	const PACKAGE_VERSION = '0.9.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1694,12 +1694,12 @@ class Contact_Form_Plugin {
 		sort( $field_names, SORT_NUMERIC );
 
 		$well_known_column_names = $this->get_well_known_column_names();
+		$result                  = array();
 
 		/**
 		 * Loop through every post, which is essentially CSV row.
 		 */
 		foreach ( $posts_data as $post_id => $single_post_data ) {
-
 			/**
 			 * Go through all the possible fields and check if the field is available
 			 * in the current post.
@@ -1715,8 +1715,15 @@ class Contact_Form_Plugin {
 				/**
 				 * Remove the numeral prefix -3_, 1_, 2_, etc, only for export results.
 				 * Prefixes can be both positive and negative numeral values, functional to the SORT_NUMERIC above.
+				 * TODO: to return fieldnames based on field label, we need to work both field names and post data:
+				 * unique -> sort -> unique/rename
+				 * $renamed_field = preg_replace( '/^(-?\d{1,2}_)/', '', $renamed_field );
 				 */
-				$renamed_field = preg_replace( '/^(-?\d{1,2}_)/', '', $renamed_field );
+
+				if ( ! isset( $result[ $renamed_field ] ) ) {
+					$result[ $renamed_field ] = array();
+				}
+
 				if (
 					isset( $single_post_data[ $single_field_name ] )
 					&& ! empty( $single_post_data[ $single_field_name ] )
@@ -2028,6 +2035,7 @@ class Contact_Form_Plugin {
 		}
 
 		$all_fields = array_unique( $all_fields );
+
 		return $all_fields;
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -1255,7 +1255,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 			'key4'         => array( 'value4', 'value4' ),
 			'key5'         => array( '', 'value5' ),
 			'key6'         => array( '', 'value6' ),
-			'Comment'      => array( 'This is my test 15', 'This is my test 16' ),
+			'4_Comment'    => array( 'This is my test 15', 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );

--- a/projects/plugins/jetpack/changelog/fix-forms-export-bug-29429
+++ b/projects/plugins/jetpack/changelog/fix-forms-export-bug-29429
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Rollback rename of columns/fields on export

--- a/projects/plugins/jetpack/changelog/fix-forms-export-bug-29429#2
+++ b/projects/plugins/jetpack/changelog/fix-forms-export-bug-29429#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -875,7 +875,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "ec6c161155b3cef7e43d45c3d715e0ef0417f6a2"
+                "reference": "18842dbeb2bb6ee37b0b67331015ffda6a592f7a"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -897,7 +897,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -1807,11 +1807,12 @@ class Grunion_Contact_Form_Plugin {
 		sort( $field_names, SORT_NUMERIC );
 
 		$well_known_column_names = $this->get_well_known_column_names();
+		$result                  = array();
+
 		/**
 		 * Loop through every post, which is essentially CSV row.
 		 */
 		foreach ( $posts_data as $post_id => $single_post_data ) {
-
 			/**
 			 * Go through all the possible fields and check if the field is available
 			 * in the current post.
@@ -1824,10 +1825,18 @@ class Grunion_Contact_Form_Plugin {
 					? $well_known_column_names[ $single_field_name ]
 					: $single_field_name;
 
-					/**
-				 * Remove the numeral prefix 1_, 2_, etc, only for export results
+				/**
+				 * Remove the numeral prefix -3_, 1_, 2_, etc, only for export results.
+				 * Prefixes can be both positive and negative numeral values, functional to the SORT_NUMERIC above.
+				 * TODO: to return fieldnames based on field label, we need to work both field names and post data:
+				 * unique -> sort -> unique/rename
+				 * $renamed_field = preg_replace( '/^(-?\d{1,2}_)/', '', $renamed_field );
 				 */
-				$renamed_field = preg_replace( '/^(-?\d{1,2}_)/', '', $renamed_field );
+
+				if ( ! isset( $result[ $renamed_field ] ) ) {
+					$result[ $renamed_field ] = array();
+				}
+
 				if (
 					isset( $single_post_data[ $single_field_name ] )
 					&& ! empty( $single_post_data[ $single_field_name ] )

--- a/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -1240,7 +1240,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			'key4'         => array( 'value4', 'value4' ),
 			'key5'         => array( '', 'value5' ),
 			'key6'         => array( '', 'value6' ),
-			'Comment'      => array( 'This is my test 15', 'This is my test 16' ),
+			'4_Comment'    => array( 'This is my test 15', 'This is my test 16' ),
 		);
 
 		$this->assertEquals( $expected_result, $result );


### PR DESCRIPTION
A bug was found when exporting form responses. The bug was introduced on #28678 and/or #28425 in the spirit of making column names look better by removing the order prefix. This led to wrong data merging upon the export process.

Fixes #29429

## Proposed changes:
This PR rolls back the rename/cleanup of field names (columns) to leave them as they were before the mentioned PRs. This doesn't mean we're completely reverting those changes, as all the other improvements remain.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Follow instructions on #29429

Exported data should now reflect the collected data more faithfully, even if that means that the same 2 fields are treated as different ones after inverting their order. This has always behaved that way and we plan to improve it on further iterations.