### PR TITLE
Protect: Fix firewall status to be considered "on" if brute force protection is enabled

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-firewall-status-when-bfp
+++ b/projects/plugins/protect/changelog/fix-protect-firewall-status-when-bfp
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix firewall status to be "on" when brute force protection is enabled.
+
+

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -237,7 +237,8 @@ const ConnectedFirewallHeader = () => {
 		isToggling,
 	} = useWafData();
 	const { hasRequiredPlan } = useProtectData();
-	const currentStatus = jetpackWafAutomaticRules || jetpackWafIpList ? 'on' : 'off';
+	const currentStatus =
+		jetpackWafAutomaticRules || jetpackWafIpList || bruteForceProtection ? 'on' : 'off';
 
 	return (
 		<FirewallHeader


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include `bruteForceProtection` as one of the values that indicates the firewall status.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

1201069996155224-as-1204310906743044

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate that the firewall header shows a green icon and "Firewall is on" text when brute force protection is enabled, and both automatic and manual rules are disabled.