### PR TITLE
Add import package menus

### DIFF
--- a/projects/packages/import/changelog/add-import-package-menus
+++ b/projects/packages/import/changelog/add-import-package-menus
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for nav-menu and nav-menu-item import.

--- a/projects/packages/import/composer.json
+++ b/projects/packages/import/composer.json
@@ -51,7 +51,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.2.x-dev"
+			"dev-trunk": "0.3.x-dev"
 		},
 		"textdomain": "jetpack-import",
 		"version-constants": {

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-import",
-	"version": "0.2.1-alpha",
+	"version": "0.3.0-alpha",
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
 	"bugs": {

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -68,6 +68,8 @@ class Main {
 			'categories' => new Endpoints\Category(),
 			'comments'   => new Endpoints\Comment(),
 			'media'      => new Endpoints\Attachment(),
+			'menu-items' => new Endpoints\Menu_Item(),
+			'menus'      => new Endpoints\Menu(),
 			'pages'      => new Endpoints\Page(),
 			'posts'      => new Endpoints\Post(),
 			'tags'       => new Endpoints\Tag(),

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.2.1-alpha';
+	const PACKAGE_VERSION = '0.3.0-alpha';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/import/src/endpoints/class-menu-item.php
+++ b/projects/packages/import/src/endpoints/class-menu-item.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Menu items REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+/**
+ * Class Menu_Item
+ */
+class Menu_Item extends \WP_REST_Menu_Items_Controller {
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import;
+
+	/**
+	 * Whether the controller supports batching. Default true.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'nav_menu_item' );
+
+		// @see add_term_meta
+		$this->import_id_meta_type = 'post';
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @see WP_REST_Terms_Controller::register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::$rest_namespace,
+			'/menu-items',
+			$this->get_route_options()
+		);
+	}
+
+	/**
+	 * Adds the schema from additional fields to a schema array.
+	 *
+	 * The type of object is inferred from the passed schema.
+	 *
+	 * @param array $schema Schema array.
+	 * @return array Modified Schema array.
+	 */
+	public function add_additional_fields_schema( $schema ) {
+		// WXR saves menu parent as slug, so we need to overwrite the schema.
+		$schema['properties']['menus']['description'] = __( 'The parent menu slug.', 'jetpack-import' );
+		$schema['properties']['menus']['type']        = 'string';
+
+		// Add the import unique ID to the schema.
+		return $this->add_unique_identifier_to_schema( $schema );
+	}
+
+	/**
+	 * Creates a single menu item.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		if ( ! empty( $request['menus'] ) ) {
+			$menu_id = \term_exists( $request['menus'], 'nav_menu' );
+
+			if ( $menu_id ) {
+				// Overwrite the menu item parent menu ID.
+				$request['menus'] = is_array( $menu_id ) ? $menu_id['term_id'] : $menu_id;
+			}
+		}
+
+		if ( ! empty( $request['parent'] ) ) {
+			$query              = $this->get_import_db_query( $request['parent'] );
+			$query['post_type'] = 'nav_menu_item';
+			$parent             = \get_posts( $query );
+
+			// Overwrite the parent ID.
+			$request['parent'] = is_array( $parent ) && count( $parent ) ? $parent[0] : 0;
+		}
+
+		// A menu item can be a custom link or a post, page, category or attachment.
+		if ( ! empty( $request['object_id'] ) ) {
+			$id = null;
+
+			if ( $request['object'] === 'category' ) {
+				if ( $request['object_id'] === 1 ) {
+					// The default category is always ID 1, no need to search.
+					$id = 1;
+				} else {
+					$query      = $this->get_import_db_query( $request['object_id'] );
+					$categories = \get_categories( $this->get_import_db_query( $request['object_id'] ) );
+
+					// Overwrite the category ID.
+					$id = is_array( $categories ) && count( $categories ) ? $categories[0] : null;
+				}
+			} elseif ( $request['object'] === 'page' ) {
+				$pages = \get_pages( $this->get_import_db_query( $request['object_id'] ) );
+
+				// Overwrite the page ID.
+				$id = is_array( $pages ) && count( $pages ) ? $pages[0]->ID : null;
+			} elseif ( $request['object'] === 'post' || $request['object'] === 'attachment' ) {
+				$posts = \get_posts( $this->get_import_db_query( $request['object_id'] ) );
+
+				// Overwrite the post ID.
+				$id = is_array( $posts ) && count( $posts ) ? $posts[0] : null;
+			}
+
+			if ( empty( $id ) ) {
+				// Not found the object or a custom menu item, remove the fields.
+				unset( $request['object_id'] );
+				unset( $request['object'] );
+			} else {
+				$request['object_id'] = $id;
+			}
+		}
+
+		$response = parent::create_item( $request );
+
+		return $this->add_import_id_metadata( $request, $response );
+	}
+}

--- a/projects/packages/import/src/endpoints/class-menu.php
+++ b/projects/packages/import/src/endpoints/class-menu.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Menus REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+/**
+ * Class Menu
+ */
+class Menu extends \WP_REST_Menus_Controller {
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import;
+
+	/**
+	 * Whether the controller supports batching. Default true.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'nav_menu' );
+
+		// @see add_term_meta
+		$this->import_id_meta_type = 'term';
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @see WP_REST_Terms_Controller::register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::$rest_namespace,
+			'/menus',
+			$this->get_route_options()
+		);
+	}
+}

--- a/projects/plugins/jetpack/changelog/add-import-package-menus
+++ b/projects/plugins/jetpack/changelog/add-import-package-menus
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1065,7 +1065,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/import",
-                "reference": "37125a5f15779eea6046766a6a78b12d9de6b810"
+                "reference": "d48cdf34e37a4831189473154bace15e30db1a55"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev"
@@ -1083,7 +1083,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "textdomain": "jetpack-import",
                 "version-constants": {


### PR DESCRIPTION
Fix: https://github.com/Automattic/dotcom-forge/issues/1957
Fix: https://github.com/Automattic/dotcom-forge/issues/1864

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add import of `nav-menu` and `nav-menu-item`
* Remove importing of categories with ID 1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See testing instructions here: D104653-code