### PR TITLE
WAF: Run PHPCS for all brute force protection files

### DIFF
--- a/projects/packages/waf/changelog/phpcs-improvements
+++ b/projects/packages/waf/changelog/phpcs-improvements
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Removed files from phpcs exclude list, no functional changes.
+
+

--- a/projects/packages/waf/src/brute-force-protection/class-transient-cleanup.php
+++ b/projects/packages/waf/src/brute-force-protection/class-transient-cleanup.php
@@ -29,7 +29,7 @@ class Brute_Force_Protection_Transient_Cleanup {
 			"SELECT REPLACE(option_name, '_transient_timeout_jpp_', '') AS transient_name FROM {$wpdb->options} WHERE option_name LIKE '\_transient\_timeout\_jpp\__%%' AND option_value < %d",
 			$older_than_time
 		);
-		$transients    = $wpdb->get_col( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared above.
+		$transients    = $wpdb->get_col( $sql ); // phpcs:ignore WordPress.DB -- $sql is prepared above.
 		$options_names = array();
 		foreach ( $transients as $transient ) {
 			$options_names[] = '_transient_jpp_' . $transient;
@@ -37,7 +37,7 @@ class Brute_Force_Protection_Transient_Cleanup {
 		}
 		if ( $options_names ) {
 			$option_names_string = implode( ', ', array_fill( 0, count( $options_names ), '%s' ) );
-			$result              = $wpdb->query(
+			$result              = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 				$wpdb->prepare(
 					"DELETE FROM {$wpdb->options} WHERE option_name IN ($option_names_string)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- the placeholders are set above.
 					$options_names

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -422,7 +422,7 @@ class Brute_Force_Protection {
 			$request['multisite'] = get_blog_count();
 			if ( ! $request['multisite'] ) {
 				global $wpdb;
-				$request['multisite'] = $wpdb->get_var( "SELECT COUNT(blog_id) as c FROM $wpdb->blogs WHERE spam = '0' AND deleted = '0' and archived = '0'" );
+				$request['multisite'] = $wpdb->get_var( "SELECT COUNT(blog_id) as c FROM $wpdb->blogs WHERE spam = '0' AND deleted = '0' and archived = '0'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			}
 		}
 

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -18,8 +18,6 @@
 	"projects/packages/sync/src/replicastore/class-table-checksum-usermeta.php",
 	"projects/packages/sync/src/replicastore/class-table-checksum-users.php",
 	"projects/packages/sync/src/replicastore/class-table-checksum.php",
-	"projects/packages/waf/src/brute-force-protection/class-transient-cleanup.php",
-	"projects/packages/waf/src/class-brute-force-protection.php",
 	"projects/plugins/beta/src/class-utils.php",
 	"projects/plugins/boost/app/class-jetpack-boost.php",
 	"projects/plugins/boost/app/lib/class-transient.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes `class-brute-force-protection.php` and `class-transient-cleanup.php` from being excluded by PHPCS.
* Adds `// phpcs:ignore` to the above files to maintain the historically passing PHPCS tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1203716242675347-as-1203812254177713

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate tests pass