### PR TITLE
Refactor importer HTTP status code

### DIFF
--- a/projects/packages/import/changelog/change-http-statuses
+++ b/projects/packages/import/changelog/change-http-statuses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Align all HTTP codes to a standard 409.

--- a/projects/packages/import/src/endpoints/class-category.php
+++ b/projects/packages/import/src/endpoints/class-category.php
@@ -67,6 +67,9 @@ class Category extends \WP_REST_Terms_Controller {
 
 		$response = parent::create_item( $request );
 
+		// Ensure that the HTTP status is a valid one.
+		$response = $this->ensure_http_status( $response, 'term_exists', 409 );
+
 		return $this->add_import_id_metadata( $request, $response );
 	}
 }

--- a/projects/packages/import/src/endpoints/class-comment.php
+++ b/projects/packages/import/src/endpoints/class-comment.php
@@ -57,7 +57,40 @@ class Comment extends \WP_REST_Comments_Controller {
 			$request['parent'] = is_array( $comments ) && count( $comments ) ? $comments[0] : 0;
 		}
 
+		$duplicated_id = null;
+
+		/**
+		 * Core comment creation function doesn't return the duplicated comment ID.
+		 * Add a filter to get the ID.
+		 */
+		$get_id_func = function ( $dupe_id, $commentdata ) use ( &$duplicated_id ) {
+			if ( $dupe_id !== null ) {
+				$duplicated_id = $dupe_id;
+			}
+
+			return $dupe_id;
+		};
+
+		// Add the filter.
+		\add_filter( 'duplicate_comment_id', $get_id_func, 10, 2 );
+
 		$response = parent::create_item( $request );
+
+		// Check if the comment is duplicated.
+		if (
+			$duplicated_id !== null &&
+			is_wp_error( $response ) &&
+			$response->get_error_code() === 'comment_duplicate' ) {
+			$data = $response->get_error_data( 'comment_duplicate' );
+
+			// Add the comment ID.
+			$data['comment_id'] = $duplicated_id;
+
+			$response->add_data( $data );
+		}
+
+		// Remove the filter.
+		\remove_filter( 'duplicate_comment_id', $get_id_func );
 
 		return $this->add_import_id_metadata( $request, $response );
 	}

--- a/projects/packages/import/src/endpoints/class-comment.php
+++ b/projects/packages/import/src/endpoints/class-comment.php
@@ -62,6 +62,8 @@ class Comment extends \WP_REST_Comments_Controller {
 		/**
 		 * Core comment creation function doesn't return the duplicated comment ID.
 		 * Add a filter to get the ID.
+		 *
+		 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		 */
 		$get_id_func = function ( $dupe_id, $commentdata ) use ( &$duplicated_id ) {
 			if ( $dupe_id !== null ) {

--- a/projects/packages/import/src/endpoints/class-menu.php
+++ b/projects/packages/import/src/endpoints/class-menu.php
@@ -33,4 +33,19 @@ class Menu extends \WP_REST_Menus_Controller {
 		// @see add_term_meta
 		$this->import_id_meta_type = 'term';
 	}
+
+	/**
+	 * Creates a single menu.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		$response = parent::create_item( $request );
+
+		// Ensure that the HTTP status is a valid one.
+		$response = $this->ensure_http_status( $response, 'menu_exists', 409 );
+
+		return $this->add_import_id_metadata( $request, $response );
+	}
 }

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -80,7 +80,7 @@ class Post extends \WP_REST_Posts_Controller {
 				'post_exists',
 				__( 'Cannot create existing post.', 'jetpack-import' ),
 				array(
-					'status'  => 400,
+					'status'  => 409,
 					'post_id' => $post_id,
 				)
 			);
@@ -243,5 +243,4 @@ class Post extends \WP_REST_Posts_Controller {
 		$name = ucwords( $name );
 		return $name;
 	}
-
 }

--- a/projects/packages/import/src/endpoints/class-tag.php
+++ b/projects/packages/import/src/endpoints/class-tag.php
@@ -33,4 +33,19 @@ class Tag extends \WP_REST_Terms_Controller {
 		// @see add_term_meta
 		$this->import_id_meta_type = 'term';
 	}
+
+	/**
+	 * Creates a tag.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		$response = parent::create_item( $request );
+
+		// Ensure that the HTTP status is a valid one.
+		$response = $this->ensure_http_status( $response, 'term_exists', 409 );
+
+		return $this->add_import_id_metadata( $request, $response );
+	}
 }

--- a/projects/packages/import/src/endpoints/trait-import.php
+++ b/projects/packages/import/src/endpoints/trait-import.php
@@ -177,4 +177,25 @@ trait Import {
 			'schema'      => array( $this, 'get_public_item_schema' ),
 		);
 	}
+
+	/**
+	 * Ensure that the HTTP status is correct.
+	 *
+	 * @param WP_Error $response   Response error object.
+	 * @param int      $error_code Error code.
+	 * @param int      $status     HTTP status.
+	 */
+	protected function ensure_http_status( $response, $error_code, $status ) {
+		if ( is_wp_error( $response ) && in_array( $error_code, $response->get_error_codes(), true ) ) {
+			$data = $response->get_error_data( $error_code );
+
+			if ( isset( $data['status'] ) ) {
+				$data['status'] = $status;
+
+				$response->add_data( $data );
+			}
+		}
+
+		return $response;
+	}
 }


### PR DESCRIPTION
All endpoints of the Unified Importer should output `HTTP 409 Conflict` when a resource already exists.

Fixes https://github.com/Automattic/dotcom-forge/issues/2055

## Proposed changes:
* `term_exists` (400 -> 409)
* `post_exists` (400 -> 409)
* `menu_exists` (400 -> 409)
* `comment_duplicate` (add missing `comment_id`)

## Testing instructions:

See D106849-code for detailed instructions.