### PR TITLE
My Jetpack: Update product detail button width to fit its content in product interstitials

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -58,7 +58,7 @@
 	display: inline-block;
 	padding: 0.5em 2em;
 	text-align: center;
-	width: 100%;
+	width: fit-content;
 	min-height: 42px;
 
 	.components-spinner {

--- a/projects/packages/my-jetpack/changelog/update-product-detail-button-width-to-fit-content-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-product-detail-button-width-to-fit-content-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update product detail button width to fit content in My Jetpack product interstitials


### PR DESCRIPTION
Proposal to handle  design request from https://github.com/Automattic/jetpack/issues/29558#issuecomment-1476231296

> Keep the primary CTA button padding the same as the secondary (right now the button stretches full width and it shouldn't)

Given that both buttons are currently occupying the full width, here's a proposal


Updates buttons to have `width: fit-content` instead of `width: 100%`

Fixes #29558 and https://github.com/Automattic/jetpack/issues/29538#issuecomment-1476232408 

<table>
<tr>
    <td><img width="1117" alt="image" src="https://user-images.githubusercontent.com/746152/226442517-db0378fe-1a67-4a29-aa87-eb1f1bdbe9e9.png">
	<td><img width="1113" alt="image" src="https://user-images.githubusercontent.com/746152/226442234-199668d5-aa8d-47c6-832f-da49fb3eeb0f.png">

<tr>
   <td>Before
	<td>After
</table>

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


## Testing instructions:
* [Launch a JN site with this branch](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=update/product-detail-button-width-to-fit-content-my-jetpack&wp-debug-log)
* Visit Jetpack -> My Jetpack
* Click Purchase in the Scan card
* Confirm the buttons look like in the screenshots in this PR

