### PR TITLE
Jetpack: Move VideoPress video block to production

### DIFF
--- a/projects/plugins/jetpack/changelog/update-videopress-move-v6-to-prod
+++ b/projects/plugins/jetpack/changelog/update-videopress-move-v6-to-prod
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack: Move VideoPress video block to production (videopress/video extension)

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -43,7 +43,8 @@
 		"payments-intro",
 		"post-publish-qr-post-panel",
 		"payment-buttons",
-		"site-editor-snackbars"
+		"site-editor-snackbars",
+		"videopress/video"
 	],
 	"beta": [
 		"amazon",
@@ -55,7 +56,6 @@
 		"launchpad-save-modal",
 		"post-publish-promote-post-panel",
 		"recipe",
-		"videopress/video",
 		"videopress/video-chapters"
 	],
 	"experimental": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR moves the VideoPress video block to production. It's doable by moving the `videopress/video` extension from `beta` to `production`

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: Move VideoPress video block to production (videopress/video extension)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Jetpack site

* Test with JN site, with Jetpack Beta plugin
* Switch to this branch
* Confirm you see the VideoPress video block (v6) available in the block editor context, even when `beta` extension is not enabled
* Confirm the block works as expected 


#### Atomic site

* Install the Jetpack Beta plugin
* Switch to this branch
* Confirm you see the VideoPress video block (v6) available in the block editor context, even when `beta` extension is not enabled
* Confirm the block works as expected 

#### Simple sites

* Confirm the VideoPress video block is still available.
* Confirm the block works as expected 

