### PR TITLE
VideoPress: Change permission check on VideoPress stats namespace to manage_options

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-stats-permission-check
+++ b/projects/packages/videopress/changelog/fix-videopress-stats-permission-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Fix the permission check for the VideoPress stats APIs, to check for manage_options capability.

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-stats.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-stats.php
@@ -61,7 +61,7 @@ class VideoPress_Rest_Api_V1_Stats {
 	 * @return boolean
 	 */
 	public static function permissions_callback() {
-		return current_user_can( 'read' ); // TODO: confirm this
+		return current_user_can( 'manage_options' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to #29785.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed permission check from `read` to `manage_options` on the `videopress/v1/stats*` API namespace

The `manage_otions` capability is the same used to check the permissions for showing the VideoPress dashboard screen and the My Jetpack screen, that is the kind of places this information will be used, so it makes sense to require the same level of access.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To test this, we need two users: one admin user (that you probably is already using for tests right now) and one with lower capabilities (may be an editor or an author for example)
   * Click here to learn [how to create a new user](https://wordpress.org/documentation/article/users-add-new-screen/)
* Using your admin user, go to the My Jetpack page, open the browser console and run the following snippet:

```
wp.apiFetch({ path: "/videopress/v1/stats/featured" })
  .then((data) => console.log(data));
```

* This will do a request to one of the stats endpoint and print the data on the console
* The expected response is similar to this:

<img width="497" alt="Screen Shot 2023-03-30 at 16 19 28" src="https://user-images.githubusercontent.com/6760046/228941582-261c07fb-c20d-476f-a86e-4e50b3d80a5d.png">

* This means that the user can perform the request
* Now, using the new user, login into the `wp-admin`, go to the block editor (so you can have the `wp` global var) and run the request on the browser console again:

```
wp.apiFetch({ path: "/videopress/v1/stats/featured" })
  .then((data) => console.log(data));
```

* The expected response is similar to this:

<img width="779" alt="Screen Shot 2023-03-30 at 16 15 12" src="https://user-images.githubusercontent.com/6760046/228940683-4d16cc5d-719a-4ca3-872d-71018d56bd7b.png">

* This means that the user can't read the stats