### PR TITLE
CRM: Resolves 2929 - adjust dashboard infobox padding

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -164,7 +164,9 @@ function jpcrm_render_dashboard_page() {
 </div>
 
 <!-- loads summary boxes -->
+<div id="crm_summary_numbers_container">
 <div id="crm_summary_numbers" class="ui cards grid"></div>
+</div>
 
 <!--- the contacts over time comes in next - PHP below is for the funnel -->
 <div class="ui grid narrow">

--- a/projects/plugins/crm/changelog/fix-crm-2929-adjust_dashboard_infobox_padding
+++ b/projects/plugins/crm/changelog/fix-crm-2929-adjust_dashboard_infobox_padding
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Adjust padding on dashboard infoboxes
+
+

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -452,6 +452,11 @@ background:white;
   }
 }
 
+/* match padding of other rows on page */
+#crm_summary_numbers_container {
+  padding: 0 1rem;
+}
+
 #crm_summary_numbers {
   font-family: "Lato", "Helvetica Neue", Arial, Helvetica, sans-serif;
   .range_total {

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -455,6 +455,7 @@ background:white;
 /* match padding of other rows on page */
 #crm_summary_numbers_container {
   padding: 0 1rem;
+  margin-bottom: 10px;
 }
 
 #crm_summary_numbers {

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -459,7 +459,6 @@ background:white;
 }
 
 #crm_summary_numbers {
-  font-family: "Lato", "Helvetica Neue", Arial, Helvetica, sans-serif;
   .range_total {
     color: #28a745;
     font-weight: bold;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#2929 - adjust dashboard infobox padding

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The infoboxes use a different Semantic UI paradigm from the other areas (flex + grid vs. block + columns), so getting these to match consistently (e.g. smaller screens, etc.) isn't trivial and is best done during a deeper overhaul.

That said, in the meantime I added CSS to match the amount of padding on both sides.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before (`trunk`):
![image](https://user-images.githubusercontent.com/32492176/229611530-8a41eb46-c246-4d67-94d6-bcd8d1691e27.png)

After (`fix/crm/2929-adjust_dashboard_infobox_padding`):
![image](https://user-images.githubusercontent.com/32492176/229613077-89f62b4e-b620-422b-b4f5-3e20d18f4614.png)


