### PR TITLE
Connection: do not attempt to load non minified files

### DIFF
--- a/projects/packages/connection/changelog/rm-nonmin-path-connection
+++ b/projects/packages/connection/changelog/rm-nonmin-path-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Do not attempt to load non minified files since they are not shipped with the package anymore.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.51.5';
+	const PACKAGE_VERSION = '1.51.6-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -125,7 +125,6 @@ class Tracking {
 				'dependencies' => array( 'jp-tracks' ),
 				'enqueue'      => $enqueue,
 				'in_footer'    => true,
-				'nonmin_path'  => 'js/tracks-callables.js',
 			)
 		);
 	}
@@ -142,7 +141,6 @@ class Tracking {
 				'dependencies' => array( 'jquery' ),
 				'enqueue'      => true,
 				'in_footer'    => true,
-				'nonmin_path'  => 'js/tracks-ajax.js',
 			)
 		);
 


### PR DESCRIPTION
## Proposed changes:

Non-minified files were removed from the shipped package in #27931. We consequently cannot expect them to be available on sites consuming the package anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com and running `trunk`.
* Add `define( 'SCRIPT_DEBUG', true );` to your site's `wp-config.php` file.
* Load your site's dashboard with the browser console open.
    * You should see a 404 for the non minified version of the Tracking script (`src/js/tracks-ajax.js`).
* Now switch to this branch and reload the page.
    * The built version should be loaded instead, no more 404: `dist/tracks-ajax.js``
