### PR TITLE
Recommendations: avoid errors when switching screens

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -20,7 +20,7 @@ const projects = [
 		project: 'Jetpack post-connection',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/post-connection', '--retries=1' ],
-		targets: [ 'plugins/jetpack' ],
+		targets: [ 'plugins/jetpack', 'monorepo' ],
 		suite: '',
 	},
 	{

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -20,7 +20,7 @@ const projects = [
 		project: 'Jetpack post-connection',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/post-connection', '--retries=1' ],
-		targets: [ 'plugins/jetpack', 'monorepo' ],
+		targets: [ 'plugins/jetpack' ],
 		suite: '',
 	},
 	{

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/discount-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/discount-card/index.jsx
@@ -40,7 +40,9 @@ const DiscountCard = ( {
 		} );
 	}, [ hasDiscount ] );
 
-	useEffect( () => markAsViewed( step ), [ markAsViewed, step ] );
+	useEffect( () => {
+		markAsViewed( step );
+	}, [ markAsViewed, step ] );
 
 	useEffect( () => {
 		if ( ! isLoading ) {

--- a/projects/plugins/jetpack/changelog/try-useeffect-issues-62
+++ b/projects/plugins/jetpack/changelog/try-useeffect-issues-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: avoid errors in the Recommendations dashboard.


### PR DESCRIPTION
## Proposed changes:

In WordPress 6.2, post-connection e2e tests are failing; see p1680165071608529-slack-C03QNBQKG73

You'll also notice a js error when in the Recommendations screen:

```
react_devtools_backend.js:2655 Warning: useEffect must not return anything besides a function, which is used for clean-up. You returned: [object Object]
react-dom.js?ver=18.2.0:22942 Uncaught TypeError: destroy is not a function
The above error occurred in one of your React components:
```

<img width="1384" alt="image" src="https://user-images.githubusercontent.com/426388/228784648-68130c54-b169-4d90-aa74-cec5c24295f5.png">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Connect your site to your WordPress.com account.
* Go to Jetpack > Dashboard > Recommendations.
* Open your browser console.
* Go through the recommendations
    * You shouldn't get any blank screen when switching screens, or js errors

The e2e tests appear to work with this branch:
https://github.com/Automattic/jetpack/actions/runs/4562525055/jobs/8050235348?pr=29798
