### PR TITLE
Repo Gardening: update triage tasks (wording and Slack notifications)

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-triage-task-messages
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-triage-task-messages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Triage tasks: update wording of messages and start warning folks of issues that do get any Priority label added automatically, so they can triage manually.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -135,7 +135,7 @@ function formatSlackMessage( payload, channel, message ) {
 	const { issue, repository } = payload;
 	const { html_url, title } = issue;
 
-	let dris = '@bug_herders';
+	let dris = '@kitkat-team';
 	switch ( repository.full_name ) {
 		case 'Automattic/jetpack':
 			dris = '@jpop-da';

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -154,17 +154,7 @@ function formatSlackMessage( payload, channel, message ) {
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: message,
-				},
-			},
-			{
-				type: 'divider',
-			},
-			{
-				type: 'section',
-				text: {
-					type: 'mrkdwn',
-					text: `${ dris } Could you take a look at it, re-prioritize and escalate if you think that's necessary, and mark this message as :done: once you've done so? Thank you!`,
+					text: `${ dris } ${ message }`,
 				},
 			},
 			{
@@ -176,20 +166,9 @@ function formatSlackMessage( payload, channel, message ) {
 					type: 'mrkdwn',
 					text: `<${ html_url }|${ title }>`,
 				},
-				accessory: {
-					type: 'button',
-					text: {
-						type: 'plain_text',
-						text: 'View',
-						emoji: true,
-					},
-					value: 'click_review',
-					url: `${ html_url }`,
-					action_id: 'button-action',
-				},
 			},
 		],
-		text: `${ message } -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
+		text: `${ dris } ${ message } -- <${ html_url }|${ title }>`, // Fallback text for display in notifications.
 		mrkdwn: true, // Formatting of the fallback text.
 		unfurl_links: false,
 		unfurl_media: false,

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -240,6 +240,16 @@ async function triageNewIssues( payload, octokit ) {
 		const message = '@kitkat-team New bug missing priority. Please do a priority assessment.';
 		const slackMessageFormat = formatSlackMessage( payload, channel, message );
 		await sendSlackMessage( message, channel, slackToken, payload, slackMessageFormat );
+
+		debug(
+			`triage-new-issues: Adding a label to issue #${ number } to show that Kitkat was warned.`
+		);
+		await octokit.rest.issues.addLabels( {
+			owner: ownerLogin,
+			repo: name,
+			issue_number: number,
+			labels: [ '[Pri] TBD' ],
+		} );
 	}
 }
 

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -218,6 +218,9 @@ async function triageNewIssues( payload, octokit ) {
 		const slackToken = getInput( 'slack_token' );
 		const channel = getInput( 'slack_quality_channel' );
 		if ( ! slackToken || ! channel ) {
+			debug(
+				`triage-new-issues: No Slack token or channel found. Not sending any Slack notification for #${ number }.`
+			);
 			return null;
 		}
 

--- a/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-new-issues/index.js
@@ -33,7 +33,7 @@ async function hasKitkatSignalLabel( octokit, owner, repo, number ) {
 async function hasPriorityLabels( octokit, owner, repo, number ) {
 	const labels = await getLabels( octokit, owner, repo, number );
 	// We're only interested in priority labels, but not if the label is [Pri] TBD.
-	return !! labels.find( label => label.match( /^(?!\[Pri\] TBD)\[Pri\].*$/ ) );
+	return !! labels.find( label => label !== '[Pri] TBD' && label.match( /^\[Pri\].*$/ ) );
 }
 
 /**


### PR DESCRIPTION
## Proposed changes:

This PR introduces changes to 2 different triage tasks:

1. For the task posting on Slack when issues have gathered more than 10 tickets:
    * Notify the Kitkat team by default.
    * Update the Slack message format to match #29636.
2. For the issue triage:
    * Notify Kitkat of issues that do not have a Priority label yet.
    * For such issues, and until Kitkat intervenes, add a "[Pri] TBD" label. This serves 2 purposes: it helps us detect issues that have triggered a Slack notification so we do not do that multiple times, and it may incite Automatticians to add the missing Priority label on their own.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1679680635165249-slack-CQD1HH4MA

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* This is hard to test before merging, so I will be testing in a separate repo.
    * Here is how the new message looks like: p1679912155246299-slack-CN2FSK7L4