### PR TITLE
Prevent warnings on parse string attributes

### DIFF
--- a/projects/packages/forms/changelog/fix-warnings-on-parse-string-attributes
+++ b/projects/packages/forms/changelog/fix-warnings-on-parse-string-attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add a check for array on $attributes before trying to set an item on it

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -240,9 +240,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( Settings::is_syncing() ) {
 			return '';
 		}
-		if ( is_array( $attributes ) && isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
+		if ( isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
 			self::style_on();
-			$attributes['block_template_part'] = $GLOBALS['grunion_block_template_part_id'];
+			if ( is_array( $attributes ) ) {
+				$attributes['block_template_part'] = $GLOBALS['grunion_block_template_part_id'];
+			}
 		}
 		// Create a new Grunion_Contact_Form object (this class)
 		$form = new Contact_Form( $attributes, $content );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -240,7 +240,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( Settings::is_syncing() ) {
 			return '';
 		}
-		if ( isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
+		if ( is_array( $attributes ) && isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
 			self::style_on();
 			$attributes['block_template_part'] = $GLOBALS['grunion_block_template_part_id'];
 		}

--- a/projects/plugins/jetpack/changelog/fix-warnings-on-parse-string-attributes
+++ b/projects/plugins/jetpack/changelog/fix-warnings-on-parse-string-attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add a check for array on $attributes before trying to set an item on it

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -2797,7 +2797,9 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		}
 		if ( isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
 			self::style_on();
-			$attributes['block_template_part'] = $GLOBALS['grunion_block_template_part_id'];
+			if ( is_array( $attributes ) ) {
+				$attributes['block_template_part'] = $GLOBALS['grunion_block_template_part_id'];
+			}
 		}
 		// Create a new Grunion_Contact_Form object (this class)
 		$form = new Grunion_Contact_Form( $attributes, $content );


### PR DESCRIPTION
We've been seeing these warnings on a single site, apparently attempting a parse with the wrong kind of parameter:

```
Warning: Illegal string offset 'block_template_part' in /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/staging/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-contact-form.php on line 245
```

## Proposed changes:
Check that the variable is an array before trying to set an item on it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
See: p1679216429714879-slack-C01CSBEN0QZ
Sadly this is hard to repro on sandbox, the check seems safe enough