### PR TITLE
VideoPress: Fix video library displaying arbitrary video in first page

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-video-first-page
+++ b/projects/packages/videopress/changelog/fix-videopress-video-first-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix video library displaying arbitrary video in first page

--- a/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/libraries.tsx
@@ -124,6 +124,12 @@ const VideoLibraryWrapper = ( {
 export const VideoPressLibrary = ( { videos, totalVideos, loading }: VideoLibraryProps ) => {
 	const history = useHistory();
 	const { search } = useVideos();
+	const videosToDisplay = [
+		// First comes the videos that are uploading
+		...videos.filter( video => video.uploading ),
+		// Then the videos that are not uploading, at most 6
+		...videos.filter( video => ! video.uploading ).slice( 0, 6 ),
+	];
 
 	const libraryTypeFromLocalStorage = localStorage.getItem(
 		LIBRARY_TYPE_LOCALSORAGE_KEY
@@ -150,14 +156,14 @@ export const VideoPressLibrary = ( { videos, totalVideos, loading }: VideoLibrar
 	const library =
 		libraryType === LibraryType.Grid ? (
 			<VideoGrid
-				videos={ videos }
+				videos={ videosToDisplay }
 				onVideoDetailsClick={ handleClickEditDetails }
 				loading={ loading }
-				count={ uploading ? videos.length : 6 }
+				count={ uploading ? videosToDisplay.length : 6 }
 			/>
 		) : (
 			<VideoList
-				videos={ videos }
+				videos={ videosToDisplay }
 				onVideoDetailsClick={ handleClickEditDetails }
 				hidePlays
 				loading={ loading }
@@ -171,7 +177,7 @@ export const VideoPressLibrary = ( { videos, totalVideos, loading }: VideoLibrar
 			libraryType={ libraryType }
 			title={ __( 'Your VideoPress library', 'jetpack-videopress-pkg' ) }
 		>
-			{ videos.length > 0 || loading ? (
+			{ videosToDisplay.length > 0 || loading ? (
 				library
 			) : (
 				<Text>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/use-edit-details.ts
@@ -106,7 +106,8 @@ export default () => {
 	const { videoId: videoIdFromParams } = useParams();
 	const videoId = Number( videoIdFromParams );
 	const { data: video, isFetching, processing, isDeleting, updateVideoPrivacy } = useVideo(
-		Number( videoId )
+		Number( videoId ),
+		true
 	);
 
 	const { playbackToken, isFetchingPlaybackToken } = usePlaybackToken( video );

--- a/projects/packages/videopress/src/client/admin/hooks/use-video/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-video/index.ts
@@ -12,14 +12,15 @@ import { VideopressSelectors, VideoPressVideo } from '../../types';
 /**
  * React custom hook to get specific video.
  *
- * @param {number} id - Video ID
+ * @param {number} id        - Video ID
+ * @param {boolean} addAtEnd - Whether to add the video to the end of the list if not loaded.
  * @returns {object} video
  */
-export default function useVideo( id: number | string ) {
+export default function useVideo( id: number | string, addAtEnd = false ) {
 	const dispatch = useDispatch( STORE_ID );
 
 	const videoData = useSelect(
-		select => ( select( STORE_ID ) as VideopressSelectors ).getVideo( id ),
+		select => ( select( STORE_ID ) as VideopressSelectors ).getVideo( id, addAtEnd ),
 		[ id ]
 	);
 

--- a/projects/packages/videopress/src/client/admin/types/index.ts
+++ b/projects/packages/videopress/src/client/admin/types/index.ts
@@ -240,7 +240,7 @@ export type VideoPressSettings = {
 
 export type VideopressSelectors = {
 	isFetchingPurchases: () => boolean;
-	getVideo: ( id: number | string ) => VideoPressVideo;
+	getVideo: ( id: number | string, addAtEnd: boolean ) => VideoPressVideo;
 	getVideoStateMetadata: ( id: number | string ) => MetadataVideo; // @todo use specific type
 	getVideos: () => VideoPressVideo[];
 	getUploadedVideoCount: () => number;

--- a/projects/packages/videopress/src/client/state/actions.js
+++ b/projects/packages/videopress/src/client/state/actions.js
@@ -108,8 +108,8 @@ const setVideos = videos => {
 	return { type: SET_VIDEOS, videos };
 };
 
-const setVideo = video => {
-	return { type: SET_VIDEO, video };
+const setVideo = ( video, addAtEnd = false ) => {
+	return { type: SET_VIDEO, video, addAtEnd };
 };
 
 const setVideoPrivacy = ( { id, privacySetting } ) => {

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -135,13 +135,13 @@ const videos = ( state, action ) => {
 		}
 
 		case SET_VIDEO: {
-			const { video } = action;
+			const { video, addAtEnd = false } = action;
 			const items = [ ...( state.items ?? [] ) ]; // Clone the array, to avoid mutating the state.
 			const videoIndex = items.findIndex( item => item.id === video.id );
 
 			if ( videoIndex === -1 ) {
-				// Add video when not found at beginning of the list.
-				items.unshift( video );
+				// Add video to the list when not found, at the end or at the beginning by default
+				addAtEnd ? items.push( video ) : items.unshift( video );
 			} else {
 				// Update video when found
 				items[ videoIndex ] = {

--- a/projects/packages/videopress/src/client/state/resolvers.js
+++ b/projects/packages/videopress/src/client/state/resolvers.js
@@ -191,7 +191,7 @@ const getVideo = {
 		return video;
 	},
 
-	fulfill: id => async ( { dispatch, resolveSelect } ) => {
+	fulfill: ( id, addAtEnd = false ) => async ( { dispatch, resolveSelect } ) => {
 		dispatch.setIsFetchingVideos( true );
 
 		try {
@@ -204,7 +204,7 @@ const getVideo = {
 				dispatch
 			);
 
-			dispatch.setVideo( mappedVideoData );
+			dispatch.setVideo( mappedVideoData, addAtEnd );
 			return video;
 		} catch ( error ) {
 			console.error( error ); // eslint-disable-line no-console


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29520

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Limits the number of videos displayed in the library to 6 + uploading videos
* Adds option to add a video at the end of the list instead of the beginning, effectively hiding videos that are accessed directly out of their normal page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the VideoPress dashboard with at least 7 videos (2 pages)
* Go to the video details page of the video in the second page
* Refresh the browser tab
* Click on `Go back`
* Check that the second page video is not rendered in the first page
* Upload a video
* Check that the second page video is not rendered with the video being uploaded