### PR TITLE
My Jetpack: Update wpwrap container background to color --jp-white-off

### DIFF
--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -19,4 +19,8 @@
 			display: none;
 		}
 	}
+	#wpwrap {
+		background-color: var(--jp-white-off);
+	}
+
 }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-container-background-color
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-container-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated My Jetpack wpwrap color to --jp-white-off


### PR DESCRIPTION
Updates #wpwrap to color --jp-white-off (#F9F9F6)

Fixes first issue in https://github.com/Automattic/jetpack/issues/29558#issuecomment-1476231296 and https://github.com/Automattic/jetpack/issues/29538#issuecomment-1476232408
<table>
<tr>
    <td><img  alt="image" src="https://user-images.githubusercontent.com/746152/226420815-a19e1538-ab6b-4a56-9527-b12ad7bf8d10.png">
	<td><img  alt="image" src="https://user-images.githubusercontent.com/746152/226420653-2687f65d-fb3c-420c-9930-99019b106d3d.png">
</tr>
<tr>
   <td>Before
	<td>After
</table>


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates My Jetpack's #wpwrap color to Emerald's --jp-white-off

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* [Launch a JN site with this branch](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=update/my-jetpack-container-background-color&wp-debug-log)
* Visit Jetpack -> My Jetpack
* Click Purchase in the Scan card
* Confirm the background is the expected one.
