### PR TITLE
blogging-prompt endpoint fix to use correct error code

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -413,7 +413,11 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 			}
 		}
 
-		return false;
+		return new WP_Error(
+			'rest_cannot_read_prompts',
+			__( 'Sorry, you are not allowed to access blogging prompts on this site.', 'jetpack' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-blogging-prompt-permissions-error-code
+++ b/projects/plugins/jetpack/changelog/fix-blogging-prompt-permissions-error-code
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Small fix for wpcom api tests
+
+


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/29432

## Proposed changes:

Fixes a change from https://github.com/Automattic/jetpack/pull/29432 that's causing wpcom api tests to fail, by returning the expected error code authentication fails.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

PT: pe7F0s-uo-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Check TeamCity build on wpcom for this PR.