### PR TITLE
e2e tests: update connection flow

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -6,7 +6,7 @@ const projects = [
 		project: 'Jetpack connection',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/connection', '--retries=1' ],
-		targets: [ 'plugins/jetpack' ],
+		targets: [ 'plugins/jetpack', 'monorepo' ],
 		suite: '',
 	},
 	{

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -6,7 +6,7 @@ const projects = [
 		project: 'Jetpack connection',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/connection', '--retries=1' ],
-		targets: [ 'plugins/jetpack', 'monorepo' ],
+		targets: [ 'plugins/jetpack' ],
 		suite: '',
 	},
 	{

--- a/tools/e2e-commons/flows/jetpack-connect.js
+++ b/tools/e2e-commons/flows/jetpack-connect.js
@@ -4,7 +4,6 @@ import {
 	JetpackPage,
 	JetpackMyPlanPage,
 	RecommendationsPage,
-	JetpackDashboardPage,
 } from '../pages/wp-admin/index.js';
 import {
 	AuthorizePage,
@@ -28,7 +27,7 @@ export async function doClassicConnection( page, plan = 'free' ) {
 
 	if ( plan === 'free' ) {
 		await ( await CompletePage.init( page ) ).select( 'free' );
-		await JetpackDashboardPage.init( page );
+		await RecommendationsPage.init( page );
 	} else {
 		await ( await CompletePage.init( page ) ).viewProducts();
 		await ( await PickAPlanPage.init( page ) ).select( plan );


### PR DESCRIPTION
## Proposed changes:

Upon connecting, users are now redirected to the Recommendations screen.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1678984809251109-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* ~Is CI happy? Let's temporarily enable the test in this PR to find out~ We happy.
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/426388/225700723-d22f2c45-5342-4583-b564-fcd74fccb739.png">

![wehappy](https://user-images.githubusercontent.com/426388/225701514-794b9634-e869-44c3-b8a4-ab42b5ad0f0b.gif)


