### PR TITLE
e2e tests: revert changes following revert in connect flow

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -6,7 +6,7 @@ const projects = [
 		project: 'Jetpack connection',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/connection', '--retries=1' ],
-		targets: [ 'plugins/jetpack' ],
+		targets: [ 'plugins/jetpack', 'monorepo' ],
 		suite: '',
 	},
 	{

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -6,7 +6,7 @@ const projects = [
 		project: 'Jetpack connection',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/connection', '--retries=1' ],
-		targets: [ 'plugins/jetpack', 'monorepo' ],
+		targets: [ 'plugins/jetpack' ],
 		suite: '',
 	},
 	{

--- a/tools/e2e-commons/flows/jetpack-connect.js
+++ b/tools/e2e-commons/flows/jetpack-connect.js
@@ -9,7 +9,6 @@ import {
 	AuthorizePage,
 	PickAPlanPage,
 	CheckoutPage,
-	CompletePage,
 	ThankYouPage,
 	LoginPage,
 } from '../pages/wpcom/index.js';
@@ -26,10 +25,9 @@ export async function doClassicConnection( page, plan = 'free' ) {
 	await ( await AuthorizePage.init( page ) ).approve();
 
 	if ( plan === 'free' ) {
-		await ( await CompletePage.init( page ) ).select( 'free' );
+		await ( await PickAPlanPage.init( page ) ).select( 'free' );
 		await RecommendationsPage.init( page );
 	} else {
-		await ( await CompletePage.init( page ) ).viewProducts();
 		await ( await PickAPlanPage.init( page ) ).select( plan );
 		await ( await CheckoutPage.init( page ) ).processPurchase( cardCredentials );
 		await ( await ThankYouPage.init( page ) ).waitForSetupAndProceed();


### PR DESCRIPTION
## Proposed changes:

See https://github.com/Automattic/wp-calypso/pull/74558

This reverts part of #29284

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Is CI happy in the test run [here](https://github.com/Automattic/jetpack/actions/runs/4477820008/jobs/7869857779?pr=29574)?
