### PR TITLE
Allow filtering feedback by status and return all totals

### DIFF
--- a/projects/packages/forms/changelog/update-jetpack-forms-dashboard-endpoint-totals
+++ b/projects/packages/forms/changelog/update-jetpack-forms-dashboard-endpoint-totals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Feedback responses endpoint now allows filtering by post status and returns all totals.

--- a/projects/plugins/jetpack/changelog/update-jetpack-forms-dashboard-endpoint-totals
+++ b/projects/plugins/jetpack/changelog/update-jetpack-forms-dashboard-endpoint-totals
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Change doesn't currently affect the plugin.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
This PR will allow the current feedback responses to be filtered by status, so we can display different results for either `spam` or `trash`.  

It also replaces the existing `total` number in the response with a `totals` object which will include the total number of results for every status, regardless of which one is currently active.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Make sure you have the new dashboard enabled before testing:

```
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
add_filter( 'jetpack_forms_dashboard_enable', '__return_true' );
```

- Go to `/wp-admin/admin.php?page=jetpack-forms`.
- Inspect the API request to `/wp-json/wpcom/v2/forms/responses`
- The response should now have a `totals` object instead of a `total` number, with numbers for every post status for the current query.
- Re-send the request but manually append a `status` param to the query string and set the value to either `trash` or `spam`.
- You should now get the responses matching the other criteria from spam or trash, but still get all the totals.