### PR TITLE
SEO: add The SEO Framework to admin UI conflicting list

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -49,6 +49,10 @@ export const conflictingSeoPluginsList = [
 		name: 'SEOKEY Pro',
 		slug: 'seo-key-pro/seo-key.php',
 	},
+	{
+		name: 'The SEO Framework',
+		slug: 'autodescription/autodescription.php',
+	},
 ];
 
 export const SEO = withModuleSettingsFormHelpers(

--- a/projects/plugins/jetpack/changelog/add-seo-framework-conflicting-plugins
+++ b/projects/plugins/jetpack/changelog/add-seo-framework-conflicting-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+SEO Tools: add message to settings screen when The SEO Framework plugin is active.


### PR DESCRIPTION
See #29643

## Proposed changes:

Disable the SEO Settings UI when The SEO Framework plugin is active.

<img width="1092" alt="Screenshot 2023-03-27 at 18 43 25" src="https://user-images.githubusercontent.com/426388/228008597-97a7e4c9-4853-452a-b510-927847d8226f.png">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Plugins > Add New
* Install and activate The SEO Framework
* Go to Jetpack > Settings > Traffic
* Scroll down to the SEO settings.
* You should see a banner showing you that the Jetpack settings aren't available.

