### PR TITLE
VideoPress: fixed issue when propagating "is-generating-poster" state to Poster panel

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-propagating-is-generating-poster-data
+++ b/projects/packages/videopress/changelog/update-videopress-fix-propagating-is-generating-poster-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fixed issuen when propagating "is-generating-poster" state to Poster panel

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -40,7 +40,7 @@ import { description, title } from '.';
 /**
  * Types
  */
-import type { VideoBlockAttributes } from './types';
+import type { VideoBlockAttributes, VideoBlockEditProps } from './types';
 import type React from 'react';
 
 import './editor.scss';
@@ -101,7 +101,7 @@ export default function VideoPressEdit( {
 	setAttributes,
 	isSelected,
 	clientId,
-} ): React.ReactNode {
+}: VideoBlockEditProps ): React.ReactNode {
 	const {
 		autoplay,
 		loop,
@@ -151,7 +151,6 @@ export default function VideoPressEdit( {
 		isRequestingVideoData,
 		error: syncError,
 		isOverwriteChapterAllowed,
-		isGeneratingPoster,
 	} = useSyncMedia( attributes, setAttributes );
 
 	const { filename, private_enabled_for_site: privateEnabledForSite } = videoData;
@@ -525,7 +524,6 @@ export default function VideoPressEdit( {
 					clientId={ clientId }
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					isGeneratingPoster={ isGeneratingPoster }
 				/>
 
 				<PrivacyAndRatingPanel

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -40,7 +40,7 @@ import { description, title } from '.';
 /**
  * Types
  */
-import type { VideoBlockAttributes, VideoBlockEditProps } from './types';
+import type { VideoBlockAttributes } from './types';
 import type React from 'react';
 
 import './editor.scss';
@@ -101,7 +101,7 @@ export default function VideoPressEdit( {
 	setAttributes,
 	isSelected,
 	clientId,
-}: VideoBlockEditProps ): React.ReactNode {
+} ): React.ReactNode {
 	const {
 		autoplay,
 		loop,
@@ -151,6 +151,7 @@ export default function VideoPressEdit( {
 		isRequestingVideoData,
 		error: syncError,
 		isOverwriteChapterAllowed,
+		isGeneratingPoster,
 	} = useSyncMedia( attributes, setAttributes );
 
 	const { filename, private_enabled_for_site: privateEnabledForSite } = videoData;
@@ -524,6 +525,7 @@ export default function VideoPressEdit( {
 					clientId={ clientId }
 					attributes={ attributes }
 					setAttributes={ setAttributes }
+					isGeneratingPoster={ isGeneratingPoster }
 				/>
 
 				<PrivacyAndRatingPanel

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -70,6 +70,8 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 
 	// CSS classes
 	className?: string;
+
+	isExample?: boolean;
 };
 
 export type VideoBlockEditProps = {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -72,6 +72,13 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	className?: string;
 };
 
+export type VideoBlockEditProps = {
+	attributes: VideoBlockAttributes;
+	setAttributes: VideoBlockSetAttributesProps;
+	isSelected: boolean;
+	clientId: string;
+};
+
 export type CoreEmbedBlockAttributes = {
 	className: string;
 	allowResponsive: boolean;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

<img width="312" alt="image" src="https://user-images.githubusercontent.com/77539/228877950-9018e1fb-08b9-4e47-8dd4-123f01ae23f4.png">
