### PR TITLE
Protect: Add missing documentation for $ip variable

### DIFF
--- a/projects/plugins/jetpack/changelog/add-missing-doc-parameter-protect
+++ b/projects/plugins/jetpack/changelog/add-missing-doc-parameter-protect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Protect: update documentation for filter.

--- a/projects/plugins/jetpack/modules/protect.php
+++ b/projects/plugins/jetpack/modules/protect.php
@@ -614,7 +614,8 @@ class Jetpack_Protect_Module {
 		 *
 		 * @since 4.4.0
 		 *
-		 * @param bool false Should we allow all logins for the current ip? Default: false
+		 * @param bool false    Should we allow all logins for the current ip? Default: false
+		 * @param string $ip    IP address we are validating.
 		 */
 		if ( apply_filters( 'jpp_allow_login', false, $ip ) ) {
 			return true;


### PR DESCRIPTION
Replay of #21217

## Proposed changes:

Filter `jpp_allow_login` actually accepts two variables (boolean and ip address), and IP address is currently missing from the documentation.
As this variable is currently undocumented, [current publicly available documentation](https://developer.jetpack.com/hooks/jpp_allow_login/) is also misleading.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here.
