### PR TITLE
VideoPress: add helper function to request update the VideoPress video poster

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-introduce-helper-to-request-video-poster
+++ b/projects/packages/videopress/changelog/update-videopress-introduce-helper-to-request-video-poster
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add helper function to request update the VideoPress video poster

--- a/projects/packages/videopress/src/client/lib/poster/index.ts
+++ b/projects/packages/videopress/src/client/lib/poster/index.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Types
+ */
+import type { VideoGUID } from '../../block-editor/blocks/video/types';
+
+export type WPComV2VideopressPostPosterProps = {
+	code: 200 | number;
+	data: {
+		generating: boolean;
+		poster: string;
+		state: 'complete';
+	};
+};
+
+export const requestUpdatePosterByVideoFrame = function (
+	guid: VideoGUID,
+	atTime: number
+): Promise< WPComV2VideopressPostPosterProps > {
+	return apiFetch( {
+		path: `/wpcom/v2/videopress/${ guid }/poster`,
+		method: 'POST',
+		data: {
+			at_time: atTime,
+			is_millisec: true,
+		},
+	} );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add helper function to request update the VideoPress video poster

### Other information:

script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Since the function is not used in any place, a visual review is enough to go. You can try to call it passing the `guid` and `atTime` params but we are going to test it pretty soon, in a follow-up PRs.
