### PR TITLE
VideoPress: support autoplay playback option when previewOnHover is enabled

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-autoplay-hover-behavior
+++ b/projects/packages/videopress/changelog/update-videopress-autoplay-hover-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: support autoplay playback option when previewOnHover is enabled

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -172,7 +172,7 @@ export default function Player( {
 	}
 
 	useVideoPlayer( videoWrapperRef, isRequestingEmbedPreview, {
-		atTime: timeToSetPlayerPosition,
+		initialTimePosition: timeToSetPlayerPosition,
 		wrapperElement: mainWrapperRef?.current,
 		previewOnHover: previewOnHover
 			? {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -160,7 +160,7 @@ export default function Player( {
 	const { atTime, previewOnHover, previewAtTime, previewLoopDuration, type } =
 		attributes.posterData;
 
-	let timeToSetPlayerPosition;
+	let timeToSetPlayerPosition = undefined;
 	if ( type === 'video-frame' ) {
 		if ( previewOnHover ) {
 			timeToSetPlayerPosition = previewAtTime;
@@ -173,6 +173,7 @@ export default function Player( {
 
 	useVideoPlayer( videoWrapperRef, isRequestingEmbedPreview, {
 		initialTimePosition: timeToSetPlayerPosition,
+		autoplay: attributes.autoplay,
 		wrapperElement: mainWrapperRef?.current,
 		previewOnHover: previewOnHover
 			? {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -265,7 +265,7 @@ function VideoFramePicker( {
 	}
 
 	const { playerIsReady } = useVideoPlayer( playerWrapperRef, isRequestingEmbedPreview, {
-		atTime,
+		initialTimePosition: atTime,
 	} );
 
 	// Listen player events.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -40,7 +40,7 @@ import { description, title } from '.';
 /**
  * Types
  */
-import type { VideoBlockAttributes } from './types';
+import type { VideoBlockAttributes, VideoBlockEditProps } from './types';
 import type React from 'react';
 
 import './editor.scss';
@@ -101,7 +101,7 @@ export default function VideoPressEdit( {
 	setAttributes,
 	isSelected,
 	clientId,
-} ): React.ReactNode {
+}: VideoBlockEditProps ): React.ReactNode {
 	const {
 		autoplay,
 		loop,
@@ -151,7 +151,6 @@ export default function VideoPressEdit( {
 		isRequestingVideoData,
 		error: syncError,
 		isOverwriteChapterAllowed,
-		isGeneratingPoster,
 	} = useSyncMedia( attributes, setAttributes );
 
 	const { filename, private_enabled_for_site: privateEnabledForSite } = videoData;
@@ -525,7 +524,6 @@ export default function VideoPressEdit( {
 					clientId={ clientId }
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					isGeneratingPoster={ isGeneratingPoster }
 				/>
 
 				<PrivacyAndRatingPanel

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -40,7 +40,7 @@ import { description, title } from '.';
 /**
  * Types
  */
-import type { VideoBlockAttributes, VideoBlockEditProps } from './types';
+import type { VideoBlockAttributes } from './types';
 import type React from 'react';
 
 import './editor.scss';
@@ -101,7 +101,7 @@ export default function VideoPressEdit( {
 	setAttributes,
 	isSelected,
 	clientId,
-}: VideoBlockEditProps ): React.ReactNode {
+} ): React.ReactNode {
 	const {
 		autoplay,
 		loop,
@@ -116,6 +116,7 @@ export default function VideoPressEdit( {
 		guid,
 		cacheHtml,
 		poster,
+		posterData,
 		align,
 		videoRatio,
 		tracks,
@@ -125,10 +126,10 @@ export default function VideoPressEdit( {
 	} = attributes;
 
 	const videoPressUrl = getVideoPressUrl( guid, {
-		autoplay,
+		autoplay: autoplay || posterData.previewOnHover, // enabled when `previewOnHover` is enabled.
 		controls,
 		loop,
-		muted,
+		muted: muted || posterData.previewOnHover, // enabled when `previewOnHover` is enabled.
 		playsinline,
 		preload,
 		seekbarColor,
@@ -151,6 +152,7 @@ export default function VideoPressEdit( {
 		isRequestingVideoData,
 		error: syncError,
 		isOverwriteChapterAllowed,
+		isGeneratingPoster,
 	} = useSyncMedia( attributes, setAttributes );
 
 	const { filename, private_enabled_for_site: privateEnabledForSite } = videoData;
@@ -524,6 +526,7 @@ export default function VideoPressEdit( {
 					clientId={ clientId }
 					attributes={ attributes }
 					setAttributes={ setAttributes }
+					isGeneratingPoster={ isGeneratingPoster }
 				/>
 
 				<PrivacyAndRatingPanel

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -70,6 +70,8 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 
 	// CSS classes
 	className?: string;
+
+	isExample?: boolean;
 };
 
 export type VideoBlockEditProps = {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -72,6 +72,13 @@ export type VideoBlockAttributes = VideoBlockColorAttributesProps & {
 	className?: string;
 };
 
+export type VideoBlockEditProps = {
+	attributes: VideoBlockAttributes;
+	setAttributes: VideoBlockSetAttributesProps;
+	isSelected: boolean;
+	clientId: string;
+};
+
 export type CoreEmbedBlockAttributes = {
 	className: string;
 	allowResponsive: boolean;

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
@@ -26,6 +26,7 @@ _Parameters_
 -   _iframeRef_ `upload` | `playback` | `upload-jwt`: Token scope.
 -   _isRequestingPreview_ `boolean`: True if the app is requesting the player preview
 -   _options_ `object`:
+-   _options.autoplay `?boolean`: It will be controlled when the previewOnHover is enabled.
 -   _options.initialTimePosition_ `?number`: The time to initially set the player to.
 -   _options.wrapperElement_ `?HTMLDivElement`: DOM player wrapper element.
 -   _options.PreviewOnHover_ `?object`

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/Readme.md
@@ -26,7 +26,7 @@ _Parameters_
 -   _iframeRef_ `upload` | `playback` | `upload-jwt`: Token scope.
 -   _isRequestingPreview_ `boolean`: True if the app is requesting the player preview
 -   _options_ `object`:
--   _options.atTime_ `?number`: The time to initially set the player to.
+-   _options.initialTimePosition_ `?number`: The time to initially set the player to.
 -   _options.wrapperElement_ `?HTMLDivElement`: DOM player wrapper element.
 -   _options.PreviewOnHover_ `?object`
 -   _options.PreviewOnHover.atTime_ The timestamp to playback the video when hovering over it

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -38,7 +38,7 @@ export const getIframeWindowFromRef = (
 const useVideoPlayer = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
 	isRequestingPreview: boolean,
-	{ atTime, wrapperElement, previewOnHover }: UseVideoPlayerOptions
+	{ initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions
 ): UseVideoPlayer => {
 	const [ playerIsReady, setPlayerIsReady ] = useState( false );
 	const playerState = useRef< PlayerStateProp >( 'not-rendered' );
@@ -74,10 +74,10 @@ const useVideoPlayer = (
 			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
 
 			// Set position at time if it was provided.
-			if ( typeof atTime !== 'undefined' ) {
-				debug( 'set position at time %o ', atTime );
+			if ( typeof initialTimePosition !== 'undefined' ) {
+				debug( 'set position at time %o ', initialTimePosition );
 				source.postMessage(
-					{ event: 'videopress_action_set_currenttime', currentTime: atTime / 1000 },
+					{ event: 'videopress_action_set_currenttime', currentTime: initialTimePosition / 1000 },
 					{ targetOrigin: '*' }
 				);
 			}

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -38,7 +38,7 @@ export const getIframeWindowFromRef = (
 const useVideoPlayer = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
 	isRequestingPreview: boolean,
-	{ initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions
+	{ autoplay, initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions
 ): UseVideoPlayer => {
 	const [ playerIsReady, setPlayerIsReady ] = useState( false );
 	const playerState = useRef< PlayerStateProp >( 'not-rendered' );
@@ -71,7 +71,12 @@ const useVideoPlayer = (
 			debug( 'state: first-play detected' );
 
 			// Pause and move the video at the desired time.
-			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
+			if ( autoplay ) {
+				debug( 'autoplay enabled. Do not pause' );
+			} else {
+				debug( 'pause video' );
+				source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
+			}
 
 			// Set position at time if it was provided.
 			if ( typeof initialTimePosition !== 'undefined' ) {

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -70,7 +70,7 @@ const useVideoPlayer = (
 			playerState.current = 'first-play';
 			debug( 'state: first-play detected' );
 
-			// Pause and move the video at the desired time.
+			// Pause the video only if the autoplay is disabled.
 			if ( autoplay ) {
 				debug( 'autoplay enabled. Do not pause' );
 			} else {

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
@@ -7,6 +7,12 @@ export type UseVideoPlayer = {
 
 export type UseVideoPlayerOptions = {
 	/*
+	 * Autoplay the video.
+	 * It will be controlled when the previewOnHover is enabled.
+	 */
+	autoplay?: boolean;
+
+	/*
 	 * The time to initially set the player to.
 	 */
 	initialTimePosition: number;

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
@@ -9,7 +9,7 @@ export type UseVideoPlayerOptions = {
 	/*
 	 * The time to initially set the player to.
 	 */
-	atTime: number;
+	initialTimePosition: number;
 
 	/*
 	 * DOM player wrapper element.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR handles the `autoplay` playback option when the `previewOnHover` feature is enabled.

To be able to control the video there are rules to follow. [Autoplay guide for media and Web Audio APIs](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide) explains in detail.

But in short, what we do is enable `autoplay` when the previewOnHover feature is enabled, stopping the player just after it plays for the first time. With this, we can play/pause the video when moues-entering/mouse-leaving the player wrapper element.

What this PR does is check the `autoplay` playback option. If enabled, it does not pause the video making the desired autoplay behavior.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: support autoplay playback option when previewOnHover is enabled #29816

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta extensions 
* Go to the block editor
* Create/edit a VideoPress video block instance
* Confirm  when the `autoplay` playback has been enabled the video will automatically without paying attention to the previewOnHover feature

<img width="915" alt="Screen Shot 2023-03-30 at 13 45 42" src="https://user-images.githubusercontent.com/77539/228908100-7ce50c32-4165-4268-9a5d-cce41ae05399.png">

* Confirm when the `autoplay` playback is disabled and the previewOnHover is enabled, the video plays/pauses when entering/leaving its area.


https://user-images.githubusercontent.com/77539/228907696-c2212c02-a70e-4922-a31b-8289fc78491b.mov

