### PR TITLE
VideoPress: handle limit-loop duration of the previewOnHover based on starting point

### DIFF
--- a/projects/packages/videopress/changelog/update-videopres-limit-loop-duration
+++ b/projects/packages/videopress/changelog/update-videopres-limit-loop-duration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: handle limit-loop duration of the previewOn based on starting point

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -40,6 +40,7 @@ import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../
 import type { PosterPanelProps, VideoControlProps, VideoGUID } from '../../types';
 import type React from 'react';
 
+const MIN_LOOP_DURATION = 3 * 1000;
 const MAX_LOOP_DURATION = 30 * 1000;
 const DEFAULT_LOOP_DURATION = 10 * 1000;
 
@@ -324,8 +325,11 @@ export function VideoHoverPreviewControl( {
 	onPreviewAtTimeChange,
 	onLoopDurationChange,
 }: VideoHoverPreviewControlProps ): React.ReactElement {
-	const maxLoopDuration = Math.min( MAX_LOOP_DURATION, videoDuration );
-	const maxStartingPoint = videoDuration - loopDuration;
+	const maxStartingPoint = videoDuration - MIN_LOOP_DURATION;
+
+	const [ maxLoopDuration, setMaxLoopDuration ] = useState(
+		Math.min( MAX_LOOP_DURATION, videoDuration - previewAtTime )
+	);
 
 	const loopDurationHelp = createInterpolateElement(
 		sprintf(
@@ -355,7 +359,10 @@ export function VideoHoverPreviewControl( {
 						fineAdjustment={ 1 }
 						decimalPlaces={ 2 }
 						value={ previewAtTime }
-						onDebounceChange={ onPreviewAtTimeChange }
+						onDebounceChange={ timestamp => {
+							onPreviewAtTimeChange( timestamp );
+							setMaxLoopDuration( Math.min( MAX_LOOP_DURATION, videoDuration - timestamp ) );
+						} }
 						wait={ 100 }
 					/>
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -309,7 +309,7 @@ type VideoHoverPreviewControlProps = {
  * @param {VideoHoverPreviewControlProps} props - Component properties
  * @returns { React.ReactElement}                 React component
  */
-function VideoHoverPreviewControl( {
+export function VideoHoverPreviewControl( {
 	previewOnHover = false,
 	previewAtTime = 0,
 	loopDuration = DEFAULT_LOOP_DURATION,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -330,7 +330,7 @@ export function VideoHoverPreviewControl( {
 	const loopDurationHelp = createInterpolateElement(
 		sprintf(
 			/* translators: placeholder is the maximum lapse duration for the previewOnHover */
-			__( 'Minimum value: 3s. Maximum value: <em>%s</em>s.', 'jetpack-videopress-pkg' ),
+			__( 'Minimum value: <em>3s</em>. Maximum value: <em>%s</em>s.', 'jetpack-videopress-pkg' ),
 			( ( maxLoopDuration / 10 ) | 0 ) / 100
 		),
 		{
@@ -355,9 +355,7 @@ export function VideoHoverPreviewControl( {
 						fineAdjustment={ 1 }
 						decimalPlaces={ 2 }
 						value={ previewAtTime }
-						onDebounceChange={ atTime => {
-							onPreviewAtTimeChange( Math.max( Math.min( maxStartingPoint, atTime ), 0 ) );
-						} }
+						onDebounceChange={ onPreviewAtTimeChange }
 						wait={ 100 }
 					/>
 
@@ -367,9 +365,7 @@ export function VideoHoverPreviewControl( {
 						decimalPlaces={ 2 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
 						value={ loopDuration }
-						onDebounceChange={ duration => {
-							onLoopDurationChange( Math.max( Math.min( MAX_LOOP_DURATION, duration ), 0 ) );
-						} }
+						onDebounceChange={ onLoopDurationChange }
 						wait={ 100 }
 						help={ loopDurationHelp }
 					/>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -342,6 +342,8 @@ export function VideoHoverPreviewControl( {
 		}
 	);
 
+	const noLoopDurationRange = maxLoopDuration <= MIN_LOOP_DURATION;
+
 	return (
 		<>
 			<ToggleControl
@@ -375,6 +377,7 @@ export function VideoHoverPreviewControl( {
 						onDebounceChange={ onLoopDurationChange }
 						wait={ 100 }
 						help={ loopDurationHelp }
+						disabled={ noLoopDurationRange }
 					/>
 				</>
 			) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -13,7 +13,13 @@ import {
 	Spinner,
 	Notice,
 } from '@wordpress/components';
-import { useRef, useEffect, useState, useCallback } from '@wordpress/element';
+import {
+	useRef,
+	useEffect,
+	useState,
+	useCallback,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { linkOff, image as imageIcon } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -321,6 +327,17 @@ export function VideoHoverPreviewControl( {
 	const maxLoopDuration = Math.min( MAX_LOOP_DURATION, videoDuration );
 	const maxStartingPoint = videoDuration - loopDuration;
 
+	const loopDurationHelp = createInterpolateElement(
+		sprintf(
+			/* translators: placeholder is the maximum lapse duration for the previewOnHover */
+			__( 'Minimum value: 3s. Maximum value: <em>%s</em>s.', 'jetpack-videopress-pkg' ),
+			( ( maxLoopDuration / 10 ) | 0 ) / 100
+		),
+		{
+			em: <em />,
+		}
+	);
+
 	return (
 		<>
 			<ToggleControl
@@ -354,6 +371,7 @@ export function VideoHoverPreviewControl( {
 							onLoopDurationChange( Math.max( Math.min( MAX_LOOP_DURATION, duration ), 0 ) );
 						} }
 						wait={ 100 }
+						help={ loopDurationHelp }
 					/>
 				</>
 			) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
@@ -47,6 +47,7 @@ _default.args = {
 };
 
 const VideoHoverPreviewControlTemplate = args => {
+	const [ previewOnHover, setPreviewOnHover ] = useState( true );
 	const [ , setPreviewAt ] = useState( args.previewAtTime );
 	const [ , setLoopDuraton ] = useState( args.loopDuration );
 	const setPreviewAtHandler = newPreviewAt => {
@@ -57,21 +58,19 @@ const VideoHoverPreviewControlTemplate = args => {
 	return (
 		<VideoHoverPreviewControl
 			{ ...args }
+			previewOnHover={ previewOnHover }
 			onPreviewAtTimeChange={ setPreviewAtHandler }
 			onLoopDurationChange={ setLoopDuraton }
+			onPreviewOnHoverChange={ setPreviewOnHover }
 		/>
 	);
 };
 
 export const VideoHoverPreviewControlStory = VideoHoverPreviewControlTemplate.bind( {} );
 VideoHoverPreviewControlStory.args = {
-	previewOnHover: false,
 	previewAtTime: 0,
 	loopDuration: 2300,
 	videoDuration: 80000, // 80 seconds
-	onPreviewOnHoverChange: () => ( {} ),
-	onPreviewAtTimeChange: () => ( {} ),
-	onLoopDurationChange: () => ( {} ),
 };
 
 VideoHoverPreviewControlTemplate.storyName = 'VideoHoverPreviewControl';

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 /**
  * Internal dependencies
  */
@@ -47,7 +47,20 @@ _default.args = {
 };
 
 const VideoHoverPreviewControlTemplate = args => {
-	return <VideoHoverPreviewControl { ...args } />;
+	const [ , setPreviewAt ] = useState( args.previewAtTime );
+	const [ , setLoopDuraton ] = useState( args.loopDuration );
+	const setPreviewAtHandler = newPreviewAt => {
+		setPreviewAt( newPreviewAt );
+		console.log( { newPreviewAt } ); // eslint-disable-line no-console
+	};
+
+	return (
+		<VideoHoverPreviewControl
+			{ ...args }
+			onPreviewAtTimeChange={ setPreviewAtHandler }
+			onLoopDurationChange={ setLoopDuraton }
+		/>
+	);
 };
 
 export const VideoHoverPreviewControlStory = VideoHoverPreviewControlTemplate.bind( {} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import PosterPanel from '..';
+import PosterPanel, { VideoHoverPreviewControl } from '..';
 import Doc from './PosterPanel.mdx';
 
 export default {
@@ -45,3 +45,20 @@ _default.args = {
 	videoRatio: 60,
 	guid: 'ezoR6kzb',
 };
+
+const VideoHoverPreviewControlTemplate = args => {
+	return <VideoHoverPreviewControl { ...args } />;
+};
+
+export const VideoHoverPreviewControlStory = VideoHoverPreviewControlTemplate.bind( {} );
+VideoHoverPreviewControlStory.args = {
+	previewOnHover: false,
+	previewAtTime: 0,
+	loopDuration: 2300,
+	videoDuration: 780000,
+	onPreviewOnHoverChange: () => ( {} ),
+	onPreviewAtTimeChange: () => ( {} ),
+	onLoopDurationChange: () => ( {} ),
+};
+
+VideoHoverPreviewControlTemplate.storyName = 'VideoHoverPreviewControl';

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
@@ -30,7 +30,13 @@ const DefaultTemplate = args => {
 		setAttributes( { ...attributes, ...newAttributes } );
 	};
 
-	return <PosterPanel attributes={ attributes } setAttributes={ setAttributesHandler } />;
+	return (
+		<PosterPanel
+			attributes={ attributes }
+			setAttributes={ setAttributesHandler }
+			isGeneratingPoster={ false }
+		/>
+	);
 };
 
 export const _default = DefaultTemplate.bind( {} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
@@ -68,7 +68,7 @@ VideoHoverPreviewControlStory.args = {
 	previewOnHover: false,
 	previewAtTime: 0,
 	loopDuration: 2300,
-	videoDuration: 780000,
+	videoDuration: 80000, // 80 seconds
 	onPreviewOnHoverChange: () => ( {} ),
 	onPreviewAtTimeChange: () => ( {} ),
 	onLoopDurationChange: () => ( {} ),

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/stories/index.tsx
@@ -73,4 +73,4 @@ VideoHoverPreviewControlStory.args = {
 	videoDuration: 80000, // 80 seconds
 };
 
-VideoHoverPreviewControlTemplate.storyName = 'VideoHoverPreviewControl';
+VideoHoverPreviewControlStory.storyName = 'VideoHoverPreviewControl';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR changes the max loop duration value according to the selected starting point of the previewOnHover effect. It does the opposite implementation already implemented in trunk, where the starting point is updated based on the loop duration value.
To do this, the PR adds a story for the `<VideoHoverPreviewControl />` conmponent.

Fixes https://github.com/Automattic/jetpack/issues/29846

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: handle limit-loop duration of the previewOn based on starting point

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with the Storybook

```cli
cd projects/js-packages/storybook
```

```cli
pnpm run storybook:dev
```

* Go to the [VideoHoverPreviewControl](http://localhost:50240/?path=/story/packages-videopress-block-editor-poster-panel--video-hover-preview-control-story&args=previewAtTime:50000) story
* Confirm the loop duration changes when the remaining time is lower than 30 seconds

<img width="626" alt="Screen Shot 2023-04-03 at 12 02 01" src="https://user-images.githubusercontent.com/77539/229549728-70a65999-e34d-4847-9310-c41b0c5a99b9.png">

Disclaimer:
We need to improve the minimum allowed value. (follow-up) PR

