### PR TITLE
VideoPress: Update comment on deprecated prop to mark it for later change

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-experimental-group-comment
+++ b/projects/packages/videopress/changelog/update-videopress-experimental-group-comment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Update comment on deprecated prop to mark it for later change

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -532,8 +532,8 @@ export default function VideoPressEdit( {
 			</InspectorControls>
 
 			{ /*
-			 * __experimentalGroup is a temporary prop to allow us to group the color panel,
-			 * and it will be replaced with the `group` prop once it's stabilized.
+			 * __experimentalGroup is a temporary prop to allow us to group the color panel, and it
+			 * will be replaced with the `group` prop once WP 6.2 becomes the minimum required version.
 			 * @see https://github.com/WordPress/gutenberg/pull/47105/files#diff-f1d682ce5edd25698e5f189ac8267ab659d6a786260478307dc1352589419309
 			 */ }
 			<InspectorControls __experimentalGroup="color">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #27795

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Marks `WP 6.2` in a comment regarding the `__experimentalGroup` deprecated prop of `InspectorControls` for future prop change when WP 6.2 becomes the minimum required version for Jetpack.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1679069762804509-slack-C03TA48NSUX

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Read the updated comment, as there is no code change.