### PR TITLE
VideoPress: check if beta extension is enabled when saving VideoPress video block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-check-beta-extensions-when-saving
+++ b/projects/packages/videopress/changelog/update-videopress-check-beta-extensions-when-saving
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: check if beta extensions are enabled when saving VideoPress video block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
@@ -10,6 +10,7 @@ import { getVideoPressUrl } from '../../../lib/url';
 /**
  * Types
  */
+import { isVideoFramePosterEnabled } from './components/poster-panel';
 import type { VideoBlockAttributes } from './types';
 import type React from 'react';
 
@@ -52,11 +53,16 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 		} ),
 	} );
 
+	const isPreviewOnHoverEnabled = isVideoFramePosterEnabled();
+
+	const autoplayArg = ! isPreviewOnHoverEnabled ? autoplay : autoplay || posterData.previewOnHover;
+	const mutedArg = ! isPreviewOnHoverEnabled ? muted : muted || posterData.previewOnHover;
+
 	const videoPressUrl = getVideoPressUrl( guid, {
-		autoplay: autoplay || posterData.previewOnHover, // enabled when `previewOnHover` is enabled.
+		autoplay: autoplayArg,
 		controls,
 		loop,
-		muted: muted || posterData.previewOnHover, // enabled when `previewOnHover` is enabled.
+		muted: mutedArg,
 		playsinline,
 		preload,
 		seekbarColor,
@@ -71,6 +77,22 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 	if ( maxWidth && maxWidth.length > 0 && '100%' !== maxWidth ) {
 		style.maxWidth = maxWidth;
 		style.margin = 'auto';
+	}
+
+	if ( ! isVideoFramePosterEnabled() ) {
+		return (
+			<figure { ...blockProps } style={ style }>
+				{ videoPressUrl && (
+					<div className="jetpack-videopress-player__wrapper">
+						{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
+					</div>
+				) }
+
+				{ ! RichText.isEmpty( caption ) && (
+					<RichText.Content tagName="figcaption" value={ caption } />
+				) }
+			</figure>
+		);
 	}
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR checks if the `beta` extension of the "Preview On Hover" feature is enabled when the block saves. If it isn't, the function will return the same makeup generated when the feature is disabled. Otherwise, it will return the new one.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: check if beta extension is enabled when saving VideoPress video block

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with an old post with a VideoPress video instance. In case you don't have, you can:
  * Create a JN site
  * Connect the site. Enable the VideoPress module
  * Do not enable beta extension
  * Create a Post
  * Add a VideoPress video block
  * Save the post
* Test with Jetpack Beta plugin
* Switch Jetpack plugin with this branch `update/videopress-check-beta-extensions-when-saving`
* Go to the testing post
* Hard-refresh
* Confirm the block doesn't have validation issues
* Enable beta exensions
* Confirm the block doesn't have validation issues
* Confirm the PreviewOnHover feature is there (block sidebar)

<img width="300" alt="Screen Shot 2023-04-04 at 19 01 45" src="https://user-images.githubusercontent.com/77539/229932633-7ccaf23e-540d-4277-9fdd-4acaaf06cfcc.png">
