### PR TITLE
 VideoPress: fix debounced callback TimestampControl issue

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-update-timestamp-control-value
+++ b/projects/packages/videopress/changelog/update-videopress-fix-update-timestamp-control-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix debounced callback TimestampControl issue

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -338,9 +338,10 @@ function VideoHoverPreviewControl( {
 						fineAdjustment={ 1 }
 						decimalPlaces={ 2 }
 						value={ previewAtTime }
-						onChange={ atTime => {
+						onDebounceChange={ atTime => {
 							onPreviewAtTimeChange( Math.max( Math.min( maxStartingPoint, atTime ), 0 ) );
 						} }
+						wait={ 100 }
 					/>
 
 					<TimestampControl
@@ -349,9 +350,10 @@ function VideoHoverPreviewControl( {
 						decimalPlaces={ 2 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
 						value={ loopDuration }
-						onChange={ duration => {
+						onDebounceChange={ duration => {
 							onLoopDurationChange( Math.max( Math.min( MAX_LOOP_DURATION, duration ), 0 ) );
 						} }
+						wait={ 100 }
 					/>
 				</>
 			) }

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -255,7 +255,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 			onChange?.( newValue );
 			debounceTimer.current = setTimeout( onDebounceChange?.bind( null, newValue ), wait );
 		},
-		[ onChange ]
+		[ onDebounceChange ]
 	);
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue in the debounced callback defined in the TimestampControl component. Updating its useCallback() dependency fixes the issue.
Also, the PR updates the VideoHoverPreviewControl component replacing the regular onChange with the onDebouncedChange to improve the UI implementation performance.

Fixes https://github.com/Automattic/jetpack/issues/29847

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix debounced callback TimestampControl issue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm the issue described [here](https://github.com/Automattic/jetpack/issues/29847) is fixed.

