### PR TITLE
VideoPress: play/pause video when previewOnHover is enabled

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-play-pause-when-hovering
+++ b/projects/packages/videopress/changelog/update-videopress-play-pause-when-hovering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: play/pause video when previewOnHover is enabled

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -5,7 +5,7 @@ import { RichText } from '@wordpress/block-editor';
 import { ResizableBox, SandBox } from '@wordpress/components';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { getIframeWindowFromRef } from '../poster-panel';
+import { getIframeWindowFromRef, usePlayerReady } from '../poster-panel';
 /**
  * Types
  */
@@ -156,6 +156,23 @@ export default function Player( {
 
 		return () => iFrameContentWindow?.removeEventListener( 'message', videoPlayerEventsHandler );
 	}, [ videoWrapperRef, isRequestingEmbedPreview ] );
+
+	const { atTime, previewOnHover, previewAtTime, type } = attributes.posterData;
+
+	let timeToSetPlayerPosition = undefined;
+	if ( type === 'video-frame' ) {
+		if ( previewOnHover ) {
+			timeToSetPlayerPosition = previewAtTime;
+		} else {
+			timeToSetPlayerPosition = atTime;
+		}
+	} else {
+		timeToSetPlayerPosition = atTime;
+	}
+
+	usePlayerReady( videoWrapperRef, isRequestingEmbedPreview, {
+		atTime: timeToSetPlayerPosition,
+	} );
 
 	useEffect( () => {
 		if ( isRequestingEmbedPreview ) {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -5,7 +5,7 @@ import { RichText } from '@wordpress/block-editor';
 import { ResizableBox, SandBox } from '@wordpress/components';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { getIframeWindowFromRef, usePlayerReady } from '../poster-panel';
+import { getIframeWindowFromRef, useVideoPlayer } from '../poster-panel';
 /**
  * Types
  */
@@ -171,7 +171,7 @@ export default function Player( {
 		timeToSetPlayerPosition = atTime;
 	}
 
-	usePlayerReady( videoWrapperRef, isRequestingEmbedPreview, {
+	useVideoPlayer( videoWrapperRef, isRequestingEmbedPreview, {
 		atTime: timeToSetPlayerPosition,
 		wrapperElement: mainWrapperRef?.current,
 		previewOnHover: {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -157,7 +157,8 @@ export default function Player( {
 		return () => iFrameContentWindow?.removeEventListener( 'message', videoPlayerEventsHandler );
 	}, [ videoWrapperRef, isRequestingEmbedPreview ] );
 
-	const { atTime, previewOnHover, previewAtTime, type } = attributes.posterData;
+	const { atTime, previewOnHover, previewAtTime, previewLoopDuration, type } =
+		attributes.posterData;
 
 	let timeToSetPlayerPosition = undefined;
 	if ( type === 'video-frame' ) {
@@ -172,6 +173,11 @@ export default function Player( {
 
 	usePlayerReady( videoWrapperRef, isRequestingEmbedPreview, {
 		atTime: timeToSetPlayerPosition,
+		wrapperElement: mainWrapperRef?.current,
+		previewOnHover: {
+			atTime: previewAtTime,
+			duration: previewLoopDuration,
+		},
 	} );
 
 	useEffect( () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -174,10 +174,12 @@ export default function Player( {
 	useVideoPlayer( videoWrapperRef, isRequestingEmbedPreview, {
 		atTime: timeToSetPlayerPosition,
 		wrapperElement: mainWrapperRef?.current,
-		previewOnHover: {
-			atTime: previewAtTime,
-			duration: previewLoopDuration,
-		},
+		previewOnHover: previewOnHover
+			? {
+					atTime: previewAtTime,
+					duration: previewLoopDuration,
+			  }
+			: undefined,
 	} );
 
 	useEffect( () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -160,7 +160,7 @@ export default function Player( {
 	const { atTime, previewOnHover, previewAtTime, previewLoopDuration, type } =
 		attributes.posterData;
 
-	let timeToSetPlayerPosition = undefined;
+	let timeToSetPlayerPosition;
 	if ( type === 'video-frame' ) {
 		if ( previewOnHover ) {
 			timeToSetPlayerPosition = previewAtTime;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -5,10 +5,10 @@ import { RichText } from '@wordpress/block-editor';
 import { ResizableBox, SandBox } from '@wordpress/components';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { getIframeWindowFromRef, useVideoPlayer } from '../poster-panel';
 /**
  * Types
  */
+import useVideoPlayer, { getIframeWindowFromRef } from '../../../../hooks/use-video-player';
 import type { PlayerProps } from './types';
 import type React from 'react';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -211,7 +211,7 @@ export const getIframeWindowFromRef = (
 	return iFrame?.contentWindow;
 };
 
-type UsePlayerReadyOptions = {
+type UseVideoPlayerOptions = {
 	/*
 	 * The time to initially set the player to.
 	 */
@@ -237,7 +237,7 @@ type UsePLayerReadyReturn = {
 	playerState: 'not-rendered' | 'loaded' | 'first-play';
 =======
 type PlayerStateProp = 'not-rendered' | 'loaded' | 'first-play' | 'ready';
-type UsePLayerReadyReturn = {
+type UseVideoPlayer = {
 	playerIsReady: boolean;
 	playerState: PlayerStateProp;
 >>>>>>> 077bfb4010 ([not verified] tidy videoPlayerEventsHandler fn)
@@ -248,14 +248,14 @@ type UsePLayerReadyReturn = {
  *
  * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - useRef of the sandbox wrapper.
  * @param {boolean} isRequestingEmbedPreview                   - Whether the preview is being requested.
- * @param {UsePlayerReadyOptions} options                      - Options object.
- * @returns {UsePLayerReadyReturn}                               playerIsReady and playerState
+ * @param {UseVideoPlayerOptions} options                      - Options object.
+ * @returns {UseVideoPlayer}                               playerIsReady and playerState
  */
-export const usePlayerReady = (
+export const useVideoPlayer = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
 	isRequestingEmbedPreview: boolean,
-	{ atTime, wrapperElement, previewOnHover }: UsePlayerReadyOptions
-): UsePLayerReadyReturn => {
+	{ atTime, wrapperElement, previewOnHover }: UseVideoPlayerOptions
+): UseVideoPlayer => {
 	const [ playerIsReady, setPlayerIsReady ] = useState( false );
 <<<<<<< HEAD
 	const playerState = useRef< 'not-rendered' | 'loaded' | 'first-play' | 'ready' >(

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -25,7 +25,7 @@ import classnames from 'classnames';
 import TimestampControl from '../../../../../components/timestamp-control';
 import { getVideoPressUrl } from '../../../../../lib/url';
 import { usePreview } from '../../../../hooks/use-preview';
-import { useVideoPlayer } from '../../../../hooks/use-video-player';
+import useVideoPlayer from '../../../../hooks/use-video-player';
 import { VIDEO_POSTER_ALLOWED_MEDIA_TYPES } from '../../constants';
 import { VideoPosterCard } from '../poster-image-block-control';
 import './style.scss';

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -240,7 +240,7 @@ type UsePLayerReadyReturn = {
  * @param {UsePlayerReadyOptions} options                      - Options object.
  * @returns {UsePLayerReadyReturn}                               playerIsReady and playerState
  */
-const usePlayerReady = (
+export const usePlayerReady = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
 	isRequestingEmbedPreview: boolean,
 	{ atTime }: UsePlayerReadyOptions
@@ -275,10 +275,14 @@ const usePlayerReady = (
 
 			// Pause and move the video at the desired time.
 			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
-			source.postMessage(
-				{ event: 'videopress_action_set_currenttime', currentTime: atTime / 1000 },
-				{ targetOrigin: '*' }
-			);
+
+			// Set position at time if it was provided.
+			if ( typeof atTime !== 'undefined' ) {
+				source.postMessage(
+					{ event: 'videopress_action_set_currenttime', currentTime: atTime / 1000 },
+					{ targetOrigin: '*' }
+				);
+			}
 
 			// Here we consider the video as ready to be controlled.
 			setPlayerIsReady( true );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -236,10 +236,10 @@ function VideoFramePicker( {
 	const playerWrapperRef = useRef< HTMLDivElement >( null );
 
 	const url = getVideoPressUrl( guid, {
-		autoplay: true, // Hack 1/2: Set autoplay true to be able to control the video.
+		autoplay: true, // Set `autoplay` and `muted` true to be able to control the video.
+		muted: true,
 		controls: false,
 		loop: false,
-		muted: true,
 	} );
 
 	const { preview = { html: null }, isRequestingEmbedPreview } = usePreview( url );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -215,9 +215,16 @@ type UsePlayerReadyOptions = {
 	atTime: number;
 };
 
+<<<<<<< HEAD
 type UsePLayerReadyReturn = {
 	playerIsReady: boolean;
 	playerState: 'not-rendered' | 'loaded' | 'first-play';
+=======
+type PlayerStateProp = 'not-rendered' | 'loaded' | 'first-play' | 'ready';
+type UsePLayerReadyReturn = {
+	playerIsReady: boolean;
+	playerState: PlayerStateProp;
+>>>>>>> 077bfb4010 ([not verified] tidy videoPlayerEventsHandler fn)
 };
 
 /**
@@ -239,9 +246,13 @@ const usePlayerReady = (
 	{ atTime }: UsePlayerReadyOptions
 ): UsePLayerReadyReturn => {
 	const [ playerIsReady, setPlayerIsReady ] = useState( false );
+<<<<<<< HEAD
 	const playerState = useRef< 'not-rendered' | 'loaded' | 'first-play' | 'ready' >(
 		'not-rendered'
 	);
+=======
+	const playerState = useRef< PlayerStateProp >( 'not-rendered' );
+>>>>>>> 077bfb4010 ([not verified] tidy videoPlayerEventsHandler fn)
 
 	/**
 	 * Handler function that listent the events

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
@@ -17,5 +17,18 @@ function myVideoComponent( { id, guid } ) {
 
 ## API
 
-### useVideoPlayer( iframeRef, isRequestingPreview, options )
+### useVideoPlayer
+
+_Parameters_
+
+( iframeRef, isRequestingPreview, options )
+
+-   _iframeRef_ `upload` | `playback` | `upload-jwt`: Token scope.
+-   _isRequestingPreview_ `boolean`: True if the app is requesting the player preview
+-   _options_ `object`:
+-   _options.atTime_ `?number`: The time to initially set the player to.
+-   _options.wrapperElement_ `?HTMLDivElement`: DOM player wrapper element.
+-   _options.PreviewOnHover_ `?object`
+-   _options.PreviewOnHover.atTime_ The timestamp to playback the video when hovering over it
+-   _options.PreviewOnHover.durantion_ PreviewOnHover time duration
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
@@ -1,0 +1,15 @@
+# useVideoPlayer()
+
+React custom hook to listen and control the video player through events provided by the client.
+
+```jsx
+function myVideoComponent( { id, guid } ) {
+	const { playerIsReady } = useVideoPlayer( iframeRef, isRequestingPreview );
+
+	if ( isRequestingVideoData ) {
+		return null;
+	}
+
+	return <p>Video title: { videoData.title }</p>;
+}
+```

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
@@ -4,12 +4,18 @@ React custom hook to listen and control the video player through events provided
 
 ```jsx
 function myVideoComponent( { id, guid } ) {
+	const iframeRef = useRef();
 	const { playerIsReady } = useVideoPlayer( iframeRef, isRequestingPreview );
 
-	if ( isRequestingVideoData ) {
-		return null;
-	}
-
-	return <p>Video title: { videoData.title }</p>;
+	return (
+		<div ref={ iframeRef }>
+			<SandBox />
+		</div>
+	);
 }
 ```
+
+## API
+
+### useVideoPlayer( iframeRef, isRequestingPreview, options )
+

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -31,13 +31,13 @@ export const getIframeWindowFromRef = (
  * Custom hook to set the player ready to use:
  *
  * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - useRef of the sandbox wrapper.
- * @param {boolean} isRequestingEmbedPreview                   - Whether the preview is being requested.
+ * @param {boolean} isRequestingPreview                        - Whether the preview is being requested.
  * @param {UseVideoPlayerOptions} options                      - Options object.
  * @returns {UseVideoPlayer}                                     playerIsReady and playerState
  */
 const useVideoPlayer = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
-	isRequestingEmbedPreview: boolean,
+	isRequestingPreview: boolean,
 	{ atTime, wrapperElement, previewOnHover }: UseVideoPlayerOptions
 ): UseVideoPlayer => {
 	const [ playerIsReady, setPlayerIsReady ] = useState( false );
@@ -90,7 +90,7 @@ const useVideoPlayer = (
 
 	// Listen player events.
 	useEffect( () => {
-		if ( isRequestingEmbedPreview ) {
+		if ( isRequestingPreview ) {
 			return;
 		}
 
@@ -105,7 +105,7 @@ const useVideoPlayer = (
 			// Remove the listener when the component is unmounted.
 			sandboxIFrameWindow.removeEventListener( 'message', listenEventsHandler );
 		};
-	}, [ iFrameRef, isRequestingEmbedPreview ] );
+	}, [ iFrameRef, isRequestingPreview ] );
 
 	const playVideo = useCallback( () => {
 		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
+import debugFactory from 'debug';
 import { useEffect, useRef, useState, useCallback } from 'react';
 /**
  * Types
  */
 import type { PlayerStateProp, UseVideoPlayerOptions, UseVideoPlayer } from './types';
 import type React from 'react';
+
+const debug = debugFactory( 'videopress:use-video-player' );
 
 /**
  * Return the (content) Window object of the iframe,
@@ -32,7 +35,7 @@ export const getIframeWindowFromRef = (
  * @param {UseVideoPlayerOptions} options                      - Options object.
  * @returns {UseVideoPlayer}                                     playerIsReady and playerState
  */
-export const useVideoPlayer = (
+const useVideoPlayer = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
 	isRequestingEmbedPreview: boolean,
 	{ atTime, wrapperElement, previewOnHover }: UseVideoPlayerOptions
@@ -58,18 +61,21 @@ export const useVideoPlayer = (
 
 		// Detect when the video has been loaded.
 		if ( eventName === 'videopress_loading_state' && eventData.state === 'loaded' ) {
+			debug( 'state: loaded' );
 			playerState.current = 'loaded';
 		}
 
 		// Detect when the video has been played for the first time.
 		if ( eventName === 'videopress_playing' && playerState.current === 'loaded' ) {
 			playerState.current = 'first-play';
+			debug( 'state: first-play detected' );
 
 			// Pause and move the video at the desired time.
 			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
 
 			// Set position at time if it was provided.
 			if ( typeof atTime !== 'undefined' ) {
+				debug( 'set position at time %o ', atTime );
 				source.postMessage(
 					{ event: 'videopress_action_set_currenttime', currentTime: atTime / 1000 },
 					{ targetOrigin: '*' }
@@ -140,3 +146,5 @@ export const useVideoPlayer = (
 		playerState: playerState.current,
 	};
 };
+
+export default useVideoPlayer;

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -1,0 +1,142 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef, useState, useCallback } from 'react';
+/**
+ * Types
+ */
+import type { PlayerStateProp, UseVideoPlayerOptions, UseVideoPlayer } from './types';
+import type React from 'react';
+
+/**
+ * Return the (content) Window object of the iframe,
+ * given the iframe's ref.
+ *
+ * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - iframe ref
+ * @returns {Window | null}	                                     Window object of the iframe
+ */
+export const getIframeWindowFromRef = (
+	iFrameRef: React.MutableRefObject< HTMLDivElement >
+): Window | null => {
+	const iFrame: HTMLIFrameElement = iFrameRef?.current?.querySelector(
+		'iframe.components-sandbox'
+	);
+	return iFrame?.contentWindow;
+};
+
+/**
+ * Custom hook to set the player ready to use:
+ *
+ * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - useRef of the sandbox wrapper.
+ * @param {boolean} isRequestingEmbedPreview                   - Whether the preview is being requested.
+ * @param {UseVideoPlayerOptions} options                      - Options object.
+ * @returns {UseVideoPlayer}                                     playerIsReady and playerState
+ */
+export const useVideoPlayer = (
+	iFrameRef: React.MutableRefObject< HTMLDivElement >,
+	isRequestingEmbedPreview: boolean,
+	{ atTime, wrapperElement, previewOnHover }: UseVideoPlayerOptions
+): UseVideoPlayer => {
+	const [ playerIsReady, setPlayerIsReady ] = useState( false );
+	const playerState = useRef< PlayerStateProp >( 'not-rendered' );
+
+	/**
+	 * Handler function that listen the events
+	 * emited by the player client.
+	 *
+	 * - Initial player state:
+	 * - - Detect the "videopress_loading_state" state.
+	 * - - Detect the first time the player plays.
+	 * - - Stop right after it plays.
+	 * - - Set the player position at the desired time.
+	 *
+	 * @param {MessageEvent} event - Message event
+	 */
+	function listenEventsHandler( event: MessageEvent ) {
+		const { data: eventData = {}, source } = event;
+		const { event: eventName } = event?.data || {};
+
+		// Detect when the video has been loaded.
+		if ( eventName === 'videopress_loading_state' && eventData.state === 'loaded' ) {
+			playerState.current = 'loaded';
+		}
+
+		// Detect when the video has been played for the first time.
+		if ( eventName === 'videopress_playing' && playerState.current === 'loaded' ) {
+			playerState.current = 'first-play';
+
+			// Pause and move the video at the desired time.
+			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
+
+			// Set position at time if it was provided.
+			if ( typeof atTime !== 'undefined' ) {
+				source.postMessage(
+					{ event: 'videopress_action_set_currenttime', currentTime: atTime / 1000 },
+					{ targetOrigin: '*' }
+				);
+			}
+
+			// Here we consider the video as ready to be controlled.
+			setPlayerIsReady( true );
+			playerState.current = 'ready';
+		}
+	}
+
+	// Listen player events.
+	useEffect( () => {
+		if ( isRequestingEmbedPreview ) {
+			return;
+		}
+
+		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
+		if ( ! sandboxIFrameWindow ) {
+			return;
+		}
+
+		sandboxIFrameWindow.addEventListener( 'message', listenEventsHandler );
+
+		return () => {
+			// Remove the listener when the component is unmounted.
+			sandboxIFrameWindow.removeEventListener( 'message', listenEventsHandler );
+		};
+	}, [ iFrameRef, isRequestingEmbedPreview ] );
+
+	const playVideo = useCallback( () => {
+		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
+		if ( ! sandboxIFrameWindow || ! playerIsReady ) {
+			return;
+		}
+
+		sandboxIFrameWindow.postMessage( { event: 'videopress_action_play' }, '*' );
+	}, [ iFrameRef, playerIsReady ] );
+
+	const stopVideo = useCallback( () => {
+		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
+		if ( ! sandboxIFrameWindow || ! playerIsReady ) {
+			return;
+		}
+
+		sandboxIFrameWindow.postMessage( { event: 'videopress_action_pause' }, '*' );
+	}, [ iFrameRef, playerIsReady ] );
+
+	// PreviewOnHover feature.
+	useEffect( () => {
+		if ( ! wrapperElement || ! previewOnHover ) {
+			return;
+		}
+
+		wrapperElement.addEventListener( 'mouseenter', playVideo );
+		wrapperElement.addEventListener( 'mouseleave', stopVideo );
+
+		return () => {
+			// Remove the listener when the component is unmounted.
+			wrapperElement.removeEventListener( 'mouseenter', playVideo );
+			wrapperElement.removeEventListener( 'mouseleave', stopVideo );
+		};
+	}, [ previewOnHover, wrapperElement, playerIsReady ] );
+
+	return {
+		playerIsReady,
+		playerState: playerState.current,
+	};
+};

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
@@ -1,0 +1,26 @@
+export type PlayerStateProp = 'not-rendered' | 'loaded' | 'first-play' | 'ready';
+
+export type UseVideoPlayer = {
+	playerIsReady: boolean;
+	playerState: PlayerStateProp;
+};
+
+export type UseVideoPlayerOptions = {
+	/*
+	 * The time to initially set the player to.
+	 */
+	atTime: number;
+
+	/*
+	 * DOM player wrapper element.
+	 */
+	wrapperElement?: HTMLDivElement | null;
+
+	/*
+	 * PreviewOnHover feature options.
+	 */
+	previewOnHover?: {
+		atTime: number;
+		duration: number;
+	};
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR plays/pauses the video player of the VideoPress video block in the editor canvas when the "Preview on hover" is enabled. Also, it iterates over the custom hook:

* Move the hook to its folder
* Create a doc 
* Tidy the types

**Limitations**

These changes put evidence that _maybe_ we should simplify the UI by removing some controls. We should probably consider that when the "Preview on hover" is enabled, the video poster should always be defined by the frame of the starting point.


Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: play/pause video when previewOnHover is enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a VideoPress video block
* Enable "Preview on hover"
*  **IMPORTANT** enable `autoplay` and `muted`
* Set the Starting point
* Save the post
* Hard refresh
* Confirm the player plays when hovering over it and pauses when leaving.

https://user-images.githubusercontent.com/77539/228691468-faa21253-76b6-4c00-b782-3b01865397a0.mov


**Disclaimer**
As usual, we need to keep polishing the implementation in follow-up tasks. 
* Playback to the starting point once it achieves the duration
* Do not playback at the starting position if the current position of the player is into the limit defined by the user
* Preview on Hover requires setting the `autoplay` and `muted` to true. Something that we'll have to do when it's enabled.
* etc