### PR TITLE
Staging Sites: Ensure `is_wpcom_staging_site` is included in site response and always defined by WPCOM

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-staging-sites-staging-site-attribute
+++ b/projects/plugins/jetpack/changelog/fix-staging-sites-staging-site-attribute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Adds the `is_wpcom_staging_site` attribute in a few more contexts

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -221,6 +221,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'subscribers_count',
 		'site_migration',
 		'site_owner',
+		'is_wpcom_staging_site',
 	);
 
 	/**
@@ -245,7 +246,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'ak_vp_bundle_enabled',
 		'is_automated_transfer',
 		'is_wpcom_atomic',
-		'is_wpcom_staging_site',
 		'is_wpcom_store',
 		'woocommerce_is_active',
 		'editing_toolkit_is_active',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -110,6 +110,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_fse_eligible',
 		'is_core_site_editor_enabled',
 		'is_wpcom_atomic',
+		'is_wpcom_staging_site',
 	);
 
 	/**
@@ -244,6 +245,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'ak_vp_bundle_enabled',
 		'is_automated_transfer',
 		'is_wpcom_atomic',
+		'is_wpcom_staging_site',
 		'is_wpcom_store',
 		'woocommerce_is_active',
 		'editing_toolkit_is_active',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -72,6 +72,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
 		'is_wpcom_atomic'             => '(bool) If the site is a WP.com Atomic one.',
+		'is_wpcom_staging_site'       => '(bool) If the site is a WP.com staging site.',
 	);
 
 	/**


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/1966

## Proposed changes:

Previously, `is_wpcom_staging_site` was only included for `/me/sites` API requests.

This pull request includes `is_wpcom_staging_site` for `/sites/<id>` API requests, and ensures the value is set by executing `SAL_Site::is_wpcom_staging_site()` and `has_blog_sticker()` on WPCOM.

It also makes the `is_wpcom_staging_site` value available on public responses.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Run `jetpack build plugins/jetpack` and `jetpack rsync jetpack wpdev` to get the code on your sandbox.
2. Create a new Business site, take it Atomic via Hosting Configuration, and then click 'Add staging site'
3. Click on 'Manage staging site' after the site is created.
4. Verify the 'Staging' badge appears when you visit 'My Home' for the staging site.