### PR TITLE
Rnmobile/vp loading style

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-vp-loading-style
+++ b/projects/packages/videopress/changelog/rnmobile-vp-loading-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Update basic styling for the native loading screen

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.tsx
@@ -36,7 +36,13 @@ export default function Player( { html, isRequestingEmbedPreview, isSelected }: 
 		<View style={ [ style[ 'videopress-player' ], loadingStyle ] }>
 			{ ! isSelected && <View style={ style[ 'videopress-player__overlay' ] } /> }
 			{ ! isRequestingEmbedPreview && <SandBox html={ html } /> }
-			{ ! html && <Text>{ __( 'Loading…', 'jetpack-videopress-pkg' ) }</Text> }
+			{ ! html && (
+				<View style={ style[ 'videopress-player--loading' ] }>
+					<Text style={ style[ 'videopress-player--loading-text' ] }>
+						{ __( 'Loading…', 'jetpack-videopress-pkg' ) }
+					</Text>
+				</View>
+			) }
 		</View>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/style.native.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/style.native.scss
@@ -10,3 +10,14 @@
 	width: 100%;
 	z-index: 1;
 }
+
+.videopress-player--loading {
+	display: flex;
+	justify-content: center;
+	height: 100%;
+	width: 100%;
+}
+
+.videopress-player--loading-text {
+	text-align: center;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes loading screen styles

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add basic styling for the player loading screen

| before | after |
|--|--|
| ![img_0007](https://user-images.githubusercontent.com/744755/229568243-20d1c364-5c44-4d42-bce6-873794975812.png) | ![img_0006-1](https://user-images.githubusercontent.com/744755/229568439-e593cc2f-cac7-4b8c-b07f-e68c8de8a899.png) |


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Testing is tricky since the loading screen is only visible while the player is loading but has not returned the iframe  markup. The best option is to modify the `player/index.native.js` file to only show the loading components 

