### PR TITLE
My Jetpack: Fix My Jetpack bottom responsiveness

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -115,10 +115,10 @@ export default function MyJetpackScreen() {
 
 			<AdminSection>
 				<Container horizontalSpacing={ 8 }>
-					<Col sm={ 2 } md={ 4 } lg={ 6 }>
+					<Col sm={ 4 } md={ 4 } lg={ 6 }>
 						<PlansSection />
 					</Col>
-					<Col sm={ 2 } md={ 4 } lg={ 6 }>
+					<Col sm={ 4 } md={ 4 } lg={ 6 }>
 						<ConnectionsSection />
 					</Col>
 				</Container>

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-bottom-responsiveness
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-bottom-responsiveness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Change the bottom of My Jetpack screen to use single-column rows on small viewports.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29754.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the bottom of My Jetpack screen to use single-column rows on small viewports, by setting the colspan to 4 on it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Change the testing device setting on your browser to see the page using a mobile screen ([Chrome](https://developer.chrome.com/docs/devtools/device-mode/), [Firefox](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/))
* Go to `Jetpack > My Jetpack`
* Scroll to the botton of the page
* Confirm that the bottom is now using just one column per row

Before:

<img width="476" alt="Screen Shot 2023-03-31 at 14 50 29" src="https://user-images.githubusercontent.com/6760046/229193625-c69559a1-73f4-4e43-8bad-8a029ada5423.png">

After:

<img width="477" alt="Screen Shot 2023-03-31 at 14 49 12" src="https://user-images.githubusercontent.com/6760046/229193696-e87b3c06-46e5-4e8a-b5f9-720b7521e832.png">

