### PR TITLE
 VideoPress: replace local state by using block attributes for the PreviewOnHover feature

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-replace-local-state-by-attrs
+++ b/projects/packages/videopress/changelog/update-videopress-replace-local-state-by-attrs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: replace local state by using block attributes for the PreviewOnHover feature

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -505,7 +505,7 @@ export default function PosterPanel( {
 }: PosterPanelProps ): React.ReactElement {
 	const { poster, posterData } = attributes;
 
-	const pickFromFrame = attributes?.posterData?.type === 'video-frame';
+	const pickPosterFromFrame = attributes?.posterData?.type === 'video-frame';
 	const previewOnHover = attributes?.posterData?.previewOnHover || false;
 	const previewAtTime = attributes?.posterData?.previewAtTime || posterData?.atTime || 0;
 	const previewLoopDuration = attributes?.posterData?.previewLoopDuration || DEFAULT_LOOP_DURATION;
@@ -599,12 +599,14 @@ export default function PosterPanel( {
 		<PanelBody title={ panelTitle } className="poster-panel" initialOpen={ false }>
 			<ToggleControl
 				label={ __( 'Pick from video frame', 'jetpack-videopress-pkg' ) }
-				checked={ pickFromFrame }
+				checked={ pickPosterFromFrame }
 				onChange={ switchPosterSource }
 			/>
 
 			<div
-				className={ classnames( 'poster-panel__frame-wrapper', { 'is-selected': pickFromFrame } ) }
+				className={ classnames( 'poster-panel__frame-wrapper', {
+					'is-selected': pickPosterFromFrame,
+				} ) }
 			>
 				<VideoFramePicker
 					isGeneratingPoster={ isGeneratingPoster }
@@ -625,7 +627,7 @@ export default function PosterPanel( {
 
 			<div
 				className={ classnames( 'poster-panel__image-wrapper', {
-					'is-selected': ! pickFromFrame,
+					'is-selected': ! pickPosterFromFrame,
 				} ) }
 			>
 				<PosterDropdown attributes={ attributes } setAttributes={ setAttributes } />

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -505,16 +505,19 @@ export default function PosterPanel( {
 }: PosterPanelProps ): React.ReactElement {
 	const { poster, posterData } = attributes;
 
-	const [ pickFromFrame, setPickFromFrame ] = useState(
-		attributes?.posterData?.type === 'video-frame'
-	);
-	const [ previewOnHover, setPreviewOnHover ] = useState(
-		attributes?.posterData?.previewOnHover || false
-	);
-	const [ previewAtTime, setPreviewAtTime ] = useState(
+	const pickFromFrame = attributes?.posterData?.type === 'video-frame';
+	const [ , setPickFromFrame ] = useState();
+
+	const previewOnHover = attributes?.posterData?.previewOnHover || false;
+	const [ , setPreviewOnHover ] = useState( attributes?.posterData?.previewOnHover || false );
+
+	const previewAtTime = attributes?.posterData?.previewAtTime || posterData?.atTime || 0;
+	const [ , setPreviewAtTime ] = useState(
 		attributes?.posterData?.previewAtTime || posterData?.atTime || 0
 	);
-	const [ previewLoopDuration, setPreviewLoopDuration ] = useState(
+
+	const previewLoopDuration = attributes?.posterData?.previewLoopDuration || DEFAULT_LOOP_DURATION;
+	const [ , setPreviewLoopDuration ] = useState(
 		attributes?.posterData?.previewLoopDuration || DEFAULT_LOOP_DURATION
 	);
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -506,20 +506,9 @@ export default function PosterPanel( {
 	const { poster, posterData } = attributes;
 
 	const pickFromFrame = attributes?.posterData?.type === 'video-frame';
-	const [ , setPickFromFrame ] = useState();
-
 	const previewOnHover = attributes?.posterData?.previewOnHover || false;
-	const [ , setPreviewOnHover ] = useState( attributes?.posterData?.previewOnHover || false );
-
 	const previewAtTime = attributes?.posterData?.previewAtTime || posterData?.atTime || 0;
-	const [ , setPreviewAtTime ] = useState(
-		attributes?.posterData?.previewAtTime || posterData?.atTime || 0
-	);
-
 	const previewLoopDuration = attributes?.posterData?.previewLoopDuration || DEFAULT_LOOP_DURATION;
-	const [ , setPreviewLoopDuration ] = useState(
-		attributes?.posterData?.previewLoopDuration || DEFAULT_LOOP_DURATION
-	);
 
 	const videoDuration = attributes?.duration;
 
@@ -529,7 +518,6 @@ export default function PosterPanel( {
 
 	const switchPosterSource = useCallback(
 		( shouldPickFromFrame: boolean ) => {
-			setPickFromFrame( shouldPickFromFrame );
 			setAttributes( {
 				// Extend the posterData attr with the new type.
 				posterData: {
@@ -546,8 +534,6 @@ export default function PosterPanel( {
 
 	const onPreviewOnHoverChange = useCallback(
 		( shouldPreviewOnHover: boolean ) => {
-			setPreviewOnHover( shouldPreviewOnHover );
-
 			setAttributes( {
 				posterData: {
 					...attributes.posterData,
@@ -560,7 +546,6 @@ export default function PosterPanel( {
 
 	const onAtTimeChange = useCallback(
 		( atTime: number ) => {
-			setPreviewAtTime( atTime );
 			setAttributes( {
 				posterData: {
 					...attributes.posterData,
@@ -573,13 +558,11 @@ export default function PosterPanel( {
 
 	const onLoopDurationChange = useCallback(
 		( loopDuration: number ) => {
-			setPreviewLoopDuration( loopDuration );
 			let previewStart = previewAtTime;
 
 			// Adjust the starting point if the loop duration is too long
 			if ( previewAtTime + loopDuration > videoDuration ) {
 				previewStart = videoDuration - loopDuration;
-				setPreviewAtTime( previewStart );
 			}
 
 			setAttributes( {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR replaces using local state instances by the block attributes. Block attributes are enough to store and update the data persistently. The usage of the local state is not needed.

Follow up of https://github.com/Automattic/jetpack/pull/29781
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  VideoPress: replace local state by using block attributes for the PreviewOnHover feature

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the Preview on hover feature
* Confirm the block attributes are updated according to the changes in the UI
* Confirm the data is persistent (are there after a hard refresh)



<img width="1178" alt="Screen Shot 2023-03-30 at 09 38 27" src="https://user-images.githubusercontent.com/77539/228838512-b20a76da-92fe-4fd3-9c7b-d4c542e67805.png">
