### PR TITLE
WP Super Cache - add support for the Accept HTTP header

### DIFF
--- a/projects/plugins/super-cache/changelog/add-accept_header_supercache
+++ b/projects/plugins/super-cache/changelog/add-accept_header_supercache
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WP Super Cache - added support for the Accept HTTP Header. Commonly used in APIs to fetch JSON.

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -51,6 +51,6 @@
 		"wp-svn-autopublish": true
 	},
 	"config": {
-		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_9_5_alpha"
+		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_10_0_alpha"
 	}
 }

--- a/projects/plugins/super-cache/package.json
+++ b/projects/plugins/super-cache/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-super-cache",
-	"version": "1.9.5-alpha",
+	"version": "1.10.0-alpha",
 	"description": "A very fast caching engine for WordPress that produces static html files.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -33,7 +33,17 @@ function get_wp_cache_key( $url = false ) {
 		$url = '';
 	}
 	$server_port = isset( $_SERVER['SERVER_PORT'] ) ? intval( $_SERVER['SERVER_PORT'] ) : 0;
-	return do_cacheaction( 'wp_cache_key', wp_cache_check_mobile( $WPSC_HTTP_HOST . $server_port . preg_replace( '/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() ) );
+	$accept      = wpsc_get_accept_header();
+	if ( $accept === 'text/html' ) {
+		$accept = '';
+	} else {
+		$accept = '-' . $accept;
+	}
+	return do_cacheaction(
+		'wp_cache_key',
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		wp_cache_check_mobile( $WPSC_HTTP_HOST . $server_port . preg_replace( '/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() . '-' . wpsc_get_accept_header() . $accept )
+	);
 }
 
 /**
@@ -128,6 +138,11 @@ function wp_cache_serve_cache_file() {
 		return false;
 	}
 
+	if ( wpsc_get_accept_header() !== 'text/html' ) {
+		wp_cache_debug( 'wp_cache_serve_cache_file: visitor does not accept text/html. Not serving cached file.' );
+		return false;
+	}
+
 	extract( wp_super_cache_init() ); // $key, $cache_filename, $meta_file, $cache_file, $meta_pathname
 
 	if (
@@ -175,6 +190,9 @@ function wp_cache_serve_cache_file() {
 			return false;
 		} elseif ( wp_cache_get_cookies_values() != '' ) {
 			wp_cache_debug( 'Cookies found. Cannot serve a supercache file. ' . wp_cache_get_cookies_values() );
+			return false;
+		} elseif ( wpsc_get_accept_header() !== 'text/html' ) {
+			wp_cache_debug( 'Accept header is not text/html. Cannot serve supercache file.' . wp_cache_get_cookies_values() );
 			return false;
 		} elseif ( isset( $wpsc_save_headers ) && $wpsc_save_headers ) {
 			wp_cache_debug( 'Saving headers. Cannot serve a supercache file.' );
@@ -443,6 +461,31 @@ function wpsc_get_auth_cookies() {
 	}
 
 	return $auth_cookies;
+}
+
+function wpsc_get_accept_header() {
+	static $accept = 'N/A';
+
+	if ( $accept === 'N/A' ) {
+		$json_list = array( 'application/json', 'application/activity+json', 'application/ld+json' );
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- $accept is checked and set below.
+		$accept = isset( $_SERVER['HTTP_ACCEPT'] ) ? strtolower( filter_var( $_SERVER['HTTP_ACCEPT'] ) ) : '';
+
+		foreach ( $json_list as $header ) {
+			if ( strpos( $accept, $header ) ) {
+				$accept = 'application/json';
+			}
+		}
+
+		if ( $accept !== 'application/json' ) {
+			$accept = 'text/html';
+		}
+
+		wp_cache_debug( 'ACCEPT: ' . $accept );
+	}
+
+	return $accept;
 }
 
 function wp_cache_get_cookies_values() {

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -33,16 +33,19 @@ function get_wp_cache_key( $url = false ) {
 		$url = '';
 	}
 	$server_port = isset( $_SERVER['SERVER_PORT'] ) ? intval( $_SERVER['SERVER_PORT'] ) : 0;
-	$accept      = wpsc_get_accept_header();
+
+	// Prepare a tag to include in the cache key if the request is anything other than text/html
+	$accept = wpsc_get_accept_header();
 	if ( $accept === 'text/html' ) {
-		$accept = '';
+		$accept_tag = '';
 	} else {
-		$accept = '-' . $accept;
+		$accept_tag = '-' . $accept;
 	}
+
 	return do_cacheaction(
 		'wp_cache_key',
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		wp_cache_check_mobile( $WPSC_HTTP_HOST . $server_port . preg_replace( '/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() . '-' . wpsc_get_accept_header() . $accept )
+		wp_cache_check_mobile( $WPSC_HTTP_HOST . $server_port . preg_replace( '/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() . '-' . wpsc_get_accept_header() . $accept_tag )
 	);
 }
 
@@ -463,6 +466,11 @@ function wpsc_get_auth_cookies() {
 	return $auth_cookies;
 }
 
+/**
+ * Returns a string containing a sanitized version of the Accept header.
+ * For now, this can only respond with `text/html` or `application/json` -
+ * used to differentiate between pages which may or may not be cacheable.
+ */
 function wpsc_get_accept_header() {
 	static $accept = 'N/A';
 

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Super Cache
  * Plugin URI: https://wordpress.org/plugins/wp-super-cache/
  * Description: Very fast caching plugin for WordPress.
- * Version: 1.9.5-alpha
+ * Version: 1.10.0-alpha
  * Author: Automattic
  * Author URI: https://automattic.com/
  * License: GPL2+


### PR DESCRIPTION
This patch allows WP Super Cache to ignore requests from clients that don't accept text/html. That allows WordPress to serve whatever content they require, which may well be JSON data.

This was prompted by the ActivityPub plugin which uses /author/X/ to deliver metadata about the author on a WordPress website to the Fediverse. If you search for a URL through the search box in Mastodon, it expects a JSON payload.

JSON requests are not cached by this plugin (yet?) but the vast majority of requests are text/html ones.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Apply patch.
Enable debugging in the plugin.
Go to your Mastodon account and search for a blog post on your blog.
Go to the debug output and filter it to search for your blog post.
Note that it says:

> ACCEPT: application/json 
> wp_cache_serve_cache_file: visitor does not accept text/html. Not serving cached file. 
> Page not cached by WP Super Cache. No closing HTML tag. Check your theme. 
> wp_cache_shutdown_callback: No cache file created. Returning. 

The content of your post should appear in the search box in your Mastodon client.