### PR TITLE
Stats: Fix links to Odyssey

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -17,7 +17,11 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { getStatsData, statsSwitchTab, fetchStatsData, getActiveStatsTab } from 'state/at-a-glance';
 import { isOfflineMode, isCurrentUserLinked, getConnectUrl } from 'state/connection';
-import { getInitialStateStatsData, getDateFormat } from 'state/initial-state';
+import {
+	isOdysseyStatsEnabled,
+	getInitialStateStatsData,
+	getDateFormat,
+} from 'state/initial-state';
 import { isModuleAvailable, getModuleOverride } from 'state/modules';
 import { emptyStatsCardDismissed } from 'state/settings';
 import DashStatsBottom from './dash-stats-bottom';
@@ -93,10 +97,12 @@ export class DashStats extends Component {
 				nestedValue: null,
 				className: 'statsChartbar',
 				data: {
-					link: getRedirectUrl( `calypso-stats-${ unit }`, {
-						site: props.siteRawUrl,
-						query: `startDate=${ date }`,
-					} ),
+					link: isOdysseyStatsEnabled
+						? `${ props.siteAdminUrl }admin.php?page=stats#!/stats/day/${ props.siteRawUrl }?startDate=${ date }`
+						: getRedirectUrl( `calypso-stats-${ unit }`, {
+								site: props.siteRawUrl,
+								query: `startDate=${ date }`,
+						  } ),
 				},
 				tooltipData: [
 					{

--- a/projects/plugins/jetpack/changelog/fix-links-to-odyssey
+++ b/projects/plugins/jetpack/changelog/fix-links-to-odyssey
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Stats: change Calypso Stats to Odyssey Stats

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1751,7 +1751,7 @@ function jetpack_stats_post_table( $columns ) {
 }
 
 /**
- * Set content for cell with link to an entry's stats in WordPress.com.
+ * Set content for cell with link to an entry's stats in Odyssey Stats.
  *
  * @param string $column  The name of the column to display.
  * @param int    $post_id The current post ID.
@@ -1768,16 +1768,12 @@ function jetpack_stats_post_table_cell( $column, $post_id ) {
 				esc_html__( 'No stats', 'jetpack' )
 			);
 		} else {
-			$stats_post_url = Redirect::get_url(
-				'calypso-stats-post',
-				array(
-					'path' => $post_id,
-				)
-			);
+			// TODO: check Atomic sites.
+			$stats_post_url = admin_url( sprintf( 'admin.php?page=stats#!/stats/post/%d/%d', $post_id, Jetpack_Options::get_option( 'id', 0 ) ) );
 			printf(
 				'<a href="%s" title="%s" class="dashicons dashicons-chart-bar" target="_blank"></a>',
 				esc_url( $stats_post_url ),
-				esc_html__( 'View stats for this post at WordPress.com', 'jetpack' )
+				esc_html__( 'View stats for this post', 'jetpack' )
 			);
 		}
 	}

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1768,8 +1768,15 @@ function jetpack_stats_post_table_cell( $column, $post_id ) {
 				esc_html__( 'No stats', 'jetpack' )
 			);
 		} else {
-			// TODO: check Atomic sites.
-			$stats_post_url = admin_url( sprintf( 'admin.php?page=stats#!/stats/post/%d/%d', $post_id, Jetpack_Options::get_option( 'id', 0 ) ) );
+			$stats_post_url = ! ( new Host() )->is_woa_site() && Stats_Options::get_option( 'enable_odyssey_stats' )
+			? admin_url( sprintf( 'admin.php?page=stats#!/stats/post/%d/%d', $post_id, Jetpack_Options::get_option( 'id', 0 ) ) )
+			: Redirect::get_url(
+				'calypso-stats-post',
+				array(
+					'path' => $post_id,
+				)
+			);
+
 			printf(
 				'<a href="%s" title="%s" class="dashicons dashicons-chart-bar" target="_blank"></a>',
 				esc_url( $stats_post_url ),


### PR DESCRIPTION
Fixes Automattic/wp-calypso#74144

## Proposed changes:
Changed the link from post list and bar chart to Odyssey Stats.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a


## Does this pull request change what data or activity we track or use?
no


## Testing instructions:
* Open `/wp-admin/edit.php`
* Ensure Stats links to Odyssey Stats if Odyssey is turned
* Open `/wp-admin/admin.php?page=jetpack#/dashboard`
* Click a bar from the bar chart
* Ensure it links to Odyssey Stats

* Turn Odyssey off
* Repeat the steps
* Ensure the links are to Calypso Stats