### PR TITLE
Video block: Fix preload behavior when value is none

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-preload-video-block
+++ b/projects/plugins/jetpack/changelog/fix-preload-video-block
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Fix preload dempty value on video block
+Fix preload behavior when none is chosen

--- a/projects/plugins/jetpack/changelog/fix-preload-video-block
+++ b/projects/plugins/jetpack/changelog/fix-preload-video-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix preload dempty value on video block

--- a/projects/plugins/jetpack/extensions/blocks/videopress/url.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/url.js
@@ -37,7 +37,7 @@ export const getVideoPressUrl = (
 		...( muted && { muted: true, persistVolume: false } ),
 		...( playsinline && { playsinline: true } ),
 		...( poster && { posterUrl: poster } ),
-		...( preload !== 'none' && { preloadContent: preload } ),
+		...( preload !== '' && { preloadContent: preload } ),
 		...( seekbarColor !== '' && { sbc: seekbarColor } ),
 		...( seekbarPlayedColor !== '' && { sbpc: seekbarPlayedColor } ),
 		...( seekbarLoadingColor !== '' && { sblc: seekbarLoadingColor } ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes unexpected behavior when selection the `none` option in the Preload Metadata option.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Whenever the `none` option is selected in the Preload metadata option, the option is not added to the player, so it then adds the default `preload` option to the video tag. Instead of doing so, add the preload none option to the video.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Discussed here: p1679320529169779-slack-C9W0QF6KA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a video to a post on a simple site using the core/video block
* Confirm that when the post is loaded it does not load the preload='none' option in the video tag
* Apply this PR to your WP sandbox and point your simple test site to it
* Confirm that it does add the preload='none' option.
* This can also be confirmed in the network tab, checking packages starting with `proxy?_envelope`   that are sent as soon as the preload option is changed. The body of the requests contains the HTML of the iframe, and it should contain the preload option on it
