### PR TITLE
Connection: fix Calypso domain names in the redirect allow-list

### DIFF
--- a/projects/packages/connection/changelog/fix-staging-calypso-domains
+++ b/projects/packages/connection/changelog/fix-staging-calypso-domains
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix redirect allow-list for Calypso domain names.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.51.2';
+	const PACKAGE_VERSION = '1.51.3-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/webhooks/class-authorize-redirect.php
+++ b/projects/packages/connection/src/webhooks/class-authorize-redirect.php
@@ -42,9 +42,9 @@ class Authorize_Redirect {
 				$domains[] = 'jetpack.wordpress.com';
 				$domains[] = 'wordpress.com';
 				// Calypso envs.
-				$domains[] = 'http://calypso.localhost:3000/';
-				$domains[] = 'https://wpcalypso.wordpress.com/';
-				$domains[] = 'https://horizon.wordpress.com/';
+				$domains[] = 'calypso.localhost';
+				$domains[] = 'wpcalypso.wordpress.com';
+				$domains[] = 'horizon.wordpress.com';
 				return array_unique( $domains );
 			}
 		);


### PR DESCRIPTION
## Proposed changes:
* Fix the safe redirect allow-list in Connection package to allow redirects to Calypso dev/staging domains.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect a Jetpack site.
2. Try to load this URL on your Jetpack site: `/wp-admin/?page=jetpack&action=authorize_redirect&dest_url=http%3A%2F%2Fhorizon.wordpress.com`.
3. Confirm you get redirected to `https://horizon.wordpress.com`.