### PR TITLE
VideoPress: add async helper fn to request video poster

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-helper-to-request-video-poster
+++ b/projects/packages/videopress/changelog/update-videopress-add-helper-to-request-video-poster
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add async helper fn to request video poster

--- a/projects/packages/videopress/src/client/lib/poster/Readme.md
+++ b/projects/packages/videopress/src/client/lib/poster/Readme.md
@@ -1,0 +1,20 @@
+# Poster library
+
+## requestVideoPoster ( guid )
+
+Async function to request the poster of the VideoPress video based on the given guid.
+It takes a guid parameter and returns a Promise that resolves to an object containing the poster image URL. 
+
+-   _guid_ `VideoGUID`: a string representing the GUID of the VideoPress video to update the poster for.
+
+## requestUpdatePosterByVideoFrame( guid, atTime )
+
+_Parameters_
+
+This function is an asynchronous function that updates the poster image of a VideoPress video at a specific frame
+using the WordPress REST API. The function takes two parameters:
+
+-   _guid_ `VideoGUID`: a string representing the GUID of the VideoPress video to update the poster for.
+-   atTime_ `number`: a number representing the time (in milliseconds) of the frame to set the poster to.
+
+The function returns a Promise that resolves to an object containing the updated poster image URL.

--- a/projects/packages/videopress/src/client/lib/poster/index.ts
+++ b/projects/packages/videopress/src/client/lib/poster/index.ts
@@ -29,3 +29,12 @@ export const requestUpdatePosterByVideoFrame = function (
 		},
 	} );
 };
+
+export const requestVideoPoster = function (
+	guid: VideoGUID
+): Promise< WPComV2VideopressPostPosterProps > {
+	return apiFetch( {
+		path: `/wpcom/v2/videopress/${ guid }/poster`,
+		method: 'GET',
+	} );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up of https://github.com/Automattic/jetpack/pull/29487


Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
VideoPress: add async helper fn to request video poster

### Other information:

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

same as https://github.com/Automattic/jetpack/pull/29487

> Since the function is not used in any place, a visual review is enough to go. You can try to call it passing the guid and atTime params but we are going to test it pretty soon, in a follow-up PRs.