### PR TITLE
Jetpack: disable the Yoast Promo banner

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -13,10 +13,8 @@ import SettingsGroup from 'components/settings-group';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import SocialLogo from 'social-logos';
-import { arePromotionsActive } from 'state/initial-state';
 import { isFetchingPluginsData, isPluginActive } from 'state/site/plugins';
 import CustomSeoTitles from './seo/custom-seo-titles.jsx';
-import YoastPromoBanner from './seo/yoast-promo-banner';
 
 export const conflictingSeoPluginsList = [
 	{
@@ -315,7 +313,6 @@ export const SEO = withModuleSettingsFormHelpers(
 								</FoldableCard>
 							</div>
 						) }
-					{ this.props.arePromotionsActive && <YoastPromoBanner /> }
 				</SettingsCard>
 			);
 		}
@@ -325,7 +322,6 @@ export const SEO = withModuleSettingsFormHelpers(
 export default connect( state => {
 	return {
 		siteData: state.jetpack.siteData.data,
-		arePromotionsActive: arePromotionsActive( state ),
 		state,
 	};
 } )( SEO );

--- a/projects/plugins/jetpack/changelog/update-yoast-promo-placement
+++ b/projects/plugins/jetpack/changelog/update-yoast-promo-placement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+General: do not load the Yoast banner.

--- a/projects/plugins/jetpack/changelog/update-yoast-promo-placement#2
+++ b/projects/plugins/jetpack/changelog/update-yoast-promo-placement#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -886,16 +886,6 @@ class Jetpack {
 		}
 
 		/*
-		 * Enable the Yoast Promo panel
-		 * if we're not in offline mode, and if promotions aren't disabled.
-		 */
-		if (
-			! ( new Status() )->is_offline_mode()
-		) {
-			$config->ensure( 'yoast_promo' );
-		}
-
-		/*
 		 * Load things that should only be in Network Admin.
 		 *
 		 * For now blow away everything else until a more full

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -49,7 +49,6 @@
 		"automattic/jetpack-videopress": "@dev",
 		"automattic/jetpack-waf": "@dev",
 		"automattic/jetpack-wordads": "@dev",
-		"automattic/jetpack-yoast-promo": "@dev",
 		"nojimage/twitter-text-php": "3.1.2"
 	},
 	"require-dev": {

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3efc194cb82cd74060cd433792873524",
+    "content-hash": "995595368021b9c25c1a1a698dde4e89",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -2486,63 +2486,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Earn income by allowing Jetpack to display high quality ads.",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-yoast-promo",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/yoast-promo",
-                "reference": "0f3490046a7dff56fac273f0dbf931f735c3df69"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "yoast/phpunit-polyfills": "1.0.4"
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "mirror-repo": "Automattic/jetpack-yoast-promo",
-                "changelogger": {
-                    "link-template": "https://github.com/automattic/jetpack-yoast-promo/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
-                },
-                "textdomain": "jetpack-yoast-promo",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-yoast-promo.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "watch": [
-                    "Composer\\Config::disableProcessTimeout",
-                    "pnpm run watch"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Components used to promote Yoast as part of our collaboration",
             "transport-options": {
                 "relative": true
             }
@@ -5433,7 +5376,6 @@
         "automattic/jetpack-videopress": 20,
         "automattic/jetpack-waf": 20,
         "automattic/jetpack-wordads": 20,
-        "automattic/jetpack-yoast-promo": 20,
         "automattic/jetpack-changelogger": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
## Proposed changes:

Disable the Yoast Promo callouts until they're ready for prime-time.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pbNhbs-4KT-p2
* p1679696188498809-slack-C01264051NE

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Traffic
    * You should not see any Yoast callout when looking at the SEO tab.
* Go to Posts > Add new
* Start writing a post and save your changes
* Hit Publish
    * You should not see any Yoast callout in the pre-publish panel.

