### PR TITLE
VideoPress: store poster panel data in a local state

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-store-poster-data-in-local-state
+++ b/projects/packages/videopress/changelog/update-videopress-store-poster-data-in-local-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: store poster panel data in a local state

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -338,9 +338,10 @@ function VideoHoverPreviewControl( {
 						fineAdjustment={ 1 }
 						decimalPlaces={ 2 }
 						value={ previewAtTime }
-						onChange={ atTime => {
+						onDebounceChange={ atTime => {
 							onPreviewAtTimeChange( Math.max( Math.min( maxStartingPoint, atTime ), 0 ) );
 						} }
+						wait={ 100 }
 					/>
 
 					<TimestampControl
@@ -349,9 +350,10 @@ function VideoHoverPreviewControl( {
 						decimalPlaces={ 2 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
 						value={ loopDuration }
-						onChange={ duration => {
+						onDebounceChange={ duration => {
 							onLoopDurationChange( Math.max( Math.min( MAX_LOOP_DURATION, duration ), 0 ) );
 						} }
+						wait={ 100 }
 					/>
 				</>
 			) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -361,7 +361,7 @@ function VideoHoverPreviewControl( {
 						fineAdjustment={ 1 }
 						decimalPlaces={ 2 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
-						value={ loopDuration }
+						value={ Math.min( loopDuration, maxLoopDuration ) }
 						onDebounceChange={ onLoopDurationChange }
 						wait={ 100 }
 						help={ loopDurationHelp }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -94,19 +94,22 @@ export function PosterDropdown( {
 	const videoPosterDescription = `video-block__poster-image-description-${ clientId }`;
 
 	const { poster } = attributes;
-	const onSelectPoster = useCallback( ( image: AdminAjaxQueryAttachmentsResponseItemProps ) => {
-		setAttributes( {
-			poster: image.url,
+	const onSelectPoster = useCallback(
+		( image: AdminAjaxQueryAttachmentsResponseItemProps ) => {
+			setAttributes( {
+				poster: image.url,
 
-			// Extend the posterData object to include the media library id and url.
-			posterData: {
-				...attributes.posterData,
-				type: 'media-library',
-				id: image.id,
-				url: image.url,
-			},
-		} );
-	}, [] );
+				// Extend the posterData object to include the media library id and url.
+				posterData: {
+					...attributes.posterData,
+					type: 'media-library',
+					id: image.id,
+					url: image.url,
+				},
+			} );
+		},
+		[ attributes.posterData ]
+	);
 
 	const selectPosterLabel = __( 'Select Poster Image', 'jetpack-videopress-pkg' );
 	const replacePosterLabel = __( 'Replace Poster Image', 'jetpack-videopress-pkg' );
@@ -380,69 +383,84 @@ export default function PosterPanel( {
 	const removePoster = useCallback( () => {
 		setLocalData( state => ( { ...state, url: '' } ) );
 		setAttributes( { poster: '', posterData: { ...localData, url: '' } } );
-	}, [] );
+	}, [ attributes.posterData ] );
 
-	const switchPosterSource = useCallback( ( shouldPickFromFrame: boolean ) => {
-		const type = shouldPickFromFrame ? 'video-frame' : 'media-library';
-		setLocalData( state => ( { ...state, type } ) );
+	const switchPosterSource = useCallback(
+		( shouldPickFromFrame: boolean ) => {
+			const type = shouldPickFromFrame ? 'video-frame' : 'media-library';
+			setLocalData( state => ( { ...state, type } ) );
 
-		setAttributes( {
-			// Extend the localData attr with the new type.
-			posterData: { ...localData, type },
+			setAttributes( {
+				// Extend the localData attr with the new type.
+				posterData: { ...localData, type },
 
-			// Clean the poster URL when it should be picked from the video frame.
-			poster: shouldPickFromFrame ? '' : localData.url || '',
-		} );
-	}, [] );
+				// Clean the poster URL when it should be picked from the video frame.
+				poster: shouldPickFromFrame ? '' : localData.url || '',
+			} );
+		},
+		[ attributes.posterData ]
+	);
 
-	const selectVideoFrame = useCallback( ( timestamp: number ) => {
-		setLocalData( state => ( { ...state, atTime: timestamp } ) );
-		setAttributes( {
-			posterData: {
-				...localData,
-				atTime: timestamp,
-			},
-			poster: '',
-		} );
-	}, [] );
+	const selectVideoFrame = useCallback(
+		( timestamp: number ) => {
+			setLocalData( state => ( { ...state, atTime: timestamp } ) );
+			setAttributes( {
+				posterData: {
+					...localData,
+					atTime: timestamp,
+				},
+				poster: '',
+			} );
+		},
+		[ attributes.posterData ]
+	);
 
-	const setPreviewOnHover = useCallback( ( shouldPreviewOnHover: boolean ) => {
-		setLocalData( state => ( { ...state, previewOnHover: shouldPreviewOnHover } ) );
-		setAttributes( {
-			posterData: {
-				...localData,
-				previewOnHover: shouldPreviewOnHover,
-			},
-		} );
-	}, [] );
+	const setPreviewOnHover = useCallback(
+		( shouldPreviewOnHover: boolean ) => {
+			setLocalData( state => ( { ...state, previewOnHover: shouldPreviewOnHover } ) );
+			setAttributes( {
+				posterData: {
+					...localData,
+					previewOnHover: shouldPreviewOnHover,
+				},
+			} );
+		},
+		[ attributes.posterData ]
+	);
 
-	const setPreviewAtTimestampValue = useCallback( ( atTime: number ) => {
-		setLocalData( state => ( { ...state, previewAtTime: atTime } ) );
-		setAttributes( {
-			posterData: {
-				...localData,
-				previewAtTime: atTime,
-			},
-		} );
-	}, [] );
+	const setPreviewAtTimestampValue = useCallback(
+		( atTime: number ) => {
+			setLocalData( state => ( { ...state, previewAtTime: atTime } ) );
+			setAttributes( {
+				posterData: {
+					...localData,
+					previewAtTime: atTime,
+				},
+			} );
+		},
+		[ attributes.posterData ]
+	);
 
-	const setPreviewOnHoverDuration = useCallback( ( loopDuration: number ) => {
-		setLocalData( state => ( { ...state, previewLoopDuration: loopDuration } ) );
-		let previewStart = previewAtTime;
+	const setPreviewOnHoverDuration = useCallback(
+		( loopDuration: number ) => {
+			setLocalData( state => ( { ...state, previewLoopDuration: loopDuration } ) );
+			let previewStart = previewAtTime;
 
-		// Adjust the starting point if the loop duration is too long
-		if ( previewAtTime + loopDuration > videoDuration ) {
-			previewStart = videoDuration - loopDuration;
-		}
+			// Adjust the starting point if the loop duration is too long
+			if ( previewAtTime + loopDuration > videoDuration ) {
+				previewStart = videoDuration - loopDuration;
+			}
 
-		setAttributes( {
-			posterData: {
-				...localData,
-				previewLoopDuration: loopDuration,
-				previewAtTime: previewStart,
-			},
-		} );
-	}, [] );
+			setAttributes( {
+				posterData: {
+					...localData,
+					previewLoopDuration: loopDuration,
+					previewAtTime: previewStart,
+				},
+			} );
+		},
+		[ attributes.posterData ]
+	);
 
 	if ( ! isVideoFramePosterEnabled() ) {
 		return (

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -13,7 +13,13 @@ import {
 	Spinner,
 	Notice,
 } from '@wordpress/components';
-import { useRef, useEffect, useState, useCallback } from '@wordpress/element';
+import {
+	useRef,
+	useEffect,
+	useState,
+	useCallback,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { linkOff, image as imageIcon } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -34,6 +40,7 @@ import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../
 import type { PosterDataProps, PosterPanelProps, VideoControlProps, VideoGUID } from '../../types';
 import type React from 'react';
 
+const MIN_LOOP_DURATION = 3 * 1000;
 const MAX_LOOP_DURATION = 30 * 1000;
 const DEFAULT_LOOP_DURATION = 10 * 1000;
 
@@ -315,20 +322,18 @@ function VideoHoverPreviewControl( {
 	onPreviewAtTimeChange,
 	onLoopDurationChange,
 }: VideoHoverPreviewControlProps ): React.ReactElement {
-	/*
-	 * maxLoopDuration is the maximum duration of the loop,
-	 * which is the minimum between the video duration and the MAX_LOOP_DURATION constant.
-	 */
-	const maxLoopDuration = Math.min( MAX_LOOP_DURATION, videoDuration );
-
-	/*
-	 * maxStartingPoint is the maximum starting point of the loop,
-	 * which is the difference between the video duration and the maxLoopDuration.
-	 * This is the maximum value that the starting point can have.
-	 * For example, if the video duration is 10 seconds and the maxLoopDuration is 3 seconds,
-	 * the maxStartingPoint will be 7 seconds.
-	 */
-	const maxStartingPoint = videoDuration - loopDuration;
+	const maxStartingPoint = Math.min( videoDuration, videoDuration - MIN_LOOP_DURATION );
+	const maxLoopDuration = Math.min( MAX_LOOP_DURATION, videoDuration - previewAtTime );
+	const loopDurationHelp = createInterpolateElement(
+		sprintf(
+			/* translators: placeholder is the maxium lapse duration for the previewOnHover */
+			__( 'Maximum lapse duration <em>%s</em>s.', 'jetpack-videopress-pkg' ),
+			( ( maxLoopDuration / 10 ) | 0 ) / 100
+		),
+		{
+			em: <em />,
+		}
+	);
 
 	return (
 		<>
@@ -359,6 +364,7 @@ function VideoHoverPreviewControl( {
 						value={ loopDuration }
 						onDebounceChange={ onLoopDurationChange }
 						wait={ 100 }
+						help={ loopDurationHelp }
 					/>
 				</>
 			) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR stores the poster panel data locally (local state) and propagates them to the dataPoster block attribute.

It fixes an issue where the poster data are not preserved while the user changes them via the UI:

https://user-images.githubusercontent.com/77539/229121922-7af568df-221b-43e5-a405-7efc4be8191b.mp4


Fixes #29846
Fixes #29847

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: store poster panel data in a local state

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a video block
* Open the Poster panel
* Confirm that all values are preserved when changing by using the UI


https://user-images.githubusercontent.com/77539/229122148-c781e3c7-315c-441e-9f32-15c184b63c8e.mov