### PR TITLE
VideoPress: Add Stats module to VideoPress plugin

### DIFF
--- a/projects/packages/videopress/changelog/add-include-stats-module-on-videopress-plugin
+++ b/projects/packages/videopress/changelog/add-include-stats-module-on-videopress-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Added Stats module to the list of enabled modules for the standalone VP plugin.

--- a/projects/packages/videopress/src/class-module-control.php
+++ b/projects/packages/videopress/src/class-module-control.php
@@ -20,8 +20,9 @@ class Module_Control {
 	public static function init() {
 		add_filter( 'jetpack_get_available_standalone_modules', array( __CLASS__, 'add_videopress_to_array' ), 10, 1 );
 		if ( Status::is_standalone_plugin_active() ) {
-			// If the stand-alone plugin is active, videopress module will always be considered active.
+			// If the stand-alone plugin is active, videopress module will always be considered active; same for the stats module
 			add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_to_array' ), 10, 2 );
+			add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_stats_to_array' ), 10, 2 );
 		}
 	}
 
@@ -33,5 +34,15 @@ class Module_Control {
 	 */
 	public static function add_videopress_to_array( $modules ) {
 		return array_merge( array( 'videopress' ), $modules );
+	}
+
+	/**
+	 * Adds stats to the list of available/active modules
+	 *
+	 * @param array $modules Array with modules slugs.
+	 * @return array
+	 */
+	public static function add_stats_to_array( $modules ) {
+		return array_merge( array( 'stats' ), $modules );
 	}
 }

--- a/projects/plugins/videopress/changelog/add-include-stats-module-on-videopress-plugin
+++ b/projects/plugins/videopress/changelog/add-include-stats-module-on-videopress-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Added Stats module as a requirement for the plugin and enabled it on plugin activation.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -13,7 +13,8 @@
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-plugins-installer": "@dev",
-		"automattic/jetpack-videopress": "@dev"
+		"automattic/jetpack-videopress": "@dev",
+		"automattic/jetpack-stats": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.4",

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75db4a73a2d94f740076bc5f6ec284ae",
+    "content-hash": "367ce04c2aecfbe718ec9eda8e27c64f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1095,6 +1095,63 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Utilities, related with user roles and capabilities.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-stats",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/stats",
+                "reference": "43bb197f177b7d4f2fad5eacba92b0545c83009b"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-status": "@dev"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/wordbless": "dev-master",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-stats",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.5.x-dev"
+                },
+                "textdomain": "jetpack-stats"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Collect valuable traffic stats and insights.",
             "transport-options": {
                 "relative": true
             }
@@ -4155,6 +4212,7 @@
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-plugins-installer": 20,
         "automattic/jetpack-videopress": 20,
+        "automattic/jetpack-stats": 20,
         "automattic/jetpack-changelogger": 20
     },
     "prefer-stable": true,

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -116,6 +116,7 @@ add_filter(
 );
 
 register_deactivation_hook( __FILE__, array( 'Jetpack_VideoPress_Plugin', 'plugin_deactivation' ) );
+register_activation_hook( __FILE__, array( 'Jetpack_VideoPress_Plugin', 'plugin_activation' ) );
 
 // Main plugin class.
 new Jetpack_VideoPress_Plugin();

--- a/projects/plugins/videopress/src/class-jetpack-videopress-plugin.php
+++ b/projects/plugins/videopress/src/class-jetpack-videopress-plugin.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Pkg_Initializer;
 
@@ -50,6 +51,9 @@ class Jetpack_VideoPress_Plugin {
 					'videopress',
 					array( 'admin_ui' => true )
 				);
+
+				// Stats package.
+				$config->ensure( 'stats' );
 			},
 			1
 		);
@@ -72,6 +76,15 @@ class Jetpack_VideoPress_Plugin {
 	public static function plugin_deactivation() {
 		$manager = new Connection_Manager( 'jetpack-videopress' );
 		$manager->remove_connection();
+	}
+
+	/**
+	 * Activation hook. Enables the Stats module since it's required
+	 * for getting stats.
+	 */
+	public static function plugin_activation() {
+		// Enable the Stats module
+		( new Modules() )->activate( 'stats', false, false );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #26546.

The request for stats was failing because there is a check for the presence of the `stats` module. To solve it, we are adding the module to VideoPress, [the same way the Search plugin did it](https://github.com/Automattic/jetpack/commit/d727387b33b6af9d72a7101881bbc6b8741a975b).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `Stats` package as a dependency for the VideoPress plugin
* Initializes the `Stats` package so we can use it on the VideoPress plugin features

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your test site has only the VideoPress plugin installed, and is connected correctly
* Go to `https://developer.wordpress.com/docs/api/console/`
* Look for the `WPCOM API` `v1.1` `/sites/$site/stats/video-plays` endpoint
* Make a request to the endpoint; as a test, use `period=year` and `complete_stats=true`
* Before the fix, you would receive a failed response with a `404` status: `This blog does not have the Stats module enabled `
* After the fix, you will receive a successful response, in the line of:

<img width="800" alt="Screen Shot 2023-03-23 at 16 56 40" src="https://user-images.githubusercontent.com/6760046/227336623-4fc93b80-bd79-40d7-9251-0f9d515baaaa.png">

* Test enabling the Jetpack plugin as well, it should keep working the same way
* Test disabling the Jetpack plugin after enabling it, it should keep working the same way
* This should affect only Jetpack sites, since WoA always have Jetpack enabled