### PR TITLE
CRM: Remove 'Restore default settings' from the General Settings page

### DIFF
--- a/projects/plugins/crm/admin/settings/general.page.php
+++ b/projects/plugins/crm/admin/settings/general.page.php
@@ -680,26 +680,6 @@ if ( ! $confirmAct ) {
 
 	</form>
 
-
-	<table class="table table-bordered table-striped wtab" style="margin-top:40px;">
-
-		<thead>
-		<tr>
-			<th class="wmid"><?php esc_html_e( 'Jetpack CRM Plugin: Extra Tools', 'zero-bs-crm' ); ?></th>
-		</tr>
-		</thead>
-
-		<tbody>
-		<tr>
-			<td>
-				<p style="padding: 10px;text-align:center;">
-					<button type="button" class="ui primary button" onclick="javascript:window.location='?page=<?php echo esc_attr( $zbs->slugs['settings'] ); ?>&resetsettings=1';"><?php esc_html_e( 'Restore default settings', 'zero-bs-crm' ); ?></button>
-				</p>
-			</td>
-		</tr>
-		</tbody>
-	</table>
-
 	<script type="text/javascript">
 
 		jQuery(function(){

--- a/projects/plugins/crm/changelog/crm-remove-restore-default-settings-button-from-settings
+++ b/projects/plugins/crm/changelog/crm-remove-restore-default-settings-button-from-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Settings: Remove 'Restore default settings' from the General Settings page


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
* This PR removes the 'Restore default settings' button from the General Settings page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/zero-bs-crm/issues/2960

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the general settings page. (`wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=settings`)

In `trunk` there will be a 'Restore default settings' button at the bottom of the page.
![image](https://user-images.githubusercontent.com/37049295/229205061-13a8f52a-ff45-4a04-b3a2-e91ef80b4c7d.png)

In `update/crm-remove-restore-default-settings-button-from-settings` this button was removed.
![image](https://user-images.githubusercontent.com/37049295/229205046-73320640-6e54-4a4f-8311-7a2161e68ed2.png)


