### PR TITLE
Components: Fix layout issue in ContextualUpgradeTrigger

### DIFF
--- a/projects/js-packages/components/changelog/fix-cut-line-break
+++ b/projects/js-packages/components/changelog/fix-cut-line-break
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix layout issue in contextual upgrade trigger.
+
+

--- a/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
+++ b/projects/js-packages/components/components/contextual-upgrade-trigger/index.tsx
@@ -22,15 +22,19 @@ const ContextualUpgradeTrigger: React.FC< CutBaseProps > = ( {
 	return (
 		<div className={ classnames( styles.cut, className ) }>
 			<div>
-				<Text className={ styles.description }>{ description }</Text>
-				{ tooltipText && (
-					<IconTooltip className={ styles.iconContainer } iconSize={ 16 } offset={ 4 }>
-						<Text variant="body-small">{ tooltipText }</Text>
-					</IconTooltip>
-				) }
-				<Tag { ...tagProps }>
-					<Text className={ styles.cta }>{ cta }</Text>
-				</Tag>
+				<div>
+					<Text className={ styles.description }>{ description }</Text>
+					{ tooltipText && (
+						<IconTooltip className={ styles.iconContainer } iconSize={ 16 } offset={ 4 }>
+							<Text variant="body-small">{ tooltipText }</Text>
+						</IconTooltip>
+					) }
+				</div>
+				<div>
+					<Tag { ...tagProps }>
+						<Text className={ styles.cta }>{ cta }</Text>
+					</Tag>
+				</div>
 			</div>
 			<Icon icon={ arrowRight } className={ styles.icon } size={ 30 } />
 		</div>

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.31.2",
+	"version": "0.31.3-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a layout issue introduced by https://github.com/Automattic/jetpack/pull/29609.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Separates the description and tooltip from the CTA by wrapping them in `<div>`s to ensure they stack on top of each other while still allowing the description and tooltip to be inline.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/pull/29609

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate that the CUTs in Jetpack Protect and Jetpack Social display appropriately:

## Screenshots

Before

<img width="696" alt="Screenshot 2023-03-30 at 11 09 09 AM" src="https://user-images.githubusercontent.com/10933065/228918927-52620068-6fb1-4ddc-abf3-e90c7fe3ff6f.png">

After

<img width="689" alt="Screenshot 2023-03-30 at 11 14 29 AM" src="https://user-images.githubusercontent.com/10933065/228918956-74881a20-e6f6-49bf-9edc-cadac217a904.png">
