### PR TITLE
Jetpack Forms: Fix a php warning in Feedback->Form Responses

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-php_warning_in_forms
+++ b/projects/plugins/jetpack/changelog/fix-php_warning_in_forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Forms: fix a PHP warning on Feedback->Response Forms when looking at old responses.

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -335,6 +335,7 @@ function grunion_manage_post_column_response( $post ) {
 	}
 
 	if ( empty( $response_fields ) ) {
+		$chunks = explode( "\nArray", $content );
 		if ( $chunks[1] ) {
 			// re-construct the array string
 			$array = 'Array' . $chunks[1];


### PR DESCRIPTION
In #29664 I left out a single line that is used to parse feedback posts. This caused a PHP warning on the next line, but the user won't notice anything as the code will fall through to a legacy method to do the same job.

This patch adds back the single line required.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
You'll need a test blog with old Jetpack Forms responses as they will be stored in a print_r format. You can use the current release version of Jetpack to create those responses.
Go to Feedback->Form Responses and you'll see a warning in your php_error log or debug.log saying:
> PHP Warning:  Undefined array key 1 in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/modules/contact-form/admin.php on line 338

Apply this patch and reload the Form Responses page. There won't be any PHP warning this time.
