### PR TITLE
VideoPress: use WP COM API to generate poster image for simple sites

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-use-poster-endpoint-depending-site-type
+++ b/projects/packages/videopress/changelog/update-videopress-use-poster-endpoint-depending-site-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: use WP COM API to generate poster image for simple sites

--- a/projects/packages/videopress/src/client/lib/poster/index.ts
+++ b/projects/packages/videopress/src/client/lib/poster/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Types
@@ -20,13 +21,25 @@ export const requestUpdatePosterByVideoFrame = function (
 	guid: VideoGUID,
 	atTime: number
 ): Promise< WPComV2VideopressPostPosterProps > {
+	const requestBody = {
+		at_time: atTime,
+		is_millisec: true,
+	};
+
+	if ( isSimpleSite() ) {
+		return apiFetch( {
+			path: `/videos/${ guid }/poster`,
+			apiNamespace: 'rest/v1.1',
+			method: 'POST',
+			global: true,
+			data: requestBody,
+		} );
+	}
+
 	return apiFetch( {
 		path: `/wpcom/v2/videopress/${ guid }/poster`,
 		method: 'POST',
-		data: {
-			at_time: atTime,
-			is_millisec: true,
-		},
+		data: requestBody,
 	} );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: use WP COM API to generate poster image for simple sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a video block
* Set a video poster by picking a frame
* Confirm it works as expected

