### PR TITLE
Forms: do not try to handle labels for dropdown fields

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-php-notice
+++ b/projects/packages/forms/changelog/fix-forms-php-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid PHP notices when using a form with a dropdown field.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -741,8 +741,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				if ( ! empty( $matches[0] ) ) {
 					$options = array();
 					foreach ( $matches[0] as $shortcode ) {
-						$attr      = shortcode_parse_atts( $shortcode );
-						$options[] = $attr['label'];
+						$attr = shortcode_parse_atts( $shortcode );
+						if ( ! empty( $attr['label'] ) ) {
+							$options[] = $attr['label'];
+						}
 					}
 
 					$attributes['options'] = $options;

--- a/projects/plugins/jetpack/changelog/fix-forms-php-notice
+++ b/projects/plugins/jetpack/changelog/fix-forms-php-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: avoid PHP notices when using a form with a dropdown field

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -3296,8 +3296,10 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				if ( ! empty( $matches[0] ) ) {
 					$options = array();
 					foreach ( $matches[0] as $shortcode ) {
-						$attr      = shortcode_parse_atts( $shortcode );
-						$options[] = $attr['label'];
+						$attr = shortcode_parse_atts( $shortcode );
+						if ( ! empty( $attr['label'] ) ) {
+							$options[] = $attr['label'];
+						}
 					}
 
 					$attributes['options'] = $options;


### PR DESCRIPTION
## Proposed changes:

Follow-up to #29290

This should avoid PHP notices like this one:

```
PHP Notice:  Undefined index: label in wp-content/plugins/jetpack-dev/modules/contact-form/grunion-contact-form.php on line 3300
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Launch a JN site with bleeding edge, and connect it to WordPress.com.
    * JN sites have `WP_DEBUG` enabled by default and `WP_DEBUG_LOG` set to true so you should see the notice right there on the page.
* Go to Pages > Add New and add a form to the page.
* In that form, add a dropdown field with a few options.
* Publish the page, and visit the frontend.
    * You should see the notice.
* Now check out this branch, and refresh the page.
    * The notice should be gone.
