### PR TITLE
VideoPress: pick duration from block attribute instead of listening player client

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-use-direction-attr-instead-of-listening-client-events
+++ b/projects/packages/videopress/changelog/update-videopress-use-direction-attr-instead-of-listening-client-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: pick duration from block attribute instead of listening player client


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Since the duration is a known value propagated from the server-side to the block through of the useSyncData() hook), we don't need to listen to the client event to pick it. Instead, let's use the block attribute.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: pick duration from block attribute instead of listening player client

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a VideoBlock video instance
* Open the block settings sidebar
* Open the Poster panel
* Confirm the duration is already there. BEFORE, the app waits for the client's event.


https://user-images.githubusercontent.com/77539/229125821-b08fafee-2ea4-4d79-8404-6a864e315bf3.mov