### PR TITLE
Jetpack: register v6-video-frame-poster beta extension

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-add-video-frame-poster-extension
+++ b/projects/plugins/jetpack/changelog/update-jetpack-add-video-frame-poster-extension
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: register v6-video-frame-poster beta extension

--- a/projects/plugins/jetpack/class.jetpack-plan.php
+++ b/projects/plugins/jetpack/class.jetpack-plan.php
@@ -48,6 +48,7 @@ class Jetpack_Plan {
 				'social-previews',
 				'videopress',
 				'videopress/video',
+				'v6-video-frame-poster',
 
 				'core/video',
 				'core/cover',

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -32,3 +32,11 @@ add_action(
 		}
 	}
 );
+
+// Register the `v6-video-frame-poster` extension.
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		\Jetpack_Gutenberg::set_availability_for_plan( 'v6-video-frame-poster' );
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -56,6 +56,7 @@
 		"launchpad-save-modal",
 		"post-publish-promote-post-panel",
 		"recipe",
+		"v6-video-frame-poster",
 		"videopress/video-chapters"
 	],
 	"experimental": [ "ai-image", "ai-paragraph", "anchor-fm", "premium-content" ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR register the `v6-video-frame-poster` beta extension to be used to hide the video frame poster feature while developing it.

Part of https://github.com/Automattic/jetpack/issues/29278
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: register v6-video-frame-poster beta extension

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test in Simple, Atomic, and Simple sites
* Go to the block editor
* Open the dev console
* With the [beta extension](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/jetpack/extensions#beta-extensions) disabled, confirm the `Jetpack_Editor_Initial_State.available_blocks['v6-video-frame-poster']` is not in `true`

```
Jetpack_Editor_Initial_State.available_blocks['v6-video-frame-poster']
```

<img width="516" alt="image" src="https://user-images.githubusercontent.com/77539/227385335-e3fcc99d-6c61-4f24-945e-1338ec291b39.png">

* With the `beta` extension enabled, confirm the `Jetpack_Editor_Initial_State.available_blocks['v6-video-frame-poster']` is in `true`:

<img width="506" alt="image" src="https://user-images.githubusercontent.com/77539/227385510-08600d68-c921-4e5d-83f3-5ac52b6e4eda.png">

