### PR TITLE
CRM: Resolves 2889 and 2972 - fixes overescaped HTML

### DIFF
--- a/projects/plugins/crm/admin/settings/mail.page.php
+++ b/projects/plugins/crm/admin/settings/mail.page.php
@@ -102,7 +102,7 @@ if ( isset( $sbupdated ) ) {
 			<tbody>
 
 			<tr>
-				<td class="wfieldname"><label for="wpzbscrm_emailtracking"><?php esc_html_e( 'Track Open Statistics', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Include tracking pixels in all outbound system emails<br/>(e.g. Welcome to the Client Portal)', 'zero-bs-crm' ); ?>.</td>
+				<td class="wfieldname"><label for="wpzbscrm_emailtracking"><?php esc_html_e( 'Track Open Statistics', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Include tracking pixels in all outbound system emails (e.g. "Welcome to the Client Portal")', 'zero-bs-crm' ); ?>.</td>
 				<td style="width:200px"><input type="checkbox" class="winput form-control" name="wpzbscrm_emailtracking" id="wpzbscrm_emailtracking" value="1"
 				<?php
 				if ( isset( $settings['emailtracking'] ) && $settings['emailtracking'] == '1' ) {

--- a/projects/plugins/crm/changelog/fix-crm-2889_and_2972_unescape_html
+++ b/projects/plugins/crm/changelog/fix-crm-2889_and_2972_unescape_html
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Listview: fixed broken link in bulk actions function

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
@@ -65,7 +65,7 @@ function zeroBSCRM_render_customerslist_page(){
                 'notcontactsdeleted' => __('Your contact(s) could not be deleted.',"zero-bs-crm"),
 
                 // bulk actions - add/remove tags
-                'notags' => __('You do not have any tags, do you want to',"zero-bs-crm").' <a target="_blank" href="'.jpcrm_esc_link('tags',-1,'zerobs_customer',false,'contact').'">'.__('Add a tag',"zero-bs-crm").'</a>',                
+								'notags' => wp_kses( sprintf( __( 'You do not have any contact tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_customer', false, 'contact' ) ), $zbs->acceptable_restricted_html ),
                 
                 // bulk actions - merge 2 records
                 'areyousurethesemerge' => __('Are you sure you want to merge these two contacts into one record? There is no way to undo this action.',"zero-bs-crm").'<br />',
@@ -126,7 +126,7 @@ function zeroBSCRM_render_companyslist_page(){
                 'notcompanysdeleted' => __('Your company(s) could not be deleted.',"zero-bs-crm"),
 
                 // bulk actions - add/remove tags
-                'notags' => __('You do not have any tags, do you want to',"zero-bs-crm").' <a target="_blank" href="'.jpcrm_esc_link('tags',-1,'zerobs_company',false,'company').'">'.__('Add a tag',"zero-bs-crm").'</a>',
+								'notags' => wp_kses( sprintf( __( 'You do not have any company tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_company', false, 'company' ) ), $zbs->acceptable_restricted_html ),
 
             ),
             'bulkActions'   => array('delete','addtag','removetag','export'),
@@ -147,54 +147,47 @@ function zeroBSCRM_render_companyslist_page(){
 /* ================================================================================
 =============================== QUOTES ========================================= */
 
-function zeroBSCRM_render_quoteslist_page(){
+function zeroBSCRM_render_quoteslist_page() {
 
-    $list = new zeroBSCRM_list(array(
+	global $zbs;
+	$list = new zeroBSCRM_list(
+		array(
 
-            'objType'       => 'quote',
-            'singular'      => __('Quote',"zero-bs-crm"),
-            'plural'        => __('Quotes',"zero-bs-crm"),
-            'tag'           => '',
-            'postType'      => 'zerobs_quote',
-            'postPage'      => 'manage-quotes',
-            'langLabels'    => array(
+			'objType'    => 'quote',
+			'singular'   => esc_html__( 'Quote', 'zero-bs-crm' ),
+			'plural'     => esc_html__( 'Quotes', 'zero-bs-crm' ),
+			'tag'        => '',
+			'postType'   => 'zerobs_quote',
+			'postPage'   => 'manage-quotes',
+			'langLabels' => array(
 
-                // bulk action labels
-                'markaccepted' => __('Mark Accepted',"zero-bs-crm"),
-                'markunaccepted' => __('Unmark Accepted',"zero-bs-crm"),
-                'delete' => __('Delete Quote(s)',"zero-bs-crm"),
-                'export' => __('Export Quote(s)',"zero-bs-crm"),
+				'markaccepted'             => esc_html__( 'Mark< Accepted', 'zero-bs-crm' ),
+				'markunaccepted'           => esc_html__( 'Unmark Accepted', 'zero-bs-crm' ),
+				'delete'                   => esc_html__( 'Delete Quote(s)', 'zero-bs-crm' ),
+				'export'                   => esc_html__( 'Export Quote(s)', 'zero-bs-crm' ),
+				'andthese'                 => esc_html__( 'Shall I also delete the associated Invoices, Quotes, Transactions, and Tasks?', 'zero-bs-crm' ),
+				'quotesdeleted'            => esc_html__( 'Your quote(s) have been deleted.', 'zero-bs-crm' ),
+				'notquotesdeleted'         => esc_html__( 'Your quote(s) could not be deleted.', 'zero-bs-crm' ),
+				'acceptareyousurequotes'   => esc_html__( 'Are you sure you want to mark these quotes as accepted?', 'zero-bs-crm' ),
+				'acceptdeleted'            => esc_html__( 'Quote(s) Accepted', 'zero-bs-crm' ),
+				'acceptquotesdeleted'      => esc_html__( 'Your quote(s) have been marked accepted.', 'zero-bs-crm' ),
+				'acceptnotdeleted'         => esc_html__( 'Could not mark accepted!', 'zero-bs-crm' ),
+				'acceptnotquotesdeleted'   => esc_html__( 'Your quote(s) could not be marked accepted.', 'zero-bs-crm' ),
+				'unacceptareyousurethese'  => esc_html__( 'Are you sure you want to mark these quotes as unaccepted?', 'zero-bs-crm' ),
+				'unacceptdeleted'          => esc_html__( 'Quote(s) Unaccepted', 'zero-bs-crm' ),
+				'unacceptquotesdeleted'    => esc_html__( 'Your quote(s) have been marked unaccepted.', 'zero-bs-crm' ),
+				'unacceptnotdeleted'       => esc_html__( 'Could not mark unaccepted!', 'zero-bs-crm' ),
+				'unacceptnotquotesdeleted' => esc_html__( 'Your quote(s) could not be marked unaccepted.', 'zero-bs-crm' ),
+				'notags'                   => wp_kses( sprintf( __( 'You do not have any quote tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_quote', false, 'quote' ) ), $zbs->acceptable_restricted_html ),
 
+			),
+			'bulkActions' => array( 'markaccepted', 'markunaccepted', 'addtag', 'removetag', 'delete', 'export' ),
+			// default 'sortables'     => array('id'),
+			// default 'unsortables'   => array('tagged','latestlog','editlink','phonelink')
+		)
+	);
 
-                // bulk actions - quote deleting
-				'andthese'                 => __( 'Shall I also delete the associated Invoices, Quotes, Transactions, and Tasks?', 'zero-bs-crm' ),
-                'quotesdeleted' => __('Your quote(s) have been deleted.',"zero-bs-crm"),
-                'notquotesdeleted' => __('Your quote(s) could not be deleted.',"zero-bs-crm"),
-
-                // bulk actions - quote accepting
-                'acceptareyousurequotes' => __('Are you sure you want to mark these quotes as accepted?',"zero-bs-crm"),
-                'acceptdeleted' => __('Quote(s) Accepted',"zero-bs-crm"),
-                'acceptquotesdeleted' => __('Your quote(s) have been marked accepted.',"zero-bs-crm"),
-                'acceptnotdeleted' => __('Could not mark accepted!',"zero-bs-crm"),
-                'acceptnotquotesdeleted' => __('Your quote(s) could not be marked accepted.',"zero-bs-crm"),
-
-                // bulk actions - quote un accepting
-                'unacceptareyousurethese' => __('Are you sure you want to mark these quotes as unaccepted?',"zero-bs-crm"),
-                'unacceptdeleted' => __('Quote(s) Unaccepted',"zero-bs-crm"),
-                'unacceptquotesdeleted' => __('Your quote(s) have been marked unaccepted.',"zero-bs-crm"),
-                'unacceptnotdeleted' => __('Could not mark unaccepted!',"zero-bs-crm"),
-                'unacceptnotquotesdeleted' => __('Your quote(s) could not be marked unaccepted.',"zero-bs-crm"),
-
-                // bulk actions - add/remove tags
-                'notags' => __('You do not have any tags, do you want to',"zero-bs-crm").' <a target="_blank" href="'.jpcrm_esc_link('tags',-1,'zerobs_quote',false,'quote').'">'.__('Add a tag',"zero-bs-crm").'</a>',
-
-            ),
-            'bulkActions'   => array('markaccepted','markunaccepted','addtag','removetag','delete','export'),
-            //default 'sortables'     => array('id'),
-            //default 'unsortables'   => array('tagged','latestlog','editlink','phonelink')
-    ));
-
-    $list->drawListView();
+	$list->drawListView();
 
 }
 
@@ -275,7 +268,7 @@ function zeroBSCRM_render_invoiceslist_page() {
 					'statusoverdue'            => __( 'Overdue', 'zero-bs-crm' ),
 					'statusdeleted'            => __( 'Deleted', 'zero-bs-crm' ),
 					// bulk actions - add/remove tags
-					'notags'                   => __( 'You do not have any tags, do you want to', 'zero-bs-crm' ) . ' <a target="_blank" href="' . jpcrm_esc_link( 'tags', -1, 'zerobs_invoice', false, 'invoice' ) . '">' . __( 'Add a tag', 'zero-bs-crm' ) . '</a>',
+					'notags'                   => wp_kses( sprintf( __( 'You do not have any invoice tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_invoice', false, 'invoice' ) ), $zbs->acceptable_restricted_html ),
 				),
 			'bulkActions' => array( 'changestatus', 'addtag', 'removetag', 'delete', 'export' ),
 			'extraBoxes'  => $upsell_box_html,
@@ -296,6 +289,7 @@ function zeroBSCRM_render_invoiceslist_page() {
 
 function zeroBSCRM_render_transactionslist_page(){
 
+		global $zbs;
     $list = new zeroBSCRM_list(array(
 
             'objType'       => 'transaction',
@@ -311,7 +305,7 @@ function zeroBSCRM_render_transactionslist_page(){
                 'export' => __('Export Transaction(s)',"zero-bs-crm"),
 
                 // bulk actions - add/remove tags
-                'notags' => __('You do not have any tags, do you want to',"zero-bs-crm").' <a target="_blank" href="'.jpcrm_esc_link('tags',-1,'zerobs_transaction',false,'transaction').'">'.__('Add a tag',"zero-bs-crm").'</a>',                
+								'notags'  => wp_kses( sprintf( __( 'You do not have any transaction tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_transaction', false, 'transaction' ) ), $zbs->acceptable_restricted_html ),
                
                 // statuses
                 'trans_status_cancelled' => __('Cancelled',"zero-bs-crm"),

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
@@ -161,7 +161,7 @@ function zeroBSCRM_render_quoteslist_page() {
 			'postPage'   => 'manage-quotes',
 			'langLabels' => array(
 
-				'markaccepted'             => esc_html__( 'Mark< Accepted', 'zero-bs-crm' ),
+				'markaccepted'             => esc_html__( 'Mark Accepted', 'zero-bs-crm' ),
 				'markunaccepted'           => esc_html__( 'Unmark Accepted', 'zero-bs-crm' ),
 				'delete'                   => esc_html__( 'Delete Quote(s)', 'zero-bs-crm' ),
 				'export'                   => esc_html__( 'Export Quote(s)', 'zero-bs-crm' ),

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
@@ -208,9 +208,9 @@ function zeroBSCRM_render_invoiceslist_page() { // phpcs:ignore WordPress.Naming
 			$upsell_box_html  = '<!-- Inv PRO box --><div class="">';
 			$upsell_box_html .= '<h4>Invoicing Pro:</h4>';
 
-			$up_title  = __( 'Supercharged Invoicing', 'zero-bs-crm' );
-			$up_desc   = __( 'Get more out of invoicing, like accepting online payments!:', 'zero-bs-crm' );
-			$up_button = __( 'Get Invoicing Pro', 'zero-bs-crm' );
+			$up_title  = esc_html__( 'Supercharged Invoicing', 'zero-bs-crm' );
+			$up_desc   = esc_html__( 'Get more out of invoicing, like accepting online payments!', 'zero-bs-crm' );
+			$up_button = esc_html__( 'Get Invoicing Pro', 'zero-bs-crm' );
 			$up_target = $zbs->urls['invpro'];
 
 			$upsell_box_html .= zeroBSCRM_UI2_squareFeedbackUpsell( $up_title, $up_desc, $up_button, $up_target );
@@ -219,9 +219,9 @@ function zeroBSCRM_render_invoiceslist_page() { // phpcs:ignore WordPress.Naming
 			$upsell_box_html  = '<!-- Inv PRO box --><div class="">';
 			$upsell_box_html .= '<h4>Invoicing Pro:</h4>';
 
-			$up_title  = __( 'Supercharged Invoicing', 'zero-bs-crm' );
-			$up_desc   = __( 'You have Invoicing Pro available because you are using a bundle. Please download and install from your account:', 'zero-bs-crm' );
-			$up_button = __( 'Your Account', 'zero-bs-crm' );
+			$up_title  = esc_html__( 'Supercharged Invoicing', 'zero-bs-crm' );
+			$up_desc   = esc_html__( 'You have Invoicing Pro available because you are using a bundle. Please download and install from your account:', 'zero-bs-crm' );
+			$up_button = esc_html__( 'Your Account', 'zero-bs-crm' );
 			$up_target = $zbs->urls['account'];
 
 			$upsell_box_html .= zeroBSCRM_UI2_squareFeedbackUpsell( $up_title, $up_desc, $up_button, $up_target );
@@ -232,32 +232,32 @@ function zeroBSCRM_render_invoiceslist_page() { // phpcs:ignore WordPress.Naming
 	$list = new zeroBSCRM_list(
 		array(
 			'objType'     => 'invoice',
-			'singular'    => __( 'Invoice', 'zero-bs-crm' ),
-			'plural'      => __( 'Invoices', 'zero-bs-crm' ),
+			'singular'    => esc_html__( 'Invoice', 'zero-bs-crm' ),
+			'plural'      => esc_html__( 'Invoices', 'zero-bs-crm' ),
 			'tag'         => '',
 			'postType'    => 'zerobs_invoice',
 			'postPage'    => 'manage-invoices',
 			'langLabels'  =>
 				array(
 					// bulk action labels
-					'delete'                   => __( 'Delete Invoice(s)', 'zero-bs-crm' ),
-					'export'                   => __( 'Export Invoice(s)', 'zero-bs-crm' ),
+					'delete'                   => esc_html__( 'Delete Invoice(s)', 'zero-bs-crm' ),
+					'export'                   => esc_html__( 'Export Invoice(s)', 'zero-bs-crm' ),
 
 					// bulk actions - invoice deleting
-					'invoicesdeleted'          => __( 'Your invoice(s) have been deleted.', 'zero-bs-crm' ),
-					'notinvoicesdeleted'       => __( 'Your invoice(s) could not be deleted.', 'zero-bs-crm' ),
+					'invoicesdeleted'          => esc_html__( 'Your invoice(s) have been deleted.', 'zero-bs-crm' ),
+					'notinvoicesdeleted'       => esc_html__( 'Your invoice(s) could not be deleted.', 'zero-bs-crm' ),
 
 					// bulk actions - invoice status update
-					'statusareyousurethese'    => __( 'Are you sure you want to change the status on marked invoice(s)?', 'zero-bs-crm' ),
-					'statusupdated'            => __( 'Invoice(s) Updated', 'zero-bs-crm' ),
-					'statusinvoicesupdated'    => __( 'Your invoice(s) have been updated.', 'zero-bs-crm' ),
-					'statusnotupdated'         => __( 'Could not update invoice!', 'zero-bs-crm' ),
-					'statusnotinvoicesupdated' => __( 'Your invoice(s) could not be updated', 'zero-bs-crm' ),
-					'statusdraft'              => __( 'Draft', 'zero-bs-crm' ),
-					'statusunpaid'             => __( 'Unpaid', 'zero-bs-crm' ),
-					'statuspaid'               => __( 'Paid', 'zero-bs-crm' ),
-					'statusoverdue'            => __( 'Overdue', 'zero-bs-crm' ),
-					'statusdeleted'            => __( 'Deleted', 'zero-bs-crm' ),
+					'statusareyousurethese'    => esc_html__( 'Are you sure you want to change the status on marked invoice(s)?', 'zero-bs-crm' ),
+					'statusupdated'            => esc_html__( 'Invoice(s) Updated', 'zero-bs-crm' ),
+					'statusinvoicesupdated'    => esc_html__( 'Your invoice(s) have been updated.', 'zero-bs-crm' ),
+					'statusnotupdated'         => esc_html__( 'Could not update invoice!', 'zero-bs-crm' ),
+					'statusnotinvoicesupdated' => esc_html__( 'Your invoice(s) could not be updated', 'zero-bs-crm' ),
+					'statusdraft'              => esc_html__( 'Draft', 'zero-bs-crm' ),
+					'statusunpaid'             => esc_html__( 'Unpaid', 'zero-bs-crm' ),
+					'statuspaid'               => esc_html__( 'Paid', 'zero-bs-crm' ),
+					'statusoverdue'            => esc_html__( 'Overdue', 'zero-bs-crm' ),
+					'statusdeleted'            => esc_html__( 'Deleted', 'zero-bs-crm' ),
 
 					// bulk actions - add/remove tags
 					/* translators: placeholder is a link to add a new object tag */
@@ -358,17 +358,17 @@ function zeroBSCRM_render_formslist_page() { // phpcs:ignore WordPress.NamingCon
 			'postPage'    => 'manage-forms',
 			'langLabels'  => array(
 
-				'naked'           => __( 'Naked', 'zero-bs-crm' ),
-				'cgrab'           => __( 'Content Grab', 'zero-bs-crm' ),
-				'simple'          => __( 'Simple', 'zero-bs-crm' ),
+				'naked'           => esc_html__( 'Naked', 'zero-bs-crm' ),
+				'cgrab'           => esc_html__( 'Content Grab', 'zero-bs-crm' ),
+				'simple'          => esc_html__( 'Simple', 'zero-bs-crm' ),
 
 				// bulk action labels
-				'delete'          => __( 'Delete Form(s)', 'zero-bs-crm' ),
-				'export'          => __( 'Export Form(s)', 'zero-bs-crm' ),
+				'delete'          => esc_html__( 'Delete Form(s)', 'zero-bs-crm' ),
+				'export'          => esc_html__( 'Export Form(s)', 'zero-bs-crm' ),
 
 				// bulk actions - deleting
-				'formsdeleted'    => __( 'Your form(s) have been deleted.', 'zero-bs-crm' ),
-				'notformsdeleted' => __( 'Your form(s) could not be deleted.', 'zero-bs-crm' ),
+				'formsdeleted'    => esc_html__( 'Your form(s) have been deleted.', 'zero-bs-crm' ),
+				'notformsdeleted' => esc_html__( 'Your form(s) could not be deleted.', 'zero-bs-crm' ),
 
 			),
 			'bulkActions' => array( 'delete' ),
@@ -404,9 +404,9 @@ function zeroBSCRM_render_segmentslist_page() { // phpcs:ignore WordPress.Naming
 		$upsell_box_html  = '<div class="">';
 		$upsell_box_html .= '<h4>' . esc_html__( 'Using Segments?', 'zero-bs-crm' ) . ':</h4>';
 
-		$up_title  = __( 'Segment like a PRO', 'zero-bs-crm' );
-		$up_desc   = __( 'Did you know that we\'ve made segments more advanced?', 'zero-bs-crm' );
-		$up_button = __( 'See Advanced Segments', 'zero-bs-crm' );
+		$up_title  = esc_html__( 'Segment like a PRO', 'zero-bs-crm' );
+		$up_desc   = esc_html__( 'Did you know that we\'ve made segments more advanced?', 'zero-bs-crm' );
+		$up_button = esc_html__( 'See Advanced Segments', 'zero-bs-crm' );
 		$up_target = $zbs->urls['advancedsegments'];
 
 		$upsell_box_html .= zeroBSCRM_UI2_squareFeedbackUpsell( $up_title, $up_desc, $up_button, $up_target );

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
@@ -1,5 +1,6 @@
-<?php 
-/*!
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+
+/*
  * Jetpack CRM
  * https://jetpackcrm.com
  * V1.0
@@ -9,157 +10,152 @@
  * Date: 26/05/16
  */
 
-/* ======================================================
-  Breaking Checks ( stops direct access )
-   ====================================================== */
-    if ( ! defined( 'ZEROBSCRM_PATH' ) ) exit;
-/* ======================================================
-  / Breaking Checks
-   ====================================================== */
-
-/* ================================================================================
-=============================== CONTACTS ======================================= */
-
-function zeroBSCRM_render_customerslist_page(){
-
-    global $zbs;
-
-    #} has no sync ext? Sell them
-    $upsellBoxHTML = '';
-    
-    #} Extrajs:
-    $status_array = $zbs->settings->get('customisedfields')['customers']['status'];
-    $statuses = is_array($status_array) && isset($status_array[1]) ? explode(',',$status_array[1]) : array();
-    $extraJS = 'var zbsStatusesForBulkActions = ' . json_encode($statuses) . ';'; 
-        
-    #} Messages:
-    #} All messages need params to match this func: 
-    #} ... zeroBSCRM_UI2_messageHTML($msgClass='',$msgHeader='',$msg='',$iconClass='',$id='')
-    $messages = array(); 
-
-    $list = new zeroBSCRM_list(array(
-
-            'objType'       => 'customer',
-            'singular'      => __('Contact',"zero-bs-crm"),
-            'plural'        => __('Contacts',"zero-bs-crm"),
-            'tag'           => 'zerobscrm_customertag',
-            'postType'      => 'zerobs_customer',
-            'postPage'      => 'manage-customers',
-            'langLabels'    => array(
-
-                
-                // bulk action labels
-                'deletecontacts' => __('Delete Contact(s)',"zero-bs-crm"),
-                'merge' => __('Merge Contacts',"zero-bs-crm"),
-                'export' => __('Export Contact(s)',"zero-bs-crm"),
-                'changestatus' => __('Change Status',"zero-bs-crm"),
-
-
-                //bulk actions - change status
-                'statusupdated' => __('Statuses Updated',"zero-bs-crm"),
-                'statusnotupdated' => __('Could not update statuses!',"zero-bs-crm"),
- 
-                // bulk actions - contact deleting
-				'andthese'             => __( 'Shall I also delete the associated Invoices, Quotes, Transactions, and Tasks?', 'zero-bs-crm' ),
-                'contactsdeleted' => __('Your contact(s) have been deleted.',"zero-bs-crm"),
-                'notcontactsdeleted' => __('Your contact(s) could not be deleted.',"zero-bs-crm"),
-
-                // bulk actions - add/remove tags
-								'notags' => wp_kses( sprintf( __( 'You do not have any contact tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_customer', false, 'contact' ) ), $zbs->acceptable_restricted_html ),
-                
-                // bulk actions - merge 2 records
-                'areyousurethesemerge' => __('Are you sure you want to merge these two contacts into one record? There is no way to undo this action.',"zero-bs-crm").'<br />',
-                'whichdominant' => __('Which is the "master" record (main record)?',"zero-bs-crm"),
-
-                'contactsmerged' => __('Contacts Merged',"zero-bs-crm"),
-                'contactsnotmerged' => __('Contacts could not be successfully merged',"zero-bs-crm"),
-
-                // tel
-                'telhome' => __('Home',"zero-bs-crm"),
-                'telwork' => __('Work',"zero-bs-crm"),
-                'telmob' => __('Mobile',"zero-bs-crm")
-
-            ),
-            'bulkActions'   => array('changestatus','delete','addtag','removetag','merge','export'),
-            'unsortables'   => array('tagged','editlink','phonelink'),
-            'extraBoxes' => $upsellBoxHTML,
-            'extraJS'   => $extraJS,
-            'messages'  => $messages
-    ));
-
-    $list->drawListView();
-
+// prevent direct access
+if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
+	exit;
 }
 
-/* ============================== / CONTACTS ====================================== 
-================================================================================ */
+/**
+ * Renders the html for the contact list.
+ *
+ * @return void
+ */
+function zeroBSCRM_render_customerslist_page() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+	global $zbs;
 
+	// has no sync ext? Sell them
+	$upsell_box_html = '';
 
+	// extra_js:
+	$status_array = $zbs->settings->get( 'customisedfields' )['customers']['status'];
+	$statuses     = is_array( $status_array ) && isset( $status_array[1] ) ? explode( ',', $status_array[1] ) : array();
+	$extra_js     = 'var zbsStatusesForBulkActions = ' . wp_json_encode( $statuses ) . ';';
 
+	// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+	// Messages:
+	// All messages need params to match this func:
+	// ... zeroBSCRM_UI2_messageHTML($msgClass='',$msgHeader='',$msg='',$iconClass='',$id='')
+	$messages = array();
 
-/* ================================================================================
-=============================== COMPANIES ====================================== */
+	$list = new zeroBSCRM_list(
+		array(
 
-function zeroBSCRM_render_companyslist_page(){
+			'objType'     => 'customer',
+			'singular'    => esc_html__( 'Contact', 'zero-bs-crm' ),
+			'plural'      => esc_html__( 'Contacts', 'zero-bs-crm' ),
+			'tag'         => 'zerobscrm_customertag',
+			'postType'    => 'zerobs_customer',
+			'postPage'    => 'manage-customers',
+			'langLabels'  => array(
 
-    global $zbs;
+				// bulk action labels
+				'deletecontacts'       => esc_html__( 'Delete Contact(s)', 'zero-bs-crm' ),
+				'merge'                => esc_html__( 'Merge Contacts', 'zero-bs-crm' ),
+				'export'               => esc_html__( 'Export Contact(s)', 'zero-bs-crm' ),
+				'changestatus'         => esc_html__( 'Change Status', 'zero-bs-crm' ),
 
-    $list = new zeroBSCRM_list(array(
+				// bulk actions - change status
+				'statusupdated'        => esc_html__( 'Statuses Updated', 'zero-bs-crm' ),
+				'statusnotupdated'     => esc_html__( 'Could not update statuses!', 'zero-bs-crm' ),
 
-            'objType'       => 'company',
-            'singular'      => jpcrm_label_company(),
-            'plural'        => jpcrm_label_company(true),
-            'tag'           => 'zerobscrm_companytag',
-            'postType'      => 'zerobs_company',
-            'postPage'      => 'manage-companies',
-            'langLabels'    => array(
+				// bulk actions - contact deleting
+				'andthese'             => esc_html__( 'Shall I also delete the associated Invoices, Quotes, Transactions, and Tasks?', 'zero-bs-crm' ),
+				'contactsdeleted'      => esc_html__( 'Your contact(s) have been deleted.', 'zero-bs-crm' ),
+				'notcontactsdeleted'   => esc_html__( 'Your contact(s) could not be deleted.', 'zero-bs-crm' ),
 
-                // bulk action labels
-                'deletecompanys' => __('Delete '.jpcrm_label_company().'(s)',"zero-bs-crm"),
-                'addtags' => __('Add tag(s)',"zero-bs-crm"),
-                'removetags' => __('Remove tag(s)',"zero-bs-crm"),
-                'export' => __('Export',"zero-bs-crm"),
+				// bulk actions - add/remove tags
+				/* translators: placeholder is a link to add a new object tag */
+				'notags'               => wp_kses( sprintf( __( 'You do not have any contact tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_customer', false, 'contact' ) ), $zbs->acceptable_restricted_html ),
 
-                // bulk actions - company deleting
-				'andthese'           => __( 'Shall I also delete the associated Contacts, Invoices, Quotes, Transactions, and Tasks? (This cannot be undone!)', 'zero-bs-crm' ),
-                'companysdeleted' => __('Your company(s) have been deleted.',"zero-bs-crm"),
-                'notcompanysdeleted' => __('Your company(s) could not be deleted.',"zero-bs-crm"),
+				// bulk actions - merge 2 records
+				'areyousurethesemerge' => esc_html__( 'Are you sure you want to merge these two contacts into one record? There is no way to undo this action.', 'zero-bs-crm' ) . '<br />',
+				'whichdominant'        => esc_html__( 'Which is the "master" record (main record)?', 'zero-bs-crm' ),
 
-                // bulk actions - add/remove tags
-								'notags' => wp_kses( sprintf( __( 'You do not have any company tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_company', false, 'company' ) ), $zbs->acceptable_restricted_html ),
+				'contactsmerged'       => esc_html__( 'Contacts Merged', 'zero-bs-crm' ),
+				'contactsnotmerged'    => esc_html__( 'Contacts could not be successfully merged', 'zero-bs-crm' ),
 
-            ),
-            'bulkActions'   => array('delete','addtag','removetag','export'),
-            //default 'sortables'     => array('id'),
-            //default 'unsortables'   => array('tagged','latestlog','editlink','phonelink')
-    ));
+				// tel
+				'telhome'              => esc_html__( 'Home', 'zero-bs-crm' ),
+				'telwork'              => esc_html__( 'Work', 'zero-bs-crm' ),
+				'telmob'               => esc_html__( 'Mobile', 'zero-bs-crm' ),
 
-    $list->drawListView();
+			),
+			'bulkActions' => array( 'changestatus', 'delete', 'addtag', 'removetag', 'merge', 'export' ),
+			'unsortables' => array( 'tagged', 'editlink', 'phonelink' ),
+			'extraBoxes'  => $upsell_box_html,
+			'extraJS'     => $extra_js,
+			'messages'    => $messages,
+		)
+	);
 
+	$list->drawListView();
 }
 
-/* ============================== / COMPANIES ===================================== 
-================================================================================ */
+/**
+ * Renders the html for the companies list.
+ *
+ * @return void
+ */
+function zeroBSCRM_render_companyslist_page() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 
+	global $zbs;
 
+	$list = new zeroBSCRM_list(
+		array(
 
+			'objType'     => 'company',
+			'singular'    => esc_html( jpcrm_label_company() ),
+			'plural'      => esc_html( jpcrm_label_company( true ) ),
+			'tag'         => 'zerobscrm_companytag',
+			'postType'    => 'zerobs_company',
+			'postPage'    => 'manage-companies',
+			'langLabels'  => array(
 
-/* ================================================================================
-=============================== QUOTES ========================================= */
+				// bulk action labels
+				/* translators: placeholder is the company label */
+				'deletecompanys'     => esc_html( sprintf( __( 'Delete %s(s)', 'zero-bs-crm' ), jpcrm_label_company() ) ),
+				'addtags'            => esc_html__( 'Add tag(s)', 'zero-bs-crm' ),
+				'removetags'         => esc_html__( 'Remove tag(s)', 'zero-bs-crm' ),
+				'export'             => esc_html__( 'Export', 'zero-bs-crm' ),
 
-function zeroBSCRM_render_quoteslist_page() {
+				// bulk actions - company deleting
+				'andthese'           => esc_html__( 'Shall I also delete the associated Contacts, Invoices, Quotes, Transactions, and Tasks? (This cannot be undone!)', 'zero-bs-crm' ),
+				'companysdeleted'    => esc_html__( 'Your company(s) have been deleted.', 'zero-bs-crm' ),
+				'notcompanysdeleted' => esc_html__( 'Your company(s) could not be deleted.', 'zero-bs-crm' ),
+
+				// bulk actions - add/remove tags
+				/* translators: placeholder is a link to add a new object tag */
+				'notags'             => wp_kses( sprintf( __( 'You do not have any company tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_company', false, 'company' ) ), $zbs->acceptable_restricted_html ),
+
+			),
+			'bulkActions' => array( 'delete', 'addtag', 'removetag', 'export' ),
+			// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			// default 'sortables'     => array('id'),
+			// default 'unsortables'   => array('tagged','latestlog','editlink','phonelink')
+		)
+	);
+
+	$list->drawListView();
+}
+
+/**
+ * Renders the html for the quotes list.
+ *
+ * @return void
+ */
+function zeroBSCRM_render_quoteslist_page() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 
 	global $zbs;
 	$list = new zeroBSCRM_list(
 		array(
 
-			'objType'    => 'quote',
-			'singular'   => esc_html__( 'Quote', 'zero-bs-crm' ),
-			'plural'     => esc_html__( 'Quotes', 'zero-bs-crm' ),
-			'tag'        => '',
-			'postType'   => 'zerobs_quote',
-			'postPage'   => 'manage-quotes',
-			'langLabels' => array(
+			'objType'     => 'quote',
+			'singular'    => esc_html__( 'Quote', 'zero-bs-crm' ),
+			'plural'      => esc_html__( 'Quotes', 'zero-bs-crm' ),
+			'tag'         => '',
+			'postType'    => 'zerobs_quote',
+			'postPage'    => 'manage-quotes',
+			'langLabels'  => array(
 
 				'markaccepted'             => esc_html__( 'Mark Accepted', 'zero-bs-crm' ),
 				'markunaccepted'           => esc_html__( 'Unmark Accepted', 'zero-bs-crm' ),
@@ -178,34 +174,27 @@ function zeroBSCRM_render_quoteslist_page() {
 				'unacceptquotesdeleted'    => esc_html__( 'Your quote(s) have been marked unaccepted.', 'zero-bs-crm' ),
 				'unacceptnotdeleted'       => esc_html__( 'Could not mark unaccepted!', 'zero-bs-crm' ),
 				'unacceptnotquotesdeleted' => esc_html__( 'Your quote(s) could not be marked unaccepted.', 'zero-bs-crm' ),
+				/* translators: placeholder is a link to add a new object tag */
 				'notags'                   => wp_kses( sprintf( __( 'You do not have any quote tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_quote', false, 'quote' ) ), $zbs->acceptable_restricted_html ),
 
 			),
 			'bulkActions' => array( 'markaccepted', 'markunaccepted', 'addtag', 'removetag', 'delete', 'export' ),
+
+			// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 			// default 'sortables'     => array('id'),
 			// default 'unsortables'   => array('tagged','latestlog','editlink','phonelink')
 		)
 	);
 
 	$list->drawListView();
-
 }
-
-/* =============================== / QUOTES ======================================= 
-================================================================================ */
-
-
-
-
-/* ================================================================================
-=============================== INVOICES ======================================= */
 
 /**
  * Renders the html for the invoices list.
  *
  * @return void
  */
-function zeroBSCRM_render_invoiceslist_page() {
+function zeroBSCRM_render_invoiceslist_page() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 	global $zbs;
 
 	$upsell_box_html = '';
@@ -253,9 +242,11 @@ function zeroBSCRM_render_invoiceslist_page() {
 					// bulk action labels
 					'delete'                   => __( 'Delete Invoice(s)', 'zero-bs-crm' ),
 					'export'                   => __( 'Export Invoice(s)', 'zero-bs-crm' ),
+
 					// bulk actions - invoice deleting
 					'invoicesdeleted'          => __( 'Your invoice(s) have been deleted.', 'zero-bs-crm' ),
 					'notinvoicesdeleted'       => __( 'Your invoice(s) could not be deleted.', 'zero-bs-crm' ),
+
 					// bulk actions - invoice status update
 					'statusareyousurethese'    => __( 'Are you sure you want to change the status on marked invoice(s)?', 'zero-bs-crm' ),
 					'statusupdated'            => __( 'Invoice(s) Updated', 'zero-bs-crm' ),
@@ -267,7 +258,9 @@ function zeroBSCRM_render_invoiceslist_page() {
 					'statuspaid'               => __( 'Paid', 'zero-bs-crm' ),
 					'statusoverdue'            => __( 'Overdue', 'zero-bs-crm' ),
 					'statusdeleted'            => __( 'Deleted', 'zero-bs-crm' ),
+
 					// bulk actions - add/remove tags
+					/* translators: placeholder is a link to add a new object tag */
 					'notags'                   => wp_kses( sprintf( __( 'You do not have any invoice tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_invoice', false, 'invoice' ) ), $zbs->acceptable_restricted_html ),
 				),
 			'bulkActions' => array( 'changestatus', 'addtag', 'removetag', 'delete', 'export' ),
@@ -278,316 +271,297 @@ function zeroBSCRM_render_invoiceslist_page() {
 	$list->drawListView();
 }
 
-/* ============================== / INVOICES ===================================== 
-================================================================================ */
+/**
+ * Renders the html for the transactions list.
+ *
+ * @return void
+ */
+function zeroBSCRM_render_transactionslist_page() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 
+	global $zbs;
+	$list = new zeroBSCRM_list(
+		array(
 
+			'objType'     => 'transaction',
+			'singular'    => esc_html__( 'Transaction', 'zero-bs-crm' ),
+			'plural'      => esc_html__( 'Transactions', 'zero-bs-crm' ),
+			'tag'         => 'zerobscrm_transactiontag',
+			'postType'    => 'zerobs_transaction',
+			'postPage'    => 'manage-transactions',
+			'langLabels'  => array(
 
+				// bulk action labels
+				'delete'                  => esc_html__( 'Delete Transaction(s)', 'zero-bs-crm' ),
+				'export'                  => esc_html__( 'Export Transaction(s)', 'zero-bs-crm' ),
 
-/* ================================================================================
-========================= TRANSACTIONS ========================================= */
+				// bulk actions - add/remove tags
+				/* translators: placeholder is a link to add a new object tag */
+				'notags'                  => wp_kses( sprintf( __( 'You do not have any transaction tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_transaction', false, 'transaction' ) ), $zbs->acceptable_restricted_html ),
 
-function zeroBSCRM_render_transactionslist_page(){
+				// statuses
+				'trans_status_cancelled'  => esc_html__( 'Cancelled', 'zero-bs-crm' ),
+				'trans_status_hold'       => esc_html__( 'Hold', 'zero-bs-crm' ),
+				'trans_status_pending'    => esc_html__( 'Pending', 'zero-bs-crm' ),
+				'trans_status_processing' => esc_html__( 'Processing', 'zero-bs-crm' ),
+				'trans_status_refunded'   => esc_html__( 'Refunded', 'zero-bs-crm' ),
+				'trans_status_failed'     => esc_html__( 'Failed', 'zero-bs-crm' ),
+				'trans_status_completed'  => esc_html__( 'Completed', 'zero-bs-crm' ),
+				'trans_status_succeeded'  => esc_html__( 'Succeeded', 'zero-bs-crm' ),
 
-		global $zbs;
-    $list = new zeroBSCRM_list(array(
+			),
+			'bulkActions' => array( 'addtag', 'removetag', 'delete', 'export' ),
+			'sortables'   => array( 'id' ),
+			'unsortables' => array( 'tagged', 'latestlog', 'editlink', 'phonelink' ),
+		)
+	);
 
-            'objType'       => 'transaction',
-            'singular'      => __('Transaction',"zero-bs-crm"),
-            'plural'        => __('Transactions',"zero-bs-crm"),
-            'tag'           => 'zerobscrm_transactiontag',
-            'postType'      => 'zerobs_transaction',
-            'postPage'      => 'manage-transactions',
-            'langLabels'    => array(
-
-                // bulk action labels
-                'delete' => __('Delete Transaction(s)',"zero-bs-crm"),
-                'export' => __('Export Transaction(s)',"zero-bs-crm"),
-
-                // bulk actions - add/remove tags
-								'notags'  => wp_kses( sprintf( __( 'You do not have any transaction tags. Do you want to <a target="_blank" href="%s">add a tag</a>?', 'zero-bs-crm' ), jpcrm_esc_link( 'tags', -1, 'zerobs_transaction', false, 'transaction' ) ), $zbs->acceptable_restricted_html ),
-               
-                // statuses
-                'trans_status_cancelled' => __('Cancelled',"zero-bs-crm"),
-                'trans_status_hold' => __('Hold',"zero-bs-crm"),
-                'trans_status_pending' => __('Pending',"zero-bs-crm"),
-                'trans_status_processing' => __('Processing',"zero-bs-crm"),
-                'trans_status_refunded' => __('Refunded',"zero-bs-crm"),
-                'trans_status_failed' => __('Failed',"zero-bs-crm"),
-                'trans_status_completed' => __('Completed',"zero-bs-crm"),
-                'trans_status_succeeded' => __('Succeeded',"zero-bs-crm"),
-
-            ),
-            'bulkActions'   => array('addtag','removetag','delete','export'),
-            'sortables'     => array('id'),
-            'unsortables'   => array('tagged','latestlog','editlink','phonelink')
-    ));
-
-    $list->drawListView();
-
+	$list->drawListView();
 }
 
-/* ============================ / TRANSACTIONS ==================================== 
-================================================================================ */
+/**
+ * Renders the html for the forms list.
+ *
+ * @return void
+ */
+function zeroBSCRM_render_formslist_page() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 
+	// has no sync ext? Sell them
+	$upsell_box_html = '';
 
+	// has sync ext? Give feedback
+	if ( ! zeroBSCRM_hasPaidExtensionActivated() ) {
 
+		##WLREMOVE
+		// first build upsell box html
+		$upsell_box_html  = '<!-- Forms PRO box --><div class="">';
+		$upsell_box_html .= '<h4>' . esc_html__( 'Need More Complex Forms?', 'zero-bs-crm' ) . '</h4>';
 
-/* ================================================================================
-================================ FORMS ========================================= */
+		$up_title  = esc_html__( 'Fully Flexible Forms', 'zero-bs-crm' );
+		$up_desc   = esc_html__( 'Jetpack CRM forms cover simple use contact and subscription forms, but if you need more we suggest using a form plugin like Contact Form 7 or Gravity Forms:', 'zero-bs-crm' );
+		$up_button = esc_html__( 'See Full Form Options', 'zero-bs-crm' );
+		$up_target = 'https://jetpackcrm.com/feature/forms/#benefit';
 
-function zeroBSCRM_render_formslist_page(){
+		$upsell_box_html .= zeroBSCRM_UI2_squareFeedbackUpsell( $up_title, $up_desc, $up_button, $up_target );
 
+		$upsell_box_html .= '</div><!-- / Inv Forms box -->';
+		##/WLREMOVE
+	}
 
-    
+	$list = new zeroBSCRM_list(
+		array(
 
-    #} has no sync ext? Sell them
-    $upsellBoxHTML = ''; 
-    
-            #} has sync ext? Give feedback
-            if (!zeroBSCRM_hasPaidExtensionActivated()){ 
+			'objType'     => 'form',
+			'singular'    => esc_html__( 'Form', 'zero-bs-crm' ),
+			'plural'      => esc_html__( 'Forms', 'zero-bs-crm' ),
+			'tag'         => '',
+			'postType'    => 'zerobs_form',
+			'postPage'    => 'manage-forms',
+			'langLabels'  => array(
 
-                ##WLREMOVE
-                // first build upsell box html
-                $upsellBoxHTML = '<!-- Forms PRO box --><div class="">';
-                $upsellBoxHTML .= '<h4>Need More Complex Forms?</h4>';
+				'naked'           => __( 'Naked', 'zero-bs-crm' ),
+				'cgrab'           => __( 'Content Grab', 'zero-bs-crm' ),
+				'simple'          => __( 'Simple', 'zero-bs-crm' ),
 
-                    $upTitle = __('Fully Flexible Forms',"zero-bs-crm");
-                    $upDesc = __('Jetpack CRM forms cover simple use contact and subscription forms, but if you need more we suggest using a form plugin like Contact Form 7 or Gravity Forms:',"zero-bs-crm");
-                    $upButton = __('See Full Form Options',"zero-bs-crm");
-                    $upTarget = 'https://jetpackcrm.com/feature/forms/#benefit';
+				// bulk action labels
+				'delete'          => __( 'Delete Form(s)', 'zero-bs-crm' ),
+				'export'          => __( 'Export Form(s)', 'zero-bs-crm' ),
 
-                    $upsellBoxHTML .= zeroBSCRM_UI2_squareFeedbackUpsell($upTitle,$upDesc,$upButton,$upTarget); 
+				// bulk actions - deleting
+				'formsdeleted'    => __( 'Your form(s) have been deleted.', 'zero-bs-crm' ),
+				'notformsdeleted' => __( 'Your form(s) could not be deleted.', 'zero-bs-crm' ),
 
-                $upsellBoxHTML .= '</div><!-- / Inv Forms box -->';
-                ##/WLREMOVE
-            }
+			),
+			'bulkActions' => array( 'delete' ),
+			// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			// default 'sortables'     => array('id'),
+			// default 'unsortables'   => array('tagged','latestlog','editlink','phonelink')
+			'extraBoxes'  => $upsell_box_html,
+		)
+	);
 
-    $list = new zeroBSCRM_list(array(
-
-            'objType'       => 'form',
-            'singular'      => __('Form',"zero-bs-crm"),
-            'plural'        => __('Forms',"zero-bs-crm"),
-            'tag'           => '',
-            'postType'      => 'zerobs_form',
-            'postPage'      => 'manage-forms',
-            'langLabels'    => array(
-
-                'naked' => __('Naked',"zero-bs-crm"),
-                'cgrab' => __('Content Grab',"zero-bs-crm"),
-                'simple' => __('Simple',"zero-bs-crm"),
-
-                // bulk action labels
-                'delete' => __('Delete Form(s)',"zero-bs-crm"),
-                'export' => __('Export Form(s)',"zero-bs-crm"),
-
-
-                // bulk actions - deleting
-                'formsdeleted' => __('Your form(s) have been deleted.',"zero-bs-crm"),
-                'notformsdeleted' => __('Your form(s) could not be deleted.',"zero-bs-crm"),
-
-            ),
-            'bulkActions'   => array('delete'),
-            //default 'sortables'     => array('id'),
-            //default 'unsortables'   => array('tagged','latestlog','editlink','phonelink')
-            'extraBoxes' => $upsellBoxHTML
-    ));
-
-    $list->drawListView();
-
+	$list->drawListView();
 }
 
-/* ============================= / FORMS ========================================== 
-================================================================================ */
+/**
+ * Renders the html for the segments list.
+ *
+ * @return void
+ */
+function zeroBSCRM_render_segmentslist_page() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 
+	global $zbs;
 
+	// Check that our segment conditions are all still available
+	// (checking here allows us to expose errors on the list view if there are any)
+	jpcrm_segments_compare_available_conditions_to_prev();
 
-/* ================================================================================
-=============================== SEGMENTS ======================================= */
+	// has no sync ext? Sell them
+	$upsell_box_html = '';
 
-function zeroBSCRM_render_segmentslist_page(){
+	if ( ! zeroBSCRM_isExtensionInstalled( 'advancedsegments' ) ) {
 
-    global $zbs;
+		// first build upsell box html
+		$upsell_box_html  = '<div class="">';
+		$upsell_box_html .= '<h4>' . esc_html__( 'Using Segments?', 'zero-bs-crm' ) . ':</h4>';
 
-    // Check that our segment conditions are all still available
-    // (checking here allows us to expose errors on the list view if there are any)
-    jpcrm_segments_compare_available_conditions_to_prev();
+		$up_title  = __( 'Segment like a PRO', 'zero-bs-crm' );
+		$up_desc   = __( 'Did you know that we\'ve made segments more advanced?', 'zero-bs-crm' );
+		$up_button = __( 'See Advanced Segments', 'zero-bs-crm' );
+		$up_target = $zbs->urls['advancedsegments'];
 
-    #} has no sync ext? Sell them
-    $upsellBoxHTML = '';
-    
-            #}
-            if (!zeroBSCRM_isExtensionInstalled('advancedsegments')){ 
+		$upsell_box_html .= zeroBSCRM_UI2_squareFeedbackUpsell( $up_title, $up_desc, $up_button, $up_target );
 
+		$upsell_box_html .= '</div>';
 
-                // first build upsell box html
-                $upsellBoxHTML = '<div class="">';
-                $upsellBoxHTML .= '<h4>'.__('Using Segments','zero-bs-crm').':</h4>';
+	} else {
 
-                        $upTitle = __('Segment like a PRO',"zero-bs-crm");
-                        $upDesc = __('Did you know that we\'ve made segments more advanced?',"zero-bs-crm");
-                        $upButton = __('See Advanced Segments',"zero-bs-crm");
-                        $upTarget = $zbs->urls['advancedsegments'];
+		// later this can point to https://kb.jetpackcrm.com/knowledge-base/how-to-get-customers-into-zero-bs-crm/
 
-                        $upsellBoxHTML .= zeroBSCRM_UI2_squareFeedbackUpsell($upTitle,$upDesc,$upButton,$upTarget); 
+		$upsell_box_html  = '<div class="">';
+		$upsell_box_html .= '<h4>' . esc_html__( 'Got Feedback?', 'zero-bs-crm' ) . ':</h4>';
 
-                $upsellBoxHTML .= '</div>';
+		$up_title  = esc_html__( 'Enjoying segments?', 'zero-bs-crm' );
+		$up_desc   = esc_html__( 'As we grow Jetpack CRM, we\'re looking for feedback!', 'zero-bs-crm' );
+		$up_button = esc_html__( 'Send Feedback', 'zero-bs-crm' );
+		$up_target = "mailto:hello@jetpackcrm.com?subject='Segments%20Feedback'";
 
-            } else { 
+		$upsell_box_html .= zeroBSCRM_UI2_squareFeedbackUpsell( $up_title, $up_desc, $up_button, $up_target );
 
-             // later this can point to https://kb.jetpackcrm.com/knowledge-base/how-to-get-customers-into-zero-bs-crm/ 
- 
-                $upsellBoxHTML = '<div class="">';
-                $upsellBoxHTML .= '<h4>'.__('Got Feedback?','zero-bs-crm').':</h4>';
+		$upsell_box_html .= '</div>';
 
-                        $upTitle = __('Enjoying segments?',"zero-bs-crm");
-                        $upDesc = __('As we grow Jetpack CRM, we\'re looking for feedback!',"zero-bs-crm");
-                        $upButton = __('Send Feedback',"zero-bs-crm");
-                        $upTarget = "mailto:hello@jetpackcrm.com?subject='Segments%20Feedback'";
+	}
 
-                        $upsellBoxHTML .= zeroBSCRM_UI2_squareFeedbackUpsell($upTitle,$upDesc,$upButton,$upTarget); 
-                
-                $upsellBoxHTML .= '</div>';
+	// pass this for filter links
+	$extra_js = '';
+	if ( zeroBSCRM_getSetting( 'filtersfromsegments' ) == '1' ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		$extra_js = " var zbsSegmentViewStemURL = '" . jpcrm_esc_link( $zbs->slugs['managecontacts'] ) . '&quickfilters=segment_' . "';";
+	}
 
-            }
+	$list = new zeroBSCRM_list(
+		array(
 
-    // pass this for filter links
-    $extraJS = ''; if (zeroBSCRM_getSetting('filtersfromsegments') == "1"){ $extraJS = " var zbsSegmentViewStemURL = '".jpcrm_esc_link($zbs->slugs['managecontacts']).'&quickfilters=segment_'."';"; }        
+			'objType'     => 'segment',
+			'singular'    => esc_html__( 'Segment', 'zero-bs-crm' ),
+			'plural'      => esc_html__( 'Segments', 'zero-bs-crm' ),
+			'tag'         => '',
+			'postType'    => 'segment',
+			'postPage'    => $zbs->slugs['segments'],
+			'langLabels'  => array(
 
-    $list = new zeroBSCRM_list(array(
+				// compiled language
+				'lastCompiled'       => esc_html__( 'Last Compiled', 'zero-bs-crm' ),
+				'notCompiled'        => esc_html__( 'Not Compiled', 'zero-bs-crm' ),
 
-            'objType'       => 'segment',
-            'singular'      => __('Segment',"zero-bs-crm"),
-            'plural'        => __('Segments',"zero-bs-crm"),
-            'tag'           => '',
-            'postType'      => 'segment',
-            'postPage'      => $zbs->slugs['segments'],
-            'langLabels'    => array(
+				// bulk action labels
+				'deletesegments'     => esc_html__( 'Delete Segment(s)', 'zero-bs-crm' ),
+				'export'             => esc_html__( 'Export Segment(s)', 'zero-bs-crm' ),
 
-                // compiled language
-                'lastCompiled' => __('Last Compiled',"zero-bs-crm"),
-                'notCompiled' => __('Not Compiled',"zero-bs-crm"),
-                
-                // bulk action labels
-                'deletesegments' => __('Delete Segment(s)',"zero-bs-crm"),
-                'export' => __('Export Segment(s)',"zero-bs-crm"),
+				// bulk actions - segment deleting
+				'segmentsdeleted'    => esc_html__( 'Your segment(s) have been deleted.', 'zero-bs-crm' ),
+				'notsegmentsdeleted' => esc_html__( 'Your segment(s) could not be deleted.', 'zero-bs-crm' ),
 
-                // bulk actions - segment deleting
-                'segmentsdeleted' => __('Your segment(s) have been deleted.',"zero-bs-crm"),
-                'notsegmentsdeleted' => __('Your segment(s) could not be deleted.',"zero-bs-crm"),
+				// export segment
+				'exportcsv'          => esc_html__( 'Export .CSV', 'zero-bs-crm' ),
 
-                // export segment
-                'exportcsv' => __( 'Export .CSV', 'zero-bs-crm' ),
+			),
+			'bulkActions' => array( 'delete' ),
+			// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			// 'sortables'   => array('id'),
+			'unsortables' => array( 'audiencecount', 'action', 'added' ),
+			'extraBoxes'  => $upsell_box_html,
+			'extraJS'     => $extra_js,
+		)
+	);
 
-            ),
-            'bulkActions'   => array('delete'),
-            //'sortables'     => array('id'),
-            'unsortables'   => array('audiencecount','action','added'),
-            'extraBoxes' => $upsellBoxHTML,
-            'extraJS' => $extraJS
-    ));
-
-    $list->drawListView();
-
+	$list->drawListView();
 }
 
-/* ============================== / SEGMENTS ====================================== 
-================================================================================ */
+/**
+ * Renders the html for the quote templates list.
+ *
+ * @return void
+ */
+function zeroBSCRM_render_quotetemplateslist_page() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 
+	// has no sync ext? Sell them
+	$upsell_box_html = '';
 
+	$list = new zeroBSCRM_list(
+		array(
 
-/* ================================================================================
-================================ QUOTETEMPLATES ================================ */
+			'objType'     => 'quotetemplate',
+			'singular'    => esc_html__( 'Quote Template', 'zero-bs-crm' ),
+			'plural'      => esc_html__( 'Quote Templates', 'zero-bs-crm' ),
+			'tag'         => '',
+			'postType'    => 'zerobs_quo_template',
+			'postPage'    => 'manage-quote-templates',
+			'langLabels'  => array(
 
-function zeroBSCRM_render_quotetemplateslist_page(){
+				// bulk action labels
+				'delete'                   => esc_html__( 'Delete Quote Template(s)', 'zero-bs-crm' ),
+				'export'                   => esc_html__( 'Export Quote Template(s)', 'zero-bs-crm' ),
 
+				// for listview
+				'defaulttemplate'          => esc_html__( 'Default Template', 'zero-bs-crm' ),
+				'deletetemplate'           => esc_html__( 'Delete Template', 'zero-bs-crm' ),
 
-    #} has no sync ext? Sell them
-    $upsellBoxHTML = ''; 
+				// bulk actions - quote template deleting
+				'quotetemplatesdeleted'    => esc_html__( 'Your Quote template(s) have been deleted.', 'zero-bs-crm' ),
+				'notquotetemplatesdeleted' => esc_html__( 'Your Quote template(s) could not be deleted.', 'zero-bs-crm' ),
 
-    $list = new zeroBSCRM_list(array(
+			),
+			'bulkActions' => array( 'delete' ),
+			'extraBoxes'  => $upsell_box_html,
+		)
+	);
 
-            'objType'       => 'quotetemplate',
-            'singular'      => __('Quote Template',"zero-bs-crm"),
-            'plural'        => __('Quote Templates',"zero-bs-crm"),
-            'tag'           => '',
-            'postType'      => 'zerobs_quo_template',
-            'postPage'      => 'manage-quote-templates',
-            'langLabels'    => array(
-
-                // bulk action labels
-                'delete' => __('Delete Quote Template(s)',"zero-bs-crm"),
-                'export' => __('Export Quote Template(s)',"zero-bs-crm"),
-
-                // for listview
-                'defaulttemplate' => __('Default Template','zero-bs-crm'),
-                'deletetemplate' => __('Delete Template','zero-bs-crm'),
-
-                // bulk actions - quote template deleting
-                'quotetemplatesdeleted' => __('Your Quote template(s) have been deleted.',"zero-bs-crm"),
-                'notquotetemplatesdeleted' => __('Your Quote template(s) could not be deleted.',"zero-bs-crm"),
-
-            ),
-            'bulkActions'   => array('delete'),
-            'extraBoxes' => $upsellBoxHTML
-    ));
-
-    $list->drawListView();
-
+	$list->drawListView();
 }
 
-/* ============================= / QUOTETEMPLATES =================================
-================================================================================ */
+/**
+ * Renders the html for the tasks list.
+ *
+ * @return void
+ */
+function zeroBSCRM_render_eventslist_page() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 
+	// has no sync ext? Sell them
+	$upsell_box_html = '';
 
+	$list = new zeroBSCRM_list(
+		array(
 
+			'objType'     => 'event',
+			'singular'    => esc_html__( 'Task', 'zero-bs-crm' ),
+			'plural'      => esc_html__( 'Tasks', 'zero-bs-crm' ),
+			'tag'         => '',
+			'postType'    => 'zerobs_event',
+			'postPage'    => 'manage-events-list',
+			'langLabels'  => array(
 
-/* ================================================================================
-=================================== EVENTS ===================================== */
+				// Status
+				'incomplete'                 => esc_html__( 'Incomplete', 'zero-bs-crm' ),
+				'complete'                   => esc_html__( 'Complete', 'zero-bs-crm' ),
 
-function zeroBSCRM_render_eventslist_page(){
+				// bulk action labels
+				'delete'                     => esc_html__( 'Delete Task(s)', 'zero-bs-crm' ),
+				'markcomplete'               => esc_html__( 'Mark Task(s) Completed', 'zero-bs-crm' ),
+				'markincomplete'             => esc_html__( 'Mark Task(s) Incomplete', 'zero-bs-crm' ),
 
+				// bulk actions - event actions
+				'eventsdeleted'              => esc_html__( 'Your Task(s) have been deleted.', 'zero-bs-crm' ),
+				'noteventsdeleted'           => esc_html__( 'Your Task(s) could not be deleted.', 'zero-bs-crm' ),
+				'areyousureeventscompleted'  => esc_html__( 'Are you sure you want to mark these tasks as completed?', 'zero-bs-crm' ),
+				'areyousureeventsincomplete' => esc_html__( 'Are you sure you want to mark these tasks as incomplete?', 'zero-bs-crm' ),
+				'eventsmarked'               => esc_html__( 'Your Task(s) have been updated.', 'zero-bs-crm' ),
+				'noteventsmarked'            => esc_html__( 'Your Task(s) could not be updated.', 'zero-bs-crm' ),
 
-    #} has no sync ext? Sell them
-    $upsellBoxHTML = ''; 
+			),
+			'bulkActions' => array( 'addtag', 'removetag', 'delete', 'markcomplete', 'markincomplete' ),
+			'unsortables' => array( 'action', 'remind', 'company', 'contact', 'showcal' ),
+			'extraBoxes'  => $upsell_box_html,
+		)
+	);
 
-    $list = new zeroBSCRM_list(array(
-
-            'objType'       => 'event',
-		'singular'        => __( 'Task', 'zero-bs-crm' ),
-		'plural'          => __( 'Tasks', 'zero-bs-crm' ),
-            'tag'           => '',
-            'postType'      => 'zerobs_event',
-            'postPage'      => 'manage-events-list',
-            'langLabels'    => array(
-
-                // Status
-                'incomplete' => __( 'Incomplete', "zero-bs-crm" ),
-                'complete' => __( 'Complete', "zero-bs-crm" ),
-
-                // bulk action labels
-                'delete' => __('Delete Task(s)',"zero-bs-crm"),
-                'markcomplete' => __('Mark Task(s) Completed',"zero-bs-crm"),
-                'markincomplete' => __('Mark Task(s) Incomplete',"zero-bs-crm"),
-
-                // bulk actions - event actions
-				'eventsdeleted'              => __( 'Your Task(s) have been deleted.', 'zero-bs-crm' ),
-				'noteventsdeleted'           => __( 'Your Task(s) could not be deleted.', 'zero-bs-crm' ),
-				'areyousureeventscompleted'  => __( 'Are you sure you want to mark these tasks as completed?', 'zero-bs-crm' ),
-				'areyousureeventsincomplete' => __( 'Are you sure you want to mark these tasks as incomplete?', 'zero-bs-crm' ),
-				'eventsmarked'               => __( 'Your Task(s) have been updated.', 'zero-bs-crm' ),
-				'noteventsmarked'            => __( 'Your Task(s) could not be updated.', 'zero-bs-crm' ),
-
-            ),
-            'bulkActions'   => array('addtag','removetag','delete','markcomplete','markincomplete'), // 'export' - possible but needs tidy /wp-admin/admin.php?page=zbs-export-tools&zbstype=event            
-            'unsortables'   => array('action','remind','company','contact','showcal'),
-            'extraBoxes' => $upsellBoxHTML
-    ));
-
-    $list->drawListView();
-
+	$list->drawListView();
 }
-
-/* ================================== / EVENTS ====================================
-================================================================================ */
-

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -1103,8 +1103,9 @@ class zeroBSCRM_list{
 			$jpcrm_listview_lang_labels = array(
 
 				'go_button'          => esc_html__( 'Go', 'zero-bs-crm' ),
+				/* translators: Placeholder is the number of selected rows. */
 				'rows_selected_x'    => esc_html__( 'Bulk actions (%s rows selected)', 'zero-bs-crm' ),
-				'rows_selected_1'    => esc_html__( 'Bulk actions (1 row selected)', 'zero-bs-crm'),
+				'rows_selected_1'    => esc_html__( 'Bulk actions (1 row selected)', 'zero-bs-crm' ),
 				'rows_selected_0'    => esc_html__( 'Bulk actions (no rows selected)', 'zero-bs-crm' ),
 				'zbs_edit'           => esc_html__( 'Edit', 'zero-bs-crm' ),
 				'today'              => esc_html__( 'Today', 'zero-bs-crm' ),
@@ -1121,9 +1122,9 @@ class zeroBSCRM_list{
 			);
 
 			// add any object-specific language labels
-			if ( count( $this->langLabels ) > 0 ) {
+			if ( count( $this->langLabels ) > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-				$jpcrm_listview_lang_labels = array_merge( $jpcrm_listview_lang_labels, $this->langLabels );
+				$jpcrm_listview_lang_labels = array_merge( $jpcrm_listview_lang_labels, $this->langLabels ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 			}
 			?>

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -1098,41 +1098,36 @@ class zeroBSCRM_list{
 
             ?>';
             var zbsClick2CallType = parseInt('<?php echo esc_url( zeroBSCRM_getSetting('clicktocalltype') ); ?>');
-            var zbsListViewLangLabels = {
 
-                'go_button': '<?php zeroBSCRM_slashOut( __( 'Go', 'zero-bs-crm' ) ); ?>',
+			<?php
+			$jpcrm_listview_lang_labels = array(
 
-                'rows_selected_x': '<?php zeroBSCRM_slashOut( __( 'Bulk actions (%s rows selected)', 'zero-bs-crm' ) ); ?>',
-                'rows_selected_1': '<?php zeroBSCRM_slashOut( __( 'Bulk actions (1 row selected)', 'zero-bs-crm') ); ?>',
-                'rows_selected_0': '<?php zeroBSCRM_slashOut( __( 'Bulk actions (no rows selected)', 'zero-bs-crm' ) ); ?>',
-                'zbs_edit': '<?php zeroBSCRM_slashOut(__('Edit',"zero-bs-crm")); ?>',
-                'today': '<?php zeroBSCRM_slashOut(__('Today',"zero-bs-crm")); ?>',
-                'days': '<?php zeroBSCRM_slashOut(__('days',"zero-bs-crm")); ?>',
-                'daysago': '<?php zeroBSCRM_slashOut(__('days ago',"zero-bs-crm")); ?>',
-                'notcontacted': '<?php zeroBSCRM_slashOut(__('Not Contacted',"zero-bs-crm")); ?>',
-                'yesterday': '<?php zeroBSCRM_slashOut(__('Yesterday',"zero-bs-crm")); ?>',
+				'go_button'          => esc_html__( 'Go', 'zero-bs-crm' ),
+				'rows_selected_x'    => esc_html__( 'Bulk actions (%s rows selected)', 'zero-bs-crm' ),
+				'rows_selected_1'    => esc_html__( 'Bulk actions (1 row selected)', 'zero-bs-crm'),
+				'rows_selected_0'    => esc_html__( 'Bulk actions (no rows selected)', 'zero-bs-crm' ),
+				'zbs_edit'           => esc_html__( 'Edit', 'zero-bs-crm' ),
+				'today'              => esc_html__( 'Today', 'zero-bs-crm' ),
+				'days'               => esc_html__( 'days', 'zero-bs-crm' ),
+				'daysago'            => esc_html__( 'days ago', 'zero-bs-crm' ),
+				'notcontacted'       => esc_html__( 'Not Contacted', 'zero-bs-crm' ),
+				'yesterday'          => esc_html__( 'Yesterday', 'zero-bs-crm' ),
+				'filteredby'         => esc_html__( 'Filtered By', 'zero-bs-crm' ),
+				'notcontactedin'     => esc_html__( 'Not Contacted in', 'zero-bs-crm' ),
+				'containing'         => esc_html__( 'Containing', 'zero-bs-crm' ),
+				'couldntupdate'      => esc_html__( 'Could not update', 'zero-bs-crm' ),
+				'couldntupdatedeets' => esc_html__( 'This record could not be updated. Please try again, if this persists please let admin know.', 'zero-bs-crm' ),
 
-                // filtered by str
-                'filteredby': '<?php zeroBSCRM_slashOut(__('Filtered By',"zero-bs-crm")); ?>',
-                'notcontactedin': '<?php zeroBSCRM_slashOut(__('Not Contacted in',"zero-bs-crm")); ?>',
-                'containing': '<?php zeroBSCRM_slashOut(__('Containing',"zero-bs-crm")); ?>',
-                
-                // for inline-edits
-                'couldntupdate': '<?php zeroBSCRM_slashOut(__('Could not update',"zero-bs-crm")); ?>',
-                'couldntupdatedeets': '<?php zeroBSCRM_slashOut(__('This record could not be updated. Please try again, if this persists please let admin know.',"zero-bs-crm")); ?>',
+			);
 
-                <?php $labelCount = 0; 
-                if (count($this->langLabels) > 0) foreach ($this->langLabels as $labelK => $labelV){
+			// add any object-specific language labels
+			if ( count( $this->langLabels ) > 0 ) {
 
-                    if ($labelCount > 0) echo ',';
+				$jpcrm_listview_lang_labels = array_merge( $jpcrm_listview_lang_labels, $this->langLabels );
 
-                    echo "'". esc_html( $labelK )."':'". esc_html( zeroBSCRM_slashOut($labelV,true) )."'";
-
-                    $labelCount++;
-
-                } ?>
-
-            };
+			}
+			?>
+			var zbsListViewLangLabels = <?php echo wp_json_encode( $jpcrm_listview_lang_labels ); ?>;
             var zbsTagsForBulkActions = <?php
 
                     // make simplified

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -144,7 +144,6 @@
 	"projects/plugins/crm/includes/ZeroBSCRM.List.CompletedEvents.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.List.Events.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.List.QuoteTemplate.php",
-	"projects/plugins/crm/includes/ZeroBSCRM.List.Views.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.List.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.Mail.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.MailTracking.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 2889 and 2972, which both dealt with over-escaped HTML.

When doing our XSS/security sweep, we accidentally escaped some strings that purposefully had HTML in them. In the first case (bulk-adding tags) I adjusted the string to use `wp_kses()`, simplified the logic so we weren't manually building a JS object, and reworded things a touch. 

In the other issue (a `<br>` in a settings description) I just removed the tag.

Note that I started doing extra linting in one function, but held off on the rest.

## Testing instructions

1. On an install that has some quotes but no quote tags, go here: `/wp-admin/admin.php?page=manage-quotes`
2. Select multiple quotes in the list view.
3. In the Bulk Actions dropdown, select "Add tags".

In `trunk`, one sees some HTML instead of a link to add tags:
![image](https://user-images.githubusercontent.com/32492176/226962815-b1d4db91-3ca4-4565-9517-c67218e59469.png)

In the `fix/crm/2889_and_2972_unescape_html` branch one sees this:
![image](https://user-images.githubusercontent.com/32492176/226962672-7de23cd7-9a0c-482a-8edc-024e7014555c.png)

4. Go here: `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=mail`

In `trunk` one sees a stray `<br/>`:
![image](https://user-images.githubusercontent.com/32492176/226963148-a181e47f-90b8-4540-8220-24e9d915bbf4.png)

In `fix/crm/2889_and_2972_unescape_html` the tag is removed (and quotes are added to example email name):
![image](https://user-images.githubusercontent.com/32492176/226963368-750aada3-4b3f-48df-86d2-44d60a4b0298.png)

## Does this pull request change what data or activity we track or use?
No