### PR TITLE
Import: fix media duplication issue

### DIFF
--- a/projects/packages/import/changelog/fix-media-duplication
+++ b/projects/packages/import/changelog/fix-media-duplication
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Prevent media duplication when it's already existed

--- a/projects/packages/import/src/endpoints/class-attachment.php
+++ b/projects/packages/import/src/endpoints/class-attachment.php
@@ -99,12 +99,18 @@ class Attachment extends \WP_REST_Attachments_Controller {
 		$file_info  = $this->get_file_info( $request );
 		$attachment = $this->get_attachment_by_file_info( $file_info );
 		if ( $attachment ) {
+			$response = $this->prepare_attachment_for_response( $attachment, $request );
+
+			if ( \is_wp_error( $response ) ) {
+				return $response;
+			}
+
 			return new \WP_Error(
 				'attachment_exists',
 				__( 'The attachment already exists.', 'jetpack-import' ),
 				array(
 					'status'        => 409,
-					'attachment'    => $this->prepare_attachment_for_response( $attachment, $request ),
+					'attachment'    => $response,
 					'attachment_id' => $attachment->ID,
 				)
 			);
@@ -295,7 +301,7 @@ class Attachment extends \WP_REST_Attachments_Controller {
 		$response = $this->prepare_item_for_response( $attachment, $request );
 
 		// Check if there was an error preparing the data
-		if ( is_wp_error( $response ) ) {
+		if ( \is_wp_error( $response ) ) {
 			return $response;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/dotcom-forge#2016

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When we upload images now they'll be created even if it's already existed. This will cause unnecessary duplication in the media library. This PR adds a check before we create the media to prevent duplication.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See issue above
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You can spin up a JN site using [this branch](https://jurassic.ninja/create/?jetpack-beta&branches.jetpack=fix/media-duplication&wp-debug-log) or spin up your local WP and your Jurrasic tube, you can do it by using `jetpack docker jt-up`. (If you're not familiar with this, you can check [the doc here](https://github.com/Automattic/jetpack/blob/trunk/tools/docker/README.md#jurassic-tube-tunneling-service).
* You can follow the rest of the test instructions and get sample WXR here: D105701-code