### PR TITLE
My Jetpack: Add Jetpack Golden Token tooltip to plan area

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1645,6 +1645,9 @@ importers:
       '@wordpress/data':
         specifier: 8.5.0
         version: 8.5.0(react@18.2.0)
+      '@wordpress/date':
+        specifier: 4.28.0
+        version: 4.28.0
       '@wordpress/element':
         specifier: 5.5.0
         version: 5.5.0
@@ -12750,7 +12753,7 @@ packages:
   /axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -15953,6 +15956,15 @@ packages:
       tabbable: 5.3.3
     dev: false
 
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -15963,6 +15975,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
+    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}

--- a/projects/packages/my-jetpack/_inc/components/golden-token/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/golden-token/index.jsx
@@ -4,6 +4,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useCallback, useRef, useState } from 'react';
+import { includesLifetimePurchase } from '../../utils/is-lifetime-purchase';
 import styles from './styles.module.scss';
 
 /**
@@ -29,10 +30,7 @@ function GoldenTokenModal( {
 
 	const ScanIcon = getIconBySlug( 'scan' );
 	const VaultPressBackupIcon = getIconBySlug( 'backup' );
-
-	// Any purchase with the partner_slug of 'goldenticket' is considered a golden token.
-	const goldenToken = purchases.filter( golden => golden.partner_slug === 'goldenticket' );
-	const hasGoldenToken = goldenToken.length > 0;
+	const hasGoldenToken = includesLifetimePurchase( purchases );
 
 	const redeemClickHandler = useCallback(
 		e => {

--- a/projects/packages/my-jetpack/_inc/components/golden-token/tooltip/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/golden-token/tooltip/index.jsx
@@ -1,0 +1,70 @@
+import { Button, JetpackIcon } from '@automattic/jetpack-components';
+import { Popover } from '@wordpress/components';
+import { dateI18n } from '@wordpress/date';
+import { __, sprintf } from '@wordpress/i18n';
+import classNames from 'classnames';
+import { useCallback, useState } from 'react';
+import styles from './style.module.scss';
+import './style.global.scss';
+
+/**
+ * Golden Token Tooltip.
+ *
+ * This is a rather quick port of the <IconTooltip> Jetpack component.
+ * We created this one because <IconTooltip> is (at the time of writing)
+ * hardcoded to only support Grid icons, and we're on a rather tight deadline.
+ *
+ * @param {object} props - Component properties.
+ * @param {string} props.productName - A product/plan name.
+ * @param {string} props.giftedDate - The date the product/plan was gifted.
+ * @returns {object} - A Golden Token Tooltip.
+ */
+export function GoldenTokenTooltip( { productName, giftedDate } ) {
+	const [ isVisible, setIsVisible ] = useState( false );
+	const showTooltip = useCallback( () => setIsVisible( true ), [ setIsVisible ] );
+	const hideTooltip = useCallback( () => setIsVisible( false ), [ setIsVisible ] );
+
+	const popoverArgs = {
+		position: 'top center',
+		placement: 'top',
+		animate: true,
+		noArrow: false,
+		resize: false,
+		flip: false,
+		offset: 6, // The distance (in px) between the anchor and the popover.
+		focusOnMount: 'container',
+		onClose: hideTooltip,
+		className: styles.container,
+	};
+
+	const wrapperClassNames = classNames( styles.wrapper, 'golden-token-icon-tooltip' );
+
+	return (
+		<div className={ wrapperClassNames }>
+			<Button variant="link" onClick={ showTooltip }>
+				<JetpackIcon className={ styles.logo } />
+			</Button>
+
+			<div className={ styles.helper }>
+				{ isVisible && (
+					<Popover { ...popoverArgs }>
+						<div>
+							<div className={ styles.title }>{ productName }</div>
+							<div className={ styles.content }>
+								{ sprintf(
+									// translators: %1$s is a product name, %2$s is the date the product was gifted.
+									__(
+										'%1$s was gifted on %2$s. It gives you access to a lifetime subscription of Jetpack VaultPress Backup and Jetpack Scan.',
+										'jetpack-my-jetpack'
+									),
+									productName,
+									dateI18n( 'F j, Y', giftedDate )
+								) }
+							</div>
+						</div>
+					</Popover>
+				) }
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/my-jetpack/_inc/components/golden-token/tooltip/style.global.scss
+++ b/projects/packages/my-jetpack/_inc/components/golden-token/tooltip/style.global.scss
@@ -1,0 +1,70 @@
+@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
+@import '@automattic/jetpack-base-styles/style';
+
+$arrow-color: var( --jp-gray );
+
+// Fix arrow color
+.components-popover:not(.is-without-arrow)::before {
+	border-color: $arrow-color;
+}
+
+// Namespace to avoid overriding global styles
+.golden-token-icon-tooltip {
+	/*
+	* Fix arrow placement - section start
+	*/
+	.components-popover:not([data-y-axis=middle])[data-x-axis=left] .components-popover__content {
+		margin-right: -62px;
+	}
+
+	.components-popover:not([data-y-axis=middle])[data-x-axis=right] .components-popover__content {
+		margin-left: -62px;
+	}
+	/*
+	* Fix arrow placement - section end
+	*/
+
+	/*
+	* Fix arrow position for legacy position option - section start
+	*/
+	.components-popover[data-y-axis=bottom] .components-popover__content {
+		top: 2px !important;
+	}
+
+	.components-popover:not(.is-without-arrow)[data-y-axis=bottom]::before {
+		top: -6px !important;
+	}
+
+	.components-popover:not(.is-without-arrow)[data-y-axis=bottom]::after {
+		top: -4px !important;
+	}
+
+	.components-popover[data-y-axis=top] .components-popover__content {
+		bottom: 10px !important;
+	}
+
+	.components-popover:not(.is-without-arrow)[data-y-axis=top]::before {
+		bottom: 3px;
+	}
+
+	.components-popover:not(.is-without-arrow)[data-y-axis=top]::after {
+		bottom: 4px;
+	}
+	/*
+	* Fix arrow position for legacy position option - section end
+	*/
+
+	.components-popover__content {
+		padding: 24px;
+		width: 304px;
+		white-space: normal;
+		border-radius: 4px;
+		outline: none;
+		border: 1px solid $arrow-color;
+	}
+
+
+	.components-button.is-link:focus:not(:disabled) {
+		box-shadow: none;
+	}
+}

--- a/projects/packages/my-jetpack/_inc/components/golden-token/tooltip/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/golden-token/tooltip/style.module.scss
@@ -1,0 +1,45 @@
+@import '@automattic/jetpack-base-styles/style';
+
+.logo {
+	fill: var(--jp-yellow-30) !important;
+	width: 1.1em !important;
+	display: inline-block !important;
+}
+
+.wrapper {
+	display: inline-block;
+	position: relative;
+}
+
+.helper {
+	// POPOVER_HELPER_WIDTH
+	width: 124px;
+	height: 18px;
+	position: absolute;
+	top: 0;
+	// -( POPOVER_HELPER_WIDTH / 2 - iconSize / 2 ) + 'px'
+	left: -53px;
+	pointer-events: none;
+}
+
+.container {
+	// Recover events
+	pointer-events: all;
+}
+
+.title {
+	font-weight: 600;
+	font-size: 16px;
+	line-height: 19px;
+	color: var( --jp-black );
+
+	&:not(:last-child) {
+		margin-bottom: 8px;
+	}
+}
+
+.content {
+	font-weight: 400;
+	font-size: 14px;
+	line-height: 24px;
+}

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -7,6 +7,8 @@ import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import usePurchases from '../../hooks/use-purchases';
 import getManageYourPlanUrl from '../../utils/get-manage-your-plan-url';
 import getPurchasePlanUrl from '../../utils/get-purchase-plan-url';
+import { isLifetimePurchase } from '../../utils/is-lifetime-purchase';
+import { GoldenTokenTooltip } from '../golden-token/tooltip';
 import styles from './style.module.scss';
 
 /**
@@ -17,14 +19,43 @@ import styles from './style.module.scss';
  * @returns {object} PlanSection react component.
  */
 function PlanSection( { purchase = {} } ) {
-	const { product_name, expiry_message } = purchase;
+	const { product_name } = purchase;
 	return (
 		<>
 			<Title>{ product_name }</Title>
-			<Text variant="body" className={ styles[ 'expire-date' ] }>
-				{ expiry_message }
-			</Text>
+			<PlanExpiry { ...purchase } />
 		</>
+	);
+}
+
+/**
+ * Plan expiry component.
+ *
+ * @param {object} purchase - WPCOM purchase object.
+ * @param {string} purchase.product_name - A product name.
+ * @param {string} purchase.subscribed_date - A subscribed date.
+ * @param {string} purchase.expiry_message - An expiry message.
+ * @param {string} purchase.partner_slug - A partner that issued the purchase.
+ * @returns {object} - A plan expiry component.
+ */
+function PlanExpiry( purchase ) {
+	const { expiry_message, product_name, subscribed_date } = purchase;
+
+	if ( isLifetimePurchase( purchase ) ) {
+		return (
+			<Text variant="body" className={ styles[ 'expire-date' ] }>
+				<span className={ styles[ 'expire-date--with-icon' ] }>
+					{ __( 'Never Expires', 'jetpack-my-jetpack' ) }
+				</span>
+				<GoldenTokenTooltip productName={ product_name } giftedDate={ subscribed_date } />
+			</Text>
+		);
+	}
+
+	return (
+		<Text variant="body" className={ styles[ 'expire-date' ] }>
+			{ expiry_message }
+		</Text>
 	);
 }
 

--- a/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/style.module.scss
@@ -6,6 +6,11 @@
 
 .expire-date {
 	margin-bottom: calc( var(--spacing-base ) * 3 );
+	display: flex;
+
+	&--with-icon {
+		margin-right: 8px;
+	}
 }
 
 .actions-list-item {

--- a/projects/packages/my-jetpack/_inc/utils/is-lifetime-purchase.js
+++ b/projects/packages/my-jetpack/_inc/utils/is-lifetime-purchase.js
@@ -2,15 +2,16 @@
  * Check if a purchase is considered "Lifetime".
  *
  * @param {object} purchase - A WPCOM purchase object.
+ * @param {string} purchase.partner_slug - A partner that issued the purchase.
  * @returns {boolean} Returns true if a purchase is considered a lifetime purchase.
  */
-export function isLifetimePurchase( purchase ) {
-	if ( typeof purchase !== 'object' || ! purchase.hasOwnProperty( 'partner_slug' ) ) {
+export function isLifetimePurchase( { partner_slug } ) {
+	if ( ! partner_slug ) {
 		return false;
 	}
 
 	// Any purchase with the partner_slug of 'goldenticket' is considered a golden token.
-	return purchase.partner_slug === 'goldenticket';
+	return partner_slug === 'goldenticket';
 }
 
 /**

--- a/projects/packages/my-jetpack/_inc/utils/is-lifetime-purchase.js
+++ b/projects/packages/my-jetpack/_inc/utils/is-lifetime-purchase.js
@@ -1,0 +1,28 @@
+/**
+ * Check if a purchase is considered "Lifetime".
+ *
+ * @param {object} purchase - A WPCOM purchase object.
+ * @returns {boolean} Returns true if a purchase is considered a lifetime purchase.
+ */
+export function isLifetimePurchase( purchase ) {
+	if ( typeof purchase !== 'object' || ! purchase.hasOwnProperty( 'partner_slug' ) ) {
+		return false;
+	}
+
+	// Any purchase with the partner_slug of 'goldenticket' is considered a golden token.
+	return purchase.partner_slug === 'goldenticket';
+}
+
+/**
+ * Look for a lifetime purchase in an array of purchases.
+ *
+ * @param {Array} purchases - An array of WPCOM purchase objects.
+ * @returns {boolean} Returns true if one of the purchase is considered a lifetime purchase.
+ */
+export function includesLifetimePurchase( purchases ) {
+	if ( ! Array.isArray( purchases ) ) {
+		return false;
+	}
+
+	return purchases.filter( purchase => isLifetimePurchase( purchase ) ).length > 0;
+}

--- a/projects/packages/my-jetpack/changelog/update-add-golden-token-tooltip
+++ b/projects/packages/my-jetpack/changelog/update-add-golden-token-tooltip
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: My Jetpack: Add Jetpack Golden Token expiration tooltip to explain why it says never expires
+
+

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/api-fetch": "6.25.0",
 		"@wordpress/components": "23.5.0",
 		"@wordpress/data": "8.5.0",
+		"@wordpress/date": "4.28.0",
 		"@wordpress/element": "5.5.0",
 		"@wordpress/i18n": "4.28.0",
 		"@wordpress/icons": "9.19.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add a Jetpack Golden Token tooltip to the My Jetpack > My Plan area to explain why it says "Never Expires".

Fixes #29655

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Generalise some of the "this is a golden token" logic that already exists in the My Jetpack package
* Add a new Golden Token tooltip component
  * This component is a close copy to the `<IconTooltip>` that already exists, but it only supports Grid Icons. The reason we copy it is that it will take longer to expand the IconTooltip component to accept custom icons and we're on a deadline which is why the "fast" argument wins.
* Update the `<PlanSection>` component that is currently responsible for displaying the My Jetpack plan.
* _Add `@wordpress/date` dependency to My Jetpack so we can use `dateI18n` to display a well formatted "gifted" date_

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

* p1HpG7-lga-p2
* p1HpG7-ljt-p2
* p1HpG7-lpL-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a site using this branch (either locally or JN)
* Connect the site to your WPCOM user account
* Use the jetpack/golden-token MC tool to give the site a "Golden Token" (2f939-pb)
* Go to `/wp-admin/admin.php?page=my-jetpack`
* Verify that the Jetpack Golden Token tooltip appears and that the Golden Token icon opens the tooltip
  * Clicking outside the container will close the tooltip again (default behaviour borrowed from other tooltips we use)

## Screenshot(s)

### Closed tooltip
![Screenshot 2023-03-28 at 01 45 06](https://user-images.githubusercontent.com/3846700/228091911-3213ac7e-d00c-4ec3-86b8-6b97dbb3d345.png)

### Opened tooltip

![Screenshot 2023-03-28 at 01 44 55](https://user-images.githubusercontent.com/3846700/228091920-a77a71cd-2322-4d37-85db-a671d64bdc00.png)
