### PR TITLE
Jetpack Social: Enable SIG by default when it is available

### DIFF
--- a/projects/packages/publicize/changelog/change-jetpack-social-enable-sig-by-default
+++ b/projects/packages/publicize/changelog/change-jetpack-social-enable-sig-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack Social: Enable Social Image Generator by default when it's available.

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -40,11 +40,7 @@ class Publicize_Setup {
 		// Adding on a higher priority to make sure we're the first field registered.
 		// The priority parameter can be removed once we deprecate WPCOM_REST_API_V2_Post_Publicize_Connections_Field
 		add_action( 'rest_api_init', array( new Connections_Post_Field(), 'register_fields' ), 5 );
-
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
-		add_action( 'rest_api_init', array( new Social_Image_Generator\REST_Settings_Controller(), 'register_routes' ) );
-
-		add_action( 'rest_api_init', array( new Social_Image_Generator\REST_Token_Controller(), 'register_routes' ) );
 
 		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
 

--- a/projects/packages/publicize/src/social-image-generator/class-settings.php
+++ b/projects/packages/publicize/src/social-image-generator/class-settings.php
@@ -26,6 +26,13 @@ class Settings {
 	public $settings;
 
 	/**
+	 * True if the SIG feature is available.
+	 *
+	 * @var bool $available;
+	 */
+	public $available;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -62,12 +69,44 @@ class Settings {
 	}
 
 	/**
+	 * Check if SIG is available.
+	 *
+	 * @return bool True if SIG is available, false otherwise.
+	 */
+	public function is_available() {
+		if ( isset( $this->available ) ) {
+			return $this->available;
+		}
+
+		global $publicize;
+
+		if ( ! $publicize ) {
+			$this->available = false;
+
+			return $this->available;
+		}
+
+		$this->available = $publicize->has_social_image_generator_feature();
+
+		return $this->available;
+	}
+
+	/**
 	 * Check if SIG is enabled.
 	 *
 	 * @return bool True if SIG is enabled, false otherwise.
 	 */
 	public function is_enabled() {
-		return ! empty( $this->settings['enabled'] );
+		// If the feature isn't available it should never be enabled.
+		if ( ! $this->is_available() ) {
+			return false;
+		}
+
+		if ( isset( $this->settings['enabled'] ) ) {
+			return $this->settings['enabled'];
+		}
+
+		return true;
 	}
 
 	/**

--- a/projects/packages/publicize/src/social-image-generator/class-settings.php
+++ b/projects/packages/publicize/src/social-image-generator/class-settings.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Publicize\Social_Image_Generator;
 
+use Automattic\Jetpack\Modules;
+
 /**
  * This class is used to get and update SIG-specific global settings.
  */
@@ -84,6 +86,11 @@ class Settings {
 	public function is_enabled() {
 		// If the feature isn't available it should never be enabled.
 		if ( ! $this->is_available() ) {
+			return false;
+		}
+
+		// SIG cannot be enabled without Publicize.
+		if ( ! ( new Modules() )->is_active( 'publicize' ) ) {
 			return false;
 		}
 

--- a/projects/packages/publicize/src/social-image-generator/class-settings.php
+++ b/projects/packages/publicize/src/social-image-generator/class-settings.php
@@ -26,13 +26,6 @@ class Settings {
 	public $settings;
 
 	/**
-	 * True if the SIG feature is available.
-	 *
-	 * @var bool $available;
-	 */
-	public $available;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -74,21 +67,13 @@ class Settings {
 	 * @return bool True if SIG is available, false otherwise.
 	 */
 	public function is_available() {
-		if ( isset( $this->available ) ) {
-			return $this->available;
-		}
-
 		global $publicize;
 
 		if ( ! $publicize ) {
-			$this->available = false;
-
-			return $this->available;
+			return false;
 		}
 
-		$this->available = $publicize->has_social_image_generator_feature();
-
-		return $this->available;
+		return $publicize->has_social_image_generator_feature();
 	}
 
 	/**

--- a/projects/packages/publicize/src/social-image-generator/class-setup.php
+++ b/projects/packages/publicize/src/social-image-generator/class-setup.php
@@ -15,10 +15,16 @@ class Setup {
 	 * Initialise SIG-related functionality.
 	 */
 	public function init() {
+		if ( ! ( new Settings() )->is_available() ) {
+			return;
+		}
+
 		// Be wary of any code that you add to this file, since this function is called on plugin load.
 		// We're using the `wp_after_insert_post` hook because we need access to the updated post meta. By using the default priority
 		// of 10 we make sure that our code runs before Sync processes the post.
 		add_action( 'wp_after_insert_post', array( $this, 'set_meta' ), 10, 2 );
+		add_action( 'rest_api_init', array( new REST_Settings_Controller(), 'register_routes' ) );
+		add_action( 'rest_api_init', array( new REST_Token_Controller(), 'register_routes' ) );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-rest-settings-controller.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-rest-settings-controller.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Current_Plan;
 use WorDBless\BaseTestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
@@ -42,6 +43,10 @@ class REST_Settings_Controller_Test extends BaseTestCase {
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
 
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array( 'social-image-generator' );
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+
 		global $wp_rest_server;
 
 		$wp_rest_server = new WP_REST_Server();
@@ -73,6 +78,10 @@ class REST_Settings_Controller_Test extends BaseTestCase {
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
+
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array();
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-rest-settings-controller.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-rest-settings-controller.php
@@ -46,6 +46,7 @@ class REST_Settings_Controller_Test extends BaseTestCase {
 		$plan                       = Current_Plan::PLAN_DATA['free'];
 		$plan['features']['active'] = array( 'social-image-generator' );
 		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+		add_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );
 
 		global $wp_rest_server;
 
@@ -75,6 +76,8 @@ class REST_Settings_Controller_Test extends BaseTestCase {
 	public function tear_down() {
 		wp_set_current_user( 0 );
 
+		remove_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );
+
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
@@ -85,13 +88,22 @@ class REST_Settings_Controller_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Mock Publicize being active.
+	 *
+	 * @return array
+	 */
+	public function mock_publicize_being_active() {
+		return array( 'publicize' );
+	}
+
+	/**
 	 * Testing the `GET /jetpack/v4/social-image-generator/settings` endpoint without proper permissions.
 	 */
 	public function test_get_settings_without_proper_permission() {
 		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/social-image-generator/settings' );
 		$response = $this->server->dispatch( $request );
-		$this->assertequals( 401, $response->get_status() );
-		$this->assertequals( 'rest_forbidden_context', $response->get_data()['code'] );
+		$this->assertEquals( 401, $response->get_status() );
+		$this->assertEquals( 'rest_forbidden_context', $response->get_data()['code'] );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-settings.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-settings.php
@@ -11,6 +11,9 @@ use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Publicize\Social_Image_Generator\Settings;
 use Automattic\Jetpack\Publicize\Social_Image_Generator\Templates;
 use WorDBless\BaseTestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Posts as WorDBless_Posts;
+use WorDBless\Users as WorDBless_Users;
 
 /**
  * Testing the Settings class.
@@ -29,6 +32,7 @@ class Settings_Test extends BaseTestCase {
 	 * @before
 	 */
 	public function set_up() {
+		add_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );
 		global $publicize_ui;
 		if ( ! isset( $publicize_ui ) ) {
 			$publicize_ui = new Publicize_UI();
@@ -46,9 +50,22 @@ class Settings_Test extends BaseTestCase {
 	 * @after
 	 */
 	public function tear_down() {
+		remove_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );
 		$plan                       = Current_Plan::PLAN_DATA['free'];
 		$plan['features']['active'] = array();
 		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Posts::init()->clear_all_posts();
+		WorDBless_Users::init()->clear_all_users();
+	}
+
+	/**
+	 * Mock Publicize being active.
+	 *
+	 * @return array
+	 */
+	public function mock_publicize_being_active() {
+		return array( 'publicize' );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-settings.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-settings.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Publicize\Social_Image_Generator\Settings;
 use Automattic\Jetpack\Publicize\Social_Image_Generator\Templates;
 use WorDBless\BaseTestCase;
@@ -24,24 +25,53 @@ class Settings_Test extends BaseTestCase {
 
 	/**
 	 * Initialize tests
+	 *
+	 * @before
 	 */
 	public function set_up() {
+		global $publicize_ui;
+		if ( ! isset( $publicize_ui ) ) {
+			$publicize_ui = new Publicize_UI();
+		}
+		global $publicize;
+
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array( 'social-image-generator' );
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
 		$this->settings = new Settings();
+	}
+
+	/**
+	 * Tear down
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array();
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+	}
+
+	/**
+	 * Test that SIG is available based on the plan check.
+	 */
+	public function test_correctly_returns_available_status() {
+		$this->assertTrue( $this->settings->is_available() );
 	}
 
 	/**
 	 * Test that it correctly returns enabled or disabled.
 	 */
 	public function test_correctly_returns_enabled_status() {
-		$this->assertFalse( $this->settings->is_enabled() );
+		$this->assertTrue( $this->settings->is_enabled() );
 	}
 
 	/**
 	 * Test that it correctly updates the enabled status.
 	 */
 	public function test_correctly_updates_enabled_status() {
-		$this->settings->set_enabled( true );
-		$this->assertTrue( $this->settings->is_enabled() );
+		$this->settings->set_enabled( false );
+		$this->assertFalse( $this->settings->is_enabled() );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-settings.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-settings.php
@@ -33,7 +33,6 @@ class Settings_Test extends BaseTestCase {
 		if ( ! isset( $publicize_ui ) ) {
 			$publicize_ui = new Publicize_UI();
 		}
-		global $publicize;
 
 		$plan                       = Current_Plan::PLAN_DATA['free'];
 		$plan['features']['active'] = array( 'social-image-generator' );

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-setup.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-setup.php
@@ -33,6 +33,7 @@ class Setup_Test extends BaseTestCase {
 		$plan                       = Current_Plan::PLAN_DATA['free'];
 		$plan['features']['active'] = array( 'social-image-generator' );
 		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+		add_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );
 		$this->sig = new Social_Image_Generator\Setup();
 		$this->sig->init();
 		// Mock site connection.
@@ -45,6 +46,7 @@ class Setup_Test extends BaseTestCase {
 	 * Returning the environment into its initial state.
 	 */
 	public function tear_down() {
+		remove_filter( 'jetpack_active_modules', array( $this, 'mock_publicize_being_active' ) );
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 		unset( $_SERVER['REQUEST_METHOD'] );
@@ -52,6 +54,15 @@ class Setup_Test extends BaseTestCase {
 		$plan                       = Current_Plan::PLAN_DATA['free'];
 		$plan['features']['active'] = array();
 		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+	}
+
+	/**
+	 * Mock Publicize being active.
+	 *
+	 * @return array
+	 */
+	public function mock_publicize_being_active() {
+		return array( 'publicize' );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/test-social-image-generator/test-setup.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/test-setup.php
@@ -30,13 +30,11 @@ class Setup_Test extends BaseTestCase {
 	 * Setting up the test.
 	 */
 	public function set_up() {
-		// Enable the feature
-		( new Social_Image_Generator\Settings() )->set_enabled( true );
-		$this->sig = new Social_Image_Generator\Setup();
-		$this->sig->init();
 		$plan                       = Current_Plan::PLAN_DATA['free'];
 		$plan['features']['active'] = array( 'social-image-generator' );
 		update_option( Current_Plan::PLAN_OPTION, $plan, true );
+		$this->sig = new Social_Image_Generator\Setup();
+		$this->sig->init();
 		// Mock site connection.
 		( new Tokens() )->update_blog_token( 'test.test' );
 		Jetpack_Options::update_option( 'id', 123 );
@@ -50,7 +48,10 @@ class Setup_Test extends BaseTestCase {
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 		unset( $_SERVER['REQUEST_METHOD'] );
-		$_GET = array();
+		$_GET                       = array();
+		$plan                       = Current_Plan::PLAN_DATA['free'];
+		$plan['features']['active'] = array();
+		update_option( Current_Plan::PLAN_OPTION, $plan, true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/change-jetpack-social-enable-sig-by-default
+++ b/projects/plugins/jetpack/changelog/change-jetpack-social-enable-sig-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack Social: Enable Social Image Generator by default when it is available

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -747,7 +747,7 @@ class Jetpack_Gutenberg {
 				'sharesData'                    => $publicize->get_publicize_shares_info( $blog_id ),
 				'hasPaidPlan'                   => $publicize->has_paid_plan(),
 				'isEnhancedPublishingEnabled'   => $publicize->is_enhanced_publishing_enabled( $blog_id ),
-				'isSocialImageGeneratorEnabled' => $publicize->has_social_image_generator_feature() && ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
+				'isSocialImageGeneratorEnabled' => ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
 			);
 		}
 

--- a/projects/plugins/social/changelog/change-jetpack-social-enable-sig-by-default
+++ b/projects/plugins/social/changelog/change-jetpack-social-enable-sig-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack Social: Enable Social Image Generator by default when it's available.

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -228,6 +228,8 @@ class Jetpack_Social {
 		);
 
 		if ( $this->is_connected() ) {
+			$sig_settings = new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings();
+
 			$state = array_merge(
 				$state,
 				array(
@@ -242,9 +244,9 @@ class Jetpack_Social {
 					),
 					'sharesData'                   => $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) ),
 					'socialImageGeneratorSettings' => array(
-						'available'       => $publicize->has_social_image_generator_feature(),
-						'enabled'         => ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
-						'defaultTemplate' => ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->get_default_template(),
+						'available'       => $sig_settings->is_available(),
+						'enabled'         => $sig_settings->is_enabled(),
+						'defaultTemplate' => $sig_settings->get_default_template(),
 					),
 				)
 			);
@@ -323,7 +325,7 @@ class Jetpack_Social {
 					),
 					'hasPaidPlan'                   => $publicize->has_paid_plan(),
 					'isEnhancedPublishingEnabled'   => $publicize->is_enhanced_publishing_enabled( Jetpack_Options::get_option( 'id' ) ),
-					'isSocialImageGeneratorEnabled' => $publicize->has_social_image_generator_feature() && ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
+					'isSocialImageGeneratorEnabled' => ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
 				),
 			)
 		);

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -24,6 +24,7 @@ const Admin = () => {
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 
 	const {
+		isModuleEnabled,
 		showPricingPage,
 		hasPaidPlan,
 		isShareLimitEnabled,
@@ -32,6 +33,7 @@ const Admin = () => {
 	} = useSelect( select => {
 		const store = select( STORE_ID );
 		return {
+			isModuleEnabled: store.isModuleEnabled(),
 			showPricingPage: store.showPricingPage(),
 			hasPaidPlan: store.hasPaidPlan(),
 			isShareLimitEnabled: store.isShareLimitEnabled(),
@@ -71,7 +73,7 @@ const Admin = () => {
 					</AdminSectionHero>
 					<AdminSection>
 						<SocialModuleToggle />
-						{ isSocialImageGeneratorAvailable && <SocialImageGeneratorToggle /> }
+						{ isModuleEnabled && isSocialImageGeneratorAvailable && <SocialImageGeneratorToggle /> }
 					</AdminSection>
 					<AdminSectionHero>
 						<InfoSection />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds a helper method to check if Social Image Generator is available (by checking if it's present in the plan) and enables SIG by default if it is available.

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site with Jetpack Social.
* Check that the toggle is not present on the Jetpack Social admin page.
* Make SIG available on the site.
* Refresh the Jetpack Social admin page and make sure the toggle is present and toggled on.
* Toggle SIG off.
* Refresh the page and make sure it's still toggled off.
