### PR TITLE
Update/lower sync hook priority

### DIFF
--- a/projects/packages/sync/changelog/update-lower-sync-hook-priority
+++ b/projects/packages/sync/changelog/update-lower-sync-hook-priority
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Lowered priority to sync so that the hook is run at the end.

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -171,7 +171,7 @@ class Actions {
 			self::should_initialize_sender()
 		) ) {
 			self::initialize_sender();
-			add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
+			add_action( 'shutdown', array( self::$sender, 'do_sync' ), 9998 );
 			add_action( 'shutdown', array( self::$sender, 'do_full_sync' ), 9999 );
 		}
 	}

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.47.4';
+	const PACKAGE_VERSION = '1.47.5-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jpop-issues/issues/8136 which was closed. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Based on [ticket](https://github.com/Automattic/jpop-issues/issues/8136) it seemed that plugins might be doing a select, using the result and not freeing it properly before we run the Sync code. The idea is to lower the priority to **9998** ( Similarly to  `full_sync` which is assigned **9999**) to try and ensure that sync gets executed at the end.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1678439449940289-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. First of all, let's make sure we are not breaking sync.
* Do some changes to the site and check in ES that sync is being run as usual.
* For example add a new post and check that you get a record with the feature `async_publish_post`.

2. Test by adding another action with lower priority and make sure it is executed prior to `sync` and `full_sync` methods.





