### PR TITLE
VideoPress: Change hover preview loop duration component to Timestamp control and fix default values

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-preview-on-hover-timestamp-control
+++ b/projects/packages/videopress/changelog/update-videopress-preview-on-hover-timestamp-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Change hover preview loop duration component to Timestamp control and fix default values

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -3,8 +3,6 @@
  */
 import { MediaUploadCheck, MediaUpload } from '@wordpress/block-editor';
 import {
-	// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
-	__experimentalNumberControl as NumberControl,
 	MenuItem,
 	PanelBody,
 	NavigableMenu,
@@ -320,6 +318,8 @@ function VideoFramePicker( {
 				max={ duration }
 				value={ timestamp }
 				wait={ 250 }
+				fineAdjustment={ 1 }
+				decimalPlaces={ 2 }
 				onChange={ setTimestamp }
 				onDebounceChange={ iframeTimePosition => {
 					const sandboxIFrameWindow = getIframeWindowFromRef( playerWrapperRef );
@@ -340,7 +340,7 @@ type VideoHoverPreviewControlProps = {
 	loopDuration?: number;
 	videoDuration: number;
 	onPreviewOnHoverChange: ( previewOnHover: boolean ) => void;
-	onAtTimeChange: ( timestamp: number ) => void;
+	onPreviewAtTimeChange: ( timestamp: number ) => void;
 	onLoopDurationChange: ( duration: number ) => void;
 };
 
@@ -356,14 +356,21 @@ function VideoHoverPreviewControl( {
 	loopDuration = DEFAULT_LOOP_DURATION,
 	videoDuration,
 	onPreviewOnHoverChange,
-	onAtTimeChange,
+	onPreviewAtTimeChange,
 	onLoopDurationChange,
 }: VideoHoverPreviewControlProps ): React.ReactElement {
 	const [ maxStartingPoint, setMaxStartingPoint ] = useState( videoDuration - loopDuration );
+	const [ maxLoopDuration, setMaxLoopDuration ] = useState(
+		Math.min( MAX_LOOP_DURATION, videoDuration )
+	);
 
 	useEffect( () => {
 		setMaxStartingPoint( videoDuration - loopDuration );
 	}, [ videoDuration, loopDuration ] );
+
+	useEffect( () => {
+		setMaxLoopDuration( Math.min( MAX_LOOP_DURATION, videoDuration ) );
+	}, [ videoDuration ] );
 
 	return (
 		<>
@@ -379,23 +386,22 @@ function VideoHoverPreviewControl( {
 					<TimestampControl
 						label={ __( 'Starting point', 'jetpack-videopress-pkg' ) }
 						max={ maxStartingPoint }
+						fineAdjustment={ 1 }
 						decimalPlaces={ 2 }
 						value={ previewAtTime }
-						onChange={ onAtTimeChange }
+						onChange={ atTime => {
+							onPreviewAtTimeChange( Math.max( Math.min( maxStartingPoint, atTime ), 0 ) );
+						} }
 					/>
 
-					<NumberControl
-						className="poster-panel__loop-duration"
-						min={ 0 }
-						max={ Math.min( MAX_LOOP_DURATION, videoDuration ) / 1000 }
-						step={ 1 }
+					<TimestampControl
+						max={ maxLoopDuration }
+						fineAdjustment={ 1 }
+						decimalPlaces={ 2 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
-						spinControls="none"
-						placeholder="00"
-						suffix={ __( 'sec', 'jetpack-videopress-pkg' ) }
-						value={ loopDuration / 1000 }
+						value={ loopDuration }
 						onChange={ duration => {
-							onLoopDurationChange( Math.max( Math.min( MAX_LOOP_DURATION, duration * 1000 ), 0 ) );
+							onLoopDurationChange( Math.max( Math.min( MAX_LOOP_DURATION, duration ), 0 ) );
 						} }
 					/>
 				</>
@@ -417,10 +423,10 @@ export default function PosterPanel( {
 }: PosterPanelProps ): React.ReactElement {
 	const { poster, posterData } = attributes;
 
-	const pickPosterFromFrame = attributes?.posterData?.type === 'video-frame';
-	const previewOnHover = attributes?.posterData?.previewOnHover || false;
-	const previewAtTime = attributes?.posterData?.previewAtTime || posterData?.atTime || 0;
-	const previewLoopDuration = attributes?.posterData?.previewLoopDuration || DEFAULT_LOOP_DURATION;
+	const pickPosterFromFrame = posterData?.type === 'video-frame';
+	const previewOnHover = posterData?.previewOnHover || false;
+	const previewAtTime = posterData?.previewAtTime ?? posterData?.atTime ?? 0;
+	const previewLoopDuration = posterData?.previewLoopDuration ?? DEFAULT_LOOP_DURATION;
 
 	const videoDuration = attributes?.duration;
 
@@ -456,7 +462,7 @@ export default function PosterPanel( {
 		[ attributes ]
 	);
 
-	const onAtTimeChange = useCallback(
+	const onPreviewAtTimeChange = useCallback(
 		( atTime: number ) => {
 			setAttributes( {
 				posterData: {
@@ -559,7 +565,7 @@ export default function PosterPanel( {
 				loopDuration={ previewLoopDuration }
 				videoDuration={ videoDuration }
 				onPreviewOnHoverChange={ onPreviewOnHoverChange }
-				onAtTimeChange={ onAtTimeChange }
+				onPreviewAtTimeChange={ onPreviewAtTimeChange }
 				onLoopDurationChange={ onLoopDurationChange }
 			/>
 		</PanelBody>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
@@ -105,13 +105,3 @@ body.modal-open .poster-panel__dropdown {
 .poster-panel__preview-toggle {
 	margin-top: 24px;
 }
-
-.poster-panel__loop-duration {
-	.components-input-control__container {
-		max-width: 60px;
-	}
-
-	.components-input-control__suffix {
-		margin-right: 8px;
-	}
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29809

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes the  `NumberControl` component to `TimestampControl` for the loop duration
* Adds two decimal places to the selectors

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add a VideoPress video block
* Go to the `Poster and review` panel
* Check the `Video preview on hover` toggle
* Check that the loop duration uses a TimestampControl component
* Check that it is not possible to select a loop duration + start time that violates the video duration

![2023-03-30_14-36-13](https://user-images.githubusercontent.com/8486249/228919429-2be7e768-ee2f-41ce-816d-8af429cd2133.png)
