### PR TITLE
Connection: remove argument deprecation notice

### DIFF
--- a/projects/packages/connection/changelog/update-remove-old-deprecation-notice
+++ b/projects/packages/connection/changelog/update-remove-old-deprecation-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove old deprecation notice.
+
+

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -487,19 +487,14 @@ class Tokens {
 	 *
 	 * @todo Refactor to properly load the XMLRPC client independently.
 	 *
-	 * @param int       $user_id The user identifier.
-	 * @param bool|null $deprecated Deprecated.
+	 * @param int $user_id The user identifier.
 	 *
 	 * @return bool Whether the disconnection of the user was successful.
 	 */
-	public function disconnect_user( $user_id, $deprecated = null ) {
+	public function disconnect_user( $user_id ) {
 		$tokens = $this->get_user_tokens();
 		if ( ! $tokens ) {
 			return false;
-		}
-
-		if ( null !== $deprecated ) {
-			_deprecated_argument( __METHOD__, '1.46.0', 'Parameter $can_overwrite_primary_user is deprecated' );
 		}
 
 		if ( ! isset( $tokens[ $user_id ] ) ) {


### PR DESCRIPTION
## Proposed changes:
* Remove an old method argument deprecation notice

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
1191179647901802-as-1203232266681901

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack, create secondary user and connect them too.
2. Go to Jetpack Dashboard as that secondary user, scroll down to "Account connection", and click "Disconnect your WordPress.com account".
3. The widget text should get replaced with "Connect..." link. Confirm you've been successfully disconnected.