### PR TITLE
Backup: fix storage details API call loop

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-api-call-loop
+++ b/projects/packages/backup/changelog/fix-backup-api-call-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Backup: validate if storage details has loaded before attempting to fetch it again.

--- a/projects/packages/backup/src/js/components/backup-storage-space/index.jsx
+++ b/projects/packages/backup/src/js/components/backup-storage-space/index.jsx
@@ -12,6 +12,10 @@ const BackupStorageSpace = () => {
 	const [ connectionStatus ] = useConnection();
 	const isFetchingPolicies = useSelect( select => select( STORE_ID ).isFetchingBackupPolicies() );
 	const isFetchingSize = useSelect( select => select( STORE_ID ).isFetchingBackupSize() );
+	const hasBackupSizeLoaded = useSelect( select => select( STORE_ID ).hasBackupSizeLoaded() );
+	const hasBackupPoliciesLoaded = useSelect( select =>
+		select( STORE_ID ).hasBackupPoliciesLoaded()
+	);
 	const storageLimit = useSelect( select => select( STORE_ID ).getBackupStorageLimit() );
 	const storageSize = useSelect( select => select( STORE_ID ).getBackupSize() );
 	const planRetentionDays = useSelect( select => select( STORE_ID ).getActivityLogLimitDays() );
@@ -35,20 +39,20 @@ const BackupStorageSpace = () => {
 			return;
 		}
 
-		if ( ! isFetchingPolicies && ! storageLimit ) {
+		if ( ! isFetchingPolicies && ! hasBackupPoliciesLoaded ) {
 			dispatch.getSitePolicies();
 		}
 
-		if ( ! isFetchingSize && ! storageSize ) {
+		if ( ! isFetchingSize && ! hasBackupSizeLoaded ) {
 			dispatch.getSiteSize();
 		}
 	}, [
 		connectionStatus,
 		dispatch,
+		hasBackupPoliciesLoaded,
+		hasBackupSizeLoaded,
 		isFetchingPolicies,
 		isFetchingSize,
-		storageLimit,
-		storageSize,
 	] );
 
 	useEffect( () => {

--- a/projects/packages/backup/src/js/selectors/site-backup.js
+++ b/projects/packages/backup/src/js/selectors/site-backup.js
@@ -6,11 +6,13 @@ const siteBackupSelectors = {
 	getDaysOfBackupsAllowed: state => state.siteBackupSize.daysOfBackupsAllowed ?? null,
 	getDaysOfBackupsSaved: state => state.siteBackupSize.daysOfBackupsSaved ?? null,
 	getBackupRetentionDays: state => state.siteBackupSize.retentionDays ?? null,
+	hasBackupSizeLoaded: state => state.siteBackupSize.loaded,
 
 	// Policies
 	isFetchingBackupPolicies: state => state.siteBackupPolicies.isFetching ?? null,
 	getBackupStorageLimit: state => state.siteBackupPolicies.storageLimitBytes ?? null,
 	getActivityLogLimitDays: state => state.siteBackupPolicies.activityLogLimitDays ?? null,
+	hasBackupPoliciesLoaded: state => state.siteBackupPolicies.loaded,
 
 	// Storage
 	getStorageUsageLevel: state => state.siteBackupStorage.usageLevel ?? null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Currently, if the site has zero storage size or has no policies, we loop API calls trying to fetch the storage size and policies until we get a different response than 0 or null. This PR aims to fix it by validating if we already fetched the storage details before attempting to do another API call.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `hasBackupSizeLoaded` and `hasBackupPoliciesLoaded` selectors to fetch the `loaded` state
* Validate if size and policies has loaded before attempting to fetch them from the API again.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* p1678716840128819-slack-CS8UYNPEE
* 1202586245449203-as-1204171618883370/f

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a Jurassic Ninja site with Jetpack VaultPress Backup plugin, but no plan.
* Connect site to Jetpack. You can do it through My Jetpack submenu.
* Open your browser developer tools and open the Network tab. Ensure `Preserve log` is unchecked.
* Navigate to VaultPress Backup admin page. You should see the backup pricing.
* Validate there's only one call for `/rewind/size` and `/rewind/policies` WPCOM endpoints.
* You can attempt to reproduce the issue we are solving by using a new Jurassic Ninja site and install [backup plugin v1.5](https://wordpress.org/plugins/jetpack-backup/).