### PR TITLE
Block editor: update deprecated component prop

### DIFF
--- a/projects/packages/videopress/changelog/update-position-placement-prop
+++ b/projects/packages/videopress/changelog/update-position-placement-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update deprecated core prop

--- a/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
@@ -45,7 +45,7 @@ const VideoDetailsActions = ( {
 	return (
 		<>
 			<Dropdown
-				position="bottom center"
+				placement="bottom center"
 				className={ styles.dropdown }
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button

--- a/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-quick-actions/index.tsx
@@ -121,7 +121,7 @@ const ThumbnailActionsDropdown = ( {
 
 	return (
 		<Dropdown
-			position="bottom left"
+			placement="bottom left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<div ref={ setAnchor }>
 					<Button
@@ -187,7 +187,7 @@ const PrivacyActionsDropdown = ( {
 
 	return (
 		<Dropdown
-			position="bottom left"
+			placement="bottom left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<div ref={ setAnchor }>
 					<Button

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
@@ -85,7 +85,7 @@ export const VideoThumbnailDropdown = ( {
 	return (
 		<div className={ styles[ 'video-thumbnail-edit' ] }>
 			<Dropdown
-				position="bottom left"
+				placement="bottom left"
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
 						variant="secondary"

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -62,7 +62,7 @@ export function PosterDropdown( {
 	return (
 		<Dropdown
 			contentClassName="poster-panel__dropdown"
-			position="top left"
+			placement="top left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					ref={ buttonRef }

--- a/projects/plugins/jetpack/changelog/update-position-placement-prop
+++ b/projects/plugins/jetpack/changelog/update-position-placement-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: update deprecated component prop.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -135,7 +135,7 @@ export function NewsletterAccess( { accessLevel, setPostMeta, withModal = true }
 										focusOnMount
 										renderToggle={ ( { isOpen, onToggle } ) => (
 											<Button
-												isTertiary
+												variant="tertiary"
 												onClick={ onToggle }
 												aria-expanded={ isOpen }
 												aria-label={ sprintf(


### PR DESCRIPTION
## Proposed changes:

See #27795

position prop is now deprecated for Dropdown and URLPopover, we must switch to the placement prop instead.

> **Note**
> ~~I have to figure out if some type definitions need to be updated somewhere.~~ It seems to be okay.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Test the different blocks impacted by the change, and ensure the layout still looks good for dropdowns.
