### PR TITLE
Boost: refactor the Snackbar

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/elements/Snackbar.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/Snackbar.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Snackbar } from '@wordpress/components';
+	import ReactComponent from './ReactComponent.svelte';
+
+	export let message: string;
+	let isActive = true;
+</script>
+
+{#if isActive}
+	<ReactComponent this={Snackbar} children={message} onDismiss={() => ( isActive = false )} />
+{/if}


### PR DESCRIPTION
This makes the snack bar component available outside the GettingStarted svelte component.


## Proposed changes:
Extract the snackbar component for reusability


### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:

1. Compile
2. Produce a getting started screen error
3. See if the snack bar is showing up

