### PR TITLE
Add import of global styles

### DIFF
--- a/projects/packages/import/changelog/add-import-package-global-styles
+++ b/projects/packages/import/changelog/add-import-package-global-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added global style import.

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -65,15 +65,16 @@ class Main {
 		Rest_Authentication::init();
 
 		$routes = array(
-			'categories' => new Endpoints\Category(),
-			'comments'   => new Endpoints\Comment(),
-			'custom-css' => new Endpoints\Custom_CSS(),
-			'media'      => new Endpoints\Attachment(),
-			'menu-items' => new Endpoints\Menu_Item(),
-			'menus'      => new Endpoints\Menu(),
-			'pages'      => new Endpoints\Page(),
-			'posts'      => new Endpoints\Post(),
-			'tags'       => new Endpoints\Tag(),
+			'categories'    => new Endpoints\Category(),
+			'comments'      => new Endpoints\Comment(),
+			'custom-css'    => new Endpoints\Custom_CSS(),
+			'global-styles' => new Endpoints\Global_Style(),
+			'media'         => new Endpoints\Attachment(),
+			'menu-items'    => new Endpoints\Menu_Item(),
+			'menus'         => new Endpoints\Menu(),
+			'pages'         => new Endpoints\Page(),
+			'posts'         => new Endpoints\Post(),
+			'tags'          => new Endpoints\Tag(),
 		);
 
 		/**

--- a/projects/packages/import/src/endpoints/class-custom-css.php
+++ b/projects/packages/import/src/endpoints/class-custom-css.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+require_once ABSPATH . 'wp-includes/theme.php';
+
 /**
  * Class Custom_CSS
  */
@@ -53,10 +55,6 @@ class Custom_CSS extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
-		if ( ! function_exists( 'wp_update_custom_css_post' ) ) {
-			require_once ABSPATH . 'wp-includes/theme.php';
-		}
-
 		$args = array(
 			'stylesheet' => $request['title'],
 		);

--- a/projects/packages/import/src/endpoints/class-global-style.php
+++ b/projects/packages/import/src/endpoints/class-global-style.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Global style REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+require_once ABSPATH . 'wp-includes/class-wp-theme-json-resolver.php';
+require_once ABSPATH . 'wp-includes/theme.php';
+
+/**
+ * Class Global_Style
+ */
+class Global_Style extends \WP_REST_Posts_Controller {
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import;
+
+	/**
+	 * Whether the controller supports batching.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'global_style' );
+
+		$this->rest_base = 'global-styles';
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @see WP_REST_Posts_Controller::register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::$rest_namespace,
+			'/' . $this->rest_base,
+			$this->get_route_options()
+		);
+	}
+
+	/**
+	 * Adds the schema from additional fields to a schema array.
+	 *
+	 * The type of object is inferred from the passed schema.
+	 *
+	 * @param array $schema Schema array.
+	 * @return array Modified Schema array.
+	 */
+	public function add_additional_fields_schema( $schema ) {
+		$schema['properties']['theme'] = array(
+			'description' => __( 'The name of the theme.', 'jetpack-import' ),
+			'type'        => 'string',
+			'required'    => true,
+		);
+
+		// The unique identifier is only required for PUT requests.
+		return $this->add_unique_identifier_to_schema( $schema, isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'PUT' );
+	}
+
+	/**
+	 * Update the globals style post.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		if ( ! class_exists( 'WP_Theme_JSON_Resolver' ) ) {
+			require_once ABSPATH . 'wp-includes/class-wp-theme-json-resolver.php';
+		}
+
+		$theme = \wp_get_theme( $request['theme'] );
+
+		// Check if the theme exists.
+		if ( ! $theme->exists() ) {
+			return new \WP_Error(
+				'theme_not_found',
+				__( 'Theme not found.', 'jetpack-import' ),
+				array(
+					'status' => 400,
+					'theme'  => $request['theme'],
+				)
+			);
+		}
+
+		/**
+		 * Get the global styles post, or create it.
+		 *
+		 * A global style post is a post with wp-global-styles-{stylesheet} as post slug.
+		 */
+		$post = \WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( $theme, true );
+
+		if ( \is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		$args = array(
+			'ID'           => $post['ID'],
+			'post_content' => $request['content'],
+		);
+
+		// Update the post with the passed data.
+		$post_id = wp_update_post( $args, true, false );
+
+		if ( is_wp_error( $post_id ) ) {
+			$post_id->add_data( array( 'status' => 400 ) );
+
+			return $post_id;
+		}
+
+		// Get the post.
+		$post = get_post( $post_id );
+
+		$response = $this->prepare_item_for_response( $post, $request );
+		$response = rest_ensure_response( $response );
+
+		return $this->add_import_id_metadata( $request, $response );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
WXR files contain the "global styles" type of post that we need to import.

Fixes https://github.com/Automattic/dotcom-forge/issues/2012

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new `/jetpack/v4/import/global-styles` endpoint that can be used to import global styles posts

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the instructions you can find here: D105604-code