### PR TITLE
Add 'launchpad' memberships status source.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -49,7 +49,18 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 							'type'              => 'string',
 							'required'          => false,
 							'validate_callback' => function ( $param ) {
-								return in_array( $param, array( 'calypso', 'earn', 'earn-newsletter', 'gutenberg', 'gutenberg-wpcom' ), true );
+								return in_array(
+									$param,
+									array(
+										'calypso',
+										'earn',
+										'earn-newsletter',
+										'gutenberg',
+										'gutenberg-wpcom',
+										'launchpad',
+									),
+									true
+								);
 							},
 						),
 						'is_editable' => array(

--- a/projects/plugins/jetpack/changelog/paid-news-add-launchpad-memberships-status-source
+++ b/projects/plugins/jetpack/changelog/paid-news-add-launchpad-memberships-status-source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add the launchpad source to memberships status endpoint.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to:
- https://github.com/Automattic/wp-calypso/issues/72651
- https://github.com/Automattic/wp-calypso/pull/73787
- D103605-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In order to navigate correctly after the stripe connection is created, we need to pass the 'launchpad' param through the memberships status endpoint. Currently the endpoint, doesn't support the 'launchpad' string.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

Testing instructions:
1. Add code to your sandbox by running `bin/jetpack-downloader test jetpack paid-news/add-launchpad-memberships-status-source`.
1. Sandbox `pubic-api.wordpress.com` and a test site.
1. Go to `https://wordpress.com/earn/payments/${site_slug}` and verify `https://public-api.wordpress.com/wpcom/v2/sites/${site_id}/memberships/status?source=earn-newsletter` endpoint (in the network tab) returns a 200 response and valid data.