### PR TITLE
VideoPress: add frame selector to Poster panel

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-implement-frame-poster-to-panel
+++ b/projects/packages/videopress/changelog/update-videopress-implement-frame-poster-to-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add frame selector to Poster panel

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -24,13 +24,13 @@ import TimestampControl from '../../../../../components/timestamp-control';
 import { getVideoPressUrl } from '../../../../../lib/url';
 import { usePreview } from '../../../../hooks/use-preview';
 import { VIDEO_POSTER_ALLOWED_MEDIA_TYPES } from '../../constants';
-import { PosterPanelProps, VideoControlProps, VideoGUID } from '../../types';
 import { VideoPosterCard } from '../poster-image-block-control';
 import './style.scss';
 /**
  * Types
  */
 import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../types';
+import type { PosterPanelProps, VideoControlProps, VideoGUID } from '../../types';
 import type React from 'react';
 
 /*

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -2,15 +2,29 @@
  *External dependencies
  */
 import { MediaUploadCheck, MediaUpload } from '@wordpress/block-editor';
-import { MenuItem, PanelBody, NavigableMenu, Dropdown, Button } from '@wordpress/components';
-import { useRef, useEffect, useState } from '@wordpress/element';
+import {
+	MenuItem,
+	PanelBody,
+	NavigableMenu,
+	Dropdown,
+	Button,
+	ToggleControl,
+	SandBox,
+	Spinner,
+	Notice,
+} from '@wordpress/components';
+import { useRef, useEffect, useState, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { linkOff, image as imageIcon } from '@wordpress/icons';
+import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import TimestampControl from '../../../../../components/timestamp-control';
+import { getVideoPressUrl } from '../../../../../lib/url';
+import { usePreview } from '../../../../hooks/use-preview';
 import { VIDEO_POSTER_ALLOWED_MEDIA_TYPES } from '../../constants';
-import { VideoControlProps } from '../../types';
+import { PosterPanelProps, VideoControlProps, VideoGUID } from '../../types';
 import { VideoPosterCard } from '../poster-image-block-control';
 import './style.scss';
 /**
@@ -18,6 +32,35 @@ import './style.scss';
  */
 import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../types';
 import type React from 'react';
+
+// Global scripts array to be run in the Sandbox context.
+const sandboxScripts = [];
+
+// Populate scripts array with videopresAjaxURLBlob blobal var.
+if ( window.videopressAjax ) {
+	const videopresAjaxURLBlob = new Blob(
+		[
+			`var videopressAjax = ${ JSON.stringify( {
+				...window.videopressAjax,
+				context: 'sandbox',
+			} ) };`,
+		],
+		{
+			type: 'text/javascript',
+		}
+	);
+
+	// Token bridge script
+	sandboxScripts.push(
+		URL.createObjectURL( videopresAjaxURLBlob ),
+		window.videopressAjax.bridgeUrl
+	);
+}
+
+// Player bridge script
+if ( window?.videoPressEditorState?.playerBridgeUrl ) {
+	sandboxScripts.push( window.videoPressEditorState.playerBridgeUrl );
+}
 
 /**
  * Sidebar Control component.
@@ -33,9 +76,22 @@ export function PosterDropdown( {
 	const videoPosterDescription = `video-block__poster-image-description-${ clientId }`;
 
 	const { poster } = attributes;
-	const onSelectPoster = ( image: AdminAjaxQueryAttachmentsResponseItemProps ) => {
-		setAttributes( { poster: image.url } );
-	};
+	const onSelectPoster = useCallback(
+		( image: AdminAjaxQueryAttachmentsResponseItemProps ) => {
+			setAttributes( {
+				poster: image.url,
+
+				// Extend the posterSource object to include the media library id and url.
+				posterSource: {
+					...attributes.posterSource,
+					type: 'media-library',
+					id: image.id,
+					url: image.url,
+				},
+			} );
+		},
+		[ attributes ]
+	);
 
 	const selectPosterLabel = __( 'Select Poster Image', 'jetpack-videopress-pkg' );
 	const replacePosterLabel = __( 'Replace Poster Image', 'jetpack-videopress-pkg' );
@@ -43,7 +99,7 @@ export function PosterDropdown( {
 	const buttonRef = useRef< HTMLButtonElement >( null );
 	const videoRatio = Number( attributes?.videoRatio ) / 100 || 9 / 16;
 
-	const [ buttonImageHeight, setButtonImageHeight ] = useState( 140 );
+	const [ posterPlaceholderHeight, setPosterPlaceholderHeight ] = useState( 140 );
 
 	useEffect( () => {
 		if ( ! poster || ! buttonRef?.current ) {
@@ -51,12 +107,12 @@ export function PosterDropdown( {
 		}
 
 		const { current: buttonElement } = buttonRef;
-		const buttonWidth = buttonElement.offsetWidth;
+		const buttonWidth = buttonElement?.offsetWidth;
 		if ( ! buttonWidth ) {
 			return;
 		}
 
-		setButtonImageHeight( buttonWidth * videoRatio );
+		setPosterPlaceholderHeight( buttonWidth * videoRatio );
 	}, [ poster, buttonRef, videoRatio ] );
 
 	return (
@@ -68,7 +124,8 @@ export function PosterDropdown( {
 					ref={ buttonRef }
 					style={ {
 						backgroundImage: poster ? `url(${ poster })` : undefined,
-						height: buttonImageHeight,
+						height: posterPlaceholderHeight,
+						minHeight: posterPlaceholderHeight,
 					} }
 					className={ `poster-panel__button ${ poster ? 'has-poster' : '' }` }
 					variant="secondary"
@@ -119,6 +176,151 @@ export function PosterDropdown( {
 	);
 }
 
+const getIframeWindowFromRef = ( iFrameRef ): Window | null => {
+	return iFrameRef?.current?.querySelector( '.components-sandbox' )?.contentWindow;
+};
+
+type PosterFramePickerProps = {
+	guid: VideoGUID;
+	atTime: number;
+	isGeneratingPoster?: boolean;
+	onVideoFrameSelect: ( timestamp: number ) => void;
+};
+
+/**
+ * React component to pick a frame from the VideoPress video
+ *
+ * @param {PosterFramePickerProps} props - Component properties
+ * @returns { React.ReactElement}          React component
+ */
+function VideoFramePicker( {
+	guid,
+	isGeneratingPoster,
+	atTime = 0.1,
+	onVideoFrameSelect,
+}: PosterFramePickerProps ): React.ReactElement {
+	const [ timestamp, setTimestamp ] = useState( atTime );
+	const [ duration, setDuration ] = useState( 0 );
+	const [ playerIsReady, setPlayerIsReady ] = useState( false );
+	const playerWrapperRef = useRef< HTMLDivElement >( null );
+
+	const url = getVideoPressUrl( guid, {
+		autoplay: true, // Hack 1/2: Set autoplay true to be able to control the video.
+		controls: false,
+		loop: false,
+		muted: true,
+	} );
+
+	const { preview = { html: null }, isRequestingEmbedPreview } = usePreview( url );
+	const { html } = preview;
+
+	const playerState = useRef< 'not-rendered' | 'loaded' | 'has-auto-played' >( 'not-rendered' );
+
+	/**
+	 * Handler function to deal with the communication
+	 * between the iframe, which contains the video,
+	 * and the parent window (block editor).
+	 *
+	 * @param {MessageEvent} event - Message event
+	 */
+	function listenEventsHandler( event: MessageEvent ) {
+		const { data: eventData = {}, source } = event;
+		const { event: eventName } = event?.data || {};
+
+		// Pick and store the video duration in a local state.
+		if ( eventName === 'videopress_durationchange' ) {
+			if ( eventData?.durationMs ) {
+				setDuration( eventData.durationMs );
+			}
+		}
+
+		// Detect when the video has been loaded.
+		if ( eventName === 'videopress_loading_state' && eventData.state === 'loaded' ) {
+			playerState.current = 'loaded';
+		}
+
+		// Hack 2/2: Pause the video right after it has been auto-loaded.
+		if ( eventName === 'videopress_playing' && playerState.current === 'loaded' ) {
+			playerState.current = 'has-auto-played';
+
+			// Pause and playback the video to ensure the video is at the desired time.
+			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
+			source.postMessage(
+				{ event: 'videopress_action_set_currenttime', currentTime: atTime / 1000 },
+				{ targetOrigin: '*' }
+			);
+
+			// Here we consider the video as ready to be controlled.
+			setPlayerIsReady( true );
+		}
+	}
+
+	// Listen player events.
+	useEffect( () => {
+		if ( isRequestingEmbedPreview ) {
+			return;
+		}
+
+		if ( ! html ) {
+			return;
+		}
+
+		const sandboxIFrameWindow = getIframeWindowFromRef( playerWrapperRef );
+		if ( ! sandboxIFrameWindow ) {
+			return;
+		}
+
+		sandboxIFrameWindow.addEventListener( 'message', listenEventsHandler );
+
+		return () => {
+			// Remove the listener when the component is unmounted.
+			sandboxIFrameWindow.removeEventListener( 'message', listenEventsHandler );
+		};
+	}, [ playerWrapperRef, isRequestingEmbedPreview, html ] );
+
+	return (
+		<div className="poster-panel__frame-picker">
+			<div
+				ref={ playerWrapperRef }
+				className={ classnames( 'poster-panel__frame-picker__sandbox-wrapper', {
+					'is-player-ready': playerIsReady,
+					'is-generating-poster': isGeneratingPoster,
+				} ) }
+			>
+				{ ( ! playerIsReady || isGeneratingPoster ) && <Spinner /> }
+				<SandBox html={ html } scripts={ sandboxScripts } />
+			</div>
+
+			{ isGeneratingPoster && (
+				<Notice status="info" className="poster-panel__notice" isDismissible={ false }>
+					{ __(
+						'Generating video poster image. It may take a few seconds.',
+						'jetpack-videopress-pkg'
+					) }
+				</Notice>
+			) }
+
+			<TimestampControl
+				label={ __( 'Video frame', 'jetpack-videopress-pkg' ) }
+				help={ __( 'Select the frame you want to use as poster image', 'jetpack-videopress-pkg' ) }
+				disabled={ isRequestingEmbedPreview || isGeneratingPoster }
+				max={ duration }
+				value={ timestamp }
+				wait={ 250 }
+				onChange={ setTimestamp }
+				onDebounceChange={ iframeTimePosition => {
+					const sandboxIFrameWindow = getIframeWindowFromRef( playerWrapperRef );
+					sandboxIFrameWindow?.postMessage( {
+						event: 'videopress_action_set_currenttime',
+						currentTime: iframeTimePosition / 1000,
+					} );
+					onVideoFrameSelect( iframeTimePosition );
+				} }
+			/>
+		</div>
+	);
+}
+
 /**
  * Sidebar Control component.
  *
@@ -128,23 +330,76 @@ export function PosterDropdown( {
 export default function PosterPanel( {
 	attributes,
 	setAttributes,
-}: VideoControlProps ): React.ReactElement {
-	const { poster } = attributes;
-
+	isGeneratingPoster,
+}: PosterPanelProps ): React.ReactElement {
+	const { poster, posterSource } = attributes;
+	const [ pickFromFrame, setPickFromFrame ] = useState(
+		attributes?.posterSource?.type === 'video-frame'
+	);
 	const onRemovePoster = () => {
-		setAttributes( { poster: '' } );
+		setAttributes( { poster: '', posterSource: { ...attributes.posterSource, url: '' } } );
 	};
+
+	const switchPosterSource = useCallback(
+		( shouldPickFromFrame: boolean ) => {
+			setPickFromFrame( shouldPickFromFrame );
+			setAttributes( {
+				// Extend the posterSource attr with the new type.
+				posterSource: {
+					...attributes.posterSource,
+					type: shouldPickFromFrame ? 'video-frame' : 'media-library',
+				},
+
+				// Clean the poster URL when it should be picked from the video frame.
+				poster: shouldPickFromFrame ? '' : attributes.posterSource.url || '',
+			} );
+		},
+		[ attributes ]
+	);
 
 	return (
 		<PanelBody title={ __( 'Poster', 'jetpack-videopress-pkg' ) } className="poster-panel">
-			<PosterDropdown attributes={ attributes } setAttributes={ setAttributes } />
-			<VideoPosterCard poster={ poster } className="poster-panel-card" />
+			<ToggleControl
+				label={ __( 'Pick from video frame', 'jetpack-videopress-pkg' ) }
+				checked={ pickFromFrame }
+				onChange={ switchPosterSource }
+			/>
 
-			{ poster && (
-				<MenuItem onClick={ onRemovePoster } icon={ linkOff } isDestructive variant="tertiary">
-					{ __( 'Remove and use default', 'jetpack-videopress-pkg' ) }
-				</MenuItem>
-			) }
+			<div
+				className={ classnames( 'poster-panel__frame-wrapper', { 'is-selected': pickFromFrame } ) }
+			>
+				<VideoFramePicker
+					isGeneratingPoster={ isGeneratingPoster }
+					guid={ attributes?.guid }
+					atTime={ posterSource?.atTime }
+					onVideoFrameSelect={ timestamp => {
+						setAttributes( {
+							posterSource: {
+								...attributes.posterSource,
+								type: 'video-frame',
+								atTime: timestamp,
+							},
+							poster: '',
+						} );
+					} }
+				/>
+			</div>
+
+			<div
+				className={ classnames( 'poster-panel__image-wrapper', {
+					'is-selected': ! pickFromFrame,
+				} ) }
+			>
+				<PosterDropdown attributes={ attributes } setAttributes={ setAttributes } />
+
+				<VideoPosterCard poster={ poster } className="poster-panel-card" />
+
+				{ poster && (
+					<MenuItem onClick={ onRemovePoster } icon={ linkOff } isDestructive variant="tertiary">
+						{ __( 'Remove and use default', 'jetpack-videopress-pkg' ) }
+					</MenuItem>
+				) }
+			</div>
 		</PanelBody>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -33,6 +33,20 @@ import './style.scss';
 import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../types';
 import type React from 'react';
 
+/*
+ * Check whether video frame poster extension is enabled.
+ * `v6-video-frame-poster` is a temporary extension handled by the Jetpack plugin.
+ * It will be used to hide the Video frame poster feature until it's ready.
+ */
+declare global {
+	interface Window {
+		Jetpack_Editor_Initial_State: { available_blocks: [ 'v6-video-frame-poster' ] };
+	}
+}
+
+export const isVideoFramePosterEnabled = () =>
+	!! window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'v6-video-frame-poster' ];
+
 // Global scripts array to be run in the Sandbox context.
 const sandboxScripts = [];
 
@@ -356,6 +370,21 @@ export default function PosterPanel( {
 		},
 		[ attributes ]
 	);
+
+	if ( ! isVideoFramePosterEnabled() ) {
+		return (
+			<PanelBody title={ __( 'Poster', 'jetpack-videopress-pkg' ) } className="poster-panel">
+				<PosterDropdown attributes={ attributes } setAttributes={ setAttributes } />
+				<VideoPosterCard poster={ poster } className="poster-panel-card" />
+
+				{ poster && (
+					<MenuItem onClick={ onRemovePoster } icon={ linkOff } isDestructive variant="tertiary">
+						{ __( 'Remove and use default', 'jetpack-videopress-pkg' ) }
+					</MenuItem>
+				) }
+			</PanelBody>
+		);
+	}
 
 	return (
 		<PanelBody title={ __( 'Poster', 'jetpack-videopress-pkg' ) } className="poster-panel">

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
@@ -23,6 +23,7 @@ const DefaultTemplate = args => {
 	const [ attributes, setAttributes ] = React.useState( {
 		poster: args.poster,
 		videoRatio: args.videoRatio,
+		guid: args.guid,
 	} );
 
 	const setAttributesHandler = newAttributes => {
@@ -36,4 +37,5 @@ export const _default = DefaultTemplate.bind( {} );
 _default.args = {
 	poster: 'https://jetpackme.files.wordpress.com/2018/04/cropped-jetpack-favicon-2018.png',
 	videoRatio: 60,
+	guid: 'ezoR6kzb',
 };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
@@ -36,6 +36,12 @@ body.modal-open .poster-panel__dropdown {
 	}
 }
 
+.poster-panel__notice {
+	margin-left: 0;
+	margin-right: 0;
+	margin-bottom: 16px;
+}
+
 .poster-panel-control__help {
 	font-size: 12px;
 	font-style: normal;
@@ -48,4 +54,50 @@ body.modal-open .poster-panel__dropdown {
 	margin-left: -$grid-unit-10;
 	padding-left: $grid-unit-20;
 	padding-right: $grid-unit-20;
+}
+
+.poster-panel__frame-picker__sandbox-wrapper {
+	margin-bottom: 8px;
+	position: relative;
+	background-color: #fAfAfA;
+
+	.components-spinner {
+		margin: 0;
+		width: 32px;
+		height: 32px;
+		position: absolute;
+		z-index: 100;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+	}
+
+	.components-sandbox {
+		opacity: 0.1;
+		transition: opacity 300ms ease-in-out;
+		transition-delay: 50ms;
+	}
+
+	&:not(.is-player-ready) {
+		aspect-ratio: 16 / 9;
+	}
+
+	&.is-player-ready .components-sandbox {
+		opacity: 1;
+	}
+
+	&.is-generating-poster .components-sandbox {
+		opacity: 0.5;
+	}
+}
+
+.poster-panel__image-wrapper,
+.poster-panel__frame-wrapper {
+	opacity: 0;
+	display: none;
+
+	&.is-selected {
+		opacity: 1;
+		display: block;
+	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -18,6 +18,14 @@ export type VideoBlockColorAttributesProps = {
 
 type BlockSupportAlignProp = 'left' | 'center' | 'right' | 'wide' | 'full' | undefined;
 
+export type PosterSourceProps = {
+	type: 'media-library' | 'video-frame';
+	atTime?: number;
+	src?: string;
+	id?: number;
+	url?: string;
+};
+
 export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	id?: VideoId;
 	guid?: VideoGUID;
@@ -28,6 +36,7 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	description?: string;
 
 	poster?: string;
+	posterSource?: PosterSourceProps;
 	videoRatio?: number;
 	tracks?: Array< TrackProps >;
 
@@ -85,6 +94,10 @@ export type VideoControlProps = {
 	clientId?: string;
 
 	privateEnabledForSite?: boolean;
+};
+
+export type PosterPanelProps = VideoControlProps & {
+	isGeneratingPoster: boolean;
 };
 
 export type VideoEditProps = VideoControlProps;

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -239,6 +239,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 
 	const debounceTimer = useRef< NodeJS.Timeout >();
 
+	// Check and add a fallback for the `useBaseControlProps` hook.
 	const { baseControlProps } = useBaseControlProps?.( props ) || {};
 
 	const onChangeHandler = useCallback(
@@ -254,14 +255,16 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 	return (
 		<BaseControl { ...baseControlProps }>
 			<div className={ styles[ 'timestamp-control__controls-wrapper' ] }>
-				<TimestampInput
-					disabled={ disabled }
-					max={ max }
-					value={ value }
-					onChange={ onChangeHandler }
-					autoHideTimeInput={ autoHideTimeInput }
-					decimalPlaces={ decimalPlaces }
-				/>
+				{ NumberControl && (
+					<TimestampInput
+						disabled={ disabled }
+						max={ max }
+						value={ value }
+						onChange={ onChangeHandler }
+						autoHideTimeInput={ autoHideTimeInput }
+						decimalPlaces={ decimalPlaces }
+					/>
+				) }
 
 				<RangeControl
 					disabled={ disabled }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the video frame selector to the Poster panel.

_**The feature is hidden behind the feature flag.**_

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add frame selector to Poster panel

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Confirm the feature is hidden behind the beta extensions 

Without `beta` extensions | With `beta` extensions
------|--------
<img width="891" alt="Screen Shot 2023-03-24 at 09 35 18" src="https://user-images.githubusercontent.com/77539/227524021-faa45e0d-9bab-4164-8225-f54666725ab0.png">|<img width="877" alt="Screen Shot 2023-03-24 at 09 40 17" src="https://user-images.githubusercontent.com/77539/227523993-1b1c9dcb-7a2b-47b0-8942-d19151faebb3.png">

#### Check the frame selector

* Go to the block editor
* Create/edit a VideoPress video block
* Set a video
* Open the block sidebar 
* Identify the `Poster` panel
* Confirm you see the toggle to switch to pick the poster from video frames
* Confirm the player changes the position while you change the timestamp by using the TimestampControl

https://user-images.githubusercontent.com/77539/227524961-7fe282ed-429d-40f7-abb0-396ef174fa5c.mov

You can take a look a the debug() logs, too

<img width="836" alt="image" src="https://user-images.githubusercontent.com/77539/227525748-f958e879-7837-4a23-9a32-6542b113a815.png">
