### PR TITLE
Blocks: avoid conflicts with Better Click to Tweet plugin

### DIFF
--- a/projects/packages/videopress/changelog/fix-conflict-bctt
+++ b/projects/packages/videopress/changelog/fix-conflict-bctt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid conflicts with Better Click To Tweet plugin

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -67,7 +67,7 @@ export const getVideoPressUrl = (
 };
 
 export const pickGUIDFromUrl: ( url: string ) => null | string = url => {
-	if ( ! url ) {
+	if ( ! url || typeof url !== 'string' ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-conflict-bctt
+++ b/projects/plugins/jetpack/changelog/fix-conflict-bctt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Blocks: avoid conflicts with Better Click To Tweet plugin.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/utils.js
@@ -65,7 +65,7 @@ export const removeFileNameExtension = name => {
 };
 
 export const pickGUIDFromUrl = url => {
-	if ( ! url ) {
+	if ( ! url || typeof url !== 'string' ) {
 		return null;
 	}
 


### PR DESCRIPTION
## Proposed changes:

This should avoid block editor crashes:

```
TypeError: e.match is not a function
const t = e.match(/^https?:\/\/(?<host>video(?:\.word|s\.files\.word)?press\.com)(?:\/v|\/embed)?\/(?<guid>[a-zA-Z\d]{8})/);
```

Discussed here:
https://fosstodon.org/@BenUNC/110075460985587457

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On a site that's connected to WordPress.com, install and activate the Better click to tweet plugin.
* Go to Posts > Add New.
* Add in some content, and a Jetpack block for example.
* Start adding in a Better click to tweet plugin.
    * See editor crash
* Check out this branch and try the steps again
    * Editor doesn't crash anymore.
