### PR TITLE
CRM: Resolves 3027 - PHP notices on Email Template page if recipient does not exist

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3027-catch_php_notices
+++ b/projects/plugins/crm/changelog/fix-crm-3027-catch_php_notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Email: caught PHP notices if recipient was deleted

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1170,105 +1170,106 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
   Email History
    ====================================================== */
 
-function zeroBSCRM_outputEmailHistory($userID = -1){
+function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid,Squiz.Commenting.FunctionComment.Missing
 
 	global $zbs;
 
-	//get the last 50 (can add pagination later...)
-    $email_hist = zeroBSCRM_get_email_history(0,50, $userID); 
-    ?>
-    <style>
-    	.zbs-email-sending-record {
-    		margin-bottom:0.8em;
-    	}
-    	.zbs-email-sending-record .avatar{
-    		margin-left: 5px;
-    		border-radius: 50%;
-    	}
-    	.zbs-email-detail {
-		    width: 80%;
-		    display: inline-block;
-    	}
+	// get the last 50 (can add pagination later...)
+	$email_hist = zeroBSCRM_get_email_history( 0, 50, $user_id );
+	?>
+	<style>
+		.zbs-email-sending-record {
+			margin-bottom:0.8em;
+		}
+		.zbs-email-sending-record .avatar{
+			margin-left: 5px;
+			border-radius: 50%;
+		}
+		.zbs-email-detail {
+			width: 80%;
+			display: inline-block;
+		}
 	</style>
-    <?php
+	<?php
 
-    if(count($email_hist) == 0){
-    	echo "<div class='ui message'><i class='icon envelope outline'></i>" . esc_html( __('No Recent Emails','zero-bs-crm') ) . "</div>";
-    }
-    
-    foreach($email_hist as $em_hist){
+	if ( count( $email_hist ) === 0 ) {
+		echo '<div class="ui message"><i class="icon envelope outline"></i>' . esc_html( __( 'No Recent Emails', 'zero-bs-crm' ) ) . '</div>';
+	}
 
-        $email_subject = zeroBSCRM_mailTemplate_getSubject($em_hist->zbsmail_type);
-        $emoji = '🤖';
-        if($email_subject ==''){
-          //then this is a custom email
-          $email_subject = $em_hist->zbsmail_subject;
-          $emoji ='😀';
-        }
-        // if still empty
-        if (empty($email_subject)) $email_subject = __('Untitled','zero-bs-crm');
-        echo "<div class='zbs-email-sending-record'>";
-		echo "<span class='label blue ui tiny hist-label' style='float:left'> " . esc_html( __('sent','zero-bs-crm') ) . ' </span>';
-		echo '<div class="zbs-email-detail">'. esc_html( $emoji );
-		echo " <strong>" . esc_html( $email_subject ) . "</strong><br />";
-		echo "<span class='sent-to'>" . esc_html( __(" sent to ", 'zero-bs-crm') ) . "</span>";
+	foreach ( $email_hist as $em_hist ) {
+
+		$email_subject = zeroBSCRM_mailTemplate_getSubject( $em_hist->zbsmail_type );
+		$emoji         = '🤖';
+
+		if ( $email_subject === '' ) {
+			// then this is a custom email
+			$email_subject = $em_hist->zbsmail_subject;
+			$emoji         = '😀';
+		}
+
+		// if still empty
+		if ( empty( $email_subject ) ) {
+			$email_subject = esc_html__( 'Untitled', 'zero-bs-crm' );
+		}
+		echo '<div class="zbs-email-sending-record">';
+		echo '<span class="label blue ui tiny hist-label" style="float:left"> ' . esc_html( __( 'sent', 'zero-bs-crm' ) ) . ' </span>';
+		echo '<div class="zbs-email-detail">' . esc_html( $emoji );
+		echo ' <strong>' . esc_html( $email_subject ) . '</strong><br />';
+		echo '<span class="sent-to">' . esc_html( __( ' sent to ', 'zero-bs-crm' ) ) . '</span>';
+
 		// -10 are the system emails sent to CUSTOMERS
-		if($em_hist->zbsmail_sender_wpid == -10){
-			$customer = zeroBS_getCustomerMeta($em_hist->zbsmail_target_objid);
-			$link = admin_url('admin.php?page='.$zbs->slugs['addedit'].'&action=view&zbsid=' .$em_hist->zbsmail_target_objid);
-			if($customer['fname'] == '' && $customer['lname'] == ''){
-				echo "<a href='".esc_url( $link )."'>" . esc_html( $customer['email'] ) . "</a>";
-			}else{ 
-				echo "<a href='".esc_url( $link )."'>" . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . "</a>";
+		if ( $em_hist->zbsmail_sender_wpid === '-10' ) {
+			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
+			$link     = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
+			if ( $customer['fname'] === '' && $customer['lname'] === '' ) {
+				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
+			} else {
+				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
 			}
-		}else if($em_hist->zbsmail_sender_wpid == -11){
-			//quote proposal accepted (sent to admin...)
-			$userIDobj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
-			echo esc_html( $userIDobj->data->display_name );
-			echo jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 ); 
-		
-		}else if($em_hist->zbsmail_sender_wpid == -12){
-			//quote proposal accepted (sent to admin...) -12 is the you have a new quote...
-			$customer = zeroBS_getCustomerMeta($em_hist->zbsmail_target_objid);
-			$link = admin_url('admin.php?page='.$zbs->slugs['addedit'].'&action=view&zbsid=' .$em_hist->zbsmail_target_objid);
-			if($customer['fname'] == '' && $customer['lname'] == ''){
-				echo "<a href='".esc_url( $link )."'>" . esc_html( $customer['email'] ) . "</a>";
-			}else{ 
-				echo "<a href='".esc_url( $link )."'>" . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . "</a>";
+		} elseif ( $em_hist->zbsmail_sender_wpid === '-11' ) {
+			// quote proposal accepted (sent to admin...)
+			$user_id_obj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
+			echo esc_html( $user_id_obj->data->display_name );
+			echo jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 );
+		} elseif ( $em_hist->zbsmail_sender_wpid === '-12' ) {
+			// quote proposal accepted (sent to admin...) -12 is the you have a new quote...
+			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
+			$link     = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
+			if ( $customer['fname'] === '' && $customer['lname'] === '' ) {
+				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
+			} else {
+				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
 			}
-		}else if($em_hist->zbsmail_sender_wpid == -13){
-			//-13 is the event notification (sent to the OWNER of the event) so a WP user (not ZBS contact)...
-			$userIDobj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
-			echo esc_html( $userIDobj->data->display_name );
-			echo jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 ); 
-		}else{
-			$customer = zeroBS_getCustomerMeta($em_hist->zbsmail_target_objid);
+		} elseif ( $em_hist->zbsmail_sender_wpid === '-13' ) {
+			// -13 is the event notification (sent to the OWNER of the event) so a WP user (not ZBS contact)...
+			$user_id_obj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
+			echo esc_html( $user_id_obj->data->display_name );
+			echo jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 );
+		} else {
+			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
 
-			//zbs_prettyprint($customer);
-
-			//then it is a CRM team member [team member is quote accept]....
-			$link = admin_url('admin.php?page='.$zbs->slugs['addedit'].'&action=view&zbsid=' .$em_hist->zbsmail_target_objid);
-			if($customer['fname'] == '' && $customer['lname'] == ''){
-				echo "<a href='".esc_url( $link )."'>" . esc_html( $customer['email'] ) . "</a>";
-			}else{ 
-				echo "<a href='".esc_url( $link )."'>" . esc_html( $customer['fname'] . " " . $customer['lname'] ) . "</a>";
+			// then it is a CRM team member [team member is quote accept]....
+			$link = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
+			if ( $customer['fname'] === '' && $customer['lname'] === '' ) {
+				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
+			} else {
+				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
 			}
 
-			$userIDobj = get_user_by( 'ID', $em_hist->zbsmail_sender_wpid );
-			if (gettype($userIDobj) == 'object'){
-				echo esc_html( __(' by ','zero-bs-crm') . $userIDobj->data->display_name );
-				echo jpcrm_get_avatar( $em_hist->zbsmail_sender_wpid, 20 ); 
+			$user_id_obj = get_user_by( 'ID', $em_hist->zbsmail_sender_wpid );
+			if ( gettype( $user_id_obj ) === 'object' ) {
+				echo esc_html( __( ' by ', 'zero-bs-crm' ) . $user_id_obj->data->display_name );
+				echo jpcrm_get_avatar( $em_hist->zbsmail_sender_wpid, 20 );
 			}
-
 		}
-		$unixts =  date('U', $em_hist->zbsmail_created);
-		$diff   = human_time_diff($unixts, time());
-		echo "<time>". esc_html( $diff . __(' ago', 'zero-bs-crm') ) . "</time>";
-		if($em_hist->zbsmail_opened == 1){
-			echo "<span class='ui green basic label mini' style='margin-left:7px;'><i class='icon check'></i> ". esc_html( __('opened','zero-bs-crm') ) ."</span>";
+		$unixts = gmdate( 'U', $em_hist->zbsmail_created );
+		$diff   = human_time_diff( $unixts, time() );
+		echo '<time>' . esc_html( $diff . __( ' ago', 'zero-bs-crm' ) ) . '</time>';
+		if ( $em_hist->zbsmail_opened === '1' ) {
+			echo '<span class="ui green basic label mini" style="margin-left:7px;"><i class="icon check"></i> ' . esc_html( __( 'opened', 'zero-bs-crm' ) ) . '</span>';
 		}
-        echo "</div></div>";
-    }
+		echo '</div></div>';
+	}
 }
 
 /* ======================================================

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1170,7 +1170,7 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
   Email History
    ====================================================== */
 
-function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid,Squiz.Commenting.FunctionComment.Missing
+function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid,Squiz.Commenting.FunctionComment.Missing,Squiz.Commenting.FunctionComment.WrongStyle
 
 	global $zbs;
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1222,7 +1222,11 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		// -10 are the system emails sent to CUSTOMERS
 		if ( $em_hist->zbsmail_sender_wpid === '-10' ) {
 			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
-			$link     = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
+			if ( ! $customer ) {
+				continue;
+			}
+
+			$link = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
 			if ( $customer['fname'] === '' && $customer['lname'] === '' ) {
 				$email_details_html .= '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
 			} else {
@@ -1237,7 +1241,11 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		} elseif ( $em_hist->zbsmail_sender_wpid === '-12' ) {
 			// quote proposal accepted (sent to admin...) -12 is the you have a new quote...
 			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
-			$link     = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
+			if ( ! $customer ) {
+				continue;
+			}
+
+			$link = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
 			if ( $customer['fname'] === '' && $customer['lname'] === '' ) {
 				$email_details_html .= '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
 			} else {
@@ -1251,6 +1259,9 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 			$email_details_html .= jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 );
 		} else {
 			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
+			if ( ! $customer ) {
+				continue;
+			}
 
 			// then it is a CRM team member [team member is quote accept]....
 			$link = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1198,6 +1198,8 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 
 	foreach ( $email_hist as $em_hist ) {
 
+		$email_details_html = '';
+
 		$email_subject = zeroBSCRM_mailTemplate_getSubject( $em_hist->zbsmail_type );
 		$emoji         = '🤖';
 
@@ -1211,64 +1213,69 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		if ( empty( $email_subject ) ) {
 			$email_subject = esc_html__( 'Untitled', 'zero-bs-crm' );
 		}
-		echo '<div class="zbs-email-sending-record">';
-		echo '<span class="label blue ui tiny hist-label" style="float:left"> ' . esc_html( __( 'sent', 'zero-bs-crm' ) ) . ' </span>';
-		echo '<div class="zbs-email-detail">' . esc_html( $emoji );
-		echo ' <strong>' . esc_html( $email_subject ) . '</strong><br />';
-		echo '<span class="sent-to">' . esc_html( __( ' sent to ', 'zero-bs-crm' ) ) . '</span>';
+		$email_details_html .= '<div class="zbs-email-sending-record">';
+		$email_details_html .= '<span class="label blue ui tiny hist-label" style="float:left"> ' . esc_html( __( 'sent', 'zero-bs-crm' ) ) . ' </span>';
+		$email_details_html .= '<div class="zbs-email-detail">' . esc_html( $emoji );
+		$email_details_html .= ' <strong>' . esc_html( $email_subject ) . '</strong><br />';
+		$email_details_html .= '<span class="sent-to">' . esc_html( __( ' sent to ', 'zero-bs-crm' ) ) . '</span>';
 
 		// -10 are the system emails sent to CUSTOMERS
 		if ( $em_hist->zbsmail_sender_wpid === '-10' ) {
 			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
 			$link     = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
 			if ( $customer['fname'] === '' && $customer['lname'] === '' ) {
-				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
+				$email_details_html .= '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
 			} else {
-				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
+				$email_details_html .= '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
 			}
 		} elseif ( $em_hist->zbsmail_sender_wpid === '-11' ) {
 			// quote proposal accepted (sent to admin...)
 			$user_id_obj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
-			echo esc_html( $user_id_obj->data->display_name );
-			echo jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 );
+
+			$email_details_html .= esc_html( $user_id_obj->data->display_name );
+			$email_details_html .= jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 );
 		} elseif ( $em_hist->zbsmail_sender_wpid === '-12' ) {
 			// quote proposal accepted (sent to admin...) -12 is the you have a new quote...
 			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
 			$link     = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
 			if ( $customer['fname'] === '' && $customer['lname'] === '' ) {
-				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
+				$email_details_html .= '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
 			} else {
-				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
+				$email_details_html .= '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
 			}
 		} elseif ( $em_hist->zbsmail_sender_wpid === '-13' ) {
 			// -13 is the event notification (sent to the OWNER of the event) so a WP user (not ZBS contact)...
 			$user_id_obj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
-			echo esc_html( $user_id_obj->data->display_name );
-			echo jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 );
+
+			$email_details_html .= esc_html( $user_id_obj->data->display_name );
+			$email_details_html .= jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 );
 		} else {
 			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
 
 			// then it is a CRM team member [team member is quote accept]....
 			$link = admin_url( 'admin.php?page=' . $zbs->slugs['addedit'] . '&action=view&zbsid=' . $em_hist->zbsmail_target_objid );
 			if ( $customer['fname'] === '' && $customer['lname'] === '' ) {
-				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
+				$email_details_html .= '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['email'] ) . '</a>';
 			} else {
-				echo '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
+				$email_details_html .= '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
 			}
 
 			$user_id_obj = get_user_by( 'ID', $em_hist->zbsmail_sender_wpid );
 			if ( gettype( $user_id_obj ) === 'object' ) {
-				echo esc_html( __( ' by ', 'zero-bs-crm' ) . $user_id_obj->data->display_name );
-				echo jpcrm_get_avatar( $em_hist->zbsmail_sender_wpid, 20 );
+				$email_details_html .= esc_html( __( ' by ', 'zero-bs-crm' ) . $user_id_obj->data->display_name );
+				$email_details_html .= jpcrm_get_avatar( $em_hist->zbsmail_sender_wpid, 20 );
 			}
 		}
 		$unixts = gmdate( 'U', $em_hist->zbsmail_created );
 		$diff   = human_time_diff( $unixts, time() );
-		echo '<time>' . esc_html( $diff . __( ' ago', 'zero-bs-crm' ) ) . '</time>';
+
+		$email_details_html .= '<time>' . esc_html( $diff . __( ' ago', 'zero-bs-crm' ) ) . '</time>';
 		if ( $em_hist->zbsmail_opened === '1' ) {
-			echo '<span class="ui green basic label mini" style="margin-left:7px;"><i class="icon check"></i> ' . esc_html( __( 'opened', 'zero-bs-crm' ) ) . '</span>';
+			$email_details_html .= '<span class="ui green basic label mini" style="margin-left:7px;"><i class="icon check"></i> ' . esc_html( __( 'opened', 'zero-bs-crm' ) ) . '</span>';
 		}
-		echo '</div></div>';
+		$email_details_html .= '</div></div>';
+
+		echo $email_details_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1234,9 +1234,12 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 			}
 		} elseif ( $em_hist->zbsmail_sender_wpid === '-11' ) {
 			// quote proposal accepted (sent to admin...)
-			$user_id_obj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
+			$user_obj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
+			if ( ! $user_obj ) {
+				continue;
+			}
 
-			$email_details_html .= esc_html( $user_id_obj->data->display_name );
+			$email_details_html .= esc_html( $user_obj->data->display_name );
 			$email_details_html .= jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 );
 		} elseif ( $em_hist->zbsmail_sender_wpid === '-12' ) {
 			// quote proposal accepted (sent to admin...) -12 is the you have a new quote...
@@ -1253,9 +1256,12 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 			}
 		} elseif ( $em_hist->zbsmail_sender_wpid === '-13' ) {
 			// -13 is the event notification (sent to the OWNER of the event) so a WP user (not ZBS contact)...
-			$user_id_obj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
+			$user_obj = get_user_by( 'ID', $em_hist->zbsmail_target_objid );
+			if ( ! $user_obj ) {
+				continue;
+			}
 
-			$email_details_html .= esc_html( $user_id_obj->data->display_name );
+			$email_details_html .= esc_html( $user_obj->data->display_name );
 			$email_details_html .= jpcrm_get_avatar( $em_hist->zbsmail_target_objid, 20 );
 		} else {
 			$customer = zeroBS_getCustomerMeta( $em_hist->zbsmail_target_objid );
@@ -1271,11 +1277,13 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 				$email_details_html .= '<a href="' . esc_url( $link ) . '">' . esc_html( $customer['fname'] . ' ' . $customer['lname'] ) . '</a>';
 			}
 
-			$user_id_obj = get_user_by( 'ID', $em_hist->zbsmail_sender_wpid );
-			if ( gettype( $user_id_obj ) === 'object' ) {
-				$email_details_html .= esc_html( __( ' by ', 'zero-bs-crm' ) . $user_id_obj->data->display_name );
-				$email_details_html .= jpcrm_get_avatar( $em_hist->zbsmail_sender_wpid, 20 );
+			$user_obj = get_user_by( 'ID', $em_hist->zbsmail_sender_wpid );
+			if ( ! $user_obj ) {
+				continue;
 			}
+
+			$email_details_html .= esc_html( __( ' by ', 'zero-bs-crm' ) . $user_obj->data->display_name );
+			$email_details_html .= jpcrm_get_avatar( $em_hist->zbsmail_sender_wpid, 20 );
 		}
 		$unixts = gmdate( 'U', $em_hist->zbsmail_created );
 		$diff   = human_time_diff( $unixts, time() );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3027 - PHP notices on Email Template page if recipient does not exist

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the CRM sent an email to a contact (or WP user), and the recipient was subsequently deleted, PHP notices would occur.

Similar to Automattic/zero-bs-crm#2393, this PR skips any emails that are orphaned.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a contact.
2. Send an email to the contact.
3. Delete the contact.
4. Go to `/wp-admin/admin.php?page=zbs-email-templates`

In `trunk` one gets some PHP notices.

In `fix/crm/3027-catch_php_notices` there are no more notices.