### PR TITLE
Social Previews | Shift the modal nav to the top

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-shift-modal-nav-to-top
+++ b/projects/js-packages/publicize-components/changelog/update-shift-modal-nav-to-top
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social Preview: Shift the modal nav to the top

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -53,7 +53,6 @@ const SocialPreviewsModal = function SocialPreviewsModal( {
 				className="jetpack-social-previews__modal-previews"
 				tabs={ tabs }
 				initialTabName={ isTweetStorm ? 'twitter' : null }
-				orientation="vertical"
 			>
 				{ tab => (
 					<div>

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -5,10 +5,11 @@
  */
 
 import { SocialServiceIcon } from '@automattic/jetpack-components';
-import { Modal, TabPanel } from '@wordpress/components';
+import { Modal, TabPanel, Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
 import { AVAILABLE_SERVICES } from './constants';
 import { getMediaSourceUrl } from './utils';
 import './modal.scss';
@@ -42,6 +43,12 @@ const SocialPreviewsModal = function SocialPreviewsModal( {
 			className="jetpack-social-previews__modal"
 			__experimentalHideHeader
 		>
+			<Button
+				className="jetpack-social-previews__modal--close-btn"
+				onClick={ onClose }
+				icon={ close }
+				label={ __( 'Close', 'jetpack' ) }
+			/>
 			<TabPanel
 				className="jetpack-social-previews__modal-previews"
 				tabs={ tabs }

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -39,8 +39,8 @@ const SocialPreviewsModal = function SocialPreviewsModal( {
 	return (
 		<Modal
 			onRequestClose={ onClose }
-			title={ __( 'Social Previews', 'jetpack' ) }
 			className="jetpack-social-previews__modal"
+			__experimentalHideHeader
 		>
 			<TabPanel
 				className="jetpack-social-previews__modal-previews"

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
@@ -20,8 +20,8 @@ $highlight-color: #3858e9;
 
 .jetpack-social-previews__modal--close-btn {
 	position: absolute;
-    right: 0.5rem;
-    top: 0.5rem;
+	right: 0.5rem;
+	top: 0.5rem;
 	height: 2rem;
 }
 

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
@@ -4,6 +4,9 @@
 
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
+$jp-gray: #dcdcde;
+$highlight-color: #3858e9;
+
 // Styles shared between modals
 .jetpack-social-previews__modal {
 	.components-modal__header {
@@ -13,6 +16,13 @@
 	.components-modal__content {
 		padding: 0;
 	}
+}
+
+.jetpack-social-previews__modal--close-btn {
+	position: absolute;
+    right: 0.5rem;
+    top: 0.5rem;
+	height: 2rem;
 }
 
 // Main modal containing the social previews
@@ -25,13 +35,15 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: center;
-		padding: 12px;
+		height: 3rem;
 		max-width: none;
+		border-bottom: 1px solid $jp-gray;
 
 		.components-button {
 			outline: 0;
-			margin: 3px 0;
 			font-size: 0;
+			height: 100%;
+			width: 2.5rem;
 			white-space: nowrap;
 
 			svg {
@@ -39,12 +51,15 @@
 				fill: currentColor;
 			}
 
-			&.is-active {
-				box-shadow: 0px 0px 0px 2px var(--wp-admin-theme-color);
+			&.is-active::after {
+				height: 0px;
+				border-bottom: 1px solid $highlight-color;
+				margin-bottom: -1px;
 			}
 
-			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-secondary ):not( .is-primary ):not( .is-tertiary ):not( .is-link ):hover {
-				box-shadow: 0px 0px 0px 2px var(--wp-admin-theme-color);
+			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-secondary ):not( .is-primary ):not( .is-tertiary ):not( .is-link ):hover::after {
+				border-bottom: 1px solid $highlight-color;
+				margin-bottom: -1px;
 			}
 		}
 	}
@@ -69,14 +84,10 @@
 	}
 
 	@media ( min-width: $break-large ) {
-		flex-direction: row;
 		width: calc( #{$break-large} - 40px );
 		min-height: 500px;
 
 		.components-tab-panel__tabs {
-			flex-direction: column;
-			justify-content: flex-start;
-			padding: 24px;
 
 			.components-button {
 				font-size: 13px;


### PR DESCRIPTION
Completes 1203820933396971-as-1204281808721001/f

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the modal nav from side to the top

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
PT: pdrWKz-Ka-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* Start writing a new post.
* Click Jetpack icon on the sidebar
* Under "Social Previews", click on "Preview"
* Confirm that the modal navigation is at the top instead of on the side
* Confirm that the navigation works as expected
* Confirm that the design matches Figma - NIq2WbeH5khnwLVaHbUvSX-fi-3113-6000

<table>
	<thead>
		<tr>
			<th>BEFORE</th>
			<th>AFTER</th>
		</tr>
	</thead>
	<tbody>
		<tr>
			<th colspan="2">Desktop</th>
		</tr>
		<tr>
			<td><img width="946" alt="Screenshot 2023-03-30 at 3 13 31 PM" src="https://user-images.githubusercontent.com/18226415/228797065-f2c3ccf0-2eed-4e18-8b4b-de839af57c01.png"></td>
			<td><img width="993" alt="Screenshot 2023-03-30 at 2 59 32 PM" src="https://user-images.githubusercontent.com/18226415/228797120-15344236-3397-4bdc-b37b-3768a0afef5e.png"></td>
		</tr>
		<tr>
			<th colspan="2">Mobile</th>
		</tr>
		<tr>
			<td><img width="413" alt="Screenshot 2023-03-30 at 3 14 42 PM" src="https://user-images.githubusercontent.com/18226415/228797444-c2cb4803-8e88-44a7-a46d-5abb3235c4e3.png"></td>
			<td><img width="416" alt="Screenshot 2023-03-30 at 2 59 15 PM" src="https://user-images.githubusercontent.com/18226415/228797512-3d7ae4a0-6a14-4914-aebc-68c325dc1f8a.png"></td>
		</tr>
	</tbody>
</table>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1204281808721001