### PR TITLE
[Boost] Follow Prettier typescript.json formatting suggestion

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-typescript-config-code-standard
+++ b/projects/plugins/boost/changelog/fix-boost-typescript-config-code-standard
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Makes the tsconfig.js follow Prettier formatting rules to avoid other PRs having to upinclude it if they correct trunk merge cconflicts
+
+

--- a/projects/plugins/boost/tsconfig.json
+++ b/projects/plugins/boost/tsconfig.json
@@ -1,8 +1,6 @@
 {
 	"extends": "jetpack-js-tools/tsconfig.base.json",
-	"include": [ "app/assets/src/js/**/*",
-      "app/modules/image-guide/src/**/*"
-    ],
+	"include": [ "app/assets/src/js/**/*", "app/modules/image-guide/src/**/*" ],
 	"exclude": [ "node_modules/*", "app/assets/dist/*", "tests/e2e/*" ],
 	"compilerOptions": {
 		"target": "es6",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I had to fix a dependency conflict while merging trunk into https://github.com/Automattic/jetpack/pull/29062/ which made the monorepo's pre-commit Prettier command format the `tsconfig.json` file.

This PR aims to correct it so it can be reviewed in isolation + to avoid other PRs potentially being affected as well.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the formatting of `jsconfig.json`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack build plugins/boost` and verify that the plugins is still built without issues.

