### PR TITLE
Rnmobile/vp native player caption

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-vp-native-player-caption
+++ b/projects/packages/videopress/changelog/rnmobile-vp-native-player-caption
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add video caption to native player

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.tsx
@@ -14,9 +14,7 @@ import style from './style.scss';
 /**
  * Types
  */
-import type { PlayerProps } from './types';
-
-type NativePlayerProps = Pick< PlayerProps, 'html' | 'isRequestingEmbedPreview' | 'isSelected' >;
+import type { NativePlayerProps } from './types';
 
 /**
  * VideoPlayer react component

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.tsx
@@ -1,8 +1,10 @@
 /**
  * WordPress dependencies
  */
+import { BlockCaption } from '@wordpress/block-editor';
 import { SandBox } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { useState, useCallback } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 /**
  * External dependencies
  */
@@ -23,13 +25,37 @@ import type { NativePlayerProps } from './types';
  * @param {string} props.html - HTML markup for the player.
  * @param {boolean} props.isRequestingEmbedPreview - Whether the preview is being requested.
  * @param {boolean} props.isSelected - Whether the block is selected.
+ * @param {string} props.clientId - Block client Id.
+ * @param {Function} props.insertBlocksAfter - Function to insert a new block after the current block.
  * @returns {object}                     - React component.
  */
 export default function Player( {
 	html,
 	isRequestingEmbedPreview,
 	isSelected,
+	clientId,
+	insertBlocksAfter,
 }: NativePlayerProps ) {
+	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
+
+	const onFocusCaption = useCallback( () => {
+		if ( ! isCaptionSelected ) {
+			setIsCaptionSelected( true );
+		}
+	}, [ isCaptionSelected ] );
+
+	const accessibilityLabelCreator = useCallback( caption => {
+		if ( caption ) {
+			return sprintf(
+				/* translators: accessibility text. %s: Video caption. */
+				__( 'Video caption. %s', 'jetpack-videopress-pkg' ),
+				caption
+			);
+		}
+		/* translators: accessibility text. Empty Video caption. */
+		return __( 'Video caption. Empty', 'jetpack-videopress-pkg' );
+	}, [] );
+
 	// Set up style for when the player is loading.
 	const loadingStyle: { height?: number } = {};
 	if ( ! html || isRequestingEmbedPreview ) {
@@ -42,6 +68,17 @@ export default function Player( {
 
 			{ ! isRequestingEmbedPreview && <SandBox html={ html } /> }
 			{ ! html && <Text>{ __( 'Loading…', 'jetpack-videopress-pkg' ) }</Text> }
+
+			{ isSelected && (
+				<BlockCaption
+					clientId={ clientId }
+					onFocus={ onFocusCaption }
+					isSelected={ isCaptionSelected }
+					insertBlocksAfter={ insertBlocksAfter }
+					accessibilityLabelCreator={ accessibilityLabelCreator }
+					accessible
+				/>
+			) }
 		</View>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/types.ts
@@ -1,4 +1,8 @@
 /**
+ * WordPress dependencies
+ */
+import { BlockInstance } from '@wordpress/blocks';
+/**
  * External dependencies
  */
 import { VideoBlockAttributes, VideoPreviewProps } from '../../types';
@@ -11,4 +15,12 @@ export type PlayerProps = {
 	setAttributes: ( attributes: VideoBlockAttributes ) => void;
 	preview: VideoPreviewProps;
 	isRequestingEmbedPreview: boolean;
+};
+
+export type NativePlayerProps = {
+	html: string;
+	isRequestingEmbedPreview: boolean;
+	isSelected: boolean;
+	clientId: string;
+	insertBlocksAfter: ( blocks: BlockInstance[] ) => void;
 };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.tsx
@@ -19,7 +19,7 @@ import { usePreview } from '../../hooks/use-preview';
 import ColorPanel from './components/color-panel';
 import DetailsPanel from './components/details-panel';
 import PlaybackPanel from './components/playback-panel';
-import Player from './components/player';
+import Player from './components/player/index.native';
 import VideoPressUploader from './components/videopress-uploader/index.native';
 import style from './style.scss';
 
@@ -32,7 +32,7 @@ import style from './style.scss';
  * @param {Function} props.setAttributes - Function to set block attributes.
  * @param {boolean} props.isSelected	 - Whether block is selected.
  * @param {Function} props.onFocus       - Callback to notify when block should gain focus.
- * @param {Function} props.insertBlockAfter - Function to insert a new block after the current block.
+ * @param {Function} props.insertBlocksAfter - Function to insert a new block after the current block.
  * @returns {React.ReactNode}            - React component.
  */
 export default function VideoPressEdit( {
@@ -41,7 +41,7 @@ export default function VideoPressEdit( {
 	setAttributes,
 	isSelected,
 	onFocus,
-	insertBlockAfter,
+	insertBlocksAfter,
 } ): React.ReactNode {
 	const {
 		autoplay,
@@ -113,7 +113,7 @@ export default function VideoPressEdit( {
 				isRequestingEmbedPreview={ isRequestingEmbedPreview }
 				isSelected={ isSelected }
 				clientId={ clientId }
-				insertBlockAfter={ insertBlockAfter }
+				insertBlocksAfter={ insertBlocksAfter }
 			/>
 		</View>
 	);

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.tsx
@@ -32,6 +32,7 @@ import style from './style.scss';
  * @param {Function} props.setAttributes - Function to set block attributes.
  * @param {boolean} props.isSelected	 - Whether block is selected.
  * @param {Function} props.onFocus       - Callback to notify when block should gain focus.
+ * @param {Function} props.insertBlockAfter - Function to insert a new block after the current block.
  * @returns {React.ReactNode}            - React component.
  */
 export default function VideoPressEdit( {
@@ -40,6 +41,7 @@ export default function VideoPressEdit( {
 	setAttributes,
 	isSelected,
 	onFocus,
+	insertBlockAfter,
 } ): React.ReactNode {
 	const {
 		autoplay,
@@ -110,6 +112,8 @@ export default function VideoPressEdit( {
 				html={ preview.html }
 				isRequestingEmbedPreview={ isRequestingEmbedPreview }
 				isSelected={ isSelected }
+				clientId={ clientId }
+				insertBlockAfter={ insertBlockAfter }
 			/>
 		</View>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Adds the video caption to the native player. 
The behavior follows the exiting React Native Video block:
- The caption is visible when the block is selected.
- The caption is always displayed regardless of the block settings * 

* Note: On the web, the caption is removed and reset when clicking the "remove caption" toggle 

Part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/5509

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the caption to the native player

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Display
* Open the mobile editor
* Add or select a VideoPress block
* If the block does not have a caption, verify the "Add caption" is visible below the video.
* If the block has a caption, verify that the caption is displayed correctly below the video.
* Deselect the block
* Verify that the caption is no longer displayed

### Syncing 
* Open a post on the web with a VideoPress block
* Disable captions on the block and save the update
* Open the post on the mobile editor
* Select the block and verify that "Add caption" is displayed
* Add a caption to the video and save the update.
* Reload the post in the web 
* Verify that the caption is displayed

