### PR TITLE
Jetpack Forms: Display carriage returns in the Feedback responses page

### DIFF
--- a/projects/packages/forms/changelog/fix-form_responses_cr
+++ b/projects/packages/forms/changelog/fix-form_responses_cr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Forms: display carriage returns in responses in the Feedback->Form Responses page.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -742,7 +742,7 @@ class Admin {
 			printf(
 				'<div class="feedback_response__item-key">%s</div><div class="feedback_response__item-value">%s</div>',
 				esc_html( preg_replace( '#^\d+_#', '', $key ) ),
-				esc_html( $value )
+				nl2br( esc_html( $value ) )
 			);
 		}
 		echo '</div>';

--- a/projects/plugins/jetpack/changelog/fix-form_responses_cr
+++ b/projects/plugins/jetpack/changelog/fix-form_responses_cr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack Forms: display carriage returns in responses in the Feedback->Form Responses page.

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -359,7 +359,7 @@ function grunion_manage_post_column_response( $post ) {
 		printf(
 			'<div class="feedback_response__item-key">%s</div><div class="feedback_response__item-value">%s</div>',
 			esc_html( preg_replace( '#^\d+_#', '', $key ) ),
-			esc_html( $value )
+			nl2br( esc_html( $value ) )
 		);
 	}
 	echo '</div>';


### PR DESCRIPTION
The Form Responses page doesn't display responses properly if they have carriage returns/newlines. This patch converts that character to the BR tag so multi-line text is displayed correctly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Fill in a contact form and make sure you enter a multi line message.
Look at Feedback->Form Responses and note that your message appears on one line.
Apply the patch and reload the Form Responses page.
The message should not show carriage returns.