### PR TITLE
VideoPress: avoid using local state to deal with previewOnHover data

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-performance-timestamp-controls
+++ b/projects/packages/videopress/changelog/update-videopress-performance-timestamp-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: avoid using local state to deal with previewOnHover data

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -359,18 +359,8 @@ function VideoHoverPreviewControl( {
 	onPreviewAtTimeChange,
 	onLoopDurationChange,
 }: VideoHoverPreviewControlProps ): React.ReactElement {
-	const [ maxStartingPoint, setMaxStartingPoint ] = useState( videoDuration - loopDuration );
-	const [ maxLoopDuration, setMaxLoopDuration ] = useState(
-		Math.min( MAX_LOOP_DURATION, videoDuration )
-	);
-
-	useEffect( () => {
-		setMaxStartingPoint( videoDuration - loopDuration );
-	}, [ videoDuration, loopDuration ] );
-
-	useEffect( () => {
-		setMaxLoopDuration( Math.min( MAX_LOOP_DURATION, videoDuration ) );
-	}, [ videoDuration ] );
+	const maxLoopDuration = Math.min( MAX_LOOP_DURATION, videoDuration );
+	const maxStartingPoint = videoDuration - loopDuration;
 
 	return (
 		<>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This janitorial PR removes the use of local state and effect hooks when dealing with the previewOnHover data.
It doesn't seem to be needed.

Follow up of https://github.com/Automattic/jetpack/pull/29819
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: avoid using local state to deal with previewOnHover data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Same testing instructions that the [followed-up PR](https://github.com/Automattic/jetpack/pull/29819).


https://user-images.githubusercontent.com/77539/228938147-81bd4bbc-4476-4fbf-a227-ff5add024c22.mov

