### PR TITLE
Make batcache aware of cookie consent response

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-cookie-consent-block-caching
+++ b/projects/plugins/jetpack/changelog/fix-cookie-consent-block-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Return fresh HTML when the users revists after accepting cookies

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
@@ -47,6 +47,8 @@ function register_block() {
 		return;
 	}
 
+	notify_betacache_that_content_changed();
+
 	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
@@ -80,3 +82,14 @@ function load_assets( $attr, $content ) {
 	);
 }
 
+/**
+ * Since the cookie consent is part of the cached response HTML, it can still render even when the cookie is set (when it shouldn't).
+ * Because, by default, the cache doesn't vary around the cookie's value.
+ * This let's the cache know that the content has changed to return fresh content.
+ */
+function notify_betacache_that_content_changed() {
+	if ( function_exists( 'vary_cache_on_function' ) ) {
+		// Cast the cookie down to a boolean, to avoid arbitrary code execution.
+		vary_cache_on_function( 'return isset( $_COOKIE[ "' . COOKIE_NAME . '" ] );' );
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
@@ -47,7 +47,7 @@ function register_block() {
 		return;
 	}
 
-	notify_betacache_that_content_changed();
+	notify_batcache_that_content_changed();
 
 	Blocks::jetpack_register_block(
 		BLOCK_NAME,
@@ -87,7 +87,7 @@ function load_assets( $attr, $content ) {
  * Because, by default, the cache doesn't vary around the cookie's value.
  * This let's the cache know that the content has changed to return fresh content.
  */
-function notify_betacache_that_content_changed() {
+function notify_batcache_that_content_changed() {
 	if ( function_exists( 'vary_cache_on_function' ) ) {
 		// Cast the cookie down to a boolean, to avoid arbitrary code execution.
 		vary_cache_on_function( 'return isset( $_COOKIE[ "' . COOKIE_NAME . '" ] );' );


### PR DESCRIPTION
Some users are reporting that the cookie consent block is still rendering even after the user approves. This is due to batcache caching the HTML response of the site with the cookie consent inside it. 

## Proposed changes:

This patch makes batcache aware of the consent cookie existence. This makes it return fresh content after the user approves. 

Context here: p7DVsv-gGa-p2#comment-45200 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Enable batcache on your sandbox. Steps are here: PCYsg-1j5-p2 (under Sandbox Testing). 
2. Sandbox punsintended418746564.wordpress.com.
3. Visit https://punsintended418746564.wordpress.com/ incognito.
4. Accept cookies. 
5. Refresh the page, the cookie consent shouldn't appear again.
