### PR TITLE
[Earn] Disable Reblogs for Newsletters

### DIFF
--- a/projects/plugins/jetpack/changelog/add-disable-reblogs-for-newsletters
+++ b/projects/plugins/jetpack/changelog/add-disable-reblogs-for-newsletters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Disable reblogs for newsletters

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -67,6 +67,11 @@ function register_block() {
 		)
 	);
 
+	// Disable reblogs for blog
+	if ( ! get_option( 'disabled_reblogs' ) ) {
+		update_option( 'disabled_reblogs', 1 );
+	}
+
 	// This ensures Jetpack will sync this post meta to WPCOM.
 	add_filter(
 		'jetpack_sync_post_meta_whitelist',

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -87,6 +87,9 @@ function register_block() {
 
 	// Gate the excerpt for a post
 	add_filter( 'get_the_excerpt', __NAMESPACE__ . '\jetpack_filter_excerpt_for_newsletter', 10, 2 );
+
+	// Disable reblogs
+	add_filter( 'option_disabled_reblogs', '__return_true' );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/29616

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent reblogging posts marked as newsletters
* My approach in [42bf6c7](https://github.com/Automattic/jetpack/pull/29642/commits/42bf6c730dadbb961b5ce454bc99f65f845c779d) doesn't appear to work as the `get_option( 'disabled_reblogs' )` appears to have run earlier.
* I also couldn't find an intuitive way to disable reblogs for a specific post (i.e., only newsletter posts ). I'm open to feedback!
 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync PR to sandbox: `bin/jetpack-downloader test jetpack add/disable-reblogs-for-newsletters`
* Sandbox a any site and view the post.  You can use [my post
](https://romarioraffearn.wordpress.com/2023/03/22/a-post-only-for-subscribers/)
* Notice the "Reblog" button is not present

