### PR TITLE
VideoPress: extract, create and expose usePlayerReady() hook

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-extract-helpers-from-poster-cmp
+++ b/projects/packages/videopress/changelog/update-videopress-extract-helpers-from-poster-cmp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: extract, create and expose usePlayerReady() hook

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -133,11 +133,10 @@ export default function Player( {
 	}, [ html ] );
 
 	/*
-	 * Callback state handler for the video player
-	 * tied to the `message` event,
+	 * Function handler that listen to the `message` event
 	 * provided by the videopress player through the bridge.
 	 */
-	const onVideoLoadingStateHandler = useCallback( ev => {
+	const videoPlayerEventsHandler = useCallback( ( ev: MessageEvent ) => {
 		const eventName = ev?.data?.event;
 		if ( ! eventName || eventName !== 'videopress_loading_state' ) {
 			return;
@@ -157,10 +156,10 @@ export default function Player( {
 		}
 
 		const iFrameContentWindow = sandboxIframeElement.contentWindow;
-		iFrameContentWindow.addEventListener( 'message', onVideoLoadingStateHandler );
+		iFrameContentWindow.addEventListener( 'message', videoPlayerEventsHandler );
 
-		return () => iFrameContentWindow?.removeEventListener( 'message', onVideoLoadingStateHandler );
-	}, [ onVideoLoadingStateHandler, sandboxIframeElement ] );
+		return () => iFrameContentWindow?.removeEventListener( 'message', videoPlayerEventsHandler );
+	}, [ videoPlayerEventsHandler, sandboxIframeElement ] );
 
 	useEffect( () => {
 		if ( isRequestingEmbedPreview ) {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -230,8 +230,8 @@ type UsePLayerReadyReturn = {
  *
  * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - useRef of the sandbox wrapper.
  * @param {boolean} isRequestingEmbedPreview                   - Whether the preview is being requested.
- * @param {UsePlayerReadyOptions} options					   - Options object.
- * @returns {UsePLayerReadyReturn} 							     playerIsReady and playerState
+ * @param {UsePlayerReadyOptions} options                      - Options object.
+ * @returns {UsePLayerReadyReturn}                               playerIsReady and playerState
  */
 const usePlayerReady = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
@@ -258,11 +258,11 @@ const usePlayerReady = (
 			playerState.current = 'loaded';
 		}
 
-		// Hack 2/2: Pause the video right after it has been auto-loaded.
+		// Detect when the video has been played for the first time.
 		if ( eventName === 'videopress_playing' && playerState.current === 'loaded' ) {
 			playerState.current = 'first-play';
 
-			// Pause and playback the video to ensure the video is at the desired time.
+			// Pause and move the video at the desired time.
 			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
 			source.postMessage(
 				{ event: 'videopress_action_set_currenttime', currentTime: atTime / 1000 },

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -195,8 +195,20 @@ export function PosterDropdown( {
 	);
 }
 
-const getIframeWindowFromRef = ( iFrameRef ): Window | null => {
-	return iFrameRef?.current?.querySelector( '.components-sandbox' )?.contentWindow;
+/**
+ * Return the (content) Window object of the iframe,
+ * given the iframe's ref.
+ *
+ * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - iframe ref
+ * @returns {Window | null}	                                     Window object of the iframe
+ */
+export const getIframeWindowFromRef = (
+	iFrameRef: React.MutableRefObject< HTMLDivElement >
+): Window | null => {
+	const iFrame: HTMLIFrameElement = iFrameRef?.current?.querySelector(
+		'iframe.components-sandbox'
+	);
+	return iFrame?.contentWindow;
 };
 
 type PosterFramePickerProps = {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -211,6 +211,95 @@ export const getIframeWindowFromRef = (
 	return iFrame?.contentWindow;
 };
 
+type UsePlayerReadyOptions = {
+	atTime: number;
+};
+
+type UsePLayerReadyReturn = {
+	playerIsReady: boolean;
+	playerState: 'not-rendered' | 'loaded' | 'first-play';
+};
+
+/**
+ * Custom hook to set the player ready to use:
+ *
+ * - Detect the "videopress_loading_state" state.
+ * - Detect the first time it was played.
+ * - Stop right after it was played
+ * - Set the player position to the desired time
+ *
+ * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - useRef of the sandbox wrapper.
+ * @param {boolean} isRequestingEmbedPreview                   - Whether the preview is being requested.
+ * @param {UsePlayerReadyOptions} options					   - Options object.
+ * @returns {UsePLayerReadyReturn} 							     playerIsReady and playerState
+ */
+const usePlayerReady = (
+	iFrameRef: React.MutableRefObject< HTMLDivElement >,
+	isRequestingEmbedPreview: boolean,
+	{ atTime }: UsePlayerReadyOptions
+): UsePLayerReadyReturn => {
+	const [ playerIsReady, setPlayerIsReady ] = useState( false );
+	const playerState = useRef< 'not-rendered' | 'loaded' | 'first-play' | 'ready' >(
+		'not-rendered'
+	);
+
+	/**
+	 * Handler function that listent the events
+	 * emited by the player client.
+	 *
+	 * @param {MessageEvent} event - Message event
+	 */
+	function listenEventsHandler( event: MessageEvent ) {
+		const { data: eventData = {}, source } = event;
+		const { event: eventName } = event?.data || {};
+
+		// Detect when the video has been loaded.
+		if ( eventName === 'videopress_loading_state' && eventData.state === 'loaded' ) {
+			playerState.current = 'loaded';
+		}
+
+		// Hack 2/2: Pause the video right after it has been auto-loaded.
+		if ( eventName === 'videopress_playing' && playerState.current === 'loaded' ) {
+			playerState.current = 'first-play';
+
+			// Pause and playback the video to ensure the video is at the desired time.
+			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
+			source.postMessage(
+				{ event: 'videopress_action_set_currenttime', currentTime: atTime / 1000 },
+				{ targetOrigin: '*' }
+			);
+
+			// Here we consider the video as ready to be controlled.
+			setPlayerIsReady( true );
+			playerState.current = 'ready';
+		}
+	}
+
+	// Listen player events.
+	useEffect( () => {
+		if ( isRequestingEmbedPreview ) {
+			return;
+		}
+
+		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
+		if ( ! sandboxIFrameWindow ) {
+			return;
+		}
+
+		sandboxIFrameWindow.addEventListener( 'message', listenEventsHandler );
+
+		return () => {
+			// Remove the listener when the component is unmounted.
+			sandboxIFrameWindow.removeEventListener( 'message', listenEventsHandler );
+		};
+	}, [ iFrameRef, isRequestingEmbedPreview ] );
+
+	return {
+		playerIsReady,
+		playerState: playerState.current,
+	};
+};
+
 type PosterFramePickerProps = {
 	guid: VideoGUID;
 	atTime: number;
@@ -232,7 +321,6 @@ function VideoFramePicker( {
 }: PosterFramePickerProps ): React.ReactElement {
 	const [ timestamp, setTimestamp ] = useState( atTime );
 	const [ duration, setDuration ] = useState( 0 );
-	const [ playerIsReady, setPlayerIsReady ] = useState( false );
 	const playerWrapperRef = useRef< HTMLDivElement >( null );
 
 	const url = getVideoPressUrl( guid, {
@@ -245,8 +333,6 @@ function VideoFramePicker( {
 	const { preview = { html: null }, isRequestingEmbedPreview } = usePreview( url );
 	const { html } = preview;
 
-	const playerState = useRef< 'not-rendered' | 'loaded' | 'has-auto-played' >( 'not-rendered' );
-
 	/**
 	 * Handler function to deal with the communication
 	 * between the iframe, which contains the video,
@@ -255,7 +341,7 @@ function VideoFramePicker( {
 	 * @param {MessageEvent} event - Message event
 	 */
 	function listenEventsHandler( event: MessageEvent ) {
-		const { data: eventData = {}, source } = event;
+		const { data: eventData = {} } = event;
 		const { event: eventName } = event?.data || {};
 
 		// Pick and store the video duration in a local state.
@@ -264,27 +350,11 @@ function VideoFramePicker( {
 				setDuration( eventData.durationMs );
 			}
 		}
-
-		// Detect when the video has been loaded.
-		if ( eventName === 'videopress_loading_state' && eventData.state === 'loaded' ) {
-			playerState.current = 'loaded';
-		}
-
-		// Hack 2/2: Pause the video right after it has been auto-loaded.
-		if ( eventName === 'videopress_playing' && playerState.current === 'loaded' ) {
-			playerState.current = 'has-auto-played';
-
-			// Pause and playback the video to ensure the video is at the desired time.
-			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
-			source.postMessage(
-				{ event: 'videopress_action_set_currenttime', currentTime: atTime / 1000 },
-				{ targetOrigin: '*' }
-			);
-
-			// Here we consider the video as ready to be controlled.
-			setPlayerIsReady( true );
-		}
 	}
+
+	const { playerIsReady } = usePlayerReady( playerWrapperRef, isRequestingEmbedPreview, {
+		atTime,
+	} );
 
 	// Listen player events.
 	useEffect( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR extracts and exposes the `usePlayerReady()` custom hook currently used by the TimestampControl but will be used when the Hover effect controls the player in the editor canvas.

It's worth mentioning that to control the video, we need to enable `autoplay` and `muted` for the video, meaning that we'll probably have to stop it immediately after the video is ready. That's what the `usePlayerReady()` function does.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: extract, create and expose usePlayerReady() hook

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm the `<VideoFramePicker />` component works as expected
* Show a _uploading_ state when the video is loading
* Updates the UI when it's loaded
* Set the video position according to the timestamp defined by using the controls

https://user-images.githubusercontent.com/77539/228575384-a75b5950-68f2-40f2-97d7-884ba00c9341.mov
