### PR TITLE
Make feedback bulk actions endpoint more explicit

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-api-fetch
+++ b/projects/packages/forms/changelog/fix-forms-api-fetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Made feedback bulk actions more explicit and easier to work with.

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -71,10 +71,10 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/responses',
+			$this->rest_base . '/responses/bulk_actions',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'update_responses' ),
+				'callback'            => array( $this, 'bulk_actions' ),
 				'permission_callback' => array( $this, 'get_responses_permission_check' ),
 			)
 		);
@@ -251,19 +251,15 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 	 *
 	 * @return WP_REST_Response A response object..
 	 */
-	public function update_responses( $request ) {
-		$content_type = $request->get_header( 'Content-Type' );
+	public function bulk_actions( $request ) {
+		$action   = $request->get_param( 'action' );
+		$post_ids = $request->get_param( 'post_ids' );
 
-		// Match 'action' directive inside Content-Type header value
-		preg_match( '/\;\s*bulk_action=([a-z_]*)/i', $content_type, $matches );
-		$bulk_action = isset( $matches[1] ) ? $matches[1] : null;
-		$post_ids    = $request->get_param( 'post_ids' );
-
-		if ( $bulk_action && ! is_array( $post_ids ) ) {
+		if ( $action && ! is_array( $post_ids ) ) {
 			return new $this->error_response( __( 'Bad request', 'jetpack-forms' ), 400 );
 		}
 
-		switch ( $bulk_action ) {
+		switch ( $action ) {
 			case 'mark_as_spam':
 				return $this->bulk_action_mark_as_spam( $post_ids );
 

--- a/projects/packages/forms/src/dashboard/data/responses.js
+++ b/projects/packages/forms/src/dashboard/data/responses.js
@@ -20,19 +20,19 @@ export const fetchResponses = query => {
 };
 
 /**
- * Updates posts status
+ * Performs a bulk action on responses.
  *
- * @param {Array}  responseIdList - The list of responses to be updated.
+ * @param {Array} responseIds - The list of responses to be updated.
  * @param {string} action  - The action to be executed.
  * @returns {Promise} Request promise.
  */
-export const updateResponseStatus = ( responseIdList, action ) => {
+export const doBulkAction = ( responseIds, action ) => {
 	return apiFetch( {
-		path: `/wpcom/v2/forms/responses`,
+		path: `/wpcom/v2/forms/responses/bulk_actions`,
 		method: 'POST',
-		headers: {
-			'Content-Type': `application/json;bulk_action=${ action }`,
+		data: {
+			action,
+			post_ids: responseIds,
 		},
-		body: JSON.stringify( { post_ids: responseIdList } ),
 	} );
 };

--- a/projects/packages/forms/src/dashboard/inbox/bulk-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/bulk-actions-menu.js
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { updateResponseStatus } from '../data/responses';
+import { doBulkAction } from '../data/responses';
 import { STORE_NAME } from '../state';
 import { ACTIONS, TABS } from './constants';
 
@@ -12,7 +12,7 @@ const ActionsMenu = ( { currentView, selectedResponses, setSelectedResponses } )
 	const onActionHandler = action => async () => {
 		try {
 			setLoading( true );
-			await updateResponseStatus( selectedResponses, action );
+			await doBulkAction( selectedResponses, action );
 			fetchResponses( query );
 			setSelectedResponses( [] );
 		} catch {

--- a/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
@@ -2,7 +2,7 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { trash, inbox, moreHorizontal } from '@wordpress/icons';
-import { updateResponseStatus } from '../data/responses';
+import { doBulkAction } from '../data/responses';
 import { STORE_NAME } from '../state';
 import { ACTIONS, TABS } from './constants';
 
@@ -20,7 +20,7 @@ const SingleActionsMenu = ( { id } ) => {
 	const onActionHandler = action => async () => {
 		try {
 			setLoading( true );
-			await updateResponseStatus( [ id ], action );
+			await doBulkAction( [ id ], action );
 			fetchResponses( query );
 		} catch {
 			//TODO: Implement error handling

--- a/projects/plugins/jetpack/changelog/fix-forms-api-fetch
+++ b/projects/plugins/jetpack/changelog/fix-forms-api-fetch
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Internal changes that don't affect the plugin yet.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This fixes an issue with the API endpoint used for handling feedback bulk actions where it's relying on `Content-Type` header to determine what action is being executed. Unfortunately, this is somewhat unreliable as `apiFetch` will override the header in case the `data` option is provided. This is the root cause of [the issue described here](https://github.com/Automattic/jetpack/pull/29848#issuecomment-1494271685).

In order to remedy this situation while keeping things clean, I updated the path to `/responses/bulk_actions` and moved the `action` value into the request payload.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to `/wp-admin/admin.php?page=jetpack-forms`
- Selecting responses and performing bulk actions (move to spam, move to trash etc.) should work as expected.

Please test on both WP.com and self-hosted.