### PR TITLE
Update/forms responses filter data

### DIFF
--- a/projects/packages/forms/changelog/update-forms-responses-filter-data
+++ b/projects/packages/forms/changelog/update-forms-responses-filter-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated form responses endpoint to embed available filter data.

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -223,7 +223,7 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			}
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$months = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -93,8 +93,12 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			'post_status' => array( 'publish', 'draft' ),
 		);
 
-		if ( isset( $request['form_id'] ) ) {
-			$args['post_parent'] = $request['form_id'];
+		if ( isset( $request['parent_id'] ) ) {
+			$args['post_parent'] = $request['parent_id'];
+		}
+
+		if ( isset( $request['month'] ) ) {
+			$args['m'] = $request['month'];
 		}
 
 		if ( isset( $request['limit'] ) ) {

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -137,7 +137,7 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 
 		$source_ids = Contact_Form_Plugin::get_all_parent_post_ids(
 			array_diff_key(
-				$args,
+				array_intersect_key( $query[ $current_query ]->query_vars, $args, array( 'post_status' => '' ) ),
 				array( 'post_parent' => '' )
 			)
 		);
@@ -175,15 +175,74 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 
 		return rest_ensure_response(
 			array(
-				'responses'  => $responses,
-				'totals'     => array_map(
+				'responses'         => $responses,
+				'totals'            => array_map(
 					function ( $subquery ) {
 						return $subquery->found_posts;
 					},
 					$query
 				),
-				'source_ids' => $source_ids,
+				'filters_available' => array(
+					'month'  => $this->get_months_filter_for_query( $query[ $current_query ]->quer_vars ),
+					'source' => array_map(
+						function ( $post_id ) {
+							return array(
+								'id'    => $post_id,
+								'title' => get_the_title( $post_id ),
+								'url'   => get_permalink( $post_id ),
+							);
+						},
+						$source_ids
+					),
+				),
 			)
+		);
+	}
+
+	/**
+	 * Returns a list of months which can be used to filter the given query.
+	 *
+	 * @param array $query Query.
+	 *
+	 * @return array List of months.
+	 */
+	private function get_months_filter_for_query( $query ) {
+		global $wpdb;
+
+		$filters = '';
+
+		if ( isset( $query['post_parent'] ) ) {
+			$filters = $wpdb->prepare( 'AND post_parent = %d ', $query['post_parent'] );
+		}
+
+		if ( isset( $query['post_status'] ) ) {
+			if ( is_array( $query['post_status'] ) ) {
+				$filters .= $wpdb->prepare( 'AND post_status IN (%s) ', implode( ',', $query['post_status'] ) );
+			} else {
+				$filters .= $wpdb->prepare( 'AND post_status = %s ', $query['post_status'] );
+			}
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$months = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+				FROM $wpdb->posts
+				WHERE post_type = 'feedback'
+				$filters
+				ORDER BY post_date DESC"
+			)
+		);
+		// phpcs:enable
+
+		return array_map(
+			function ( $row ) {
+				return array(
+					'month' => intval( $row->month ),
+					'year'  => intval( $row->year ),
+				);
+			},
+			$months
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/update-forms-responses-filter-data
+++ b/projects/plugins/jetpack/changelog/update-forms-responses-filter-data
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Internal change to the package that doesn't currently affect the plugin.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This patch updates the form responses API endpoint used by the new Jetpack Forms dashboard to return available filter data together with the response.

I removed the `source_ids` key added earlier and replaced it with an `available_filters` object. The object currently has two keys, `date` or `source` and this is how you can expect the response to look now:

```
{
    responses: [ ... ],
    totals: { ... },
    available_filters: {
        date: [
            { year: 2023, month: 1 },
            { year: 2023, month: 2 },
            ...
        ],
        source: [
            { id: 123, title: 'Some post title', url: 'https://your.site/your/post' },
            ...
        ]
    }
}
```

**Note:** Months start at `1` for January.

Applying a filter will affect all filters other than the one applied. So for example if you filter by source, the endpoint will still return the full source filter list, but it narrow down the date filter so it only shows months in which responses from the given source came in.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pcsBup-Pl-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to `admin.php?page=jetpack-forms`
- Inspect the request that goes out to `/responses` when the dashboard loads.
- You should see the new `available_filters` key on the response.