### PR TITLE
VideoPress: get rid of script const / component prop

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-remove-scripts-const
+++ b/projects/packages/videopress/changelog/update-videopress-remove-scripts-const
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: get rid of script const / component prop

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -12,7 +12,7 @@ import type { PlayerProps } from './types';
 import type React from 'react';
 
 // Global scripts array to be run in the Sandbox context.
-const globalScripts = [];
+const sandboxScripts = [];
 
 // Populate scripts array with videopresAjaxURLBlob blobal var.
 if ( window.videopressAjax ) {
@@ -28,14 +28,14 @@ if ( window.videopressAjax ) {
 		}
 	);
 
-	globalScripts.push(
+	sandboxScripts.push(
 		URL.createObjectURL( videopresAjaxURLBlob ),
 		window.videopressAjax.bridgeUrl
 	);
 }
 
 if ( window?.videoPressEditorState?.playerBridgeUrl ) {
-	globalScripts.push( window.videoPressEditorState.playerBridgeUrl );
+	sandboxScripts.push( window.videoPressEditorState.playerBridgeUrl );
 }
 
 /**
@@ -50,7 +50,6 @@ export default function Player( {
 	isSelected,
 	attributes,
 	setAttributes,
-	scripts = [],
 	preview,
 	isRequestingEmbedPreview,
 }: PlayerProps ): React.ReactElement {
@@ -227,9 +226,7 @@ export default function Player( {
 					style={ wrapperElementStyle }
 				>
 					<>
-						{ ! isRequestingEmbedPreview && (
-							<SandBox html={ html } scripts={ [ ...globalScripts, ...scripts ] } />
-						) }
+						{ ! isRequestingEmbedPreview && <SandBox html={ html } scripts={ sandboxScripts } /> }
 
 						{ ! isVideoPlayerLoaded && (
 							<div className="jetpack-videopress-player__loading">

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/types.ts
@@ -9,7 +9,6 @@ export type PlayerProps = {
 	isSelected: boolean;
 	attributes: VideoBlockAttributes;
 	setAttributes: ( attributes: VideoBlockAttributes ) => void;
-	scripts: string[];
 	preview: VideoPreviewProps;
 	isRequestingEmbedPreview: boolean;
 };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -161,11 +161,6 @@ export default function VideoPressEdit( {
 	// Pick video properties from preview.
 	const { html: previewHtml, width: previewWidth, height: previewHeight } = preview;
 
-	// The `scripts` const was being pulled form the preview object but the preview object doesn't have scripts property.
-	// Since preview.scripts was undefined, it was removed from the VideoPreviewProps type.
-	// @TODO - determine if scripts is needed as a prop to the Player component. if not needed this scripts const can be removed.
-	const scripts = [];
-
 	/*
 	 * Store the preview markup and video thumbnail image
 	 * into a block `html` and `thumbnail` attributes respectively.
@@ -565,7 +560,6 @@ export default function VideoPressEdit( {
 				showCaption={ showCaption }
 				html={ html }
 				isRequestingEmbedPreview={ isRequestingEmbedPreview }
-				scripts={ scripts }
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				isSelected={ isSelected }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR removes the unused `scripts` constant defined in the edit function of the VideoPress video component, as well as the `scripts` property of the `<Player />` component.

It also renames the scripts variable of the Sandbox component.

Follow-up of https://github.com/Automattic/jetpack/pull/29447

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: get rid of script const / component prop

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a VideoPress video instance
* Set the video
* Open the network tab. Filter by Scritps
* Confirm the `token-bridge` and the `player-bridge` are loaded

<img width="823" alt="Screen Shot 2023-03-14 at 16 53 34" src="https://user-images.githubusercontent.com/77539/225121389-335e8ee8-8c59-40ad-9f7e-81855a63ce1b.png">

* Change the video privacy. Confirm the token provider works as expected

<img width="821" alt="image" src="https://user-images.githubusercontent.com/77539/225121072-66783cbf-8c93-4bc3-beca-6fe98875fd2c.png">


