### PR TITLE
Social: Add an endpoint to generate the token for the SIG preview

### DIFF
--- a/projects/packages/publicize/changelog/add-generate-social-preview-endpoint
+++ b/projects/packages/publicize/changelog/add-generate-social-preview-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social: Added an endpoint to generate a token for use as the preview of the social image.

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -44,6 +44,8 @@ class Publicize_Setup {
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 		add_action( 'rest_api_init', array( new Social_Image_Generator\REST_Settings_Controller(), 'register_routes' ) );
 
+		add_action( 'rest_api_init', array( new Social_Image_Generator\REST_Token_Controller(), 'register_routes' ) );
+
 		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
 	}
 

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -101,45 +101,6 @@ class REST_Controller {
 				),
 			)
 		);
-
-		register_rest_route(
-			'jetpack/v4',
-			'/publicize/generate-preview-token',
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'generate_preview_token' ),
-				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
-				'args'                => array(
-					'text'      => array(
-						'description'       => __( 'The text to be used to generate the image.', 'jetpack-publicize-pkg' ),
-						'type'              => 'string',
-						'required'          => true,
-						'validate_callback' => function ( $param ) {
-							return is_string( $param );
-						},
-						'sanitize_callback' => 'sanitize_textarea_field',
-					),
-					'image_url' => array(
-						'description'       => __( 'The URL of the background image to use when generating the social image.', 'jetpack-publicize-pkg' ),
-						'type'              => 'string',
-						'required'          => false,
-						'validate_callback' => function ( $param ) {
-							return is_string( $param );
-						},
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'template'  => array(
-						'description'       => __( 'Array of external connection IDs to skip sharing.', 'jetpack-publicize-pkg' ),
-						'type'              => 'array',
-						'required'          => false,
-						'validate_callback' => function ( $param ) {
-							return in_array( $param, array( 'highway', 'dois', 'fullscreen', 'edge' ), true );
-						},
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-				),
-			)
-		);
 	}
 
 	/**
@@ -233,20 +194,6 @@ class REST_Controller {
 		);
 
 		return rest_ensure_response( $this->make_proper_response( $response ) );
-	}
-
-	/**
-	 * Passes the request parameters to the WPCOM endpoint to generate a preview image token.
-	 *
-	 * @param WP_Request $request The request object, which includes the parameters.
-	 * @return array|WP_Error The token or an error.
-	 */
-	public function generate_preview_token( $request ) {
-		$text      = $request->get_param( 'text' );
-		$image_url = $request->get_param( 'image_url' );
-		$template  = $request->get_param( 'template' );
-
-		return Social_Image_Generator\fetch_token( $text, $image_url, $template );
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -101,6 +101,45 @@ class REST_Controller {
 				),
 			)
 		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'/publicize/generate-preview-token',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'generate_preview_token' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+				'args'                => array(
+					'text'      => array(
+						'description'       => __( 'The text to be used to generate the image.', 'jetpack-publicize-pkg' ),
+						'type'              => 'string',
+						'required'          => true,
+						'validate_callback' => function ( $param ) {
+							return is_string( $param );
+						},
+						'sanitize_callback' => 'sanitize_textarea_field',
+					),
+					'image_url' => array(
+						'description'       => __( 'The URL of the background image to use when generating the social image.', 'jetpack-publicize-pkg' ),
+						'type'              => 'string',
+						'required'          => false,
+						'validate_callback' => function ( $param ) {
+							return is_string( $param );
+						},
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'template'  => array(
+						'description'       => __( 'Array of external connection IDs to skip sharing.', 'jetpack-publicize-pkg' ),
+						'type'              => 'array',
+						'required'          => false,
+						'validate_callback' => function ( $param ) {
+							return in_array( $param, array( 'highway', 'dois', 'fullscreen', 'edge' ), true );
+						},
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -194,6 +233,20 @@ class REST_Controller {
 		);
 
 		return rest_ensure_response( $this->make_proper_response( $response ) );
+	}
+
+	/**
+	 * Passes the request parameters to the WPCOM endpoint to generate a preview image token.
+	 *
+	 * @param WP_Request $request The request object, which includes the parameters.
+	 * @return array|WP_Error The token or an error.
+	 */
+	public function generate_preview_token( $request ) {
+		$text      = $request->get_param( 'text' );
+		$image_url = $request->get_param( 'image_url' );
+		$template  = $request->get_param( 'template' );
+
+		return Social_Image_Generator\fetch_token( $text, $image_url, $template );
 	}
 
 	/**

--- a/projects/packages/publicize/src/social-image-generator/class-rest-token-controller.php
+++ b/projects/packages/publicize/src/social-image-generator/class-rest-token-controller.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Defines the endpoints used for handling tokens for the Social Image Generator.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize\Social_Image_Generator;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Server;
+
+/**
+ * Class used to register token related REST API endpoints used by Social Image Generator.
+ */
+class REST_Token_Controller extends WP_REST_Controller {
+
+	/**
+	 * Register REST API endpoints.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'jetpack/v4',
+			'/social-image-generator/generate-preview-token',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'generate_preview_token' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				'schema'              => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Passes the request parameters to the WPCOM endpoint to generate a preview image token.
+	 *
+	 * @param WP_Request $request The request object, which includes the parameters.
+	 * @return array|WP_Error The token or an error.
+	 */
+	public function generate_preview_token( $request ) {
+		$text      = $request->get_param( 'text' );
+		$image_url = $request->get_param( 'image_url' );
+		$template  = $request->get_param( 'template' );
+
+		return fetch_token( $text, $image_url, $template );
+	}
+
+	/**
+	 * Check the current user has admin privleges for accessing the endpoints.
+	 *
+	 * @return bool|WP_Error True if user can manage options.
+	 */
+	public function require_admin_privilege_callback() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden_context',
+				__( 'Sorry, you are not allowed to access this endpoint.', 'jetpack-publicize-pkg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the JSON schema for the token generation.
+	 *
+	 * @return array Schema data.
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'social-image-generator-token',
+			'type'       => 'object',
+			'properties' => array(
+				'text'      => array(
+					'description' => __( 'The text to be used to generate the image.', 'jetpack-publicize-pkg' ),
+					'type'        => 'string',
+					'required'    => true,
+					'context'     => array( 'edit' ),
+				),
+				'image_url' => array(
+					'description' => __( 'The URL of the background image to use when generating the social image.', 'jetpack-publicize-pkg' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'required'    => false,
+					'context'     => array( 'edit' ),
+				),
+				'template'  => array(
+					'description' => __( 'The template slug', 'jetpack-publicize-pkg' ),
+					'type'        => 'string',
+					'enum'        => Templates::TEMPLATES,
+					'required'    => false,
+				),
+			),
+		);
+
+		return rest_default_additional_properties_to_false( $schema );
+	}
+}

--- a/projects/packages/publicize/src/social-image-generator/class-setup.php
+++ b/projects/packages/publicize/src/social-image-generator/class-setup.php
@@ -7,9 +7,6 @@
 
 namespace Automattic\Jetpack\Publicize\Social_Image_Generator;
 
-use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Publicize\REST_Controller;
-
 /**
  * Class for setting up Social Image Generator-related functionality.
  */
@@ -24,22 +21,6 @@ class Setup {
 	}
 
 	/**
-	 * Get the parameters for the token body.
-	 *
-	 * @param string $text Text to use in the generated image.
-	 * @param string $image_url Image to use in the generated image.
-	 * @param string $template Template to use in the generated image.
-	 * @return array
-	 */
-	public function get_token_body( $text, $image_url, $template ) {
-		return array(
-			'text'      => $text,
-			'image_url' => $image_url,
-			'template'  => $template,
-		);
-	}
-
-	/**
 	 * Get a token from WPCOM to generate the social image for the post, and save it locally.
 	 *
 	 * @param int $post_id Post ID.
@@ -51,20 +32,11 @@ class Setup {
 			return;
 		}
 
-		$body = $this->get_token_body( $post_settings->get_custom_text(), $post_settings->get_image_url(), $post_settings->get_template() );
-
-		$rest_controller = new REST_Controller();
-		$response        = Client::wpcom_json_api_request_as_blog(
-			sprintf( 'sites/%d/jetpack-social/generate-image-token', absint( \Jetpack_Options::get_option( 'id' ) ) ),
-			'2',
-			array(
-				'headers' => array( 'content-type' => 'application/json' ),
-				'method'  => 'POST',
-			),
-			wp_json_encode( array_filter( $body ) ),
-			'wpcom'
+		$token = fetch_token(
+			$post_settings->get_custom_text(),
+			$post_settings->get_image_url(),
+			$post_settings->get_template()
 		);
-		$token           = $rest_controller->make_proper_response( $response );
 
 		if ( is_wp_error( $token ) ) {
 			return;

--- a/projects/packages/publicize/src/social-image-generator/utilities.php
+++ b/projects/packages/publicize/src/social-image-generator/utilities.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Publicize\Social_Image_Generator;
 
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Publicize\REST_Controller;
 use Automattic\Jetpack\Redirect;
 
 /**
@@ -28,3 +30,44 @@ function get_image_url( $post_id ) {
 		Redirect::get_url( 'sigenerate', array( 'site' => null ) )
 	);
 }
+
+/**
+ * Get the parameters for the token body.
+ *
+ * @param string $text Text to use in the generated image.
+ * @param string $image_url Image to use in the generated image.
+ * @param string $template Template to use in the generated image.
+ * @return array
+ */
+function get_token_body( $text, $image_url, $template ) {
+	return array(
+		'text'      => $text,
+		'image_url' => $image_url,
+		'template'  => $template,
+	);
+}
+
+/**
+ * Fetch a token from the WPCOM endpoint.
+ *
+ * @param string $text      The text that will be displayed on the generated image.
+ * @param string $image_url The background image URL to be used in the generated image.
+ * @param string $template  The template slug to use for generating the image.
+ * @return string|WP_Error  The generated token or a WP_Error object if there's been a problem.
+ */
+function fetch_token( $text, $image_url, $template ) {
+	$body            = get_token_body( $text, $image_url, $template );
+	$rest_controller = new REST_Controller();
+	$response        = Client::wpcom_json_api_request_as_blog(
+		sprintf( 'sites/%d/jetpack-social/generate-image-token', absint( \Jetpack_Options::get_option( 'id' ) ) ),
+		'2',
+		array(
+			'headers' => array( 'content-type' => 'application/json' ),
+			'method'  => 'POST',
+		),
+		wp_json_encode( array_filter( $body ) ),
+		'wpcom'
+	);
+	return $rest_controller->make_proper_response( $response );
+}
+

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-rest-token-controller.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-rest-token-controller.php
@@ -1,0 +1,152 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\Publicize\Social_Image_Generator;
+
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Constants;
+use Jetpack_Options;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Unit tests for the REST_Token_Controller class.
+ *
+ * @package automattic/jetpack-publicize
+ */
+class Test_REST_Token_Controller extends TestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Setting up the test.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		$this->admin_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_user',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( 0 );
+
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'new.blogtoken' );
+		Jetpack_Options::update_option( 'id', get_current_blog_id() );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		// Register REST routes.
+		add_action( 'rest_api_init', array( new REST_Token_Controller(), 'register_routes' ) );
+
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+
+		unset( $_SERVER['REQUEST_METHOD'] );
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/social-image-generater/generate-preview-token` endpoint without proper permissions.
+	 */
+	public function test_generate_preview_token_without_proper_permission() {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/social-image-generator/generate-preview-token' );
+		$request->set_body_params(
+			array(
+				'text' => 'Testing the token generation',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+		$this->assertEquals( 'Sorry, you are not allowed to access this endpoint.', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/social-image-generater/generate-preview-token` endpoint without required parameter.
+	 */
+	public function test_generate_preview_token_without_required_parameters() {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/social-image-generator/generate-preview-token' );
+		wp_set_current_user( $this->admin_id );
+		$user = wp_get_current_user();
+		$user->add_cap( 'manage_options' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'rest_missing_callback_param', $response->as_error()->get_error_code() );
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/social-image-generater/generate-preview-token` endpoint with the happy path.
+	 */
+	public function test_generate_preview_token() {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/social-image-generator/generate-preview-token' );
+		$request->set_body_params(
+			array(
+				'text' => 'Testing the token generation',
+			)
+		);
+		wp_set_current_user( $this->admin_id );
+		$user = wp_get_current_user();
+		$user->add_cap( 'manage_options' );
+		add_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
+		$response = $this->server->dispatch( $request );
+		remove_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'dummy-token', $response->get_data() );
+	}
+
+	/**
+	 * Mocks a successful response from WPCOM
+	 */
+	public function mock_success_response() {
+		return array(
+			'body'     => wp_json_encode( 'dummy-token' ),
+			'response' => array(
+				'code'    => 200,
+				'message' => '',
+			),
+		);
+	}
+
+	/**
+	 * Mock fixture for publicize connections.
+	 */
+	public function mock_success_data() {
+		return array(
+			'body'     => wp_json_encode( array( 'facebook' => array( 'connection_id' => 1234 ) ) ),
+			'response' => array(
+				'code'    => 200,
+				'message' => '',
+			),
+		);
+	}
+}

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-setup.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-setup.php
@@ -122,7 +122,7 @@ class Setup_Test extends BaseTestCase {
 	 * Test that the token request has the required information in the body.
 	 */
 	public function test_token_request_has_required_information() {
-		$body = array_keys( $this->sig->get_token_body( 'one', 'two', 'three' ) );
+		$body = array_keys( Social_Image_Generator\get_token_body( 'one', 'two', 'three' ) );
 		$this->assertEquals( $body, array( 'text', 'image_url', 'template' ) );
 	}
 


### PR DESCRIPTION
So we can display a preview of the generated image, we need to call the WPCOM endpoint to generate the token to pass to the generator service.

## Proposed changes:
This change adds an endpoint to the Jetpack site, that calls the WPCOM endpoint and returns the resulting token.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1202583289493814-as-1204165892483474/f

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

* On your dev site with this branch, create an Application Password for your user
* Make sure you have access to SIG on your site.
* Call the endpoint on the using curl, with a command like:

```bash
curl --user "TEST USER:APPLICATION PASSWORD" -d text="This is a test from the CLI" https://TESTSITE.HOST/wp-json/jetpack/v4/publicize/generate-preview-token
```

This should return a token e.g. `eyJ0eHQiOiJ0aGlzIGlzIGEgdGVzdCBmcm9tIHRoZSBDTEkifQ.LTkEfqxiZSfFfz_hmoqzuspSy2uqjiLYAwO7hM2U3ywMQ` which can be used with the generator service.