### PR TITLE
Fix post meta import issue

### DIFF
--- a/projects/packages/import/changelog/fix-meta-import
+++ b/projects/packages/import/changelog/fix-meta-import
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fixed post meta imports issue

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -187,7 +187,7 @@ class Post extends \WP_REST_Posts_Controller {
 			$meta_keys,
 			function ( $key ) use ( $excluded_keys ) {
 				// We also don't want to include any oembed post meta because it gets created after a post created
-				return ! in_array( $key, $excluded_keys ) && strpos( $key, '_oembed' ) === false;
+				return ! in_array( $key, $excluded_keys, true ) && strpos( $key, '_oembed' ) === false;
 			}
 		);
 		// Return the filtered array

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -163,9 +163,15 @@ class Post extends \WP_REST_Posts_Controller {
 
 		if ( is_array( $metas ) ) {
 			foreach ( $metas as $meta_key => $meta_value ) {
-				// Add the meta data to the post
+
 				$meta_value = maybe_unserialize( $meta_value );
-				add_post_meta( $post->ID, $meta_key, $meta_value );
+				if ( ! $creating && $meta_key === '_edit_last' ) {
+					update_post_meta( $post->ID, $meta_key, $meta_value );
+				} else {
+					// Add the meta data to the post
+					add_post_meta( $post->ID, $meta_key, $meta_value );
+				}
+
 				do_action( 'import_post_meta', $post->ID, $meta_key, $meta_value );
 			}
 		}

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use Automattic\Jetpack\Sync\Settings;
+
 if ( ! function_exists( 'post_exists' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/post.php';
 }
@@ -38,6 +40,7 @@ class Post extends \WP_REST_Posts_Controller {
 
 		// @see add_post_meta
 		$this->import_id_meta_type = $post_type;
+		add_action( "rest_insert_{$post_type}", array( $this, 'process_post_meta' ), 10, 3 );
 	}
 
 	/**
@@ -138,4 +141,57 @@ class Post extends \WP_REST_Posts_Controller {
 			return array();
 		}
 	}
+
+	/**
+	 * Processes the metadata of a WordPress post when creating or updating it.
+	 *
+	 * @param \WP_Post $post An object representing the post being created or updated.
+	 * @param mixed    $request An object containing the metadata being added to the post.
+	 * @param bool     $creating A flag indicating whether the post is being created or updated.
+	 * @return void
+	 */
+	public function process_post_meta( \WP_Post $post, $request, $creating ) {
+		$metas = $request->get_param( 'meta' );
+
+		if ( empty( $metas ) ) {
+			return;
+		}
+
+		$meta_keys_array = $this->filter_post_meta_keys( $metas );
+		// Adding it to the whitelist
+		Settings::update_settings( array( 'post_meta_whitelist' => $meta_keys_array ) );
+
+		if ( is_array( $metas ) ) {
+			foreach ( $metas as $meta_key => $meta_value ) {
+				// Add the meta data to the post
+				$meta_value = maybe_unserialize( $meta_value );
+				add_post_meta( $post->ID, $meta_key, $meta_value );
+				do_action( 'import_post_meta', $post->ID, $meta_key, $meta_value );
+			}
+		}
+	}
+
+	/**
+	 * Filters an array of post meta keys.
+	 *
+	 * @param array $metas An array of metas to filter.
+	 * @return array The filtered array of meta keys.
+	 */
+	private function filter_post_meta_keys( $metas ) {
+		// Define an array of keys to exclude from the filtered array
+		$excluded_keys = array();
+		// Convert array of keys to a plain array of key strings
+		$meta_keys = array_unique( array_values( array_keys( $metas ) ) );
+		// // Filter the array by removing the excluded keys and any keys that include '_oembed'
+		$filtered_keys = array_filter(
+			$meta_keys,
+			function ( $key ) use ( $excluded_keys ) {
+				// We also don't want to include any oembed post meta because it gets created after a post created
+				return ! in_array( $key, $excluded_keys ) && strpos( $key, '_oembed' ) === false;
+			}
+		);
+		// Return the filtered array
+		return $filtered_keys;
+	}
+
 }

--- a/projects/plugins/jetpack/changelog/fix-meta-import
+++ b/projects/plugins/jetpack/changelog/fix-meta-import
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/dotcom-forge#1689

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Previously some of the post meta was filtered out when importing a post, in this PR, we add some actions to process post meta after a post is created. We'll also need to add post meta into the whitelist to make it works properly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See issue above
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site using [this branch](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack=fix/meta-import&wp-debug-log)
* Connect it to your wpcom user.
* Navigate to http://calypso.lcoalhost:3000/import/${SITE_SLUG}
* Click WordPress and upload a WXR file
* Once it's finished, go to your sandbox and check if metadata gets imported correctly. ( The _oembed ones shouldn't be imported because it'll regenerate once the post is created ).
* You can use wpsh to check: `wp_${site_id}_postmeta` is the table you're looking for.