### PR TITLE
Change/forms inbox records limit

### DIFF
--- a/projects/packages/forms/changelog/change-forms_inbox_records_limit
+++ b/projects/packages/forms/changelog/change-forms_inbox_records_limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Forms: Change default entries per page on responses inbox

--- a/projects/packages/forms/src/dashboard/inbox/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/index.js
@@ -13,7 +13,7 @@ import InboxList from './list';
 import InboxResponse from './response';
 import './style.scss';
 
-const RESPONSES_FETCH_LIMIT = 10;
+const RESPONSES_FETCH_LIMIT = 50;
 
 const TABS = [
 	{


### PR DESCRIPTION
This PR reverses #29406 and changes the number of records shown on the new Feedback Forms page to 50.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply patch
Enable the new Forms Feedback page by adding the following lines to the contructor in projects/plugins/jetpack/class.jetpack.php
```
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
add_filter( 'jetpack_forms_dashboard_enable', '__return_true' );
```

Go to http://localhost/wp-admin/admin.php?page=jetpack-forms where you will hopefully see more than 10 records, and 50 if you have that many feedback records.

