### PR TITLE
VideoPress: Fix TimestampControl input width and mobile UI

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-timestamp-control
+++ b/projects/packages/videopress/changelog/fix-videopress-timestamp-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix TimestampControl input width and mobile UI

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -239,7 +239,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 
 	const debounceTimer = useRef< NodeJS.Timeout >();
 
-	const { baseControlProps } = useBaseControlProps( props );
+	const { baseControlProps } = useBaseControlProps?.( props ) || {};
 
 	const onChangeHandler = useCallback(
 		( newValue: number ) => {

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useBreakpointMatch } from '@automattic/jetpack-components';
 import {
 	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl,
@@ -236,6 +237,8 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 		decimalPlaces,
 	} = props;
 
+	const [ isSm ] = useBreakpointMatch( 'sm' );
+
 	const debounceTimer = useRef< NodeJS.Timeout >();
 
 	const { baseControlProps } = useBaseControlProps( props );
@@ -252,7 +255,11 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 
 	return (
 		<BaseControl { ...baseControlProps }>
-			<div className={ styles[ 'timestamp-control__controls-wrapper' ] }>
+			<div
+				className={ classNames( styles[ 'timestamp-control__controls-wrapper' ], {
+					[ styles.small ]: isSm,
+				} ) }
+			>
 				<TimestampInput
 					disabled={ disabled }
 					max={ max }

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -198,6 +198,7 @@ export const TimestampInput = ( {
 					<TimeDivider char="." />
 					<NumberControl
 						className={ styles[ 'timestamp-control-input' ] }
+						style={ { '--input-width': `${ 12 * decimalPlaces }px` } }
 						disabled={ disabled }
 						min={ 0 }
 						max={ Number( '9'.repeat( decimalPlaces ) ) }

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useBreakpointMatch } from '@automattic/jetpack-components';
 import {
 	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl,
@@ -238,8 +237,6 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 		decimalPlaces,
 	} = props;
 
-	const [ isSm ] = useBreakpointMatch( 'sm' );
-
 	const debounceTimer = useRef< NodeJS.Timeout >();
 
 	const { baseControlProps } = useBaseControlProps( props );
@@ -256,11 +253,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 
 	return (
 		<BaseControl { ...baseControlProps }>
-			<div
-				className={ classNames( styles[ 'timestamp-control__controls-wrapper' ], {
-					[ styles.small ]: isSm,
-				} ) }
-			>
+			<div className={ styles[ 'timestamp-control__controls-wrapper' ] }>
 				<TimestampInput
 					disabled={ disabled }
 					max={ max }

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -4,14 +4,10 @@
 	align-items: center;
 	gap: 8px;
 	margin-bottom: 8px;
+	flex-wrap: wrap;
 
-	&.small {
-		flex-direction: column;
-		align-items: inherit;
-
-		.timestamp-input-wrapper {
-			max-width: unset;
-		}
+	.timestamp-range-control {
+		min-width: 270px;
 	}
 
 	.timestamp-range-control,

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -1,4 +1,5 @@
 .timestamp-control__controls-wrapper {
+	--input-width: 24px;
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -33,11 +34,14 @@
 	justify-content: space-around;
 	border-width: 1px;
 	padding: 0px;
-	max-width: calc( var( --spacing-base ) * 30 ); // 240px
 
 	.timestamp-control-input {
 		padding: 0 1px;
 		margin-bottom: 0;
+
+		input {
+			max-width: var( --input-width );
+		}
 
 		&:last-child{
 			margin-bottom: 0;

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -3,7 +3,6 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	margin-bottom: 8px;
 	flex-wrap: wrap;
 
 	.timestamp-range-control {
@@ -45,10 +44,28 @@
 	}
 
 	:global {
+		.components-input-control:last-child {
+			margin-bottom: 0;
+		}
+
 		.components-input-control__input {
 			padding-left: 0 !important;
 			padding-right: 0 !important;
 			text-align: center;
+
+			/*
+			 * Remove arrows from the number input
+			 * backward compatibility for Firefox, Safari, and Chrome
+			 */
+			 &::-webkit-outer-spin-button,
+			 &::-webkit-inner-spin-button {
+				 -webkit-appearance: none;
+			 }
+ 
+			 &[type=number] {
+				 appearance: textfield;
+				 -moz-appearance: textfield;
+			 }
 		}
 
 		.components-input-control__backdrop {

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -24,7 +24,7 @@
 	display: flex;
 	align-items: center;
 	border-color: #949494;
-	background-color: var( --jp-white );
+	background-color: #fff;
 	border-style: solid;
 	justify-content: space-around;
 	border-width: 1px;

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -4,6 +4,15 @@
 	gap: 8px;
 	margin-bottom: 8px;
 
+	&.small {
+		flex-direction: column;
+		align-items: inherit;
+
+		.timestamp-input-wrapper {
+			max-width: unset;
+		}
+	}
+
 	.timestamp-range-control,
 	.timestamp-range-control:last-child {
 		margin-bottom: 0;
@@ -19,15 +28,17 @@
 	display: flex;
 	align-items: center;
 	border-color: #949494;
-	background-color: #fff;
-    border-style: solid;
+	background-color: var( --jp-white );
+	border-style: solid;
 	justify-content: space-around;
-    border-width: 1px;
+	border-width: 1px;
 	padding: 0px;
+	max-width: calc( var( --spacing-base ) * 30 ); // 240px
 
 	.timestamp-control-input {
 		padding: 0 1px;
 		margin-bottom: 0;
+
 		&:last-child{
 			margin-bottom: 0;
 		}
@@ -39,6 +50,7 @@
 			padding-right: 0 !important;
 			text-align: center;
 		}
+
 		.components-input-control__backdrop {
 			border-style: none !important;
 		}

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -3,11 +3,6 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	flex-wrap: wrap;
-
-	.timestamp-range-control {
-		min-width: 270px;
-	}
 
 	.timestamp-range-control,
 	.timestamp-range-control:last-child {

--- a/projects/packages/videopress/src/client/components/timestamp-control/types.ts
+++ b/projects/packages/videopress/src/client/components/timestamp-control/types.ts
@@ -1,3 +1,8 @@
+/*
+ * Types
+ */
+import type { ReactNode } from 'react';
+
 export type DecimalPlacesProp = 1 | 2 | 3;
 
 export type TimestampInputProps = {
@@ -11,6 +16,8 @@ export type TimestampInputProps = {
 };
 
 export type TimestampControlProps = TimestampInputProps & {
+	label?: ReactNode;
+	help?: ReactNode;
 	wait?: number;
 	onDebounceChange?: ( ms: number ) => void;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29634

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Explicitly sets the maximum width of the number input group and moves the slider down on small viewports

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `( cd projects/js-packages/storybook && pnpm run storybook:dev )`
* Go to the `Timestamp Control` component
* Check that the number input group has a fixed size on normal viewports independent of browser
* Change the viewport to `Small mobile`
![2023-03-22_18-33-37](https://user-images.githubusercontent.com/8486249/227043683-27694b04-18b9-4c50-af2a-4b964c5d3a9c.png)
* Check that the slider now is beneath the inputs

