### PR TITLE
Add support for wp_block, wp_navigation, wp_template, wp_template_part import

### DIFF
--- a/projects/packages/import/changelog/add-import-package-custom-posts
+++ b/projects/packages/import/changelog/add-import-package-custom-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for wp_block, wp_navigation, wp_template, wp_template_part import.

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -65,16 +65,20 @@ class Main {
 		Rest_Authentication::init();
 
 		$routes = array(
-			'categories'    => new Endpoints\Category(),
-			'comments'      => new Endpoints\Comment(),
-			'custom-css'    => new Endpoints\Custom_CSS(),
-			'global-styles' => new Endpoints\Global_Style(),
-			'media'         => new Endpoints\Attachment(),
-			'menu-items'    => new Endpoints\Menu_Item(),
-			'menus'         => new Endpoints\Menu(),
-			'pages'         => new Endpoints\Page(),
-			'posts'         => new Endpoints\Post(),
-			'tags'          => new Endpoints\Tag(),
+			'blocks'         => new Endpoints\Block(),
+			'categories'     => new Endpoints\Category(),
+			'comments'       => new Endpoints\Comment(),
+			'custom-css'     => new Endpoints\Custom_CSS(),
+			'global-styles'  => new Endpoints\Global_Style(),
+			'media'          => new Endpoints\Attachment(),
+			'menu-items'     => new Endpoints\Menu_Item(),
+			'menus'          => new Endpoints\Menu(),
+			'navigation'     => new Endpoints\Navigation(),
+			'pages'          => new Endpoints\Page(),
+			'posts'          => new Endpoints\Post(),
+			'tags'           => new Endpoints\Tag(),
+			'templates'      => new Endpoints\Template(),
+			'template-parts' => new Endpoints\Template_Part(),
 		);
 
 		/**

--- a/projects/packages/import/src/endpoints/class-attachment.php
+++ b/projects/packages/import/src/endpoints/class-attachment.php
@@ -141,7 +141,6 @@ class Attachment extends \WP_REST_Attachments_Controller {
 	 * @return array Modified Schema array.
 	 */
 	public function add_additional_fields_schema( $schema ) {
-
 		// Validate the upload_date, used for placing the uploaded file in the correct upload directory.
 		$schema['properties']['upload_date'] = array(
 			'description' => __( 'The date for the upload directory of the attachment.', 'jetpack-import' ),

--- a/projects/packages/import/src/endpoints/class-block.php
+++ b/projects/packages/import/src/endpoints/class-block.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Blocks REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+/**
+ * Class Block
+ */
+class Block extends \WP_REST_Blocks_Controller {
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import;
+
+	/**
+	 * Whether the controller supports batching.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'wp_block' );
+	}
+}

--- a/projects/packages/import/src/endpoints/class-category.php
+++ b/projects/packages/import/src/endpoints/class-category.php
@@ -35,19 +35,6 @@ class Category extends \WP_REST_Terms_Controller {
 	}
 
 	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @see WP_REST_Terms_Controller::register_rest_route()
-	 */
-	public function register_routes() {
-		register_rest_route(
-			self::$rest_namespace,
-			'/categories',
-			$this->get_route_options()
-		);
-	}
-
-	/**
 	 * Adds the schema from additional fields to a schema array.
 	 *
 	 * The type of object is inferred from the passed schema.

--- a/projects/packages/import/src/endpoints/class-comment.php
+++ b/projects/packages/import/src/endpoints/class-comment.php
@@ -35,19 +35,6 @@ class Comment extends \WP_REST_Comments_Controller {
 	}
 
 	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @see WP_REST_Comments_Controller::register_rest_route()
-	 */
-	public function register_routes() {
-		register_rest_route(
-			self::$rest_namespace,
-			$this->rest_base,
-			$this->get_route_options()
-		);
-	}
-
-	/**
 	 * Creates a comment.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.

--- a/projects/packages/import/src/endpoints/class-comment.php
+++ b/projects/packages/import/src/endpoints/class-comment.php
@@ -41,6 +41,7 @@ class Comment extends \WP_REST_Comments_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or error object on failure.
 	 */
 	public function create_item( $request ) {
+		error_log( print_r( $request, true ) );
 		// Resolve comment post ID.
 		if ( ! empty( $request['post'] ) ) {
 			$posts = \get_posts( $this->get_import_db_query( $request['post'] ) );

--- a/projects/packages/import/src/endpoints/class-comment.php
+++ b/projects/packages/import/src/endpoints/class-comment.php
@@ -41,7 +41,6 @@ class Comment extends \WP_REST_Comments_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or error object on failure.
 	 */
 	public function create_item( $request ) {
-		error_log( print_r( $request, true ) );
 		// Resolve comment post ID.
 		if ( ! empty( $request['post'] ) ) {
 			$posts = \get_posts( $this->get_import_db_query( $request['post'] ) );

--- a/projects/packages/import/src/endpoints/class-custom-css.php
+++ b/projects/packages/import/src/endpoints/class-custom-css.php
@@ -36,19 +36,6 @@ class Custom_CSS extends \WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @see WP_REST_Posts_Controller::register_rest_route()
-	 */
-	public function register_routes() {
-		register_rest_route(
-			self::$rest_namespace,
-			'/' . $this->rest_base,
-			$this->get_route_options()
-		);
-	}
-
-	/**
 	 * Update the custom CSS post.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.

--- a/projects/packages/import/src/endpoints/class-global-style.php
+++ b/projects/packages/import/src/endpoints/class-global-style.php
@@ -37,19 +37,6 @@ class Global_Style extends \WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @see WP_REST_Posts_Controller::register_rest_route()
-	 */
-	public function register_routes() {
-		register_rest_route(
-			self::$rest_namespace,
-			'/' . $this->rest_base,
-			$this->get_route_options()
-		);
-	}
-
-	/**
 	 * Adds the schema from additional fields to a schema array.
 	 *
 	 * The type of object is inferred from the passed schema.

--- a/projects/packages/import/src/endpoints/class-menu-item.php
+++ b/projects/packages/import/src/endpoints/class-menu-item.php
@@ -35,19 +35,6 @@ class Menu_Item extends \WP_REST_Menu_Items_Controller {
 	}
 
 	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @see WP_REST_Terms_Controller::register_rest_route()
-	 */
-	public function register_routes() {
-		register_rest_route(
-			self::$rest_namespace,
-			'/menu-items',
-			$this->get_route_options()
-		);
-	}
-
-	/**
 	 * Adds the schema from additional fields to a schema array.
 	 *
 	 * The type of object is inferred from the passed schema.

--- a/projects/packages/import/src/endpoints/class-menu.php
+++ b/projects/packages/import/src/endpoints/class-menu.php
@@ -33,17 +33,4 @@ class Menu extends \WP_REST_Menus_Controller {
 		// @see add_term_meta
 		$this->import_id_meta_type = 'term';
 	}
-
-	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @see WP_REST_Terms_Controller::register_rest_route()
-	 */
-	public function register_routes() {
-		register_rest_route(
-			self::$rest_namespace,
-			'/menus',
-			$this->get_route_options()
-		);
-	}
 }

--- a/projects/packages/import/src/endpoints/class-navigation.php
+++ b/projects/packages/import/src/endpoints/class-navigation.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Navigation REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+/**
+ * Navigation Block
+ */
+class Navigation extends \WP_REST_Posts_Controller {
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import;
+
+	/**
+	 * Whether the controller supports batching.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'wp_navigation' );
+	}
+}

--- a/projects/packages/import/src/endpoints/class-page.php
+++ b/projects/packages/import/src/endpoints/class-page.php
@@ -20,19 +20,6 @@ class Page extends Post {
 	}
 
 	/**
-	 * Adds the schema from additional fields to a schema array.
-	 *
-	 * The type of object is inferred from the passed schema.
-	 *
-	 * @param array $schema Schema array.
-	 * @return array Modified Schema array.
-	 */
-	public function add_additional_fields_schema( $schema ) {
-		// Add the import unique ID to the schema.
-		return $this->add_unique_identifier_to_schema( $schema );
-	}
-
-	/**
 	 * Creates a single page.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -43,19 +43,6 @@ class Post extends \WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @see WP_REST_Posts_Controller::register_rest_route()
-	 */
-	public function register_routes() {
-		register_rest_route(
-			self::$rest_namespace,
-			'/' . $this->rest_base,
-			$this->get_route_options()
-		);
-	}
-
-	/**
 	 * Adds the schema from additional fields to a schema array.
 	 *
 	 * The type of object is inferred from the passed schema.

--- a/projects/packages/import/src/endpoints/class-tag.php
+++ b/projects/packages/import/src/endpoints/class-tag.php
@@ -33,17 +33,4 @@ class Tag extends \WP_REST_Terms_Controller {
 		// @see add_term_meta
 		$this->import_id_meta_type = 'term';
 	}
-
-	/**
-	 * Registers the routes for the objects of the controller.
-	 *
-	 * @see WP_REST_Terms_Controller::register_rest_route()
-	 */
-	public function register_routes() {
-		register_rest_route(
-			self::$rest_namespace,
-			'/tags',
-			$this->get_route_options()
-		);
-	}
 }

--- a/projects/packages/import/src/endpoints/class-template-part.php
+++ b/projects/packages/import/src/endpoints/class-template-part.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Template parts REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+/**
+ * Class Template_Part
+ */
+class Template_Part extends \WP_REST_Templates_Controller {
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import;
+
+	/**
+	 * Whether the controller supports batching.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'wp_template_part' );
+	}
+}

--- a/projects/packages/import/src/endpoints/class-template.php
+++ b/projects/packages/import/src/endpoints/class-template.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Templates REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+/**
+ * Class Template
+ */
+class Template extends \WP_REST_Templates_Controller {
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import;
+
+	/**
+	 * Whether the controller supports batching.
+	 *
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'wp_template' );
+	}
+
+	/**
+	 * Update the template post.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		$response = parent::create_item( $request );
+
+		return $this->add_import_id_metadata( $request, $response );
+	}
+}

--- a/projects/packages/import/src/endpoints/trait-import.php
+++ b/projects/packages/import/src/endpoints/trait-import.php
@@ -59,6 +59,19 @@ trait Import {
 	}
 
 	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @see WP_REST_Controller::register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::$rest_namespace,
+			'/' . $this->rest_base,
+			$this->get_route_options()
+		);
+	}
+
+	/**
 	 * Adds the unique identifier to the schema array.
 	 *
 	 * @param array $schema Schema array.


### PR DESCRIPTION
This diff adds support for importing four new custom post types:

1. `wp_block`
2. `wp_navigation`
3. `wp_template`
4. `wp_template_part`

Fixes https://github.com/Automattic/dotcom-forge/issues/2069

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add support for the missing post types.
* Remove the redundant call to `register_routes()` and move the method to the `Import` trait.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See D105908-code for details