### PR TITLE
VideoPress: Add video duration to block attributes

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-video-block-video-duration
+++ b/projects/packages/videopress/changelog/add-videopress-video-block-video-duration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add video duration to block attributes

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -118,6 +118,9 @@
 		"isExample": {
 			"type": "boolean",
 			"default": false
+		},
+		"duration": {
+			"type": "number"
 		}
 	},
 	"textdomain": "jetpack-videopress",

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -35,7 +35,7 @@ import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../
 import type { PosterPanelProps, VideoControlProps, VideoGUID } from '../../types';
 import type React from 'react';
 
-const MAX_LOOP_DURATION = 20 * 1000;
+const MAX_LOOP_DURATION = 30 * 1000;
 const DEFAULT_LOOP_DURATION = 10 * 1000;
 
 /*
@@ -385,6 +385,7 @@ function VideoHoverPreviewControl( {
 					<TimestampControl
 						label={ __( 'Starting point', 'jetpack-videopress-pkg' ) }
 						max={ maxStartingPoint }
+						decimalPlaces={ 2 }
 						value={ previewAtTime }
 						onChange={ onAtTimeChange }
 					/>
@@ -392,7 +393,7 @@ function VideoHoverPreviewControl( {
 					<NumberControl
 						className="poster-panel__loop-duration"
 						min={ 0 }
-						max={ MAX_LOOP_DURATION }
+						max={ Math.min( MAX_LOOP_DURATION, videoDuration ) / 1000 }
 						step={ 1 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
 						spinControls="none"
@@ -435,7 +436,7 @@ export default function PosterPanel( {
 		attributes?.posterData?.previewLoopDuration || DEFAULT_LOOP_DURATION
 	);
 
-	const videoDuration = 720000; // TODO: get the video duration from the block attributes
+	const videoDuration = attributes?.duration;
 
 	const onRemovePoster = () => {
 		setAttributes( { poster: '', posterData: { ...attributes.posterData, url: '' } } );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -66,6 +66,8 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 
 	isPrivate?: boolean;
 
+	duration?: number;
+
 	// CSS classes
 	className?: string;
 };

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data-update/index.ts
@@ -78,6 +78,7 @@ const videoFieldsToUpdate = [
 	'allow_download',
 	'display_embed',
 	'is_private',
+	'duration',
 ];
 
 /*

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -58,6 +58,7 @@ export default function useVideoData( {
 				const filename = response.original?.split( '/' )?.at( -1 );
 
 				setVideoData( {
+					duration: response.duration,
 					allow_download: response.allow_download,
 					post_id: response.post_id,
 					guid: response.guid,

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/types.ts
@@ -12,6 +12,7 @@ export type UseVideoDataArgumentsProps = {
 };
 
 export type VideoDataProps = {
+	duration?: number;
 	allow_download?: boolean;
 	description?: string;
 	display_embed?: boolean;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29778

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the video duration to the block attributes and uses it in the hover start time selector

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor, add a VideoPress block and upload a video
* Go to the `Poster and preview` panel and turn on the `Video preview on hover` option
* Check that the start time selector, with a loop time of 0, has the video duration as max value ( you can check it by logging it to the console with `localStorage.debug='*'`


https://user-images.githubusercontent.com/8486249/228666795-b876ab22-7e94-474f-8d75-91f426dfaf92.mp4
