### PR TITLE
RNA: tweak secondary button styling

### DIFF
--- a/projects/js-packages/components/changelog/update-js-components-tweak-secondary-button-styles
+++ b/projects/js-packages/components/changelog/update-js-components-tweak-secondary-button-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RNA: tweak secondary button styling

--- a/projects/js-packages/components/components/button/style.module.scss
+++ b/projects/js-packages/components/components/button/style.module.scss
@@ -81,6 +81,7 @@
 	// Only Secondary
 	&:global(.is-secondary) {
 		background: var(--jp-white);
+		box-shadow: inset 0 0 0 1.5px var(--jp-black);
 
 		// Hover & Active
 		&:active:not(:disabled),
@@ -146,12 +147,12 @@
 			&:not(:disabled) {
 				color: var(--jp-red-50);
 				background: var(--jp-white);
-				box-shadow: inset 0 0 0 1px var(--jp-red-50);
+				box-shadow: inset 0 0 0 1.5px var(--jp-red-50);
 			}
 
 			&:hover:not(:disabled) {
 				background: var(--jp-red-0);
-				box-shadow: inset 0 0 0 1px var(--jp-red-60);
+				box-shadow: inset 0 0 0 1.5px var(--jp-red-60);
 				color: var(--jp-red-60);
 			}
 

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.30.0",
+	"version": "0.30.1-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR tweaks the secondary button styles, increasing the button border width (actually, it's defined by the box-shadow) from 1px to 1.5px.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* RNA: tweak secondary button styling

## Jetpack product discussion

p6TEKc-6Yo-p2#comment-11396

<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with storybook

```cli
cd projects/js-packages/storybook
```

```cli
pnpm run storybook:dev
```

* Search the Button stories 
* Use the `Variant & Props` story to compare the button instances
* Confirm the `secondary` variant has a border (box-shadow) of 1.5px

before | after
------|------
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/77539/225301571-a5ea18f8-663f-4011-8d6a-d5877352a363.png"> | <img width="1146" alt="image" src="https://user-images.githubusercontent.com/77539/225301524-cad46545-7e6d-4ae2-8fb9-012ce3810735.png">