### PR TITLE
Triage tasks: only send Slack notifications for bugs.

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-triage-slack-notification-rules
+++ b/projects/github-actions/repo-gardening/changelog/update-triage-slack-notification-rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Only send Slack notifications for bugs.


### PR DESCRIPTION
## Proposed changes:

Slack notifications were getting a bit noisy. Let's avoid sending notifications for things that are not bugs, and thus can be prioritized by the teams working on those features.

This applies to 2 types of Slack notifications:

- Notifications sent about High and Blocker bugs.
- Notifications sent about bugs that do not have a priority set yet.

See p1680138879376599/1680113001.137749-slack-C04TRTZUSP9 for extra discussion.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1680138879376599/1680113001.137749-slack-C04TRTZUSP9

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* This is better  tested once merged.
