### PR TITLE
WAF: Make Brute_Force_Protection properties and methods static

### DIFF
--- a/projects/packages/sync/changelog/add-brute-force-static-methods
+++ b/projects/packages/sync/changelog/add-brute-force-static-methods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Compatibility fix for brute force protection and older versions of Jetpack.
+
+

--- a/projects/packages/sync/src/modules/class-protect.php
+++ b/projects/packages/sync/src/modules/class-protect.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
+use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
 
 /**
  * Class to handle sync for Protect.
@@ -45,6 +46,11 @@ class Protect extends Module {
 	 * @param array $failed_attempt Failed attempt data.
 	 */
 	public function maybe_log_failed_login_attempt( $failed_attempt ) {
+		// Older versions of Jetpack do not include the 'has_login_ability' property.
+		if ( ! isset( $failed_attempt['has_login_ability'] ) ) {
+			$failed_attempt['has_login_ability'] = Brute_Force_Protection::has_login_ability();
+		}
+
 		if ( $failed_attempt['has_login_ability'] && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}

--- a/projects/packages/waf/changelog/add-brute-force-static-methods
+++ b/projects/packages/waf/changelog/add-brute-force-static-methods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Compatibility fix for brute force protection and older versions of Jetpack.
+
+

--- a/projects/packages/waf/src/brute-force-protection/class-math-fallback.php
+++ b/projects/packages/waf/src/brute-force-protection/class-math-fallback.php
@@ -50,8 +50,7 @@ if ( ! class_exists( 'Brute_Force_Protection_Math_Authenticate' ) ) {
 		 */
 		public static function math_authenticate() {
 			if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
-				$brute_force_protection = Brute_Force_Protection::instance();
-				$transient              = $brute_force_protection->get_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );
+				$transient = Brute_Force_Protection::get_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );
 
 				if ( ! $transient || $transient < 1 ) {
 					self::generate_math_page();
@@ -131,8 +130,7 @@ if ( ! class_exists( 'Brute_Force_Protection_Math_Authenticate' ) ) {
 			} else {
 				$temp_pass = substr( hash_hmac( 'sha1', wp_rand( 1, 100000000 ), get_site_option( 'jetpack_protect_key' ) ), 5, 25 );
 
-				$brute_force_protection = Brute_Force_Protection::instance();
-				$brute_force_protection->set_transient( 'jpp_math_pass_' . $temp_pass, 3, DAY_IN_SECONDS );
+				Brute_Force_Protection::set_transient( 'jpp_math_pass_' . $temp_pass, 3, DAY_IN_SECONDS );
 				setcookie( 'jpp_math_pass', $temp_pass, time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false, true );
 				remove_action( 'login_form', array( $this, 'math_form' ) );
 				return true;
@@ -147,8 +145,7 @@ if ( ! class_exists( 'Brute_Force_Protection_Math_Authenticate' ) ) {
 		public static function math_form() {
 			// Check if jpp_math_pass cookie is set and it matches valid transient.
 			if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
-				$brute_force_protection = Brute_Force_Protection::instance();
-				$transient              = $brute_force_protection->get_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );
+				$transient = Brute_Force_Protection::get_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );
 
 				if ( $transient && $transient > 0 ) {
 					return '';

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -68,8 +68,7 @@ class Waf_Initializer {
 			return $e->get_wp_error();
 		}
 
-		$brute_force_protection = Brute_Force_Protection::instance();
-		$brute_force_protection->on_activation();
+		Brute_Force_Protection::on_activation();
 
 		return true;
 	}
@@ -86,8 +85,7 @@ class Waf_Initializer {
 			return $e->get_wp_error();
 		}
 
-		$brute_force_protection = Brute_Force_Protection::instance();
-		$brute_force_protection->on_deactivation();
+		Brute_Force_Protection::on_deactivation();
 
 		return true;
 	}

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -735,9 +735,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'jetpack_protect_key':
-					$brute_force_protection = Brute_Force_Protection::instance();
 					if ( 'create' === $value ) {
-						$result = $brute_force_protection->get_protect_key();
+						$result = Brute_Force_Protection::get_protect_key();
 					} else {
 						$result = false;
 					}

--- a/projects/plugins/jetpack/changelog/add-brute-force-static-methods
+++ b/projects/plugins/jetpack/changelog/add-brute-force-static-methods
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Compatibility fix for brute force protection.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR updates the `Brute_Force_Protection` class to use static properties and methods. Currently, the class must be instantiated in order to access methods such as `has_login_ability`. This becomes a problem when a site is running the latest package version, but an older version of Jetpack that initializes the BFP code from the plugin. In those cases, we return early from the package. However, any time a package wants to use a method from the `Brute_Force_Protection` class, it needs to call the `instance()` method and all of the hooks will end up registering twice (once by the Jetpack plugin, once by the package).

By using static properties and methods, we can avoid this issue.

Getting to this decision took a few steps:
1. Currently, the `maybe_log_failed_login_attempt()` method from the `Sync` package expects a "has_login_ability" property to be included in the provided `$failed_attempt` argument. However, this argument was only added in Jetpack 12.0. Sites running the latest version of the Sync package, and an older version of Jetpack, will end up with a warning because `$failed_attempt['has_login_ability']` is not set.
2. To fix this, we need the `maybe_log_failed_login_attempt()` in the `Sync` package to work in a way that is backwards compatible.
3. The method used to use `Jetpack_Protect_Module::instance()->has_login_ability()` to get the required value, but that class has been renamed to `Brute_Force_Protection` and moved into the `waf` package as part of the currently ongoing Jetpack 12.0 release. So, it seems ideal to use the new `Brute_Force_Protection` class here. But...
4. Sites running an old version of Jetpack will always instantiate `Jetpack_Protect_Module`. For this reason, we don't instantiate the new `Brute_Force_Protection` class when this is the case, to avoid initializing all of the brute force protection hooks/logic twice.
5. To use the `has_login_ability()` method from the new `Brute_Force_Protection` class 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* TBD

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

TBD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

