### PR TITLE
Forms: Add Single Actions menu

### DIFF
--- a/projects/packages/forms/changelog/add-single-actions-menu
+++ b/projects/packages/forms/changelog/add-single-actions-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add single actions menu to the Dashboard inbox view

--- a/projects/packages/forms/src/dashboard/inbox/bulk-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/bulk-actions-menu.js
@@ -3,20 +3,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { updateResponseStatus } from '../data/responses';
 import { STORE_NAME } from '../state';
-
-const ACTIONS = {
-	moveToTrash: 'trash',
-	removeFromTrash: 'untrash',
-	markAsSpam: 'mark_as_spam',
-	markAsNotSpam: 'mark_as_not_spam',
-	spamCheck: 'spam_check',
-};
-
-const VIEWS = {
-	inbox: 'inbox',
-	spam: 'spam',
-	trash: 'trash',
-};
+import { ACTIONS, TABS } from './constants';
 
 const ActionsMenu = ( { currentView, selectedResponses, setSelectedResponses } ) => {
 	const { fetchResponses, setLoading } = useDispatch( STORE_NAME );
@@ -35,25 +22,25 @@ const ActionsMenu = ( { currentView, selectedResponses, setSelectedResponses } )
 
 	return (
 		<>
-			{ currentView !== VIEWS.trash && (
+			{ currentView !== TABS.trash && (
 				<Button onClick={ onActionHandler( ACTIONS.moveToTrash ) } variant="secondary">
 					{ __( 'Move to trash', 'jetpack-forms' ) }
 				</Button>
 			) }
 
-			{ currentView === VIEWS.trash && (
+			{ currentView === TABS.trash && (
 				<Button onClick={ onActionHandler( ACTIONS.removeFromTrash ) } variant="secondary">
 					{ __( 'Remove from trash', 'jetpack-forms' ) }
 				</Button>
 			) }
 
-			{ currentView !== VIEWS.spam && (
+			{ currentView !== TABS.spam && (
 				<Button onClick={ onActionHandler( ACTIONS.markAsSpam ) } variant="secondary">
 					{ __( 'Mark as spam', 'jetpack-forms' ) }
 				</Button>
 			) }
 
-			{ currentView === VIEWS.spam && (
+			{ currentView === TABS.spam && (
 				<Button onClick={ onActionHandler( ACTIONS.markAsNotSpam ) } variant="secondary">
 					{ __( 'Remove from spam', 'jetpack-forms' ) }
 				</Button>

--- a/projects/packages/forms/src/dashboard/inbox/constants.js
+++ b/projects/packages/forms/src/dashboard/inbox/constants.js
@@ -1,0 +1,13 @@
+export const TABS = {
+	inbox: 'inbox',
+	spam: 'spam',
+	trash: 'trash',
+};
+
+export const ACTIONS = {
+	moveToTrash: 'trash',
+	removeFromTrash: 'untrash',
+	markAsSpam: 'mark_as_spam',
+	markAsNotSpam: 'mark_as_not_spam',
+	spamCheck: 'spam_check',
+};

--- a/projects/packages/forms/src/dashboard/inbox/constants.js
+++ b/projects/packages/forms/src/dashboard/inbox/constants.js
@@ -7,6 +7,7 @@ export const TABS = {
 export const ACTIONS = {
 	moveToTrash: 'trash',
 	removeFromTrash: 'untrash',
+	delete: 'delete',
 	markAsSpam: 'mark_as_spam',
 	markAsNotSpam: 'mark_as_not_spam',
 	spamCheck: 'spam_check',

--- a/projects/packages/forms/src/dashboard/inbox/list.js
+++ b/projects/packages/forms/src/dashboard/inbox/list.js
@@ -3,6 +3,7 @@ import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PageNavigation from '../components/page-navigation';
 import Table from '../components/table';
+import SingleActionsMenu from './single-actions-menu';
 
 const COLUMNS = [
 	{
@@ -21,6 +22,10 @@ const COLUMNS = [
 			href: item.entry_permalink,
 			variant: 'link',
 		} ),
+	},
+	{
+		key: 'actions',
+		component: SingleActionsMenu,
 	},
 ];
 

--- a/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
@@ -24,7 +24,27 @@ const SingleActionsMenu = () => {
 					) }
 
 					{ currentTab !== TABS.spam && (
-						<MenuItem onClick={ onClose } iconPosition="left" icon={ inbox }>
+						<MenuItem
+							onClick={ onClose }
+							iconPosition="left"
+							icon={
+								<svg
+									width="24"
+									height="24"
+									viewBox="0 0 24 24"
+									fill="none"
+									xmlns="http://www.w3.org/2000/svg"
+								>
+									<path d="M11 13V7H13V13H11Z" />
+									<path d="M11 15V17H13V15H11Z" />
+									<path
+										fillRule="evenodd"
+										clipRule="evenodd"
+										d="M20.75 12C20.75 16.8325 16.8325 20.75 12 20.75C7.16751 20.75 3.25 16.8325 3.25 12C3.25 7.16751 7.16751 3.25 12 3.25C16.8325 3.25 20.75 7.16751 20.75 12ZM12 19.25C16.0041 19.25 19.25 16.0041 19.25 12C19.25 7.99594 16.0041 4.75 12 4.75C7.99594 4.75 4.75 7.99594 4.75 12C4.75 16.0041 7.99594 19.25 12 19.25Z"
+									/>
+								</svg>
+							}
+						>
 							{ __( 'Mark as spam', 'jetpack-forms' ) }
 						</MenuItem>
 					) }

--- a/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
@@ -1,0 +1,55 @@
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { trash, inbox, moreHorizontal } from '@wordpress/icons';
+import { STORE_NAME } from '../state';
+import { TABS } from './constants';
+
+const SingleActionsMenu = () => {
+	const currentTab = useSelect( select => select( STORE_NAME ).getResponsesQuery().status, [] );
+
+	return (
+		<DropdownMenu
+			icon={ moreHorizontal }
+			popoverProps={ {
+				position: 'bottom left',
+			} }
+		>
+			{ ( { onClose } ) => (
+				<MenuGroup>
+					{ currentTab === TABS.spam && (
+						<MenuItem onClick={ onClose } iconPosition="left" icon={ inbox }>
+							{ __( 'Remove from spam', 'jetpack-forms' ) }
+						</MenuItem>
+					) }
+
+					{ currentTab !== TABS.spam && (
+						<MenuItem onClick={ onClose } iconPosition="left" icon={ inbox }>
+							{ __( 'Mark as spam', 'jetpack-forms' ) }
+						</MenuItem>
+					) }
+
+					{ currentTab === TABS.trash && (
+						<MenuItem onClick={ onClose } iconPosition="left" icon={ inbox }>
+							{ __( 'Remove from trash', 'jetpack-forms' ) }
+						</MenuItem>
+					) }
+
+					{ currentTab !== TABS.trash && (
+						<MenuItem
+							onClick={ onClose }
+							iconPosition="left"
+							icon={ trash }
+							variant="tertiary"
+							isDestructive
+						>
+							{ __( 'Delete', 'jetpack-forms' ) }
+						</MenuItem>
+					) }
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+};
+
+export default SingleActionsMenu;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -9,6 +9,12 @@ $action-bar-height: 72px;
 		font-size: 14px;
 	}
 
+	.components-dropdown-menu {
+		.components-menu-item__button {
+			font-size: 1rem;
+		}
+	}
+
 	@media (min-width: 1025px) {
 		a.back-button {
 			display: none !important;
@@ -190,6 +196,29 @@ $action-bar-height: 72px;
 		width: 27.5%;
 	}
 
+	.jp-forms__table-cell.is-actions {
+		max-width: 64px;
+
+		.components-dropdown-menu__toggle {
+			color: currentColor;
+			padding: 0;
+
+			> svg {
+				width: 32px;
+				height: 32px;
+			}
+		}
+
+		.components-dropdown__content {
+			white-space: normal;
+
+			.components-button.is-tertiary:hover:not(:disabled) {
+				color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
+				background: transparent;
+			}
+		}
+	}
+
 	@media (max-width: 660px) {
 		.jp-forms__table-cell.is-name {
 			width: 60%;
@@ -330,12 +359,6 @@ $action-bar-height: 72px;
 
 		@media (min-width: 1025px) {
 			display: flex;
-		}
-	}
-
-	.components-dropdown-menu {
-		.components-menu-item__button {
-			font-size: 1rem;
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:

* Add the Single Action menu (AKA "..." menu) to each response record on the response inbox

![image](https://user-images.githubusercontent.com/7811225/229214511-61e23601-7d2b-4505-a131-90404830426f.png)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Enable the jetpack forms package and the new dashboard before testing with:

```
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
add_filter( 'jetpack_forms_dashboard_enable', '__return_true' );
```

- Go to `/wp-admin/admin.php?page=jetpack-forms`
- Play with the Single Actions and check if they work correctly

