### PR TITLE
WAF: Prevent Brute_Force_Protection::__construct from registering hooks when Jetpack already has

### DIFF
--- a/projects/packages/sync/changelog/fix-log-failed-login-isset-warning
+++ b/projects/packages/sync/changelog/fix-log-failed-login-isset-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed a php warning for a non-set array property.
+
+

--- a/projects/packages/sync/src/modules/class-protect.php
+++ b/projects/packages/sync/src/modules/class-protect.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
+use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
 
 /**
  * Class to handle sync for Protect.
@@ -45,7 +46,8 @@ class Protect extends Module {
 	 * @param array $failed_attempt Failed attempt data.
 	 */
 	public function maybe_log_failed_login_attempt( $failed_attempt ) {
-		if ( $failed_attempt['has_login_ability'] && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
+		$brute_force_protection = Brute_Force_Protection::instance();
+		if ( $brute_force_protection->has_login_ability() && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}
 	}

--- a/projects/packages/waf/changelog/fix-brute-force-multi-construct
+++ b/projects/packages/waf/changelog/fix-brute-force-multi-construct
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix: prevent brute force protection hooks from being registered twice.
+
+

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -122,6 +122,12 @@ class Brute_Force_Protection {
 	 * Registers actions
 	 */
 	private function __construct() {
+		// Older versions of Jetpack initialize brute force protection directly in the plugin.
+		// Return early to avoid running it twice.
+		if ( Waf_Compatibility::is_brute_force_running_in_jetpack() ) {
+			return;
+		}
+
 		add_action( 'jetpack_modules_loaded', array( $this, 'modules_loaded' ) );
 		add_action( 'login_form', array( $this, 'check_use_math' ), 0 );
 		add_filter( 'authenticate', array( $this, 'check_preauth' ), 10, 3 );
@@ -151,7 +157,6 @@ class Brute_Force_Protection {
 	 * @return void
 	 */
 	public static function initialize() {
-
 		// Older versions of Jetpack initialize brute force protection directly in the plugin.
 		// Return early to avoid running it twice.
 		if ( Waf_Compatibility::is_brute_force_running_in_jetpack() ) {

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -503,16 +503,9 @@ class Brute_Force_Protection {
 		 * @param array Information about failed login attempt
 		 *   [
 		 *     'login'             => (string) Username or email used in failed login attempt
-		 *     'has_login_ability' => (bool) Whether the user has the ability to login based on their IP address
 		 *   ]
 		 */
-		do_action(
-			'jpp_log_failed_attempt',
-			array(
-				'login'             => $login_user,
-				'has_login_ability' => $this->has_login_ability(),
-			)
-		);
+		do_action( 'jpp_log_failed_attempt', array( 'login' => $login_user ) );
 
 		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #29794

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevents the hooks from the brute force protection code from being registered by a call to `Brute_Force_Protection::instance()` in cases where an older version of Jetpack is running.
* Uses the `Brute_Force_Protection` class in the `Sync` package, instead of introducing a new property to the `jpp_log_failed_attempt` hook and creating backwards compatibility issues.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Boot up a JN site with the production version of Jetpack, and Jetpack Protect running this branch.
* Attempt to log in with invalid credentials. Validate the following functionality:
  * Math block
  * Hard block
  * Email recovery
  * IP allow list

