### PR TITLE
CRM: Resolves 3015 - escape invoice html

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3015-escape_invoice_html
+++ b/projects/plugins/crm/changelog/fix-crm-3015-escape_invoice_html
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -913,23 +913,23 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	$css_url     = ZEROBSCRM_URL . 'css/ZeroBSCRM.admin.invoicepreview' . wp_scripts_get_suffix() . '.css';
 	$ref_label   = $zbs->settings->get( 'reflabel' );
 
-	$logoURL = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$logo_url = '';
 	if ( isset( $invoice['logo_url'] ) ) {
 
 		if ( isset( $invoice['logo_url'] ) ) {
-			$logoURL = $invoice['logo_url']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$logo_url = $invoice['logo_url'];
 		}
 	} elseif ( isset( $invsettings['invoicelogourl'] ) && $invsettings['invoicelogourl'] != '' ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
-		$logoURL = $invsettings['invoicelogourl']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$logo_url = $invsettings['invoicelogourl'];
 	}
 
-	if ( $logoURL != '' && isset( $invoice['logo_url'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,Universal.Operators.StrictComparisons.LooseNotEqual
+	if ( $logo_url != '' && isset( $invoice['logo_url'] ) ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
 		$logoClass    = 'show'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$logoURL      = $invoice['logo_url']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$logo_url     = $invoice['logo_url'];
 		$bizInfoClass = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	} else {
 		$logoClass    = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$logoURL      = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$logo_url     = '';
 		$bizInfoClass = 'biz-up'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	}
 
@@ -1215,7 +1215,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-title'               => __( 'Invoice', 'zero-bs-crm' ),
 		'css'                         => $css_url,
 		'logo-class'                  => $logoClass, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		'logo-url'                    => esc_url( $logoURL ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'logo-url'                    => esc_url( $logo_url ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-number'              => $invNoStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-date'                => $invDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-id-styles'           => $invIDStyles, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -935,9 +935,8 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 
 	// Invoice Number or Reference
 	// Reference, falling back to ID
-	$inv_id_styles = '';
-	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$invRefStyles = 'display:none;'; // none initially
+	$inv_id_styles  = '';
+	$inv_ref_styles = 'display:none;'; // none initially
 
 	// ID
 	$thisInvReference = $invoice['id']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -959,8 +958,8 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		}
 
 		// and we don't show ID, do show ref label:
-		$inv_id_styles = 'display:none;';
-		$invRefStyles  = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$inv_id_styles  = 'display:none;';
+		$inv_ref_styles = '';
 
 	}
 
@@ -1220,7 +1219,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-date'                => $invDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-id-styles'           => $inv_id_styles,
 		'invoice-ref'                 => $invNoStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		'invoice-ref-styles'          => $invRefStyles, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-ref-styles'          => $inv_ref_styles,
 		'invoice-due-date'            => $dueDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-custom-fields'       => $invoice_custom_fields_html,
 		'invoice-biz-class'           => $biz_info_class,

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -1118,12 +1118,12 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	$totalsTable .= '</table>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	// == Partials (Transactions against Invs)
-	$partialsTable = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$partials_table = '';
 
 	if ( $invoice['total'] == 0 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
-		$partialsTable .= '<table id="partials" class="hide table-totals zebra">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$partials_table .= '<table id="partials" class="hide table-totals zebra">';
 	} else {
-		$partialsTable .= '<table id="partials" class="table-totals zebra">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$partials_table .= '<table id="partials" class="table-totals zebra">';
 	}
 
 	$balance = $invoice['total'];
@@ -1131,7 +1131,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	if ( is_array( $partials ) && count( $partials ) > 0 ) {
 
 		// header
-		$partialsTable .= '<tr><td colspan="2" style="text-align:center;font-weight:bold;  border-radius: 0px;"><span class="zbs-total">' . esc_html__( 'Payments', 'zero-bs-crm' ) . '</span></td></tr>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$partials_table .= '<tr><td colspan="2" style="text-align:center;font-weight:bold;  border-radius: 0px;"><span class="zbs-total">' . esc_html__( 'Payments', 'zero-bs-crm' ) . '</span></td></tr>';
 
 		foreach ( $partials as $partial ) {
 
@@ -1148,16 +1148,16 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 					$balance = $balance - $partial['total'];
 				}
 
-				$partialsTable .= '<tr class="total-top">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				$partialsTable .= '<td class="bord bord-l" style="text-align:right">' . esc_html__( 'Payment', 'zero-bs-crm' ) . '<br/>(' . esc_html( $partial['ref'] ) . ')</td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				$partialsTable .= '<td class="bord row-amount"><span class="zbs-partial-value">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				$partials_table .= '<tr class="total-top">';
+				$partials_table .= '<td class="bord bord-l" style="text-align:right">' . esc_html__( 'Payment', 'zero-bs-crm' ) . '<br/>(' . esc_html( $partial['ref'] ) . ')</td>';
+				$partials_table .= '<td class="bord row-amount"><span class="zbs-partial-value">';
 				if ( ! empty( $partial['total'] ) ) {
-					$partialsTable .= esc_html( zeroBSCRM_formatCurrency( $partial['total'] ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					$partials_table .= esc_html( zeroBSCRM_formatCurrency( $partial['total'] ) );
 				} else {
-					$partialsTable .= esc_html( zeroBSCRM_formatCurrency( 0 ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					$partials_table .= esc_html( zeroBSCRM_formatCurrency( 0 ) );
 				}
-				$partialsTable .= '</span></td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				$partialsTable .= '</tr>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				$partials_table .= '</span></td>';
+				$partials_table .= '</tr>';
 			}
 		}
 	}
@@ -1168,12 +1168,11 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		$balance_hide = '';
 	}
 
-	$partialsTable .= '<tr class="zbs_grand_total' . $balance_hide . '">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$partialsTable .= '<td class="bord bord-l" style="text-align:right; font-weight:bold;  border-radius: 0px;"><span class="zbs-minitotal">' . esc_html__( 'Amount due', 'zero-bs-crm' ) . '</td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$partialsTable .= '<td class="bord row-amount"><span class="zbs-subtotal-value">' . esc_html( zeroBSCRM_formatCurrency( $balance ) ) . '</span></td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$partialsTable .= '</tr>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$partialsTable .= '</table>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-
+	$partials_table .= '<tr class="zbs_grand_total' . $balance_hide . '">';
+	$partials_table .= '<td class="bord bord-l" style="text-align:right; font-weight:bold;  border-radius: 0px;"><span class="zbs-minitotal">' . esc_html__( 'Amount due', 'zero-bs-crm' ) . '</td>';
+	$partials_table .= '<td class="bord row-amount"><span class="zbs-subtotal-value">' . esc_html( zeroBSCRM_formatCurrency( $balance ) ) . '</span></td>';
+	$partials_table .= '</tr>';
+	$partials_table .= '</table>';
 
 	// generate a templated paybutton (depends on template :))
 	$potentialPayButton = zeroBSCRM_invoicing_generateInvPart_payButton( $invoiceID, $zbs_stat, $template ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -1227,7 +1226,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-table-headers'       => $tableHeaders, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-line-items'          => $lineItems, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-totals-table'        => $totalsTable, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		'invoice-partials-table'      => $partialsTable, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-partials-table'      => $partials_table,
 		'invoice-pay-button'          => $potentialPayButton, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'pre-invoice-payment-details' => '',
 		'invoice-payment-details'     => $pay_details,
@@ -1255,7 +1254,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 
 	// Switch. If partials, put the payment deets on the left next to the partials,
 	// rather than in it's own line:
-	if ( ! empty( $partialsTable ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	if ( ! empty( $partials_table ) ) {
 		// partials, split to two columns
 		$replacements['pre-invoice-payment-details'] = $pay_details;
 		$replacements['invoice-payment-details']     = '';

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -465,278 +465,277 @@ function zeroBSCRM_invoicing_generateStatementHTML( $contact_id = -1, $return = 
 }
 
 // 3.0+ (could now run off contact or company, but that's not written in yet)
-function zeroBSCRM_invoicing_generateStatementHTML_v3($contactID=-1,$return=true,$templatedHTML=''){
-
-    if ($contactID > 0 && $templatedHTML !== ''){
-
-        global $zbs,$wpdb;
-
-        #} Globals
-        $bizName = zeroBSCRM_getSetting('businessname');
-        $bizContactName =  zeroBSCRM_getSetting('businessyourname');
-        $bizContactEmail =  zeroBSCRM_getSetting('businessyouremail');
-        $bizURL =  zeroBSCRM_getSetting('businessyoururl');
-        $bizExtra = zeroBSCRM_getSetting('businessextra');
-        $bizTel = zeroBSCRM_getSetting('businesstel');
-        $statementExtra = zeroBSCRM_getSetting('statementextra');
-        $logoURL = zeroBSCRM_getSetting('invoicelogourl');
-
-        // invoices          
-        $invoices = $zbs->DAL->invoices->getInvoices(array(
-
-            'assignedContact'   => $contactID, // assigned to contact id (int)
-            'assignedCompany'   => false, // assigned to company id (int)
-
-            // returns
-            'withLineItems'     => true,
-            'withCustomFields'  => true,
-            'withTransactions'  => true, // partials
-            'withTags'          => false,
-
-            // sort
-            'sortByField'   => 'ID',
-            'sortOrder'     => 'ASC',
-
-        ));
-
-        // statement table wrapper
-        $statementTable = '<table id="zbs-statement-table" border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;background-color:#FFF;width:100%;">';
-
-            // logo header
-            if (!empty($logoURL)) $statementTable .= '<tr><td colspan="3" style="text-align:right"><img src="'.$logoURL.'" alt="'.$bizName.'" style="max-width:200px;max-height:140px" /></td></tr>';
-
-
-            // title
-            $statementTable .= '<tr><td colspan="3"><h2 class="zbs-statement">'.__('STATEMENT','zero-bs-crm').'</h2></td></tr>';
-
-
-            // address | dates | biz deets line
-            $statementTable .= '<tr>';
-
-                // contact address
-
-                    // get co addr
-                    $coAddr = '';
-                        // v3.0
-                        $contactDetails = $zbs->DAL->contacts->getContact($contactID,array(
-                            'withCustomFields'  => true,
-                            // anything else?
-                            'withQuotes'        => false,
-                            'withInvoices'      => false,
-                            'withTransactions'  => false,
-                            'withLogs'          => false,
-                            'withLastLog'       => false,
-                            'withTags'          => false,
-                            'withCompanies'     => false,
-                            'withOwner'         => false,
-                            'withValues'        => false
-                        ));
-                    if (is_array($contactDetails) && isset($contactDetails['fname'])){
-                        $invoice_customer_info_table_html = '<div class="zbs-line-info zbs-line-info-title">'.$contactDetails['fname'].' ' .$contactDetails['lname'] . '</div>';
-                        if (isset($contactDetails['addr1']) && !empty($contactDetails['addr1'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$contactDetails['addr1'].'</div>';
-                        if (isset($contactDetails['addr2']) && !empty($contactDetails['addr2'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$contactDetails['addr2'].'</div>';
-                        if (isset($contactDetails['city']) && !empty($contactDetails['city'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$contactDetails['city'].'</div>';
-                        if (isset($contactDetails['county']) && !empty($contactDetails['county'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$contactDetails['county'].'</div>';
-                        if (isset($contactDetails['postcode']) && !empty($contactDetails['postcode'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$contactDetails['postcode'].'</div>';
-                    }
-
-                    // add
-                    $statementTable .= '<td><div style="text-align:left">'.$invoice_customer_info_table_html.'</div></td>';
-
-                // Dates
-                $statementTable .= '<td>';
-                    $statementTable .= '<div class="zbs-statement-date"><strong>'.__('Statement Date','zero-bs-crm').'</strong><br />'.zeroBSCRM_locale_utsToDate(time()).'</div>';
-                    // VAT NUMBER? Not req. in quote of 23/10/2018 $statementTable .= '<div class=""><strong>'.__('Statement Date','zero-bs-crm').'<strong><br />'.zeroBSCRM_locale_utsToDate(time()).'</div>';
-                $statementTable .= '</td>';
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+function zeroBSCRM_invoicing_generateStatementHTML_v3( $contact_id = -1, $return = true, $templated_html = '' ) {
+
+	if ( $contact_id > 0 && $templated_html !== '' ) {
+
+		global $zbs;
+
+		// Globals
+		$biz_name          = zeroBSCRM_getSetting( 'businessname' );
+		$biz_contact_name  = zeroBSCRM_getSetting( 'businessyourname' );
+		$biz_contact_email = zeroBSCRM_getSetting( 'businessyouremail' );
+		$biz_url           = zeroBSCRM_getSetting( 'businessyoururl' );
+		$biz_extra         = zeroBSCRM_getSetting( 'businessextra' );
+		$biz_tel           = zeroBSCRM_getSetting( 'businesstel' );
+		$statement_extra   = zeroBSCRM_getSetting( 'statementextra' );
+		$logo_url          = zeroBSCRM_getSetting( 'invoicelogourl' );
+
+		// invoices
+		$invoices = $zbs->DAL->invoices->getInvoices( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			array(
+
+				'assignedContact'  => $contact_id, // assigned to contact id (int)
+				'assignedCompany'  => false, // assigned to company id (int)
+
+				// returns
+				'withLineItems'    => true,
+				'withCustomFields' => true,
+				'withTransactions' => true, // partials
+				'withTags'         => false,
+
+				// sort
+				'sortByField'      => 'ID',
+				'sortOrder'        => 'ASC',
+
+			)
+		);
+
+		// statement table wrapper
+		$statement_table = '<table id="zbs-statement-table" border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;background-color:#FFF;width:100%;">';
+
+		// logo header
+		if ( ! empty( $logo_url ) ) {
+			$statement_table .= '<tr><td colspan="3" style="text-align:right"><img src="' . esc_url( $logo_url ) . '" alt="' . esc_attr( $biz_name ) . '" style="max-width:200px;max-height:140px" /></td></tr>';
+		}
+
+		// title
+		$statement_table .= '<tr><td colspan="3"><h2 class="zbs-statement">' . esc_html__( 'STATEMENT', 'zero-bs-crm' ) . '</h2></td></tr>';
+
+		// address | dates | biz deets line
+		$statement_table .= '<tr>';
+
+		// contact address
+
+		// v3.0
+		$contact_details = $zbs->DAL->contacts->getContact( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$contact_id,
+			array(
+				'withCustomFields' => true,
+				'withQuotes'       => false,
+				'withInvoices'     => false,
+				'withTransactions' => false,
+				'withLogs'         => false,
+				'withLastLog'      => false,
+				'withTags'         => false,
+				'withCompanies'    => false,
+				'withOwner'        => false,
+				'withValues'       => false,
+			)
+		);
+		if ( is_array( $contact_details ) && isset( $contact_details['fname'] ) ) {
+			$invoice_customer_info_table_html = '<div class="zbs-line-info zbs-line-info-title">' . esc_html( $contact_details['fname'] ) . ' ' . esc_html( $contact_details['lname'] ) . '</div>';
+			if ( isset( $contact_details['addr1'] ) && ! empty( $contact_details['addr1'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $contact_details['addr1'] ) . '</div>';
+			}
+			if ( isset( $contact_details['addr2'] ) && ! empty( $contact_details['addr2'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $contact_details['addr2'] ) . '</div>';
+			}
+			if ( isset( $contact_details['city'] ) && ! empty( $contact_details['city'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $contact_details['city'] ) . '</div>';
+			}
+			if ( isset( $contact_details['county'] ) && ! empty( $contact_details['county'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $contact_details['county'] ) . '</div>';
+			}
+			if ( isset( $contact_details['postcode'] ) && ! empty( $contact_details['postcode'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $contact_details['postcode'] ) . '</div>';
+			}
+		}
+
+		// add
+		$statement_table .= '<td><div style="text-align:left">' . $invoice_customer_info_table_html . '</div></td>';
+
+		// Dates
+		$statement_table .= '<td>';
+		$statement_table .= '<div class="zbs-statement-date"><strong>' . esc_html__( 'Statement Date', 'zero-bs-crm' ) . '</strong><br />' . esc_html( zeroBSCRM_locale_utsToDate( time() ) ) . '</div>';
+		$statement_table .= '</td>';
+
+		// Biz deets
+
+		// get biz deets
+		$biz_info_table = '<div class="zbs-line-info zbs-line-info-title">' . esc_html( $biz_name ) . '</div>';
+		if ( ! empty( $biz_contact_name ) ) {
+			$biz_info_table .= '<div class="zbs-line-info">' . esc_html( $biz_contact_name ) . '</div>';
+		}
+		if ( ! empty( $biz_extra ) ) {
+			$biz_info_table .= '<div class="zbs-line-info">' . nl2br( esc_html( $biz_extra ) ) . '</div>';
+		}
+		if ( ! empty( $biz_contact_email ) ) {
+			$biz_info_table .= '<div class="zbs-line-info">' . esc_html( $biz_contact_email ) . '</div>';
+		}
+		if ( ! empty( $biz_url ) ) {
+			$biz_info_table .= '<div class="zbs-line-info">' . esc_html( $biz_url ) . '</div>';
+		}
+		if ( ! empty( $biz_tel ) ) {
+			$biz_info_table .= '<div class="zbs-line-info">' . esc_html( $biz_tel ) . '</div>';
+		}
+
+		// add
+		$statement_table .= '<td><div class="zbs-biz-info">' . $biz_info_table . '</div></td>';
 
-                // Biz deets
+		$statement_table .= '</tr>';
 
-                    // get biz deets
-                    $bizInfoTable = '<div class="zbs-line-info zbs-line-info-title">'.$bizName.'</div>';
-                    if (!empty($bizContactName)) $bizInfoTable .= '<div class="zbs-line-info">'.$bizContactName.'</div>';
-                    if (!empty($bizExtra)) $bizInfoTable .= '<div class="zbs-line-info">'.zeroBSCRM_textExpose(nl2br($bizExtra)).'</div>';
-                    if (!empty($bizContactEmail)) $bizInfoTable .= '<div class="zbs-line-info">'.$bizContactEmail.'</div>';
-                    if (!empty($bizURL)) $bizInfoTable .= '<div class="zbs-line-info">'.$bizURL.'</div>';
-                    if (!empty($bizTel)) $bizInfoTable .= '<div class="zbs-line-info">'.$bizTel.'</div>';
-
-                    // add
-                    $statementTable .= '<td><div class="zbs-biz-info">'.$bizInfoTable.'</div></td>';
+		// STATEMENT table
+
+		// start
+		$s_table = '<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;background-color:#FFF;width:100%">';
+
+		// header
+		$s_table .= '<tr><th cellpadding="0" cellspacing="0" >' . esc_html__( 'Date', 'zero-bs-crm' ) . '</th>';
+		$s_table .= '<th cellpadding="0" cellspacing="0" >' . esc_html( $zbs->settings->get( 'reflabel' ) ) . '</th>';
+		$s_table .= '<th cellpadding="0" cellspacing="0" >' . esc_html__( 'Due date', 'zero-bs-crm' ) . '</th>';
+		$s_table .= '<th class="zbs-accountant-td" style="text-align:right">' . esc_html__( 'Amount', 'zero-bs-crm' ) . '</th>';
+		$s_table .= '<th class="zbs-accountant-td" style="text-align:right">' . esc_html__( 'Payments', 'zero-bs-crm' ) . '</th>';
+		$s_table .= '<th class="zbs-accountant-td" style="text-align:right">' . esc_html__( 'Balance', 'zero-bs-crm' ) . '</th></tr>';
+
+		// should be all of em so can do 'outstanding balance' from this
+		$balance_due = 0.00;
+
+		// rows. (all invs for this contact)
+		if ( is_array( $invoices ) && count( $invoices ) > 0 ) {
+
+			foreach ( $invoices as $invoice ) {
+
+				// number
+				$invoice_reference = $invoice['id'];
+				if ( isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ) {
+					$invoice_reference = $invoice['id_override'];
+				}
+
+				// date
+				$invoice_date = $invoice['date_date'];
+
+				// due
+				if ( $invoice['due_date'] <= 0 ) {
+
+					//no due date;
+					$due_date_str = __( 'No due date', 'zero-bs-crm' );
 
-            $statementTable .= '</tr>';
+				} else {
 
-        // STATEMENT table
+					$due_date_str = $invoice['due_date_date'];
 
-            // start
-            $sTable = '<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt;background-color:#FFF;width:100%">';
+					// is it due?
+					if ( zeroBSCRM_invoiceBuilder_isInvoiceDue( $invoice ) ) {
+						$due_date_str .= ' [' . esc_html__( 'Due', 'zero-bs-crm' ) . ']';
+					}
+				}
 
-                // header
-                $sTable .= '<tr><th cellpadding="0" cellspacing="0" >'.__('Date','zero-bs-crm').'</th>';
-                $sTable .= '<th cellpadding="0" cellspacing="0" >' . $zbs->settings->get('reflabel') . '</th>';
-                $sTable .= '<th cellpadding="0" cellspacing="0" >'.__('Due date','zero-bs-crm').'</th>';
-                $sTable .= '<th class="zbs-accountant-td" style="text-align:right">'.__('Amount','zero-bs-crm').'</th>';
-                $sTable .= '<th class="zbs-accountant-td" style="text-align:right">'.__('Payments','zero-bs-crm').'</th>';
-                $sTable .= '<th class="zbs-accountant-td" style="text-align:right">'.__('Balance','zero-bs-crm').'</th></tr>';
+				// partials = transactions associated in v3.0 model
+				$partials = $invoice['transactions'];
 
-                // should be all of em so can do 'outstanding balance' from this
-                $balanceDue = 0.00;
+				// ================= / DATA RETRIEVAL ===================================
 
-                // rows. (all invs for this contact)
-                if (is_array($invoices) && count($invoices) > 0){
+				// total etc.
+				$total    = 0.00;
+				$payments = 0.00;
+				$balance  = 0.00;
+				if ( isset( $invoice['total'] ) && $invoice['total'] > 0 ) {
+					$total   = $invoice['total'];
+					$balance = $total;
+				}
 
-                    foreach ($invoices as $invoice){
+				// 2 ways here - if marked 'paid', then assume balance
+				// ... if not, then trans allocation check
+				if ( isset( $invoice['status'] ) && $invoice['status'] === __( 'Paid', 'zero-bs-crm' ) ) {
 
-                            // number
-                            $invoiceReference = $invoice['id'];
-                            if (isset($invoice['id_override']) && !empty($invoice['id_override'])) {
-                                $invoiceReference = $invoice['id_override'];
-                            }
+					// assume fully paid
+					$balance  = 0.00;
+					$payments = $total;
 
-                            // date
-                            $invoiceDate = $invoice['date_date'];
+				} elseif ( is_array( $partials ) ) {
 
-                            // due
-                            if ($invoice['due_date'] <= 0){
-                                
-                                //no due date;
-                                $dueDateStr = __("No due date", "zero-bs-crm");
+					foreach ( $partials as $partial ) {
 
-                            } else {
+						// ignore if status_bool (non-completed status)
+						$partial['status_bool'] = (int) $partial['status_bool'];
+						if ( isset( $partial ) && $partial['status_bool'] == 1 && isset( $partial['total'] ) && $partial['total'] > 0 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 
-                                $dueDateStr = $invoice['due_date_date'];
+							// v3.0+ has + or - partials. Account for that:
+							if ( $partial['type_accounting'] === 'credit' ) {
 
-                                // is it due?
-                                if (zeroBSCRM_invoiceBuilder_isInvoiceDue($invoice)) $dueDateStr .= ' ['.__('Due','zero-bs-crm').']';
-                            
-                            }
+								// credit note, or refund
+								$balance = $balance + $partial['total'];
+								// add to payments
+								$payments += $partial['total'];
 
-                            // status
-                            if (!isset($invoice['status'])) 
-                                $zbs_stat = __('Draft','zero-bs-crm');
-                            else
-                                $zbs_stat = $invoice['status'];     
+							} else {
 
-                            // inv lines
-                            $invlines = $invoice['lineitems'];
+								// assume debit
+								$balance = $balance - $partial['total'];
 
-                            // is this stored same format?
-                            $zbsInvoiceHorQ = $invoice['hours_or_quantity'];
+								// add to payments
+								$payments += $partial['total'];
+							}
+						}
+					} // /foreach
 
-                            // partials = transactions associated in v3.0 model
-                            $partials = $invoice['transactions'];
+				} // if is array
 
-                            // ================= / DATA RETRIEVAL ===================================
+				// now we add any outstanding bal to the total bal for table
+				if ( $balance > 0 ) {
+					$balance_due += $balance;
+				}
 
+				// output
+				$s_table .= '<tr><td>' . esc_html( $invoice_date ) . '</td>';
+				$s_table .= '<td>' . esc_html( $invoice_reference ) . '</td>';
+				$s_table .= '<td>' . esc_html( $due_date_str ) . '</td>';
+				$s_table .= '<td class="zbs-accountant-td">' . esc_html( zeroBSCRM_formatCurrency( $total ) ) . '</td>';
+				$s_table .= '<td class="zbs-accountant-td">' . esc_html( zeroBSCRM_formatCurrency( $payments ) ) . '</td>';
+				$s_table .= '<td class="zbs-accountant-td">' . esc_html( zeroBSCRM_formatCurrency( $balance ) ) . '</td></tr>';
+			}
+		} else {
 
-                        // total etc.
-                        $total = 0.00; $payments = 0.00; $balance = 0.00;
-                        if (isset($invoice['total']) && $invoice['total'] > 0) {
-                            $total = $invoice['total'];
-                            $balance = $total;
-                        }
+			// No invoices?
+			$s_table .= '<tr><td colspan="6" style="text-align:center;font-size:14px;font-weight:bold;padding:2em">' . esc_html__( 'No Activity', 'zero-bs-crm' ) . '</td></tr>';
+		}
 
-                        // 2 ways here - if marked 'paid', then assume balance
-                        // ... if not, then trans allocation check
-                        if (isset($invoice['status']) && $invoice['status'] == __('Paid','zero-bs-crm')) {
+		// footer
+		$s_table .= '<tr class="zbs-statement-footer"><td colspan="6">' . esc_html__( 'BALANCE DUE', 'zero-bs-crm' ) . ' ' . esc_html( zeroBSCRM_formatCurrency( $balance_due ) ) . '</td></tr>';
 
-                            // assume fully paid
-                            $balance = 0.00;
-                            $payments = $total;
+		// close table
+		$s_table .= '</table>';
 
-                        } else {
+		// add
+		$statement_table .= '<tr><td colspan="3">' . $s_table . '</td></tr>';
 
-                            // cycle through partial trans + calc
-                            if (is_array($partials)){
+		// Extra Info
+		$statement_table .= '<tr><td colspan="3" style="text-align:left;padding: 30px;">' . nl2br( esc_html( $statement_extra ) ) . '</td></tr>';
 
-                                foreach ($partials as $partial){ 
+		// close table
+		$statement_table .= '</table>';
 
-                                    // ignore if status_bool (non-completed status)
-                                    $partial['status_bool'] = (int)$partial['status_bool'];
-                                    if (isset($partial) && $partial['status_bool'] == 1 && isset($partial['total']) && $partial['total'] > 0){
+		// load templating
+		$placeholder_templating = $zbs->get_templating();
 
-                                        // v3.0+ has + or - partials. Account for that:
-                                        if ($partial['type_accounting'] == 'credit'){
-                                            
-                                            // credit note, or refund
-                                            $balance = $balance + $partial['total'];
-                                            // add to payments
-                                            $payments += $partial['total'];  
+		// main content build
+		$html = $placeholder_templating->replace_single_placeholder( 'invoice-statement-html', $statement_table, $templated_html );
 
-                                        } else {
+		// return
+		if ( ! $return ) {
 
-                                            // assume debit
-                                            $balance = $balance - $partial['total']; 
+			echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			exit();
 
-                                            // add to payments
-                                            $payments += $partial['total'];
-                                        }
-                                
-                                    }
+		}
 
-                                } // /foreach 
+		return $html;
 
-                            } // if is array
+	} // /if anything
 
-                        }
-
-                        // now we add any outstanding bal to the total bal for table
-                        if ($balance > 0) $balanceDue += $balance;
-
-
-                        // output
-                        $sTable .= '<tr><td>'.$invoiceDate.'</td>';
-                        $sTable .= '<td>'.$invoiceReference.'</td>';
-                        $sTable .= '<td>'.$dueDateStr.'</td>';
-                        $sTable .= '<td class="zbs-accountant-td">'.zeroBSCRM_formatCurrency($total).'</td>';
-                        $sTable .= '<td class="zbs-accountant-td">'.zeroBSCRM_formatCurrency($payments).'</td>';
-                        $sTable .= '<td class="zbs-accountant-td">'.zeroBSCRM_formatCurrency($balance).'</td></tr>';
-
-
-                    }
-                
-                } else {
-
-                    // No invoices?           
-                    $sTable .= '<tr><td colspan="6" style="text-align:center;font-size:14px;font-weight:bold;padding:2em">'.__('No Activity','zero-bs-crm').'</td></tr>';
-
-                }
-
-
-                // footer                  
-                $sTable .= '<tr class="zbs-statement-footer"><td colspan="6">'.__('BALANCE DUE','zero-bs-crm').' '.zeroBSCRM_formatCurrency($balanceDue).'</td></tr>';
-
-
-            // close table
-            $sTable .= '</table>';
-
-            // add
-            $statementTable .= '<tr><td colspan="3">'.$sTable.'</td></tr>';
-
-
-        // Extra Info
-        $statementTable .= '<tr><td colspan="3" style="text-align:left;padding: 30px;">'.zeroBSCRM_textExpose(nl2br($statementExtra)).'</td></tr>';
-
-        // close table
-        $statementTable .= '</table>';
-
-        // load templating
-        $placeholder_templating = $zbs->get_templating();
-
-        // main content build
-        $html = $placeholder_templating->replace_single_placeholder( 'invoice-statement-html', $statementTable, $templatedHTML );
-
-        // return
-        if ( !$return ){
-            
-            echo $html; 
-            exit(); 
-            
-        }
-
-        return $html;
-
-    } // /if anything
-
-    return false;
+	return false;
 }
 
 // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag,Generic.Commenting.DocComment.MissingShort

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -910,7 +910,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 
 	// Globals
 	$invsettings = $zbs->settings->getAll();
-	$cssURL      = ZEROBSCRM_URL . 'css/ZeroBSCRM.admin.invoicepreview' . wp_scripts_get_suffix() . '.css'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$css_url     = ZEROBSCRM_URL . 'css/ZeroBSCRM.admin.invoicepreview' . wp_scripts_get_suffix() . '.css';
 	$ref_label   = $zbs->settings->get( 'reflabel' );
 
 	$logoURL = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -1213,7 +1213,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 
 		// invoice specific
 		'invoice-title'               => __( 'Invoice', 'zero-bs-crm' ),
-		'css'                         => $cssURL, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'css'                         => $css_url,
 		'logo-class'                  => $logoClass, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'logo-url'                    => esc_url( $logoURL ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-number'              => $invNoStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -924,11 +924,11 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	}
 
 	if ( $logo_url != '' && isset( $invoice['logo_url'] ) ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
-		$logoClass    = 'show'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$logo_class   = 'show';
 		$logo_url     = $invoice['logo_url'];
 		$bizInfoClass = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	} else {
-		$logoClass    = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$logo_class   = '';
 		$logo_url     = '';
 		$bizInfoClass = 'biz-up'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	}
@@ -1214,7 +1214,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		// invoice specific
 		'invoice-title'               => __( 'Invoice', 'zero-bs-crm' ),
 		'css'                         => $css_url,
-		'logo-class'                  => $logoClass, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'logo-class'                  => $logo_class,
 		'logo-url'                    => esc_url( $logo_url ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-number'              => $invNoStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-date'                => $invDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -432,42 +432,36 @@ function zeroBSCRM_invoicing_generateStatementPDF( $contactID = -1, $returnPDF =
     ZBS Invoicing - STATEMENT HTML GENERATOR
    ====================================================== */
 
-#} Generates the HTML of an invoice based on the template in templates/invoices/statement-pdf.html
-#} if $return, it'll return, otherwise it'll echo + exit
-function zeroBSCRM_invoicing_generateStatementHTML($contactID=-1,$return=true){
+// phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag
+/**
+ * Generates the HTML of an invoice based on the template in templates/invoices/statement-pdf.html
+ * if $return, it'll return, otherwise it'll echo + exit
+ **/
+function zeroBSCRM_invoicing_generateStatementHTML( $contact_id = -1, $return = true ) {
 
-    global $zbs;
+	if ( ! empty( $contact_id ) && $contact_id > 0 ) {
 
-    if (!empty($contactID) && $contactID > 0){
+		// Discern template and retrieve
+		$global_statement_pdf_template = zeroBSCRM_getSetting( 'statement_pdf_template' );
+		if ( ! empty( $global_statement_pdf_template ) ) {
+			$templated_html = jpcrm_retrieve_template( $global_statement_pdf_template, false );
+		}
 
-        // Discern template and retrieve    
-        $global_statement_pdf_template = zeroBSCRM_getSetting( 'statement_pdf_template' );
-        if ( !empty( $global_statement_pdf_template ) ){
-            $templatedHTML = jpcrm_retrieve_template( $global_statement_pdf_template, false );
-        }
+		// fallback to default template
+		if ( ! isset( $templated_html ) || empty( $templated_html ) ) {
+			// template failed as setting potentially holds out of date (removed) template
+			// so use the default
+			$templated_html = jpcrm_retrieve_template( 'invoices/statement-pdf.html', false );
+		}
 
-        // fallback to default template
-        if ( !isset( $templatedHTML ) || empty( $templatedHTML ) ){
+		// Act
+		if ( ! empty( $templated_html ) ) {
+			return zeroBSCRM_invoicing_generateStatementHTML_v3( $contact_id, $return, $templated_html );
+		}
+	}
 
-            // template failed as setting potentially holds out of date (removed) template
-            // so use the default
-            $templatedHTML = jpcrm_retrieve_template( 'invoices/statement-pdf.html', false );
-
-        }
-
-        #} Act
-        if (!empty($templatedHTML)){
-
-            global $zbs;
-
-            return zeroBSCRM_invoicing_generateStatementHTML_v3($contactID,$return,$templatedHTML);
-
-        }
-
-    } 
-
-    #} Empty inv id
-    return false;
+	// Empty inv id
+	return false;
 }
 
 // 3.0+ (could now run off contact or company, but that's not written in yet)

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -798,17 +798,17 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	}
 
 	// date
-	$invDateStr = jpcrm_uts_to_date_str( $invoice['date'] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$inv_date_str = jpcrm_uts_to_date_str( $invoice['date'] );
 
 	// due
 	if ( $invoice['due_date'] <= 0 ) {
 
 		//no due date
-		$dueDateStr = __( 'No due date', 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$due_date_str = __( 'No due date', 'zero-bs-crm' );
 
 	} else {
 
-		$dueDateStr = jpcrm_uts_to_date_str( $invoice['due_date'] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$due_date_str = jpcrm_uts_to_date_str( $invoice['due_date'] );
 	}
 
 	// Custom fields
@@ -979,7 +979,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	$zbs_biz_yoururl   = zeroBSCRM_getSetting( 'businessyoururl' );
 
 	// generate a templated biz info table
-	$bizInfoTable = zeroBSCRM_invoicing_generateInvPart_bizTable( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$biz_info_table = zeroBSCRM_invoicing_generateInvPart_bizTable(
 		array(
 			'zbs_biz_name'      => $zbs_biz_name,
 			'zbs_biz_yourname'  => $zbs_biz_yourname,
@@ -1210,13 +1210,13 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-title'               => __( 'Invoice', 'zero-bs-crm' ),
 		'css'                         => $css_url,
 		'logo-class'                  => $logo_class,
-		'logo-url'                    => esc_url( $logo_url ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'logo-url'                    => esc_url( $logo_url ),
 		'invoice-number'              => $inv_no_str,
-		'invoice-date'                => $invDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-date'                => $inv_date_str,
 		'invoice-id-styles'           => $inv_id_styles,
 		'invoice-ref'                 => $inv_no_str,
 		'invoice-ref-styles'          => $inv_ref_styles,
-		'invoice-due-date'            => $dueDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-due-date'            => $due_date_str,
 		'invoice-custom-fields'       => $invoice_custom_fields_html,
 		'invoice-biz-class'           => $biz_info_class,
 		'invoice-customer-info'       => $invoice_customer_info_table_html,
@@ -1245,7 +1245,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-pay-terms'           => __( 'Payment terms', 'zero-bs-crm' ) . ': ' . __( 'Due', 'zero-bs-crm' ) . ' ',
 
 		// global
-		'biz-info'                    => $bizInfoTable, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'biz-info'                    => $biz_info_table,
 		'powered-by'                  => $powered_by,
 
 	);

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -999,24 +999,24 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 
 	// == Lineitem table > Line items
 	// generate a templated lineitems
-	$lineItems = zeroBSCRM_invoicing_generateInvPart_lineitems( $invlines, $template ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$line_items = zeroBSCRM_invoicing_generateInvPart_lineitems( $invlines, $template );
 
 	// == Lineitem table > Totals
 	// due to withTotals parameter on get above, we now don't need ot calc anything here, just expose
-	$totalsTable = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$totals_table = '';
 
-	$totalsTable .= '<table id="invoice_totals" class="table-totals zebra" style="width: 100%;"><tbody>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	if ( $invsettings['invtax'] != 0 || $invsettings['invpandp'] != 0 || $invsettings['invdis'] != 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,Universal.Operators.StrictComparisons.LooseNotEqual
-		$totalsTable .= '<tr class="total-top">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$totalsTable .= '<td  class="bord bord-l" style="text-align:right; width: 80%; text-transform: uppercase;">' . esc_html__( 'Subtotal', 'zero-bs-crm' ) . '</td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$totalsTable .= '<td class="bord row-amount" class="bord" style="text-align:right; "><span class="zbs-totals">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$totals_table .= '<table id="invoice_totals" class="table-totals zebra" style="width: 100%;"><tbody>';
+	if ( $invsettings['invtax'] != 0 || $invsettings['invpandp'] != 0 || $invsettings['invdis'] != 0 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+		$totals_table .= '<tr class="total-top">';
+		$totals_table .= '<td  class="bord bord-l" style="text-align:right; width: 80%; text-transform: uppercase;">' . esc_html__( 'Subtotal', 'zero-bs-crm' ) . '</td>';
+		$totals_table .= '<td class="bord row-amount" class="bord" style="text-align:right; "><span class="zbs-totals">';
 		if ( isset( $invoice['net'] ) && ! empty( $invoice['net'] ) ) {
-			$totalsTable .= esc_html( zeroBSCRM_formatCurrency( $invoice['net'] ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$totals_table .= esc_html( zeroBSCRM_formatCurrency( $invoice['net'] ) );
 		} else {
-			$totalsTable .= esc_html( zeroBSCRM_formatCurrency( 0 ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$totals_table .= esc_html( zeroBSCRM_formatCurrency( 0 ) );
 		}
-		$totalsTable .= '</span></td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$totalsTable .= '</tr>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$totals_table .= '</span></td>';
+		$totals_table .= '</tr>';
 	}
 
 	// discount
@@ -1027,31 +1027,29 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 			if ( $invoice['discount_type'] == '%' && $invoice['discount'] != 0 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual,Universal.Operators.StrictComparisons.LooseNotEqual
 				$invoice_percent = (float) $invoice['discount'] . '% ';
 			}
-			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			$totalsTable .= '<tr class="discount">
+			$totals_table .= '<tr class="discount">
 				<td class="bord bord-l" style="text-align:right; text-transform: uppercase;">' . esc_html( $invoice_percent . __( 'Discount', 'zero-bs-crm' ) ) . '</td>
 				<td class="bord row-amount" id="zbs_discount_combi" style="text-align:right"><span class="zbs-totals">';
 
-			$totalsTable .= '-' . esc_html( zeroBSCRM_formatCurrency( $invoice['totals']['discount'] ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$totals_table .= '-' . esc_html( zeroBSCRM_formatCurrency( $invoice['totals']['discount'] ) );
 
-			$totalsTable .= '</td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			$totalsTable .= '</tr>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$totals_table .= '</td>';
+			$totals_table .= '</tr>';
 		}
 	}
 
 	// shipping
 	if ( $invsettings['invpandp'] == 1 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$totalsTable .= '<tr class="postage_and_pack">
+		$totals_table .= '<tr class="postage_and_pack">
 			<td class="bord bord-l" style="text-align:right; text-transform: uppercase;">' . esc_html__( 'Postage and packaging', 'zero-bs-crm' ) . '</td>
 			<td class="bord row-amount" id="pandptotal" style="text-align:right;"><span class="zbs-totals">';
 		if ( isset( $invoice['shipping'] ) && ! empty( $invoice['shipping'] ) ) {
-			$totalsTable .= esc_html( zeroBSCRM_formatCurrency( $invoice['shipping'] ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$totals_table .= esc_html( zeroBSCRM_formatCurrency( $invoice['shipping'] ) );
 		} else {
-			$totalsTable .= esc_html( zeroBSCRM_formatCurrency( 0 ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$totals_table .= esc_html( zeroBSCRM_formatCurrency( 0 ) );
 		}
-		$totalsTable .= '</td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$totalsTable .= '</tr>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$totals_table .= '</td>';
+		$totals_table .= '</tr>';
 	}
 
 	// tax
@@ -1072,48 +1070,45 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 					$tax_name = $tax['name'];
 				}
 
-				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				$totalsTable .= '<tr class="ttclass">
+				$totals_table .= '<tr class="ttclass">
 					<td class="bord bord-l" style="text-align:right">' . esc_html( $tax_name ) . '</td>
 					<td class="bord bord-l row-amount zbs-tax-total-span" style="text-align:right"><span class="zbs-totals">';
 				if ( isset( $tax['value'] ) && ! empty( $tax['value'] ) ) {
-					$totalsTable .= esc_html( zeroBSCRM_formatCurrency( $tax['value'] ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					$totals_table .= esc_html( zeroBSCRM_formatCurrency( $tax['value'] ) );
 				} else {
-					$totalsTable .= esc_html( zeroBSCRM_formatCurrency( 0 ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					$totals_table .= esc_html( zeroBSCRM_formatCurrency( 0 ) );
 				}
-				$totalsTable .= '</td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				$totalsTable .= '</tr>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				$totals_table .= '</td>';
+				$totals_table .= '</tr>';
 			}
 		} else {
 
 			// simple fallback
-			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			$totalsTable .= '<tr class="ttclass">
+			$totals_table .= '<tr class="ttclass">
 				<td class="bord bord-l" style="text-align:right">' . esc_html__( 'Tax', 'zero-bs-crm' ) . '</td>
 				<td class="bord bord-l row-amount zbs-tax-total-span" style="text-align:right"><span class="zbs-totals">';
 			if ( isset( $invoice['tax'] ) && ! empty( $invoice['tax'] ) ) {
-				$totalsTable .= esc_html( zeroBSCRM_formatCurrency( $invoice['tax'] ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				$totals_table .= esc_html( zeroBSCRM_formatCurrency( $invoice['tax'] ) );
 			} else {
-				$totalsTable .= esc_html( zeroBSCRM_formatCurrency( 0 ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				$totals_table .= esc_html( zeroBSCRM_formatCurrency( 0 ) );
 			}
-			$totalsTable .= '</td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			$totalsTable .= '</tr>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$totals_table .= '</td>';
+			$totals_table .= '</tr>';
 		}
 	}
 
-	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$totalsTable .= '<tr class="zbs_grand_total" style="line-height:30px;">
+	$totals_table .= '<tr class="zbs_grand_total" style="line-height:30px;">
 		<td class="bord-l"  style="text-align:right; font-weight:bold;  border-radius: 0px;"><span class="zbs-total">' . __( 'Total', 'zero-bs-crm' ) . '</span></td>
 		<td class="row-amount" style="text-align:right; font-weight:bold; border: 3px double #111!important; "><span class="zbs-total">';
 	if ( isset( $invoice['total'] ) && ! empty( $invoice['total'] ) ) {
-		$totalsTable .= esc_html( zeroBSCRM_formatCurrency( $invoice['total'] ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$totals_table .= esc_html( zeroBSCRM_formatCurrency( $invoice['total'] ) );
 	} else {
-		$totalsTable .= esc_html( zeroBSCRM_formatCurrency( 0 ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$totals_table .= esc_html( zeroBSCRM_formatCurrency( 0 ) );
 	}
-	$totalsTable .= '</span></td>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$totalsTable .= '</tr>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$totals_table .= '</span></td>';
+	$totals_table .= '</tr>';
 
-	$totalsTable .= '</table>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$totals_table .= '</table>';
 
 	// == Partials (Transactions against Invs)
 	$partials_table = '';
@@ -1222,8 +1217,8 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-customer-info'       => $invoice_customer_info_table_html,
 		'invoice-html-status'         => $top_status,
 		'invoice-table-headers'       => $table_headers,
-		'invoice-line-items'          => $lineItems, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		'invoice-totals-table'        => $totalsTable, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-line-items'          => $line_items,
+		'invoice-totals-table'        => $totals_table,
 		'invoice-partials-table'      => $partials_table,
 		'invoice-pay-button'          => $potential_pay_button,
 		'pre-invoice-payment-details' => '',

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -897,7 +897,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	}
 
 	// is this stored same format?
-	$zbsInvoiceHorQ = $invoice['hours_or_quantity']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$zbs_invoice_hours_or_quantity = $invoice['hours_or_quantity'];
 
 	// partials = transactions associated in v3.0 model
 	$partials = $invoice['transactions'];
@@ -995,7 +995,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 
 	// == Lineitem table > Column headers
 	// generate a templated customer info table
-	$tableHeaders = zeroBSCRM_invoicing_generateInvPart_tableHeaders( $zbsInvoiceHorQ, $template ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$table_headers = zeroBSCRM_invoicing_generateInvPart_tableHeaders( $zbs_invoice_hours_or_quantity, $template );
 
 	// == Lineitem table > Line items
 	// generate a templated lineitems
@@ -1221,7 +1221,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-biz-class'           => $biz_info_class,
 		'invoice-customer-info'       => $invoice_customer_info_table_html,
 		'invoice-html-status'         => $top_status,
-		'invoice-table-headers'       => $tableHeaders, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-table-headers'       => $table_headers,
 		'invoice-line-items'          => $lineItems, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-totals-table'        => $totalsTable, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-partials-table'      => $partials_table,

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -935,7 +935,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 
 	// Invoice Number or Reference
 	// Reference, falling back to ID
-	$invIDStyles = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$inv_id_styles = '';
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$invRefStyles = 'display:none;'; // none initially
 
@@ -959,8 +959,8 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		}
 
 		// and we don't show ID, do show ref label:
-		$invIDStyles  = 'display:none;'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$invRefStyles = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$inv_id_styles = 'display:none;';
+		$invRefStyles  = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	}
 
@@ -1218,7 +1218,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'logo-url'                    => esc_url( $logo_url ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-number'              => $invNoStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-date'                => $invDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		'invoice-id-styles'           => $invIDStyles, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-id-styles'           => $inv_id_styles,
 		'invoice-ref'                 => $invNoStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-ref-styles'          => $invRefStyles, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-due-date'            => $dueDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -924,13 +924,13 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	}
 
 	if ( $logo_url != '' && isset( $invoice['logo_url'] ) ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
-		$logo_class   = 'show';
-		$logo_url     = $invoice['logo_url'];
-		$bizInfoClass = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$logo_class     = 'show';
+		$logo_url       = $invoice['logo_url'];
+		$biz_info_class = '';
 	} else {
-		$logo_class   = '';
-		$logo_url     = '';
-		$bizInfoClass = 'biz-up'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$logo_class     = '';
+		$logo_url       = '';
+		$biz_info_class = 'biz-up';
 	}
 
 	// Invoice Number or Reference
@@ -1223,7 +1223,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-ref-styles'          => $invRefStyles, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-due-date'            => $dueDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-custom-fields'       => $invoice_custom_fields_html,
-		'invoice-biz-class'           => $bizInfoClass, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-biz-class'           => $biz_info_class,
 		'invoice-customer-info'       => $invoice_customer_info_table_html,
 		'invoice-html-status'         => $topStatus, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-table-headers'       => $tableHeaders, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -1177,7 +1177,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 
 
 	$pay_details  = '<div class="deets"><h2>' . esc_html__( 'Payment Details', 'zero-bs-crm' ) . '</h2>';
 	$pay_details .= '<div class="deets-line"><span class="deets-content">' . nl2br( esc_html( $payment_info_text ) ) . '</span></div>';
-	$pay_details .= '<div class="deets-line"><span class="deets-title">' . esc_html__( 'Payment Reference:', 'zero-bs-crm' ) . '</span> <span>' . esc_html( $inv_no_str ) . '</span></div>';
+	$pay_details .= '<div class="deets-line"><span class="deets-title">' . esc_html__( 'Payment Reference:', 'zero-bs-crm' ) . '</span> <span>' . $inv_no_str . '</span></div>';
 	$pay_details .= '</div>';
 
 	// == Template -> HTML build
@@ -1462,32 +1462,28 @@ function jpcrm_invoicing_generate_customer_custom_fields_lines( $customer, $temp
 
                 }
 
-                // skip empties
-                if ( empty( $custom_field_str ) ) {
-                    continue;
-                }
+				// skip empties
+				if ( empty( $custom_field_str ) ) {
+						continue;
+				}
 
-                switch ( $template ){
+				switch ( $template ) {
 
-                    case 'pdf':
-                    case 'notification':
-                        $customer_custom_fields_html .= '<div class="zbs-line-info">' . $field_info[1] . ': ' . $custom_field_str . '</div>';
-                        break;
+					case 'pdf':
+					case 'notification':
+						$customer_custom_fields_html .= '<div class="zbs-line-info">' . esc_html( $field_info[1] ) . ': ' . esc_html( $custom_field_str ) . '</div>';
+						break;
 
-                    case 'portal':
-                        $customer_custom_fields_html .= '<div><strong>' . $field_info[1] . ':</strong> ' . $custom_field_str . '</div>';
-                        break;
+					case 'portal':
+						$customer_custom_fields_html .= '<div><strong>' . esc_html( $field_info[1] ) . ':</strong> ' . esc_html( $custom_field_str ) . '</div>';
+						break;
 
-                }
+				}
+			}
+		}
+	}
 
-            }
-
-        }     
-
-    }
-
-    return $customer_custom_fields_html;
-
+	return $customer_custom_fields_html;
 }
 
 
@@ -1537,139 +1533,116 @@ function jpcrm_invoicing_generate_invoice_custom_fields_lines( $invoice, $templa
                     }
                 }
 
-                // skip empties
-                if ( empty( $custom_field_str ) ) {
-                    continue;
-                }
+				// skip empties
+				if ( empty( $custom_field_str ) ) {
+						continue;
+				}
 
-                switch ( $template ){
+				switch ( $template ) {
 
-                    case 'pdf':
-                    case 'notification':
+					case 'pdf':
+					case 'notification':
+						$invoice_custom_fields_html .= '<tr class="zbs-top-right-box-line">';
+						$invoice_custom_fields_html .= '    <td><label for="' . esc_attr( $field_key ) . '">' . esc_html( $field_info[1] ) . ':</label></td>';
+						$invoice_custom_fields_html .= '    <td style="text-align:right;">' . esc_html( $custom_field_str ) . '</td>';
+						$invoice_custom_fields_html .= '</tr>';
+						break;
 
-                        $invoice_custom_fields_html .= '<tr class="zbs-top-right-box-line">';
-                        $invoice_custom_fields_html .= '    <td><label for="' . $field_key . '">' . $field_info[1] . ':</label></td>';
-                        $invoice_custom_fields_html .= '    <td style="text-align:right;">' . $custom_field_str . '</td>';
-                        $invoice_custom_fields_html .= '</tr>';
-                        break;
+					case 'portal':
+						$invoice_custom_fields_html .= '<div><strong>' . esc_html( $field_info[1] ) . ':</strong> ' . esc_html( $custom_field_str ) . '</div>';
+						break;
+				}
+			}
+		}
+	}
 
-                    case 'portal':
-
-                        $invoice_custom_fields_html .= '<div><strong>' . $field_info[1] . ':</strong> ' . $custom_field_str . '</div>';
-                        break;
-
-                }
-
-            }
-
-        }     
-
-    }
-
-    return $invoice_custom_fields_html;
-
+	return $invoice_custom_fields_html;
 }
 
 
 // Used to generate specific part of invoice pdf: (Lineitem row in inv table)
-function zeroBSCRM_invoicing_generateInvPart_lineitems($invlines=array(),$template='pdf'){
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+function zeroBSCRM_invoicing_generateInvPart_lineitems( $invlines = array(), $template = 'pdf' ) {
 
-    $lineItemHTML = '';
+	$line_item_html = '';
 
+	switch ( $template ) {
 
-        switch ($template){
+		case 'pdf':
+			if ( $invlines != '' ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+				$i = 1;
+				foreach ( $invlines as $invline ) {
 
-            case 'pdf':
+					$line_item_html .=
+						'<tr>
+						<td style="width:55%;"><div class="item-name">' . esc_html( $invline['title'] ) . '</div><div class="item-description">' . nl2br( esc_html( $invline['desc'] ) ) . '</div></td>
+						<td style="width:15%;text-align:center;" class="cen">' . esc_html( zeroBSCRM_format_quantity( $invline['quantity'] ) ) . '</td>
+						<td style="width:15%;text-align:center;" class="cen">' . esc_html( zeroBSCRM_formatCurrency( $invline['price'] ) ) . '</td>
+						<td style="width:15%;text-align:right;" class="row-amount">' . esc_html( zeroBSCRM_formatCurrency( $invline['net'] ) ) . '</td>
+						</tr>';
 
-                if ($invlines != ''){
-                    $i=1;
-                    foreach($invlines as $invline){
+					++$i;
 
-                        $lineItemHTML .= 
-                        '<tr>
-                                    <td style="width:55%;"><div class="item-name">'.$invline['title'].'</div><div class="item-description">'.nl2br($invline['desc']).'</div></td>
-                                    <td style="width:15%;text-align:center;" class="cen">'.zeroBSCRM_format_quantity( $invline['quantity'] ).'</td>
-                                    <td style="width:15%;text-align:center;" class="cen">'. zeroBSCRM_formatCurrency($invline['price']).'</td>
-                                    <td style="width:15%;text-align:right;" class="row-amount">' . zeroBSCRM_formatCurrency($invline['net']).'</td>
-                        </tr>'; 
+				}
+			}
 
-                        $i++;
+			break;
 
-                    }
-                }
+		case 'portal':
+			if ( $invlines != '' ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+				$i = 1;
+				foreach ( $invlines as $invline ) {
 
+					$line_item_html .=
+						'<tbody class="zbs-item-block" data-tableid="' . esc_attr( $i ) . '" id="tblock' . esc_attr( $i ) . '">
+						<tr class="top-row">
+						<td style="width:50%">' . esc_html( $invline['title'] ) . '<br/><span class="dz">' . nl2br( esc_html( $invline['desc'] ) ) . '</span></td>
+						<td style="width:15%;text-align:center;" rowspan="3" class="cen">' . esc_html( zeroBSCRM_format_quantity( $invline['quantity'] ) ) . '</td>
+						<td style="width:15%;text-align:center;" rowspan="3"class="cen">' . esc_html( zeroBSCRM_formatCurrency( $invline['price'] ) ) . '</td>
+						<td style="width:15%;text-align:right;" rowspan="3" class="row-amount">' . esc_html( zeroBSCRM_formatCurrency( $invline['net'] ) ) . '</td>
+						</tr>
+						</tbody>';
 
-            break;
+					++$i;
+				}
+			}
 
-            case 'portal':
+			break;
 
-                if ($invlines != ''){
-                    $i=1;
-                    foreach($invlines as $invline){
-                                
-                        // Note for MS: I've approximately changed these fields to match those in DAL3.Obj.Lineitems
-                        // ... however some extras (tax) will need to be added?
-                        /* WH: this isn't used anywhere? 
-                        $zbs_extra_li = "";
-                        if ($i == 1){
-                            $zbs_extra_li  = '<td class="row-1-pad" colspan="2"></td>';
-                        } */
-                        $lineItemHTML .= 
-                        '<tbody class="zbs-item-block" data-tableid="'.$i.'" id="tblock'.$i.'">
-                                <tr class="top-row">
-                                    <td style="width:50%">'.$invline['title'].'<br/><span class="dz">'.nl2br($invline['desc']).'</span></td>
-                                    <td style="width:15%;text-align:center;" rowspan="3" class="cen">'.zeroBSCRM_format_quantity( $invline['quantity'] ).'</td>
-                                    <td style="width:15%;text-align:center;" rowspan="3"class="cen">'. zeroBSCRM_formatCurrency($invline['price']) .'</td>
-                                    <td style="width:15%;text-align:right;" rowspan="3" class="row-amount">' . zeroBSCRM_formatCurrency($invline['net']) .'</td>
-                                </tr>
-                        </tbody>'; 
+		case 'notification':
+			if ( $invlines != '' ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+				$i = 1;
+				foreach ( $invlines as $invline ) {
 
-                        $i++;
+					$line_item_html = '<tbody class="zbs-item-block" data-tableid="' . esc_attr( $i ) . '" id="tblock' . esc_attr( $i ) . '">';
+					foreach ( $invlines as $invline ) {
 
-                    }
-                }  
+						$line_item_html .= '
+							<tr class="top-row">
+							<td style="width:70%;font-weight:bold">' . esc_html( $invline['title'] ) . '</td>
+							<td style="width:7.5%;text-align:center;" rowspan="3" class="cen">' . esc_html( $invline['quantity'] ) . '</td>
+							<td style="width:7.5%;text-align:center;" rowspan="3"class="cen">' . esc_html( zeroBSCRM_formatCurrency( $invline['price'] ) ) . '</td>
+							<td style="width:7.5%;text-align:right;" rowspan="3" class="row-amount">' . esc_html( zeroBSCRM_formatCurrency( $invline['net'] ) ) . '</td>
+							</tr>
+							<tr class="bottom-row">
+							<td colspan="4" class="tapad">' . esc_html( $invline['desc'] ) . '</td>
+							</tr>
+							<tr class="add-row"></tr>';
 
-            break;
+						++$i;
+					}
 
-            case 'notification':
+					$line_item_html .= '</tbody>';
 
-                if ($invlines != ''){
-                    $i=1;
-                    foreach($invlines as $invline){
+					++$i;
+				}
+			}
 
-                        // Note for MS: I've approximately changed these fields to match those in DAL3.Obj.Lineitems
-                        // ... however some extras (tax) will need to be added?                        
-                        $lineItemHTML = '<tbody class="zbs-item-block" data-tableid="'.$i.'" id="tblock'.$i.'">';
-                        foreach($invlines as $invline){
+			break;
 
-                            $lineItemHTML .= '
-                                    <tr class="top-row">
-                                        <td style="width:70%;font-weight:bold">'.$invline['title'].'</td>
-                                        <td style="width:7.5%;text-align:center;" rowspan="3" class="cen">'.$invline['quantity'].'</td>
-                                        <td style="width:7.5%;text-align:center;" rowspan="3"class="cen">'. zeroBSCRM_formatCurrency($invline['price']) .'</td>
-                                        <td style="width:7.5%;text-align:right;" rowspan="3" class="row-amount">' . zeroBSCRM_formatCurrency($invline['net']) .'</td>
-                                    </tr>
-                                    <tr class="bottom-row">
-                                        <td colspan="4" class="tapad">'.$invline['desc'].'</td>     
-                                    </tr>
-                                    <tr class="add-row"></tr>';
-                            
+	}
 
-                            $i++;
-                        }
-
-                        $lineItemHTML .= '</tbody>';  
-
-                        $i++;
-
-                    }
-                }
-
-            break;
-
-        }
-
-    return $lineItemHTML;
+	return $line_item_html;
 }
 // Used to generate specific part of invoice pdf: (pay button)
 function zeroBSCRM_invoicing_generateInvPart_payButton($invoiceID=-1,$zbs_stat='',$template='pdf'){
@@ -1727,60 +1700,51 @@ function zeroBSCRM_invoicing_generateInvPart_payButton($invoiceID=-1,$zbs_stat='
     return $potentialPayButton;
 }
 // Used to generate specific part of invoice pdf: (table headers)
-function zeroBSCRM_invoicing_generateInvPart_tableHeaders($zbsInvoiceHorQ = 1,$template='pdf'){
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+function zeroBSCRM_invoicing_generateInvPart_tableHeaders( $zbs_invoice_hours_or_quantity = 1, $template = 'pdf' ) {
 
-    $tableHeaders = '';
+	$table_headers = '';
 
-        switch ($template){
+	switch ( $template ) {
 
-            case 'pdf':
-    
-                $tableHeaders = '<th style="text-align:left;"><span class="table-title">'.__('Description','zero-bs-crm').'</span></th>';
+		case 'pdf':
+			$table_headers = '<th style="text-align:left;"><span class="table-title">' . esc_html__( 'Description', 'zero-bs-crm' ) . '</span></th>';
 
-                     if($zbsInvoiceHorQ == 1){ 
-                        $tableHeaders .= '<th id="zbs_inv_qoh"><span class="table-title">'.__("Quantity","zero-bs-crm").'</th>';
-                        $tableHeaders .= '<th id="zbs_inv_por"><span class="table-title">'.__("Price","zero-bs-crm").'</th>';
-                     }else{ 
-                        $tableHeaders .= '<th id="zbs_inv_qoh"><span class="table-title">'.__("Hours","zero-bs-crm").'</th>';
-                        $tableHeaders .= '<th id="zbs_inv_por"><span class="table-title">'.__("Rate","zero-bs-crm").'</th>';
-                     }
-                $tableHeaders .= '<th style="text-align: right;"><span class="table-title">'.__("Amount","zero-bs-crm").'</span></th>';
+			if ( $zbs_invoice_hours_or_quantity == 1 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+				$table_headers .= '<th id="zbs_inv_qoh"><span class="table-title">' . esc_html__( 'Quantity', 'zero-bs-crm' ) . '</th>';
+				$table_headers .= '<th id="zbs_inv_por"><span class="table-title">' . esc_html__( 'Price', 'zero-bs-crm' ) . '</th>';
+			} else {
+				$table_headers .= '<th id="zbs_inv_qoh"><span class="table-title">' . esc_html__( 'Hours', 'zero-bs-crm' ) . '</th>';
+				$table_headers .= '<th id="zbs_inv_por"><span class="table-title">' . esc_html__( 'Rate', 'zero-bs-crm' ) . '</th>';
+			}
+			$table_headers .= '<th style="text-align: right;"><span class="table-title">' . esc_html__( 'Amount', 'zero-bs-crm' ) . '</span></th>';
 
-            break;
+			break;
 
-            case 'portal':
+		case 'portal':
+			$table_headers = '<th class="left">' . esc_html__( 'Description', 'zero-bs-crm' ) . '</th>';
 
-                $tableHeaders = '<th class="left">'.__('Description','zero-bs-crm').'</th>';
+			if ( $zbs_invoice_hours_or_quantity == 1 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+					$table_headers .= '<th class="cen" id="zbs_inv_qoh">' . esc_html__( 'Quantity', 'zero-bs-crm' ) . '</th>';
+					$table_headers .= '<th class="cen" id="zbs_inv_por">' . esc_html__( 'Price', 'zero-bs-crm' ) . '</th>';
+			} else {
+					$table_headers .= '<th class="cen" id="zbs_inv_qoh"> ' . esc_html__( 'Hours', 'zero-bs-crm' ) . '</th>';
+					$table_headers .= '<th class="cen" id="zbs_inv_por">' . esc_html__( 'Rate', 'zero-bs-crm' ) . '</th>';
+			}
 
-                if($zbsInvoiceHorQ == 1){
-                    $tableHeaders .= '<th class="cen" id="zbs_inv_qoh">'.__("Quantity","zero-bs-crm").'</th>';
-                    $tableHeaders .= '<th class="cen" id="zbs_inv_por">'.__("Price","zero-bs-crm").'</th>';
-                }else{
-                    $tableHeaders .= '<th class="cen" id="zbs_inv_qoh">'.__("Hours","zero-bs-crm").'</th>';
-                    $tableHeaders .= '<th class="cen" id="zbs_inv_por">'.__("Rate","zero-bs-crm").'</th>';
-                }
+			$table_headers .= '<th class="ri">' . esc_html__( 'Amount', 'zero-bs-crm' ) . '</th>';
 
-                $tableHeaders .= '<th class="ri">'.__("Amount","zero-bs-crm").'</th>';
-                // v3.0 rc2 - doesn't seem to be needed: $tableHeaders .= '<th class="ri">'.__("Net","zero-bs-crm").'</th>';
+			break;
 
-            break;
+		case 'notification':
+			if ( $zbs_invoice_hours_or_quantity == 1 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+				$table_headers = '<th class="left">' . esc_html__( 'Description', 'zero-bs-crm' ) . '</th><th>' . esc_html__( 'Quantity', 'zero-bs-crm' ) . '</th><th>' . esc_html__( 'Price', 'zero-bs-crm' ) . '</th><th>' . esc_html__( 'Total', 'zero-bs-crm' ) . '</th>';
+			} else {
+				$table_headers = '<th class="left">' . esc_html__( 'Description', 'zero-bs-crm' ) . '</th><th>' . esc_html__( 'Hours', 'zero-bs-crm' ) . '</th><th>' . esc_html__( 'Rate', 'zero-bs-crm' ) . '</th><th>' . esc_html__( 'Total', 'zero-bs-crm' ) . '</th>';
+			}
 
-            case 'notification':
+			break;
+	}
 
-
-                        if($zbsInvoiceHorQ == 1){ 
-                        
-                            $tableHeaders = '<th class="left">'.__("Description",'zero-bs-crm').'</th><th>'.__("Quantity",'zero-bs-crm').'</th><th>'.__("Price",'zero-bs-crm').'</th><th>'.__("Total",'zero-bs-crm').'</th>';
-
-                        }else{ 
-
-                            $tableHeaders = '<th class="left">'.__("Description",'zero-bs-crm').'</th><th>'.__("Hours",'zero-bs-crm').'</th><th>'.__("Rate",'zero-bs-crm').'</th><th>'.__("Total",'zero-bs-crm').'</th>';
-
-                        }
-
-            break;
-
-        }
-
-    return $tableHeaders;
-}    
+	return $table_headers;
+}

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -1187,11 +1187,10 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	}
 	$payment_info_text = zeroBSCRM_getSetting( 'paymentinfo' );
 
-	$payDetails  = '<div class="deets"><h2>' . esc_html__( 'Payment Details', 'zero-bs-crm' ) . '</h2>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$payDetails .= '<div class="deets-line"><span class="deets-content">' . nl2br( esc_html( $payment_info_text ) ) . '</span></div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$payDetails .= '<div class="deets-line"><span class="deets-title">' . esc_html__( 'Payment Reference:', 'zero-bs-crm' ) . '</span> <span>' . esc_html( $inv_no_str ) . '</span></div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$payDetails .= '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-
+	$pay_details  = '<div class="deets"><h2>' . esc_html__( 'Payment Details', 'zero-bs-crm' ) . '</h2>';
+	$pay_details .= '<div class="deets-line"><span class="deets-content">' . nl2br( esc_html( $payment_info_text ) ) . '</span></div>';
+	$pay_details .= '<div class="deets-line"><span class="deets-title">' . esc_html__( 'Payment Reference:', 'zero-bs-crm' ) . '</span> <span>' . esc_html( $inv_no_str ) . '</span></div>';
+	$pay_details .= '</div>';
 
 	// == Template -> HTML build
 
@@ -1231,7 +1230,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-partials-table'      => $partialsTable, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-pay-button'          => $potentialPayButton, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'pre-invoice-payment-details' => '',
-		'invoice-payment-details'     => $payDetails, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-payment-details'     => $pay_details,
 		'invoice-pay-thanks'          => $payThanks, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		// client portal
@@ -1258,7 +1257,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	// rather than in it's own line:
 	if ( ! empty( $partialsTable ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		// partials, split to two columns
-		$replacements['pre-invoice-payment-details'] = $payDetails; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$replacements['pre-invoice-payment-details'] = $pay_details;
 		$replacements['invoice-payment-details']     = '';
 	}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -1175,14 +1175,14 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	$partials_table .= '</table>';
 
 	// generate a templated paybutton (depends on template :))
-	$potentialPayButton = zeroBSCRM_invoicing_generateInvPart_payButton( $invoiceID, $zbs_stat, $template ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$potential_pay_button = zeroBSCRM_invoicing_generateInvPart_payButton( $invoiceID, $zbs_stat, $template ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	// == Payment terms, thanks etc. will only replace when present in template, so safe to generically check
-	$payThanks = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$pay_thanks = '';
 	if ( $zbs_stat === __( 'Paid', 'zero-bs-crm' ) ) {
-		$payThanks  = '<div class="deets"><h3>' . esc_html__( 'Thank You', 'zero-bs-crm' ) . '</h3>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$payThanks .= '<div>' . nl2br( esc_html( zeroBSCRM_getSetting( 'paythanks' ) ) ) . '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$payThanks .= '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$pay_thanks  = '<div class="deets"><h3>' . esc_html__( 'Thank You', 'zero-bs-crm' ) . '</h3>';
+		$pay_thanks .= '<div>' . nl2br( esc_html( zeroBSCRM_getSetting( 'paythanks' ) ) ) . '</div>';
+		$pay_thanks .= '</div>';
 	}
 	$payment_info_text = zeroBSCRM_getSetting( 'paymentinfo' );
 
@@ -1227,10 +1227,10 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-line-items'          => $lineItems, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-totals-table'        => $totalsTable, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-partials-table'      => $partials_table,
-		'invoice-pay-button'          => $potentialPayButton, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-pay-button'          => $potential_pay_button,
 		'pre-invoice-payment-details' => '',
 		'invoice-payment-details'     => $pay_details,
-		'invoice-pay-thanks'          => $payThanks, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-pay-thanks'          => $pay_thanks,
 
 		// client portal
 		'portal-view-button'          => $view_in_portal_button,

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -939,22 +939,22 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	$inv_ref_styles = 'display:none;'; // none initially
 
 	// ID
-	$thisInvReference = $invoice['id']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$this_inv_reference = $invoice['id'];
 
 	// ID - Portal
 	if ( $template === 'portal' ) {
-		$thisInvReference = __( 'Invoice #', 'zero-bs-crm' ) . ' ' . $thisInvReference; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$this_inv_reference = __( 'Invoice #', 'zero-bs-crm' ) . ' ' . $this_inv_reference;
 	}
 
 	// Reference
 	if ( isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ) {
 
 		// Ref
-		$thisInvReference = $invoice['id_override']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$this_inv_reference = $invoice['id_override'];
 
 		// Ref - Portal
 		if ( $template === 'portal' ) {
-			$thisInvReference = $ref_label . ' ' . $thisInvReference; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$this_inv_reference = $ref_label . ' ' . $this_inv_reference;
 		}
 
 		// and we don't show ID, do show ref label:
@@ -964,11 +964,11 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	}
 
 	// replacement str
-	$invNoStr = $thisInvReference; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$inv_no_str = $this_inv_reference;
 
 	// Portal
 	if ( $template === 'portal' ) {
-		$invNoStr = '<div class="zbs-normal">' . esc_html( $thisInvReference ) . '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$inv_no_str = '<div class="zbs-normal">' . esc_html( $this_inv_reference ) . '</div>';
 	}
 
 	// == Build biz info table.
@@ -1189,7 +1189,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 
 	$payDetails  = '<div class="deets"><h2>' . esc_html__( 'Payment Details', 'zero-bs-crm' ) . '</h2>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$payDetails .= '<div class="deets-line"><span class="deets-content">' . nl2br( esc_html( $payment_info_text ) ) . '</span></div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$payDetails .= '<div class="deets-line"><span class="deets-title">' . esc_html__( 'Payment Reference:', 'zero-bs-crm' ) . '</span> <span>' . esc_html( $invNoStr ) . '</span></div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$payDetails .= '<div class="deets-line"><span class="deets-title">' . esc_html__( 'Payment Reference:', 'zero-bs-crm' ) . '</span> <span>' . esc_html( $inv_no_str ) . '</span></div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$payDetails .= '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 
@@ -1215,10 +1215,10 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'css'                         => $css_url,
 		'logo-class'                  => $logo_class,
 		'logo-url'                    => esc_url( $logo_url ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		'invoice-number'              => $invNoStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-number'              => $inv_no_str,
 		'invoice-date'                => $invDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-id-styles'           => $inv_id_styles,
-		'invoice-ref'                 => $invNoStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-ref'                 => $inv_no_str,
 		'invoice-ref-styles'          => $inv_ref_styles,
 		'invoice-due-date'            => $dueDateStr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-custom-fields'       => $invoice_custom_fields_html,

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -1261,53 +1261,49 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 // Used to generate specific part of invoice pdf: Biz table (Pay To)
 function zeroBSCRM_invoicing_generateInvPart_bizTable($args=array()){
 
-    #} =========== LOAD ARGS ==============
-    $defaultArgs = array(
+	#} =========== LOAD ARGS ==============
+	$defaultArgs = array( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
-        'zbs_biz_name' => '',
-        'zbs_biz_yourname' => '',
-        'zbs_biz_extra' => '',
-        'zbs_biz_youremail' => '',
-        'zbs_biz_yoururl' => '',
+		'zbs_biz_name'      => '',
+		'zbs_biz_yourname'  => '',
+		'zbs_biz_extra'     => '',
+		'zbs_biz_youremail' => '',
+		'zbs_biz_yoururl'   => '',
 
-        'template' => 'pdf' // this'll choose between the html output variants below, e.g. pdf, portal, notification
+		'template'          => 'pdf', // this'll choose between the html output variants below, e.g. pdf, portal, notification
 
     ); foreach ($defaultArgs as $argK => $argV){ $$argK = $argV; if (is_array($args) && isset($args[$argK])) {  if (is_array($args[$argK])){ $newData = $$argK; if (!is_array($newData)) $newData = array(); foreach ($args[$argK] as $subK => $subV){ $newData[$subK] = $subV; }$$argK = $newData;} else { $$argK = $args[$argK]; } } }
-    #} =========== / LOAD ARGS =============
+	#} =========== / LOAD ARGS =============
 
-    $bizInfoTable = '';
+	$biz_info_table = '';
 
-        switch ($template){
+	switch ( $template ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
-            case 'pdf':
-            case 'notification':
+		case 'pdf':
+		case 'notification':
+			$biz_info_table  = '<div class="zbs-line-info zbs-line-info-title">' . esc_html( $zbs_biz_name ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$biz_info_table .= '<div class="zbs-line-info">' . esc_html( $zbs_biz_yourname ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$biz_info_table .= '<div class="zbs-line-info">' . nl2br( esc_html( $zbs_biz_extra ) ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$biz_info_table .= '<div class="zbs-line-info">' . esc_html( $zbs_biz_youremail ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$biz_info_table .= '<div class="zbs-line-info">' . esc_html( $zbs_biz_yoururl ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			break;
 
-                $bizInfoTable = '<div class="zbs-line-info zbs-line-info-title">'.$zbs_biz_name.'</div>';
-                $bizInfoTable .= '<div class="zbs-line-info">'.$zbs_biz_yourname.'</div>';
-                $bizInfoTable .= '<div class="zbs-line-info">'.nl2br($zbs_biz_extra).'</div>';
-                $bizInfoTable .= '<div class="zbs-line-info">'.$zbs_biz_youremail.'</div>';
-                $bizInfoTable .= '<div class="zbs-line-info">'.$zbs_biz_yoururl.'</div>'; 
+		case 'portal':
+			$biz_info_table  = '<div class="pay-to">';
+			$biz_info_table .= '<div class="zbs-portal-label">' . esc_html__( 'Pay To', 'zero-bs-crm' ) . '</div>';
+			$biz_info_table .= '<div class="zbs-portal-biz">';
+			$biz_info_table .= '<div class="pay-to-name">' . esc_html( $zbs_biz_name ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$biz_info_table .= '<div>' . esc_html( $zbs_biz_yourname ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$biz_info_table .= '<div>' . nl2br( esc_html( $zbs_biz_extra ) ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$biz_info_table .= '<div>' . esc_html( $zbs_biz_youremail ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$biz_info_table .= '<div>' . esc_html( $zbs_biz_yoururl ) . '</div>'; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			$biz_info_table .= '</div>';
+			$biz_info_table .= '</div>';
+			break;
 
-            break;
+	}
 
-            case 'portal':
-    
-                $bizInfoTable = '<div class="pay-to">';
-                    $bizInfoTable .= '<div class="zbs-portal-label">' . __('Pay To', 'zero-bs-crm') . '</div>';
-                    $bizInfoTable .= '<div class="zbs-portal-biz">';
-                        $bizInfoTable .= '<div class="pay-to-name">'.$zbs_biz_name.'</div>';
-                        $bizInfoTable .= '<div>'.$zbs_biz_yourname.'</div>';
-                        $bizInfoTable .= '<div>'.nl2br($zbs_biz_extra).'</div>';
-                        $bizInfoTable .= '<div>'.$zbs_biz_youremail.'</div>';
-                        $bizInfoTable .= '<div>'.$zbs_biz_yoururl.'</div>';
-                    $bizInfoTable .= '</div>';
-                $bizInfoTable .= '</div>';
-
-            break;
-
-        }
-
-    return $bizInfoTable;
+	return $biz_info_table;
 }
 // Used to generate specific part of invoice pdf: (Customer table)
 function zeroBSCRM_invoicing_generateInvPart_custTable($invTo=array(),$template='pdf'){

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -1305,65 +1305,87 @@ function zeroBSCRM_invoicing_generateInvPart_bizTable($args=array()){
 
 	return $biz_info_table;
 }
-// Used to generate specific part of invoice pdf: (Customer table)
-function zeroBSCRM_invoicing_generateInvPart_custTable($invTo=array(),$template='pdf'){
+/** // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag,Generic.Commenting.DocComment.MissingShort
+ * Used to generate specific part of invoice pdf: (Customer table)
+ **/
+function zeroBSCRM_invoicing_generateInvPart_custTable( $inv_to = array(), $template = 'pdf' ) {
 
-    $invoice_customer_info_table_html = '<div class="customer-info-wrapped">';
+	$invoice_customer_info_table_html = '<div class="customer-info-wrapped">';
 
-        switch ($template){
+	switch ( $template ) {
+		case 'pdf':
+		case 'notification':
+			if ( isset( $inv_to['fname'] ) && isset( $inv_to['fname'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info zbs-line-info-title">' . esc_html( $inv_to['fname'] ) . ' ' . esc_html( $inv_to['lname'] ) . '</div>';
+			}
+			if ( isset( $inv_to['addr1'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $inv_to['addr1'] ) . '</div>';
+			}
+			if ( isset( $inv_to['addr2'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $inv_to['addr2'] ) . '</div>';
+			}
+			if ( isset( $inv_to['city'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $inv_to['city'] ) . '</div>';
+			}
+			if ( isset( $inv_to['county'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $inv_to['county'] ) . '</div>';
+			}
+			if ( isset( $inv_to['postcode'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $inv_to['postcode'] ) . '</div>';
+			}
+			if ( isset( $inv_to['country'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="zbs-line-info">' . esc_html( $inv_to['country'] ) . '</div>';
+			}
 
-            case 'pdf':
-            case 'notification':
+			// Append custom fields if specified in settings
+			$invoice_customer_info_table_html .= jpcrm_invoicing_generate_customer_custom_fields_lines( $inv_to, $template );
 
-                if (isset($invTo['fname']) && isset($invTo['fname'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info zbs-line-info-title">'.$invTo['fname'].' ' .$invTo['lname'] . '</div>';
-                if (isset($invTo['addr1'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$invTo['addr1'].'</div>';
-                if (isset($invTo['addr2'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$invTo['addr2'].'</div>';
-                if (isset($invTo['city'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$invTo['city'].'</div>';
-                if (isset($invTo['county'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$invTo['county'].'</div>';
-                if (isset($invTo['postcode'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$invTo['postcode'].'</div>';
-                if (isset($invTo['country'])) $invoice_customer_info_table_html .= '<div class="zbs-line-info">'.$invTo['country'].'</div>';
+			// the abilty to add in extra info to the customer info area.
+			$extra_cust_info = '';
+			$extra_cust_info = apply_filters( 'zbs_invoice_customer_info_line', $extra_cust_info );
 
-                // Append custom fields if specified in settings
-                $invoice_customer_info_table_html .= jpcrm_invoicing_generate_customer_custom_fields_lines( $invTo, $template );
+			$invoice_customer_info_table_html .= $extra_cust_info;
+			break;
 
-                // the abilty to add in extra info to the customer info area.
-                $extraCustInfo = '';
-                $extraCustInfo = apply_filters('zbs_invoice_customer_info_line', $extraCustInfo);
-                $invoice_customer_info_table_html .= $extraCustInfo;
+		case 'portal':
+			$invoice_customer_info_table_html .= '<div class="pay-to">';
+			$invoice_customer_info_table_html .= '<div class="zbs-portal-label">' . esc_html__( 'Invoice To', 'zero-bs-crm' ) . '</div><div style="margin-top:18px;">&nbsp;</div>';
+			$invoice_customer_info_table_html .= '<div class="zbs-portal-biz">';
+			if ( isset( $inv_to['fname'] ) && isset( $inv_to['fname'] ) ) {
+				$invoice_customer_info_table_html .= '<div class="pay-to-name">' . esc_html( $inv_to['fname'] ) . ' ' . esc_html( $inv_to['lname'] ) . '</div>';
+			}
+			if ( isset( $inv_to['addr1'] ) ) {
+				$invoice_customer_info_table_html .= '<div>' . esc_html( $inv_to['addr1'] ) . '</div>';
+			}
+			if ( isset( $inv_to['addr2'] ) ) {
+				$invoice_customer_info_table_html .= '<div>' . esc_html( $inv_to['addr2'] ) . '</div>';
+			}
+			if ( isset( $inv_to['city'] ) ) {
+				$invoice_customer_info_table_html .= '<div>' . esc_html( $inv_to['city'] ) . '</div>';
+			}
+			if ( isset( $inv_to['postcode'] ) ) {
+				$invoice_customer_info_table_html .= '<div>' . esc_html( $inv_to['postcode'] ) . '</div>';
+			}
 
-            break;
+			// Append custom fields if specified in settings
+			$invoice_customer_info_table_html .= jpcrm_invoicing_generate_customer_custom_fields_lines( $inv_to, $template );
 
-            case 'portal':
-                
-                $invoice_customer_info_table_html .= '<div class="pay-to">';
-                    $invoice_customer_info_table_html .= '<div class="zbs-portal-label">' . __('Invoice To', 'zero-bs-crm') . '</div><div style="margin-top:18px;">&nbsp;</div>';
-                    $invoice_customer_info_table_html .= '<div class="zbs-portal-biz">';
-                        if (isset($invTo['fname']) && isset($invTo['fname'])) $invoice_customer_info_table_html .= '<div class="pay-to-name">'.$invTo['fname'].' ' .$invTo['lname'] . '</div>';
-                        if (isset($invTo['addr1'])) $invoice_customer_info_table_html .= '<div>'.$invTo['addr1'].'</div>';
-                        if (isset($invTo['addr2'])) $invoice_customer_info_table_html .= '<div>'.$invTo['addr2'].'</div>';
-                        if (isset($invTo['city'])) $invoice_customer_info_table_html .= '<div>'.$invTo['city'].'</div>';
-                        if (isset($invTo['postcode'])) $invoice_customer_info_table_html .= '<div>'.$invTo['postcode'].'</div>';
+			// the abilty to add in extra info to the customer info area.
+			$extra_cust_info = apply_filters( 'zbs_invoice_customer_info_line', '' );
 
-                        // Append custom fields if specified in settings
-                        $invoice_customer_info_table_html .= jpcrm_invoicing_generate_customer_custom_fields_lines( $invTo, $template );
+			$invoice_customer_info_table_html .= $extra_cust_info;
+			$invoice_customer_info_table_html .= '</div>';
+			$invoice_customer_info_table_html .= '</div>';
+			break;
 
-                        // the abilty to add in extra info to the customer info area.
-                        $extraCustInfo = apply_filters('zbs_invoice_customer_info_line', '');
-                        $invoice_customer_info_table_html .= $extraCustInfo;
+	}
 
-                    $invoice_customer_info_table_html .= '</div>';
-                $invoice_customer_info_table_html .= '</div>';
+		$invoice_customer_info_table_html .= '</div>';
 
-            break;
+		//filter the whole thing if you really want to modify it
+		$invoice_customer_info_table_html = apply_filters( 'zbs_invoice_customer_info_table', $invoice_customer_info_table_html );
 
-        }
-
-    $invoice_customer_info_table_html .= '</div>';
-
-    //filter the whole thing if you really want to modify it
-    $invoice_customer_info_table_html = apply_filters('zbs_invoice_customer_info_table', $invoice_customer_info_table_html);
-
-    return $invoice_customer_info_table_html;
+		return $invoice_customer_info_table_html;
 }
 
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -825,28 +825,28 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	if ( $template === 'portal' ) {
 
 		// portal version: Includes status label and amount (shown at top of portal invoice)
-		$topStatus  = '<div class="zbs-portal-label">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$topStatus .= esc_html( $zbs_stat ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$topStatus .= '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$top_status  = '<div class="zbs-portal-label">';
+		$top_status .= esc_html( $zbs_stat );
+		$top_status .= '</div>';
 		// WH added quickly to get around fact this is sometimes empty, please tidy when you address currency formatting :)
 		$inv_g_total = '';
 		if ( isset( $invoice['total'] ) ) {
 			$inv_g_total = zeroBSCRM_formatCurrency( $invoice['total'] );
 		}
-		$topStatus .= '<h1 class="zbs-portal-value">' . esc_html( $inv_g_total ) . '</h1>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$top_status .= '<h1 class="zbs-portal-value">' . esc_html( $inv_g_total ) . '</h1>';
 		if ( $zbs_stat === __( 'Paid', 'zero-bs-crm' ) ) {
-			$topStatus .= '<div class="zbs-invoice-paid"><i class="fa fa-check"></i>' . esc_html__( 'Paid', 'zero-bs-crm' ) . '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$top_status .= '<div class="zbs-invoice-paid"><i class="fa fa-check"></i>' . esc_html__( 'Paid', 'zero-bs-crm' ) . '</div>';
 		}
 	} elseif ( $template === 'pdf' ) {
 
 		// pdf status
 		if ( $zbs_stat === __( 'Paid', 'zero-bs-crm' ) ) {
 
-			$topStatus = '<div class="jpcrm-invoice-status jpcrm-invoice-paid">' . esc_html__( 'Paid', 'zero-bs-crm' ) . '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$top_status = '<div class="jpcrm-invoice-status jpcrm-invoice-paid">' . esc_html__( 'Paid', 'zero-bs-crm' ) . '</div>';
 
 		} else {
 
-			$topStatus = '<div class="jpcrm-invoice-status">' . esc_html( $zbs_stat ) . '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$top_status = '<div class="jpcrm-invoice-status">' . esc_html( $zbs_stat ) . '</div>';
 
 		}
 	}
@@ -1220,7 +1220,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		'invoice-custom-fields'       => $invoice_custom_fields_html,
 		'invoice-biz-class'           => $biz_info_class,
 		'invoice-customer-info'       => $invoice_customer_info_table_html,
-		'invoice-html-status'         => $topStatus, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		'invoice-html-status'         => $top_status,
 		'invoice-table-headers'       => $tableHeaders, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-line-items'          => $lineItems, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		'invoice-totals-table'        => $totalsTable, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -867,35 +867,33 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	// switch for Company if set...
 	if ( $zbsCompanyID > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
-		$invTo = zeroBS_getCompany( $zbsCompanyID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		if ( is_array( $invTo ) && ( isset( $invTo['name'] ) || isset( $invTo['coname'] ) ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$inv_to = zeroBS_getCompany( $zbsCompanyID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		if ( is_array( $inv_to ) && ( isset( $inv_to['name'] ) || isset( $inv_to['coname'] ) ) ) {
 
-			if ( isset( $invTo['name'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				$invTo['fname'] = $invTo['name']; // DAL3
+			if ( isset( $inv_to['name'] ) ) {
+				$inv_to['fname'] = $inv_to['name']; // DAL3
 			}
-			if ( isset( $invTo['coname'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				$invTo['fname'] = $invTo['coname']; // DAL2
+			if ( isset( $inv_to['coname'] ) ) {
+				$inv_to['fname'] = $inv_to['coname']; // DAL2
 			}
-			$invTo['lname'] = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$inv_to['lname'] = '';
 
 		} else {
 
-			$invTo = array( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$inv_to = array(
 				'fname' => '',
 				'lname' => '',
 			);
 		}
 
 		// object type flag used downstream, I wonder if we should put these in at the DAL level..
-		$invTo['objtype'] = ZBS_TYPE_COMPANY; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$inv_to['objtype'] = ZBS_TYPE_COMPANY;
 	} else {
 
-		$invTo = $zbs->DAL->contacts->getContact( $zbsCustomerID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$inv_to = $zbs->DAL->contacts->getContact( $zbsCustomerID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		// object type flag used downstream, I wonder if we should put these in at the DAL level..
-		$invTo['objtype'] = ZBS_TYPE_CONTACT; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$inv_to['objtype'] = ZBS_TYPE_CONTACT;
 	}
 
 	// is this stored same format?
@@ -993,7 +991,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	);
 
 	// generate a templated customer info table
-	$invoice_customer_info_table_html = zeroBSCRM_invoicing_generateInvPart_custTable( $invTo, $template ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$invoice_customer_info_table_html = zeroBSCRM_invoicing_generateInvPart_custTable( $inv_to, $template );
 
 	// == Lineitem table > Column headers
 	// generate a templated customer info table
@@ -1266,8 +1264,8 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		$html,
 		$replacements,
 		array(
-			ZBS_TYPE_INVOICE  => $invoice,
-			$invTo['objtype'] => $invTo, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			ZBS_TYPE_INVOICE   => $invoice,
+			$inv_to['objtype'] => $inv_to,
 		)
 	);
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -788,13 +788,13 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	);
 
 	// retrieve
-	$zbsCustomerID = -1; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$zbs_customer_id = -1;
 	if ( is_array( $invoice ) && isset( $invoice['contact'] ) && is_array( $invoice['contact'] ) && count( $invoice['contact'] ) > 0 ) {
-		$zbsCustomerID = $invoice['contact'][0]['id']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$zbs_customer_id = $invoice['contact'][0]['id'];
 	}
-	$zbsCompanyID = -1; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$zbs_company_id = -1;
 	if ( is_array( $invoice ) && isset( $invoice['company'] ) && is_array( $invoice['company'] ) && count( $invoice['company'] ) > 0 ) {
-		$zbsCompanyID = $invoice['company'][0]['id']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$zbs_company_id = $invoice['company'][0]['id'];
 	}
 
 	// date
@@ -865,9 +865,9 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	}
 
 	// switch for Company if set...
-	if ( $zbsCompanyID > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	if ( $zbs_company_id > 0 ) {
 
-		$inv_to = zeroBS_getCompany( $zbsCompanyID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$inv_to = zeroBS_getCompany( $zbs_company_id );
 		if ( is_array( $inv_to ) && ( isset( $inv_to['name'] ) || isset( $inv_to['coname'] ) ) ) {
 
 			if ( isset( $inv_to['name'] ) ) {
@@ -890,7 +890,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 		$inv_to['objtype'] = ZBS_TYPE_COMPANY;
 	} else {
 
-		$inv_to = $zbs->DAL->contacts->getContact( $zbsCustomerID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$inv_to = $zbs->DAL->contacts->getContact( $zbs_customer_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		// object type flag used downstream, I wonder if we should put these in at the DAL level..
 		$inv_to['objtype'] = ZBS_TYPE_CONTACT;

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -745,16 +745,19 @@ function zeroBSCRM_invoicing_generateStatementHTML_v3($contactID=-1,$return=true
     return false;
 }
 
-
-// Generate an invoice as html (where the actual holder-html is passed)
-// ... this is a refactor of what was being replicated 3 places 
-// ... 1) Invoice PDF Gen (zeroBSCRM_invoice_generateInvoiceHTML)
-// ... 2) Invoice Portal Gen (zeroBSCRM_invoice_generatePortalInvoiceHTML)
-// ... 3) Invoice email notification Gen (zeroBSCRM_invoice_generateNotificationHTML in mail-templating.php)
-// ... now the generic element of the above are all wired through here :) 
-// Note:
-// $template is crucial. pdf | portal | notification *currently v3.0
-function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$html=''){
+// phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag,Generic.Commenting.DocComment.MissingShort
+/**
+ *
+ * Generate an invoice as html (where the actual holder-html is passed)
+ * ... this is a refactor of what was being replicated 3 places
+ * ... 1) Invoice PDF Gen (zeroBSCRM_invoice_generateInvoiceHTML)
+ * ... 2) Invoice Portal Gen (zeroBSCRM_invoice_generatePortalInvoiceHTML)
+ * ... 3) Invoice email notification Gen (zeroBSCRM_invoice_generateNotificationHTML in mail-templating.php)
+ * ... now the generic element of the above are all wired through here :)
+ * Note:
+ * $template is crucial. pdf | portal | notification *currently v3.0
+ **/
+function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 'pdf', $html = '' ) {
 
 	global $zbs;
 
@@ -762,7 +765,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	$placeholder_templating = $zbs->get_templating();
 
 	// need this.
-	if ( $invoiceID <= 0 || $html == '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,Universal.Operators.StrictComparisons.LooseEqual
+	if ( $invoice_id <= 0 || $html == '' ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 		return '';
 	}
 
@@ -772,7 +775,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	// ================== DATA RETRIEVAL ===================================
 
 	$invoice = $zbs->DAL->invoices->getInvoice( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$invoiceID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$invoice_id,
 		array(
 
 			// we want all this:
@@ -1168,7 +1171,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 	$partials_table .= '</table>';
 
 	// generate a templated paybutton (depends on template :))
-	$potential_pay_button = zeroBSCRM_invoicing_generateInvPart_payButton( $invoiceID, $zbs_stat, $template ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$potential_pay_button = zeroBSCRM_invoicing_generateInvPart_payButton( $invoice_id, $zbs_stat, $template );
 
 	// == Payment terms, thanks etc. will only replace when present in template, so safe to generically check
 	$pay_thanks = '';
@@ -1194,7 +1197,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML($invoiceID=-1,$template='pdf',$
 
 	// got portal?
 	if ( zeroBSCRM_isExtensionInstalled( 'portal' ) ) {
-		$view_in_portal_link   = zeroBSCRM_portal_linkObj( $invoiceID, ZBS_TYPE_INVOICE ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$view_in_portal_link   = zeroBSCRM_portal_linkObj( $invoice_id, ZBS_TYPE_INVOICE );
 		$view_in_portal_button = '<div style="text-align:center;margin:1em;margin-top:2em">' . zeroBSCRM_mailTemplate_emailSafeButton( $view_in_portal_link, esc_html__( 'View Invoice', 'zero-bs-crm' ) ) . '</div>';
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3015 - escape invoice html

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR escapes output in the invoice builder. However, the bulk of the work was dealing with the linter (each small change  triggered a cascade of linting errors). On the plus side, the code should be significantly easier to read.

No logic should have been impacted by this PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Ideally if all is well, there should be no outward-facing change.

