### PR TITLE
Sync: Fix failed_login_attempt undefined index warning

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-failed-login-attempt-undefined-index
+++ b/projects/packages/sync/changelog/fix-sync-failed-login-attempt-undefined-index
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: fix undefined index php warning.
+
+

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.47.4';
+	const PACKAGE_VERSION = '1.47.5-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-protect.php
+++ b/projects/packages/sync/src/modules/class-protect.php
@@ -45,7 +45,7 @@ class Protect extends Module {
 	 * @param array $failed_attempt Failed attempt data.
 	 */
 	public function maybe_log_failed_login_attempt( $failed_attempt ) {
-		if ( $failed_attempt['has_login_ability'] && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
+		if ( ! empty( $failed_attempt['has_login_ability'] ) && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}
 	}

--- a/projects/packages/sync/src/modules/class-protect.php
+++ b/projects/packages/sync/src/modules/class-protect.php
@@ -45,7 +45,8 @@ class Protect extends Module {
 	 * @param array $failed_attempt Failed attempt data.
 	 */
 	public function maybe_log_failed_login_attempt( $failed_attempt ) {
-		if ( ! empty( $failed_attempt['has_login_ability'] ) && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
+		$protect = \Jetpack_Protect_Module::instance();
+		if ( $protect->has_login_ability() && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}
 	}

--- a/projects/packages/sync/src/modules/class-protect.php
+++ b/projects/packages/sync/src/modules/class-protect.php
@@ -8,6 +8,8 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
+use Automattic\Jetpack\Waf\Waf_Compatibility;
+use Jetpack_Protect_Module;
 
 /**
  * Class to handle sync for Protect.
@@ -45,8 +47,12 @@ class Protect extends Module {
 	 * @param array $failed_attempt Failed attempt data.
 	 */
 	public function maybe_log_failed_login_attempt( $failed_attempt ) {
-		$protect = \Jetpack_Protect_Module::instance();
-		if ( $protect->has_login_ability() && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
+		if ( ! isset( $failed_attempt['has_login_ability'] ) && Waf_Compatibility::is_brute_force_running_in_jetpack() ) {
+			$protect                             = Jetpack_Protect_Module::instance();
+			$failed_attempt['has_login_ability'] = $protect->has_login_ability();
+		}
+
+		if ( $failed_attempt['has_login_ability'] && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}
 	}

--- a/projects/packages/waf/changelog/fix-brute-force-protection-running-twice
+++ b/projects/packages/waf/changelog/fix-brute-force-protection-running-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Return early if we detect the older BFP implementation from the main plugin

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -150,6 +150,12 @@ class Brute_Force_Protection {
 	 * @return void
 	 */
 	public static function initialize() {
+
+		// Older versions of Jetpack might have the older pre-package implementation of this feature, let's try to detect it and return early so both don't run.
+		if ( class_exists( 'Jetpack_Protect_Module' ) ) {
+			return;
+		}
+
 		$brute_force_protection_is_enabled = self::is_enabled();
 		if ( $brute_force_protection_is_enabled && ( new Connection_Manager() )->is_connected() ) {
 			global $pagenow;

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -151,8 +151,8 @@ class Brute_Force_Protection {
 	 */
 	public static function initialize() {
 
-		// Older versions of Jetpack might have the older pre-package implementation of this feature, let's try to detect it and return early so both don't run.
-		if ( class_exists( 'Jetpack_Protect_Module' ) ) {
+		// Let's try to detect older versions of Jetpack that don't use this package for the Brute Force protection feature and return early so we don't run twice.
+		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '12', '<' ) ) {
 			return;
 		}
 

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\CookieState;
 use Automattic\Jetpack\IP\Utils as IP_Utils;
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Waf\Waf_Compatibility;
 use Automattic\Jetpack\Waf\Waf_Constants;
 use Jetpack_IXR_Client;
 use Jetpack_Options;
@@ -151,8 +152,9 @@ class Brute_Force_Protection {
 	 */
 	public static function initialize() {
 
-		// Let's try to detect older versions of Jetpack that don't use this package for the Brute Force protection feature and return early so we don't run twice.
-		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '12', '<' ) ) {
+		// Older versions of Jetpack initialize brute force protection directly in the plugin.
+		// Return early to avoid running it twice.
+		if ( Waf_Compatibility::is_brute_force_running_in_jetpack() ) {
 			return;
 		}
 

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -214,4 +214,15 @@ class Waf_Compatibility {
 		return $waf_allow_list;
 	}
 
+	/**
+	 * Check if the brute force protection code is being run by an older version of Jetpack (< 12.0).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_brute_force_running_in_jetpack() {
+		return defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '12', '<' );
+	}
+
 }

--- a/projects/plugins/jetpack/changelog/fix-sync-failed-login-attempt-undefined-index
+++ b/projects/plugins/jetpack/changelog/fix-sync-failed-login-attempt-undefined-index
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Bug fix: reintroduce and deprecate a class to keep methods available
+
+

--- a/projects/plugins/jetpack/modules/protect.php
+++ b/projects/plugins/jetpack/modules/protect.php
@@ -12,3 +12,40 @@
  * Feature: Security
  * Additional Search Queries: security, jetpack protect, secure, protection, botnet, brute force, protect, login, bot, password, passwords, strong passwords, strong password, wp-login.php,  protect admin
  */
+
+use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
+
+/**
+ * Jetpack project module class.
+ *
+ * @deprecated $$next_version$$ - Use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection instead.
+ */
+class Jetpack_Protect_Module {
+	/**
+	 * Instance of the class.
+	 *
+	 * @var Jetpack_Protect_Module()
+	 */
+	private static $instance = null;
+
+	/**
+	 * Singleton implementation
+	 *
+	 * @return object
+	 */
+	public static function instance() {
+		if ( ! is_a( self::$instance, 'Jetpack_Protect_Module' ) ) {
+			self::$instance = new Jetpack_Protect_Module();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Check if someone is able to login based on IP.
+	 */
+	public function has_login_ability() {
+		$brute_force_protection = Brute_Force_Protection::instance();
+		return $brute_force_protection->has_login_ability();
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If a user is still using Jetpack 11.9, the "jpp_log_failed_attempt" action will not receive the "has_login_ability" property. To resolve this, this PR re-introduces the recently removed `Jetpack_Protect_Module` class, deprecates it, and restores the methods required to keep the old logic in the Sync plugin when the old logic is also running in Jetpack.

```
Notice: Undefined index: has_login_ability in /srv/users/user18852a9f/apps/user18852a9f/public/wp-content/plugins/jetpack-protect/jetpack_vendor/automattic/jetpack-sync/src/modules/class-protect.php on line 48
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Restores `Jetpack_Protect_Module` class in the Jetpack plugin.
* Uses the above class in the Sync package when Jetpack < 12 is running, to maintain backwards compatibility.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a site running the production version of Jetpack, and Jetpack Protect running this branch.
* Ensure your site is connected and brute force protection is enabled.
* Fail a login attempt and validate that no warning is displayed or logged.


## Screenshots

<img width="1415" alt="Screenshot 2023-03-29 at 6 00 26 PM" src="https://user-images.githubusercontent.com/10933065/228695095-c8ef2e01-2793-487e-a81a-ceaa3de0fc10.png">
