### PR TITLE
Connection: switch the "plugin activated" banner to the common connection flow

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -385,6 +385,8 @@ class Main extends React.Component {
 		}
 
 		if ( this.isMainConnectScreen() ) {
+			const searchParams = new URLSearchParams( location.search.split( '?' )[ 1 ] );
+
 			return (
 				<ConnectScreen
 					apiNonce={ this.props.apiNonce }
@@ -394,6 +396,7 @@ class Main extends React.Component {
 					assetBaseUrl={ this.props.pluginBaseUrl }
 					autoTrigger={ this.shouldAutoTriggerConnection() }
 					redirectUri="admin.php?page=jetpack"
+					from={ searchParams && searchParams.get( 'from' ) }
 				>
 					<p>
 						{ __(

--- a/projects/plugins/jetpack/_inc/connect-button.js
+++ b/projects/plugins/jetpack/_inc/connect-button.js
@@ -1,159 +1,24 @@
 /* global jpConnect */
 
-jQuery( document ).ready( function ( $ ) {
-	var connectButton = $( '.jp-connect-button, #jp-connect-button--alt' ).eq( 0 );
-	var tosText = $( '.jp-connect-full__tos-blurb' );
-	// Sections that only show up in the first Set Up screen
-	var connectionHelpSections = $(
-		'#jetpack-connection-cards, .jp-connect-full__dismiss-paragraph, .jp-connect-full__testimonial'
-	);
-	// Sections that only show up in the "Authorize user" screen
-	var connectButtonFrom = '';
+const connectButtons = document.querySelectorAll( '.jp-connect-button, #jp-connect-button--alt' );
 
-	connectButton.on( 'click', function ( event ) {
+connectButtons.forEach( function ( connectButton ) {
+	connectButton.addEventListener( 'click', function ( event ) {
 		event.preventDefault();
-
-		if ( 'undefined' === typeof URLSearchParams ) {
-			connectButtonFrom = '';
-		} else {
-			var searchParams = new URLSearchParams( $( this ).prop( 'search' ) );
-			connectButtonFrom = searchParams && searchParams.get( 'from' );
-		}
-
-		if ( connectionHelpSections.length ) {
-			connectionHelpSections.fadeOut( 600 );
-		}
-
-		jetpackConnectButton.startConnectionFlow();
+		startConnectionFlow( connectButton );
 	} );
-
-	var jetpackConnectButton = {
-		isRegistering: false,
-		isPaidPlan: false,
-		startConnectionFlow: function () {
-			var connectionHelpSections = $( '#jetpack-connection-cards, .jp-connect-full__testimonial' );
-			if ( connectionHelpSections.length ) {
-				connectionHelpSections.fadeOut( 600 );
-			}
-
-			if ( ! jetpackConnectButton.isRegistering ) {
-				jetpackConnectButton.handleConnection();
-			}
-		},
-		startAuthorizationFlow: function ( data ) {
-			if ( data.alternateAuthorizeUrl ) {
-				window.location = data.alternateAuthorizeUrl;
-			} else {
-				window.location = data.authorizeUrl;
-			}
-		},
-		handleConnection: function () {
-			// Alternative connection buttons should redirect to the main one for the "connect in place" flow.
-			if ( connectButton.attr( 'id' ) === 'jp-connect-button--alt' ) {
-				// Make sure we don't lose the `from` parameter, if set.
-				var fromParam = ( connectButtonFrom && '&from=' + connectButtonFrom ) || '';
-				window.location = jpConnect.connectInPlaceUrl + fromParam;
-				return;
-			}
-
-			jetpackConnectButton.isRegistering = true;
-			tosText.hide();
-			connectButton.hide();
-			jetpackConnectButton.triggerLoadingState();
-
-			var registerUrl = jpConnect.apiBaseUrl + '/connection/register';
-
-			// detect Calypso Env and add to API URL
-			if ( window.Initial_State && window.Initial_State.calypsoEnv ) {
-				registerUrl =
-					registerUrl + '?' + $.param( { calypso_env: window.Initial_State.calypsoEnv } );
-			}
-
-			$.ajax( {
-				url: registerUrl,
-				type: 'POST',
-				data: {
-					registration_nonce: jpConnect.registrationNonce,
-					_wpnonce: jpConnect.apiNonce,
-					from: connectButtonFrom,
-				},
-				error: jetpackConnectButton.handleConnectionError,
-				success: jetpackConnectButton.startAuthorizationFlow,
-			} );
-		},
-		triggerLoadingState: function () {
-			var loadingText = $( '<span>' )
-				.addClass( 'jp-connect-full__button-container-loading' )
-				.text( jpConnect.buttonTextRegistering )
-				.appendTo( '.jp-connect-full__button-container' );
-
-			var spinner = $( '<div>' ).addClass( 'jp-spinner' );
-			var spinnerOuter = $( '<div>' ).addClass( 'jp-spinner__outer' ).appendTo( spinner );
-			$( '<div>' ).addClass( 'jp-spinner__inner' ).appendTo( spinnerOuter );
-			loadingText.after( spinner );
-		},
-		fetchPlanType: function () {
-			return $.ajax( {
-				url: jpConnect.apiBaseUrl + '/site',
-				type: 'GET',
-				data: {
-					_wpnonce: jpConnect.apiSiteDataNonce,
-				},
-				success: function ( data ) {
-					var siteData = JSON.parse( data.data );
-					jetpackConnectButton.isPaidPlan =
-						siteData.options.is_pending_plan || ! siteData.plan.is_free;
-				},
-			} );
-		},
-		receiveData: function ( event ) {
-			if ( event.origin !== jpConnect.jetpackApiDomain ) {
-				return;
-			}
-
-			switch ( event.data ) {
-				case 'close':
-					window.removeEventListener( 'message', this.receiveData );
-					jetpackConnectButton.handleAuthorizationComplete();
-					break;
-				case 'wpcom_nocookie':
-					jetpackConnectButton.handleConnectionError();
-					break;
-			}
-		},
-		handleAuthorizationComplete: function () {
-			jetpackConnectButton.isRegistering = false;
-
-			// Fetch plan type late to make sure any stored license keys have been
-			// attached to the site during the connection.
-			jetpackConnectButton.fetchPlanType().always( function () {
-				if ( ! jetpackConnectButton.isPaidPlan ) {
-					window.location.assign( jpConnect.plansPromptUrl );
-					return;
-				}
-
-				var parser = document.createElement( 'a' );
-				parser.href = jpConnect.dashboardUrl;
-				var reload =
-					window.location.pathname === parser.pathname &&
-					window.location.hash.length &&
-					parser.hash.length;
-
-				window.location.assign( jpConnect.dashboardUrl );
-
-				if ( reload ) {
-					// The Jetpack admin page has hashes in the URLs, so we need to reload the page after .assign()
-					window.location.reload( true );
-				}
-			} );
-		},
-		handleConnectionError: function ( error ) {
-			jetpackConnectButton.isRegistering = false;
-			// If something goes wrong, we take users to Calypso.
-			window.location = connectButton.attr( 'href' );
-		},
-	};
-
-	// In case the parameter has been manually set in the URL after redirect.
-	connectButtonFrom = location.hash.split( '&from=' )[ 1 ];
 } );
+
+function startConnectionFlow( connectButton ) {
+	connectButton.classList.add( 'button-disabled' );
+
+	const searchParams = new URLSearchParams(
+		connectButton.getAttribute( 'href' ).split( '?' )[ 1 ]
+	);
+	window.location =
+		searchParams && searchParams.get( 'from' )
+			? jpConnect.connectUrl
+					.split( '?page=jetpack' )
+					.join( '?page=jetpack&from=' + searchParams.get( 'from' ) )
+			: jpConnect.connectUrl;
+}

--- a/projects/plugins/jetpack/changelog/update-connection-plugin-activated-flow
+++ b/projects/plugins/jetpack/changelog/update-connection-plugin-activated-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Connection: switch the "plugin activated" banner to the common connection flow.

--- a/projects/plugins/jetpack/class.jetpack-connection-banner.php
+++ b/projects/plugins/jetpack/class.jetpack-connection-banner.php
@@ -8,7 +8,6 @@
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Licensing;
-use Automattic\Jetpack\Redirect;
 
 /**
  * Jetpack connection banner.
@@ -249,15 +248,8 @@ class Jetpack_Connection_Banner {
 			'jetpack-connect-button',
 			'jpConnect',
 			array(
-				'apiBaseUrl'            => esc_url_raw( rest_url( 'jetpack/v4' ) ),
-				'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
-				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-				'apiSiteDataNonce'      => wp_create_nonce( 'wp_rest' ),
 				'buttonTextRegistering' => __( 'Loading...', 'jetpack' ),
-				'jetpackApiDomain'      => $jetpack_api_url['scheme'] . '://' . $jetpack_api_url['host'],
-				'connectInPlaceUrl'     => Jetpack::admin_url( 'page=jetpack#/setup' ),
-				'dashboardUrl'          => Jetpack::admin_url( 'page=jetpack#/dashboard' ),
-				'plansPromptUrl'        => Redirect::get_url( 'jetpack-connect-plans' ),
+				'connectUrl'            => Jetpack::admin_url( 'page=jetpack#/setup' ),
 				'identity'              => $identity,
 				'preFetchScript'        => plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ) . '?ver=' . JETPACK__VERSION,
 			)

--- a/projects/plugins/jetpack/class.jetpack-connection-banner.php
+++ b/projects/plugins/jetpack/class.jetpack-connection-banner.php
@@ -239,8 +239,6 @@ class Jetpack_Connection_Banner {
 			JETPACK__VERSION
 		);
 
-		$jetpack_api_url = wp_parse_url( Jetpack::connection()->api_url( '' ) );
-
 		$tracking = new Automattic\Jetpack\Tracking();
 		$identity = $tracking->tracks_get_identity( get_current_user_id() );
 

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -54,7 +54,6 @@
 	"projects/plugins/jetpack/_inc/client/utils/onkeydown-callback.js",
 	"projects/plugins/jetpack/_inc/client/writing/composing.jsx",
 	"projects/plugins/jetpack/_inc/client/writing/theme-enhancements.jsx",
-	"projects/plugins/jetpack/_inc/connect-button.js",
 	"projects/plugins/jetpack/_inc/jetpack-deactivate-dialog.js",
 	"projects/plugins/jetpack/_inc/jetpack-modules.js",
 	"projects/plugins/jetpack/_inc/lib/debugger/jetpack-debugger-site-health.js",


### PR DESCRIPTION
## Proposed changes:
- The connection banner that appears after plugin activation relies on the old connection flow, and sends API requests itself. We'll switch it to using the new "Connection Screen" flow.
- Make the Connection Screen utilize the `from` parameter, and pass it further to Calypso.
- Remove a bunch of legacy code that's no longer needed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
1191179647901802-as-1203777512323068

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Disconnect and deactivate Jetpack.
2. Go to "Plugins", activate Jetpack. You should see the full-screen connection banner, confirm that it looks good: <img width="858" alt="Screen Shot 2023-03-16 at 21 24 17" src="https://user-images.githubusercontent.com/1341249/225788402-c5828565-290f-413b-ba38-55c7a539bd9a.png">
3. Click "Set up Jetpack", the button should turn grey, and you should get redirected to the connection screen with the flow already started.
4. Finish the connection, confirm it went smoothly.
5. Disconnect, go to the WP-admin Dashboard (not Jetpack Dashboard), you should see the top banner, confirm it looks good: <img width="1303" alt="Screen Shot 2023-03-16 at 21 28 14" src="https://user-images.githubusercontent.com/1341249/225788874-8da33a27-19bd-4c1d-b2ea-3121a8c25177.png">
6. Click "Set up Jetpack", the button should turn grey, and you should get redirected to the connection screen with the flow already started.
7. Finish the flow, confirm it goes smoothly.