### PR TITLE
CRM: Adding contact actions metabox and moving the save button

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-contact-save-button
+++ b/projects/plugins/crm/changelog/update-crm-contact-save-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+CRM: change location of save button and add Contact Actions metabox for contacts

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1040,16 +1040,11 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 					$html .= '<a href="' . jpcrm_esc_link( $key, $navigation['next'], 'zerobs_customer', false ) . '" class="ui right labeled icon button mini" id="zbs-nav-next">' . esc_html( __( 'Next', 'zero-bs-crm' ) ) . '<i class="right chevron icon"></i></a>';
 				}
 			}
-
 			#} If in edit mode, add in save + view
 			if ( $key === 'edit' ) {
-				if( $id > 0 ) {
-					$html .= '<a style="margin-left:6px;" class="ui icon button blue mini labeled" href="' . jpcrm_esc_link( 'view', $id, 'zerobs_customer' ) . '" id="zbs-nav-view"><i class="eye left icon"></i> ' . esc_html( __( 'View', 'zero-bs-crm' ) ) . '</a>';
+				if ( $id > 0 ) {
+					$html .= '<a style="margin-right:5px;margin-left:5px;" class="ui icon button blue mini labeled" href="' . jpcrm_esc_link( 'view', $id, 'zerobs_customer' ) . '" id="zbs-nav-view"><i class="eye left icon"></i> ' . esc_html( __( 'View', 'zero-bs-crm' ) ) . '</a>';
 				}
-				if ( zeroBSCRM_permsCustomers() ) {
-					$html .= '<button class="ui icon button mini green labeled" type="button" id="zbs-edit-save" style="margin-right:5px;margin-left:5px;"><i class="icon save"></i>' . esc_html( __( 'Save', 'zero-bs-crm' ) ) . '</button>';
-				}
-
 			}
 
 			$html .= '</span>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -826,7 +826,6 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
         $this->metaboxArea = 'side';
         $this->metaboxLocation = 'high';
         $this->headless = true;
-        $this->metaboxClasses = 'basic';
         $this->capabilities = array(
 
             'can_hide'          => false, // can be hidden
@@ -843,27 +842,32 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
             $id = (int)sanitize_text_field($_GET['zbsid']);
             // call this, if actions
             $this->actions = zeroBS_contact_actions($id);
-            if (count($this->actions) > 0) $this->initMetabox();
-        }
 
-    }
+		}
+		$this->initMetabox();
+	}
 
     public function html( $contact, $metabox ) {
 
-        global $zbs;
-        
         $avatarMode = zeroBSCRM_getSetting( 'avatarmode' );
         $avatarStr = '';
+		$is_new_contact = count( $this->actions ) > 0 ? false : true;
         if ( $avatarMode !== 3 ) {
 
             $cID = -1; if (is_array($contact) && isset($contact['id'])) $cID = (int)$contact['id'];
             $avatarStr = zeroBS_customerAvatarHTML($cID);
-            $avatarURL = zeroBS_customerAvatar($cID); // url
 
         }
 
+		?>
+		<div class="zbs-generic-save-wrap">
+			<div class="ui medium dividing header"><i class="save icon"></i> <?php esc_html_e( 'Contact Actions', 'zero-bs-crm' ); ?></div>
+			<div class="clear"></div>
+		<?php
+
         # https://codepen.io/kyleshockey/pen/bdeLrE 
-        if (count($this->actions) > 0) { ?>
+		if ( ! $is_new_contact ) {
+			?>
 
         <?php #} Show avatar if avail
         if (!empty($avatarStr)){
@@ -950,7 +954,12 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
         });
         </script>
        <?php }
-
+		?>
+			<div class="zbs-contact-actions-bottom zbs-objedit-actions-bottom">
+				<button class="ui button green" type="button" id="zbs-edit-save"><?php $is_new_contact ? esc_html_e( 'Save', 'zero-bs-crm' ) : esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Contact', 'zero-bs-crm' ); ?></button>
+				<div class='clear'></div>
+			</div>
+			<?php
     }
 
     public function save_data( $contact_id, $contact ) {    


### PR DESCRIPTION


## Proposed changes:

* This PR moves the 'save' button which was showing at the top right of the 'Add New' and 'Edit' pages for contacts, to a Contact Actions metabox in the sidebar. The reason for this is to be more consistent with the styling on other 'Add New' and 'Edit' pages, for example for Quotes and Invoices.
* On the 'Add New' contact page (`/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact`, the metabox has the exact same styling as the 'Add New' quotes page.
* On the 'Edit' contact page (`/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact&zbsid={contactid}`), the styling is similar to the 'Edit' quotes page but differs in that it retains the avatar (or placeholder image) from the original edit contact page, plus the Contact Actions dropdown. The 'Save' button wording on this page is now 'Update'. The 'View' button remains where it was.
* I've not changed the original Contact Actions dropdown itself, as it works well. There's a similar dropdown on the 'View customer' page ( `wp-admin/admin.php?page=zbs-add-edit&action=view&zbstype=contact&zbsid={contactid}`) so the consistency may be a useful thing here.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2941

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test this, using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, visit the 'Add New' contact page: `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact`. You should see a Contact Actions metabox matching that on the Add New Quotes page.
* Test the functionality to make sure it works as expected.
* Once the new contact is created, the metabox should change to include the Contact Actions dropdown. Test the functionality to make sure that still works as expected.
* Also test the Update button to make sure that works as expected.

## Screenshots

**Before**

This is what was seen when editing a contact:
<img width="693" alt="Screenshot 2023-03-21 at 13 35 23" src="https://user-images.githubusercontent.com/16754605/226622455-787bf073-50da-4fe0-b828-a076929d9a4d.png">


This is what was seen when adding a new contact:

<img width="668" alt="Screenshot 2023-03-21 at 13 34 03" src="https://user-images.githubusercontent.com/16754605/226622007-62461b68-1d52-4a6b-b46a-f6487d412ada.png">

**After**

This is what is seen when editing a contact:
<img width="788" alt="Screenshot 2023-03-21 at 13 32 28" src="https://user-images.githubusercontent.com/16754605/226621610-8f17b838-0353-42cf-9628-87d5862a33b2.png">


This is what is seen when adding a new contact:

<img width="724" alt="Screenshot 2023-03-21 at 11 19 03" src="https://user-images.githubusercontent.com/16754605/226621445-b2114677-c924-419b-9158-b186a64080f9.png">
