### PR TITLE
Blocks: only use strings in block descriptions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-extensions-description-string
+++ b/projects/plugins/jetpack/changelog/update-extensions-description-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Blocks: avoid using complex block descriptions to avoid notices with WordPress 6.2.

--- a/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-image/index.js
@@ -1,6 +1,3 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
@@ -16,24 +13,9 @@ export const title = __( 'AI Image (Experimental)', 'jetpack' );
 export const settings = {
 	apiVersion: 2,
 	title,
-	description: (
-		<Fragment>
-			<p>
-				{ __(
-					'Automatically generate an illustration for your post, powered by AI magic.',
-					'jetpack'
-				) }
-			</p>
-			<p>
-				{ __(
-					'We are experimenting with this feature and can tweak or remove it at any point.',
-					'jetpack'
-				) }
-			</p>
-			<ExternalLink href={ getRedirectUrl( 'jetpack_ai_feedback' ) }>
-				{ __( 'Share your feedback.', 'jetpack' ) }
-			</ExternalLink>
-		</Fragment>
+	description: __(
+		'Automatically generate an illustration for your post, powered by AI magic. We are experimenting with this feature and can tweak or remove it at any point.',
+		'jetpack'
 	),
 	icon: {
 		src: 'superhero',

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/index.js
@@ -1,8 +1,6 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
 import { useBlockProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { ExternalLink } from '@wordpress/components';
-import { Fragment, RawHTML } from '@wordpress/element';
+import { RawHTML } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
@@ -18,24 +16,9 @@ export const title = __( 'AI Paragraph (Experimental)', 'jetpack' );
 export const settings = {
 	apiVersion: 2,
 	title,
-	description: (
-		<Fragment>
-			<p>
-				{ __(
-					'Automatically generate new paragraphs using your existing content, powered by AI magic.',
-					'jetpack'
-				) }
-			</p>
-			<p>
-				{ __(
-					'We are experimenting with this feature and can tweak or remove it at any point.',
-					'jetpack'
-				) }
-			</p>
-			<ExternalLink href={ getRedirectUrl( 'jetpack_ai_feedback' ) }>
-				{ __( 'Share your feedback.', 'jetpack' ) }
-			</ExternalLink>
-		</Fragment>
+	description: __(
+		'Automatically generate new paragraphs using your existing content, powered by AI magic. We are experimenting with this feature and can tweak or remove it at any point.',
+		'jetpack'
 	),
 	icon: {
 		src: 'superhero',

--- a/projects/plugins/jetpack/extensions/blocks/markdown/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/index.js
@@ -1,6 +1,4 @@
-import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
-import { ExternalLink, Path, Rect, SVG } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Path, Rect, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import getCategoryWithFallbacks from '../../shared/get-category-with-fallbacks';
@@ -33,31 +31,16 @@ const icon = (
 	</SVG>
 );
 
-const supportLink =
-	isSimpleSite() || isAtomicSite()
-		? 'https://en.support.wordpress.com/markdown-quick-reference/'
-		: 'https://jetpack.com/support/jetpack-blocks/markdown-block/';
-
 export const settings = {
 	title: __( 'Markdown', 'jetpack' ),
-
-	description: (
-		<Fragment>
-			<p>
-				{ __(
-					'Use regular characters and punctuation to style text, links, and lists.',
-					'jetpack'
-				) }
-			</p>
-			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
-		</Fragment>
+	description: __(
+		'Use regular characters and punctuation to style text, links, and lists.',
+		'jetpack'
 	),
-
 	icon: {
 		src: icon,
 		foreground: getIconColor(),
 	},
-
 	category: getCategoryWithFallbacks( 'text', 'formatting' ),
 	keywords: [
 		_x( 'formatting', 'block search term', 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/index.js
@@ -1,6 +1,4 @@
-import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
-import { Path, Rect, SVG, G, ExternalLink } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Path, Rect, SVG, G } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import { settings as paymentButtonSettings } from '../recurring-payments';
@@ -19,11 +17,6 @@ export const icon = (
 	</SVG>
 );
 
-const supportLink =
-	isSimpleSite() || isAtomicSite()
-		? 'https://wordpress.com/support/video-tutorials-add-payments-features-to-your-site-with-our-guides/#how-to-use-the-payments-block-video'
-		: 'https://jetpack.com/support/jetpack-blocks/payments-block/';
-
 export const settings = {
 	apiVersion: 2,
 	title,
@@ -31,16 +24,9 @@ export const settings = {
 		src: icon,
 		foreground: getIconColor(),
 	},
-	description: (
-		<Fragment>
-			<p>
-				{ __(
-					'Prompt visitors to purchase your products and subscriptions with a group of buttons.',
-					'jetpack'
-				) }
-			</p>
-			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
-		</Fragment>
+	description: __(
+		'Prompt visitors to purchase your products and subscriptions with a group of buttons.',
+		'jetpack'
 	),
 	category: 'earn',
 	keywords: [ ...new Set( [ paymentButtonSettings.title, ...paymentButtonSettings.keywords ] ) ],

--- a/projects/plugins/jetpack/extensions/blocks/recipe/details/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/details/index.js
@@ -1,4 +1,3 @@
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../../shared/block-icons';
 import icon from '../icon';
@@ -12,11 +11,7 @@ export const name = 'recipe-details';
 
 export const settings = {
 	title: __( 'Recipe Details', 'jetpack' ),
-	description: (
-		<Fragment>
-			<p>{ __( 'Recipe Details', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'Recipe Details', 'jetpack' ),
 	keywords: [],
 	supports: {
 		align: [ 'left', 'right', 'center' ],

--- a/projects/plugins/jetpack/extensions/blocks/recipe/hero/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/hero/index.js
@@ -1,4 +1,3 @@
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../../shared/block-icons';
 import icon from '../icon';
@@ -9,11 +8,7 @@ export const name = 'recipe-hero';
 export const title = __( 'Recipe Hero', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'Image area for the recipe.', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'Image area for the recipe.', 'jetpack' ),
 	keywords: [],
 	icon: {
 		src: icon,

--- a/projects/plugins/jetpack/extensions/blocks/recipe/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/index.js
@@ -1,5 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import { name as detailsName, settings as detailsSettings } from './details/';
@@ -19,16 +17,9 @@ export const name = 'recipe';
 export const title = __( 'Recipe', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>
-				{ __(
-					'Add images, ingredients and cooking steps to display an easy to read recipe.',
-					'jetpack'
-				) }
-			</p>
-			<ExternalLink href="#">{ __( 'Learn more about Recipe', 'jetpack' ) }</ExternalLink>
-		</Fragment>
+	description: __(
+		'Add images, ingredients and cooking steps to display an easy to read recipe.',
+		'jetpack'
 	),
 	icon: {
 		src: icon,

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredient-item/index.js
@@ -1,4 +1,3 @@
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../../shared/block-icons';
 import icon from '../icon';
@@ -10,11 +9,7 @@ export const name = 'recipe-ingredient-item';
 export const title = __( 'Recipe Ingredient Item', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'A single ingredient associated with a recipe.', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'A single ingredient associated with a recipe.', 'jetpack' ),
 	keywords: [],
 	icon: {
 		src: icon,

--- a/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/ingredients-list/index.js
@@ -1,4 +1,3 @@
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../../shared/block-icons';
 import icon from '../icon';
@@ -12,11 +11,7 @@ export const name = 'recipe-ingredients-list';
 export const title = __( 'Recipe Ingredients List', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'Recipe ingredient list', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'Recipe ingredient list', 'jetpack' ),
 	icon: {
 		src: icon,
 		foreground: getIconColor(),

--- a/projects/plugins/jetpack/extensions/blocks/recipe/step/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/step/index.js
@@ -1,4 +1,3 @@
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../../shared/block-icons';
 import icon from '../icon';
@@ -9,11 +8,7 @@ export const name = 'recipe-step';
 export const title = __( 'Recipe Step', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'A single recipe step.', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'A single recipe step.', 'jetpack' ),
 	keywords: [],
 	icon: {
 		src: icon,

--- a/projects/plugins/jetpack/extensions/blocks/recipe/steps/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/steps/index.js
@@ -1,4 +1,3 @@
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../../shared/block-icons';
 import icon from '../icon';
@@ -12,11 +11,7 @@ export const name = 'recipe-steps';
 export const title = __( 'Recipe Steps', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'Step by step instructions for the recipe.', 'jetpack' ) }</p>
-		</Fragment>
-	),
+	description: __( 'Step by step instructions for the recipe.', 'jetpack' ),
 	keywords: [],
 	icon: {
 		src: icon,

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/index.js
@@ -1,7 +1,5 @@
-import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { createBlock } from '@wordpress/blocks';
-import { Path, Rect, SVG, G, ExternalLink } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Path, Rect, SVG, G } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import { isPriceValid } from '../../shared/currencies';
@@ -22,11 +20,6 @@ export const icon = (
 	</SVG>
 );
 
-const supportLink =
-	isSimpleSite() || isAtomicSite()
-		? 'https://wordpress.com/support/video-tutorials-add-payments-features-to-your-site-with-our-guides/#how-to-use-the-payments-block-video'
-		: 'https://jetpack.com/support/jetpack-blocks/payments-block/';
-
 export const settings = {
 	apiVersion: 2,
 	title,
@@ -34,12 +27,7 @@ export const settings = {
 		src: icon,
 		foreground: getIconColor(),
 	},
-	description: (
-		<Fragment>
-			<p>{ __( 'Button allowing you to sell products and subscriptions.', 'jetpack' ) }</p>
-			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
-		</Fragment>
-	),
+	description: __( 'Button allowing you to sell products and subscriptions.', 'jetpack' ),
 	category: 'earn',
 	keywords: [
 		_x( 'buy', 'block search term', 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/deprecated/v2/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/deprecated/v2/index.js
@@ -1,6 +1,4 @@
-import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
-import { ExternalLink, Path, SVG } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Path, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../../../shared/block-icons';
 import { DEFAULT_CURRENCY } from '../../constants';
@@ -14,29 +12,12 @@ export const icon = (
 	</SVG>
 );
 
-const supportLink =
-	isSimpleSite() || isAtomicSite()
-		? 'https://wordpress.com/support/pay-with-paypal/'
-		: 'https://jetpack.com/support/jetpack-blocks/pay-with-paypal/';
-
 const settings = {
 	title: __( 'Pay with PayPal', 'jetpack' ),
-
-	description: (
-		<Fragment>
-			<p>
-				{ __(
-					'Lets you add credit and debit card payment buttons with minimal setup.',
-					'jetpack'
-				) }
-			</p>
-			<p>
-				{ __( 'Good for collecting donations or payments for products and services.', 'jetpack' ) }
-			</p>
-			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
-		</Fragment>
+	description: __(
+		'Lets you add credit and debit card payment buttons with minimal setup. Good for collecting donations or payments for products and services.',
+		'jetpack'
 	),
-
 	icon: {
 		src: icon,
 		foreground: getIconColor(),

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/index.js
@@ -1,6 +1,4 @@
-import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
-import { ExternalLink, Path, SVG } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Path, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import { DEFAULT_CURRENCY } from './constants';
@@ -21,29 +19,12 @@ export const icon = (
 	</SVG>
 );
 
-const supportLink =
-	isSimpleSite() || isAtomicSite()
-		? 'https://wordpress.com/support/pay-with-paypal/'
-		: 'https://jetpack.com/support/jetpack-blocks/pay-with-paypal/';
-
 export const settings = {
 	title: __( 'Pay with PayPal', 'jetpack' ),
-
-	description: (
-		<Fragment>
-			<p>
-				{ __(
-					'Lets you add credit and debit card payment buttons with minimal setup.',
-					'jetpack'
-				) }
-			</p>
-			<p>
-				{ __( 'Good for collecting donations or payments for products and services.', 'jetpack' ) }
-			</p>
-			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
-		</Fragment>
+	description: __(
+		'Lets you add credit and debit card payment buttons with minimal setup. Good for collecting donations or payments for products and services.',
+		'jetpack'
 	),
-
 	icon: {
 		src: icon,
 		foreground: getIconColor(),

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/index.js
@@ -1,6 +1,5 @@
 import { createBlock } from '@wordpress/blocks';
-import { ExternalLink, Path, SVG } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { Path, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
@@ -21,19 +20,9 @@ export const icon = (
 );
 export const settings = {
 	title: __( 'Subscribe', 'jetpack' ),
-	description: (
-		<>
-			<p>{ __( "Let readers subscribe to this blog's posts as a newsletter.", 'jetpack' ) }</p>
-			<p>
-				{ createInterpolateElement(
-					__(
-						'Subscribers can read the posts in their email inbox or <ExternalLink>the Reader app</ExternalLink>.',
-						'jetpack'
-					),
-					{ ExternalLink: <ExternalLink href={ 'https://wordpress.com/read' } /> }
-				) }
-			</p>
-		</>
+	description: __(
+		'Let readers subscribe to this blog’s posts as a newsletter. Subscribers can read the posts in their email inbox or the WordPress.com Reader app.',
+		'jetpack'
 	),
 	icon: {
 		src: icon,

--- a/projects/plugins/jetpack/extensions/blocks/wordads/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/index.js
@@ -1,5 +1,4 @@
-import { ExternalLink, Path, SVG } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+import { Path, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import { DEFAULT_FORMAT } from './constants';
@@ -20,16 +19,7 @@ export const icon = (
 
 export const settings = {
 	title,
-
-	description: (
-		<Fragment>
-			<p>{ __( 'Earn income by adding high quality ads to your post', 'jetpack' ) }</p>
-			<ExternalLink href="https://wordads.co/">
-				{ __( 'Learn all about WordAds', 'jetpack' ) }
-			</ExternalLink>
-		</Fragment>
-	),
-
+	description: __( 'Earn income by adding high quality ads to your post', 'jetpack' ),
 	icon: {
 		src: icon,
 		foreground: getIconColor(),


### PR DESCRIPTION
> **Note**
> I'm opening this PR as a suggestion to remove notices. **We do not have to merge this if we are comfortable keeping notices in the browser console (thus increasing noise for developers) to ensure a better user experience for site owners.**

## Proposed changes:

Discussion: #26792

Until we have a better way to have custom descriptions for blocks, let's keep only strings to avoid notices. This isn't ideal since we're using useful information like links to support documentation, but at least we're getting rid of notices.

Closes #29402

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* #26792
* WordPress 6.2 compat' primary issue: #27795 

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

On a site that runs WordPress 6.2 RC, go to Posts > Add New and open the browser console. You should not see any notices like this one:

<img width="1374" alt="image" src="https://user-images.githubusercontent.com/426388/228311234-5c820d06-ec51-4480-8bf3-7bb1bfca57fa.png">