### PR TITLE
VideoPress: store and control TimestampControl value externally

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-control-timestamp-value-internally
+++ b/projects/packages/videopress/changelog/update-videopress-control-timestamp-value-internally
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: store and control TimestampControl value externally

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -8,7 +8,7 @@ import {
 	BaseControl,
 	useBaseControlProps,
 } from '@wordpress/components';
-import { useCallback, useRef } from '@wordpress/element';
+import { useCallback, useRef, useState } from '@wordpress/element';
 import classNames from 'classnames';
 /**
  * Internal dependencies
@@ -238,6 +238,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 	} = props;
 
 	const debounceTimer = useRef< NodeJS.Timeout >();
+	const [ controledValue, setControledValue ] = useState( value );
 
 	// Check and add a fallback for the `useBaseControlProps` hook.
 	const { baseControlProps } = useBaseControlProps?.( props ) || {};
@@ -246,6 +247,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 		( newValue: number ) => {
 			clearTimeout( debounceTimer?.current );
 
+			setControledValue( newValue );
 			onChange?.( newValue );
 			debounceTimer.current = setTimeout( onDebounceChange?.bind( null, newValue ), wait );
 		},
@@ -259,7 +261,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 					<TimestampInput
 						disabled={ disabled }
 						max={ max }
-						value={ value }
+						value={ controledValue }
 						onChange={ onChangeHandler }
 						autoHideTimeInput={ autoHideTimeInput }
 						decimalPlaces={ decimalPlaces }
@@ -271,8 +273,8 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 					className={ styles[ 'timestamp-range-control' ] }
 					min={ 0 }
 					step={ fineAdjustment }
-					initialPosition={ value }
-					value={ value }
+					initialPosition={ controledValue }
+					value={ controledValue }
 					max={ max }
 					showTooltip={ false }
 					withInputField={ false }

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -8,7 +8,7 @@ import {
 	BaseControl,
 	useBaseControlProps,
 } from '@wordpress/components';
-import { useCallback, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import classNames from 'classnames';
 /**
  * Internal dependencies
@@ -239,6 +239,10 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 
 	const debounceTimer = useRef< NodeJS.Timeout >();
 	const [ controledValue, setControledValue ] = useState( value );
+
+	useEffect( () => {
+		setControledValue( value );
+	}, [ value ] );
 
 	// Check and add a fallback for the `useBaseControlProps` hook.
 	const { baseControlProps } = useBaseControlProps?.( props ) || {};

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
@@ -99,3 +99,15 @@ Time, in milliseconds, for every step of the Range control.
 
 A boolean property that controls whether the component should automatically
 hide the hours, and minutes inputs that are not needed based on the `max` value.
+
+## Delegate the control value
+
+By default, the component will handle its value internally through a local state. The `value` property will define its initial value.
+However, updating the `value` property is possible if you need it. The component will follow the new value provided.
+
+In the example below, it's possible to update the Timestamp value internally, but also it's doable by using the additional range control.
+
+The story 
+<Canvas>
+  <Story id="packages-videopress-timestamp-control--changing-value-externally" />
+</Canvas>

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
@@ -97,17 +97,19 @@ Time, in milliseconds, for every step of the Range control.
 - type: `boolean`
 - default: `True`
 
-A boolean property that controls whether the component should automatically
-hide the hours, and minutes inputs that are not needed based on the `max` value.
+## Handling the value property
 
-## Delegate the control value
+By default, the component will handle its value internally through a local state.
+The `value` property will define its initial value.
+It simplifies its usage since consumers 
+won't be concerned about storing and propagating the updated value.
 
-By default, the component will handle its value internally through a local state. The `value` property will define its initial value.
-However, updating the `value` property is possible if you need it. The component will follow the new value provided.
+However, updating the `value` property externally is possible if you need it.
+The TimestampControl component will follow the new value provided.
 
-In the example below, it's possible to update the Timestamp value internally, but also it's doable by using the additional range control.
+In the example below, it's possible to update the Timestamp value internally,
+but also it's doable by using the additional range control.
 
-The story 
 <Canvas>
   <Story id="packages-videopress-timestamp-control--changing-value-externally" />
 </Canvas>

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
@@ -65,13 +65,20 @@ const ChangingValueTemplate: ComponentStory< typeof TimestampControl > = args =>
 
 	return (
 		<>
-			<TimestampControl { ...args } value={ value } onDebounceChange={ setValue } />
+			<TimestampControl
+				{ ...args }
+				label="TimestampControl component"
+				help="The value is handled internally by the component."
+				value={ value }
+				onDebounceChange={ setValue }
+			/>
 			<br />
 			<RangeControl
+				label="RangeControl component"
+				help="The value is handled externally, and passed to the <TimestampControl /> above component."
 				value={ value }
 				onChange={ setValue }
 				max={ args.max }
-				help="Change the value of the <TimestampControl /> above component from here."
 			/>
 		</>
 	);

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { useState } from 'react';
-/**
  * Internal dependencies
  */
 import TimestampControl from '..';
@@ -23,17 +19,7 @@ export default {
 } as ComponentMeta< typeof TimestampControl >;
 
 const Template: ComponentStory< typeof TimestampControl > = args => {
-	const [ time, setTime ] = useState( args.value );
-	return (
-		<TimestampControl
-			{ ...args }
-			value={ time }
-			onChange={ newTime => {
-				setTime( newTime );
-				args?.onChange( newTime );
-			} }
-		/>
-	);
+	return <TimestampControl { ...args } />;
 };
 
 export const _default = Template.bind( {} );
@@ -57,13 +43,7 @@ _default.args = {
 
 _default.storyName = 'Timestamp Control';
 
-// decimalPlaces story
-const decimalPlacesStoryTemplate: ComponentStory< typeof TimestampControl > = args => {
-	const [ time, setTime ] = useState( args.value );
-	return <TimestampControl { ...args } value={ time } onChange={ setTime } />;
-};
-
-export const decimalPlaces = decimalPlacesStoryTemplate.bind( {} );
+export const decimalPlaces = Template.bind( {} );
 decimalPlaces.args = {
 	value: 3500, // 3.5 seconds
 	max: 1000 * 5, // five seconds
@@ -71,12 +51,7 @@ decimalPlaces.args = {
 };
 
 // disabled story
-const disabledStoryTemplate: ComponentStory< typeof TimestampControl > = args => {
-	const [ time, setTime ] = useState( args.value );
-	return <TimestampControl { ...args } value={ time } onChange={ setTime } />;
-};
-
-export const disabled = disabledStoryTemplate.bind( {} );
+export const disabled = Template.bind( {} );
 disabled.args = {
 	max: 3600 * 1000 * 2, // 2 hours
 	value: 3600 * 1000 + 15 * 60 * 1000 + 43 * 1000, // 1.5 hours

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
@@ -1,6 +1,8 @@
 /**
  * Internal dependencies
  */
+import { RangeControl } from '@wordpress/components';
+import { useState } from 'react';
 import TimestampControl from '..';
 import Doc from './TimestampControl.mdx';
 /**
@@ -56,4 +58,29 @@ disabled.args = {
 	max: 3600 * 1000 * 2, // 2 hours
 	value: 3600 * 1000 + 15 * 60 * 1000 + 43 * 1000, // 1.5 hours
 	disabled: true,
+};
+
+const ChangingValueTemplate: ComponentStory< typeof TimestampControl > = args => {
+	const [ value, setValue ] = useState( args.value );
+
+	return (
+		<>
+			<TimestampControl { ...args } value={ value } onDebounceChange={ setValue } />
+			<br />
+			<RangeControl
+				value={ value }
+				onChange={ setValue }
+				max={ args.max }
+				help="Change the value of the <TimestampControl /> above component from here."
+			/>
+		</>
+	);
+};
+
+export const changingValueExternally = ChangingValueTemplate.bind( {} );
+changingValueExternally.args = {
+	value: 3500, // 3.5 seconds
+	max: 1000 * 5, // five seconds
+	decimalPlaces: 2,
+	wait: 100,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The need to store, provide and propagate the `value` to/from the `<TimestampControl />` component is fine but it can be avoidable. This PR handles the component value internally, discarding the need to address it externally.
It simplifies the component API.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: store and control TimestampControl value externally

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Storybook
* There is a new story that explains and shows how it works: 
http://localhost:50240/?path=/docs/packages-videopress-timestamp-control--changing-value-externally#handling-the-value-property


https://user-images.githubusercontent.com/77539/229118255-c6ec7c97-b157-44cc-8142-be89ad20ee9b.mov
