### PR TITLE
CRM: Resolves 3026 - move package data folder

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3026-move_package_data_folder
+++ b/projects/plugins/crm/changelog/fix-crm-3026-move_package_data_folder
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+OAuth: dependencies are now downloaded to wp-content/jpcrm-storage/packages

--- a/projects/plugins/crm/includes/class-package-installer.php
+++ b/projects/plugins/crm/includes/class-package-installer.php
@@ -30,34 +30,39 @@ class Package_Installer {
 	/*
 	* Init
 	*/
-	public function __construct( ) {
+	public function __construct() { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
+
+		$root_storage_info = jpcrm_storage_dir_info();
+
+		if ( ! $root_storage_info ) {
+			throw new Exception( 'Jetpack CRM data folder could not be created!' );
+		}
 
 		// set $package_dir
-		$this->package_dir = dirname( ZEROBSCRM_PATH ) . '/jpcrm-data/packages/';
+		$this->package_dir = $root_storage_info['path'] . '/packages/';
 
 		// define packages
 		$this->packages = array(
 
-					'oauth_dependencies' => array(
+			'oauth_dependencies' => array(
 
-						'title'              => __( 'OAuth Connection dependencies', 'zero-bs-crm' ),
-						'version'            => 1.0,
-						'target_dir'         => $this->package_dir,
-						'install_method'     => 'unzip',
-						'post_install_call'  => '',
+				'title'             => __( 'OAuth Connection dependencies', 'zero-bs-crm' ),
+				'version'           => 1.0,
+				'target_dir'        => $this->package_dir,
+				'install_method'    => 'unzip',
+				'post_install_call' => '',
 
-					)
+			),
 
 		);
 
 		// does the working directory exist? If not create
-		if ( !file_exists( $this->package_dir ) ){ 
-			
+		if ( ! file_exists( $this->package_dir ) ) {
+
 			wp_mkdir_p( $this->package_dir );
-			//chmod( $this->package_dir, 0777 );
 
 			// double check
-			if ( !file_exists( $this->package_dir ) ){ 
+			if ( ! file_exists( $this->package_dir ) ) {
 
 				// we're going to struggle to install packages
 				// Add admin notification
@@ -66,11 +71,8 @@ class Package_Installer {
 			} else {
 				jpcrm_create_and_secure_dir_from_external_access( $this->package_dir, true );
 			}
-
 		}
-
 	}
-
 
 	/*
 	* Returns a list of packages available via our CDN


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3026 - move package data folder

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Dependencies (e.g. OAuth) are now downloaded to `wp-content/jpcrm-storage/packages` instead of `wp-content/plugins/jpcrm-data`.

I did not bother with a deletion of the old folder, as theoretically it could have been modified by the user.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In `fix/crm/3026-move_package_data_folder`:

* Go to `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=oauth`
* Create an OAuth connection
* Verify it connects
* Verify the `/wp-content/jpcrm-storage/packages/oauth_dependencies` folder was created
* Verify OAuth shows as installed at the bottom of the System Status page: `/wp-admin/admin.php?page=zerobscrm-systemstatus&tab=status`