### PR TITLE
[RNMobile] Disable auto play in the native editor

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-vp-disable-autoplay
+++ b/projects/packages/videopress/changelog/rnmobile-vp-disable-autoplay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disable autoplay in the native editor

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.tsx
@@ -51,7 +51,6 @@ export default function VideoPressEdit( {
 	onFocus,
 } ): React.ReactNode {
 	const {
-		autoplay,
 		controls,
 		guid,
 		loop,
@@ -82,7 +81,7 @@ export default function VideoPressEdit( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const videoPressUrl = getVideoPressUrl( guid, {
-		autoplay,
+		autoplay: false,
 		controls,
 		loop,
 		muted,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.tsx
@@ -81,7 +81,7 @@ export default function VideoPressEdit( {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const videoPressUrl = getVideoPressUrl( guid, {
-		autoplay: false,
+		autoplay: false, // Note: Autoplay is disabled to prevent the video from playing fullscreen when loading the editor.
 		controls,
 		loop,
 		muted,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5602

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
By default the native editor plays videos full screen. This causes a bad experience when autoplay is enabled in the native player.
This PR sets autoplay to false when rendering the player in the native editor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set a video to autoplay in the web editor
* Load the video in the mobile editor.
* Note that the video does not auto play
* Disable autoplay in the native editor and update the post.
* Re enable autoplay
* Note that enabling autoplay in the mobile editor does not autoplay the video.
* Verify that the video will play when touched (iOS only)

