### PR TITLE
Integrate SIG with other SEO plugins.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-use-sig-seo-tags
+++ b/projects/plugins/jetpack/changelog/update-use-sig-seo-tags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Use SIG for OG tags even with conflicting plugins

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -29,6 +29,7 @@ use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\Paths;
 use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
+use Automattic\Jetpack\Publicize\Social_Image_Generator;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -2038,7 +2039,8 @@ class Jetpack {
 
 		$active_plugins = self::get_active_plugins();
 
-		if ( ! empty( $active_plugins ) ) {
+		// If SIG is enabled we render our own og tags, even if conflicting plugins are active.
+		if ( ! empty( $active_plugins ) && empty( Social_Image_Generator\get_image_url( get_the_ID() ) ) ) {
 			foreach ( $this->open_graph_conflicting_plugins as $plugin ) {
 				if ( in_array( $plugin, $active_plugins, true ) ) {
 					add_filter( 'jetpack_enable_open_graph', '__return_false', 99 );

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -11,7 +11,7 @@
  * @package automattic/jetpack
  */
 
-add_action( 'wp_head', 'jetpack_og_tags' );
+add_action( 'wp_head', 'jetpack_og_tags', 100 );
 add_action( 'web_stories_story_head', 'jetpack_og_tags' );
 
 /**

--- a/projects/plugins/social/changelog/update-use-sig-seo-tags
+++ b/projects/plugins/social/changelog/update-use-sig-seo-tags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use SIG for OG tags even with conflicting plugins

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -111,7 +111,7 @@ class Jetpack_Social {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_scripts' ) );
 
 		// Add meta tags.
-		add_action( 'wp_head', array( new Automattic\Jetpack\Social\Meta_Tags(), 'render_tags' ) );
+		add_action( 'wp_head', array( new Automattic\Jetpack\Social\Meta_Tags(), 'render_tags' ), 100 );
 
 		add_filter( 'jetpack_get_available_standalone_modules', array( $this, 'social_filter_available_modules' ), 10, 1 );
 

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Social;
 
+use Automattic\Jetpack\Publicize\Social_Image_Generator;
+
 /**
  * Adds the meta tags.
  */
@@ -20,7 +22,6 @@ class Meta_Tags {
 	 * @var array Array of plugin slugs.
 	 */
 	private $open_graph_conflicting_plugins = array(
-		'jetpack/jetpack.php',                                   // The Jetpack plugin adds its own meta tags.
 		'2-click-socialmedia-buttons/2-click-socialmedia-buttons.php', // 2 Click Social Media Buttons.
 		'add-link-to-facebook/add-link-to-facebook.php',         // Add Link to Facebook.
 		'add-meta-tags/add-meta-tags.php',                       // Add Meta Tags.
@@ -105,11 +106,19 @@ class Meta_Tags {
 
 	/**
 	 * Check if meta tags should be rendered.
+	 * If we have conflicting plugins, we won't render meta tags, unless Social Image Generator is active.
+	 * Jetpack is an exception to avoid duplicates, as it's handling SIG on it's own too.
 	 *
 	 * @return bool True if meta tags should be rendered.
 	 */
 	public function should_render_meta_tags() {
-		if ( ! empty( array_intersect( $this->get_active_plugins(), $this->open_graph_conflicting_plugins ) ) ) {
+		if (
+			is_plugin_active( 'jetpack/jetpack.php' ) ||
+			(
+				! empty( array_intersect( $this->get_active_plugins(), $this->open_graph_conflicting_plugins ) ) &&
+				empty( Social_Image_Generator\get_image_url( get_the_ID() ) )
+			)
+		) {
 			return false;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR changes how we disable our own OG tags if there is a conflicting SEO plugin active. With this change if Social Image Generator is active, we won't disable our tags even if there is another SEO plugin.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updated disabling logic so we render our tags even with conflicting plugins if SIG is active.
* Jetpack is exception, as it's handling SIG on it's own too
* Increased hook priority so we run our tag later

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Have Jetpack and Social active at the same time**
* Create a new post with a featured image and SIG enabled
  * Check the post's tags with the inspector and look for `og:image`.
  * Make sure it's the valid SIG url.
  * Make sure it's not duplicated.
* Disable SIG on the post in the block editor.
  * Refresh the post.
  * `og:image` should contain the URL to the featured image.

**Activate another conflicting plugin.** (For example [this](https://wordpress.org/plugins/complete-open-graph/))
* Refresh the post. 
  * You should only see one `og:image` url, which comes from the new plugin.
* Enable SIG in the editor
  * Refresh the post again. 
  * You should see an extra `og:image` url, which is the SIG url. It should appear later. 
  * Feed [Hey Meta](https://www.heymeta.com/) the post URL, and make sure that the image is the SIG generated image

**Disable Jetpack** (So you have Social, and the conflicting plugin active)
* Refresh the post
  * Check that you still have the SIG generated url as the latter tag.
* Disable SIG in the blog editor for the post.
  * Refresh it, now you should only have one tag which is the featured image.

