### PR TITLE
CRM: Update Jetpack CRM stable tag in readme.txt to 5.6.0

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-readme-5.6.0
+++ b/projects/plugins/crm/changelog/update-crm-readme-5.6.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Readme: Update stable tag.

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, woodyhayday, mikemayhem3030
 Tags: CRM, Invoice, Woocommerce CRM, Clients, Lead Generation, contacts, customers, billing, email marketing, Marketing Automation, contact form, automations
 Tested up to: 6.2
-Stable tag: 5.5.3
+Stable tag: 5.6.0
 Requires at least: 5.0
 Requires PHP: 7.2
 License: GPLv2


### PR DESCRIPTION


## Proposed changes:

* As Jetpack CRM 5.6.0 is live, this PR updates the stable tag in the monorepo (and mirror repo) to reflect this.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read - the stable tag should be correct (5.6.0).

