### PR TITLE
autoloader: Don't fail on packages with bad PSR paths

### DIFF
--- a/projects/packages/autoloader/changelog/fix-autoloader-package-with-bad-psr-paths
+++ b/projects/packages/autoloader/changelog/fix-autoloader-package-with-bad-psr-paths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't error when processing packages specifying missing PSR paths.

--- a/projects/packages/autoloader/src/AutoloadGenerator.php
+++ b/projects/packages/autoloader/src/AutoloadGenerator.php
@@ -308,7 +308,7 @@ class AutoloadGenerator {
 
 				// Composer 2.4 changed the name of the class.
 				if ( class_exists( \Composer\ClassMapGenerator\ClassMapGenerator::class ) ) {
-					if ( ! is_dir( $dir ) ) {
+					if ( ! is_dir( $dir ) && ! is_file( $dir ) ) {
 						return array();
 					}
 					$generator = new \Composer\ClassMapGenerator\ClassMapGenerator();

--- a/projects/packages/autoloader/src/AutoloadGenerator.php
+++ b/projects/packages/autoloader/src/AutoloadGenerator.php
@@ -308,6 +308,9 @@ class AutoloadGenerator {
 
 				// Composer 2.4 changed the name of the class.
 				if ( class_exists( \Composer\ClassMapGenerator\ClassMapGenerator::class ) ) {
+					if ( ! is_dir( $dir ) ) {
+						return array();
+					}
 					$generator = new \Composer\ClassMapGenerator\ClassMapGenerator();
 					$generator->scanPaths( $dir, $excludedClasses, 'classmap', empty( $namespace ) ? null : $namespace );
 					return $generator->getClassMap()->getMap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If a package lists psr-4 or psr-0 paths that don't exist, we need to filter those out before passing them to Composer's `ClassMapGenerator->scanPaths()` function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #29647

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a new project of some sort, install this along with whichbrowser/parser 2.1.7.
* Run `composer dump-autoload -o`