### PR TITLE
CRM: Adding the reset default settings option to the bottom of the settings page

### DIFF
--- a/projects/plugins/crm/admin/settings/partials/menu.block.php
+++ b/projects/plugins/crm/admin/settings/partials/menu.block.php
@@ -241,5 +241,5 @@ foreach ( $tabs as $tab => $name ) {
 	<?php // WLREMOVE ?>
 	<a class="item" href="<?php echo jpcrm_esc_link( $zbs->slugs['extensions'] ); ?>"><i class="ui orange puzzle piece icon"></i> <?php echo esc_html__( 'Extensions', 'zero-bs-crm' ); ?></a>
 	<?php // /WLREMOVE ?>
-	<a class="item" href="<?php echo jpcrm_esc_link( $zbs->slugs['settings'] ); ?>&resetsettings=1"></i> <?php echo esc_html__( 'Restore default settings', 'zero-bs-crm' ); ?></a>
+	<a class="item" href="<?php echo jpcrm_esc_link( wp_nonce_url( $zbs->slugs['settings'] . '&resetsettings=1' ) ); ?> "></i> <?php echo esc_html__( 'Restore default settings', 'zero-bs-crm' ); ?></a>
 </div>

--- a/projects/plugins/crm/admin/settings/partials/menu.block.php
+++ b/projects/plugins/crm/admin/settings/partials/menu.block.php
@@ -240,6 +240,6 @@ foreach ( $tabs as $tab => $name ) {
 	<?php endforeach ?>
 	<?php // WLREMOVE ?>
 	<a class="item" href="<?php echo jpcrm_esc_link( $zbs->slugs['extensions'] ); ?>"><i class="ui orange puzzle piece icon"></i> <?php echo esc_html__( 'Extensions', 'zero-bs-crm' ); ?></a>
-	<a class="item" href="<?php echo jpcrm_esc_link( $zbs->slugs['settings'] ); ?>&resetsettings=1"></i> <?php echo esc_html__( 'Restore default settings', 'zero-bs-crm' ); ?></a>
 	<?php // /WLREMOVE ?>
+	<a class="item" href="<?php echo jpcrm_esc_link( $zbs->slugs['settings'] ); ?>&resetsettings=1"></i> <?php echo esc_html__( 'Restore default settings', 'zero-bs-crm' ); ?></a>
 </div>

--- a/projects/plugins/crm/admin/settings/partials/menu.block.php
+++ b/projects/plugins/crm/admin/settings/partials/menu.block.php
@@ -240,5 +240,6 @@ foreach ( $tabs as $tab => $name ) {
 	<?php endforeach ?>
 	<?php // WLREMOVE ?>
 	<a class="item" href="<?php echo jpcrm_esc_link( $zbs->slugs['extensions'] ); ?>"><i class="ui orange puzzle piece icon"></i> <?php echo esc_html__( 'Extensions', 'zero-bs-crm' ); ?></a>
+	<a class="item" href="<?php echo jpcrm_esc_link( $zbs->slugs['settings'] ); ?>&resetsettings=1"></i> <?php echo esc_html__( 'Restore default settings', 'zero-bs-crm' ); ?></a>
 	<?php // /WLREMOVE ?>
 </div>

--- a/projects/plugins/crm/changelog/add-crm-restore-default-settings-link-menu
+++ b/projects/plugins/crm/changelog/add-crm-restore-default-settings-link-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+CRM: add restore default settings menu item to settings page menu


### PR DESCRIPTION

## Proposed changes:

* This PR adds a 'Remove default settings' link to the settings menu.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2961

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test this, using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, visit the CRM Settings page (`wp-admin/admin.php?page=zerobscrm-plugin-settings`)
* At the bottom of the CRM Settings menu you should see the 'Restore default settings' menu item.
* Clicking on this link will take you to the page where you can confirm (or cancel) restoring default settings.

<img width="461" alt="Screenshot 2023-03-15 at 14 11 25" src="https://user-images.githubusercontent.com/16754605/225335249-70e5345c-9d86-4a7c-9aa6-3fd8da85ef3b.png">


