### PR TITLE
Social: Fix API call on every page load with Publicize enabled

### DIFF
--- a/projects/packages/publicize/changelog/fix-jetpack-social-api-request
+++ b/projects/packages/publicize/changelog/fix-jetpack-social-api-request
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Disabling a feature that's still in development
+
+

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -44,8 +44,6 @@ class Publicize_Setup {
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 
 		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
-
-		self::init_social_image_generator();
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

https://github.com/Automattic/jetpack/pull/29118/files introduced a bug where the WPCOM API gets called on every page load when a site has Publicize enabled. This PR removes initialisation of the SIG library until we improve how we approach this API call.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Internal: p1678900213786529-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
N/A