### PR TITLE
Jetpack Forms: Fix carriage returns in the Feedback responses page

### DIFF
--- a/projects/packages/forms/changelog/add-json_encode_forms_responses
+++ b/projects/packages/forms/changelog/add-json_encode_forms_responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Forms: json_encode form responses instead of using print_r.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -742,7 +742,7 @@ class Admin {
 			printf(
 				'<div class="feedback_response__item-key">%s</div><div class="feedback_response__item-value">%s</div>',
 				esc_html( preg_replace( '#^\d+_#', '', $key ) ),
-				esc_html( $value )
+				nl2br( esc_html( $value ) )
 			);
 		}
 		echo '</div>';

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -704,17 +704,28 @@ class Admin {
 		$post_content = get_post_field( 'post_content', $post->ID );
 		$content      = explode( '<!--more-->', $post_content );
 		$content      = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
-		$chunks       = explode( "\nArray", $content );
-		if ( $chunks[1] ) {
-			// re-construct the array string
-			$array = 'Array' . $chunks[1];
-			// re-construct the array
-			$rearray         = Contact_Form_Plugin::reverse_that_print( $array, true );
+		$chunks       = explode( "\nJSON_DATA", $content );
+
+		$response_fields = array();
+
+		if ( is_array( $chunks ) ) {
+			$rearray         = json_decode( $chunks[1], true );
 			$response_fields = is_array( $rearray ) ? $rearray : array();
-		} else {
-			// couldn't reconstruct array, use the old method
-			$content_fields  = Contact_Form_Plugin::parse_fields_from_content( $post->ID );
-			$response_fields = isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array();
+		}
+
+		if ( empty( $response_fields ) ) {
+			$chunks = explode( "\nArray", $content );
+			if ( $chunks[1] ) {
+				// re-construct the array string
+				$array = 'Array' . $chunks[1];
+				// re-construct the array
+				$rearray         = Contact_Form_Plugin::reverse_that_print( $array, true );
+				$response_fields = is_array( $rearray ) ? $rearray : array();
+			} else {
+				// couldn't reconstruct array, use the old method
+				$content_fields  = Contact_Form_Plugin::parse_fields_from_content( $post->ID );
+				$response_fields = isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array();
+			}
 		}
 
 		$response_fields = array_diff_key( $response_fields, array_flip( $non_printable_keys ) );

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -708,9 +708,11 @@ class Admin {
 
 		$response_fields = array();
 
-		if ( is_array( $chunks ) ) {
-			$rearray         = json_decode( $chunks[1], true );
-			$response_fields = is_array( $rearray ) ? $rearray : array();
+		if ( is_array( $chunks ) && isset( $chunks[1] ) ) {
+			$rearray = json_decode( $chunks[1], true );
+			if ( is_array( $rearray ) && isset( $rearray['feedback_id'] ) ) {
+				$response_fields = $rearray;
+			}
 		}
 
 		if ( empty( $response_fields ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2081,17 +2081,26 @@ class Contact_Form_Plugin {
 		$lines        = array();
 
 		if ( count( $content ) > 1 ) {
-			$content      = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
-			$fields_array = preg_replace( '/.*Array\s\( (.*)\)/msx', '$1', $content );
+			$content = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
+			if ( strpos( $content, 'JSON_DATA' ) !== false ) {
+				$chunks     = explode( "\nJSON_DATA", $content );
+				$all_values = json_decode( $chunks[1], true );
+				if ( is_array( $all_values ) ) {
+					$fields_array = array_keys( $all_values );
+				}
+				$lines = array_filter( explode( "\n", $chunks[0] ) );
+			} else {
+				$fields_array = preg_replace( '/.*Array\s\( (.*)\)/msx', '$1', $content );
 
-			// TODO: some explanation on this regex could help
-			preg_match_all( '/^\s*\[([^\]]+)\] =\&gt\; (.*)(?=^\s*(\[[^\]]+\] =\&gt\;)|\z)/msU', $fields_array, $matches );
+				// TODO: some explanation on this regex could help
+				preg_match_all( '/^\s*\[([^\]]+)\] =\&gt\; (.*)(?=^\s*(\[[^\]]+\] =\&gt\;)|\z)/msU', $fields_array, $matches );
 
-			if ( count( $matches ) > 1 ) {
-				$all_values = array_combine( array_map( 'trim', $matches[1] ), array_map( 'trim', $matches[2] ) );
+				if ( count( $matches ) > 1 ) {
+					$all_values = array_combine( array_map( 'trim', $matches[1] ), array_map( 'trim', $matches[2] ) );
+				}
+
+				$lines = array_filter( explode( "\n", $content ) );
 			}
-
-			$lines = array_filter( explode( "\n", $content ) );
 		}
 
 		$var_map = array(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1322,7 +1322,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'post_parent'  => $post ? (int) $post->ID : 0,
 				'post_title'   => addslashes( wp_kses( $feedback_title, array() ) ),
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DevelopmentFunctions.error_log_print_r
-				'post_content' => addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\nIP: {$comment_author_IP}\n" . @print_r( $all_values, true ), array() ) ), // so that search will pick up this data
+				'post_content' => addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\nIP: {$comment_author_IP}\nJSON_DATA\n" . @wp_json_encode( $all_values, true ), array() ) ), // so that search will pick up this data
 				'post_name'    => $feedback_id,
 			)
 		);

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -321,10 +321,10 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$submission  = get_post( $feedback_id );
 		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
 
-		$this->assertStringContains( '"1_Name":"John Doe"', $submission->post_content, 'Post content did not contain the name label and/or value' );
-		$this->assertStringContains( '"2_Dropdown":"First option"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
-		$this->assertStringContains( '"3_Radio":"Second option"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
-		$this->assertStringContains( '"4_Text":"Texty text"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
+		$this->assertStringContains( '\"1_Name\":\"John Doe\"', $submission->post_content, 'Post content did not contain the name label and/or value' );
+		$this->assertStringContains( '\"2_Dropdown\":\"First option\"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
+		$this->assertStringContains( '\"3_Radio\":\"Second option\"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
+		$this->assertStringContains( '\"4_Text\":\"Texty text\"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -321,10 +321,10 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$submission  = get_post( $feedback_id );
 		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
 
-		$this->assertStringContains( '[1_Name] =&gt; John Doe', $submission->post_content, 'Post content did not contain the name label and/or value' );
-		$this->assertStringContains( '[2_Dropdown] =&gt; First option', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
-		$this->assertStringContains( '[3_Radio] =&gt; Second option', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
-		$this->assertStringContains( '[4_Text] =&gt; Texty text', $submission->post_content, 'Post content did not contain the text field label and/or value' );
+		$this->assertStringContains( '"1_Name":"John Doe"', $submission->post_content, 'Post content did not contain the name label and/or value' );
+		$this->assertStringContains( '"2_Dropdown":"First option"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
+		$this->assertStringContains( '"3_Radio":"Second option"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
+		$this->assertStringContains( '"4_Text":"Texty text"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-json_encode_forms_responses
+++ b/projects/plugins/jetpack/changelog/add-json_encode_forms_responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Forms: json_encode form responses instead of using print_r.

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -359,7 +359,7 @@ function grunion_manage_post_column_response( $post ) {
 		printf(
 			'<div class="feedback_response__item-key">%s</div><div class="feedback_response__item-value">%s</div>',
 			esc_html( preg_replace( '#^\d+_#', '', $key ) ),
-			esc_html( $value )
+			nl2br( esc_html( $value ) )
 		);
 	}
 	echo '</div>';

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -327,9 +327,11 @@ function grunion_manage_post_column_response( $post ) {
 
 	$response_fields = array();
 
-	if ( is_array( $chunks ) ) {
-		$rearray         = json_decode( $chunks[1], true );
-		$response_fields = is_array( $rearray ) ? $rearray : array();
+	if ( is_array( $chunks ) && isset( $chunks[1] ) ) {
+		$rearray = json_decode( $chunks[1], true );
+		if ( is_array( $rearray ) && isset( $rearray['feedback_id'] ) ) {
+			$response_fields = $rearray;
+		}
 	}
 
 	if ( empty( $response_fields ) ) {

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -323,17 +323,27 @@ function grunion_manage_post_column_response( $post ) {
 	$post_content = get_post_field( 'post_content', $post->ID );
 	$content      = explode( '<!--more-->', $post_content );
 	$content      = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
-	$chunks       = explode( "\nArray", $content );
-	if ( $chunks[1] ) {
-		// re-construct the array string
-		$array = 'Array' . $chunks[1];
-		// re-construct the array
-		$rearray         = Grunion_Contact_Form_Plugin::reverse_that_print( $array, true );
+	$chunks       = explode( "\nJSON_DATA", $content );
+
+	$response_fields = array();
+
+	if ( is_array( $chunks ) ) {
+		$rearray         = json_decode( $chunks[1], true );
 		$response_fields = is_array( $rearray ) ? $rearray : array();
-	} else {
-		// couldn't reconstruct array, use the old method
-		$content_fields  = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post->ID );
-		$response_fields = isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array();
+	}
+
+	if ( empty( $response_fields ) ) {
+		if ( $chunks[1] ) {
+			// re-construct the array string
+			$array = 'Array' . $chunks[1];
+			// re-construct the array
+			$rearray         = Grunion_Contact_Form_Plugin::reverse_that_print( $array, true );
+			$response_fields = is_array( $rearray ) ? $rearray : array();
+		} else {
+			// couldn't reconstruct array, use the old method
+			$content_fields  = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post->ID );
+			$response_fields = isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array();
+		}
 	}
 
 	$response_fields = array_diff_key( $response_fields, array_flip( $non_printable_keys ) );

--- a/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -306,10 +306,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		// Default metadata should be saved.
 		$submission = $feedback[0];
 
-		$this->assertStringContainsString( '[1_Name] =&gt; John Doe', $submission->post_content, 'Post content did not contain the name label and/or value' );
-		$this->assertStringContainsString( '[2_Dropdown] =&gt; First option', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
-		$this->assertStringContainsString( '[3_Radio] =&gt; Second option', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
-		$this->assertStringContainsString( '[4_Text] =&gt; Texty text', $submission->post_content, 'Post content did not contain the text field label and/or value' );
+		$this->assertStringContainsString( '"1_Name":"John Doe"', $submission->post_content, 'Post content did not contain the name label and/or value' );
+		$this->assertStringContainsString( '"2_Dropdown":"First option"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
+		$this->assertStringContainsString( '"3_Radio":"Second option"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
+		$this->assertStringContainsString( '"4_Text":"Texty text"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -306,10 +306,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		// Default metadata should be saved.
 		$submission = $feedback[0];
 
-		$this->assertStringContainsString( '"1_Name":"John Doe"', $submission->post_content, 'Post content did not contain the name label and/or value' );
-		$this->assertStringContainsString( '"2_Dropdown":"First option"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
-		$this->assertStringContainsString( '"3_Radio":"Second option"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
-		$this->assertStringContainsString( '"4_Text":"Texty text"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
+		$this->assertStringContainsString( '\"1_Name\":\"John Doe\"', $submission->post_content, 'Post content did not contain the name label and/or value' );
+		$this->assertStringContainsString( '\"2_Dropdown\":\"First option\"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
+		$this->assertStringContainsString( '\"3_Radio\":\"Second option\"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
+		$this->assertStringContainsString( '\"4_Text\":\"Texty text\"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/projects/plugins/jetpack/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -306,10 +306,10 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		// Default metadata should be saved.
 		$submission = $feedback[0];
 
-		$this->assertStringContainsString( '\"1_Name\":\"John Doe\"', $submission->post_content, 'Post content did not contain the name label and/or value' );
-		$this->assertStringContainsString( '\"2_Dropdown\":\"First option\"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
-		$this->assertStringContainsString( '\"3_Radio\":\"Second option\"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
-		$this->assertStringContainsString( '\"4_Text\":\"Texty text\"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
+		$this->assertStringContainsString( '"1_Name":"John Doe"', $submission->post_content, 'Post content did not contain the name label and/or value' );
+		$this->assertStringContainsString( '"2_Dropdown":"First option"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
+		$this->assertStringContainsString( '"3_Radio":"Second option"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
+		$this->assertStringContainsString( '"4_Text":"Texty text"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
 	}
 
 	/**


### PR DESCRIPTION
The Form Responses page doesn't display responses properly if they have carriage returns/newlines. This patch converts that character to the BR tag so multi-line text is displayed correctly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Fill in a contact form and make sure you enter a multi line message.
Look at Feedback->Form Responses and note that your message appears on one line.
Apply the patch and reload the Form Responses page.
The message should not show carriage returns.