### PR TITLE
VideoPress: Retry video data fetch if data is not fully available yet

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-video-duration
+++ b/projects/packages/videopress/changelog/fix-videopress-video-duration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Retry video data fetch if data is not fully available yet

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -325,6 +325,7 @@ export function VideoHoverPreviewControl( {
 	onPreviewAtTimeChange,
 	onLoopDurationChange,
 }: VideoHoverPreviewControlProps ): React.ReactElement {
+	const disabled = ! videoDuration;
 	const maxStartingPoint = videoDuration - MIN_LOOP_DURATION;
 
 	const [ maxLoopDuration, setMaxLoopDuration ] = useState(
@@ -351,6 +352,7 @@ export function VideoHoverPreviewControl( {
 				label={ __( 'Video preview on hover', 'jetpack-videopress-pkg' ) }
 				checked={ previewOnHover }
 				onChange={ onPreviewOnHoverChange }
+				disabled={ ! previewOnHover && disabled }
 			/>
 
 			{ previewOnHover && (
@@ -366,6 +368,7 @@ export function VideoHoverPreviewControl( {
 							setMaxLoopDuration( Math.min( MAX_LOOP_DURATION, videoDuration - timestamp ) );
 						} }
 						wait={ 100 }
+						disabled={ disabled }
 					/>
 
 					<TimestampControl
@@ -377,7 +380,7 @@ export function VideoHoverPreviewControl( {
 						onDebounceChange={ onLoopDurationChange }
 						wait={ 100 }
 						help={ loopDurationHelp }
-						disabled={ noLoopDurationRange }
+						disabled={ disabled || noLoopDurationRange }
 					/>
 				</>
 			) }

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -17,6 +17,7 @@ import { UseVideoDataProps, UseVideoDataArgumentsProps, VideoDataProps } from '.
 const debug = debugFactory( 'videopress:video:use-video-data' );
 
 const isUserConnected = getIsUserConnected();
+
 /**
  * React hook to fetch the video data from the media library.
  *
@@ -45,12 +46,28 @@ export default function useVideoData( {
 		 */
 		async function setFromVideo( token: string | null = null ) {
 			try {
-				const response = await fetchVideoItem( {
-					guid,
-					isPrivate: maybeIsPrivate,
-					token,
-					skipRatingControl,
-				} );
+				let response;
+
+				// Some video data is not available immediately after upload, so we retry a few times.
+				for ( let retries = 0; retries < 5; retries++ ) {
+					response = await fetchVideoItem( {
+						guid,
+						isPrivate: maybeIsPrivate,
+						token,
+						skipRatingControl,
+					} );
+
+					if ( response.duration ) {
+						debug(
+							`video duration available: ${ response.duration }, retried ${ retries } times`,
+							response
+						);
+						break;
+					}
+
+					debug( `video duration not yet available, retrying (${ retries + 1 })`, response );
+					await new Promise( resolve => setTimeout( resolve, 1500 ) );
+				}
 
 				setIsRequestingVideoData( false );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29890

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a simple retry mechanism for video data fetch to make sure we have the video duration or disable the hover effect option

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add a videopress/video block
* Upload a video
* Check the browser console logs
![2023-04-04_11-42-21](https://user-images.githubusercontent.com/8486249/229829006-f960dd1a-9dbe-4ac5-ab59-10845180aa30.png)
* Check that the preview on hover feature works after successfully getting the video duration

https://user-images.githubusercontent.com/8486249/229829325-0a4e73d4-410f-4d93-ba2e-a0aed8789cf8.mp4
