### PR TITLE
Fix/access level

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-access-level
+++ b/projects/plugins/jetpack/changelog/fix-access-level
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Fix an issue where Subscribe block on homepage would return as paid if the first blog post was a paid blog (because it is looping)

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -427,12 +427,12 @@ function render_block( $attributes ) {
 function get_post_access_level() {
 	if ( ! is_singular() ) {
 		// There is no "actual" current post.
-		return null;
+		return 'everybody';
 	}
 
 	$post_id = get_the_ID();
 	if ( ! $post_id ) {
-		return null;
+		return 'everybody';
 	}
 	$meta = get_post_meta( $post_id, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 	if ( empty( $meta ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -425,9 +425,14 @@ function render_block( $attributes ) {
  * @return string the actual post access level (see projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js for the values).
  */
 function get_post_access_level() {
+	if ( ! is_singular() ) {
+		// There is no "actual" current post.
+		return null;
+	}
+
 	$post_id = get_the_ID();
 	if ( ! $post_id ) {
-		return 'everybody';
+		return null;
 	}
 	$meta = get_post_meta( $post_id, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 	if ( empty( $meta ) ) {


### PR DESCRIPTION
Fix issue for subscribe block access level on home page

 
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a paid newsletter plan 
* Create a paid newsletter post
* Go to the homepage and try to subscribe
* Notice an option is there to subscribe for free

