### PR TITLE
VideoPress: fix computing decimal part in the TimestampControl component

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-timestamp-control-computing-decimal-value
+++ b/projects/packages/videopress/changelog/fix-videopress-timestamp-control-computing-decimal-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix computing decimal part in the TimestampControl component

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -116,9 +116,12 @@ export const TimestampInput = ( {
 		time.value = { ...getTimeDataByValue( value, decimalPlaces ), [ unit ]: newValue };
 
 		// Call onChange callback.
+		const decimalValue = time.value.decimal
+			? time.value.decimal * Number( `1e${ 3 - decimalPlaces }` )
+			: 0;
+
 		onChange?.(
-			( time.value.hh * 3600 + time.value.mm * 60 + time.value.ss ) * 1000 +
-				time.value.decimal * Number( `1e${ 3 - decimalPlaces }` )
+			( time.value.hh * 3600 + time.value.mm * 60 + time.value.ss ) * 1000 + decimalValue
 		);
 	};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Quick fix that happens when the component doesn't have a decimal part and the value is changed from on of the input controls

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix computing decimal part in the TimestampControl component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with story book
* Go to the doc page (http://localhost:50240/?path=/docs/packages-videopress-timestamp-control--default(
* Focus on one of the inputs control
* Open the dev console
* change the value (UP/DOWN)

<img width="267" alt="image" src="https://user-images.githubusercontent.com/77539/226986708-fb9d10b4-0556-4bf6-8d5a-544f3ae17917.png">

**BEFORE**
* Confirm the computed value is `NaN`

**AFTER**
* Confirm it works as expected


before | after
------|------
<img width="249" alt="image" src="https://user-images.githubusercontent.com/77539/226986939-ed507e50-0271-4aae-8481-d13721936d20.png"> | <img width="245" alt="image" src="https://user-images.githubusercontent.com/77539/226986772-2e40fde7-e461-4243-a5ca-465dccb9bada.png">
 

