### PR TITLE
VideoPress: handle max value of the TimestampControl component

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-support-max-value-in-timestamp-cmp
+++ b/projects/packages/videopress/changelog/update-videopress-support-max-value-in-timestamp-cmp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: handle max value of the TimestampControl component

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -111,7 +111,7 @@ export type VideoControlProps = {
 };
 
 export type PosterPanelProps = VideoControlProps & {
-	isGeneratingPoster: boolean;
+	isGeneratingPoster?: boolean;
 };
 
 export type VideoEditProps = VideoControlProps;

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -58,9 +58,18 @@ type TimeDataProps = {
  *
  * @param {number} value                    - The value to be converted.
  * @param {DecimalPlacesProp} decimalPlaces - The number of decimal places to be used.
+ * @param {number} max                      - The maximum value.
  * @returns {TimeDataProps}                   The time data.
  */
-function getTimeDataByValue( value: number, decimalPlaces: DecimalPlacesProp ): TimeDataProps {
+function getTimeDataByValue(
+	value: number,
+	decimalPlaces: DecimalPlacesProp,
+	max: number
+): TimeDataProps {
+	if ( value > max ) {
+		value = max;
+	}
+
 	const valueIsNaN = Number.isNaN( value );
 
 	// Compute decimal part based on the decimalPlaces.
@@ -86,7 +95,7 @@ export const TimestampInput = ( {
 	decimalPlaces,
 }: TimestampInputProps ): React.ReactElement => {
 	const time = {
-		value: getTimeDataByValue( value, decimalPlaces ),
+		value: getTimeDataByValue( value, decimalPlaces, max ),
 	};
 
 	// Check whether it should add hours input.
@@ -113,7 +122,7 @@ export const TimestampInput = ( {
 		}
 
 		// Update time object data.
-		time.value = { ...getTimeDataByValue( value, decimalPlaces ), [ unit ]: newValue };
+		time.value = { ...getTimeDataByValue( value, decimalPlaces, max ), [ unit ]: newValue };
 
 		// Call onChange callback.
 		const decimalValue = time.value.decimal
@@ -251,11 +260,15 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 		( newValue: number ) => {
 			clearTimeout( debounceTimer?.current );
 
+			if ( newValue > max ) {
+				newValue = max;
+			}
+
 			setControledValue( newValue );
 			onChange?.( newValue );
 			debounceTimer.current = setTimeout( onDebounceChange?.bind( null, newValue ), wait );
 		},
-		[ onDebounceChange ]
+		[ onDebounceChange, onChange, max, wait ]
 	);
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR handles the max value of the TimestampControl property. 

When the value typed into the inputs is bigger than the `max`, the component will pass, through the callback, the `max` value allowed, even though the input does show the bigger one.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: handle max value of the TimestampControl component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with the Storybook
* Confirm that the component never passes (through the callback) a value bigger than the `max`.

https://user-images.githubusercontent.com/77539/229247159-f0fa158f-3113-49e3-ba5c-b79bca1b4210.mov


