### PR TITLE
Add import of custom CSS

### DIFF
--- a/projects/packages/import/changelog/add-import-package-custom-css
+++ b/projects/packages/import/changelog/add-import-package-custom-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added import of custom CSS

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -67,6 +67,7 @@ class Main {
 		$routes = array(
 			'categories' => new Endpoints\Category(),
 			'comments'   => new Endpoints\Comment(),
+			'custom-css' => new Endpoints\Custom_CSS(),
 			'media'      => new Endpoints\Attachment(),
 			'menu-items' => new Endpoints\Menu_Item(),
 			'menus'      => new Endpoints\Menu(),

--- a/projects/packages/import/src/endpoints/class-custom-css.php
+++ b/projects/packages/import/src/endpoints/class-custom-css.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Custom CSS REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+/**
+ * Class Custom_CSS
+ */
+class Custom_CSS extends \WP_REST_Posts_Controller {
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import;
+
+	/**
+	 * Whether the controller supports batching.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'custom_css' );
+
+		$this->rest_base = 'custom-css';
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @see WP_REST_Posts_Controller::register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::$rest_namespace,
+			'/' . $this->rest_base,
+			$this->get_route_options()
+		);
+	}
+
+	/**
+	 * Update the custom CSS post.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		if ( ! function_exists( 'wp_update_custom_css_post' ) ) {
+			require_once ABSPATH . 'wp-includes/theme.php';
+		}
+
+		$args = array(
+			'stylesheet' => $request['title'],
+		);
+
+		$post = wp_update_custom_css_post( $request['content'], $args );
+
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		$response = $this->prepare_item_for_response( $post, $request );
+		$response = rest_ensure_response( $response );
+
+		return $this->add_import_id_metadata( $request, $response );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
WXR files contain the "custom CSS" type of post that we need to import.

Fixes https://github.com/Automattic/dotcom-forge/issues/1977

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new `/jetpack/v4/import/custom-css` endpoint that can be used to import custom CSS posts

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the instructions you can find here: D105485-code