### PR TITLE
CRM: Change the Give Feedback link to send to Leave a Review

### DIFF
--- a/projects/plugins/crm/changelog/crm-fix-feedback-broken-page
+++ b/projects/plugins/crm/changelog/crm-fix-feedback-broken-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the Give Feedback link to send to the reviews on .org

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -802,7 +802,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 				?>
 					<?php ##/WLREMOVE ?>
 					
-					<a class="item" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['feedback'] ) ); ?>"><i class="idea icon" aria-hidden="true"></i> <?php esc_html_e( 'Give Feedback', 'zero-bs-crm' ); ?></a>
+					<a class="item" href="<?php echo esc_url( $zbs->urls['rateuswporg'] ); ?>"><i class="star icon" aria-hidden="true"></i> <?php esc_html_e( 'Leave a review', 'zero-bs-crm' ); ?></a>
 					
 					<?php
 					// welcome tour and crm resources page for admins :)

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -1013,7 +1013,6 @@ final class ZeroBSCRM {
 		$this->slugs['logout']       = 'zerobscrm-logout';
 		$this->slugs['datatools']    = 'zerobscrm-datatools';
 		$this->slugs['welcome']      = 'zerobscrm-welcome';
-		$this->slugs['feedback']     = 'zerobscrm-feedback';
 		$this->slugs['crmresources'] = 'jpcrm-resources';
 		$this->slugs['extensions']   = 'zerobscrm-extensions';
 		$this->slugs['modules']      = 'zerobscrm-modules';


### PR DESCRIPTION
The existing Give Feedback link in the menu takes you to a page which does not exist (you are not permitted to access it) - changing it to send to WP.org reviews page instead.

### Testing instructions
On the drop down menu, Give Feedback takes you to a page which you cannot access. This branch changes the behaviour to link to the WP.org reviews page instead. Before:-

<img width="1278" alt="Screenshot 2023-04-03 at 14 33 54" src="https://user-images.githubusercontent.com/4077604/229547952-19cf0c6e-3e61-482c-9bb5-965ed38c9965.png">

After:
<img width="1279" alt="Screenshot 2023-04-03 at 15 57 23" src="https://user-images.githubusercontent.com/4077604/229548268-fba594bf-e20b-4c5b-a6fc-c35db6ff463b.png">

