### PR TITLE
Dashboard: improve upgrade description for users with Akismet already installed and active

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -110,14 +110,9 @@ class DashAkismet extends Component {
 				);
 			} else if ( 'invalid_key' === akismetData ) {
 				description = createInterpolateElement(
-					__( 'Already have an API key? <Button>Get started</Button>.', 'jetpack' ),
+					__( 'Already have an API key? <a>Get started</a>.', 'jetpack' ),
 					{
-						Button: (
-							<Button
-								className="jp-link-button"
-								href={ siteAdminUrl + 'admin.php?page=akismet-key-config' }
-							/>
-						),
+						a: <a href={ siteAdminUrl + 'admin.php?page=akismet-key-config' } />,
 					}
 				);
 			}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -103,14 +103,14 @@ class DashAkismet extends Component {
 
 			if ( 'not_active' === akismetData ) {
 				description = createInterpolateElement(
-					__( 'Already have a key? <Button>Activate Akismet Anti-spam</Button>.', 'jetpack' ),
+					__( 'Already have an API key? <Button>Activate Akismet Anti-spam</Button>.', 'jetpack' ),
 					{
 						Button: <Button className="jp-link-button" onClick={ this.onActivateClick } />,
 					}
 				);
 			} else if ( 'invalid_key' === akismetData ) {
 				description = createInterpolateElement(
-					__( 'Already have a key? <Button>Get started</Button>.', 'jetpack' ),
+					__( 'Already have an API key? <Button>Get started</Button>.', 'jetpack' ),
 					{
 						Button: (
 							<Button

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -86,7 +86,7 @@ class DashAkismet extends Component {
 	};
 
 	getContent() {
-		const akismetData = this.props.akismetData;
+		const { akismetData, siteAdminUrl } = this.props;
 		const labelName = __( 'Akismet Anti-spam', 'jetpack' );
 
 		const support = {
@@ -99,12 +99,28 @@ class DashAkismet extends Component {
 		};
 
 		const getAkismetUpgradeBanner = () => {
-			const description = createInterpolateElement(
-				__( 'Already have a key? <Button>Activate Akismet Anti-spam</Button>', 'jetpack' ),
-				{
-					Button: <Button className="jp-link-button" onClick={ this.onActivateClick } />,
-				}
-			);
+			let description;
+
+			if ( 'not_active' === akismetData ) {
+				description = createInterpolateElement(
+					__( 'Already have a key? <Button>Activate Akismet Anti-spam</Button>.', 'jetpack' ),
+					{
+						Button: <Button className="jp-link-button" onClick={ this.onActivateClick } />,
+					}
+				);
+			} else if ( 'invalid_key' === akismetData ) {
+				description = createInterpolateElement(
+					__( 'Already have a key? <Button>Get started</Button>.', 'jetpack' ),
+					{
+						Button: (
+							<Button
+								className="jp-link-button"
+								href={ siteAdminUrl + 'admin.php?page=akismet-key-config' }
+							/>
+						),
+					}
+				);
+			}
 
 			return (
 				<JetpackBanner

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -31,6 +31,12 @@
 	}
 }
 
+.dops-banner__description {
+	.jp-link-button {
+		padding: 0;
+	}
+}
+
 .jp-at-a-glance__stats-empty {
 	text-align: center;
 	margin-bottom: 0;

--- a/projects/plugins/jetpack/changelog/fix-dashboard-akismet-upgrade-description
+++ b/projects/plugins/jetpack/changelog/fix-dashboard-akismet-upgrade-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: improve upgrade description for users with Akismet already installed and active


### PR DESCRIPTION
## Proposed changes:
The Akismet panel on the Jetpack dashboard shows this upgrade prompt to anyone without an active subscription or Akismet API key:

<img width="534" alt="Screenshot 2023-03-31 at 4 03 05 PM" src="https://user-images.githubusercontent.com/17325/229012341-4b979864-fb4c-436a-86ea-a0bd05044a63.png">

If the Akismet plugin is installed, the "Activate Akismet Anti-spam" link is currently shown to everyone, even if the user already has the plugin activated. **In this situation, clicking the link fails and there is no user feedback.**

This PR changes the behavior so that:
* The 'Activate Akismet Anti-spam' message is only shown to users with the plugin installed, but currently deactivated.
* A different message is shown to users who have the plugin active but no API key entered yet.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

1. Start on a test site with Jetpack and the Akismet plugin _not_ installed. Visit the Jetpack dashboard at `/wp-admin/admin.php?page=jetpack#/dashboard` and verify that the Akismet panel looks like this:

<img width="526" alt="Screenshot 2023-04-03 at 11 37 15 AM" src="https://user-images.githubusercontent.com/17325/229385200-dea22e21-6ee7-4024-a1e5-65aec1c2d4a2.png">

2. Install the Akismet plugin, but make sure it is deactivated. Visit the Jetpack dashboard again. It should look like this:

<img width="533" alt="Screenshot 2023-04-03 at 11 05 23 AM" src="https://user-images.githubusercontent.com/17325/229384891-ec00293c-20ee-4aae-80b9-ad18dcf6240f.png">

3. Finally, activate the Akismet plugin and revisit the Jetpack dashboard. The messaging should now have changed to:

<img width="527" alt="Screenshot 2023-04-03 at 11 03 11 AM" src="https://user-images.githubusercontent.com/17325/229384945-d3b95e85-aa42-4365-ab3c-03b18cbeb1c3.png">

The 'Get started' link should take you to the Akismet key config page.