### PR TITLE
tools: partial dep updates are needed for easy-way too

### DIFF
--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -12,7 +12,7 @@ BASE=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 # Print help and exit.
 function usage {
 	cat <<-EOH
-		usage: $0 [-v] [-p] [-H] [-a|-b|-r <version>] <slug>
+		usage: $0 [-v] [-p] [-R] [-a|-b|-r <version>] <slug>
 
 		Prepare a release of the specified project and everything it depends on.
 		 - Run \`changelogger write\`
@@ -23,7 +23,7 @@ function usage {
 		Pass \`-a\` to prepare a developer release by passing \`--prerelease=a.N\` to changelogger.
 		Pass \`-b\` to prepare a beta release by passing \`--prerelease=beta\` to changelogger.
 		Pass \`-r <version>\` to prepare a release for a specific version number, passing \`--use-version=<version>\` to changelogger.
-		Pass \`-H\` if doing a hard-way package release on a plugin release branch.
+		Pass \`-R\` if doing a package release on a plugin release branch.
 	EOH
 	exit 1
 }
@@ -36,8 +36,8 @@ fi
 VERBOSE=
 ADDPRNUM=
 ALPHABETA=
-HARDWAY=
-while getopts ":vpabhHr:" opt; do
+RELEASEBRANCH=
+while getopts ":vpabhHRr:" opt; do
 	case ${opt} in
 		v)
 			if [[ -n "$VERBOSE" ]]; then
@@ -58,8 +58,9 @@ while getopts ":vpabhHr:" opt; do
 		r)
 			ALPHABETA=$OPTARG
 			;;
-		H)
-			HARDWAY=-H
+		H|R)
+			# -H is an old name, kept for back compat.
+			RELEASEBRANCH=-R
 			;;
 		h)
 			usage
@@ -194,11 +195,11 @@ TEMP=$(mktemp "${TMPDIR%/}/changelogger-release-XXXXXXXX")
 
 for DEPENDENCY_SLUG in "${SLUGS[@]}"; do
 	if [[ -n "${RELEASED[$DEPENDENCY_SLUG]}" ]]; then
-		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -U $DEPENDENCY_SLUG"
-		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -U "$DEPENDENCY_SLUG"
+		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -U $DEPENDENCY_SLUG"
+		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -U "$DEPENDENCY_SLUG"
 	else
-		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -u $DEPENDENCY_SLUG"
-		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $HARDWAY -u "$DEPENDENCY_SLUG"
+		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -u $DEPENDENCY_SLUG"
+		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -u "$DEPENDENCY_SLUG"
 	fi
 done
 

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -12,7 +12,7 @@ BASE=$PWD
 # Print help and exit.
 function usage {
 	cat <<-EOH
-		usage: $0 [-a] [-n <name>] [-v] [-H] [-U|-u] [<slug> ...]
+		usage: $0 [-a] [-n <name>] [-v] [-R] [-U|-u] [<slug> ...]
 
 		Check that all composer and pnpm dependencies between monorepo projects are up to date.
 
@@ -27,7 +27,7 @@ function usage {
 		 -a: Pass --filename-auto-suffix to changelogger (avoids "file already exists" errors).
 		 -n: Set changelogger filename.
 		 -v: Output debug information.
-		 -H: When on a release branch, skip updating the corresponding plugin.
+		 -R: When on a release branch, skip updating the corresponding plugins.
 	EOH
 	exit 1
 }
@@ -38,8 +38,8 @@ VERBOSE=false
 DOCL_EVER=true
 AUTO_SUFFIX=false
 CL_FILENAME=
-HARDWAY=false
-while getopts ":uUvhHan:" opt; do
+RELEASEBRANCH=false
+while getopts ":uUvhHRan:" opt; do
 	case ${opt} in
 		u)
 			UPDATE=true
@@ -57,8 +57,9 @@ while getopts ":uUvhHan:" opt; do
 		v)
 			VERBOSE=true
 			;;
-		H)
-			HARDWAY=true
+		H|R)
+			# -H is an old name, kept for back compat.
+			RELEASEBRANCH=true
 			;;
 		h)
 			usage
@@ -91,8 +92,8 @@ else
 fi
 
 declare -A SKIPSLUGS
-if $HARDWAY; then
-	debug "Checking for release branch for -H"
+if $RELEASEBRANCH; then
+	debug "Checking for release branch for -R"
 	BRANCH="$(git symbolic-ref --short HEAD)"
 	if [[ "$BRANCH" == */branch-* ]]; then
 		for k in $(jq -r --arg prefix "${BRANCH%%/*}" 'if .extra["release-branch-prefix"] == $prefix then input_filename | capture( "projects/(?<s>[^/]+/[^/]+)/composer.json" ).s else empty end' projects/*/*/composer.json); do
@@ -100,14 +101,14 @@ if $HARDWAY; then
 			SKIPSLUGS[$k]=$k
 		done
 		if [[ "${#SKIPSLUGS[@]}" -eq 0 ]]; then
-			warn "-H was specified, but the current branch (\"$BRANCH\") does not appear to be a release branch for any monorepo plugin"
-			HARDWAY=false
+			warn "-R was specified, but the current branch (\"$BRANCH\") does not appear to be a release branch for any monorepo plugin"
+			RELEASEBRANCH=false
 		else
 			debug "Release branch matches ${SKIPSLUGS[*]}"
 		fi
 	else
-		warn "-H was specified, but the current branch (\"$BRANCH\") does not appear to be a release branch"
-		HARDWAY=false
+		warn "-R was specified, but the current branch (\"$BRANCH\") does not appear to be a release branch"
+		RELEASEBRANCH=false
 	fi
 fi
 
@@ -307,13 +308,13 @@ if ! $UPDATE && [[ "$EXIT" != "0" ]]; then
 	jetpackGreen 'You might use `tools/check-intra-monorepo-deps.sh -u` to fix these errors.'
 fi
 
-if $HARDWAY && [[ "${#SKIPPED[@]}" -gt 0 && "$EXIT" == "0" ]]; then
+if $RELEASEBRANCH && [[ "${#SKIPPED[@]}" -gt 0 && "$EXIT" == "0" ]]; then
 	jetpackGreen <<-EOF
-		Due to use of \`-H\`, dependencies may not be fully updated. If you're doing a
-		"hard way" package release, next steps are:
+		Due to use of \`-R\`, dependencies may not be fully updated. If you're doing a
+		package release from a release branch, next steps are:
 		 1. Commit the changes and push to the release branch. Note the
 		    "Check plugin monorepo dep versions" test will fail.
-		 2. Use the build artifact to do the package releases.
+		 2. Use the build artifact to do the package releases for any not auto-tagged.
 		 3. Update the release plugin's deps by running
 		      tools/check-intra-monorepo-deps.sh -aU ${SKIPPED[*]}
 		    then commit and push.

--- a/tools/fixup-project-versions.sh
+++ b/tools/fixup-project-versions.sh
@@ -10,28 +10,29 @@ BASE=$PWD
 # Print help and exit.
 function usage {
 	cat <<-EOH
-		usage: $0 [-v] [-H]
+		usage: $0 [-v] [-R]
 
 		Make sure that all package versions and intra-monorepo dependencies are
 		up to date.
 
 		Options:
 		 -v: Output debug information. Repeat to output additional information.
-		 -H: When on a release branch, skip updating the corresponding plugin.
+		 -R: When on a release branch, skip updating the corresponding plugins.
 	EOH
 	exit 1
 }
 
 # Sets options.
 VERBOSE=
-HARDWAY=
-while getopts ":vhH" opt; do
+RELEASEBRANCH=
+while getopts ":vhHR" opt; do
 	case ${opt} in
 		v)
 			VERBOSE="${VERBOSE:--}v"
 			;;
-		H)
-			HARDWAY="-H"
+		H|R)
+			# -H is an old name, kept for back compat.
+			RELEASEBRANCH="-R"
 			;;
 		h)
 			usage
@@ -52,4 +53,4 @@ info 'Checking project versions'
 tools/changelogger-validate-all.sh -f $VERBOSE
 
 info 'Checking intra-monorepo dependencies'
-tools/check-intra-monorepo-deps.sh -ua $VERBOSE $HARDWAY
+tools/check-intra-monorepo-deps.sh -ua $VERBOSE $RELEASEBRANCH


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #26613 added a `-H` option to various scripts, to avoid trying to update plugin package deps in the middle of a hard-way package release.

It turns out that we need to do that for easy-way too. So update the relevant output text, and rename the option to `-R` since it's no longer hard-way specific. `-H` is kept as an undocumented alias for `-R` for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1680551642934979-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out a56b2a6d0c28c21dc6fb7e01d1fea6c37ed8a2d9 as a branch named something like `jetpack/branch-12.0-test`.
* Cherry-pick this.
* Run `tools/changelogger-release.sh -p -R packages/waf`. It should successfully run to completion and produce the same results as `tools/changelogger-release.sh -p -H packages/waf` did.