### PR TITLE
CRM: Checking segment index exists to prevent export issues

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-exports-add-segment-check
+++ b/projects/plugins/crm/changelog/fix-crm-exports-add-segment-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: fix some export cases by adding a check for the segment index.

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
@@ -251,7 +251,7 @@ function jpcrm_export_process_file_export() {
 
 				// == segment specific loading =================================
 
-			if ( is_array( $extraParams['segment'] ) ) {
+			if ( isset( $extraParams['segment'] ) && is_array( $extraParams['segment'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 				$extra_file_name_str = '-segment-' . $extraParams['segment']['id'];
 


### PR DESCRIPTION
## Proposed changes:

* In some instances, exports were not working. PHP warnings and errors were displaying after clicking the export button, and the export did not take place. This was the case exporting quotes, transactions, contacts and invoices.
* It looks like the issues occur when wp_debug is set to true on a site (`define( 'WP_DEBUG', 'true' ); ` in wp-config) as well as the debug display not explicitly disabled (so `define( 'WP_DEBUG_DISPLAY', false );` not added to the wp-config file) , however as well as printing out the errors is still prevents the export from taking place.
* This PR adds a check to see if the segment index exists before checking to see if it is an array, [on this line](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php#L254). This prevents the error messages and allows the exports to go ahead on the sites where the issue existed.

The warnings / errors:

```
Notice: Undefined index: segment in /srv/users/usered83e0e7/apps/usered83e0e7/public/wp-content/plugins/zero-bs-crm/includes/ZeroBSCRM.DAL3.Export.php on line 230

Warning: Cannot modify header information - headers already sent by (output started at /srv/users/usered83e0e7/apps/usered83e0e7/public/wp-content/plugins/zero-bs-crm/includes/ZeroBSCRM.DAL3.Export.php:230) in /srv/users/usered83e0e7/apps/usered83e0e7/public/wp-content/plugins/zero-bs-crm/includes/ZeroBSCRM.DAL3.Export.php on line 244

Warning: Cannot modify header information - headers already sent by (output started at /srv/users/usered83e0e7/apps/usered83e0e7/public/wp-content/plugins/zero-bs-crm/includes/ZeroBSCRM.DAL3.Export.php:230) in /srv/users/usered83e0e7/apps/usered83e0e7/public/wp-content/plugins/zero-bs-crm/includes/ZeroBSCRM.DAL3.Export.php on line 245
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2919

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To replicate the original issue, on a Jurassic Ninja site using CRM version 5.5.2 or above (or any site with the following added to the wp-config.php file: `define( 'WP_DEBUG', 'true' ); ` and `define( 'WP_DEBUG_DISPLAY', false );` ), add a contact (or invoice, transaction or quote), and attempt to export them (from Quotes > Export / Transactions > Export etc).
* On the export page, click on the Export button and you should see the warnings shared above, and no export happens.
* To test the fix, using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, attempt the same export. The export should download without issue, and no errors should display.

