### PR TITLE
Admin Page / AAG: simplify Akismet logic to fix display issue

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -150,22 +150,6 @@ class DashAkismet extends Component {
 		};
 
 		const getBanner = () => {
-			if ( this.props.isOfflineMode ) {
-				return (
-					<DashItem
-						label={ labelName }
-						module="akismet"
-						support={ support }
-						pro={ true }
-						className="jp-dash-item__is-inactive"
-					>
-						<p className="jp-dash-item__description">
-							{ __( 'Unavailable in Offline Mode.', 'jetpack' ) }
-						</p>
-					</DashItem>
-				);
-			}
-
 			return this.props.hasConnectedOwner ? getAkismetUpgradeBanner() : getConnectBanner();
 		};
 
@@ -193,6 +177,7 @@ class DashAkismet extends Component {
 			);
 		};
 
+		// If we don't have data from Akismet yet, show a loading state.
 		if ( 'N/A' === akismetData ) {
 			return (
 				<DashItem label={ labelName } module="akismet" support={ support } pro={ true }>
@@ -201,56 +186,38 @@ class DashAkismet extends Component {
 			);
 		}
 
-		if ( ! this.props.hasAntiSpam && ! this.props.hasAkismet ) {
-			if ( 'not_installed' === akismetData ) {
-				return (
-					<DashItem
-						label={ labelName }
-						module="akismet"
-						support={ support }
-						className="jp-dash-item__is-inactive"
-						pro={ true }
-						overrideContent={ getBanner() }
-					/>
-				);
-			}
-
-			if ( 'not_active' === akismetData ) {
-				return (
-					<DashItem
-						label={ labelName }
-						module="akismet"
-						support={ support }
-						className="jp-dash-item__is-inactive"
-						pro={ true }
-						overrideContent={ getBanner() }
-					/>
-				);
-			}
-
-			if ( 'invalid_key' === akismetData ) {
-				return (
-					<DashItem
-						label={ labelName }
-						module="akismet"
-						support={ support }
-						className="jp-dash-item__is-inactive"
-						pro={ true }
-						overrideContent={ getBanner() }
-					/>
-				);
-			}
-		}
-
+		// If Akismet is not installed or not configured yet, show a banner to install it.
 		if ( [ 'not_installed', 'not_active', 'invalid_key' ].includes( akismetData ) ) {
+			const commonProps = {
+				label: labelName,
+				module: 'akismet',
+				support: support,
+				className: 'jp-dash-item__is-inactive',
+				pro: true,
+			};
+
+			// Akismet is not installed nor activated.
+			if ( ! this.props.hasAntiSpam && ! this.props.hasAkismet ) {
+				// In Offline Mode, we can't prompt to connect to WordPress.com
+				// the site will not be able to communicate with Akismet servers,
+				// and is very likely not to get any comments.
+				// Akismet will not be useful for them.
+				if ( this.props.isOfflineMode ) {
+					return (
+						<DashItem { ...commonProps }>
+							<p className="jp-dash-item__description">
+								{ __( 'Unavailable in Offline Mode.', 'jetpack' ) }
+							</p>
+						</DashItem>
+					);
+				}
+
+				return <DashItem { ...commonProps } overrideContent={ getBanner() } />;
+			}
+
+			// The plugin is installed and activated, but not configured yet.
 			return (
-				<DashItem
-					label={ labelName }
-					module="akismet"
-					support={ support }
-					className="jp-dash-item__is-inactive"
-					pro={ true }
-				>
+				<DashItem { ...commonProps }>
 					{ __(
 						"Your Jetpack plan provides anti-spam protection through Akismet. Click 'set up' to enable it on your site.",
 						'jetpack'

--- a/projects/plugins/jetpack/changelog/update-aag-ak-logic
+++ b/projects/plugins/jetpack/changelog/update-aag-ak-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin Page: simplify Akismet logic to fix display issue.


### PR DESCRIPTION
## Proposed changes:

There was quite a bit of duplication in the code handling the different states of the Akismet card in the At A Glance dashboard. This PR removes much of it, and by doing so fixes a display issue with the card when the site is in offline mode:

<img width="581" alt="Screenshot 2023-04-03 at 12 24 16" src="https://user-images.githubusercontent.com/426388/229498781-6b7123a3-b679-4764-b801-dc0998430d80.png">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

On a brand new site, you will want to test as many scenarios as possible:

- [ ] Offline Mode, Akismet not installed
- [ ] Offline Mode, Akismet installed but not active
- [ ] Offline Mode, Akismet active, but no API key added.
- [ ] Offline Mode, Akismet active and configured.
- [ ] Site-connected to WordPress.com, Akismet not installed
- [ ] Site-connected to WordPress.com, Akismet installed but not active
- [ ] Site-connected to WordPress.com, Akismet active, but no API key added. 
- [ ] Site-connected to WordPress.com, Akismet active and configured.
- [ ] User-connected to WordPress.com, Akismet not installed
- [ ] User-connected to WordPress.com, Akismet installed but not active
- [ ] User-connected to WordPress.com, Akismet active, but no API key added.
- [ ] User-connected to WordPress.com, Akismet active and configured.
