### PR TITLE
VideoPress: enqueue the VideoPress IFrame API asset file

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-enqueue-iframe-api-asset-file-version
+++ b/projects/packages/videopress/changelog/update-videopress-enqueue-iframe-api-asset-file-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: update URL and add version when enqueuing VideoPress IFrame API file

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -230,7 +230,7 @@ class Initializer {
 
 		wp_enqueue_script(
 			self::JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER . '-iframe-api',
-			'https://wordpress.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
+			'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
 			array(),
 			'1.0.0',
 			false

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -231,7 +231,9 @@ class Initializer {
 		wp_enqueue_script(
 			self::JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER . '-iframe-api',
 			'https://wordpress.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
-			array()
+			array(),
+			'1.0.0',
+			false
 		);
 
 		// Register VideoPress video block.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -231,9 +231,7 @@ class Initializer {
 		wp_enqueue_script(
 			self::JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER . '-iframe-api',
 			'https://wordpress.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
-			array(),
-			'1.0.0',
-			false
+			array()
 		);
 
 		// Register VideoPress video block.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -232,7 +232,7 @@ class Initializer {
 			self::JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER . '-iframe-api',
 			'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
 			array(),
-			'1.0.0',
+			gmdate( 'YW' ),
 			false
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: enqueue the VideoPress IFrame API asset file

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test in the front end and block editor contexts
* Open the network tab
* Filter JS files
* Filter by `iframe-api` 
* Confirm the file is loaded in the client

<img width="867" alt="Screen Shot 2023-04-04 at 17 07 08" src="https://user-images.githubusercontent.com/77539/229908351-92d1d4d7-d4c7-48af-bcfc-d531787fdd56.png">
