### PR TITLE
VideoPress: pause player when previewOnHover enables

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-stop-when-enabling-preview-on-hover
+++ b/projects/packages/videopress/changelog/update-videopress-stop-when-enabling-preview-on-hover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: pause player when previewOnHover enables

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -112,7 +112,7 @@ const useVideoPlayer = (
 		};
 	}, [ iFrameRef, isRequestingPreview ] );
 
-	const playVideo = useCallback( () => {
+	const play = useCallback( () => {
 		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
 		if ( ! sandboxIFrameWindow || ! playerIsReady ) {
 			return;
@@ -121,7 +121,7 @@ const useVideoPlayer = (
 		sandboxIFrameWindow.postMessage( { event: 'videopress_action_play' }, '*' );
 	}, [ iFrameRef, playerIsReady ] );
 
-	const stopVideo = useCallback( () => {
+	const stop = useCallback( () => {
 		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
 		if ( ! sandboxIFrameWindow || ! playerIsReady ) {
 			return;
@@ -137,13 +137,13 @@ const useVideoPlayer = (
 			return;
 		}
 
-		wrapperElement.addEventListener( 'mouseenter', playVideo );
-		wrapperElement.addEventListener( 'mouseleave', stopVideo );
+		wrapperElement.addEventListener( 'mouseenter', play );
+		wrapperElement.addEventListener( 'mouseleave', stop );
 
 		return () => {
 			// Remove the listener when the component is unmounted.
-			wrapperElement.removeEventListener( 'mouseenter', playVideo );
-			wrapperElement.removeEventListener( 'mouseleave', stopVideo );
+			wrapperElement.removeEventListener( 'mouseenter', play );
+			wrapperElement.removeEventListener( 'mouseleave', stop );
 		};
 	}, [ isPreviewOnHoverEnabled, wrapperElement, playerIsReady ] );
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { usePrevious } from '@wordpress/compose';
 import debugFactory from 'debug';
 import { useEffect, useRef, useState, useCallback } from 'react';
 /**
@@ -93,6 +94,11 @@ const useVideoPlayer = (
 		}
 	}
 
+	// PreviewOnHover feature.
+	const isPreviewOnHoverEnabled = !! previewOnHover;
+	const wasPreviewOnHoverEnabled = usePrevious( isPreviewOnHoverEnabled );
+	const wasPreviewOnHoverJustEnabled = isPreviewOnHoverEnabled && ! wasPreviewOnHoverEnabled;
+
 	// Listen player events.
 	useEffect( () => {
 		if ( isRequestingPreview ) {
@@ -104,13 +110,14 @@ const useVideoPlayer = (
 			return;
 		}
 
+		debug( 'player is ready to listen events' );
 		sandboxIFrameWindow.addEventListener( 'message', listenEventsHandler );
 
 		return () => {
 			// Remove the listener when the component is unmounted.
 			sandboxIFrameWindow.removeEventListener( 'message', listenEventsHandler );
 		};
-	}, [ iFrameRef, isRequestingPreview ] );
+	}, [ iFrameRef, isRequestingPreview, wasPreviewOnHoverJustEnabled ] );
 
 	const play = useCallback( () => {
 		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
@@ -130,8 +137,6 @@ const useVideoPlayer = (
 		sandboxIFrameWindow.postMessage( { event: 'videopress_action_pause' }, '*' );
 	}, [ iFrameRef, playerIsReady ] );
 
-	// PreviewOnHover feature.
-	const isPreviewOnHoverEnabled = !! previewOnHover;
 	useEffect( () => {
 		if ( ! wrapperElement || ! isPreviewOnHoverEnabled ) {
 			return;

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -149,7 +149,6 @@ const useVideoPlayer = (
 
 	return {
 		playerIsReady,
-		playerState: playerState.current,
 	};
 };
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -131,8 +131,9 @@ const useVideoPlayer = (
 	}, [ iFrameRef, playerIsReady ] );
 
 	// PreviewOnHover feature.
+	const isPreviewOnHoverEnabled = !! previewOnHover;
 	useEffect( () => {
-		if ( ! wrapperElement || ! previewOnHover ) {
+		if ( ! wrapperElement || ! isPreviewOnHoverEnabled ) {
 			return;
 		}
 
@@ -144,7 +145,7 @@ const useVideoPlayer = (
 			wrapperElement.removeEventListener( 'mouseenter', playVideo );
 			wrapperElement.removeEventListener( 'mouseleave', stopVideo );
 		};
-	}, [ previewOnHover, wrapperElement, playerIsReady ] );
+	}, [ isPreviewOnHoverEnabled, wrapperElement, playerIsReady ] );
 
 	return {
 		playerIsReady,

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -121,7 +121,7 @@ const useVideoPlayer = (
 		sandboxIFrameWindow.postMessage( { event: 'videopress_action_play' }, '*' );
 	}, [ iFrameRef, playerIsReady ] );
 
-	const stop = useCallback( () => {
+	const pause = useCallback( () => {
 		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
 		if ( ! sandboxIFrameWindow || ! playerIsReady ) {
 			return;
@@ -138,17 +138,19 @@ const useVideoPlayer = (
 		}
 
 		wrapperElement.addEventListener( 'mouseenter', play );
-		wrapperElement.addEventListener( 'mouseleave', stop );
+		wrapperElement.addEventListener( 'mouseleave', pause );
 
 		return () => {
 			// Remove the listener when the component is unmounted.
 			wrapperElement.removeEventListener( 'mouseenter', play );
-			wrapperElement.removeEventListener( 'mouseleave', stop );
+			wrapperElement.removeEventListener( 'mouseleave', pause );
 		};
 	}, [ isPreviewOnHoverEnabled, wrapperElement, playerIsReady ] );
 
 	return {
 		playerIsReady,
+		play,
+		pause,
 	};
 };
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
@@ -2,6 +2,8 @@ export type PlayerStateProp = 'not-rendered' | 'loaded' | 'first-play' | 'ready'
 
 export type UseVideoPlayer = {
 	playerIsReady: boolean;
+	play: () => void;
+	pause: () => void;
 };
 
 export type UseVideoPlayerOptions = {

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/types.ts
@@ -2,7 +2,6 @@ export type PlayerStateProp = 'not-rendered' | 'loaded' | 'first-play' | 'ready'
 
 export type UseVideoPlayer = {
 	playerIsReady: boolean;
-	playerState: PlayerStateProp;
 };
 
 export type UseVideoPlayerOptions = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

`autoplay` video option is mandatory when we want the app to control the player imperatively.  But it autoplays the video when the previewOnHover is enabled.

This PR detects when the feature enables in the useVideoPlayer() hook (decoupled of the UI) and pauses it.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: pause player when previewOnHover enables

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a VideoPress video block
* Enable/disable the previewOnHover feature
* Confirm the video doesn't play (pauses) when it's enabled


https://user-images.githubusercontent.com/77539/229190511-d72275db-a75c-4342-9070-519adebaa65f.mov


