### PR TITLE
VideoPress: change the way to propagate the Preview On Hover data

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-expose-poh-data-by-using-script-element
+++ b/projects/packages/videopress/changelog/update-videopress-expose-poh-data-by-using-script-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: change the way to propagate the Preview On Hover data

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
@@ -52,8 +52,6 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 		} ),
 	} );
 
-	const previewAtTimeJSON = previewOnHover ? { previewAtTime, previewLoopDuration } : null;
-
 	const videoPressUrl = getVideoPressUrl( guid, {
 		autoplay,
 		controls,
@@ -80,7 +78,13 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 			{ videoPressUrl && (
 				<>
 					{ previewOnHover && (
-						<script type="application/json">{ JSON.stringify( previewAtTimeJSON ) }</script>
+						<span
+							style={ { display: 'none', visibility: 'hidden', position: 'absolute' } }
+							className="videopress-poh"
+						>
+							<span className="videopress-poh__sp">{ previewAtTime }</span>
+							<span className="videopress-poh__duration">{ previewLoopDuration }</span>
+						</span>
 					) }
 					<div className="jetpack-videopress-player__wrapper">
 						{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
@@ -52,12 +52,7 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 		} ),
 	} );
 
-	if ( previewOnHover && [ previewAtTime, previewLoopDuration ].every( value => value != null ) ) {
-		blockProps[ 'data-preview-on-hover' ] = JSON.stringify( {
-			previewAtTime,
-			previewLoopDuration,
-		} );
-	}
+	const previewAtTimeJSON = previewOnHover ? { previewAtTime, previewLoopDuration } : null;
 
 	const videoPressUrl = getVideoPressUrl( guid, {
 		autoplay,
@@ -83,9 +78,14 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 	return (
 		<figure { ...blockProps } style={ style }>
 			{ videoPressUrl && (
-				<div className="jetpack-videopress-player__wrapper">
-					{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
-				</div>
+				<>
+					{ previewOnHover && (
+						<script type="application/json">{ JSON.stringify( previewAtTimeJSON ) }</script>
+					) }
+					<div className="jetpack-videopress-player__wrapper">
+						{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
+					</div>
+				</>
 			) }
 
 			{ ! RichText.isEmpty( caption ) && (

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -2,14 +2,62 @@
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
+/**
+ * Preview on Hover effect for VideoPress videos.
+ *
+ * @returns {void}
+ */
+function previewOnHoverEffect(): void {
+	/*
+	 * Pick all VideoPress video block intances,
+	 * based on the class name.
+	 */
+	const videoPlayers = document.querySelectorAll( '.wp-block-videopress-video' );
+	if ( videoPlayers.length === 0 ) {
+		return;
+	}
+
+	videoPlayers.forEach( function ( videoPlayerElement: HTMLDivElement ) {
+		// Get the iFrame element.
+		const iFrame = videoPlayerElement.querySelector( 'iframe' );
+		if ( ! iFrame ) {
+			return;
+		}
+
+		// Get the data container element.
+		const dataContainer: HTMLScriptElement = videoPlayerElement.querySelector(
+			'script[type="application/json"]'
+		);
+
+		/*
+		 * Try to pick the POH data from the data container element.
+		 * If it fails, log the error and return.
+		 */
+		let previewOnHoverData: {
+			previewAtTime: number;
+			previewLoopDuration: number;
+		};
+
+		try {
+			previewOnHoverData = JSON.parse( dataContainer.text );
+		} catch ( error ) {
+			console.error( error ); // eslint-disable-line no-console
+			return;
+		}
+
+		// Clean the data container element. It isn't needed anymore.
+		dataContainer.remove();
+
+		console.log( 'previewOnHoverData: ', previewOnHoverData ); // eslint-disable-line no-console
+	} );
+}
+
 domReady( function () {
-	// eslint-disable-next-line no-console
-	console.log( __( 'VideoPress init', 'jetpack-videopress-pkg' ) );
+	previewOnHoverEffect();
 } );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -32,15 +32,21 @@ function previewOnHoverEffect(): void {
 
 		// Get the data container element.
 		const dataContainer = videoPlayerElement.querySelector( 'span.videopress-poh' );
+		if ( ! dataContainer ) {
+			return;
+		}
 
 		/*
 		 * Try to pick the POH data from the data container element.
 		 * If it fails, log the error and return.
 		 */
 		const previewOnHoverData = {
-			previewAtTime: dataContainer.querySelector( 'span.videopress-poh__sp' )?.textContent,
-			previewLoopDuration: dataContainer.querySelector( 'span.videopress-poh__duration' )
-				?.textContent,
+			previewAtTime: Number(
+				dataContainer.querySelector( 'span.videopress-poh__sp' )?.textContent
+			),
+			previewLoopDuration: Number(
+				dataContainer.querySelector( 'span.videopress-poh__duration' )?.textContent
+			),
 		};
 
 		// Clean the data container element. It isn't needed anymore.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -31,25 +31,17 @@ function previewOnHoverEffect(): void {
 		}
 
 		// Get the data container element.
-		const dataContainer: HTMLScriptElement = videoPlayerElement.querySelector(
-			'script[type="application/json"]'
-		);
+		const dataContainer = videoPlayerElement.querySelector( 'span.videopress-poh' );
 
 		/*
 		 * Try to pick the POH data from the data container element.
 		 * If it fails, log the error and return.
 		 */
-		let previewOnHoverData: {
-			previewAtTime: number;
-			previewLoopDuration: number;
+		const previewOnHoverData = {
+			previewAtTime: dataContainer.querySelector( 'span.videopress-poh__sp' )?.textContent,
+			previewLoopDuration: dataContainer.querySelector( 'span.videopress-poh__duration' )
+				?.textContent,
 		};
-
-		try {
-			previewOnHoverData = JSON.parse( dataContainer.text );
-		} catch ( error ) {
-			console.error( error ); // eslint-disable-line no-console
-			return;
-		}
 
 		// Clean the data container element. It isn't needed anymore.
 		dataContainer.remove();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: change the way to propagate the Preview On Hover data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a few VideoPress block instances
* Enable pOH feature. Set different starting points and durations for them
* Save the post
* Go to the front end
* Confirm the console shows the starting point and duration values

<img width="570" alt="Screen Shot 2023-04-04 at 16 56 15" src="https://user-images.githubusercontent.com/77539/229905663-96c3e07f-ecd7-49e1-8cf1-5e884010dfaf.png">
