### PR TITLE
Fix Jetpack tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-tests
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix tests broken by #29527
+
+

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-blogging-prompts.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-blogging-prompts.php
@@ -15,7 +15,7 @@ class WP_Test_Jetpack_Blogging_Prompts extends WP_UnitTestCase {
 	public function test_adds_post_meta_and_tags_when_answering_prompt() {
 		$prompt_id = 1234;
 
-		\Patchwork\redefine( 'jetpack_get_blogging_prompt_by_id', \Patchwork\always( array( 'id' => $prompt_id ) ) );
+		$handle = \Patchwork\redefine( 'jetpack_get_blogging_prompt_by_id', \Patchwork\always( array( 'id' => $prompt_id ) ) );
 
 		// Simulate the editor screen to create a new post() .
 		set_current_screen( 'post-new' );
@@ -36,13 +36,13 @@ class WP_Test_Jetpack_Blogging_Prompts extends WP_UnitTestCase {
 		$this->assertContains( 'dailyprompt', $post_tags );
 		$this->assertContains( "dailyprompt-{$prompt_id}", $post_tags );
 
-		\Patchwork\restoreAll();
+		\Patchwork\restore( $handle );
 	}
 
 	public function test_dont_add_post_meta_or_tags_when_answering_invalid_prompt() {
 		$prompt_id = 999;
 
-		\Patchwork\redefine( 'jetpack_get_blogging_prompt_by_id', \Patchwork\always( null ) );
+		$handle = \Patchwork\redefine( 'jetpack_get_blogging_prompt_by_id', \Patchwork\always( null ) );
 
 		// Simulate the editor screen to create a new post() .
 		set_current_screen( 'post-new' );
@@ -62,7 +62,7 @@ class WP_Test_Jetpack_Blogging_Prompts extends WP_UnitTestCase {
 		$this->assertSame( '', $prompt_meta );
 		$this->assertEmpty( $post_tags );
 
-		\Patchwork\restoreAll();
+		\Patchwork\restore( $handle );
 	}
 
 	public function test_mark_post_as_prompt_answer_when_it_has_block_and_tags() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #29527 accidentally broke Jetpack's tests by adding a call to `Patchwork\restoreAll()`, which removes our redefinitions of `exit()` and `die()` that other tests are relying on.

The immediate fix for that is to only restore the redefinition that was defined in that test.

Then, to prevent this from happening again, we use `->addExpirationHandler()` to catch when our redefinitions get removed and exit immediately with an unsuccessful code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does a call to `Patchwork\restoreAll()` make CI fail?
  * [x] https://github.com/Automattic/jetpack/actions/runs/4512942401/jobs/7947083373#step:9:245
* Do the tests run to completion now?
  * [x] https://github.com/Automattic/jetpack/actions/runs/4512999136/jobs/7947220272#step:9:281 