### PR TITLE
Protect: Add tracks events for the firewall page toggles

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-waf-tracks
+++ b/projects/plugins/protect/changelog/add-protect-waf-tracks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added tracks events.
+
+

--- a/projects/plugins/protect/src/js/components/firewall-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-page/index.jsx
@@ -65,7 +65,7 @@ const FirewallPage = () => {
 		productSlug: JETPACK_SCAN_SLUG,
 		redirectUrl: `${ ADMIN_URL }#/firewall`,
 	} );
-	const { recordEventHandler, recordEventAsync } = useAnalyticsTracks();
+	const { recordEventHandler, recordEvent } = useAnalyticsTracks();
 
 	const canToggleAutomaticRules = isEnabled && ( hasRequiredPlan || automaticRulesAvailable );
 
@@ -224,7 +224,7 @@ const FirewallPage = () => {
 								/* dummy arg to avoid bad minification */ 0
 						  ),
 				} );
-				recordEventAsync(
+				recordEvent(
 					newValue
 						? 'jetpack_protect_automatic_rules_enabled'
 						: 'jetpack_protect_automatic_rules_disabled'
@@ -245,7 +245,7 @@ const FirewallPage = () => {
 		formState,
 		toggleAutomaticRules,
 		setNotice,
-		recordEventAsync,
+		recordEvent,
 		upgradeIsSeen,
 		setWafUpgradeIsSeen,
 		handleApiError,
@@ -278,7 +278,7 @@ const FirewallPage = () => {
 								/* dummy arg to avoid bad minification */ 0
 						  ),
 				} );
-				recordEventAsync(
+				recordEvent(
 					newValue
 						? 'jetpack_protect_brute_force_protection_enabled'
 						: 'jetpack_protect_brute_force_protection_disabled'
@@ -286,7 +286,7 @@ const FirewallPage = () => {
 			} )
 			.catch( handleApiError )
 			.finally( () => setFormIsSubmitting( false ) );
-	}, [ formState, toggleBruteForceProtection, handleApiError, setNotice, recordEventAsync ] );
+	}, [ formState, toggleBruteForceProtection, handleApiError, setNotice, recordEvent ] );
 
 	/**
 	 * Handle Manual Rules Change
@@ -312,7 +312,7 @@ const FirewallPage = () => {
 								/* dummy arg to avoid bad minification */ 0
 						  ),
 				} );
-				recordEventAsync(
+				recordEvent(
 					newManualRulesStatus
 						? 'jetpack_protect_manual_rules_enabled'
 						: 'jetpack_protect_manual_rules_disabled'
@@ -320,7 +320,7 @@ const FirewallPage = () => {
 			} )
 			.catch( handleApiError )
 			.finally( () => setFormIsSubmitting( false ) );
-	}, [ formState, toggleManualRules, handleApiError, setNotice, recordEventAsync ] );
+	}, [ formState, toggleManualRules, handleApiError, setNotice, recordEvent ] );
 
 	/**
 	 * Handle Show Manual Rules Click

--- a/projects/plugins/protect/src/js/components/firewall-page/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-page/index.jsx
@@ -65,7 +65,7 @@ const FirewallPage = () => {
 		productSlug: JETPACK_SCAN_SLUG,
 		redirectUrl: `${ ADMIN_URL }#/firewall`,
 	} );
-	const { recordEventHandler } = useAnalyticsTracks();
+	const { recordEventHandler, recordEventAsync } = useAnalyticsTracks();
 
 	const canToggleAutomaticRules = isEnabled && ( hasRequiredPlan || automaticRulesAvailable );
 
@@ -224,6 +224,11 @@ const FirewallPage = () => {
 								/* dummy arg to avoid bad minification */ 0
 						  ),
 				} );
+				recordEventAsync(
+					newValue
+						? 'jetpack_protect_automatic_rules_enabled'
+						: 'jetpack_protect_automatic_rules_disabled'
+				);
 			} )
 			.then( () => {
 				if ( ! upgradeIsSeen ) {
@@ -240,6 +245,7 @@ const FirewallPage = () => {
 		formState,
 		toggleAutomaticRules,
 		setNotice,
+		recordEventAsync,
 		upgradeIsSeen,
 		setWafUpgradeIsSeen,
 		handleApiError,
@@ -272,10 +278,15 @@ const FirewallPage = () => {
 								/* dummy arg to avoid bad minification */ 0
 						  ),
 				} );
+				recordEventAsync(
+					newValue
+						? 'jetpack_protect_brute_force_protection_enabled'
+						: 'jetpack_protect_brute_force_protection_disabled'
+				);
 			} )
 			.catch( handleApiError )
 			.finally( () => setFormIsSubmitting( false ) );
-	}, [ formState, toggleBruteForceProtection, setNotice, handleApiError ] );
+	}, [ formState, toggleBruteForceProtection, handleApiError, setNotice, recordEventAsync ] );
 
 	/**
 	 * Handle Manual Rules Change
@@ -289,7 +300,7 @@ const FirewallPage = () => {
 		setFormIsSubmitting( true );
 		setFormState( { ...formState, jetpack_waf_ip_list: newManualRulesStatus } );
 		toggleManualRules()
-			.then( () =>
+			.then( () => {
 				setNotice( {
 					type: 'success',
 					duration: SUCCESS_NOTICE_DURATION,
@@ -300,11 +311,16 @@ const FirewallPage = () => {
 								'jetpack-protect',
 								/* dummy arg to avoid bad minification */ 0
 						  ),
-				} )
-			)
+				} );
+				recordEventAsync(
+					newManualRulesStatus
+						? 'jetpack_protect_manual_rules_enabled'
+						: 'jetpack_protect_manual_rules_disabled'
+				);
+			} )
 			.catch( handleApiError )
 			.finally( () => setFormIsSubmitting( false ) );
-	}, [ formState, toggleManualRules, handleApiError, setNotice ] );
+	}, [ formState, toggleManualRules, handleApiError, setNotice, recordEventAsync ] );
 
 	/**
 	 * Handle Show Manual Rules Click


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the following tracks events to the firewall tab:
  * `jetpack_protect_automatic_rules_enabled`
  * `jetpack_protect_automatic_rules_disabled`
  * `jetpack_protect_manual_rules_enabled`
  * `jetpack_protect_manual_rules_disabled`
  * `jetpack_protect_brute_force_protection_enabled`
  * `jetpack_protect_brute_force_protection_disabled`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p6TEKc-6Lx-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. New tracks events are adding to the Jetpack Protect plugin, on the setting toggles in the firewall tab. See above for list of new event names.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the firewall tab and update your settings.
* Validate the appropriate tracks events are recorded.