### PR TITLE
Jetpack Social: Add toggle to Social admin page to enable or disable SIG and pick a default template

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,6 +693,9 @@ importers:
       '@wordpress/icons':
         specifier: 9.19.0
         version: 9.19.0
+      '@wordpress/notices':
+        specifier: 3.28.0
+        version: 3.28.0(react@18.2.0)
       classnames:
         specifier: 2.3.1
         version: 2.3.1

--- a/projects/js-packages/publicize-components/changelog/add-jetpack-social-add-sig-settings-to-publicize-store
+++ b/projects/js-packages/publicize-components/changelog/add-jetpack-social-add-sig-settings-to-publicize-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added toggle to Social admin page to enable or disable Social Image Generator as well as an option to pick a default template

--- a/projects/js-packages/publicize-components/index.js
+++ b/projects/js-packages/publicize-components/index.js
@@ -11,6 +11,7 @@ export { default as TwitterOptions } from './src/components/twitter/options';
 export { default as SocialPreviewsModal } from './src/components/social-previews/modal';
 export { default as SocialPreviewsPanel } from './src/components/social-previews/panel';
 export { default as SocialImageGeneratorPanel } from './src/components/social-image-generator/panel';
+export { default as SocialImageGeneratorTemplatePicker } from './src/components/social-image-generator/template-picker';
 export { default as PublicizePanel } from './src/components/panel';
 export { default as ReviewPrompt } from './src/components/review-prompt';
 

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/hooks": "3.28.0",
 		"@wordpress/i18n": "4.28.0",
 		"@wordpress/icons": "9.19.0",
+		"@wordpress/notices": "3.28.0",
 		"classnames": "2.3.1",
 		"lodash": "4.17.21",
 		"prop-types": "15.8.1",

--- a/projects/packages/publicize/changelog/add-jetpack-social-add-sig-settings-to-publicize-store
+++ b/projects/packages/publicize/changelog/add-jetpack-social-add-sig-settings-to-publicize-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use picked default template for Social Image Generator

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1063,7 +1063,7 @@ abstract class Publicize_Base {
 			'single'        => true,
 			'default'       => array(
 				'image_generator_settings' => array(
-					'template' => Social_Image_Generator\Templates::DEFAULT_TEMPLATE,
+					'template' => ( new Social_Image_Generator\Settings() )->get_default_template(),
 				),
 			),
 			'show_in_rest'  => array(

--- a/projects/packages/publicize/src/social-image-generator/class-setup.php
+++ b/projects/packages/publicize/src/social-image-generator/class-setup.php
@@ -15,6 +15,10 @@ class Setup {
 	 * Initialise SIG-related functionality.
 	 */
 	public function init() {
+		if ( ! ( new Settings() )->is_enabled() ) {
+			return;
+		}
+
 		// Be wary of any code that you add to this file, since this function is called on plugin load.
 		// We're using the `wp_after_insert_post` hook because we need access to the updated post meta. By using the default priority
 		// of 10 we make sure that our code runs before Sync processes the post.

--- a/projects/packages/publicize/src/social-image-generator/class-setup.php
+++ b/projects/packages/publicize/src/social-image-generator/class-setup.php
@@ -15,10 +15,6 @@ class Setup {
 	 * Initialise SIG-related functionality.
 	 */
 	public function init() {
-		if ( ! ( new Settings() )->is_enabled() ) {
-			return;
-		}
-
 		// Be wary of any code that you add to this file, since this function is called on plugin load.
 		// We're using the `wp_after_insert_post` hook because we need access to the updated post meta. By using the default priority
 		// of 10 we make sure that our code runs before Sync processes the post.
@@ -57,6 +53,10 @@ class Setup {
 	 * @param \WP_Post $post Post that's being updated.
 	 */
 	public function set_meta( $post_id, $post ) {
+		if ( ! ( new Settings() )->is_enabled() ) {
+			return;
+		}
+
 		global $publicize;
 
 		if ( ! $publicize->has_social_image_generator_feature() ) {

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-setup.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-setup.php
@@ -30,6 +30,8 @@ class Setup_Test extends BaseTestCase {
 	 * Setting up the test.
 	 */
 	public function set_up() {
+		// Enable the feature
+		( new Social_Image_Generator\Settings() )->set_enabled( true );
 		$this->sig = new Social_Image_Generator\Setup();
 		$this->sig->init();
 		$plan                       = Current_Plan::PLAN_DATA['free'];
@@ -99,9 +101,22 @@ class Setup_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that SIG gets enabled by default.
+	 * Test that SIG does not get enabled by default if the feature is not active.
 	 */
-	public function test_sig_gets_enabled_by_default_when_a_post_gets_saved() {
+	public function test_sig_does_not_get_enabled_by_default_when_a_post_gets_saved() {
+		( new Social_Image_Generator\Settings() )->set_enabled( false );
+		add_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
+		$post_id = $this->create_post();
+		remove_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
+
+		$settings = new Social_Image_Generator\Post_Settings( $post_id );
+		$this->assertFalse( $settings->is_enabled() );
+	}
+
+	/**
+	 * Test that SIG gets enabled by default when the feature is active.
+	 */
+	public function test_sig_gets_enabled_by_default_when_a_post_gets_saved_and_the_feature_is_active() {
 		add_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
 		$post_id = $this->create_post();
 		remove_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );

--- a/projects/plugins/jetpack/changelog/add-jetpack-social-add-sig-settings-to-publicize-store
+++ b/projects/plugins/jetpack/changelog/add-jetpack-social-add-sig-settings-to-publicize-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Prevent SIG from running when it is disabled

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -747,7 +747,7 @@ class Jetpack_Gutenberg {
 				'sharesData'                    => $publicize->get_publicize_shares_info( $blog_id ),
 				'hasPaidPlan'                   => $publicize->has_paid_plan(),
 				'isEnhancedPublishingEnabled'   => $publicize->is_enhanced_publishing_enabled( $blog_id ),
-				'isSocialImageGeneratorEnabled' => $publicize->has_social_image_generator_feature(),
+				'isSocialImageGeneratorEnabled' => $publicize->has_social_image_generator_feature() && ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
 			);
 		}
 

--- a/projects/plugins/social/changelog/add-jetpack-social-add-sig-settings-to-publicize-store
+++ b/projects/plugins/social/changelog/add-jetpack-social-add-sig-settings-to-publicize-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added toggle to Social admin page to enable or disable Social Image Generator as well as an option to pick a default template

--- a/projects/plugins/social/jest.config.js
+++ b/projects/plugins/social/jest.config.js
@@ -5,4 +5,8 @@ module.exports = {
 	roots: [ '<rootDir>/src' ],
 	moduleDirectories: [ 'node_modules', '<rootDir>/src' ],
 	setupFilesAfterEnv: [ ...baseConfig.setupFilesAfterEnv, '<rootDir>/jest.setup.js' ],
+	moduleNameMapper: {
+		...baseConfig.moduleNameMapper,
+		'\\.(css|less|sass|scss)$': '<rootDir>/tests/styles-mock.js',
+	},
 };

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -323,7 +323,7 @@ class Jetpack_Social {
 					),
 					'hasPaidPlan'                   => $publicize->has_paid_plan(),
 					'isEnhancedPublishingEnabled'   => $publicize->is_enhanced_publishing_enabled( Jetpack_Options::get_option( 'id' ) ),
-					'isSocialImageGeneratorEnabled' => $publicize->has_social_image_generator_feature(),
+					'isSocialImageGeneratorEnabled' => $publicize->has_social_image_generator_feature() && ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
 				),
 			)
 		);

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -231,16 +231,21 @@ class Jetpack_Social {
 			$state = array_merge(
 				$state,
 				array(
-					'jetpackSettings' => array(
+					'jetpackSettings'              => array(
 						'publicize_active'  => self::is_publicize_active(),
 						'show_pricing_page' => self::should_show_pricing_page(),
 						'showNudge'         => ! $publicize->has_paid_plan( true ),
 					),
-					'connectionData'  => array(
+					'connectionData'               => array(
 						'connections' => $publicize->get_all_connections_for_user(), // TODO: Sanitize the array
 						'adminUrl'    => esc_url_raw( $publicize->publicize_connections_url( 'jetpack-social-connections-admin-page' ) ),
 					),
-					'sharesData'      => $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) ),
+					'sharesData'                   => $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) ),
+					'socialImageGeneratorSettings' => array(
+						'available'       => $publicize->has_social_image_generator_feature(),
+						'enabled'         => ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
+						'defaultTemplate' => ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->get_default_template(),
+					),
 				)
 			);
 		}

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -23,17 +23,22 @@ const Admin = () => {
 	const { isUserConnected, isRegistered } = useConnection();
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 
-	const { showPricingPage, hasPaidPlan, isShareLimitEnabled, pluginVersion } = useSelect(
-		select => {
-			const store = select( STORE_ID );
-			return {
-				showPricingPage: store.showPricingPage(),
-				hasPaidPlan: store.hasPaidPlan(),
-				isShareLimitEnabled: store.isShareLimitEnabled(),
-				pluginVersion: store.getPluginVersion(),
-			};
-		}
-	);
+	const {
+		showPricingPage,
+		hasPaidPlan,
+		isShareLimitEnabled,
+		pluginVersion,
+		isSocialImageGeneratorAvailable,
+	} = useSelect( select => {
+		const store = select( STORE_ID );
+		return {
+			showPricingPage: store.showPricingPage(),
+			hasPaidPlan: store.hasPaidPlan(),
+			isShareLimitEnabled: store.isShareLimitEnabled(),
+			pluginVersion: store.getPluginVersion(),
+			isSocialImageGeneratorAvailable: store.isSocialImageGeneratorAvailable(),
+		};
+	} );
 
 	const moduleName = `Jetpack Social ${ pluginVersion }`;
 
@@ -66,7 +71,7 @@ const Admin = () => {
 					</AdminSectionHero>
 					<AdminSection>
 						<SocialModuleToggle />
-						<SocialImageGeneratorToggle />
+						{ isSocialImageGeneratorAvailable && <SocialImageGeneratorToggle /> }
 					</AdminSection>
 					<AdminSectionHero>
 						<InfoSection />

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -10,6 +10,7 @@ import { useSelect } from '@wordpress/data';
 import React from 'react';
 import { STORE_ID } from '../../store';
 import PricingPage from '../pricing-page';
+import SocialImageGeneratorToggle from '../social-image-generator-toggle';
 import SocialModuleToggle from '../social-module-toggle';
 import SupportSection from '../support-section';
 import ConnectionScreen from './../connection-screen';
@@ -65,6 +66,7 @@ const Admin = () => {
 					</AdminSectionHero>
 					<AdminSection>
 						<SocialModuleToggle />
+						<SocialImageGeneratorToggle />
 					</AdminSection>
 					<AdminSectionHero>
 						<InfoSection />

--- a/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-image-generator-toggle/index.tsx
@@ -1,0 +1,78 @@
+import { Button, Text, useBreakpointMatch } from '@automattic/jetpack-components';
+import { SocialImageGeneratorTemplatePicker as TemplatePicker } from '@automattic/jetpack-publicize-components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState, useCallback, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+import { STORE_ID } from '../../store';
+import ToggleSection from '../toggle-section';
+import { SocialStoreSelectors } from '../types/types';
+import styles from './styles.module.scss';
+
+const SocialImageGeneratorToggle: React.FC = () => {
+	const [ currentTemplate, setCurrentTemplate ] = useState( null );
+	const { isEnabled, isUpdating, defaultTemplate } = useSelect( select => {
+		const store = select( STORE_ID ) as SocialStoreSelectors;
+		return {
+			isEnabled: store.isSocialImageGeneratorEnabled(),
+			isUpdating: store.isUpdatingSocialImageGeneratorSettings(),
+			defaultTemplate: store.getSocialImageGeneratorDefaultTemplate(),
+		};
+	}, [] );
+
+	const updateOptions = useDispatch( STORE_ID ).updateSocialImageGeneratorSettings;
+
+	const toggleStatus = useCallback( () => {
+		const newOption = {
+			enabled: ! isEnabled,
+		};
+		updateOptions( newOption );
+	}, [ isEnabled, updateOptions ] );
+
+	useEffect( () => {
+		if ( currentTemplate ) {
+			const newOption = { defaults: { template: currentTemplate } };
+			updateOptions( newOption );
+		}
+	}, [ currentTemplate, updateOptions ] );
+
+	const [ isSmall ] = useBreakpointMatch( 'sm' );
+
+	const renderTemplatePicker = useCallback(
+		( { open } ) => (
+			<Button
+				fullWidth={ isSmall }
+				className={ styles.button }
+				variant="secondary"
+				disabled={ isUpdating || ! isEnabled }
+				onClick={ open }
+			>
+				{ __( 'Change default template', 'jetpack-social' ) }
+			</Button>
+		),
+		[ isEnabled, isSmall, isUpdating ]
+	);
+
+	return (
+		<ToggleSection
+			title={ __( 'Enable Social Image Generator', 'jetpack-social' ) }
+			disabled={ isUpdating }
+			checked={ isEnabled }
+			onChange={ toggleStatus }
+		>
+			<Text className={ styles.text }>
+				{ __(
+					'When enabled, Social Image Generator will automatically generate social images for your posts. You can use the button below to choose a default template for new posts.',
+					'jetpack-social'
+				) }
+			</Text>
+			<TemplatePicker
+				value={ currentTemplate || defaultTemplate }
+				onSelect={ setCurrentTemplate }
+				render={ renderTemplatePicker }
+			/>
+		</ToggleSection>
+	);
+};
+
+export default SocialImageGeneratorToggle;

--- a/projects/plugins/social/src/js/components/social-image-generator-toggle/styles.module.scss
+++ b/projects/plugins/social/src/js/components/social-image-generator-toggle/styles.module.scss
@@ -1,0 +1,21 @@
+.text {
+	grid-column: span 2;
+
+	a {
+		color: inherit;
+	}
+
+	@media ( min-width: 600px ) {
+		grid-column: 2;
+	}
+}
+
+.button {
+	margin-top: calc( var( --spacing-base ) * 2 );
+	grid-column: span 2;
+	justify-self: flex-start;
+
+	@media ( min-width: 600px ) {
+		grid-column: 2;
+	}
+}

--- a/projects/plugins/social/src/js/components/types/types.ts
+++ b/projects/plugins/social/src/js/components/types/types.ts
@@ -28,6 +28,20 @@ type SiteDataSelectors = {
 	getSiteTitle: () => string;
 };
 
+type SocialImageGeneratorSettingsSelectors = {
+	getSocialImageGeneratorSettings: () => {
+		available: boolean;
+		enabled: boolean;
+		defaults: () => {
+			template: string;
+		};
+	};
+	isSocialImageGeneratorAvailable: () => boolean;
+	isSocialImageGeneratorEnabled: () => boolean;
+	isUpdatingSocialImageGeneratorSettings: () => boolean;
+	getSocialImageGeneratorDefaultTemplate: () => string;
+};
+
 /**
  * Types of the Social Store selectors.
  *
@@ -36,4 +50,5 @@ type SiteDataSelectors = {
 export type SocialStoreSelectors = JetpackSettingsSelectors &
 	ConnectionDataSelectors &
 	SharesDataSelectors &
-	SiteDataSelectors;
+	SiteDataSelectors &
+	SocialImageGeneratorSettingsSelectors;

--- a/projects/plugins/social/src/js/store/actions/index.js
+++ b/projects/plugins/social/src/js/store/actions/index.js
@@ -1,7 +1,9 @@
 import siteSettingActions from './jetpack-settings';
+import socialImageGeneratorSettingActions from './social-image-generator-settings';
 
 const actions = {
 	...siteSettingActions,
+	...socialImageGeneratorSettingActions,
 };
 
 export default actions;

--- a/projects/plugins/social/src/js/store/actions/social-image-generator-settings.js
+++ b/projects/plugins/social/src/js/store/actions/social-image-generator-settings.js
@@ -1,0 +1,62 @@
+import { select } from '@wordpress/data';
+import { STORE_ID } from '../../store';
+import {
+	fetchSocialImageGeneratorSettings,
+	updateSocialImageGeneratorSettings as updateSocialImageGeneratorSettingsControl,
+} from '../controls';
+
+export const SET_SOCIAL_IMAGE_GENERATOR_SETTINGS = 'SET_SOCIAL_IMAGE_GENERATOR_SETTINGS';
+
+/**
+ * Yield actions to update settings
+ *
+ * @param {object} settings - settings to apply.
+ * @yields {object} - an action object.
+ * @returns {object} - an action object.
+ */
+export function* updateSocialImageGeneratorSettings( settings ) {
+	try {
+		yield setUpdatingSocialImageGeneratorSettings();
+		yield setSocialImageGeneratorSettings( settings );
+		yield updateSocialImageGeneratorSettingsControl( settings );
+		const updatedSettings = yield fetchSocialImageGeneratorSettings();
+		yield setSocialImageGeneratorSettings( updatedSettings );
+		return true;
+	} catch ( e ) {
+		const oldSettings = select( STORE_ID ).getSocialImageGeneratorSettings();
+		yield setSocialImageGeneratorSettings( oldSettings );
+		return false;
+	} finally {
+		yield setUpdatingSocialImageGeneratorSettingsDone();
+	}
+}
+
+/**
+ * Set state updating action
+ *
+ * @returns {object} - an action object.
+ */
+export function setUpdatingSocialImageGeneratorSettings() {
+	return setSocialImageGeneratorSettings( { isUpdating: true } );
+}
+
+/**
+ * Set state updating finished
+ *
+ * @returns {object} - an action object.
+ */
+export function setUpdatingSocialImageGeneratorSettingsDone() {
+	return setSocialImageGeneratorSettings( { isUpdating: false } );
+}
+
+/**
+ * Set Social Image Generator settings action
+ *
+ * @param {object} options - Social Image Generator settings.
+ * @returns {object} - an action object.
+ */
+export function setSocialImageGeneratorSettings( options ) {
+	return { type: SET_SOCIAL_IMAGE_GENERATOR_SETTINGS, options };
+}
+
+export default { updateSocialImageGeneratorSettings, setSocialImageGeneratorSettings };

--- a/projects/plugins/social/src/js/store/controls.js
+++ b/projects/plugins/social/src/js/store/controls.js
@@ -2,6 +2,8 @@ import apiFetch from '@wordpress/api-fetch';
 
 export const FETCH_JETPACK_SETTINGS = 'FETCH_JETPACK_SETTINGS';
 export const UPDATE_JETPACK_SETTINGS = 'UPDATE_JETPACK_SETTINGS';
+export const FETCH_SOCIAL_IMAGE_GENERATOR_SETTINGS = 'FETCH_SOCIAL_IMAGE_GENERATOR_SETTINGS';
+export const UPDATE_SOCIAL_IMAGE_GENERATOR_SETTINGS = 'UPDATE_SOCIAL_IMAGE_GENERATOR_SETTINGS';
 
 /**
  * fetchJetpackSettings action
@@ -27,6 +29,30 @@ export const updateJetpackSettings = settings => {
 	};
 };
 
+/**
+ * fetchSocialImageGeneratorSettings action
+ *
+ * @returns {object} - an action object.
+ */
+export const fetchSocialImageGeneratorSettings = () => {
+	return {
+		type: FETCH_SOCIAL_IMAGE_GENERATOR_SETTINGS,
+	};
+};
+
+/**
+ * updateSocialImageGeneratorSettings action
+ *
+ * @param {*} settings - Social Image Generator settings object.
+ * @returns {object} - an action object.
+ */
+export const updateSocialImageGeneratorSettings = settings => {
+	return {
+		type: UPDATE_SOCIAL_IMAGE_GENERATOR_SETTINGS,
+		settings,
+	};
+};
+
 export default {
 	[ FETCH_JETPACK_SETTINGS ]: function () {
 		return apiFetch( { path: '/jetpack/v4/social/settings' } );
@@ -34,6 +60,16 @@ export default {
 	[ UPDATE_JETPACK_SETTINGS ]: function ( action ) {
 		return apiFetch( {
 			path: '/jetpack/v4/social/settings',
+			method: 'POST',
+			data: action.settings,
+		} );
+	},
+	[ FETCH_SOCIAL_IMAGE_GENERATOR_SETTINGS ]: function () {
+		return apiFetch( { path: '/jetpack/v4/social-image-generator/settings' } );
+	},
+	[ UPDATE_SOCIAL_IMAGE_GENERATOR_SETTINGS ]: function ( action ) {
+		return apiFetch( {
+			path: '/jetpack/v4/social-image-generator/settings',
 			method: 'POST',
 			data: action.settings,
 		} );

--- a/projects/plugins/social/src/js/store/reducer/index.js
+++ b/projects/plugins/social/src/js/store/reducer/index.js
@@ -3,12 +3,14 @@ import connectionData from './connection-data';
 import jetpackSettings from './jetpack-settings';
 import sharesData from './shares-data';
 import siteData from './site-data';
+import socialImageGeneratorSettings from './social-image-generator-settings';
 
 const reducer = combineReducers( {
 	sharesData,
 	siteData,
 	connectionData,
 	jetpackSettings,
+	socialImageGeneratorSettings,
 } );
 
 export default reducer;

--- a/projects/plugins/social/src/js/store/reducer/social-image-generator-settings.js
+++ b/projects/plugins/social/src/js/store/reducer/social-image-generator-settings.js
@@ -1,0 +1,14 @@
+import { SET_SOCIAL_IMAGE_GENERATOR_SETTINGS } from '../actions/social-image-generator-settings';
+
+const socialImageGeneratorSettings = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SET_SOCIAL_IMAGE_GENERATOR_SETTINGS:
+			return {
+				...state,
+				...action.options,
+			};
+	}
+	return state;
+};
+
+export default socialImageGeneratorSettings;

--- a/projects/plugins/social/src/js/store/resolvers.js
+++ b/projects/plugins/social/src/js/store/resolvers.js
@@ -1,5 +1,6 @@
 import { setJetpackSettings } from './actions/jetpack-settings';
-import { fetchJetpackSettings } from './controls';
+import { setSocialImageGeneratorSettings } from './actions/social-image-generator-settings';
+import { fetchJetpackSettings, fetchSocialImageGeneratorSettings } from './controls';
 
 /**
  * Yield actions to get the Jetpack settings.
@@ -19,4 +20,22 @@ export function* getJetpackSettings() {
 	}
 }
 
-export default { getJetpackSettings };
+/**
+ * Yield actions to get the Social Image Generator settings.
+ *
+ * @yields {object} - an action object.
+ * @returns {object} - an action object.
+ */
+export function* getSocialImageGeneratorSettings() {
+	try {
+		const settings = yield fetchSocialImageGeneratorSettings();
+		if ( settings ) {
+			return setSocialImageGeneratorSettings( settings );
+		}
+	} catch ( e ) {
+		// TODO: Add proper error handling here
+		console.log( e ); // eslint-disable-line no-console
+	}
+}
+
+export default { getJetpackSettings, getSocialImageGeneratorSettings };

--- a/projects/plugins/social/src/js/store/selectors/index.js
+++ b/projects/plugins/social/src/js/store/selectors/index.js
@@ -2,12 +2,14 @@ import connectionDataSelectors from './connection-data';
 import jetpackSettingSelectors from './jetpack-settings';
 import sharesDataSelectors from './shares-data';
 import siteDataSelectors from './site-data';
+import socialImageGeneratorSettingsSelectors from './social-image-generator-settings';
 
 const selectors = {
 	...siteDataSelectors,
 	...connectionDataSelectors,
 	...jetpackSettingSelectors,
 	...sharesDataSelectors,
+	...socialImageGeneratorSettingsSelectors,
 };
 
 export default selectors;

--- a/projects/plugins/social/src/js/store/selectors/social-image-generator-settings.js
+++ b/projects/plugins/social/src/js/store/selectors/social-image-generator-settings.js
@@ -1,0 +1,10 @@
+const socialImageGeneratorSettingsSelectors = {
+	getSocialImageGeneratorSettings: state => state.socialImageGeneratorSettings,
+	isSocialImageGeneratorAvailable: state => state.socialImageGeneratorSettings.available,
+	isSocialImageGeneratorEnabled: state => state.socialImageGeneratorSettings.enabled,
+	isUpdatingSocialImageGeneratorSettings: state => state.socialImageGeneratorSettings.isUpdating,
+	getSocialImageGeneratorDefaultTemplate: state =>
+		state.socialImageGeneratorSettings.defaultTemplate,
+};
+
+export default socialImageGeneratorSettingsSelectors;

--- a/projects/plugins/social/tests/styles-mock.js
+++ b/projects/plugins/social/tests/styles-mock.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds a toggle to the Social admin page that can be used to enable or disable Social Image Generator. It also adds a button that opens a template picker for choosing a default template.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1202816441505085-as-1204116019981285/f
1202816441505085-as-1204097909752714/f

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable SIG on your site and open the Social admin page.
* Make sure that the toggle matches the screenshot.
* Check that the toggle updates the status by running `( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled();`
* * Check that the template picker updates the default template by running `( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->get_default_template();`

<img width="770" alt="image" src="https://user-images.githubusercontent.com/1713699/227970283-fda132be-d682-4942-9286-11fa73efa974.png">
<img width="742" alt="image" src="https://user-images.githubusercontent.com/1713699/227970315-71f1ab22-34e1-4340-8019-3f842abb0fed.png">
