### PR TITLE
Stats Admin: refactor odyssey assets loading

### DIFF
--- a/projects/packages/stats-admin/changelog/update-refactoring-odyssey-assets-loading
+++ b/projects/packages/stats-admin/changelog/update-refactoring-odyssey-assets-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats Admin: moved Odyssey assets loading to separate class

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
-use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 
 /**
@@ -17,16 +16,6 @@ use Automattic\Jetpack\Stats\Options as Stats_Options;
  * @package jetpack-stats-admin
  */
 class Dashboard {
-	// This is a fixed list @see https://github.com/Automattic/wp-calypso/pull/71442/
-	const JS_DEPENDENCIES                 = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
-	const ODYSSEY_CDN_URL                 = 'https://widgets.wp.com/odyssey-stats/%s/%s';
-	const OPT_OUT_NEW_STATS_FEATURE_CLASS = 'opt-out-new-stats';
-	/**
-	 * We bump the asset version when the Jetpack back end is not compatible anymore.
-	 */
-	const ODYSSEY_STATS_VERSION                = 'v1';
-	const ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY = 'odyssey_stats_admin_asset_cache_buster';
-
 	/**
 	 * Whether the class has been initialized
 	 *
@@ -134,64 +123,9 @@ class Dashboard {
 	}
 
 	/**
-	 * Enqueue admin scripts.
+	 * Load the admin scripts.
 	 */
 	public function load_admin_scripts() {
-		if ( file_exists( __DIR__ . '/../dist/build.min.js' ) ) {
-			// Load local assets for the convinience of development.
-			Assets::register_script(
-				'jp-stats-dashboard',
-				'../dist/build.min.js',
-				__FILE__,
-				array(
-					'in_footer'  => true,
-					'textdomain' => 'jetpack-stats-admin',
-				)
-			);
-			Assets::enqueue_script( 'jp-stats-dashboard' );
-		} else {
-			// In production, we load the assets from our CDN.
-			$css_url = 'build.min' . ( is_rtl() ? '.rtl' : '' ) . '.css';
-			wp_register_script( 'jp-stats-dashboard', sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, 'build.min.js' ), self::JS_DEPENDENCIES, $this->get_cdn_asset_cache_buster(), true );
-			wp_register_style( 'jp-stats-dashboard-style', sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, $css_url ), array(), $this->get_cdn_asset_cache_buster() );
-			wp_enqueue_script( 'jp-stats-dashboard' );
-			wp_enqueue_style( 'jp-stats-dashboard-style' );
-		}
-
-		wp_add_inline_script(
-			'jp-stats-dashboard',
-			( new Odyssey_Config_Data() )->get_js_config_data(),
-			'before'
-		);
-	}
-
-	/**
-	 * Returns cache buster string for assets.
-	 * Development mode doesn't need this, as it's handled by `Assets` class.
-	 */
-	protected function get_cdn_asset_cache_buster() {
-		// Use cached cache buster in production.
-		$remote_asset_version = get_transient( self::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY );
-		if ( ! empty( $remote_asset_version ) ) {
-			return $remote_asset_version;
-		}
-
-		// If no cached cache buster, we fetch it from CDN and set to transient.
-		$response = wp_remote_get( sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, 'build_meta.json' ), array( 'timeout' => 5 ) );
-
-		if ( is_wp_error( $response ) ) {
-			// fallback to the package version.
-			return Main::VERSION;
-		}
-
-		$build_meta = json_decode( wp_remote_retrieve_body( $response ), true );
-		if ( ! empty( $build_meta['cache_buster'] ) ) {
-			// Cache the cache buster for a day.
-			set_transient( self::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY, $build_meta['cache_buster'], 15 * MINUTE_IN_SECONDS );
-			return $build_meta['cache_buster'];
-		}
-
-		// fallback to the package version.
-		return Main::VERSION;
+		( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'build.min' );
 	}
 }

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -16,9 +16,9 @@ use Automattic\Jetpack\Assets;
  */
 class Odyssey_Assets {
 	// This is a fixed list @see https://github.com/Automattic/wp-calypso/pull/71442/
-	const JS_DEPENDENCIES                 = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
-	const ODYSSEY_CDN_URL                 = 'https://widgets.wp.com/odyssey-stats/%s/%s';
-	const OPT_OUT_NEW_STATS_FEATURE_CLASS = 'opt-out-new-stats';
+	const JS_DEPENDENCIES = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
+	const ODYSSEY_CDN_URL = 'https://widgets.wp.com/odyssey-stats/%s/%s';
+
 	/**
 	 * We bump the asset version when the Jetpack back end is not compatible anymore.
 	 */

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Stats Assets
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Assets;
+
+/**
+ * Class Odyssey_Config_Data
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+class Odyssey_Assets {
+	// This is a fixed list @see https://github.com/Automattic/wp-calypso/pull/71442/
+	const JS_DEPENDENCIES                 = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
+	const ODYSSEY_CDN_URL                 = 'https://widgets.wp.com/odyssey-stats/%s/%s';
+	const OPT_OUT_NEW_STATS_FEATURE_CLASS = 'opt-out-new-stats';
+	/**
+	 * We bump the asset version when the Jetpack back end is not compatible anymore.
+	 */
+	const ODYSSEY_STATS_VERSION                = 'v1';
+	const ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY = 'odyssey_stats_admin_asset_cache_buster';
+
+	/**
+	 * Load the admin scripts.
+	 *
+	 * @param string $asset_handle The handle of the asset.
+	 * @param string $asset_name The name of the asset.
+	 * @param array  $options The options.
+	 */
+	public function load_admin_scripts( $asset_handle, $asset_name, $options = array() ) {
+		$default_options = array(
+			'config_data'          => ( new Odyssey_Config_Data() )->get_data(),
+			'config_variable_name' => 'configData',
+		);
+		$options         = wp_parse_args( $options, $default_options );
+		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.js" ) ) {
+			// Load local assets for the convinience of development.
+			Assets::register_script(
+				$asset_handle,
+				"../dist/{$asset_name}.js",
+				__FILE__,
+				array(
+					'in_footer'  => true,
+					'textdomain' => 'jetpack-stats-admin',
+				)
+			);
+			Assets::enqueue_script( $asset_handle );
+		} else {
+			// In production, we load the assets from our CDN.
+			$css_url    = $asset_name . ( is_rtl() ? '.rtl' : '' ) . '.css';
+			$css_handle = $asset_handle . '-style';
+			wp_register_script( $asset_handle, sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, "{$asset_name}.js" ), self::JS_DEPENDENCIES, $this->get_cdn_asset_cache_buster(), true );
+			wp_register_style( $css_handle, sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, $css_url ), array(), $this->get_cdn_asset_cache_buster() );
+			wp_enqueue_script( $asset_handle );
+			wp_enqueue_style( $css_handle );
+		}
+
+		wp_add_inline_script(
+			$asset_handle,
+			$this->get_config_data_js( $options['config_data'], $options['config_variable_name'] ),
+			'before'
+		);
+	}
+
+	/**
+	 * Returns the config data for the JS app.
+	 *
+	 * @param string $config_variable_name The config variable name.
+	 * @param array  $config_data The config data.
+	 */
+	protected function get_config_data_js( $config_variable_name, $config_data ) {
+		return "window.{$config_variable_name} = " . wp_json_encode( $config_data ) . ';';
+	}
+
+	/**
+	 * Returns cache buster string for assets.
+	 * Development mode doesn't need this, as it's handled by `Assets` class.
+	 */
+	protected function get_cdn_asset_cache_buster() {
+		// Use cached cache buster in production.
+		$remote_asset_version = get_transient( self::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY );
+		if ( ! empty( $remote_asset_version ) ) {
+			return $remote_asset_version;
+		}
+
+		// If no cached cache buster, we fetch it from CDN and set to transient.
+		$response = wp_remote_get( sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, 'build_meta.json' ), array( 'timeout' => 5 ) );
+
+		if ( is_wp_error( $response ) ) {
+			// fallback to the package version.
+			return Main::VERSION;
+		}
+
+		$build_meta = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! empty( $build_meta['cache_buster'] ) ) {
+			// Cache the cache buster for a day.
+			set_transient( self::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY, $build_meta['cache_buster'], 15 * MINUTE_IN_SECONDS );
+			return $build_meta['cache_buster'];
+		}
+
+		// fallback to the package version.
+		return Main::VERSION;
+	}
+}

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -62,19 +62,9 @@ class Odyssey_Assets {
 
 		wp_add_inline_script(
 			$asset_handle,
-			$this->get_config_data_js( $options['config_variable_name'], $options['config_data'] ),
+			( new Odyssey_Config_Data() )->get_js_config_data( $options['config_variable_name'], $options['config_data'] ),
 			'before'
 		);
-	}
-
-	/**
-	 * Returns the config data for the JS app.
-	 *
-	 * @param string $config_variable_name The config variable name.
-	 * @param array  $config_data The config data.
-	 */
-	protected function get_config_data_js( $config_variable_name, $config_data ) {
-		return "window.{$config_variable_name} = " . wp_json_encode( $config_data ) . ';';
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -62,7 +62,7 @@ class Odyssey_Assets {
 
 		wp_add_inline_script(
 			$asset_handle,
-			$this->get_config_data_js( $options['config_data'], $options['config_variable_name'] ),
+			$this->get_config_data_js( $options['config_variable_name'], $options['config_data'] ),
 			'before'
 		);
 	}

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -88,7 +88,7 @@ class Odyssey_Assets {
 
 		$build_meta = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( ! empty( $build_meta['cache_buster'] ) ) {
-			// Cache the cache buster for a day.
+			// Cache the cache buster for 15 mins.
 			set_transient( self::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY, $build_meta['cache_buster'], 15 * MINUTE_IN_SECONDS );
 			return $build_meta['cache_buster'];
 		}

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -20,10 +20,11 @@ class Odyssey_Config_Data {
 	/**
 	 * Set configData to window.configData.
 	 *
-	 * @param array $config_data The config data.
+	 * @param string $config_variable_name The config variable name.
+	 * @param array  $config_data The config data.
 	 */
-	public function get_js_config_data( $config_data = null ) {
-		return 'window.configData = ' . wp_json_encode(
+	public function get_js_config_data( $config_variable_name = 'configData', $config_data = null ) {
+		return "window.{$config_variable_name} = " . wp_json_encode(
 			$config_data === null ? $this->get_data() : $config_data
 		) . ';';
 	}

--- a/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
@@ -1,0 +1,21 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName: This is necessary to ensure that PHPUnit runs these tests.
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Stats_Admin\Test_Case as Stats_Test_Case;
+
+/**
+ * Unit tests for the Odyssey_Assets class.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+class Test_Odyssey_Assets extends Stats_Test_Case {
+	/**
+	 * Test remote cache buster.
+	 */
+	public function test_get_cdn_asset_cache_buster() {
+		$odyssey_assets             = new Odyssey_Assets();
+		$get_cdn_asset_cache_buster = new \ReflectionMethod( $odyssey_assets, 'get_cdn_asset_cache_buster' );
+		$get_cdn_asset_cache_buster->setAccessible( true );
+		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) );
+	}
+}

--- a/projects/packages/stats-admin/tests/php/test-odyssey-config-data.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-config-data.php
@@ -22,8 +22,8 @@ class Test_Odyssey_Config_Data extends Stats_Test_Case {
 	 */
 	public function test_render_config_data_with_param() {
 		$config_data = new Odyssey_Config_Data();
-		$this->assertTrue( strpos( $config_data->get_js_config_data( array( 'testtesttest' ) ), 'window.configData' ) === 0 );
-		$this->assertTrue( strpos( $config_data->get_js_config_data( array( 'testtesttest' ) ), 'testtesttest' ) > 0 );
+		$this->assertTrue( strpos( $config_data->get_js_config_data( 'configData', array( 'testtesttest' ) ), 'window.configData' ) === 0 );
+		$this->assertTrue( strpos( $config_data->get_js_config_data( 'configData', array( 'testtesttest' ) ), 'testtesttest' ) > 0 );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-dashboard.php
@@ -28,14 +28,4 @@ class Test_Dashboard extends Stats_Test_Case {
 		$this->expectOutputRegex( '/<div id="wpcom" class="jp-stats-dashboard".*>/i' );
 		( new Dashboard() )->render();
 	}
-
-	/**
-	 * Test remote cache buster.
-	 */
-	public function test_get_cdn_asset_cache_buster() {
-		$dashboard                  = new Dashboard();
-		$get_cdn_asset_cache_buster = new \ReflectionMethod( $dashboard, 'get_cdn_asset_cache_buster' );
-		$get_cdn_asset_cache_buster->setAccessible( true );
-		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $get_cdn_asset_cache_buster->invoke( $dashboard ) );
-	}
 }


### PR DESCRIPTION
## Proposed changes:

The PR is branched off https://github.com/Automattic/jetpack/pull/29772. The PR moves the asset loading for Odyssey to a separate class, exposing the ability to load Stats Widget assets.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Ensure all PHP tests pass
* Spin up a JN site
* Ensure Odyssey Stats works well