### PR TITLE
VideoPress: Delay enabling "Done" button to mitigate failed video preview requests

### DIFF
--- a/projects/packages/videopress/changelog/update-delay-button-enabling-to-mitigate-race-condition
+++ b/projects/packages/videopress/changelog/update-delay-button-enabling-to-mitigate-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: delay Done button activation to mitigate the chance of a race condition when saving the post too fast.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -181,7 +181,7 @@ const UploaderProgress = ( {
 	 * wait for some time and then release the "Done" button.
 	 */
 	useEffect( () => {
-		if ( uploadedVideoData && ! isFinishingUpdate ) {
+		if ( uploadedVideoData && ! isFinishingUpdate && isProcessing ) {
 			debug( 'Waiting for some time before enabling the DONE button...' );
 			setTimeout( () => {
 				debug( 'Done, enabling the DONE button now...' );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -7,6 +7,7 @@ import { useDebounce } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, sprintf } from '@wordpress/i18n';
+import debugFactory from 'debug';
 import filesize from 'filesize';
 /**
  * Internal dependencies
@@ -17,6 +18,8 @@ import usePosterUpload from '../../../../../hooks/use-poster-upload.js';
 import { removeFileNameExtension } from '../../../../../lib/url';
 import { PlaceholderWrapper } from '../../edit';
 import UploadingEditor from './uploader-editor.js';
+
+const debug = debugFactory( 'videopress:block:uploader' );
 
 const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 	const [ isFinishingUpdate, setIsFinishingUpdate ] = useState( false );
@@ -179,7 +182,9 @@ const UploaderProgress = ( {
 	 */
 	useEffect( () => {
 		if ( uploadedVideoData && ! isFinishingUpdate ) {
+			debug( 'Waiting for some time before enabling the DONE button...' );
 			setTimeout( () => {
+				debug( 'Done, enabling the DONE button now...' );
 				setIsProcessing( false );
 			}, 2500 );
 		}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -168,6 +168,23 @@ const UploaderProgress = ( {
 		onDone,
 	} );
 
+	/**
+	 * Flag to control the processing state
+	 */
+	const [ isProcessing, setIsProcessing ] = useState( true );
+
+	/**
+	 * When the upload and the metadata update is ready,
+	 * wait for some time and then release the "Done" button.
+	 */
+	useEffect( () => {
+		if ( uploadedVideoData && ! isFinishingUpdate ) {
+			setTimeout( () => {
+				setIsProcessing( false );
+			}, 2500 );
+		}
+	}, [ uploadedVideoData, isFinishingUpdate ] );
+
 	const roundedProgress = Math.round( progress );
 	const cssWidth = { width: `${ roundedProgress }%` };
 	const resumeText = __( 'Resume', 'jetpack-videopress-pkg' );
@@ -234,7 +251,7 @@ const UploaderProgress = ( {
 					</>
 				) : (
 					<>
-						{ uploadedVideoData ? (
+						{ ! isProcessing ? (
 							<span>{ __( 'Upload Complete!', 'jetpack-videopress-pkg' ) } 🎉</span>
 						) : (
 							<span>{ __( 'Finishing up …', 'jetpack-videopress-pkg' ) } 🎬</span>
@@ -242,8 +259,8 @@ const UploaderProgress = ( {
 						<Button
 							variant="primary"
 							onClick={ handleDoneUpload }
-							disabled={ ! uploadedVideoData || isFinishingUpdate }
-							isBusy={ ! uploadedVideoData || isFinishingUpdate }
+							disabled={ isProcessing }
+							isBusy={ isProcessing }
 						>
 							{ __( 'Done', 'jetpack-videopress-pkg' ) }
 						</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28727.

When the user adds a VideoPress block and uploads a new video, we show the following screen:

<img width="600" alt="Screen Shot 2023-03-16 at 14 27 42" src="https://user-images.githubusercontent.com/6760046/225703528-118e1fb2-3b2a-4b91-aa6a-d02a85ffd367.png">

Currently, the `Done` button appears when the upload of the video is complete and the title + poster settings are saved on the backend.

When the user clicks the `Done` button right after finishing the upload and then quickly saves the post containing the block, there is a chance that the oembed caching mechanism will fail to get a preview for the video. This makes the post show a link instead of a player.

This happens because when VideoPress backend is still not ready to give a preview response for the fresh uploaded video, a classical race condition.

See #28727 for more details on the issue and detailed instructions to replicate it.

By adding a little delay before enabling the `Done` button, we give some time to the VideoPress backend to be ready to process the preview request, reducing the risk of a failed request.

The delay is added to the "Finishing up …" step on the upload, so it does not disrupt the user experience while uploading the video:

<img width="600" alt="Screen Shot 2023-03-16 at 14 27 29" src="https://user-images.githubusercontent.com/6760046/225704126-a0567b5a-54b4-47f5-a315-60951bbf7f7c.png">

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include a `2500 ms` delay before enabling the `Done` button on the VideoPress uploaded, keeping the uploader on the "Finishing up ..." state and giving this time to the backend to be ready to process any preview requests that may come, reducing the risk of a failed request

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the browser developer console and enable the debug messages for `videopress:*` messages with `localStorage.setItem( 'debug', 'videopress:*' )`
* Insert a new VideoPress block on the editor
* Click the `Upload` button, select a video to upload and start the upload
* Notice the progress of the upload on the uploader box
* Notice that after the upload finishes, the uploader enter a "Finishing up..." state:

<img width="270" alt="Screen Shot 2023-03-16 at 14 55 15" src="https://user-images.githubusercontent.com/6760046/225709999-e786062e-486d-41e4-a4c6-e089c1d05b19.png">

* On the console, notice that two messages will appear:

<img width="690" alt="Screen Shot 2023-03-16 at 14 57 48" src="https://user-images.githubusercontent.com/6760046/225710561-57fcaef1-48e9-4c02-a6c7-7655281a56ae.png">

* Notice that the `Done` button will not be active until the "Done, enabling the DONE button now..." shows up on the console
* Try to replicate the bug described on #28727, you should not be able to replicate it
* If possible, test on Simple, Atomic and Jetpack sites