### PR TITLE
Protect: Add WAF subheadings

### DIFF
--- a/projects/plugins/protect/changelog/update-firewall-subheading
+++ b/projects/plugins/protect/changelog/update-firewall-subheading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improved the firewall status heading to provide more information based on the current configuration.

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -27,66 +27,16 @@ const UpgradePrompt = () => {
 	const { recordEventHandler } = useAnalyticsTracks();
 	const getScan = recordEventHandler( 'jetpack_protect_waf_header_get_scan_link_click', run );
 
-	const [ showPopover, setShowPopover ] = useState( false );
-
-	const handleEnter = useCallback( () => {
-		setShowPopover( true );
-	}, [] );
-
-	const handleOut = useCallback( () => {
-		setShowPopover( false );
-	}, [] );
-
 	return (
-		<>
-			<div className={ styles[ 'manual-rules-notice' ] }>
-				<Text weight={ 600 }>
-					{ ! automaticRulesAvailable
-						? __( 'Only manual rules will be applied', 'jetpack-protect' )
-						: __(
-								'Your site is not receiving the latest updates to automatic rules.',
-								'jetpack-protect',
-								/* dummy arg to avoid bad minification */ 0
-						  ) }
-				</Text>
-				<div
-					className={ styles[ 'icon-popover' ] }
-					onMouseLeave={ handleOut }
-					onMouseEnter={ handleEnter }
-					onClick={ handleEnter }
-					onFocus={ handleEnter }
-					onBlur={ handleOut }
-					role="presentation"
-				>
-					<Icon icon={ help } />
-					{ showPopover && (
-						<Popover noArrow={ false } offset={ 5 }>
-							<Text className={ styles[ 'popover-text' ] } variant={ 'body-small' }>
-								{ ! automaticRulesAvailable
-									? __(
-											'The free version of the firewall only allows for use of manual rules.',
-											'jetpack-protect'
-									  )
-									: __(
-											'The free version of the firewall does not receive updates to automatic firewall rules.',
-											'jetpack-protect',
-											/* dummy arg to avoid bad minification */ 0
-									  ) }
-							</Text>
-						</Popover>
-					) }
-				</div>
-			</div>
-			<Button onClick={ getScan }>
-				{ ! automaticRulesAvailable
-					? __( 'Upgrade to enable automatic rules', 'jetpack-protect' )
-					: __(
-							'Upgrade to update automatic rules',
-							'jetpack-protect',
-							/* dummy arg to avoid bad minification */ 0
-					  ) }
-			</Button>
-		</>
+		<Button className={ styles[ 'upgrade-button' ] } onClick={ getScan }>
+			{ ! automaticRulesAvailable
+				? __( 'Upgrade to enable automatic rules', 'jetpack-protect' )
+				: __(
+						'Upgrade to update automatic rules',
+						'jetpack-protect',
+						/* dummy arg to avoid bad minification */ 0
+				  ) }
+		</Button>
 	);
 };
 
@@ -231,7 +181,6 @@ const FirewallHeader = ( {
 								hasRequiredPlan={ hasRequiredPlan }
 								automaticRulesAvailable={ automaticRulesAvailable }
 							/>
-							{ ! hasRequiredPlan && <UpgradePrompt /> }
 						</>
 					) }
 					{ 'off' === status && (
@@ -255,7 +204,6 @@ const FirewallHeader = ( {
 								hasRequiredPlan={ hasRequiredPlan }
 								automaticRulesAvailable={ automaticRulesAvailable }
 							/>
-							{ ! hasRequiredPlan && <UpgradePrompt /> }
 						</>
 					) }
 					{ 'loading' === status && (

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -90,11 +90,117 @@ const UpgradePrompt = () => {
 	);
 };
 
+const FirewallSubheadingPopover = ( {
+	children = __(
+		'The free version of the firewall does not receive updates to automatic firewall rules.',
+		'jetpack-protect'
+	),
+} ) => {
+	const [ showPopover, setShowPopover ] = useState( false );
+
+	const handleEnter = useCallback( () => {
+		setShowPopover( true );
+	}, [] );
+
+	const handleOut = useCallback( () => {
+		setShowPopover( false );
+	}, [] );
+
+	return (
+		<div
+			className={ styles[ 'icon-popover' ] }
+			onMouseLeave={ handleOut }
+			onMouseEnter={ handleEnter }
+			onClick={ handleEnter }
+			onFocus={ handleEnter }
+			onBlur={ handleOut }
+			role="presentation"
+		>
+			<Icon icon={ help } />
+			{ showPopover && (
+				<Popover noArrow={ false } offset={ 5 }>
+					<Text className={ styles[ 'popover-text' ] } variant={ 'body-small' }>
+						{ children }
+					</Text>
+				</Popover>
+			) }
+		</div>
+	);
+};
+
+const FirewallSubheadingContent = ( { className, text = '', popover = false, children } ) => {
+	return (
+		<div className={ styles[ 'firewall-subheading__content' ] }>
+			<Text className={ styles[ className ] } weight={ 600 }>
+				{ text }
+			</Text>
+			{ popover && <FirewallSubheadingPopover children={ children } /> }
+		</div>
+	);
+};
+
+const FirewallSubheading = ( {
+	hasRequiredPlan,
+	automaticRulesAvailable,
+	jetpackWafIpList,
+	jetpackWafAutomaticRules,
+	bruteForceProtectionIsEnabled,
+} ) => {
+	const allRules = jetpackWafAutomaticRules && jetpackWafIpList;
+	const automaticRules = jetpackWafAutomaticRules && ! jetpackWafIpList;
+	const manualRules = ! jetpackWafAutomaticRules && jetpackWafIpList;
+	const noRules = ! jetpackWafAutomaticRules && ! jetpackWafIpList;
+
+	return (
+		<>
+			<div className={ styles[ 'firewall-subheading' ] }>
+				{ bruteForceProtectionIsEnabled && (
+					<FirewallSubheadingContent
+						className={ 'brute-force-protection-subheading' }
+						text={ __( 'Brute force protection is active.', 'jetpack-protect' ) }
+					/>
+				) }
+				{ noRules && (
+					<FirewallSubheadingContent
+						text={ __( 'There are no firewall rules applied.', 'jetpack-protect' ) }
+					/>
+				) }
+				{ automaticRules && (
+					<FirewallSubheadingContent
+						text={ __( 'Only automatic rules apply.', 'jetpack-protect' ) }
+						popover={ ! hasRequiredPlan }
+					/>
+				) }
+				{ manualRules && (
+					<FirewallSubheadingContent
+						text={ __( 'Only manual rules apply.', 'jetpack-protect' ) }
+						popover={ ! hasRequiredPlan && ! automaticRulesAvailable }
+						children={ __(
+							'The free version of the firewall only allows for use of manual rules.',
+							'jetpack-protect'
+						) }
+					/>
+				) }
+				{ allRules && (
+					<FirewallSubheadingContent
+						text={ __( 'All firewall rules apply.', 'jetpack-protect' ) }
+						popover={ ! hasRequiredPlan }
+					/>
+				) }
+			</div>
+			{ ! hasRequiredPlan && <UpgradePrompt /> }
+		</>
+	);
+};
+
 const FirewallHeader = ( {
 	status,
 	hasRequiredPlan,
 	automaticRulesEnabled,
 	automaticRulesAvailable,
+	jetpackWafIpList,
+	jetpackWafAutomaticRules,
+	bruteForceProtectionIsEnabled,
 } ) => {
 	return (
 		<AdminSectionHero>
@@ -118,6 +224,13 @@ const FirewallHeader = ( {
 											/* dummy arg to avoid bad minification */ 0
 									  ) }
 							</H3>
+							<FirewallSubheading
+								jetpackWafIpList={ jetpackWafIpList }
+								jetpackWafAutomaticRules={ jetpackWafAutomaticRules }
+								bruteForceProtectionIsEnabled={ bruteForceProtectionIsEnabled }
+								hasRequiredPlan={ hasRequiredPlan }
+								automaticRulesAvailable={ automaticRulesAvailable }
+							/>
 							{ ! hasRequiredPlan && <UpgradePrompt /> }
 						</>
 					) }
@@ -135,6 +248,13 @@ const FirewallHeader = ( {
 											/* dummy arg to avoid bad minification */ 0
 									  ) }
 							</H3>
+							<FirewallSubheading
+								jetpackWafIpList={ jetpackWafIpList }
+								jetpackWafAutomaticRules={ jetpackWafAutomaticRules }
+								bruteForceProtectionIsEnabled={ bruteForceProtectionIsEnabled }
+								hasRequiredPlan={ hasRequiredPlan }
+								automaticRulesAvailable={ automaticRulesAvailable }
+							/>
 							{ ! hasRequiredPlan && <UpgradePrompt /> }
 						</>
 					) }
@@ -160,7 +280,12 @@ const FirewallHeader = ( {
 
 const ConnectedFirewallHeader = () => {
 	const {
-		config: { jetpackWafAutomaticRules, jetpackWafIpList, automaticRulesAvailable },
+		config: {
+			jetpackWafAutomaticRules,
+			jetpackWafIpList,
+			automaticRulesAvailable,
+			bruteForceProtection,
+		},
 		isToggling,
 	} = useWafData();
 	const { hasRequiredPlan } = useProtectData();
@@ -172,6 +297,9 @@ const ConnectedFirewallHeader = () => {
 			hasRequiredPlan={ hasRequiredPlan }
 			automaticRulesEnabled={ jetpackWafAutomaticRules }
 			automaticRulesAvailable={ automaticRulesAvailable }
+			jetpackWafIpList={ jetpackWafIpList }
+			jetpackWafAutomaticRules={ jetpackWafAutomaticRules }
+			bruteForceProtectionIsEnabled={ bruteForceProtection }
 		/>
 	);
 };

--- a/projects/plugins/protect/src/js/components/firewall-header/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/firewall-header/styles.module.scss
@@ -48,6 +48,10 @@ svg.spinner {
     }
 }
 
+.upgrade-button {
+    margin-top: calc( var( --spacing-base ) * 4 ); // 32px
+}
+
 .firewall-header {
     display: flex;
     flex-wrap: wrap;

--- a/projects/plugins/protect/src/js/components/firewall-header/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/firewall-header/styles.module.scss
@@ -27,16 +27,24 @@ svg.spinner {
     color: var( --jp-black );
 }
 
-.manual-rules-notice {
+.firewall-subheading {
     display: flex;
     justify-content: flex-start;
+    flex-wrap: wrap;
     align-items: center;
-    margin-bottom: calc( var( --spacing-base ) * 4 ); // 32px
 
-    > .icon-popover {
+    .brute-force-protection-subheading {
+        margin-right: calc( var( --spacing-base ) / 2 ); // 4px
+    }
+
+    &__content {
         display: flex;
-        margin-left: calc( var( --spacing-base ) * .5 ); // 4px
-        fill: var( --jp-gray-20 );
+    
+        > .icon-popover {
+            display: flex;
+            margin-left: calc( var( --spacing-base ) / 2 ); // 4px
+            fill: var( --jp-gray-20 );
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds various subheadings to the primary WAF header component depending on the combination of settings enabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1203846677289621
p6TEKc-6Lx-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* Start up your Jurassic Tube and enable Protect
* Jump to the Firewall page
* Toggle the various settings available and ensure that each subheading displayed is appropriate for the combination enabled (as per the designs), for each of the following:
   * With no plan
   * After upgrading
   * After downgrading
   * After manually deleting the rules directory
   * After manually disabling the WAF module via Jetpack Settings (not yet accounted for)

