### PR TITLE
Writing prompts: fix tags and post meta not being added for Simple sites

### DIFF
--- a/projects/plugins/jetpack/_inc/blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/blogging-prompts.php
@@ -110,6 +110,9 @@ add_action( 'wp_after_insert_post', 'jetpack_mark_if_post_answers_blogging_promp
  * @return stdClass|null Prompt object or null.
  */
 function jetpack_get_blogging_prompt_by_id( $prompt_id ) {
+	// Ensure the REST API endpoint we need is loaded.
+	require_once __DIR__ . '/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php';
+
 	$locale = get_locale();
 	$route  = sprintf( '/wpcom/v3/blogging-prompts/%d', $prompt_id );
 

--- a/projects/plugins/jetpack/changelog/fix-answer-blogging-prompt-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-answer-blogging-prompt-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Small fix for blogging prompts specfic to Simple sites
+
+


### PR DESCRIPTION
## Proposed changes:

Adds a require statement to ensure that /wpcom/v3/blogging-prompts endpoints are loaded when getting a prompt.

This fixes an issue where prompt tags and meta are not added when using the `?answer_prompt` query param to answer a writing prompt.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

PT: pe7F0s-uo-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Apply this branch to your wpcom sandbox and sandbox public-api and a site url (like example.wordpress.com)
- Using a Simple site, make sure that posts are set to show in the homepage in Settings > Reading
- Go to My Home for the site in Calypso and click on "Post Answer" for one of the writing prompts.
- When the editor loads, see that the tags `dailyprompt` and `dailyprompt-{prompt_id}` are added to the post, along with the post meta `_jetpack_blogging_prompt_key`