### PR TITLE
VideoPress: playback video into the boundaries defined the previewOnHover

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-preview-on-hover-playback-time
+++ b/projects/packages/videopress/changelog/update-videopress-preview-on-hover-playback-time
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: playback video into the boundaries defined the previewOnHover

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -92,6 +92,21 @@ const useVideoPlayer = (
 			setPlayerIsReady( true );
 			playerState.current = 'ready';
 		}
+
+		if ( eventName === 'videopress_timeupdate' ) {
+			const currentTime = eventData.currentTimeMs;
+			const startLimit = previewOnHover.atTime;
+			const endLimit = previewOnHover.atTime + previewOnHover.duration;
+			if (
+				currentTime < startLimit || // Before the start limit.
+				currentTime > endLimit // After the end limit.
+			) {
+				source.postMessage(
+					{ event: 'videopress_action_set_currenttime', currentTime: startLimit / 1000 },
+					{ targetOrigin: '*' }
+				);
+			}
+		}
 	}
 
 	// PreviewOnHover feature.

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -93,7 +93,7 @@ const useVideoPlayer = (
 			playerState.current = 'ready';
 		}
 
-		if ( eventName === 'videopress_timeupdate' ) {
+		if ( eventName === 'videopress_timeupdate' && previewOnHover ) {
 			const currentTime = eventData.currentTimeMs;
 			const startLimit = previewOnHover.atTime;
 			const endLimit = previewOnHover.atTime + previewOnHover.duration;
@@ -132,7 +132,7 @@ const useVideoPlayer = (
 			// Remove the listener when the component is unmounted.
 			sandboxIFrameWindow.removeEventListener( 'message', listenEventsHandler );
 		};
-	}, [ iFrameRef, isRequestingPreview, wasPreviewOnHoverJustEnabled ] );
+	}, [ iFrameRef, isRequestingPreview, wasPreviewOnHoverJustEnabled, previewOnHover ] );
 
 	const play = useCallback( () => {
 		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

These PR adds the changes to playback the video to the starting point defined by the Preview on Hover future when it's enabled. Also, it detects when the video's current time achieves the "duration" limit, playing back to the starting point again, producing the loop effect.

Fixes https://github.com/Automattic/jetpack/issues/29808

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: playback video into the boundaries defined the previewOnHover

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Create/edit a VideoPress video instance
* Enable "Preview on hover" feature
* Set the starting point and duration
* Confirm the video plays to the desired position by mouse enter over it 
* Confirm it playbacks at the starting point time once the player archives the duration time

https://user-images.githubusercontent.com/77539/229628410-d49bbf74-5397-4a69-8118-bd6feb592ea4.mov

