### PR TITLE
autotagger: Don't tag packages with alpha deps

### DIFF
--- a/.github/files/gh-autotagger/workflows/autotagger.yml
+++ b/.github/files/gh-autotagger/workflows/autotagger.yml
@@ -48,25 +48,54 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Tag
+      - name: Check version
+        id: version
         if: steps.check-branch.outputs.run == 'true'
         run: |
           VER=$(sed -nEe 's/^## \[?([^]]*)\]? - .*/\1/;T;p;q' CHANGELOG.md || true)
           echo "Version from changelog is ${VER:-<unknown>}"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
           if [[ "$VER" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
-            export GIT_AUTHOR_NAME=matticbot
-            export GIT_AUTHOR_EMAIL=matticbot@users.noreply.github.com
-            export GIT_COMMITTER_NAME=matticbot
-            export GIT_COMMITTER_EMAIL=matticbot@users.noreply.github.com
-            if [[ -e composer.json ]] && ! jq -e 'if try ( .extra.autotagger | has("v") ) catch false then .extra.autotagger.v else true end' composer.json >/dev/null; then
-              TAG="$VER"
-            else
-              TAG="v$VER"
+            echo "Version $VER ok to tag"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Not tagging version $VER"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check deps
+        id: check-deps
+        if: steps.check-branch.outputs.run == 'true' && steps.version.outputs.run == 'true'
+        run: |
+          RUN=true
+          if [[ -e composer.json ]]; then
+            TMP=$(jq -r '.require // {} | to_entries[] | select( .value | test( "-(alpha|a.[0-9]+)$" ) ) | "\(.key) (\(.value))"' composer.json)
+            if [[ -n "$TMP" ]]; then
+              echo "::notice::Not tagging due to -alpha deps on ${TMP//$'\n'/ }"
+              RUN=false
             fi
-            git tag "$TAG"
-            git push origin "$TAG"
-            if [[ -e composer.json ]] && jq -e '.extra.autotagger.major?' composer.json >/dev/null; then
-              git tag --force "${TAG%%.*}"
-              git push --force origin "${TAG%%.*}"
-            fi
+          fi
+          echo "run=$RUN" >> "$GITHUB_OUTPUT"
+
+      - name: Tag
+        if: steps.check-branch.outputs.run == 'true' && steps.version.outputs.run == 'true' && steps.check-deps.outputs.run == 'true'
+        env:
+          VER: ${{ steps.version.outputs.version }}
+        run: |
+          export GIT_AUTHOR_NAME=matticbot
+          export GIT_AUTHOR_EMAIL=matticbot@users.noreply.github.com
+          export GIT_COMMITTER_NAME=matticbot
+          export GIT_COMMITTER_EMAIL=matticbot@users.noreply.github.com
+          if [[ -e composer.json ]] && ! jq -e 'if try ( .extra.autotagger | has("v") ) catch false then .extra.autotagger.v else true end' composer.json >/dev/null; then
+            TAG="$VER"
+          else
+            TAG="v$VER"
+          fi
+          echo "::notice::Tagging $TAG"
+          git tag "$TAG"
+          git push origin "$TAG"
+          if [[ -e composer.json ]] && jq -e '.extra.autotagger.major?' composer.json >/dev/null; then
+            echo "::notice::Tagging ${TAG%%.*}"
+            git tag --force "${TAG%%.*}"
+            git push --force origin "${TAG%%.*}"
           fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When cherry-picking packages to a release branch, releasing them, and then backporting to trunk for possible auto-tagging, we need to avoid the case where a package itself would be ok to tag but something it depends on is not, as this results in the package having a dependency on an -alpha version of the depended-on package.

This happened with #29891, for example: waf was auto-tagged at v0.11.1 with a dependency on connection 1.51.6-alpha, because in trunk connection had some extra commits.

This also makes it somewhat easier to see if an auto-tagging actually happened, by outputting a notice for GH's summary screen in all cases.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1680619469401189/1680614538.532029-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷 I guess copy this into a copy of a mirror repo, then trigger it in various cases.