### PR TITLE
Fix fatal caused by require old module file

### DIFF
--- a/projects/packages/forms/changelog/fix-replace-require-module-file
+++ b/projects/packages/forms/changelog/fix-replace-require-module-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use Contact_Form_Plugin::init instead of requiring the old module file

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -1043,7 +1043,9 @@ class Admin {
 			wp_die( esc_html__( 'You are not allowed to manage this item.', 'jetpack-forms' ) );
 		}
 
-		require_once __DIR__ . '/grunion-contact-form.php';
+		// init will construct/get the instance and make sure all the filters and actions
+		// are in place for this process to go through
+		Contact_Form_Plugin::init();
 
 		$current_menu = '';
 		if ( isset( $_POST['sub_menu'] ) && preg_match( '|post_type=feedback|', sanitize_text_field( wp_unslash( $_POST['sub_menu'] ) ) ) ) {

--- a/projects/plugins/jetpack/changelog/fix-replace-require-module-file
+++ b/projects/plugins/jetpack/changelog/fix-replace-require-module-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Use Contact_Form_Plugin::init instead of requiring the old module file


### PR DESCRIPTION
## Proposed changes:
Use Contact_Form_Plugin::init, which ensures all the actions/filters are in place, instead of requiring the old module file `__DIR__ . '/grunion-contact-form.php'`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1679501497665749-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use Feedback menu on wp-admin, select one of the responses and mark it as spam. Keep an eye on the logs, there shouldn't be any fatals