### PR TITLE
Akismet: use product interstitial for upgrades

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -48,6 +48,7 @@ const MyJetpack = () => (
 			<Routes>
 				<Route path="/" element={ <MyJetpackScreen /> } />
 				<Route path="/connection" element={ <ConnectionScreen /> } />
+				<Route path="/add-anti-spam" element={ <AntiSpamInterstitial /> } />
 				<Route path="/add-akismet" element={ <AntiSpamInterstitial /> } />
 				<Route path="/add-backup" element={ <BackupInterstitial /> } />
 				<Route path="/add-boost" element={ <BoostInterstitial /> } />

--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -48,7 +48,7 @@ const MyJetpack = () => (
 			<Routes>
 				<Route path="/" element={ <MyJetpackScreen /> } />
 				<Route path="/connection" element={ <ConnectionScreen /> } />
-				<Route path="/add-anti-spam" element={ <AntiSpamInterstitial /> } />
+				<Route path="/add-akismet" element={ <AntiSpamInterstitial /> } />
 				<Route path="/add-backup" element={ <BackupInterstitial /> } />
 				<Route path="/add-boost" element={ <BoostInterstitial /> } />
 				<Route path="/add-crm" element={ <CRMInterstitial /> } />

--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -4,7 +4,7 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import * as WPElement from '@wordpress/element';
 import React, { useEffect } from 'react';
-import { HashRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { HashRouter, Navigate, Routes, Route, useLocation } from 'react-router-dom';
 /**
  * Internal dependencies
  */
@@ -48,8 +48,9 @@ const MyJetpack = () => (
 			<Routes>
 				<Route path="/" element={ <MyJetpackScreen /> } />
 				<Route path="/connection" element={ <ConnectionScreen /> } />
-				<Route path="/add-anti-spam" element={ <AntiSpamInterstitial /> } />
 				<Route path="/add-akismet" element={ <AntiSpamInterstitial /> } />
+				{ /* Redirect the old route for Anti Spam */ }
+				<Route path="/add-anti-spam" element={ <Navigate replace to="/add-akismet" /> } />
 				<Route path="/add-backup" element={ <BackupInterstitial /> } />
 				<Route path="/add-boost" element={ <BoostInterstitial /> } />
 				<Route path="/add-crm" element={ <CRMInterstitial /> } />

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -62,7 +62,7 @@ function Price( { value, currency, isOld } ) {
  * @param {Function} props.onClick               - Callback for Call To Action button click
  * @param {Function} props.trackButtonClick      - Function to call for tracking clicks on Call To Action button
  * @param {string} props.className               - A className to be concat with default ones
- * @param {boolean} props.preferProductName		 - Use product name instead of title
+ * @param {boolean} props.preferProductName      - Use product name instead of title
  * @param {React.ReactNode} props.supportingInfo - Complementary links or support/legal text
  * @returns {object}                               ProductDetailCard react component.
  */

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -206,6 +206,9 @@ const ProductDetailCard = ( {
 		);
 	}
 
+	// If we prefer the product name, use that everywhere instead of the title
+	const productMoniker = name && preferProductName ? name : title;
+
 	return (
 		<div
 			className={ classnames( styles.card, className, {
@@ -223,7 +226,7 @@ const ProductDetailCard = ( {
 				{ isBundle && <div className={ styles[ 'product-bundle-icons' ] }>{ icons }</div> }
 				<ProductIcon slug={ slug } />
 
-				<H3>{ name && preferProductName ? name : title }</H3>
+				<H3>{ productMoniker }</H3>
 				<Text mb={ 3 }>{ longDescription }</Text>
 
 				<ul className={ styles.features }>
@@ -258,7 +261,7 @@ const ProductDetailCard = ( {
 									"Due to your server settings, we can't automatically install the plugin for you. Please manually install the %s plugin.",
 									'jetpack-my-jetpack'
 								),
-								title
+								productMoniker
 							) }
 							&nbsp;
 							<ExternalLink href={ `https://wordpress.org/plugins/${ pluginSlug }` }>
@@ -280,7 +283,7 @@ const ProductDetailCard = ( {
 					>
 						{
 							/* translators: placeholder is product name. */
-							sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), title )
+							sprintf( __( 'Add %s', 'jetpack-my-jetpack' ), productMoniker )
 						}
 					</Text>
 				) }

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -62,14 +62,23 @@ function Price( { value, currency, isOld } ) {
  * @param {Function} props.onClick               - Callback for Call To Action button click
  * @param {Function} props.trackButtonClick      - Function to call for tracking clicks on Call To Action button
  * @param {string} props.className               - A className to be concat with default ones
+ * @param {boolean} props.preferProductName		 - Use product name instead of title
  * @param {React.ReactNode} props.supportingInfo - Complementary links or support/legal text
  * @returns {object}                               ProductDetailCard react component.
  */
-const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, supportingInfo } ) => {
+const ProductDetailCard = ( {
+	slug,
+	onClick,
+	trackButtonClick,
+	className,
+	preferProductName,
+	supportingInfo,
+} ) => {
 	const { fileSystemWriteAccess, siteSuffix, myJetpackUrl } = window?.myJetpackInitialState ?? {};
 
 	const { detail, isFetching } = useProduct( slug );
 	const {
+		name,
 		title,
 		longDescription,
 		features,
@@ -214,7 +223,7 @@ const ProductDetailCard = ( { slug, onClick, trackButtonClick, className, suppor
 				{ isBundle && <div className={ styles[ 'product-bundle-icons' ] }>{ icons }</div> }
 				<ProductIcon slug={ slug } />
 
-				<H3>{ title }</H3>
+				<H3>{ name && preferProductName ? name : title }</H3>
 				<Text mb={ 3 }>{ longDescription }</Text>
 
 				<ul className={ styles.features }>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -1,4 +1,4 @@
-import { Container, Col, AdminPage, Text } from '@automattic/jetpack-components';
+import { AdminPage, Button, Col, Container, Text } from '@automattic/jetpack-components';
 import { select } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -115,14 +115,15 @@ export default function ProductInterstitial( {
 					<Text variant="body-small">
 						{ createInterpolateElement(
 							__(
-								'Already have an existing plan or license key? <a>Click here to get started</a>',
+								'Already have an existing plan or license key? <a>Get started</a>.',
 								'jetpack-my-jetpack'
 							),
 							{
 								a: (
-									<a
+									<Button
 										className={ styles[ 'product-interstitial__license-activation-link' ] }
-										href="admin.php?page=my-jetpack#/add-license"
+										href={ existingLicenseKeyUrl || 'admin.php?page=my-jetpack#/add-license' }
+										variant="link"
 									/>
 								),
 							}

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -23,12 +23,14 @@ import videoPressImage from './videopress.png';
  * @param {string} props.slug                    - Product slug
  * @param {string} props.bundle                  - Bundle including this product
  * @param {object} props.children                - Product additional content
+ * @param {string} props.existingLicenseKeyUrl 	 - URL to enter an existing license key (e.g. Akismet)
  * @param {boolean} props.installsPlugin         - Whether the interstitial button installs a plugin*
  * @param {React.ReactNode} props.supportingInfo - Complementary links or support/legal text
  * @returns {object}                               ProductInterstitial react component.
  */
 export default function ProductInterstitial( {
 	bundle,
+	existingLicenseKeyUrl = null,
 	installsPlugin = false,
 	slug,
 	supportingInfo,
@@ -168,7 +170,14 @@ export default function ProductInterstitial( {
  * @returns {object} AntiSpamInterstitial react component.
  */
 export function AntiSpamInterstitial() {
-	return <ProductInterstitial slug="anti-spam" installsPlugin={ true } bundle="security" />;
+	return (
+		<ProductInterstitial
+			slug="anti-spam"
+			installsPlugin={ true }
+			bundle="security"
+			existingLicenseKeyUrl="admin.php?page=akismet-key-config"
+		/>
+	);
 }
 
 /**

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -26,7 +26,7 @@ import videoPressImage from './videopress.png';
  * @param {string} props.existingLicenseKeyUrl 	 - URL to enter an existing license key (e.g. Akismet)
  * @param {boolean} props.installsPlugin         - Whether the interstitial button installs a plugin*
  * @param {React.ReactNode} props.supportingInfo - Complementary links or support/legal text
- * @param {boolean} props.preferProductName		 - Use product name instead of title
+ * @param {boolean} props.preferProductName      - Use product name instead of title
  * @returns {object}                               ProductInterstitial react component.
  */
 export default function ProductInterstitial( {

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -176,12 +176,16 @@ export default function ProductInterstitial( {
  * @returns {object} AntiSpamInterstitial react component.
  */
 export function AntiSpamInterstitial() {
+	const slug = 'anti-spam';
+	const { detail } = useProduct( slug );
+	const { isPluginActive } = detail;
+
 	return (
 		<ProductInterstitial
-			slug="anti-spam"
+			slug={ slug }
 			installsPlugin={ true }
 			bundle="security"
-			existingLicenseKeyUrl={ null }
+			existingLicenseKeyUrl={ isPluginActive ? 'admin.php?page=akismet-key-config' : null }
 			preferProductName={ true }
 		/>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -31,7 +31,7 @@ import videoPressImage from './videopress.png';
  */
 export default function ProductInterstitial( {
 	bundle,
-	existingLicenseKeyUrl = null,
+	existingLicenseKeyUrl = 'admin.php?page=my-jetpack#/add-license',
 	installsPlugin = false,
 	slug,
 	supportingInfo,
@@ -114,23 +114,25 @@ export default function ProductInterstitial( {
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col className={ styles[ 'product-interstitial__header' ] }>
 					<GoBackLink onClick={ onClickGoBack } />
-					<Text variant="body-small">
-						{ createInterpolateElement(
-							__(
-								'Already have an existing plan or license key? <a>Get started</a>.',
-								'jetpack-my-jetpack'
-							),
-							{
-								a: (
-									<Button
-										className={ styles[ 'product-interstitial__license-activation-link' ] }
-										href={ existingLicenseKeyUrl || 'admin.php?page=my-jetpack#/add-license' }
-										variant="link"
-									/>
+					{ existingLicenseKeyUrl && (
+						<Text variant="body-small">
+							{ createInterpolateElement(
+								__(
+									'Already have an existing plan or license key? <a>Get started</a>.',
+									'jetpack-my-jetpack'
 								),
-							}
-						) }
-					</Text>
+								{
+									a: (
+										<Button
+											className={ styles[ 'product-interstitial__license-activation-link' ] }
+											href={ existingLicenseKeyUrl }
+											variant="link"
+										/>
+									),
+								}
+							) }
+						</Text>
+					) }
 				</Col>
 				<Col>
 					<Container
@@ -179,7 +181,7 @@ export function AntiSpamInterstitial() {
 			slug="anti-spam"
 			installsPlugin={ true }
 			bundle="security"
-			existingLicenseKeyUrl="admin.php?page=akismet-key-config"
+			existingLicenseKeyUrl={ null }
 			preferProductName={ true }
 		/>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -26,6 +26,7 @@ import videoPressImage from './videopress.png';
  * @param {string} props.existingLicenseKeyUrl 	 - URL to enter an existing license key (e.g. Akismet)
  * @param {boolean} props.installsPlugin         - Whether the interstitial button installs a plugin*
  * @param {React.ReactNode} props.supportingInfo - Complementary links or support/legal text
+ * @param {boolean} props.preferProductName		 - Use product name instead of title
  * @returns {object}                               ProductInterstitial react component.
  */
 export default function ProductInterstitial( {
@@ -34,6 +35,7 @@ export default function ProductInterstitial( {
 	installsPlugin = false,
 	slug,
 	supportingInfo,
+	preferProductName = false,
 	children = null,
 } ) {
 	const { activate, detail } = useProduct( slug );
@@ -144,6 +146,7 @@ export default function ProductInterstitial( {
 								onClick={ installsPlugin ? clickHandler : undefined }
 								className={ isUpgradableByBundle ? styles.container : null }
 								supportingInfo={ supportingInfo }
+								preferProductName={ preferProductName }
 							/>
 						</Col>
 						<Col sm={ 4 } md={ 4 } lg={ 5 } className={ styles.imageContainer }>
@@ -177,6 +180,7 @@ export function AntiSpamInterstitial() {
 			installsPlugin={ true }
 			bundle="security"
 			existingLicenseKeyUrl="admin.php?page=akismet-key-config"
+			preferProductName={ true }
 		/>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/style.module.scss
@@ -26,4 +26,8 @@
 
 .product-interstitial__license-activation-link {
 	white-space: nowrap;
+
+	& > span {
+		font-size: var(--font-body-small);
+	}
 }

--- a/projects/packages/my-jetpack/changelog/fix-akismet-upgrade-screen
+++ b/projects/packages/my-jetpack/changelog/fix-akismet-upgrade-screen
@@ -4,3 +4,4 @@ Type: changed
 * Updated add-anti-spam path to add-akismet to match the product key
 * Updated product interstitial component to accept an existingLicenseKeyUrl
 * Updated product interstitial component to display a product name instead of a title where preferProductName is set
+* Make is_plugin_active available from the API

--- a/projects/packages/my-jetpack/changelog/fix-akismet-upgrade-screen
+++ b/projects/packages/my-jetpack/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated add-anti-spam path to add-akismet to match product key

--- a/projects/packages/my-jetpack/changelog/fix-akismet-upgrade-screen
+++ b/projects/packages/my-jetpack/changelog/fix-akismet-upgrade-screen
@@ -1,5 +1,6 @@
-Significance: patch
+Significance: minor
 Type: changed
 
-* Updated add-anti-spam path to add-akismet
+* Updated add-anti-spam path to add-akismet to match the product key
 * Updated product interstitial component to accept an existingLicenseKeyUrl
+* Updated product interstitial component to display a product name instead of a title where preferProductName is set

--- a/projects/packages/my-jetpack/changelog/fix-akismet-upgrade-screen
+++ b/projects/packages/my-jetpack/changelog/fix-akismet-upgrade-screen
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
 
-Updated add-anti-spam path to add-akismet to match product key
+* Updated add-anti-spam path to add-akismet
+* Updated product interstitial component to accept an existingLicenseKeyUrl

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.9.x-dev"
+			"dev-trunk": "2.10.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.9.1",
+	"version": "2.10.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.9.1';
+	const PACKAGE_VERSION = '2.10.0-alpha';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -58,7 +58,7 @@ class Anti_Spam extends Product {
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Jetpack Akismet Anti-spam', 'jetpack-my-jetpack' );
+		return __( 'Akismet Anti-spam', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -87,7 +87,6 @@ class Anti_Spam extends Product {
 	public static function get_features() {
 		return array(
 			_x( 'Comment and form spam protection', 'Anti-Spam Product Feature', 'jetpack-my-jetpack' ),
-			_x( 'Powered by Akismet', 'Anti-Spam Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'Block spam without CAPTCHAs', 'Anti-Spam Product Feature', 'jetpack-my-jetpack' ),
 			_x( 'Advanced stats', 'Anti-Spam Product Feature', 'jetpack-my-jetpack' ),
 		);

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -58,7 +58,7 @@ class Anti_Spam extends Product {
 	 * @return string
 	 */
 	public static function get_title() {
-		return __( 'Akismet Anti-spam', 'jetpack-my-jetpack' );
+		return __( 'Jetpack Akismet Anti-spam', 'jetpack-my-jetpack' );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -122,6 +122,7 @@ abstract class Product {
 			'status'                   => static::get_status(),
 			'pricing_for_ui'           => static::get_pricing_for_ui(),
 			'is_bundle'                => static::is_bundle_product(),
+			'is_plugin_active'         => static::is_plugin_active(),
 			'is_upgradable_by_bundle'  => static::is_upgradable_by_bundle(),
 			'supported_products'       => static::get_supported_products(),
 			'wpcom_product_slug'       => static::get_wpcom_product_slug(),

--- a/projects/plugins/backup/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/backup/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -842,7 +842,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "54b9109d3dd39eb6bfd59613703bdf92e943ddf7"
+                "reference": "5a2b5091724708902ba182b6178c6c9b293acb3b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -869,7 +869,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.9.x-dev"
+                    "dev-trunk": "2.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/boost/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -701,7 +701,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "54b9109d3dd39eb6bfd59613703bdf92e943ddf7"
+                "reference": "5a2b5091724708902ba182b6178c6c9b293acb3b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -728,7 +728,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.9.x-dev"
+                    "dev-trunk": "2.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/constants.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/constants.js
@@ -20,6 +20,7 @@ export const productDescriptionRoutes = [
 ];
 
 export const myJetpackRoutes = [
+	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_ANTI_SPAM }`,
 	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_BACKUP }`,
 	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_SCAN }`,
 	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_SEARCH }`,

--- a/projects/plugins/jetpack/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/jetpack/changelog/fix-akismet-upgrade-screen
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Akismet: visual and copy edits on upgrade screen
+Akismet: use product interstitial for upgrades

--- a/projects/plugins/jetpack/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/jetpack/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Akismet: visual and copy edits on upgrade screen

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -6738,7 +6738,7 @@ endif;
 		);
 
 		$products['akismet'] = array(
-			'title'             => __( 'Jetpack Anti-Spam', 'jetpack' ),
+			'title'             => __( 'Akismet Anti-Spam', 'jetpack' ),
 			'slug'              => 'jetpack_anti_spam',
 			'description'       => __( 'Save time and get better responses by automatically blocking spam from your comments and forms.', 'jetpack' ),
 			'show_promotion'    => true,
@@ -6746,7 +6746,6 @@ endif;
 			'included_in_plans' => array( 'security' ),
 			'features'          => array(
 				_x( 'Comment and form spam protection', 'Anti-Spam Product Feature', 'jetpack' ),
-				_x( 'Powered by Akismet', 'Anti-Spam Product Feature', 'jetpack' ),
 				_x( 'Block spam without CAPTCHAs', 'Anti-Spam Product Feature', 'jetpack' ),
 				_x( 'Advanced stats', 'Anti-Spam Product Feature', 'jetpack' ),
 			),

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1408,7 +1408,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "54b9109d3dd39eb6bfd59613703bdf92e943ddf7"
+                "reference": "5a2b5091724708902ba182b6178c6c9b293acb3b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1435,7 +1435,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.9.x-dev"
+                    "dev-trunk": "2.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/migration/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -760,7 +760,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "54b9109d3dd39eb6bfd59613703bdf92e943ddf7"
+                "reference": "5a2b5091724708902ba182b6178c6c9b293acb3b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -787,7 +787,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.9.x-dev"
+                    "dev-trunk": "2.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/protect/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -760,7 +760,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "54b9109d3dd39eb6bfd59613703bdf92e943ddf7"
+                "reference": "5a2b5091724708902ba182b6178c6c9b293acb3b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -787,7 +787,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.9.x-dev"
+                    "dev-trunk": "2.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/search/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -760,7 +760,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "54b9109d3dd39eb6bfd59613703bdf92e943ddf7"
+                "reference": "5a2b5091724708902ba182b6178c6c9b293acb3b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -787,7 +787,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.9.x-dev"
+                    "dev-trunk": "2.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/social/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -760,7 +760,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "54b9109d3dd39eb6bfd59613703bdf92e943ddf7"
+                "reference": "5a2b5091724708902ba182b6178c6c9b293acb3b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -787,7 +787,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.9.x-dev"
+                    "dev-trunk": "2.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/starter-plugin/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -760,7 +760,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "54b9109d3dd39eb6bfd59613703bdf92e943ddf7"
+                "reference": "5a2b5091724708902ba182b6178c6c9b293acb3b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -787,7 +787,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.9.x-dev"
+                    "dev-trunk": "2.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/videopress/changelog/fix-akismet-upgrade-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -760,7 +760,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "54b9109d3dd39eb6bfd59613703bdf92e943ddf7"
+                "reference": "5a2b5091724708902ba182b6178c6c9b293acb3b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -787,7 +787,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.9.x-dev"
+                    "dev-trunk": "2.10.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
Fixes #29584 and https://github.com/Automattic/jetpack/issues/29743.

## Proposed changes:

On the Akismet upgrade page in wp-admin, this PR will:

* Switch to use the My Jetpack product interstitial for Akismet upgrades (see p1HpG7-loc-p2)
* Change title to ‘Akismet Anti-Spam’
* Add header link to add an Akismet license key if the Akismet plugin is installed and active
* Small improvements to 'add license key' header as outlined in #29743.

![image](https://user-images.githubusercontent.com/17325/226747296-a5352fef-b97d-48e6-8961-3031b8abc583.png)

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-l2l-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Navigate to `/wp-admin/admin.php?page=my-jetpack#/add-akismet` and check that the changes above have been applied.

Navigate to `/wp-admin/admin.php?page=my-jetpack#/add-anti-spam` and check that you are redirected to `add-akismet`.

Check that the license key header text appears if the Akismet plugin is installed and active. If it is inactive or not installed, this text should not appear:

<img width="422" alt="Screenshot 2023-03-29 at 1 53 23 PM" src="https://user-images.githubusercontent.com/17325/228398769-093136ab-c4f8-424e-b1ce-41d7327fc43e.png">

The changes to the license key header affect all product interstitial pages. To test the changes to this header elsewhere, navigate to any other product interstitial, like `/wp-admin/admin.php?page=my-jetpack#/add-backup`.

