### PR TITLE
Editors: Update Launchpad modal content for Newsletter flow

### DIFF
--- a/projects/plugins/jetpack/changelog/add-launchpad_newsletter_modal_copy
+++ b/projects/plugins/jetpack/changelog/add-launchpad_newsletter_modal_copy
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+update modal content for newsletter flow

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -21,6 +21,8 @@ export const settings = {
 			} )
 		);
 
+		const { link: postLink } = useSelect( select => select( 'core/editor' ).getCurrentPost(), [] );
+
 		const prevIsSavingSite = usePrevious( isSavingSite );
 		const prevIsSavingPost = usePrevious( isSavingPost );
 		const prevIsPublishingPost = usePrevious( isPublishingPost );
@@ -42,6 +44,7 @@ export const settings = {
 		const launchPadUrl = getRedirectUrl( `wpcom-launchpad-setup-${ siteIntentOption }`, {
 			query: `siteSlug=${ siteFragment }`,
 		} );
+		const isNewsletter = siteIntentOption === 'newsletter';
 
 		const { tracks } = useAnalytics();
 
@@ -118,13 +121,20 @@ export const settings = {
 					<div className="launchpad__save-modal-body">
 						<div className="launchpad__save-modal-text">
 							<h1 className="launchpad__save-modal-heading">
-								{ __( 'Great progress!', 'jetpack' ) }
+								{ isNewsletter
+									? __( 'Your first post is published!', 'jetpack' )
+									: __( 'Great progress!', 'jetpack' ) }
 							</h1>
 							<p className="launchpad__save-modal-message">
-								{ __(
-									'You are one step away from bringing your site to life. Check out the next steps that will help you to launch your site.',
-									'jetpack'
-								) }
+								{ isNewsletter
+									? __(
+											'Congratulations! You did it. View your post to see how it will look on your site.',
+											'jetpack'
+									  )
+									: __(
+											'You are one step away from bringing your site to life. Check out the next steps that will help you to launch your site.',
+											'jetpack'
+									  ) }
 							</p>
 						</div>
 						<div className="launchpad__save-modal-controls">
@@ -146,11 +156,17 @@ export const settings = {
 								</Button>
 								<Button
 									variant="primary"
-									href={ launchPadUrl }
-									onClick={ () => recordTracksEvent( 'jetpack_launchpad_save_modal_next_steps' ) }
+									href={ isNewsletter ? postLink : launchPadUrl }
+									onClick={ () =>
+										recordTracksEvent(
+											isNewsletter
+												? 'jetpack_launchpad_save_modal_view_post'
+												: 'jetpack_launchpad_save_modal_next_steps'
+										)
+									}
 									target="_top"
 								>
-									{ __( 'Next Steps', 'jetpack' ) }
+									{ isNewsletter ? __( 'View Post', 'jetpack' ) : __( 'Next Steps', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -12,16 +12,19 @@ export const name = 'launchpad-save-modal';
 
 export const settings = {
 	render: function LaunchpadSaveModal() {
-		const { isSavingSite, isSavingPost, isPublishingPost, isCurrentPostPublished } = useSelect(
-			selector => ( {
-				isSavingSite: selector( editorStore ).isSavingNonPostEntityChanges(),
-				isSavingPost: selector( editorStore ).isSavingPost(),
-				isPublishingPost: selector( editorStore ).isPublishingPost(),
-				isCurrentPostPublished: selector( editorStore ).isCurrentPostPublished(),
-			} )
-		);
-
-		const { link: postLink } = useSelect( select => select( 'core/editor' ).getCurrentPost(), [] );
+		const {
+			isSavingSite,
+			isSavingPost,
+			isPublishingPost,
+			isCurrentPostPublished,
+			postLink,
+		} = useSelect( selector => ( {
+			isSavingSite: selector( editorStore ).isSavingNonPostEntityChanges(),
+			isSavingPost: selector( editorStore ).isSavingPost(),
+			isPublishingPost: selector( editorStore ).isPublishingPost(),
+			isCurrentPostPublished: selector( editorStore ).isCurrentPostPublished(),
+			postLink: selector( editorStore ).getPermalink(),
+		} ) );
 
 		const prevIsSavingSite = usePrevious( isSavingSite );
 		const prevIsSavingPost = usePrevious( isSavingPost );

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -44,7 +44,7 @@ export const settings = {
 		const launchPadUrl = getRedirectUrl( `wpcom-launchpad-setup-${ siteIntentOption }`, {
 			query: `siteSlug=${ siteFragment }`,
 		} );
-		const isNewsletter = siteIntentOption === 'newsletter';
+		const showNewsletterPostCopy = siteIntentOption === 'newsletter' && isInsidePostEditor;
 
 		const { tracks } = useAnalytics();
 
@@ -121,12 +121,12 @@ export const settings = {
 					<div className="launchpad__save-modal-body">
 						<div className="launchpad__save-modal-text">
 							<h1 className="launchpad__save-modal-heading">
-								{ isNewsletter
+								{ showNewsletterPostCopy
 									? __( 'Your first post is published!', 'jetpack' )
 									: __( 'Great progress!', 'jetpack' ) }
 							</h1>
 							<p className="launchpad__save-modal-message">
-								{ isNewsletter
+								{ showNewsletterPostCopy
 									? __(
 											'Congratulations! You did it. View your post to see how it will look on your site.',
 											'jetpack'
@@ -156,17 +156,19 @@ export const settings = {
 								</Button>
 								<Button
 									variant="primary"
-									href={ isNewsletter ? postLink : launchPadUrl }
+									href={ showNewsletterPostCopy ? postLink : launchPadUrl }
 									onClick={ () =>
 										recordTracksEvent(
-											isNewsletter
+											showNewsletterPostCopy
 												? 'jetpack_launchpad_save_modal_view_post'
 												: 'jetpack_launchpad_save_modal_next_steps'
 										)
 									}
 									target="_top"
 								>
-									{ isNewsletter ? __( 'View Post', 'jetpack' ) : __( 'Next Steps', 'jetpack' ) }
+									{ showNewsletterPostCopy
+										? __( 'View Post', 'jetpack' )
+										: __( 'Next Steps', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -18,12 +18,14 @@ export const settings = {
 			isPublishingPost,
 			isCurrentPostPublished,
 			postLink,
+			postType,
 		} = useSelect( selector => ( {
 			isSavingSite: selector( editorStore ).isSavingNonPostEntityChanges(),
 			isSavingPost: selector( editorStore ).isSavingPost(),
 			isPublishingPost: selector( editorStore ).isPublishingPost(),
 			isCurrentPostPublished: selector( editorStore ).isCurrentPostPublished(),
 			postLink: selector( editorStore ).getPermalink(),
+			postType: selector( editorStore ).getCurrentPostType(),
 		} ) );
 
 		const prevIsSavingSite = usePrevious( isSavingSite );
@@ -71,7 +73,7 @@ export const settings = {
 			};
 
 			if ( siteIntentOption === 'newsletter' ) {
-				if ( isInsidePostEditor ) {
+				if ( postType === 'post' ) {
 					modalContent.title = __( 'Your first post is published!', 'jetpack' );
 					modalContent.body = __(
 						'Congratulations! You did it. View your post to see how it will look on your site.',
@@ -80,7 +82,7 @@ export const settings = {
 					modalContent.actionButtonHref = postLink;
 					modalContent.actionButtonTracksEvent = 'jetpack_launchpad_save_modal_view_post';
 					modalContent.actionButtonText = __( 'View Post', 'jetpack' );
-				} else if ( isInsideSiteEditor ) {
+				} else {
 					modalContent.body = __(
 						'You are one step away from bringing your site to life. Check out the next steps that will help you to setup your newsletter.',
 						'jetpack'

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -38,9 +38,6 @@ export const settings = {
 			window?.Jetpack_LaunchpadSaveModal || {};
 		const isInsideSiteEditor = document.getElementById( 'site-editor' ) !== null;
 		const isInsidePostEditor = document.querySelector( '.block-editor' ) !== null;
-		const isNewsletter = siteIntentOption === 'newsletter';
-		const isNewsletterPostEditor = isNewsletter && isInsidePostEditor;
-		const isNewsletterSiteEditor = isNewsletter && isInsideSiteEditor;
 		const prevHasNeverPublishedPostOption = useRef( hasNeverPublishedPostOption );
 
 		const siteFragment = getSiteFragment();
@@ -59,40 +56,36 @@ export const settings = {
 			} );
 
 		function getModalContent() {
-			let modalBody;
+			const modalContent = {
+				title: __( 'Great progress!', 'jetpack' ),
+				body: __(
+					'You are one step away from bringing your site to life. Check out the next steps that will help you to launch your site.',
+					'jetpack'
+				),
+				actionButtonHref: launchPadUrl,
+				actionButtonTracksEvent: 'jetpack_launchpad_save_modal_next_steps',
+				actionButtonText: __( 'Next Steps', 'jetpack' ),
+			};
 
-			if ( isNewsletter ) {
-				if ( isNewsletterPostEditor ) {
-					modalBody = __(
+			if ( siteIntentOption === 'newsletter' ) {
+				if ( isInsidePostEditor ) {
+					modalContent.title = __( 'Your first post is published!', 'jetpack' );
+					modalContent.body = __(
 						'Congratulations! You did it. View your post to see how it will look on your site.',
 						'jetpack'
 					);
-				} else if ( isNewsletterSiteEditor ) {
-					modalBody = __(
+					modalContent.actionButtonHref = postLink;
+					modalContent.actionButtonTracksEvent = 'jetpack_launchpad_save_modal_view_post';
+					modalContent.actionButtonText = __( 'View Post', 'jetpack' );
+				} else if ( isInsideSiteEditor ) {
+					modalContent.body = __(
 						'You are one step away from bringing your site to life. Check out the next steps that will help you to setup your newsletter.',
 						'jetpack'
 					);
 				}
-			} else {
-				modalBody = __(
-					'You are one step away from bringing your site to life. Check out the next steps that will help you to launch your site.',
-					'jetpack'
-				);
 			}
 
-			return {
-				title: isNewsletterPostEditor
-					? __( 'Your first post is published!', 'jetpack' )
-					: __( 'Great progress!', 'jetpack', /* dummy arg to avoid bad minification */ 0 ),
-				body: modalBody,
-				actionButtonHref: isNewsletterPostEditor ? postLink : launchPadUrl,
-				actionButtonTracksEvent: isNewsletterPostEditor
-					? 'jetpack_launchpad_save_modal_view_post'
-					: 'jetpack_launchpad_save_modal_next_steps',
-				actionButtonText: isNewsletterPostEditor
-					? __( 'View Post', 'jetpack' )
-					: __( 'Next Steps', 'jetpack', /* dummy arg to avoid bad minification */ 0 ),
-			};
+			return modalContent;
 		}
 
 		useEffect( () => {

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -133,13 +133,8 @@ export const settings = {
 			}
 		}, [ isCurrentPostPublished ] );
 
-		const {
-			title,
-			body,
-			actionButtonHref,
-			actionButtonTracksEvent,
-			actionButtonText,
-		} = getModalContent();
+		const { title, body, actionButtonHref, actionButtonTracksEvent, actionButtonText } =
+			getModalContent();
 
 		const showModal =
 			( ( isInsidePostEditor && isCurrentPostPublished ) || isInsideSiteEditor ) &&


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74415

## Proposed changes
This PR updates the contents of the Launchpad modal when inside the Newsletter flow. Since a Newsletter site doesn't need launching, we are changing the copy and replacing the **Next Steps** button with **View Post**

![jetest](https://user-images.githubusercontent.com/20927667/225716780-d41ae72a-1a8c-4a3c-9e24-c99e2c45d6a0.png)

## Jetpack product discussion
paYE8P-2kx-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. SSH into your wpcom sandbox
2. Run the provided bin script `bin/jetpack-downloader test jetpack add/launchpad_newsletter_modal_copy` in order to sync this branch to your sandbox
3. Create a new Launchpad site
4. Once you choose your domain, sandbox `public-api.wordpress.com` and your new site's domain

### Newsletter Flow
1. Create a new Newsletter site
2. Confirm the modal contents match the screenshot above for both the Site Editor and Post Editor

### Non-Newsletter Flow
1. Create a new Non-Newsletter site
2. Confirm the modal contents match the screenshot above for both the Site Editor and Post Editor