### PR TITLE
Forms: Update dashboard inbox view scroll behavior

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dashboard-inbox-scroll
+++ b/projects/packages/forms/changelog/update-forms-dashboard-inbox-scroll
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update Forms dashboard inbox view scroll behavior

--- a/projects/packages/forms/src/dashboard/components/layout/index.js
+++ b/projects/packages/forms/src/dashboard/components/layout/index.js
@@ -1,5 +1,3 @@
-import { JetpackFooter } from '@automattic/jetpack-components';
-import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import JetpackFormsLogo from '../logo';
 
@@ -18,11 +16,6 @@ const Layout = ( { children, className, title, subtitle } ) => {
 			</div>
 
 			{ children }
-
-			<JetpackFooter
-				className="jp-forms__layout-footer"
-				moduleName={ __( 'Jetpack Forms', 'jetpack-forms' ) }
-			/>
 		</div>
 	);
 };

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -1,24 +1,11 @@
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { Fragment, useEffect, useState } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { map } from 'lodash';
 import { formatFieldName, getDisplayName, getPath } from './util';
 
 const InboxResponse = ( { loading, response } ) => {
-	const [ responseStyle, setResponseStyle ] = useState( {} );
-
-	useEffect( () => {
-		const content = document.querySelector( '#wpbody-content' );
-		const topOffset = content?.getBoundingClientRect()?.top;
-
-		if ( ! topOffset ) {
-			return;
-		}
-
-		setResponseStyle( { '--wp-content-offset-top': `${ topOffset }px` } );
-	}, [] );
-
 	const classes = classnames( 'jp-forms__inbox-response', {
 		'has-email': true,
 	} );
@@ -33,7 +20,7 @@ const InboxResponse = ( { loading, response } ) => {
 	}
 
 	return (
-		<div className={ classes } style={ responseStyle }>
+		<div className={ classes }>
 			<div className="jp-forms__inbox-response-avatar">
 				<img
 					src="https://gravatar.com/avatar/6e998f49bfee1a92cfe639eabb350bc5?size=68&default=identicon"

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -1,11 +1,24 @@
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { map } from 'lodash';
 import { formatFieldName, getDisplayName, getPath } from './util';
 
 const InboxResponse = ( { loading, response } ) => {
+	const [ responseStyle, setResponseStyle ] = useState( {} );
+
+	useEffect( () => {
+		const content = document.querySelector( '#wpbody-content' );
+		const topOffset = content?.getBoundingClientRect()?.top;
+
+		if ( ! topOffset ) {
+			return;
+		}
+
+		setResponseStyle( { '--wp-content-offset-top': `${ topOffset }px` } );
+	}, [] );
+
 	const classes = classnames( 'jp-forms__inbox-response', {
 		'has-email': true,
 	} );
@@ -20,7 +33,7 @@ const InboxResponse = ( { loading, response } ) => {
 	}
 
 	return (
-		<div className={ classes }>
+		<div className={ classes } style={ responseStyle }>
 			<div className="jp-forms__inbox-response-avatar">
 				<img
 					src="https://gravatar.com/avatar/6e998f49bfee1a92cfe639eabb350bc5?size=68&default=identicon"

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -151,17 +151,24 @@
 .jp-forms__inbox-response {
 	position: relative;
 
+	@media (min-width: 1025px) {
+		position: sticky;
+		top: calc(var(--wp-content-offset-top) + 20px);
+		max-height: calc(100vh - calc(var(--wp-content-offset-top) + 40px));
+		overflow-y: auto;
+	}
+
 	&::before {
 		background: linear-gradient(30deg, #eaeff5, #f2f3e3);
 		border-bottom: 1px solid #dcdcde;
 		box-sizing: border-box;
 		content: "";
 		display: flex;
-		height: 32px;
+		padding-top: 32px;
 	}
 
 	&.has-email::before {
-		height: 70px;
+		padding-top: 70px;
 		margin-bottom: 62px;
 	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -1,5 +1,7 @@
 .jp-forms__inbox {
-	 a.back-button {
+	padding-bottom: 20px;
+
+	a.back-button {
 	 	align-items: center;
 	 	color: #2C3338;
 		display: none;
@@ -38,6 +40,7 @@
 
 	@media (min-width: 1025px) {
 		gap: 24px;
+		padding-bottom: 68px;
 		padding-left: 64px;
 		padding-right: 64px;
 	}
@@ -79,6 +82,11 @@
 		&:last-child {
 			flex: 2;
 		}
+
+		.jp-forms__page-navigation {
+			bottom: 0;
+			position: absolute;
+		}
 	}
 
 	.jp-forms__page-navigation {
@@ -90,6 +98,7 @@
 .jp-forms__inbox-response {
 	border: 1px solid #dcdcde;
 	border-radius: 5px;
+	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	min-height: 300px;
@@ -124,6 +133,11 @@
 		}
 	}
 
+	@media (min-width: 1025px) {
+		display: flex;
+		min-height: calc(100vh - calc(var(--wp-admin--admin-bar--height) + 40px));
+	}
+
 	.jp-forms__table-cell {
 		white-space: nowrap;
 	}
@@ -152,10 +166,10 @@
 	position: relative;
 
 	@media (min-width: 1025px) {
-		position: sticky;
-		top: calc(var(--wp-content-offset-top) + 20px);
-		max-height: calc(100vh - calc(var(--wp-content-offset-top) + 40px));
+		height: calc(100vh - calc(var(--wp-admin--admin-bar--height) + 40px));
 		overflow-y: auto;
+		position: sticky;
+		top: calc(var(--wp-admin--admin-bar--height) + 20px);
 	}
 
 	&::before {

--- a/projects/packages/forms/src/dashboard/index.js
+++ b/projects/packages/forms/src/dashboard/index.js
@@ -1,5 +1,6 @@
 import { render } from '@wordpress/element';
 import Inbox from './inbox';
+import './style.scss';
 
 window.addEventListener( 'load', () => {
 	const container = document.getElementById( 'jp-forms-dashboard' );

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -1,0 +1,10 @@
+body.toplevel_page_jetpack-forms,
+body.admin_page_jetpack-forms {
+	#wpbody-content {
+		padding-bottom: 0;
+	}
+
+	#wpfooter {
+		display: none;
+	}
+}


### PR DESCRIPTION
## Proposed changes:

* Updates the Forms dashboard inbox view to keep the selected response always visible when scrolling the page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Enable the jetpack forms package and the new dashboard before testing with:

```
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
add_filter( 'jetpack_forms_dashboard_enable', '__return_true' );
```

- Go to `/wp-admin/admin.php?page=jetpack-forms`
- Select a response and scroll the page
- Check if the selected response sticks to the top of the page when scrolling

