### PR TITLE
VideoPress: Add unit test for VideoPress package processedAllVideosBeingRemoved selector

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-package-unit-test-forprocessedAllVideosBeingRemoved-selector
+++ b/projects/packages/videopress/changelog/add-videopress-package-unit-test-forprocessedAllVideosBeingRemoved-selector
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just a unit test
+
+

--- a/projects/packages/videopress/src/client/state/test/selectors.js
+++ b/projects/packages/videopress/src/client/state/test/selectors.js
@@ -1,0 +1,26 @@
+import { getProcessedAllVideosBeingRemoved } from '../selectors';
+
+describe( 'getProcessedAllVideosBeingRemoved()', () => {
+	it( 'should return true when videos finished being removed', () => {
+		const state = {
+			videos: {
+				_meta: {
+					processedAllVideosBeingRemoved: true,
+				},
+			},
+		};
+		const output = getProcessedAllVideosBeingRemoved( state );
+		expect( output ).toBe( true );
+	} );
+
+	it( 'should return false when there is no indication of videos having been removed yet', () => {
+		const state = {
+			videos: {
+				_meta: {},
+			},
+		};
+		const output = getProcessedAllVideosBeingRemoved( state );
+		// This would return undefined, which is falsy.
+		expect( output ).toBeFalsy();
+	} );
+} );


### PR DESCRIPTION
Introduces a selector test

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds projects/packages/videopress/src/client/state/test/selectors.js
* Tests truthy and falsey values for processedAllVideosBeingRemoved

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
1. Checkout this branch
2. Run jetpack test packages/videopress js
3. Expect all tests to pass
  ```
   Test Suites: 5 passed, 5 total
   Tests:       20 passed, 20 total
   Snapshots:   0 total
   Time:        1.679 s
   ```
