### PR TITLE
Return early if we detect older Brute Force Protection implementation

### DIFF
--- a/projects/packages/waf/changelog/fix-brute-force-protection-running-twice
+++ b/projects/packages/waf/changelog/fix-brute-force-protection-running-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Return early if we detect the older BFP implementation from the main plugin

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -150,6 +150,12 @@ class Brute_Force_Protection {
 	 * @return void
 	 */
 	public static function initialize() {
+
+		// Older versions of Jetpack might have the older pre-package implementation of this feature, let's try to detect it and return early so both don't run.
+		if ( class_exists( 'Jetpack_Protect_Module' ) ) {
+			return;
+		}
+
 		$brute_force_protection_is_enabled = self::is_enabled();
 		if ( $brute_force_protection_is_enabled && ( new Connection_Manager() )->is_connected() ) {
 			global $pagenow;

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -151,8 +151,8 @@ class Brute_Force_Protection {
 	 */
 	public static function initialize() {
 
-		// Older versions of Jetpack might have the older pre-package implementation of this feature, let's try to detect it and return early so both don't run.
-		if ( class_exists( 'Jetpack_Protect_Module' ) ) {
+		// Let's try to detect older versions of Jetpack that don't use this package for the Brute Force protection feature and return early so we don't run twice.
+		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '12', '<' ) ) {
 			return;
 		}
 

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\CookieState;
 use Automattic\Jetpack\IP\Utils as IP_Utils;
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Waf\Waf_Compatibility;
 use Automattic\Jetpack\Waf\Waf_Constants;
 use Jetpack_IXR_Client;
 use Jetpack_Options;
@@ -151,8 +152,9 @@ class Brute_Force_Protection {
 	 */
 	public static function initialize() {
 
-		// Let's try to detect older versions of Jetpack that don't use this package for the Brute Force protection feature and return early so we don't run twice.
-		if ( defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '12', '<' ) ) {
+		// Older versions of Jetpack initialize brute force protection directly in the plugin.
+		// Return early to avoid running it twice.
+		if ( Waf_Compatibility::is_brute_force_running_in_jetpack() ) {
 			return;
 		}
 

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -214,4 +214,15 @@ class Waf_Compatibility {
 		return $waf_allow_list;
 	}
 
+	/**
+	 * Check if the brute force protection code is being run by an older version of Jetpack (< 12.0).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_brute_force_running_in_jetpack() {
+		return defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '12', '<' );
+	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This change is to detect inside the package older versions of Jetpack that don't use the WAF package yet and return early so we don't end up running twice.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a site with the Brute Force Protection enabled.
* Install the 1.4.0 beta for the Protect plugin.
* Install the 11.9.1 version of the main Jetpack plugin (latest stable version as of when this was written).
* Logout and try to login with the wrong password until the math question appears.
* Make sure the math question doesn't appear twice.
* Verify in the Protect backend that every failed attempt is only logged once.
* Update the main Jetpack plugin to the latest release candidate version.
* Run all the tests above again.

