### PR TITLE
CRM: Moving Quote status underneath Quote ID

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-move-quote-status
+++ b/projects/plugins/crm/changelog/update-crm-move-quote-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+CRM: move Quote Status underneath Quote ID

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
@@ -110,6 +110,23 @@
 
                 global $zbs;
 
+				// Define Quote statuses.
+				$acceptable_quote_statuses = array(
+					'draft'     => __( 'Draft', 'zero-bs-crm' ),
+					'published' => __( 'Published, Unaccepted', 'zero-bs-crm' ),
+					'accepted'  => __( 'Accepted', 'zero-bs-crm' ),
+				);
+
+				// status
+				$status = __( 'Draft', 'zero-bs-crm' );
+			if ( is_array( $quote ) && isset( $quote['status'] ) ) {
+				if ( $quote['status'] === -2 ) {
+					$status = __( 'Published, Unaccepted', 'zero-bs-crm' );
+				}
+				if ( $quote['status'] === 1 ) {
+					$status = __( 'Accepted', 'zero-bs-crm' );
+				}
+			}
                 // Debug echo 'Quote:<pre>'.print_r($quote,1).'</pre>';
     
                 ?>                
@@ -182,7 +199,28 @@
                         </td></tr><?php
 
                     }
+					// Quote status.
+				?>
+					<tr class="wh-large"><th><label for="quote_status"><?php esc_html_e( 'Status', 'zero-bs-crm' ); ?>:</label></th>
+						<td>
+							<div class="zbs-prominent">
 
+							<select id="quote_status" name="quote_status">
+							<?php
+						foreach ( $acceptable_quote_statuses as $status_opt => $status_str ) {
+							$sel = '';
+							if ( $status_str === $status ) {
+								$sel = ' selected="selected"';
+							}
+							/* Translators:  %s is the Quote status. */
+							echo '<option value="' . esc_attr( $status_opt ) . '"' . esc_attr( $sel ) . '>' . esc_html( sprintf( __( '%s', 'zero-bs-crm' ), $status_str ) ) . '</option>'; // phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
+						}
+						?>
+							</select>
+							
+						</div>
+						</td></tr>
+						<?php
 
                     #} ALSO customer assigning is seperate:
                     ?><tr class="wh-large"><th><label><?php esc_html_e('Contact',"zero-bs-crm");?>:</label></th>
@@ -1317,49 +1355,8 @@ class zeroBS__Metabox_QuoteTags extends zeroBS__Metabox_Tags{
             
                 #} if a saved post...
                 //if (isset($post->post_status) && $post->post_status != "auto-draft"){
-                if ($quoteID > 0){ // existing
-
-                    // hard typed for now.
-                    $acceptableQuoteStatuses = array(
-                        "draft" => __('Draft','zero-bs-crm'),
-                        "published" => __('Published, Unaccepted','zero-bs-crm'),
-                        "accepted" => __('Accepted','zero-bs-crm')
-                    );
-
-                    // status
-                    $status = __('Draft','zero-bs-crm');
-                    if (is_array($quote) && isset($quote['status'])){
-                        if ($quote['status'] == -2) $status = __('Published, Unaccepted','zero-bs-crm');
-                        if ($quote['status'] == 1) $status = __('Accepted','zero-bs-crm');
-                    }
-
-                    /* grid doesn't work great for long-named:
-
-                    <div class="ui grid">
-                        <div class="six wide column">
-                        </div>
-                        <div class="ten wide column">
-                        </div>
-                    </div>
-
-                    */
-                    ?>
-                    <div>
-                        <label for="quote_status"><?php esc_html_e('Status',"zero-bs-crm"); ?>: </label>
-                        <select id="quote_status" name="quote_status">
-                            <?php foreach($acceptableQuoteStatuses as $statusOpt => $statusStr){
-
-                                $sel = '';
-                                if ($statusStr == $status) $sel = ' selected="selected"';
-                                echo '<option value="' . esc_attr( $statusOpt ) . '"'. esc_attr( $sel ) .'>'.esc_html__($statusStr,"zero-bs-crm").'</option>';
-
-                            } ?>
-                        </select>
-                    </div>
-
-                    <div class="clear"></div>
-
-
+			if ( $quoteID > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				?>
                     <div class="zbs-quote-actions-bottom zbs-objedit-actions-bottom">
 
                         <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Update","zero-bs-crm"); ?> <?php esc_html_e("Quote","zero-bs-crm"); ?></button>
@@ -1383,7 +1380,8 @@ class zeroBS__Metabox_QuoteTags extends zeroBS__Metabox_Tags{
 
                 } else {
 
-                    // NEW quote ?>
+				// NEW quote
+				?>
 
                     <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Save","zero-bs-crm"); ?> <?php esc_html_e("Quote","zero-bs-crm"); ?></button>
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
@@ -200,27 +200,30 @@
 
                     }
 					// Quote status.
-				?>
+				if ( $quoteID > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					?>
+				
 					<tr class="wh-large"><th><label for="quote_status"><?php esc_html_e( 'Status', 'zero-bs-crm' ); ?>:</label></th>
 						<td>
 							<div class="zbs-prominent">
 
 							<select id="quote_status" name="quote_status">
 							<?php
-						foreach ( $acceptable_quote_statuses as $status_opt => $status_str ) {
-							$sel = '';
-							if ( $status_str === $status ) {
-								$sel = ' selected="selected"';
+							foreach ( $acceptable_quote_statuses as $status_opt => $status_str ) {
+								$sel = '';
+								if ( $status_str === $status ) {
+									$sel = ' selected="selected"';
+								}
+								/* Translators:  %s is the Quote status. */
+								echo '<option value="' . esc_attr( $status_opt ) . '"' . esc_attr( $sel ) . '>' . esc_html( sprintf( __( '%s', 'zero-bs-crm' ), $status_str ) ) . '</option>'; // phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
 							}
-							/* Translators:  %s is the Quote status. */
-							echo '<option value="' . esc_attr( $status_opt ) . '"' . esc_attr( $sel ) . '>' . esc_html( sprintf( __( '%s', 'zero-bs-crm' ), $status_str ) ) . '</option>'; // phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
-						}
-						?>
+							?>
 							</select>
 							
 						</div>
 						</td></tr>
 						<?php
+				} // end if
 
                     #} ALSO customer assigning is seperate:
                     ?><tr class="wh-large"><th><label><?php esc_html_e('Contact',"zero-bs-crm");?>:</label></th>


### PR DESCRIPTION


## Proposed changes:
* This PR moves the Quote Status options from the Quote Action Metabox to underneath the Quote ID (on the Quote Edit page)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2948

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test this, using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, visit the 'Edit' Quote page: `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=quote&zbsid={quoteid}`. * Underneath the Quote ID you should see a Status heading, with a dropdown for the available statuses.
* Try changing the status and saving - the change should save and the status should be visible on the 'View All' Quotes page.
* The Status dropdown should no longer be visible in the Quote Actions metabox.

**Before**
<img width="1687" alt="Screenshot 2023-03-23 at 11 52 18" src="https://user-images.githubusercontent.com/16754605/227195482-b3565ccd-6143-4f79-b1eb-d53674edbe25.png">


**After**
<img width="1704" alt="Screenshot 2023-03-23 at 11 51 44" src="https://user-images.githubusercontent.com/16754605/227195360-b514196b-8f31-4b94-93bf-f11fb1358dad.png">

