### PR TITLE
VideoPress: first previewOnHover implementation in the front-end

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-enqueue-iframe-api-asset-file
+++ b/projects/packages/videopress/changelog/update-videopress-enqueue-iframe-api-asset-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: enqueue the VideoPress IFrame API asset file

--- a/projects/packages/videopress/changelog/update-videopress-expose-poh-data-by-using-script-element
+++ b/projects/packages/videopress/changelog/update-videopress-expose-poh-data-by-using-script-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: change the way to propagate the Preview On Hover data

--- a/projects/packages/videopress/changelog/update-videopress-play-pause-in-frontend
+++ b/projects/packages/videopress/changelog/update-videopress-play-pause-in-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: first previewOnHover implementation in the front-end

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -231,7 +231,9 @@ class Initializer {
 		wp_enqueue_script(
 			self::JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER . '-iframe-api',
 			'https://wordpress.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
-			array()
+			array(),
+			'1.0.0',
+			false
 		);
 
 		// Register VideoPress video block.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -228,6 +228,12 @@ class Initializer {
 			)
 		);
 
+		wp_enqueue_script(
+			self::JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER . '-iframe-api',
+			'https://wordpress.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
+			array()
+		);
+
 		// Register VideoPress video block.
 		register_block_type( $videopress_video_metadata_file );
 	}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
@@ -52,8 +52,6 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 		} ),
 	} );
 
-	const previewAtTimeJSON = previewOnHover ? { previewAtTime, previewLoopDuration } : null;
-
 	const videoPressUrl = getVideoPressUrl( guid, {
 		autoplay,
 		controls,
@@ -80,7 +78,13 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 			{ videoPressUrl && (
 				<>
 					{ previewOnHover && (
-						<script type="application/json">{ JSON.stringify( previewAtTimeJSON ) }</script>
+						<span
+							style={ { display: 'none', visibility: 'hidden', position: 'absolute' } }
+							className="videopress-poh"
+						>
+							<span className="videopress-poh__sp">{ previewAtTime }</span>
+							<span className="videopress-poh__duration">{ previewLoopDuration }</span>
+						</span>
 					) }
 					<div className="jetpack-videopress-player__wrapper">
 						{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
@@ -52,12 +52,7 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 		} ),
 	} );
 
-	if ( previewOnHover && [ previewAtTime, previewLoopDuration ].every( value => value != null ) ) {
-		blockProps[ 'data-preview-on-hover' ] = JSON.stringify( {
-			previewAtTime,
-			previewLoopDuration,
-		} );
-	}
+	const previewAtTimeJSON = previewOnHover ? { previewAtTime, previewLoopDuration } : null;
 
 	const videoPressUrl = getVideoPressUrl( guid, {
 		autoplay,
@@ -83,9 +78,14 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 	return (
 		<figure { ...blockProps } style={ style }>
 			{ videoPressUrl && (
-				<div className="jetpack-videopress-player__wrapper">
-					{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
-				</div>
+				<>
+					{ previewOnHover && (
+						<script type="application/json">{ JSON.stringify( previewAtTimeJSON ) }</script>
+					) }
+					<div className="jetpack-videopress-player__wrapper">
+						{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
+					</div>
+				</>
 			) }
 
 			{ ! RichText.isEmpty( caption ) && (

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
@@ -53,10 +53,10 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 	} );
 
 	const videoPressUrl = getVideoPressUrl( guid, {
-		autoplay,
+		autoplay: autoplay || posterData.previewOnHover, // enabled when `previewOnHover` is enabled.
 		controls,
 		loop,
-		muted,
+		muted: muted || posterData.previewOnHover, // enabled when `previewOnHover` is enabled.
 		playsinline,
 		preload,
 		seekbarColor,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -1,5 +1,36 @@
 import { trackKindOptionProps } from '../../../lib/video-tracks/types';
 
+type playerStatuses = 'ready' | 'playing' | 'paused' | 'ended' | 'stalled';
+declare global {
+	interface Window {
+		VideoPressIframeApi: (
+			iframe: HTMLIFrameElement,
+			callback: () => void
+		) => {
+			info: {
+				guid: () => Promise< string >;
+				title: () => Promise< string >;
+				duration: () => Promise< number >;
+				poster: () => Promise< string >;
+				privacy: () => Promise< number >;
+				onInfoUpdated: ( fn: () => void ) => void;
+			};
+			status: {
+				onPlayerStatusChanged: (
+					fn: ( oldStatus: playerStatuses, newStatus: playerStatuses ) => void
+				) => void;
+				onPlaybackTimeUpdated: ( fn: ( playbackTime: number ) => void ) => void;
+				onTimeUpdate: ( fn: ( playbackTime: number ) => void ) => void;
+			};
+			controls: {
+				play: () => void;
+				pause: () => void;
+				seek: ( time: number ) => void;
+			};
+		};
+	}
+}
+
 export type VideoId = number;
 export type VideoGUID = string;
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -51,8 +51,36 @@ function previewOnHoverEffect(): void {
 
 		// Clean the data container element. It isn't needed anymore.
 		dataContainer.remove();
+		if ( ! window?.VideoPressIframeApi ) {
+			return;
+		}
 
-		console.log( 'previewOnHoverData: ', previewOnHoverData ); // eslint-disable-line no-console
+		const iframeApi = window.VideoPressIframeApi( iFrame, () => {
+			iframeApi.status.onPlayerStatusChanged( ( oldStatus, newStatus ) => {
+				if ( oldStatus === 'ready' && newStatus === 'playing' ) {
+					iframeApi.controls.pause();
+					iframeApi.controls.seek( previewOnHoverData.previewAtTime );
+				}
+			} );
+
+			iframeApi.status.onTimeUpdate( playbackTime => {
+				const playback = playbackTime * 1000;
+				const start = previewOnHoverData.previewAtTime;
+				const end = start + previewOnHoverData.previewLoopDuration;
+
+				if ( playback < start || playback > end ) {
+					iframeApi.controls.seek( start );
+				}
+			} );
+		} );
+
+		videoPlayerElement.addEventListener( 'mouseenter', function () {
+			iframeApi.controls.play();
+		} );
+
+		videoPlayerElement.addEventListener( 'mouseleave', function () {
+			iframeApi.controls.pause();
+		} );
 	} );
 }
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -2,14 +2,62 @@
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
+/**
+ * Preview on Hover effect for VideoPress videos.
+ *
+ * @returns {void}
+ */
+function previewOnHoverEffect(): void {
+	/*
+	 * Pick all VideoPress video block intances,
+	 * based on the class name.
+	 */
+	const videoPlayers = document.querySelectorAll( '.wp-block-videopress-video' );
+	if ( videoPlayers.length === 0 ) {
+		return;
+	}
+
+	videoPlayers.forEach( function ( videoPlayerElement: HTMLDivElement ) {
+		// Get the iFrame element.
+		const iFrame = videoPlayerElement.querySelector( 'iframe' );
+		if ( ! iFrame ) {
+			return;
+		}
+
+		// Get the data container element.
+		const dataContainer: HTMLScriptElement = videoPlayerElement.querySelector(
+			'script[type="application/json"]'
+		);
+
+		/*
+		 * Try to pick the POH data from the data container element.
+		 * If it fails, log the error and return.
+		 */
+		let previewOnHoverData: {
+			previewAtTime: number;
+			previewLoopDuration: number;
+		};
+
+		try {
+			previewOnHoverData = JSON.parse( dataContainer.text );
+		} catch ( error ) {
+			console.error( error ); // eslint-disable-line no-console
+			return;
+		}
+
+		// Clean the data container element. It isn't needed anymore.
+		dataContainer.remove();
+
+		console.log( 'previewOnHoverData: ', previewOnHoverData ); // eslint-disable-line no-console
+	} );
+}
+
 domReady( function () {
-	// eslint-disable-next-line no-console
-	console.log( __( 'VideoPress init', 'jetpack-videopress-pkg' ) );
+	previewOnHoverEffect();
 } );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -32,15 +32,21 @@ function previewOnHoverEffect(): void {
 
 		// Get the data container element.
 		const dataContainer = videoPlayerElement.querySelector( 'span.videopress-poh' );
+		if ( ! dataContainer ) {
+			return;
+		}
 
 		/*
 		 * Try to pick the POH data from the data container element.
 		 * If it fails, log the error and return.
 		 */
 		const previewOnHoverData = {
-			previewAtTime: dataContainer.querySelector( 'span.videopress-poh__sp' )?.textContent,
-			previewLoopDuration: dataContainer.querySelector( 'span.videopress-poh__duration' )
-				?.textContent,
+			previewAtTime: Number(
+				dataContainer.querySelector( 'span.videopress-poh__sp' )?.textContent
+			),
+			previewLoopDuration: Number(
+				dataContainer.querySelector( 'span.videopress-poh__duration' )?.textContent
+			),
 		};
 
 		// Clean the data container element. It isn't needed anymore.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -31,25 +31,17 @@ function previewOnHoverEffect(): void {
 		}
 
 		// Get the data container element.
-		const dataContainer: HTMLScriptElement = videoPlayerElement.querySelector(
-			'script[type="application/json"]'
-		);
+		const dataContainer = videoPlayerElement.querySelector( 'span.videopress-poh' );
 
 		/*
 		 * Try to pick the POH data from the data container element.
 		 * If it fails, log the error and return.
 		 */
-		let previewOnHoverData: {
-			previewAtTime: number;
-			previewLoopDuration: number;
+		const previewOnHoverData = {
+			previewAtTime: dataContainer.querySelector( 'span.videopress-poh__sp' )?.textContent,
+			previewLoopDuration: dataContainer.querySelector( 'span.videopress-poh__duration' )
+				?.textContent,
 		};
-
-		try {
-			previewOnHoverData = JSON.parse( dataContainer.text );
-		} catch ( error ) {
-			console.error( error ); // eslint-disable-line no-console
-			return;
-		}
 
 		// Clean the data container element. It isn't needed anymore.
 		dataContainer.remove();

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -74,13 +74,8 @@ function previewOnHoverEffect(): void {
 			} );
 		} );
 
-		videoPlayerElement.addEventListener( 'mouseenter', function () {
-			iframeApi.controls.play();
-		} );
-
-		videoPlayerElement.addEventListener( 'mouseleave', function () {
-			iframeApi.controls.pause();
-		} );
+		videoPlayerElement.addEventListener( 'mouseenter', iframeApi.controls.play );
+		videoPlayerElement.addEventListener( 'mouseleave', iframeApi.controls.pause );
 	} );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the first approach of the Preview On Hover feature on the front-end side. It enqueues and uses the iFrame API to dialog with the player.

Fixes https://github.com/Automattic/jetpack/issues/29758

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: first previewOnHover implementation in the front-end

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and create a VideoPress video block instance
* Enable the `Preview on hover` feature
* Set a valid starting point and duration
* Save the post
* View the post on the front-end side
* Confirm the video initially sets the position in the starting point 
* Confirm the player plays when mouse-entering into the player area
* Confirm the player pauses when mouse-leaving into the player area
* Confirm the player playbacks at the starting point once the end limit achieves


https://user-images.githubusercontent.com/77539/229848209-f83aad7e-cd46-41b4-8d71-6d1c137beb4b.mov

