### PR TITLE
Stats Admin: refactor config data to `Odyssey_Config_Data`

### DIFF
--- a/projects/packages/stats-admin/changelog/update-refactoring-config-data
+++ b/projects/packages/stats-admin/changelog/update-refactoring-config-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats Admin: refactoring config data code to Odyssey_Config_Data

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.6.3",
+	"version": "0.6.4-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -9,9 +9,7 @@ namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
-use Jetpack_Options;
 
 /**
  * Responsible for adding a stats dashboard to wp-admin.
@@ -162,7 +160,7 @@ class Dashboard {
 
 		wp_add_inline_script(
 			'jp-stats-dashboard',
-			$this->get_config_data_js(),
+			( new Odyssey_Config_Data() )->get_js_config_data(),
 			'before'
 		);
 	}
@@ -196,145 +194,4 @@ class Dashboard {
 		// fallback to the package version.
 		return Main::VERSION;
 	}
-
-	/**
-	 * Set configData to window.configData.
-	 */
-	protected function get_config_data_js() {
-		return 'window.configData = ' . wp_json_encode(
-			$this->config_data()
-		) . ';';
-	}
-
-	/**
-	 * Return the config for the app.
-	 */
-	protected function config_data() {
-		$blog_id      = Jetpack_Options::get_option( 'id' );
-		$empty_object = json_decode( '{}' );
-		return array(
-			'admin_page_base'                => static::get_admin_path(),
-			'api_root'                       => esc_url_raw( rest_url() ),
-			'blog_id'                        => Jetpack_Options::get_option( 'id' ),
-			'enable_all_sections'            => false,
-			'env_id'                         => 'production',
-			'google_analytics_key'           => 'UA-10673494-15',
-			'google_maps_and_places_api_key' => '',
-			'hostname'                       => wp_parse_url( get_site_url(), PHP_URL_HOST ),
-			'i18n_default_locale_slug'       => 'en',
-			'i18n_locale_slug'               => static::get_site_locale(),
-			'mc_analytics_enabled'           => false,
-			'meta'                           => array(),
-			'nonce'                          => wp_create_nonce( 'wp_rest' ),
-			'site_name'                      => \get_bloginfo( 'name' ),
-			'sections'                       => array(),
-			// Features are inlined @see https://github.com/Automattic/wp-calypso/pull/70122
-			'features'                       => array(),
-			'intial_state'                   => array(
-				'currentUser' => array(
-					'id'           => 1000,
-					'user'         => array(
-						'ID'       => 1000,
-						'username' => 'no-user',
-					),
-					'capabilities' => array(
-						"$blog_id" => self::get_current_user_capabilities(),
-					),
-				),
-				'sites'       => array(
-					'items'    => array(
-						"$blog_id" => array(
-							'ID'            => $blog_id,
-							'URL'           => site_url(),
-							'jetpack'       => true,
-							'visible'       => true,
-							'capabilities'  => $empty_object,
-							'products'      => array(),
-							'plan'          => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
-							'options'       => array(
-								'wordads'   => ( new Modules() )->is_active( 'wordads' ),
-								'admin_url' => admin_url(),
-							),
-							'stats_notices' => ( new Notices() )->get_notices_to_show(),
-						),
-					),
-					'features' => array( "$blog_id" => array( 'data' => self::get_plan_features() ) ),
-				),
-			),
-		);
-	}
-
-	/**
-	 * Page base for the Calypso admin page.
-	 */
-	protected static function get_admin_path() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( ! isset( $_SERVER['PHP_SELF'] ) || ! isset( $_SERVER['QUERY_STRING'] ) ) {
-			$parsed = wp_parse_url( admin_url( 'admin.php?page=stats' ) );
-			return $parsed['path'] . '?' . $parsed['query'];
-		}
-		// We do this because page.js requires the exactly page base to be set otherwise it will not work properly.
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		return wp_unslash( $_SERVER['PHP_SELF'] ) . '?' . wp_unslash( $_SERVER['QUERY_STRING'] );
-	}
-
-	/**
-	 * Get locale acceptable by Calypso.
-	 */
-	protected static function get_site_locale() {
-		// Stolen from `projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php`
-
-		/*
-		 * Trim the locale to an ISO 639 language code as required by Google.
-		 * Special cases are zh-cn (Simplified Chinese) and zh-tw (Traditional Chinese).
-		 * @link https://www.loc.gov/standards/iso639-2/php/code_list.php
-		 */
-		$locale = strtolower( get_locale() );
-
-		if ( in_array( $locale, array( 'zh_tw', 'zh_cn' ), true ) ) {
-			$locale = str_replace( '_', '-', $locale );
-		} else {
-			$locale = preg_replace( '/(_.*)$/i', '', $locale );
-		}
-		return $locale;
-	}
-
-	/**
-	 * Get the features of the current plan.
-	 */
-	protected static function get_plan_features() {
-		if ( ! class_exists( 'Jetpack_Plan' ) ) {
-			return array();
-		}
-		$plan = \Jetpack_Plan::get();
-		if ( empty( $plan['features'] ) ) {
-			return array();
-		}
-		return $plan['features'];
-	}
-
-	/**
-	 * Get the capabilities of the current user.
-	 *
-	 * @return array An array of capabilities.
-	 */
-	protected static function get_current_user_capabilities() {
-		$user = wp_get_current_user();
-		if ( ! $user || is_wp_error( $user ) ) {
-			return array();
-		}
-		return $user->allcaps;
-	}
-
-	/**
-	 * Return ture if the opt-out notice should be shown.
-	 *
-	 * @return bool
-	 */
-	protected static function has_opt_out_new_stats_notice() {
-		$new_stats_enabled = Stats_Options::get_option( 'enable_odyssey_stats' );
-		$hidden_jitms      = \Jetpack_Options::get_option( 'hide_jitm' );
-		return $new_stats_enabled && ! isset( $hidden_jitms[ self::OPT_OUT_NEW_STATS_FEATURE_CLASS ] );
-	}
-
 }

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.6.3';
+	const VERSION = '0.6.4-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -19,10 +19,12 @@ class Odyssey_Config_Data {
 
 	/**
 	 * Set configData to window.configData.
+	 *
+	 * @param array $config_data The config data.
 	 */
-	public function get_js_config_data() {
+	public function get_js_config_data( $config_data = null ) {
 		return 'window.configData = ' . wp_json_encode(
-			$this->get_data()
+			$config_data === null ? $this->get_data() : $config_data
 		) . ';';
 	}
 

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Stats Initial State
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Modules;
+use Jetpack_Options;
+
+/**
+ * Class Odyssey_Config_Data
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+class Odyssey_Config_Data {
+
+	/**
+	 * Set configData to window.configData.
+	 */
+	public function get_js_config_data() {
+		return 'window.configData = ' . wp_json_encode(
+			$this->get_data()
+		) . ';';
+	}
+
+	/**
+	 * Return the config for the app.
+	 */
+	public function get_data() {
+		$blog_id      = Jetpack_Options::get_option( 'id' );
+		$empty_object = json_decode( '{}' );
+		return array(
+			'admin_page_base'                => $this->get_admin_path(),
+			'api_root'                       => esc_url_raw( rest_url() ),
+			'blog_id'                        => Jetpack_Options::get_option( 'id' ),
+			'enable_all_sections'            => false,
+			'env_id'                         => 'production',
+			'google_analytics_key'           => 'UA-10673494-15',
+			'google_maps_and_places_api_key' => '',
+			'hostname'                       => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+			'i18n_default_locale_slug'       => 'en',
+			'i18n_locale_slug'               => $this->get_site_locale(),
+			'mc_analytics_enabled'           => false,
+			'meta'                           => array(),
+			'nonce'                          => wp_create_nonce( 'wp_rest' ),
+			'site_name'                      => \get_bloginfo( 'name' ),
+			'sections'                       => array(),
+			// Features are inlined @see https://github.com/Automattic/wp-calypso/pull/70122
+			'features'                       => array(),
+			'intial_state'                   => array(
+				'currentUser' => array(
+					'id'           => 1000,
+					'user'         => array(
+						'ID'       => 1000,
+						'username' => 'no-user',
+					),
+					'capabilities' => array(
+						"$blog_id" => $this->get_current_user_capabilities(),
+					),
+				),
+				'sites'       => array(
+					'items'    => array(
+						"$blog_id" => array(
+							'ID'            => $blog_id,
+							'URL'           => site_url(),
+							'jetpack'       => true,
+							'visible'       => true,
+							'capabilities'  => $empty_object,
+							'products'      => array(),
+							'plan'          => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
+							'options'       => array(
+								'wordads'   => ( new Modules() )->is_active( 'wordads' ),
+								'admin_url' => admin_url(),
+							),
+							'stats_notices' => ( new Notices() )->get_notices_to_show(),
+						),
+					),
+					'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Page base for the Calypso admin page.
+	 */
+	protected function get_admin_path() {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( ! isset( $_SERVER['PHP_SELF'] ) || ! isset( $_SERVER['QUERY_STRING'] ) ) {
+			$parsed = wp_parse_url( admin_url( 'admin.php?page=stats' ) );
+			return $parsed['path'] . '?' . $parsed['query'];
+		}
+		// We do this because page.js requires the exactly page base to be set otherwise it will not work properly.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		return wp_unslash( $_SERVER['PHP_SELF'] ) . '?' . wp_unslash( $_SERVER['QUERY_STRING'] );
+	}
+
+	/**
+	 * Get locale acceptable by Calypso.
+	 */
+	protected function get_site_locale() {
+		// Stolen from `projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php`
+
+		/*
+		 * Trim the locale to an ISO 639 language code as required by Google.
+		 * Special cases are zh-cn (Simplified Chinese) and zh-tw (Traditional Chinese).
+		 * @link https://www.loc.gov/standards/iso639-2/php/code_list.php
+		 */
+		$locale = strtolower( get_locale() );
+
+		if ( in_array( $locale, array( 'zh_tw', 'zh_cn' ), true ) ) {
+			$locale = str_replace( '_', '-', $locale );
+		} else {
+			$locale = preg_replace( '/(_.*)$/i', '', $locale );
+		}
+		return $locale;
+	}
+
+	/**
+	 * Get the features of the current plan.
+	 */
+	protected function get_plan_features() {
+		if ( ! class_exists( 'Jetpack_Plan' ) ) {
+			return array();
+		}
+		$plan = \Jetpack_Plan::get();
+		if ( empty( $plan['features'] ) ) {
+			return array();
+		}
+		return $plan['features'];
+	}
+
+	/**
+	 * Get the capabilities of the current user.
+	 *
+	 * @return array An array of capabilities.
+	 */
+	protected function get_current_user_capabilities() {
+		$user = wp_get_current_user();
+		if ( ! $user || is_wp_error( $user ) ) {
+			return array();
+		}
+		return $user->allcaps;
+	}
+}

--- a/projects/packages/stats-admin/tests/php/test-odyssey-config-data.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-config-data.php
@@ -18,6 +18,15 @@ class Test_Odyssey_Config_Data extends Stats_Test_Case {
 	}
 
 	/**
+	 * Test configData set to JS.
+	 */
+	public function test_render_config_data_with_param() {
+		$config_data = new Odyssey_Config_Data();
+		$this->assertTrue( strpos( $config_data->get_js_config_data( array( 'testtesttest' ) ), 'window.configData' ) === 0 );
+		$this->assertTrue( strpos( $config_data->get_js_config_data( array( 'testtesttest' ) ), 'testtesttest' ) > 0 );
+	}
+
+	/**
 	 * Test config_data has all necessary keys.
 	 */
 	public function test_config_data() {

--- a/projects/packages/stats-admin/tests/php/test-odyssey-config-data.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-config-data.php
@@ -1,0 +1,38 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName: This is necessary to ensure that PHPUnit runs these tests.
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Stats_Admin\Test_Case as Stats_Test_Case;
+
+/**
+ * Unit tests for the Odyssey_Config_Data class.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+class Test_Odyssey_Config_Data extends Stats_Test_Case {
+	/**
+	 * Test configData set to JS.
+	 */
+	public function test_render_config_data() {
+		$config_data = new Odyssey_Config_Data();
+		$this->assertTrue( strpos( $config_data->get_js_config_data(), 'window.configData' ) === 0 );
+	}
+
+	/**
+	 * Test config_data has all necessary keys.
+	 */
+	public function test_config_data() {
+		$config_data = new Odyssey_Config_Data();
+		$data        = $config_data->get_data();
+		$this->assertArrayHasKey( 'admin_page_base', $data );
+		$this->assertArrayHasKey( 'api_root', $data );
+		$this->assertArrayHasKey( 'blog_id', $data );
+		$this->assertArrayHasKey( 'env_id', $data );
+		$this->assertArrayHasKey( 'google_analytics_key', $data );
+		$this->assertArrayHasKey( 'google_maps_and_places_api_key', $data );
+		$this->assertArrayHasKey( 'i18n_default_locale_slug', $data );
+		$this->assertArrayHasKey( 'nonce', $data );
+		$this->assertArrayHasKey( 'site_name', $data );
+		$this->assertArrayHasKey( 'intial_state', $data );
+		$this->assertEmpty( $data['features'] );
+	}
+}

--- a/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
@@ -8,7 +8,7 @@ use Automattic\Jetpack\Stats_Admin\Test_Case as Stats_Test_Case;
  *
  * @package automattic/jetpack-stats-admin
  */
-class Test_Plan extends Stats_Test_Case {
+class Test_Dashboard extends Stats_Test_Case {
 	/**
 	 * Test that init sets $initialized.
 	 */
@@ -37,36 +37,5 @@ class Test_Plan extends Stats_Test_Case {
 		$get_cdn_asset_cache_buster = new \ReflectionMethod( $dashboard, 'get_cdn_asset_cache_buster' );
 		$get_cdn_asset_cache_buster->setAccessible( true );
 		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $get_cdn_asset_cache_buster->invoke( $dashboard ) );
-	}
-
-	/**
-	 * Test configData set to JS.
-	 */
-	public function test_render_config_data() {
-		$dashboard   = new Dashboard();
-		$config_data = new \ReflectionMethod( $dashboard, 'get_config_data_js' );
-		$config_data->setAccessible( true );
-		$this->assertTrue( strpos( $config_data->invoke( $dashboard ), 'window.configData' ) === 0 );
-	}
-
-	/**
-	 * Test config_data has all necessary keys.
-	 */
-	public function test_config_data() {
-		$dashboard   = new Dashboard();
-		$config_data = new \ReflectionMethod( $dashboard, 'config_data' );
-		$config_data->setAccessible( true );
-		$data = $config_data->invoke( $dashboard );
-		$this->assertArrayHasKey( 'admin_page_base', $data );
-		$this->assertArrayHasKey( 'api_root', $data );
-		$this->assertArrayHasKey( 'blog_id', $data );
-		$this->assertArrayHasKey( 'env_id', $data );
-		$this->assertArrayHasKey( 'google_analytics_key', $data );
-		$this->assertArrayHasKey( 'google_maps_and_places_api_key', $data );
-		$this->assertArrayHasKey( 'i18n_default_locale_slug', $data );
-		$this->assertArrayHasKey( 'nonce', $data );
-		$this->assertArrayHasKey( 'site_name', $data );
-		$this->assertArrayHasKey( 'intial_state', $data );
-		$this->assertEmpty( $data['features'] );
 	}
 }


### PR DESCRIPTION
## Proposed changes:

The PR refactors config_data related code to `Odyssey_Config_Data` and changes unit tests accordingly. The PR is broken off #29772, which is meant to share the config data code with the Stats widget if required.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
no

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Ensure All PHP unit tests pass
* Spin up a JN site
* Ensure Odyssey Stats works okay
