### PR TITLE
Fix Newsletter Locked Content Post and Open Learn More text in a new tab

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-locked-text
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-locked-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Display the correct newsletter locked content text for paid newsletters

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -182,6 +182,8 @@ export function NewsletterAccess( { accessLevel, setPostMeta, withModal = true }
 													href={ getRedirectUrl( 'paid-newsletter-info', {
 														anchor: 'memberships-and-subscriptions',
 													} ) }
+													rel="noopener noreferrer"
+													target="_blank"
 												/>
 											),
 										}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Extensions\Subscriptions;
 
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
 use Automattic\Jetpack\Status;
 use Jetpack;
 use Jetpack_Gutenberg;
@@ -696,7 +697,9 @@ function maybe_get_locked_content( $the_content ) {
 	if ( Jetpack_Memberships::user_can_view_post() ) {
 		return $the_content;
 	}
-	return get_locked_content_placeholder_text();
+
+	$newsletter_access_level = Jetpack_Memberships::get_newsletter_access_level();
+	return get_locked_content_placeholder_text( $newsletter_access_level );
 }
 
 /**
@@ -737,13 +740,21 @@ function maybe_gate_existing_comments( $comment ) {
 /**
  * Placeholder text for non-subscribers
  *
+ * @param string $newsletter_access_level The newsletter access level.
  * @return string
  */
-function get_locked_content_placeholder_text() {
+function get_locked_content_placeholder_text( $newsletter_access_level ) {
+	$access_level = $newsletter_access_level === Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS ? 'paid subscribers' : 'subscribers';
+
 	return do_blocks(
 		'<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","right":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80"}},"border":{"width":"1px","radius":"4px"}},"borderColor":"primary","layout":{"type":"constrained","contentSize":"400px"}} -->
 			<div class="wp-block-group has-border-color has-primary-border-color" style="border-width:1px;border-radius:4px;padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--80)"><!-- wp:heading {"textAlign":"center","style":{"typography":{"fontSize":"24px"},"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} -->
-			<h2 class="wp-block-heading has-text-align-center" style="margin-bottom:var(--wp--preset--spacing--60);font-size:24px">' . esc_html__( 'This post is for paid subscribers', 'jetpack' ) . '</h2>
+			<h2 class="wp-block-heading has-text-align-center" style="margin-bottom:var(--wp--preset--spacing--60);font-size:24px">' .
+
+			/* translators: Newsletter access level */
+			sprintf( esc_html__( 'This post is for %s', 'jetpack' ), $access_level )
+
+			. '</h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/29615
Fixes https://github.com/Automattic/jetpack/issues/29861

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Display the correct paid newsletter text for locked content. Previously we were displaying "This post is for paid subscribers" for posts marked for "all subscribers" as well as "paid subscribers". This PR changes the text to "This post is for subscribers" when the post is marked as "all subscribers" 

| Subscribers | Paid Subscribers |
| ------------- | ------------- |
| <img width="912" alt="Screenshot 2023-04-02 at 5 28 05 PM" src="https://user-images.githubusercontent.com/7076981/229379954-83a87f7b-7425-419d-9f9a-644d41805632.png">  | <img width="909" alt="Screenshot 2023-04-02 at 5 27 54 PM" src="https://user-images.githubusercontent.com/7076981/229379959-cc823f7c-3b9a-4c67-aafb-10c0959e4da7.png">

* Open the "Learn more" link in the Newsletter Access panel in a new tab

<img width="279" alt="Screenshot 2023-04-02 at 6 01 03 PM" src="https://user-images.githubusercontent.com/7076981/229381259-8a00eb67-3216-4454-ab46-d9b1235b569b.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Test Case A**
1. Go to a site with a newsletter setup
2. Create a post marked as "All Subscribers"
3. Open the post in an incognito window and verify the locked content displays the text: "This post is for subscribers"
4. Create a post marked as "Paid Subscribers"
5. Open the post in an incognito window and verify the locked content displays the text: "This post is for paid subscribers"

**Test Case B**
1. Go to a site with a newsletter setup
2. Click on the "Learn More" link in the newsletter access setting
3. Notice the "Learn More" link opens in a new tab


