### PR TITLE
Writing Prompt block: adds email specific styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-writing-prompt-email-styles
+++ b/projects/plugins/jetpack/changelog/fix-writing-prompt-email-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Small bugfix for unreleased beta block
+
+

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/style.scss
@@ -16,6 +16,7 @@
 
 	&__text {
 		font-size: 24px;
+		margin-bottom: $grid-unit-20;
 	}
 
 	&__answers-link {
@@ -26,7 +27,6 @@
 
 	&__answers {
 		font-size: 16px;
-		margin-top: $grid-unit-20;
 	}
 
 	&__answers-gravatar {
@@ -43,5 +43,24 @@
 
 	&__spinner {
 		text-align: center;
+	}
+
+	@media only email {
+		&__label {
+			background: none;
+			padding-left: 0;
+		}
+
+		&__answers {
+			margin-bottom: 0;
+		}
+
+		&__answers-gravatar {
+			margin-bottom: 0;
+
+			&:not(:first-child) {
+				margin-left: 0;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Proposed changes:

Adds email specific styles to the writing prompts block to render correctly in email clients.

| **Before** | **After** |
| - | - |
| <img width="690" alt="image" src="https://user-images.githubusercontent.com/1699996/225115612-af51980e-20fe-483a-88d4-8c8f2cbd6738.png"> | <img width="675" alt="image" src="https://user-images.githubusercontent.com/1699996/225115636-bdeae533-62fb-4b83-8587-a4884713eebb.png"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

PT: pe7F0s-uo-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Apply this change to a wpcom sandbox with `bin/jetpack-downloader test jetpack fix/writing-prompt-email-styles`
- Add the following code to your sandbox to turn off caching and load beta blocks when testing emails
```
define( 'BLOCK_FALLBACKS_DEBUG', true );
add_filter( 'jetpack_blocks_variation', function( $variation ) { return 'beta'; }, 9999 );
```
- Sandbox public-api and a Simple site domain
- Create a post on a simple site and insert a blogging prompts block
- Use the following command to send yourself an email `php bin/subscriptions/send.php BLOG_ID post POST_ID YOUR_EMAIL@automattic.com `