### PR TITLE
VideoPress: store poster data into video block attribute

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-frame-poster-block-attr
+++ b/projects/packages/videopress/changelog/update-videopress-add-frame-poster-block-attr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: store poster data into video block attribute

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -83,6 +83,10 @@
 		"poster": {
 			"type": "string"
 		},
+		"posterSource": {
+			"type": "object",
+			"default": {}
+		},
 		"videoRatio": {
 			"type": "number"
 		},

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -83,7 +83,7 @@
 		"poster": {
 			"type": "string"
 		},
-		"posterSource": {
+		"posterData": {
 			"type": "object",
 			"default": {}
 		},

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -95,9 +95,9 @@ export function PosterDropdown( {
 			setAttributes( {
 				poster: image.url,
 
-				// Extend the posterSource object to include the media library id and url.
-				posterSource: {
-					...attributes.posterSource,
+				// Extend the posterData object to include the media library id and url.
+				posterData: {
+					...attributes.posterData,
 					type: 'media-library',
 					id: image.id,
 					url: image.url,
@@ -346,26 +346,26 @@ export default function PosterPanel( {
 	setAttributes,
 	isGeneratingPoster,
 }: PosterPanelProps ): React.ReactElement {
-	const { poster, posterSource } = attributes;
+	const { poster, posterData } = attributes;
 	const [ pickFromFrame, setPickFromFrame ] = useState(
-		attributes?.posterSource?.type === 'video-frame'
+		attributes?.posterData?.type === 'video-frame'
 	);
 	const onRemovePoster = () => {
-		setAttributes( { poster: '', posterSource: { ...attributes.posterSource, url: '' } } );
+		setAttributes( { poster: '', posterData: { ...attributes.posterData, url: '' } } );
 	};
 
 	const switchPosterSource = useCallback(
 		( shouldPickFromFrame: boolean ) => {
 			setPickFromFrame( shouldPickFromFrame );
 			setAttributes( {
-				// Extend the posterSource attr with the new type.
-				posterSource: {
-					...attributes.posterSource,
+				// Extend the posterData attr with the new type.
+				posterData: {
+					...attributes.posterData,
 					type: shouldPickFromFrame ? 'video-frame' : 'media-library',
 				},
 
 				// Clean the poster URL when it should be picked from the video frame.
-				poster: shouldPickFromFrame ? '' : attributes.posterSource.url || '',
+				poster: shouldPickFromFrame ? '' : attributes.posterData.url || '',
 			} );
 		},
 		[ attributes ]
@@ -400,11 +400,11 @@ export default function PosterPanel( {
 				<VideoFramePicker
 					isGeneratingPoster={ isGeneratingPoster }
 					guid={ attributes?.guid }
-					atTime={ posterSource?.atTime }
+					atTime={ posterData?.atTime }
 					onVideoFrameSelect={ timestamp => {
 						setAttributes( {
-							posterSource: {
-								...attributes.posterSource,
+							posterData: {
+								...attributes.posterData,
 								type: 'video-frame',
 								atTime: timestamp,
 							},

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -36,7 +36,7 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	description?: string;
 
 	poster?: string;
-	posterSource?: PosterSourceProps;
+	posterData?: PosterSourceProps;
 	videoRatio?: number;
 	tracks?: Array< TrackProps >;
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -18,7 +18,7 @@ export type VideoBlockColorAttributesProps = {
 
 type BlockSupportAlignProp = 'left' | 'center' | 'right' | 'wide' | 'full' | undefined;
 
-export type PosterSourceProps = {
+export type PosterDataProps = {
 	type: 'media-library' | 'video-frame';
 	atTime?: number;
 	src?: string;
@@ -36,7 +36,7 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	description?: string;
 
 	poster?: string;
-	posterData?: PosterSourceProps;
+	posterData?: PosterDataProps;
 	videoRatio?: number;
 	tracks?: Array< TrackProps >;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR renames and registers the block attribute to store the video poster.  It only holds the poster URL, defined by a static image. With the `posterData` attribute, the block will store the more [required data](https://github.com/Automattic/jetpack/blob/d0fd434bc44ac29eacbd680ce85d50d39010543a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts#L21-L27) such as type, atTime, etc:

```ts
export type PosterDataProps = {
	type: 'media-library' | 'video-frame';
	atTime?: number;
	src?: string;
	id?: number;
	url?: string;
};
```

Fixes https://github.com/Automattic/jetpack/issues/29715

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: store poster data into video block attribute

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a VideoBlock video instance
* Check how the block populates the `posterData` attribute by using the dev tools.
* Confirm the data is persistent

https://user-images.githubusercontent.com/77539/227964685-75a302bb-4920-49e7-9729-97f1b0b88d96.mov

