### PR TITLE
Don't use post_status for calculating available filters for form responses

### DIFF
--- a/projects/packages/forms/changelog/update-dont-filter-filters-by-feedback-status
+++ b/projects/packages/forms/changelog/update-dont-filter-filters-by-feedback-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Disregard post_status when calculating available filters for form responses.

--- a/projects/plugins/jetpack/changelog/update-dont-filter-filters-by-feedback-status
+++ b/projects/plugins/jetpack/changelog/update-dont-filter-filters-by-feedback-status
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Internal change that doesn't impact the plugin yet.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes an issue that came up during testing in #29694, where if you switch to a different tab with filters applied, the dropdown might suddenly become empty.

With this change, we're no longer taking `post_status` into account when calculating `filters_available`, so you should always get a complete list regardless of what tab you're currently viewing. This makes sense as all three tabs are always available, even if there might not be any responses in either of them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Make a request to `/wp-json/wpcom/v2/forms/responses?status=` with different `status` values (`trash`, `spam`, `inbox` or empty).
- `available_filters` on the response should not change, even if there are different, less, or no responses for the given status.