### PR TITLE
CRM: Resolves 2988, 2989, 2991, 2992, and 2993 - CSV Importer visual tweaks

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-2989-csv_importer_visual_tweaks
+++ b/projects/plugins/crm/changelog/fix-crm-2989-csv_importer_visual_tweaks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+CSV Importer: various UI/UX tweaks

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -478,7 +478,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 						?>
 							<hr />
 						<div style="text-align:center">
-							<button type="submit" name="csv-map-submit" id="csv-map-submit" class="button button-primary button-large" type="submit"><?php esc_html_e( 'Continue', 'zero-bs-crm' ); ?></button>	
+							<button type="submit" name="csv-map-submit" id="csv-map-submit" class="ui button button-primary button-large green" type="submit"><?php esc_html_e( 'Continue', 'zero-bs-crm' ); ?></button>	
 						</div>
 					</form>
 				</div>
@@ -587,7 +587,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 						?>
 						<hr />
 						<div style="text-align:center">
-							<button type="submit" name="csv-map-submit" id="csv-map-submit" class="button button-primary button-large" type="submit"><?php esc_html_e( 'Run Import', 'zero-bs-crm' ); ?></button>	
+							<button type="submit" name="csv-map-submit" id="csv-map-submit" class="ui button button-primary button-large green" type="submit"><?php esc_html_e( 'Run Import', 'zero-bs-crm' ); ?></button>	
 						</div>
 					</form>
 				</div>
@@ -796,7 +796,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 						?>
 						<hr />
-						<button type="button" class="button button-primary button-large" onclick="javascript:window.location='admin.php?page=<?php echo esc_attr( $zbs->slugs['managecontacts'] ); ?>';"><?php esc_html_e( 'Finish', 'zero-bs-crm' ); ?></button>
+						<a href="<?php echo jpcrm_esc_link( $zbs->slugs['managecontacts'] ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>" target="_blank" class="ui button green"><?php esc_html_e( 'Finish', 'zero-bs-crm' ); ?></a>
 					</div>
 				</div>
 			</div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -602,7 +602,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 			?>
 			<div class="zbscrm-csvimport-wrap">
-				<h2><?php esc_html_e( 'Running Import...', 'zero-bs-crm' ); ?></h2>
+				<h2 id="jpcrm_final_step_heading"><?php esc_html_e( 'Running Import...', 'zero-bs-crm' ); ?></h2>
 				<?php
 				if ( isset( $stageError ) && ! empty( $stageError ) ) {
 					zeroBSCRM_html_msg( -1, $stageError ); }
@@ -800,6 +800,10 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 					</div>
 				</div>
 			</div>
+			<script>
+				// this is a quick hack until the importer rewrite
+				document.getElementById('jpcrm_final_step_heading').innerHTML = '<?php esc_html_e( 'Import complete!', 'zero-bs-crm' ); ?>';
+			</script>
 			<?php
 
 			break;

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -796,7 +796,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 						?>
 						<hr />
-						<button type="button" class="button button-primary button-large" onclick="javascript:window.location='admin.php?page=<?php echo esc_attr( $zbs->slugs['datatools'] ); ?>';"><?php esc_html_e( 'Finish', 'zero-bs-crm' ); ?></button>
+						<button type="button" class="button button-primary button-large" onclick="javascript:window.location='admin.php?page=<?php echo esc_attr( $zbs->slugs['managecontacts'] ); ?>';"><?php esc_html_e( 'Finish', 'zero-bs-crm' ); ?></button>
 					</div>
 				</div>
 			</div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -607,8 +607,13 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 				if ( isset( $stageError ) && ! empty( $stageError ) ) {
 					zeroBSCRM_html_msg( -1, $stageError ); }
 				?>
-				<div class="zbscrm-final-stage">
-					<div class="zbscrm-import-log">
+				<div class="zbscrm-final-stage" style="text-align: center;">
+					<p>New contacts added: <span id="jpcrm_new_contact_count">0</span></p>
+					<p>Existing contacts updated: <span id="jpcrm_update_contact_count">0</span></p>
+					<button id="jpcrm_toggle_log_button" class="ui button grey"><?php esc_html_e( 'Toggle log', 'zero-bs-crm' ); ?></button>
+					<a id="jpcrm_import_finish_button" href="<?php echo jpcrm_esc_link( $zbs->slugs['managecontacts'] ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>" class="ui button green hidden"><?php esc_html_e( 'Finish', 'zero-bs-crm' ); ?></a>
+				</div>
+					<div id="jpcrm_import_log_div" class="zbscrm-import-log hidden">
 						<div class="zbscrm-import-log-line"><?php esc_html_e( 'Loading CSV File...', 'zero-bs-crm' ); ?> <i class="fa fa-check"></i></div>
 						<div class="zbscrm-import-log-line"><?php esc_html_e( 'Parsing rows...', 'zero-bs-crm' ); ?> <i class="fa fa-check"></i></div>
 						<div class="zbscrm-import-log-line"><?php echo esc_html( sprintf( __( 'Beginning Import of %s rows...', 'zero-bs-crm' ), zeroBSCRM_prettifyLongInts( $file_details['num_lines'] ) ) ); ?></div>
@@ -796,13 +801,20 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 						?>
 						<hr />
-						<a href="<?php echo jpcrm_esc_link( $zbs->slugs['managecontacts'] ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>" class="ui button green"><?php esc_html_e( 'Finish', 'zero-bs-crm' ); ?></a>
 					</div>
-				</div>
 			</div>
 			<script>
-				// this is a quick hack until the importer rewrite
+				// these are some quick hacks for better usability until the importer rewrite
+
+				function jpcrm_toggle_csv_log() {
+					document.getElementById('jpcrm_import_log_div').classList.toggle('hidden');
+				}
+
+				document.getElementById('jpcrm_toggle_log_button').addEventListener('click',jpcrm_toggle_csv_log);
 				document.getElementById('jpcrm_final_step_heading').innerHTML = '<?php esc_html_e( 'Import complete!', 'zero-bs-crm' ); ?>';
+				document.getElementById('jpcrm_new_contact_count').innerHTML = <?php echo esc_html( $linesAdded ); /* phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase */ ?>;
+				document.getElementById('jpcrm_update_contact_count').innerHTML = <?php echo esc_html( count( $existingOverwrites ) ); /* phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase */ ?>;
+				document.getElementById('jpcrm_import_finish_button').classList.remove('hidden');
 			</script>
 			<?php
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -142,7 +142,7 @@ function zeroBSCRM_CSVImporterLitepages_header( $subpage = '' ) {
 				if ( ! empty( $zbs->urls['extcsvimporterpro'] ) ) {
 					?>
 
-						<p><?php esc_html_e( 'Want to import companies as well as keep a record of your imports.', 'zero-bs-crm' ); ?>
+						<p><?php esc_html_e( 'Want to import companies as well as keep a record of your imports?', 'zero-bs-crm' ); ?>
 						<a href="<?php echo esc_url( $zbs->urls['extcsvimporterpro'] ); ?>" target="_blank">
 						<?php esc_html_e( 'CSV importer PRO is the perfect tool.', 'zero-bs-crm' ); ?></a></p>
 
@@ -400,13 +400,13 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 			?>
 			<div class="zbscrm-csvimport-wrap">
-				<h2><?php esc_html_e( 'Map Columns from your CSV to Contact Fields', 'zero-bs-crm' ); ?></h2>
+				<h2><?php esc_html_e( 'Map columns from your CSV to contact fields', 'zero-bs-crm' ); ?></h2>
 				<?php
 				if ( isset( $stageError ) && ! empty( $stageError ) ) {
 					zeroBSCRM_html_msg( -1, $stageError ); }
 				?>
 				<div class="zbscrm-csv-map">
-					<p class="zbscrm-csv-map-help"><?php esc_html_e( 'Your CSV File has been successfully uploaded. Before we can complete your import, you\'ll need to specify which field in your CSV file matches which field in your CRM.<br />You can do so by using the drop down options below:', 'zero-bs-crm' ); ?></p>
+					<p class="zbscrm-csv-map-help"><?php esc_html_e( 'Your CSV file has been successfully uploaded. Please map your CSV columns to their corresponding CRM fields with the drop down options below.', 'zero-bs-crm' ); ?></p>
 					<form method="post" class="zbscrm-csv-map-form">
 						<input type="hidden" id="zbscrmcsvimpstage" name="zbscrmcsvimpstage" value="2" />
 						<input type="hidden" id="zbscrmcsvimpf" name="zbscrmcsvimpf" value="<?php echo esc_attr( $file_details['public_name'] ); ?>" />
@@ -415,7 +415,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 						<hr />
 						<div class="zbscrm-csv-map-ignorefirst">
 							<input type="checkbox" id="zbscrmcsvimpignorefirst" name="zbscrmcsvimpignorefirst" value="1" />
-							<label for="zbscrmcsvimpignorefirst" ><?php echo esc_html__( 'Ignore first line of CSV file when running import.', 'zero-bs-crm' ) . '<br />' . esc_html__( 'Use this if you have a "header line" in your CSV file.)', 'zero-bs-crm' ); ?></label>
+							<label for="zbscrmcsvimpignorefirst" ><?php echo esc_html__( 'Ignore first line of CSV file when running import.', 'zero-bs-crm' ) . '<br />' . esc_html__( 'Use this if you have a "header line" in your CSV file.', 'zero-bs-crm' ); ?></label>
 						</div>
 						<hr />
 
@@ -493,17 +493,16 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 			// Stolen from plugin-install.php?tab=upload
 			?>
 			<div class="zbscrm-csvimport-wrap">
-				<h2>Complete Contact Import</h2>
+				<h2>Verify field mapping</h2>
 				<?php
 				if ( isset( $stageError ) && ! empty( $stageError ) ) {
 					zeroBSCRM_html_msg( -1, $stageError ); }
 				?>
 				<div class="zbscrm-confirmimport-csv">
-					<p class="zbscrm-csv-help"><?php __( 'Ready to run the import.<br />Please confirm the following is correct <i>before</i> continuing.', 'zero-bs-crm' ); ?><br /></p>
-					<div style="">
+					<div>
 						<?php
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo zeroBSCRM_html_msg( 1, __( 'Note: There is no easy way to "undo" a CSV import. To remove any contacts that have been added you will need to manually remove them.', 'zero-bs-crm' ) );
+						echo zeroBSCRM_html_msg( 1, esc_html__( 'Note: There is no automatic way to undo a CSV import. To remove any contacts that have been added you will need to manually remove them.', 'zero-bs-crm' ) );
 						?>
 					<form method="post" enctype="multipart/form-data" class="zbscrm-csv-import-form">
 						<input type="hidden" id="zbscrmcsvimpstage" name="zbscrmcsvimpstage" value="3" />
@@ -587,7 +586,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 						?>
 						<hr />
 						<div style="text-align:center">
-							<button type="submit" name="csv-map-submit" id="csv-map-submit" class="ui button button-primary button-large green" type="submit"><?php esc_html_e( 'Run Import', 'zero-bs-crm' ); ?></button>	
+							<button type="submit" name="csv-map-submit" id="csv-map-submit" class="ui button button-primary button-large green" type="submit"><?php esc_html_e( 'Run import', 'zero-bs-crm' ); ?></button>	
 						</div>
 					</form>
 				</div>
@@ -602,7 +601,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 			?>
 			<div class="zbscrm-csvimport-wrap">
-				<h2 id="jpcrm_final_step_heading"><?php esc_html_e( 'Running Import...', 'zero-bs-crm' ); ?></h2>
+				<h2 id="jpcrm_final_step_heading"><?php esc_html_e( 'Running import...', 'zero-bs-crm' ); ?></h2>
 				<?php
 				if ( isset( $stageError ) && ! empty( $stageError ) ) {
 					zeroBSCRM_html_msg( -1, $stageError ); }
@@ -826,7 +825,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 			// } Stolen from plugin-install.php?tab=upload
 			?>
 			<div class="zbscrm-csvimport-wrap">
-				<h2><?php esc_html_e( 'Import Contacts from a CSV File', 'zero-bs-crm' ); ?></h2>
+				<h2><?php esc_html_e( 'Import contacts from a CSV file', 'zero-bs-crm' ); ?></h2>
 				<?php
 				if ( isset( $stageError ) && ! empty( $stageError ) ) {
 					zeroBSCRM_html_msg( -1, $stageError ); }
@@ -839,7 +838,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 						<label class="screen-reader-text" for="zbscrmcsvfile"><?php esc_html_e( '.CSV file', 'zero-bs-crm' ); ?></label>
 						<input type="file" id="zbscrmcsvfile" name="zbscrmcsvfile">
 						<div class="csv-import__start-btn">
-							<input type="submit" name="csv-file-submit" id="csv-file-submit" class="ui button green" value="<?php esc_attr_e( 'Start CSV Import Now', 'zero-bs-crm' ); ?>">
+							<input type="submit" name="csv-file-submit" id="csv-file-submit" class="ui button green" value="<?php esc_attr_e( 'Upload CSV file', 'zero-bs-crm' ); ?>">
 						</div>
 					</form>
 				</div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -796,7 +796,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 
 						?>
 						<hr />
-						<a href="<?php echo jpcrm_esc_link( $zbs->slugs['managecontacts'] ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>" target="_blank" class="ui button green"><?php esc_html_e( 'Finish', 'zero-bs-crm' ); ?></a>
+						<a href="<?php echo jpcrm_esc_link( $zbs->slugs['managecontacts'] ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>" class="ui button green"><?php esc_html_e( 'Finish', 'zero-bs-crm' ); ?></a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#2988, Automattic/zero-bs-crm#2989, Automattic/zero-bs-crm#2991, Automattic/zero-bs-crm#2992, and Automattic/zero-bs-crm#2993 - CSV Importer visual tweaks

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The CSV Importer is in a sorry state in general, and will ultimately need a code cleanup, but in the meantime I did a quick facelift on some of the items. All the items are closely related, so I bundled them into one PR.

Most of the changes were on the final page of the import. Since it's not a dynamic page, but instead processes the import as it echos content, I added some JS toward the bottom of the page that will run after the import completes. This is a stopgap improvement for now.

Changes:
* The final page heading changes from "Running Import..." to "Import complete!" after it completes (2988).
* The full log is hidden by default (2989), and instead one gets a very simple count of added and updated contacts. I didn't change the actual log output at this stage; this can be done in a future iteration as needed.
* The "Finish" button is now above the (hidden) log (2991).
* The buttons on each stage are now green instead of purplish-pink (2992). This isn't a perfect JP green (which would require some extensive overrides or uber-specific CSS), but is closer to JP green than it was and should do for now.
* Clicking the "Finish" button now takes one to the Contacts listview instead of the Data Tools page (2993).
I also tweaked some wording in the last commit, pushed after my screenshots.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Import the test CSV below and make sure it looks like the screenshots below.

Test CSV:
```
fname,lname,email
normala,persona,normala@oasdgoag.asdgkoagj
normalb,personb,normalb@oasdgoag.asdgkoagj
normalc,personc,normalc@oasdgoag.asdgkoagj
```


`trunk`:

> ![image](https://user-images.githubusercontent.com/32492176/229245892-29c2ea24-9793-406a-b097-0907d22bcf45.png)
> ![image](https://user-images.githubusercontent.com/32492176/229245922-9699b312-7f9f-4a8d-9ac6-e2677d34ef0f.png)
> ![image](https://user-images.githubusercontent.com/32492176/229245955-2db8a63a-a638-455b-94f8-6441ba293be1.png)
> ![image](https://user-images.githubusercontent.com/32492176/229245970-17f526d7-d256-4710-a2f9-b4744e5e6e91.png)



`fix/crm/2989-csv_importer_visual_tweaks`:
> ![image](https://user-images.githubusercontent.com/32492176/229245370-a6498efc-95c4-47c0-898c-b0864d37406b.png)
> ![image](https://user-images.githubusercontent.com/32492176/229245601-62046ade-d34c-4484-a910-166d803aaf8a.png)
> ![image](https://user-images.githubusercontent.com/32492176/229245625-6b37419f-a877-4ee5-85e1-6cb9fa0e998e.png)
> ![image](https://user-images.githubusercontent.com/32492176/229245696-74c91455-5aa6-43c1-a941-7f5a969b26ca.png)
> ![image](https://user-images.githubusercontent.com/32492176/229245717-72bf377e-ba44-4fd4-a82a-6a7a44c3de48.png)
