### PR TITLE
VideoPress: polish TimestampControl component styles

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-tweak-styles
+++ b/projects/packages/videopress/changelog/update-videopress-tweak-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: polish TimestampControl component styles

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -9,6 +9,7 @@ import {
 	useBaseControlProps,
 } from '@wordpress/components';
 import { useCallback, useRef } from '@wordpress/element';
+import classNames from 'classnames';
 /**
  * Internal dependencies
  */
@@ -122,7 +123,11 @@ export const TimestampInput = ( {
 	};
 
 	return (
-		<div className={ styles[ 'timestamp-input-wrapper' ] }>
+		<div
+			className={ classNames( styles[ 'timestamp-input-wrapper' ], {
+				[ styles[ 'is-disabled' ] ]: disabled,
+			} ) }
+		>
 			{ ( biggerThanOneHour || ! autoHideTimeInput ) && (
 				<>
 					<NumberControl

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -61,9 +61,9 @@ type TimeDataProps = {
  * @returns {TimeDataProps}                   The time data.
  */
 function getTimeDataByValue( value: number, decimalPlaces: DecimalPlacesProp ): TimeDataProps {
-	const valueIsNaN = isNaN( value );
+	const valueIsNaN = Number.isNaN( value );
 
-	// Compute decimal part based on tyhe decimalPlaces.
+	// Compute decimal part based on the decimalPlaces.
 	const decimal =
 		valueIsNaN || typeof decimalPlaces === 'undefined'
 			? 0

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
@@ -26,6 +26,10 @@ The timestamp value in milliseconds
 
 - type `boolean`
 
+<Canvas withSource="false">
+  <Story id="packages-videopress-timestamp-control--disabled" />
+</Canvas>
+
 ### label
 
 - type `ReactNode`

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
@@ -69,3 +69,16 @@ decimalPlaces.args = {
 	max: 1000 * 5, // five seconds
 	decimalPlaces: 2,
 };
+
+// disabled story
+const disabledStoryTemplate: ComponentStory< typeof TimestampControl > = args => {
+	const [ time, setTime ] = useState( args.value );
+	return <TimestampControl { ...args } value={ time } onChange={ setTime } />;
+};
+
+export const disabled = disabledStoryTemplate.bind( {} );
+disabled.args = {
+	max: 3600 * 1000 * 2, // 2 hours
+	value: 3600 * 1000 + 15 * 60 * 1000 + 43 * 1000, // 1.5 hours
+	disabled: true,
+};

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -42,6 +42,14 @@
 			border-style: none !important;
 		}
 	}
+
+	&.is-disabled {
+		background-color: #f0f0f0;
+
+		.timestamp-control-divider {
+			color: #949494;
+		}
+	}
 }
 
 .timestamp-control-divider {

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -43,3 +43,7 @@
 		}
 	}
 }
+
+.timestamp-control-divider {
+	font-weight: 900;
+}

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -19,6 +19,7 @@
 	display: flex;
 	align-items: center;
 	border-color: #949494;
+	background-color: #fff;
     border-style: solid;
 	justify-content: space-around;
     border-width: 1px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR polishes the TimestampControl component:

* The disabled style of the component
* The font weight of the internal `<TimeDivider />` component

Part of https://github.com/Automattic/jetpack/issues/29278
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: polish TimestampControl component styles

### Other information:

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with the Storybook
* Confirm the `disabled` state

<img width="833" alt="image" src="https://user-images.githubusercontent.com/77539/226776960-3eff8683-081d-4f4c-9c76-6f0f0929fbb0.png">
