### PR TITLE
Jetpack: enable the video frame poster extension without concerning the site plan

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-video-frame-poster-for-all-plans
+++ b/projects/plugins/jetpack/changelog/update-jetpack-video-frame-poster-for-all-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack: enable the video frame poster extension without concerning the site plan

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -37,6 +37,6 @@ add_action(
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
-		\Jetpack_Gutenberg::set_availability_for_plan( 'v6-video-frame-poster' );
+		\Jetpack_Gutenberg::set_extension_available( 'v6-video-frame-poster' );
 	}
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up of https://github.com/Automattic/jetpack/pull/29678
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack: enable the video frame poster extension without concerning the site plan

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the feature is enabled for Simple sites without concerning the site plan


