### PR TITLE
CRM: Initializing 5.6.1-alpha and removing the dev-releases flag from composer.json

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 5.6.0
+ * Version: 5.6.1-alpha
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/update-crm-composer-and-versions
+++ b/projects/plugins/crm/changelog/update-crm-composer-and-versions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -37,7 +37,7 @@
 		"platform": {
 			"php": "7.3"
 		},
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_6_0",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_6_1_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
@@ -71,7 +71,6 @@
 		},
 		"autorelease": true,
 		"mirror-repo": "Automattic/jetpack-crm",
-		"dev-releases": true,
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-crm/compare/v${old}...v${new}"
 		},

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e59b6b8652075cd2d5ed1b2b532ad43",
+    "content-hash": "12727c9fc9c563b001577d1577726de1",
     "packages": [
         {
             "name": "automattic/jetpack-assets",

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "5.6.0",
+	"version": "5.6.1-alpha",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",


### PR DESCRIPTION


## Proposed changes:

* After yesterday's CRM 5.6.0 release, this PR initializes the next cycle (making sure there is an alpha version in place for the next version), as well as removing the dev-releases flag from composer.json. The dev-releases flag was added after our GitHub-only release some weeks back, so that we could be working with an additional alpha until this recent release. Sinc we won't be doing alpha releases in the future we don't need this flag.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read - the changes should just be changing versions (where needed for release tooling) from 5.6.0 to 5.6.1-alpha, as well as the removal of the dev-releases flag in composer.json.

