### PR TITLE
VideoPress: Fix minimum loop duration and default hover values

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-hover-default
+++ b/projects/packages/videopress/changelog/fix-videopress-hover-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix minimum loop duration and default hover values

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -332,12 +332,6 @@ export function VideoHoverPreviewControl( {
 		Math.min( MAX_LOOP_DURATION, videoDuration - previewAtTime )
 	);
 
-	useEffect( () => {
-		if ( loopDuration > maxLoopDuration ) {
-			onLoopDurationChange( maxLoopDuration );
-		}
-	}, [ maxLoopDuration ] );
-
 	const loopDurationHelp = createInterpolateElement(
 		sprintf(
 			/* translators: placeholder is the maximum lapse duration for the previewOnHover */
@@ -371,7 +365,14 @@ export function VideoHoverPreviewControl( {
 						value={ previewAtTime }
 						onDebounceChange={ timestamp => {
 							onPreviewAtTimeChange( timestamp );
-							setMaxLoopDuration( Math.min( MAX_LOOP_DURATION, videoDuration - timestamp ) );
+
+							const max = Math.min( MAX_LOOP_DURATION, videoDuration - timestamp );
+							setMaxLoopDuration( max );
+
+							// Adjust loop duration if it's needed
+							if ( loopDuration > max ) {
+								onLoopDurationChange( max );
+							}
 						} }
 						wait={ 100 }
 						disabled={ disabled }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -37,7 +37,7 @@ import './style.scss';
  * Types
  */
 import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../../../types';
-import type { PosterPanelProps, VideoControlProps, VideoGUID } from '../../types';
+import type { PosterDataProps, PosterPanelProps, VideoControlProps, VideoGUID } from '../../types';
 import type React from 'react';
 
 const MIN_LOOP_DURATION = 3 * 1000;
@@ -430,11 +430,22 @@ export default function PosterPanel( {
 
 	const onPreviewOnHoverChange = useCallback(
 		( shouldPreviewOnHover: boolean ) => {
+			let newPosterData: PosterDataProps = {
+				...attributes.posterData,
+				previewOnHover: shouldPreviewOnHover,
+			};
+
+			// Add default values for the preview options on activation
+			if ( shouldPreviewOnHover ) {
+				newPosterData = {
+					previewAtTime,
+					previewLoopDuration,
+					...newPosterData,
+				};
+			}
+
 			setAttributes( {
-				posterData: {
-					...attributes.posterData,
-					previewOnHover: shouldPreviewOnHover,
-				},
+				posterData: newPosterData,
 			} );
 		},
 		[ attributes ]

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -332,6 +332,12 @@ export function VideoHoverPreviewControl( {
 		Math.min( MAX_LOOP_DURATION, videoDuration - previewAtTime )
 	);
 
+	useEffect( () => {
+		if ( loopDuration > maxLoopDuration ) {
+			onLoopDurationChange( maxLoopDuration );
+		}
+	}, [ maxLoopDuration ] );
+
 	const loopDurationHelp = createInterpolateElement(
 		sprintf(
 			/* translators: placeholder is the maximum lapse duration for the previewOnHover */
@@ -373,6 +379,7 @@ export function VideoHoverPreviewControl( {
 
 					<TimestampControl
 						max={ maxLoopDuration }
+						min={ MIN_LOOP_DURATION }
 						fineAdjustment={ 1 }
 						decimalPlaces={ 2 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -236,7 +236,8 @@ export const TimestampInput = ( {
 export const TimestampControl = ( props: TimestampControlProps ): React.ReactElement => {
 	const {
 		disabled = false,
-		max,
+		min = 0,
+		max = Number.MAX_SAFE_INTEGER,
 		value,
 		onChange,
 		onDebounceChange,
@@ -264,11 +265,15 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 				newValue = max;
 			}
 
+			if ( newValue < min ) {
+				newValue = min;
+			}
+
 			setControledValue( newValue );
 			onChange?.( newValue );
 			debounceTimer.current = setTimeout( onDebounceChange?.bind( null, newValue ), wait );
 		},
-		[ onDebounceChange, onChange, max, wait ]
+		[ onDebounceChange, onChange, max, min, wait ]
 	);
 
 	return (
@@ -288,7 +293,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 				<RangeControl
 					disabled={ disabled }
 					className={ styles[ 'timestamp-range-control' ] }
-					min={ 0 }
+					min={ min }
 					step={ fineAdjustment }
 					initialPosition={ controledValue }
 					value={ controledValue }

--- a/projects/packages/videopress/src/client/components/timestamp-control/types.ts
+++ b/projects/packages/videopress/src/client/components/timestamp-control/types.ts
@@ -8,6 +8,7 @@ export type DecimalPlacesProp = 1 | 2 | 3;
 export type TimestampInputProps = {
 	disabled?: boolean;
 	value: number;
+	min?: number;
 	max?: number;
 	fineAdjustment?: number;
 	onChange?: ( ms: number ) => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29917
Fixes #29919

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the default values when first enabling hover effect and checks for minimum loop duration

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add a VideoPress video block
* Go to the `Poster and preview` panel
* Enable the preview on hover feature and do not change the default values
* Save the post and reload
* Check the block attributes for the `previewAtTime` and `previewLoopDuration` values, they should be persisted with the default values
* Change the starting point to a value that makes the maximum loop duration value get below the current loop duration
* Check that the loop duration is updated to the max value

https://user-images.githubusercontent.com/8486249/229915226-0feebb08-9804-4e48-9bde-8af9501dc170.mp4
