### PR TITLE
Stats Widget: Fix incorrect invocation of module-specific functions

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-29773
+++ b/projects/plugins/jetpack/changelog/fix-29773
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Stats Widget: Fix incorrect invocation of module-restricted functions

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -53,8 +53,7 @@ class Jetpack_Stats_Dashboard_Widget {
 		}
 
 		if ( Jetpack::is_connection_ready() ) {
-			// TODO: Migrate this head function into this class.
-			add_action( 'admin_head', 'stats_dashboard_head' );
+			add_action( 'admin_head', array( static::class, 'admin_head' ) );
 
 			$widget_title = sprintf(
 				__( 'Jetpack Stats', 'jetpack' )
@@ -76,6 +75,61 @@ class Jetpack_Stats_Dashboard_Widget {
 			);
 			wp_style_add_data( 'jetpack-dashboard-widget', 'rtl', 'replace' );
 		}
+	}
+
+	/**
+	 * JavaScript and CSS for dashboard widget.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public static function admin_head() {
+		?>
+			<script type="text/javascript">
+				/* <![CDATA[ */
+				jQuery( function($) {
+					var dashStats = jQuery( '#dashboard_stats div.inside' );
+
+					if ( dashStats.find( '.dashboard-widget-control-form' ).length ) {
+						return;
+					}
+
+					if ( ! dashStats.length ) {
+						dashStats = jQuery( '#dashboard_stats div.dashboard-widget-content' );
+						var h = parseInt( dashStats.parent().height() ) - parseInt( dashStats.prev().height() );
+						var args = 'width=' + dashStats.width() + '&height=' + h.toString();
+					} else {
+						if ( jQuery('#dashboard_stats' ).hasClass('postbox') ) {
+							var args = 'width=' + ( dashStats.prev().width() * 2 ).toString();
+						} else {
+							var args = 'width=' + ( dashStats.width() * 2 ).toString();
+						}
+					}
+
+					dashStats
+						.not( '.dashboard-widget-control' )
+						.load( 'admin.php?page=stats&noheader&dashboard&' + args, function() {
+							jQuery( '#dashboard_stats' ).removeClass( 'is-loading' );
+							jQuery( '#stat-chart' ).css( 'width', 'auto' );
+						} );
+
+					// Widget settings toggle container.
+					var toggle = $( '.js-toggle-stats_dashboard_widget_control' );
+
+					// Move the toggle in the widget header.
+					toggle.appendTo( '#jetpack_summary_widget .handle-actions' );
+
+					// Toggle settings when clicking on it.
+					toggle.show().click( function( e ) {
+						e.preventDefault();
+						e.stopImmediatePropagation();
+						$( this ).parent().toggleClass( 'controlVisible' );
+						$( '#stats_dashboard_widget_control' ).slideToggle();
+					} );
+				} );
+				/* ]]> */
+			</script>
+		<?php
 	}
 
 	/**

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -136,7 +136,10 @@ class Jetpack_Stats_Dashboard_Widget {
 	 * Renders the widget and fires a dashboard widget action.
 	 */
 	public static function render_widget() {
-		stats_jetpack_dashboard_widget();
+		// This function won't exist if the stats module is disabled.
+		if ( function_exists( 'stats_jetpack_dashboard_widget' ) ) {
+			stats_jetpack_dashboard_widget();
+		}
 
 		/**
 		 * Fires when the dashboard is loaded, but no longer used anywhere in the Jetpack plugin.

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -12,6 +12,9 @@ use Automattic\Jetpack\Status;
 
 /**
  * Class that adds the Jetpack stats widget to the WordPress admin dashboard.
+ *
+ * Note that this widget renders whether or not the stats module is active because it currently
+ * displays information about Akismet and Protect.
  */
 class Jetpack_Stats_Dashboard_Widget {
 

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1246,63 +1246,6 @@ function stats_jetpack_dashboard_widget() {
 }
 
 /**
- * JavaScript and CSS for dashboard widget.
- *
- * TODO: This should be moved into class-jetpack-stats-dashboard-widget.php.
- *
- * @access public
- * @return void
- */
-function stats_dashboard_head() {
-	?>
-<script type="text/javascript">
-/* <![CDATA[ */
-jQuery( function($) {
-	var dashStats = jQuery( '#dashboard_stats div.inside' );
-
-	if ( dashStats.find( '.dashboard-widget-control-form' ).length ) {
-		return;
-	}
-
-	if ( ! dashStats.length ) {
-		dashStats = jQuery( '#dashboard_stats div.dashboard-widget-content' );
-		var h = parseInt( dashStats.parent().height() ) - parseInt( dashStats.prev().height() );
-		var args = 'width=' + dashStats.width() + '&height=' + h.toString();
-	} else {
-		if ( jQuery('#dashboard_stats' ).hasClass('postbox') ) {
-			var args = 'width=' + ( dashStats.prev().width() * 2 ).toString();
-		} else {
-			var args = 'width=' + ( dashStats.width() * 2 ).toString();
-		}
-	}
-
-	dashStats
-		.not( '.dashboard-widget-control' )
-		.load( 'admin.php?page=stats&noheader&dashboard&' + args, function() {
-			jQuery( '#dashboard_stats' ).removeClass( 'is-loading' );
-			jQuery( '#stat-chart' ).css( 'width', 'auto' );
-		} );
-
-	// Widget settings toggle container.
-	var toggle = $( '.js-toggle-stats_dashboard_widget_control' );
-
-	// Move the toggle in the widget header.
-	toggle.appendTo( '#jetpack_summary_widget .handle-actions' );
-
-	// Toggle settings when clicking on it.
-	toggle.show().click( function( e ) {
-		e.preventDefault();
-		e.stopImmediatePropagation();
-		$( this ).parent().toggleClass( 'controlVisible' );
-		$( '#stats_dashboard_widget_control' ).slideToggle();
-	} );
-} );
-/* ]]> */
-</script>
-	<?php
-}
-
-/**
  * Stats Dashboard Widget Content.
  *
  * TODO: This should be moved into class-jetpack-stats-dashboard-widget.php.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29773

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes a regression introduced by #29524, where we invoke functions (`stats_dashboard_head` and `stats_jetpack_dashboard_widget`) that are defined only if the stats module is enabled.
    * Migrates `stats_dashboard_head` into the stats widget class.
    * Check for the existence of `stats_jetpack_dashboard_widget` before invocation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply these changes to your unconnected Jetpack site.
2. Ensure that navigating to `/wp-admin/` works as expected.
3. Connect your Jetpack site, which should automatically enable the `stats` module.
4. Ensure that the following pages work as expected:
    * `/wp-admin/`
    * `/wp-admin/admin.php?page=jetpack#/dashboard`
    * `/wp-admin/admin.php?page=stats`
5. Disable the `stats` module via `/wp-admin/admin.php?page=jetpack_modules&module_tag=Site Stats`.
6. Ensure that these pages work as expected:
    * `/wp-admin/`
    * `/wp-admin/admin.php?page=jetpack#/dashboard`