### PR TITLE
Jetpack plugin: add explicit deps on jQuery

### DIFF
--- a/projects/packages/forms/changelog/update-add-explicit-jquery-dependencies
+++ b/projects/packages/forms/changelog/update-add-explicit-jquery-dependencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: This change is only meant to prevent future bugs, and should have no visibility to users.
+
+

--- a/projects/packages/forms/src/contact-form/class-form-view.php
+++ b/projects/packages/forms/src/contact-form/class-form-view.php
@@ -36,7 +36,7 @@ class Form_View {
 				'_inc/build/contact-form/js/grunion.min.js',
 				'modules/contact-form/js/grunion.js'
 			),
-			array( 'jquery-ui-sortable', 'jquery-ui-draggable' ),
+			array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-draggable' ),
 			\JETPACK__VERSION,
 			false
 		);
@@ -73,7 +73,7 @@ class Form_View {
 		<script type="text/javascript">
 			var ajaxurl = <?php echo wp_json_encode( admin_url( 'admin-ajax.php' ) ); ?>;
 			var postId = <?php echo isset( $_GET['post_id'] ) ? absint( $_GET['post_id'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- not making a site change. ?>;
-			var ajax_nonce_shortcode = <?php echo wp_json_encode( wp_create_nonce( 'grunion_shortcode' ) ); ?>; 
+			var ajax_nonce_shortcode = <?php echo wp_json_encode( wp_create_nonce( 'grunion_shortcode' ) ); ?>;
 			var ajax_nonce_json = <?php echo wp_json_encode( wp_create_nonce( 'grunion_shortcode_to_json' ) ); ?>;
 		</script>
 		<?php wp_print_scripts( 'grunion' ); ?>

--- a/projects/packages/jitm/changelog/update-add-explicit-jquery-dependencies
+++ b/projects/packages/jitm/changelog/update-add-explicit-jquery-dependencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: This change is only meant to prevent future bugs, and should have no visibility to users.
+
+

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.3.2';
+	const PACKAGE_VERSION = '2.3.3-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -1,3 +1,5 @@
+import jQuery from 'jquery';
+
 import '../css/jetpack-admin-jitm.scss';
 
 jQuery( document ).ready( function ( $ ) {

--- a/projects/packages/publicize/changelog/update-add-explicit-jquery-dependencies
+++ b/projects/packages/publicize/changelog/update-add-explicit-jquery-dependencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: This change is only meant to prevent future bugs, and should have no visibility to users.
+
+

--- a/projects/packages/publicize/src/js/classic-editor-connections.js
+++ b/projects/packages/publicize/src/js/classic-editor-connections.js
@@ -1,4 +1,5 @@
 import { _n } from '@wordpress/i18n';
+import jQuery from 'jquery';
 
 const { ajaxUrl, connectionsUrl } = window.jetpackSocialClassicEditorConnections;
 

--- a/projects/packages/publicize/src/js/classic-editor-share-limits.js
+++ b/projects/packages/publicize/src/js/classic-editor-share-limits.js
@@ -1,3 +1,5 @@
+import jQuery from 'jquery';
+
 jQuery( function ( $ ) {
 	const state = window.jetpackSocialClassicEditorInitialState ?? {};
 	const form = $( '#publicize-form' );

--- a/projects/packages/search/changelog/update-add-explicit-jquery-dependencies
+++ b/projects/packages/search/changelog/update-add-explicit-jquery-dependencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: This change is only meant to prevent future bugs, and should have no visibility to users.
+
+

--- a/projects/packages/search/src/customizer/customize-controls/class-excluded-post-types-control.php
+++ b/projects/packages/search/src/customizer/customize-controls/class-excluded-post-types-control.php
@@ -36,7 +36,7 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 			__FILE__,
 			array(
 				'css_path'     => 'class-excluded-post-types-control.css',
-				'dependencies' => array( 'customize-controls' ),
+				'dependencies' => array( 'jquery', 'customize-controls' ),
 				'in_footer'    => true,
 				'textdomain'   => 'jetpack-search-pkg',
 			)

--- a/projects/plugins/beta/changelog/update-add-explicit-jquery-dependencies
+++ b/projects/plugins/beta/changelog/update-add-explicit-jquery-dependencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: This change is only meant to prevent future bugs, and should have no visibility to users.
+
+

--- a/projects/plugins/beta/src/admin/show-needed-updates.template.php
+++ b/projects/plugins/beta/src/admin/show-needed-updates.template.php
@@ -35,7 +35,7 @@ $tmp = function ( $plugin ) {
 		return;
 	}
 
-	wp_enqueue_script( 'jetpack-beta-updates', plugins_url( 'updates.js', __FILE__ ), array( 'updates' ), JPBETA_VERSION, true );
+	wp_enqueue_script( 'jetpack-beta-updates', plugins_url( 'updates.js', __FILE__ ), array( 'jquery', 'updates' ), JPBETA_VERSION, true );
 	wp_localize_script(
 		'jetpack-beta-updates',
 		'JetpackBetaUpdates',

--- a/projects/plugins/jetpack/_inc/client/components/admin-notices/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/admin-notices/index.jsx
@@ -1,3 +1,4 @@
+import jQuery from 'jquery';
 import React from 'react';
 
 class AdminNotices extends React.Component {

--- a/projects/plugins/jetpack/_inc/client/components/modal/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/modal/index.jsx
@@ -4,6 +4,7 @@
 
 import classNames from 'classnames';
 import { createFocusTrap } from 'focus-trap';
+import jQuery from 'jquery';
 import { assign, omit } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/projects/plugins/jetpack/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/upgrade-notice-content/index.jsx
@@ -1,6 +1,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import ModernOverlay from 'components/jetpack-dialogue-modern';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import jQuery from 'jquery';
 import analytics from 'lib/analytics';
 import React, { Component } from 'react';
 

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -22,6 +22,7 @@ import NonAdminView from 'components/non-admin-view';
 import ReconnectModal from 'components/reconnect-modal';
 import SupportCard from 'components/support-card';
 import Tracker from 'components/tracker';
+import jQuery from 'jquery';
 import analytics from 'lib/analytics';
 import MyPlan from 'my-plan/index.jsx';
 import ProductDescriptions from 'product-descriptions';

--- a/projects/plugins/jetpack/_inc/client/state/modules/actions.js
+++ b/projects/plugins/jetpack/_inc/client/state/modules/actions.js
@@ -1,6 +1,7 @@
 import restApi from '@automattic/jetpack-api';
 import { __, sprintf } from '@wordpress/i18n';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
+import jQuery from 'jquery';
 import { forEach, some } from 'lodash';
 import {
 	JETPACK_MODULES_LIST_FETCH,

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -262,7 +262,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		$is_offline_mode     = $status->is_offline_mode();
 		$site_suffix         = $status->get_site_suffix();
 		$script_deps_path    = JETPACK__PLUGIN_DIR . '_inc/build/admin.asset.php';
-		$script_dependencies = array( 'wp-polyfill' );
+		$script_dependencies = array( 'jquery', 'wp-polyfill' );
 		$version             = JETPACK__VERSION;
 		if ( file_exists( $script_deps_path ) ) {
 			$asset_manifest      = include $script_deps_path;

--- a/projects/plugins/jetpack/_inc/lib/debugger/debug-functions.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/debug-functions.php
@@ -135,7 +135,7 @@ function jetpack_debugger_enqueue_site_health_scripts( $hook ) {
 		wp_enqueue_script(
 			'jetpack_debug_site_health_script',
 			plugins_url( 'jetpack-debugger-site-health.js', __FILE__ ),
-			array( 'jquery-ui-progressbar' ),
+			array( 'jquery', 'jquery-ui-progressbar' ),
 			JETPACK__VERSION,
 			false
 		);

--- a/projects/plugins/jetpack/changelog/update-add-explicit-jquery-dependencies
+++ b/projects/plugins/jetpack/changelog/update-add-explicit-jquery-dependencies
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: This change is only meant to prevent future bugs, and should have no visibility to users.
+
+

--- a/projects/plugins/jetpack/class-jetpack-gallery-settings.php
+++ b/projects/plugins/jetpack/class-jetpack-gallery-settings.php
@@ -71,7 +71,7 @@ class Jetpack_Gallery_Settings {
 			wp_register_script(
 				'jetpack-gallery-settings',
 				Assets::get_file_url_for_environment( '_inc/build/gallery-settings.min.js', '_inc/gallery-settings.js' ),
-				array( 'media-views' ),
+				array( 'jquery', 'media-views' ),
 				'20121225',
 				false
 			);

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -51,7 +51,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 				'_inc/build/jetpack-modules.models.min.js',
 				'_inc/jetpack-modules.models.js'
 			),
-			array( 'backbone', 'underscore' ),
+			array( 'jquery', 'backbone', 'underscore' ),
 			JETPACK__VERSION,
 			false // @todo Can this be put in the footer?
 		);
@@ -61,7 +61,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 				'_inc/build/jetpack-modules.views.min.js',
 				'_inc/jetpack-modules.views.js'
 			),
-			array( 'backbone', 'underscore', 'wp-util' ),
+			array( 'jquery', 'backbone', 'underscore', 'wp-util' ),
 			JETPACK__VERSION,
 			false // @todo Can this be put in the footer?
 		);

--- a/projects/plugins/jetpack/modules/calypsoify/class-jetpack-calypsoify.php
+++ b/projects/plugins/jetpack/modules/calypsoify/class-jetpack-calypsoify.php
@@ -68,7 +68,7 @@ class Jetpack_Calypsoify {
 		wp_style_add_data( 'calypsoify_wpadminmods_css', 'rtl', 'replace' );
 		wp_style_add_data( 'calypsoify_wpadminmods_css', 'suffix', '.min' );
 
-		wp_enqueue_script( 'calypsoify_wpadminmods_js', plugin_dir_url( __FILE__ ) . 'mods-gutenberg.js', false, JETPACK__VERSION, false );
+		wp_enqueue_script( 'calypsoify_wpadminmods_js', plugin_dir_url( __FILE__ ) . 'mods-gutenberg.js', array( 'jquery' ), JETPACK__VERSION, false );
 		wp_localize_script(
 			'calypsoify_wpadminmods_js',
 			'calypsoifyGutenberg',

--- a/projects/plugins/jetpack/modules/contact-form/grunion-form-view.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-form-view.php
@@ -23,7 +23,7 @@ wp_register_script(
 		'_inc/build/contact-form/js/grunion.min.js',
 		'modules/contact-form/js/grunion.js'
 	),
-	array( 'jquery-ui-sortable', 'jquery-ui-draggable' ),
+	array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-draggable' ),
 	JETPACK__VERSION,
 	false
 );
@@ -60,7 +60,7 @@ wp_localize_script(
 <script type="text/javascript">
 	var ajaxurl = <?php echo wp_json_encode( admin_url( 'admin-ajax.php' ) ); ?>;
 	var postId = <?php echo isset( $_GET['post_id'] ) ? absint( $_GET['post_id'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- not making a site change. ?>;
-	var ajax_nonce_shortcode = <?php echo wp_json_encode( wp_create_nonce( 'grunion_shortcode' ) ); ?>; 
+	var ajax_nonce_shortcode = <?php echo wp_json_encode( wp_create_nonce( 'grunion_shortcode' ) ); ?>;
 	var ajax_nonce_json = <?php echo wp_json_encode( wp_create_nonce( 'grunion_shortcode_to_json' ) ); ?>;
 </script>
 <?php wp_print_scripts( 'grunion' ); ?>

--- a/projects/plugins/jetpack/modules/custom-css/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css/custom-css.php
@@ -65,6 +65,7 @@ class Jetpack_Custom_CSS_Enhancements {
 			'jetpack-customizer-css',
 			$src,
 			array(
+				'jquery',
 				'customize-controls',
 				'underscore',
 			),
@@ -78,7 +79,7 @@ class Jetpack_Custom_CSS_Enhancements {
 				'_inc/build/custom-css/custom-css/js/core-customizer-css-preview.min.js',
 				'modules/custom-css/custom-css/js/core-customizer-css-preview.js'
 			),
-			array( 'customize-selective-refresh' ),
+			array( 'jquery', 'customize-selective-refresh' ),
 			JETPACK__VERSION,
 			true
 		);

--- a/projects/plugins/jetpack/modules/custom-post-types/nova.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/nova.php
@@ -847,7 +847,7 @@ class Nova_Restaurant {
 				'_inc/build/custom-post-types/js/nova-drag-drop.min.js',
 				'modules/custom-post-types/js/nova-drag-drop.js'
 			),
-			array( 'jquery-ui-sortable' ),
+			array( 'jquery', 'jquery-ui-sortable' ),
 			$this->version,
 			true
 		);

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -548,7 +548,7 @@ class The_Neverending_Home_Page {
 				'_inc/build/infinite-scroll/infinity-customizer.min.js',
 				'modules/infinite-scroll/infinity-customizer.js'
 			),
-			array( 'customize-base' ),
+			array( 'jquery', 'customize-base' ),
 			JETPACK__VERSION . '-is5.0.0', // Added for ability to cachebust on WP.com.
 			true
 		);

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -351,7 +351,7 @@ class Jetpack_Likes {
 					'_inc/build/likes/post-count-jetpack.min.js',
 					'modules/likes/post-count-jetpack.js'
 				),
-				array( 'likes-post-count' ),
+				array( 'jquery', 'likes-post-count' ),
 				JETPACK__VERSION,
 				$in_footer = false
 			);

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -52,7 +52,7 @@ class Sharing_Admin {
 				'_inc/build/sharedaddy/admin-sharing.min.js',
 				'modules/sharedaddy/admin-sharing.js'
 			),
-			array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable', 'jquery-form' ),
+			array( 'jquery', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable', 'jquery-form' ),
 			2,
 			false
 		);

--- a/projects/plugins/jetpack/modules/shortcodes/slideshow.php
+++ b/projects/plugins/jetpack/modules/shortcodes/slideshow.php
@@ -252,7 +252,7 @@ class Jetpack_Slideshow_Shortcode {
 		wp_enqueue_script(
 			'jetpack-slideshow',
 			Assets::get_file_url_for_environment( '_inc/build/shortcodes/js/slideshow-shortcode.min.js', 'modules/shortcodes/js/slideshow-shortcode.js' ),
-			array( 'jquery-cycle' ),
+			array( 'jquery', 'jquery-cycle' ),
 			'20160119.1',
 			true
 		);

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/customizer.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/customizer.php
@@ -472,7 +472,7 @@ function jetpack_content_options_customize_preview_js() {
 	$author       = ( ! empty( $post_details['author'] ) ) ? $post_details['author'] : null;
 	$comment      = ( ! empty( $post_details['comment'] ) ) ? $post_details['comment'] : null;
 
-	wp_enqueue_script( 'jetpack-content-options-customizer', plugins_url( 'customizer.js', __FILE__ ), array( 'customize-preview' ), '1.0', true );
+	wp_enqueue_script( 'jetpack-content-options-customizer', plugins_url( 'customizer.js', __FILE__ ), array( 'jquery', 'customize-preview' ), '1.0', true );
 
 	wp_localize_script(
 		'jetpack-content-options-customizer',

--- a/projects/plugins/jetpack/modules/theme-tools/featured-content.php
+++ b/projects/plugins/jetpack/modules/theme-tools/featured-content.php
@@ -590,7 +590,7 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 		 * Enqueue the tag suggestion script.
 		 */
 		public static function enqueue_scripts() {
-			wp_enqueue_script( 'featured-content-suggest', plugins_url( 'js/suggest.js', __FILE__ ), array( 'suggest' ), '20131022', true );
+			wp_enqueue_script( 'featured-content-suggest', plugins_url( 'js/suggest.js', __FILE__ ), array( 'jquery', 'suggest' ), '20131022', true );
 		}
 
 		/**

--- a/projects/plugins/jetpack/modules/theme-tools/site-logo/inc/class-site-logo.php
+++ b/projects/plugins/jetpack/modules/theme-tools/site-logo/inc/class-site-logo.php
@@ -184,7 +184,7 @@ class Site_Logo {
 			wp_enqueue_script(
 				'site-logo-header-text',
 				plugins_url( '../js/site-logo-header-text.js', __FILE__ ),
-				array( 'media-views' ),
+				array( 'jquery', 'media-views' ),
 				JETPACK__VERSION,
 				true
 			);

--- a/projects/plugins/jetpack/modules/widgets.php
+++ b/projects/plugins/jetpack/modules/widgets.php
@@ -71,7 +71,7 @@ function jetpack_widgets_customizer_assets_preview() {
 	wp_enqueue_script(
 		'jetpack-customizer-widget-utils',
 		plugins_url( '/widgets/customizer-utils.js', __FILE__ ),
-		array( 'customize-base' ),
+		array( 'jquery', 'customize-base' ),
 		JETPACK__VERSION,
 		false
 	);

--- a/projects/plugins/jetpack/modules/widgets/gallery.php
+++ b/projects/plugins/jetpack/modules/widgets/gallery.php
@@ -444,7 +444,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 				'_inc/build/widgets/gallery/js/gallery.min.js',
 				'modules/widgets/gallery/js/gallery.js'
 			),
-			array(),
+			array( 'jquery' ),
 			JETPACK__VERSION,
 			false
 		);
@@ -468,6 +468,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 					'modules/widgets/gallery/js/admin.js'
 				),
 				array(
+					'jquery',
 					'media-models',
 					'media-views',
 				),

--- a/projects/plugins/jetpack/modules/widgets/social-icons.php
+++ b/projects/plugins/jetpack/modules/widgets/social-icons.php
@@ -80,7 +80,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 		wp_enqueue_script(
 			'jetpack-widget-social-icons-script',
 			plugins_url( 'social-icons/social-icons-admin.js', __FILE__ ),
-			array( 'jquery-ui-sortable' ),
+			array( 'jquery', 'jquery-ui-sortable' ),
 			'20170506',
 			true
 		);


### PR DESCRIPTION
As we work on removing `jQuery`-dependant code and replacing it with vanilla JS, we run the risk of stumbling across errors caused by scripts that are expecting `jQuery` to be present, but don't explicitly request it. Indirect dependencies aren't sufficient, as a dependency that loads `jQuery` today could stop doing so in the future, if it's rewritten.

This PR attempts to prevent future bugs, by adding explicit dependencies; every script that directly depends on `jQuery` should directly list it as a dependency. This will help ensure that the library is always present when needed.

This PR only deals with external scripts; a follow-up PR will look at inline scripts that make use of `jQuery`.

## Proposed changes:
* Add `jQuery` as a dependency to registrations for scripts that directly depend on `jQuery`.

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
The changes are pretty trivial, so they shouldn't require any active testing. Ensuring that the code looks good, and that all the relevant scripts do indeed require `jQuery` directly should be sufficient.

