### PR TITLE
CRM: Resolves 2979 - use native CSV parsing when importing

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-2979-csv_importer_fixes
+++ b/projects/plugins/crm/changelog/fix-crm-2979-csv_importer_fixes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+Allow import of application/csv mime type
+Better parsing of CSV fields

--- a/projects/plugins/crm/changelog/fix-crm-2979-csv_importer_fixes
+++ b/projects/plugins/crm/changelog/fix-crm-2979-csv_importer_fixes
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
 
-Allow import of application/csv mime type
-Better parsing of CSV fields
+Importer: Allow import of application/csv mime type
+Importer: Better parsing of CSV fields

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -424,8 +424,8 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 							// } Cycle through each field and display a mapping option
 							// } Using first line of import
-							$firstLine      = $file_details['csv_data'][0];
-							$firstLineParts = explode( ',', $firstLine );
+							$first_line       = $file_details['csv_data'][0];
+							$first_line_parts = str_getcsv( $first_line );
 
 							// } Retrieve possible map fields from fields model
 							$possibleFields = array();
@@ -443,7 +443,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 							// } Loop
 							$indx = 1;
-						foreach ( $firstLineParts as $userField ) {
+						foreach ( $first_line_parts as $userField ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 							// } Clean user field - ""
 							if ( substr( $userField, 0, 1 ) == '"' && substr( $userField, -1 ) == '"' ) {
@@ -521,8 +521,8 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 						// Cycle through each field
 						// Using first line of import
-						$firstLine      = $file_details['csv_data'][0];
-						$firstLineParts = explode( ',', $firstLine );
+						$first_line       = $file_details['csv_data'][0];
+						$first_line_parts = str_getcsv( $first_line );
 
 						foreach ( $file_details['field_map'] as $fieldID => $fieldTarget ) {
 
@@ -536,8 +536,8 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 							}
 
 							$fromStr = '';
-							if ( isset( $firstLineParts[ $fieldID - 1 ] ) ) {
-								$fromStr = $firstLineParts[ $fieldID - 1 ];
+							if ( isset( $first_line_parts[ $fieldID - 1 ] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+								$fromStr = $first_line_parts[ $fieldID - 1 ]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 							}
 
 							// Clean user field - ""
@@ -629,7 +629,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 							} else {
 
 								// } split
-								$lineParts = explode( ',', $line );
+								$lineParts = str_getcsv( $line ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 								// debug echo '<pre>'; print_r(array($lineParts,$fieldMap)); echo '</pre>';
 
 								// } build arr

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -670,7 +670,8 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 								if ( count( $customerFields ) > 0 ) {
 
 									// } Try and find a unique id for this user
-									$userUniqueID = md5( $line . '#' . $file_details['public_name'] );
+									// adjusted for backward-compatibility, but this should be rewritten
+									$userUniqueID = md5( implode( ',', $lineParts ) . '#' . $file_details['public_name'] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 										// } 1st use email if there
 									if ( isset( $customerFields['zbsc_email'] ) && ! empty( $customerFields['zbsc_email'] ) ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -246,7 +246,7 @@ function jpcrm_csvimporter_lite_preflight_checks( $stage ) {
 		}
 
 		// verify file extension and MIME
-		if ( ! jpcrm_file_check_mime_extension( $csv_file_data, '.csv', array( 'text/csv', 'text/plain' ) ) ) {
+		if ( ! jpcrm_file_check_mime_extension( $csv_file_data, '.csv', array( 'text/csv', 'text/plain', 'application/csv' ) ) ) {
 			throw new Exception( __( 'Your file is not a correctly-formatted CSV file. Please check your file format. If you continue to have issues please contact support.', 'zero-bs-crm' ) );
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -654,18 +654,11 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 										$cleanUserField = trim( $cleanUserField );
 
-										// } Clean user field - ""
-										if ( substr( $cleanUserField, 0, 1 ) == '"' && substr( $cleanUserField, -1 ) == '"' ) {
-											$cleanUserField = substr( $cleanUserField, 1, strlen( $cleanUserField ) - 2 );
-										}
-										// } Clean user field - ''
-										if ( substr( $cleanUserField, 0, 1 ) == "'" && substr( $cleanUserField, -1 ) == "'" ) {
-											$cleanUserField = substr( $cleanUserField, 1, strlen( $cleanUserField ) - 2 );
-										}
-
 										if ( $cleanUserField == 'NULL' ) {
 											$cleanUserField = '';
 										}
+
+										$cleanUserField = sanitize_text_field( $cleanUserField ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 										// } set customer fields
 										$customerFields[ 'zbsc_' . $fieldTarget ] = $cleanUserField;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#2979 - use native CSV parsing when importing

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Previously when importing a CSV, we naively used `explode()` on commas. However, CSVs often have newlines or commas within fields, using double quotes as the default field enclosure character, and when these CSVs are encountered, things are parsed rather messily. I've switched it to use ~`str_getcsv()`~ `fgetcsv()` instead (quick gains prior to a better rewrite).

The same patch has been ported to the CSV Importer Pro extension: Automattic/jetpack-crm-extensions#654

Additional good news: it should be trivial to implement Automattic/jetpack-crm-extensions#82 during the rewrite.

Also, it seems CSV files are sometimes interpreted by the server with a `application/csv` mime type, so I've whitelisted that as a valid CSV import type.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to the core CSV Importer: `/wp-admin/admin.php?page=zerobscrm-csvimporterlite-app`
2. Import the CSV below, mapping the fields as usual.

In `trunk`, the fields will result in some shiftiness.

In `fix/crm/2979-csv_importer_fixes`, the fields will import properly.

Sample CSV:
```
fname,lname,email,phone
"george, jr.",some_surname,aflkjasdfkj@ljasdg.asdg,"930,3,33"
```