### PR TITLE
Fix for unified navigation on mobile in WordPress 6.2

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,10 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.4] - 2023-03-27
-### Added
-- Fix for the unified navigation on mobile in WordPress 6.2 [#]
-
 ## [1.1.3] - 2023-03-20
 ### Changed
 - Updated package dependencies. [#29480]

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2023-03-27
+### Added
+- Fix for the unified navigation on mobile in WordPress 6.2 [#]
+
 ## [1.1.3] - 2023-03-20
 ### Changed
 - Updated package dependencies. [#29480]

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-fix-for-unified-navigation-on-mobile-in-wordpress-6.2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-fix-for-unified-navigation-on-mobile-in-wordpress-6.2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Fix for the unified navigation on mobile in WordPress 6.2.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -44,7 +44,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "1.1.x-dev"
+			"dev-trunk": "1.2.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "1.1.3",
+	"version": "1.2.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '1.1.4';
+	const PACKAGE_VERSION = '1.2.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '1.1.3';
+	const PACKAGE_VERSION = '1.1.4';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -34,6 +34,9 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_coming_soon' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
 
+		// Unified navigation fix for changes in WordPress 6.2.
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );
+
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *
@@ -84,5 +87,14 @@ class Jetpack_Mu_Wpcom {
 		foreach ( array_filter( $plugins, 'is_file' ) as $plugin ) {
 			require_once $plugin;
 		}
+	}
+
+	/**
+	 * Unbinds focusout event handler on #wp-admin-bar-menu-toggle introduced in WordPress 6.2.
+	 *
+	 * The focusout event handler is preventing the unified navigation from being closed on mobile.
+	 */
+	public static function unbind_focusout_on_wp_admin_bar_menu_toggle() {
+		wp_add_inline_script( 'common', '(function($){ $(document).on("wp-responsive-activate", function(){ $(".is-nav-unification #wp-admin-bar-menu-toggle, .is-nav-unification #adminmenumain").off("focusout"); } ); }(jQuery) );' );
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-fix-for-unified-navigation-on-mobile-in-wordpress-6.2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-fix-for-unified-navigation-on-mobile-in-wordpress-6.2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -42,6 +42,6 @@
 		"release-branch-prefix": "jetpack"
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_0_11"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_0_12_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "b2be1ea9e61c669f45e6921fa58735cc7c8ab24d"
+                "reference": "c63c2d08828384c96b707878d3d79a53f18e051b"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -27,7 +27,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "1.1.x-dev"
+                    "dev-trunk": "1.2.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.0.11
+ * Version: 1.0.12-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.0.11",
+	"version": "1.0.12-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

WordPress 6.2 improves the mobile experience by closing the admin menu upon clicking on the content ( see https://core.trac.wordpress.org/ticket/53587 for more details ).

However the improvement breaks the implementation of the unified navigation on WordPress.com simple and atomic sites (Jetpack sites with the WordPress.com toolbar are not affected), as it would not close when opened and clicking the WordPress logo.

This commit is adding an inline script after the `common` script loading on wp-admin. The script adds a handler for the `wp-responsive-activate` event where the `focusout` handler added in WordPress core ( see https://core.trac.wordpress.org/changeset/55326 ) is being removed.

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* adds an inline script for fixing the unified navigation bug in WordPress 6.2

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
p94tqY-t5#comment-1407

<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

WoA

* Have a WoA site with the WordPress beta pin
* Open the wp-admin of the site on mobile (or simulate the mobile in your desktop browser)
* Click the WordPress logo in the left hand top corner to open the unified navigation
* Click the WordPress logo again, the navigation does not close
* Apply this patch, it should fix the navigation toggle

Simple sites
* Apply D103044-code on your sandbox
* Open the wp-admin of the site on mobile (or simulate the mobile in your desktop browser)
* Click the WordPress logo in the left hand top corner to open the unified navigation
* Click the WordPress logo again, the navigation does not close
* Apply this patch, it should fix the navigation toggle

