### PR TITLE
VideoPress: trigger video events to client via player-bridge

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-control-player-from-bridge
+++ b/projects/packages/videopress/changelog/update-videopress-control-player-from-bridge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: trigger video events to client via player-bridge

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -148,15 +148,19 @@ export default function Player( {
 	}, [] );
 
 	// Listen to the `message` event.
+	const sandboxIframeElement: HTMLIFrameElement = videoWrapperRef?.current?.querySelector(
+		'iframe.components-sandbox'
+	);
 	useEffect( () => {
-		if ( ! window ) {
+		if ( ! sandboxIframeElement?.contentWindow ) {
 			return;
 		}
 
-		window.addEventListener( 'message', onVideoLoadingStateHandler );
+		const iFrameContentWindow = sandboxIframeElement.contentWindow;
+		iFrameContentWindow.addEventListener( 'message', onVideoLoadingStateHandler );
 
-		return () => window?.removeEventListener( 'message', onVideoLoadingStateHandler );
-	}, [ onVideoLoadingStateHandler ] );
+		return () => iFrameContentWindow?.removeEventListener( 'message', onVideoLoadingStateHandler );
+	}, [ onVideoLoadingStateHandler, sandboxIframeElement ] );
 
 	useEffect( () => {
 		if ( isRequestingEmbedPreview ) {

--- a/projects/packages/videopress/src/client/lib/player-bridge/Readme.md
+++ b/projects/packages/videopress/src/client/lib/player-bridge/Readme.md
@@ -1,3 +1,26 @@
 # Player Bridge
 
 Bridge to communicate player with the block editor.
+
+## How
+
+The file script is intended to be provided and run to a children document,
+usually implemented via a core Sandbox component.
+
+
+## Listen to player events
+
+You don't need to use the bridge for this.
+It's possible to get subscribed just by picking the `contentWindow` of the sandbox iFrame element,
+since the player emits evens to its window and parent window.
+
+## Triggering events to the player
+
+You need to get the `contentWindow` of the sandbox iFrame element, and trigger the events just by calling the postMessage() function:
+
+```es6
+const iFrame = getElementById( 'my-sandbox-element' );
+const iFrameWindow = iFrame?.contentWindow;
+
+iFrameWindow?.postMessage( { event: 'videopress_action_pause' } );
+```

--- a/projects/packages/videopress/src/client/lib/player-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/player-bridge/index.ts
@@ -11,6 +11,20 @@ type Origin = 'https://videopress.com' | 'https://video.wordpress.com';
 
 const debug = debugFactory( 'videopress:player-bridge' );
 
+const VIDEOPRESS_ALLOWED_LISTENING_EVENTS = [
+	'videopress_playing',
+	'videopress_pause',
+	'videopress_seeking',
+	'videopress_resize',
+	'videopress_volumechange',
+	'videopress_ended',
+	'videopress_timeupdate',
+	'videopress_durationchange',
+	'videopress_progress',
+	'videopress_loading_state',
+	'videopress_toggle_fullscreen',
+] as const;
+
 const VIDEOPRESS_ALLOWED_EMITTING_EVENTS = [
 	'videopress_action_play',
 	'videopress_action_pause',
@@ -19,7 +33,7 @@ const VIDEOPRESS_ALLOWED_EMITTING_EVENTS = [
 ] as const;
 
 type PlayerBrigeEventProps = {
-	event: typeof VIDEOPRESS_ALLOWED_EMITTING_EVENTS[ number ];
+	event: typeof VIDEOPRESS_ALLOWED_LISTENING_EVENTS[ number ];
 	id: VideoGUID;
 	origin: Origin;
 };
@@ -35,6 +49,20 @@ export async function playerBridgeHandler(
 ): Promise< void > {
 	const { data = { event: null } } = event || {};
 	const { event: eventName } = data;
+
+	// Propagate only allowed events.
+	if ( VIDEOPRESS_ALLOWED_LISTENING_EVENTS.includes( eventName ) ) {
+		// Propagate only allowed origins.
+		const allowed_origins: Array< Origin > = [
+			'https://videopress.com',
+			'https://video.wordpress.com',
+		];
+
+		if ( -1 !== allowed_origins.indexOf( event.origin as Origin ) ) {
+			debug( 'broadcast %o event: %o', eventName, data );
+			window.top.postMessage( event.data, '*' );
+		}
+	}
 
 	if ( VIDEOPRESS_ALLOWED_EMITTING_EVENTS.includes( eventName ) ) {
 		const videoPressIFrame = document.querySelector( 'iframe' );

--- a/projects/packages/videopress/src/client/lib/player-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/player-bridge/index.ts
@@ -11,20 +11,6 @@ type Origin = 'https://videopress.com' | 'https://video.wordpress.com';
 
 const debug = debugFactory( 'videopress:player-bridge' );
 
-const VIDEOPRESS_ALLOWED_LISTENING_EVENTS = [
-	'videopress_playing',
-	'videopress_pause',
-	'videopress_seeking',
-	'videopress_resize',
-	'videopress_volumechange',
-	'videopress_ended',
-	'videopress_timeupdate',
-	'videopress_durationchange',
-	'videopress_progress',
-	'videopress_loading_state',
-	'videopress_toggle_fullscreen',
-] as const;
-
 const VIDEOPRESS_ALLOWED_EMITTING_EVENTS = [
 	'videopress_action_play',
 	'videopress_action_pause',
@@ -33,7 +19,7 @@ const VIDEOPRESS_ALLOWED_EMITTING_EVENTS = [
 ] as const;
 
 type PlayerBrigeEventProps = {
-	event: typeof VIDEOPRESS_ALLOWED_LISTENING_EVENTS[ number ];
+	event: typeof VIDEOPRESS_ALLOWED_EMITTING_EVENTS[ number ];
 	id: VideoGUID;
 	origin: Origin;
 };

--- a/projects/packages/videopress/src/client/lib/player-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/player-bridge/index.ts
@@ -71,7 +71,7 @@ export async function playerBridgeHandler(
 			return;
 		}
 
-		debug( 'emit %o event', eventName );
+		debug( 'emit %o event - %o', eventName, data );
 		videoPressWindow.postMessage( data, '*' );
 	}
 }

--- a/projects/packages/videopress/src/client/lib/player-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/player-bridge/index.ts
@@ -50,20 +50,6 @@ export async function playerBridgeHandler(
 	const { data = { event: null } } = event || {};
 	const { event: eventName } = data;
 
-	// Propagate only allowed events.
-	if ( VIDEOPRESS_ALLOWED_LISTENING_EVENTS.includes( eventName ) ) {
-		// Propagate only allowed origins.
-		const allowed_origins: Array< Origin > = [
-			'https://videopress.com',
-			'https://video.wordpress.com',
-		];
-
-		if ( -1 !== allowed_origins.indexOf( event.origin as Origin ) ) {
-			// debug( 'broadcast %o event: %o', eventName, data );
-			// window.top.postMessage( event.data, '*' );
-		}
-	}
-
 	if ( VIDEOPRESS_ALLOWED_EMITTING_EVENTS.includes( eventName ) ) {
 		const videoPressIFrame = document.querySelector( 'iframe' );
 		const videoPressWindow = videoPressIFrame?.contentWindow;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR propagates some events from the player-bridge to the client allowing control of the player.
Also, listen to the player (client) events from the iFrame window instead of from the parent (block editor) window. Improve doc.

Part of https://github.com/Automattic/jetpack/issues/29278
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: trigger video events to client via player-bridge

### Other information:


## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Create/edit a VideoPress video block
* Set a block video
* Play/Stop the video (we need this to allow controlling the video via Javascript)
* Open the dev console
* Focus on the iframe element (you can filter by `components-sandbox`)
* Play/Pause the video by sending post message:

```js
$0.contentWindow.postMessage( { event: 'videopress_action_play' } )
```

```js
$0.contentWindow.postMessage( { event: 'videopress_action_pause' } )
```


https://user-images.githubusercontent.com/77539/226932702-1a9033e0-0108-43ac-8e18-612ee959670a.mov

