### PR TITLE
Updated to-test.md for 12.0-beta.

### DIFF
--- a/projects/plugins/jetpack/changelog/Amended to-test
+++ b/projects/plugins/jetpack/changelog/Amended to-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Amended the to-test.md file for non-a11n testers.

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -31,7 +31,7 @@ No new features were added, so the only thing to test here is that they work as 
 
 ### WordPress 6.2 compatibility
 
-This version of Jetpack included several small fixes to ensure it’s compatible with the latest WordPress. Most test sites are already set to use the WordPress 6.2 RC version. However, if you are using Jurassic Ninja, Atomic, or your standalone site, you may need to install the WordPress beta tester plugin, or you have set it up to use the appropriate version in some other way (through the Pressable dashboard). Also, by the time you try testing, the WP 6.2 may already be published.
+This version of Jetpack included several small fixes to ensure it’s compatible with the latest WordPress. WordPress 6.2 is already available to users, so make sure you update your site to the latest version.
 
 ### Things to check:
 
@@ -54,6 +54,6 @@ This version of Jetpack included several small fixes to ensure it’s compatible
 
 ### And More!
 
-You can see a [full list of changes in this release here](https://github.com/Automattic/jetpack/blob/jetpack/branch-11.9/projects/plugins/jetpack/CHANGELOG.md). Please feel free to test any and all functionality mentioned! 
+You can see a [full list of changes in this release here](https://github.com/Automattic/jetpack/blob/jetpack/branch-12.0/projects/plugins/jetpack/CHANGELOG.md). Please feel free to test any and all functionality mentioned! 
 
 **Thank you for all your help!**

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -12,45 +12,42 @@ No new features were added, so the only thing to test here is that they work as 
 
 **VideoPress** - add a block and try adding and playing a video.
 
-**Cookie consent block** - Make sure you are using a block theme. Go to the site editor and try adding a Cookie consent block.
+**Cookie Consent block** - make sure you are using a block-based theme such as "Twenty Twenty-Three". Go to the site editor and try adding a Cookie consent block.
 
-**Writing prompt block** - Create a new post and add a Writing prompt block to it. Save or publish the post and check if appropriate tags, such as dailyprompt, dailyprompt-1810 are added.
+**Writing Prompt block** - create a new post and add a Writing Prompt block to it. Save or publish the post and check if appropriate tags, such as 'dailyprompt' and 'dailyprompt-1810' are added.
 
 ### The Form block
 
 **Multiple Choice and Single Choice** fields had some design updates. To test it:
 
-- Create a post and a Form block.
+- Create a post and add a Form block.
 - Include a Multiple Choice and a Single Choice field.
 - Check if they work as expected.
 - Publish the post and check if it looks as expected on the frontend.
 - Multiline feedback message support:
-- Create and publish a post that includes a contact form
-- Submit a multi-line message through a form
+- Create and publish a post that includes a contact form.
+- Submit a multi-line message through a form.
 - Look at Feedback->Form Responses and make sure the message is not showing up as a single line.
 
 ### WordPress 6.2 compatibility
 
-This version of Jetpack included several small fixes to ensure it’s compatible with the latest WordPress. WordPress 6.2 is already available to users, so make sure you update your site to the latest version.
+This version of Jetpack included several small fixes to ensure compatibility with the latest WordPress. WordPress 6.2 is now available to all users, so make sure you update your site to the latest version.
 
 ### Things to check:
 
 #### Twitter block
 
 - Create a new post and add a Twitter block.
-- paste a Twitter URL for a thread (tweetstorm).
+- Paste a Twitter URL for a thread (tweetstorm).
 - Click on Unroll.
 - Change Publicize options to publish a thread instead of a single tweet.
-- Watch the separators added to the post content.
+- Observe separators being added to the post content.
 - Click on the "Social Previews" section at the bottom of the sidebar.
-- You should see previews under some of the tweets, and you should not see any notices in your logs.
+- You should see previews under some of the tweets, and you should not see any notices in your error logs.
 
 ### Pinterest block
 
-- Go to Posts > Add New and add a Pinterest block. When adding a Pinterest URL, no Fatal error should appear in your logs.
-- Install the WordPress Beta tester and switch to WP's Bleeding edge option.
-- Update to WP 6.2 latest Beta in Dashboard > Updates
-- Go to Posts > Add New and repeat your test. The Pinterest block should still trigger no fatal error.
+- Create a new post and add a Pinterest block. When adding a Pinterest URL, no errors should appear in your logs.
 
 ### And More!
 

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -1,4 +1,4 @@
-## Jetpack 11.9
+## Jetpack 12.0
 
 ### Before you start:
 
@@ -29,13 +29,6 @@ No new features were added, so the only thing to test here is that they work as 
 - Submit a multi-line message through a form
 - Look at Feedback->Form Responses and make sure the message is not showing up as a single line.
 
-### Golden ticket
-
-- Go to the golden-token MC tool https://mc.a8c.com/jetpack/golden-token/
-- Generate a new license key and assign it to your test site using URL or the Blog ID
-- Go to /wp-admin/admin.php?page=jetpack#/my-plan
-- Verify that the Jetpack Golden Token plan appears
-
 ### WordPress 6.2 compatibility
 
 This version of Jetpack included several small fixes to ensure it’s compatible with the latest WordPress. Most test sites are already set to use the WordPress 6.2 RC version. However, if you are using Jurassic Ninja, Atomic, or your standalone site, you may need to install the WordPress beta tester plugin, or you have set it up to use the appropriate version in some other way (through the Pressable dashboard). Also, by the time you try testing, the WP 6.2 may already be published.
@@ -58,14 +51,6 @@ This version of Jetpack included several small fixes to ensure it’s compatible
 - Install the WordPress Beta tester and switch to WP's Bleeding edge option.
 - Update to WP 6.2 latest Beta in Dashboard > Updates
 - Go to Posts > Add New and repeat your test. The Pinterest block should still trigger no fatal error.
-
-### Mobile navigation
-
-**Use a WoA site.**
-
-- Open the wp-admin of the site on mobile (or simulate the mobile in your desktop browser)
-- Click the WordPress logo in the left-hand top corner to open the unified navigation
-- Click the WordPress logo again, and make sure the navigation closes.
 
 ### And More!
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes the to-test.md header and removes testing instructions that can't be carried out by the general audience.

## Proposed changes:
* Changed to-test.md.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open to-test.md and observe the header that says 12.0 instead of 11.9.

