### PR TITLE
Added can_blaze property to /sites/{siteId} endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-new-has-promote-widget-property-to-endpoint
+++ b/projects/plugins/jetpack/changelog/add-new-has-promote-widget-property-to-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Added has_blaze property to /sites/{siteId} endpoint (inside options attribute)
+Added can_blaze property to /sites/{siteId} endpoint (inside options attribute)

--- a/projects/plugins/jetpack/changelog/add-new-has-promote-widget-property-to-endpoint
+++ b/projects/plugins/jetpack/changelog/add-new-has-promote-widget-property-to-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Added has_promote_widget property to /sites/{siteId} endpoint (inside options attribute)
+Added has_blaze property to /sites/{siteId} endpoint (inside options attribute)

--- a/projects/plugins/jetpack/changelog/add-new-has-promote-widget-property-to-endpoint
+++ b/projects/plugins/jetpack/changelog/add-new-has-promote-widget-property-to-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added has_promote_widget property to /sites/{siteId} endpoint (inside options attribute)

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -200,7 +200,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'launchpad_checklist_tasks_statuses',
 		'wpcom_production_blog_id',
 		'wpcom_staging_blog_ids',
-		'has_promote_widget',
+		'can_blaze',
 	);
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -200,6 +200,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'launchpad_checklist_tasks_statuses',
 		'wpcom_production_blog_id',
 		'wpcom_staging_blog_ids',
+		'has_promote_widget',
 	);
 
 	/**
@@ -871,6 +872,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'wpcom_staging_blog_ids':
 					$options[ $key ] = $site->get_wpcom_staging_blog_ids();
+					break;
+				case 'has_promote_widget':
+					$options[ $key ] = apply_filters( 'dsp_promote_posts_enabled', false, $site->blog_id );
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -873,8 +873,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'wpcom_staging_blog_ids':
 					$options[ $key ] = $site->get_wpcom_staging_blog_ids();
 					break;
-				case 'has_promote_widget':
-					$options[ $key ] = apply_filters( 'dsp_promote_posts_enabled', false, $site->blog_id );
+				case 'can_blaze':
+					$options[ $key ] = $site->can_blaze();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -11,6 +11,7 @@
  * @package automattic/jetpack
  **/
 
+use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
@@ -1499,5 +1500,14 @@ abstract class SAL_Site {
 	 */
 	public function get_wpcom_staging_blog_ids() {
 		return get_option( 'wpcom_staging_blog_ids', array() );
+	}
+
+	/**
+	 * Get the site's Blaze eligibility status.
+	 *
+	 * @return bool
+	 */
+	public function can_blaze() {
+		return (bool) Blaze::site_supports_blaze( $this->blog_id );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1532-gh-Automattic/dotcom-forge

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Added `can_blaze` property to /sites/{siteId} endpoint (inside options attribute), so Calypso can understand when to allow users to use it. We're also checking it by each `blog_id`, so we don't need to rely on the primary blog info.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

More context to this change can be found here: p1679438980595779/1679438966.648259-slack-C04DZ725FEK

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR change in your sandbox with the command: `bin/jetpack-downloader test jetpack add/new-has-promote-widget-property-to-endpoint`
* Make sure your example site has En locale and it's published
* Open [your WordPress console](https://developer.wordpress.com/docs/api/console/), access the `/sites/{siteId}?http_envelope=1` wpcom v1.1 endpoint, and test if the `options->can_blaze` attribute is true
* Change your example site to a PT-br locale
* The `options->can_blaze` attribute should now be false
* Test with Simple, Atomic and Self-hosted sites, by installing jetpack beta plugin and follow these instructions: pb5gDS-2kZ-p2#comment-3156 and applying the code of `add/new-has-promote-widget-property-to-endpoint` branch on them


<img width="708" alt="image" src="https://user-images.githubusercontent.com/1044309/226924521-8197d53a-0175-4196-a7ba-10f0f6000c6d.png">


You can also test it using [the complement Calypso PR](https://github.com/Automattic/wp-calypso/pull/74795)

## Does this pull request change what data or activity we track or use?

No.