### PR TITLE
Jetpack Boost: Cloud CSS - refactor the follow up process

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
@@ -36,7 +36,10 @@ class Critical_CSS_Invalidator {
 	public static function handle_clear_cache( $is_major_change ) {
 		if ( $is_major_change ) {
 			self::clear_data();
-			do_action( 'jetpack_boost_after_clear_cache' );
+
+			$cloud_css = new Cloud_CSS();
+			$cloud_css->regenerate_cloud_css();
+			Cloud_CSS_Followup::schedule();
 		}
 	}
 

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
@@ -6,7 +6,8 @@
  */
 namespace Automattic\Jetpack_Boost\Lib\Critical_CSS;
 
-use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS_Cron;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS_Followup;
 
 class Critical_CSS_Invalidator {
 	/**
@@ -26,7 +27,7 @@ class Critical_CSS_Invalidator {
 		$storage = new Critical_CSS_Storage();
 		$storage->clear();
 		jetpack_boost_ds_delete( 'critical_css_state' );
-		Cloud_CSS_Cron::uninstall();
+		Cloud_CSS_Followup::unschedule();
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -38,7 +38,6 @@ class Cloud_CSS implements Pluggable, Has_Endpoints {
 
 	public function setup() {
 		add_action( 'wp', array( $this, 'display_critical_css' ) );
-		add_action( 'jetpack_boost_after_clear_cache', array( $this, 'regenerate_cloud_css' ) );
 		add_action( 'save_post', array( $this, 'handle_save_post' ), 10, 2 );
 		add_filter( 'jetpack_boost_total_problem_count', array( $this, 'update_total_problem_count' ) );
 
@@ -105,9 +104,6 @@ class Cloud_CSS implements Pluggable, Has_Endpoints {
 	 * with a specific post.
 	 */
 	public function generate_cloud_css( $providers = array() ) {
-		// Set a one off cron job one hour from now. This will resend the request in case it failed.
-		Cloud_CSS_Cron::install( time() + HOUR_IN_SECONDS );
-
 		$grouped_urls = array();
 
 		foreach ( $providers as $source ) {

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -43,7 +43,7 @@ class Cloud_CSS implements Pluggable, Has_Endpoints {
 		add_filter( 'jetpack_boost_total_problem_count', array( $this, 'update_total_problem_count' ) );
 
 		Critical_CSS_Invalidator::init();
-		Cloud_CSS_Cron::init();
+		Cloud_CSS_Followup::init();
 
 		return true;
 	}

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS_Followup.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS_Followup.php
@@ -4,9 +4,9 @@ namespace Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS;
 
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 
-class Cloud_CSS_Cron {
+class Cloud_CSS_Followup {
 
-	const SCHEDULER_HOOK = 'jetpack_boost_check_cloud_css';
+	const SCHEDULER_HOOK = 'jetpack_boost_cloud_css_followup';
 
 	/**
 	 * Initiate the scheduler
@@ -27,10 +27,9 @@ class Cloud_CSS_Cron {
 	 */
 	public static function run() {
 		$state = new Critical_CSS_State();
-
 		if ( $state->has_errors() ) {
-			$client = new Cloud_CSS_Request();
-			$client->request_generate();
+			$cloud_css = new Cloud_CSS();
+			$cloud_css->regenerate_cloud_css();
 		}
 	}
 
@@ -41,17 +40,16 @@ class Cloud_CSS_Cron {
 	 *
 	 * @return void
 	 */
-	public static function install( $when ) {
+	public static function schedule() {
 		// Remove any existing schedule
-		self::uninstall();
-
-		wp_schedule_single_event( $when, self::SCHEDULER_HOOK );
+		self::unschedule();
+		wp_schedule_single_event( time() + HOUR_IN_SECONDS, self::SCHEDULER_HOOK );
 	}
 
 	/**
 	 * Remove the cron-job
 	 */
-	public static function uninstall() {
+	public static function unschedule() {
 		wp_clear_scheduled_hook( self::SCHEDULER_HOOK );
 	}
 }

--- a/projects/plugins/boost/app/rest-api/endpoints/Critical_CSS_Start.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/Critical_CSS_Start.php
@@ -8,6 +8,7 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
 use Automattic\Jetpack_Boost\Modules\Modules;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS_Followup;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Generator;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Endpoint;
 use Automattic\Jetpack_Boost\REST_API\Permissions\Current_User_Admin;
@@ -43,6 +44,7 @@ class Critical_CSS_Start implements Endpoint {
 			// of the CSS and return the URL to the CSS file.
 			$cloud_css = new Cloud_CSS();
 			$cloud_css->regenerate_cloud_css();
+			Cloud_CSS_Followup::schedule();
 		} else {
 			$generator = new Generator();
 			$data      = array_merge( $data, $generator->get_generation_metadata() );

--- a/projects/plugins/boost/changelog/boost-update-cloud-css-followup-scheduler
+++ b/projects/plugins/boost/changelog/boost-update-cloud-css-followup-scheduler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cloud CSS: Refactor the follow-up process.


### PR DESCRIPTION
This fixes an issue where the Cloud CSS would get re-scheduled every hour upon failure, instead - only retrying once. Also renamed the class to make it easier to understand the context.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
1. Apply the patch
2. Regenerate cloud css
3. Ensure that the cron job is scheduled