### PR TITLE
Photon: do not host Flickr images with Photon

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-photon-flickr-embeds
+++ b/projects/plugins/jetpack/changelog/fix-photon-flickr-embeds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Image CDN: do not process Flickr-hosted images with Jetpack's Image CDN.

--- a/projects/plugins/jetpack/functions.photon.php
+++ b/projects/plugins/jetpack/functions.photon.php
@@ -311,6 +311,7 @@ function jetpack_photon_banned_domains( $skip, $image_url ) {
 		'/\.cdninstagram\.com$/',
 		'/^(commons|upload)\.wikimedia\.org$/',
 		'/\.wikipedia\.org$/',
+		'/^live\.staticflickr\.com$/',
 	);
 
 	$host = wp_parse_url( $image_url, PHP_URL_HOST );


### PR DESCRIPTION
Fixes 8159-gh-jpop-issues

## Proposed changes:

Flickr has its own CDN, we do not need to host their images with Jetpack's image CDN. It also ensures that images embedded ia a Flickr embed code retain the additional functionality the Flickr embed offers.

<img width="1040" alt="image" src="https://user-images.githubusercontent.com/426388/227142823-a20ee83b-686d-482d-b49d-972654015c19.png">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Activate Photon on your site by going to Jetpack > Settings > Performance and enabling the first toggle of the site accelerator.
* Go to Posts > Add New
* Add a new HTML block
* In that block, paste the following:

```html
<a data-flickr-embed="true" href="https://www.flickr.com/photos/tsadri/6951539682/in/album-72157601986903754/" title="Iskolabusz"><img src="https://live.staticflickr.com/5333/6951539682_193c49a5cd_k.jpg" width="1365" height="2048" alt="Iskolabusz"/></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
```

* Publish your post.
* Load your post on the frontend, and open your browser dev tools
    * You should not see any js errors related to Flickr.
    * In the inspector, you should see the image served directly from Flickr's domain, `live.staticflickr.com`.
    * When moving your mouse over the image, you should see options appear at the top of the image.
