### PR TITLE
My Jetpack: Use Product Detail Table for Jetpack Boost

### DIFF
--- a/projects/js-packages/components/changelog/use-wide-tooltips-in-pricing-table
+++ b/projects/js-packages/components/changelog/use-wide-tooltips-in-pricing-table
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update tooltips in pricing table to use wide variant when both title and content is present.
+
+

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -93,7 +93,9 @@ export const PricingTableItem: React.FC< PricingTableItemProps > = ( {
 					offset={ 4 }
 					wide={ Boolean( tooltipTitle && tooltipInfo ) }
 				>
-					<Text variant="body-small">{ tooltipInfo || defaultTooltipInfo }</Text>
+					<Text variant="body-small" component="div">
+						{ tooltipInfo || defaultTooltipInfo }
+					</Text>
 				</IconTooltip>
 			) }
 		</div>

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -91,6 +91,7 @@ export const PricingTableItem: React.FC< PricingTableItemProps > = ( {
 					placement={ 'bottom-end' }
 					iconSize={ 14 }
 					offset={ 4 }
+					wide={ Boolean( tooltipTitle && tooltipInfo ) }
 				>
 					<Text variant="body-small">{ tooltipInfo || defaultTooltipInfo }</Text>
 				</IconTooltip>
@@ -167,6 +168,7 @@ const PricingTable: React.FC< PricingTableProps > = ( {
 										placement={ 'bottom-end' }
 										iconSize={ 14 }
 										offset={ 4 }
+										wide={ Boolean( item.tooltipTitle && item.tooltipInfo ) }
 									>
 										<Text variant="body-small">{ item.tooltipInfo }</Text>
 									</IconTooltip>

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.33.0",
+	"version": "0.33.1-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
@@ -44,6 +44,7 @@ const ProductDetailTableColumn = ( {
 		featuresByTier = [],
 		pricingForUi: { tiers: tiersPricingForUi },
 		title,
+		postActivationUrl,
 	} = detail;
 
 	// Extract the pricing details for the provided tier.
@@ -60,7 +61,7 @@ const ProductDetailTableColumn = ( {
 	const { run: runCheckout, hasCheckoutStarted } = useProductCheckoutWorkflow( {
 		from: 'my-jetpack',
 		productSlug: wpcomProductSlug,
-		redirectUrl: myJetpackUrl,
+		redirectUrl: postActivationUrl || myJetpackUrl,
 		siteSuffix,
 	} );
 

--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/stories/mock-data.js
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/stories/mock-data.js
@@ -25,7 +25,8 @@ export const boostProductData = {
 					description: 'Must be done manually',
 					info: {
 						title: 'Manual Critical CSS regeneration',
-						content: `To enhance the speed of your site, with this plan you will need to optimize CSS by using the Manual Critical CSS generation feature whenever you:<br><br>
+						content: `
+							<p>To enhance the speed of your site, with this plan you will need to optimize CSS by using the Manual Critical CSS generation feature whenever you:</p>
 							<ul>
 								<li>Make theme changes.</li>
 								<li>Write a new post/page.</li>
@@ -41,8 +42,8 @@ export const boostProductData = {
 					description: 'Automatically updated',
 					info: {
 						title: 'Automatic Critical CSS regeneration',
-						content:
-							'It’s essential to regenerate Critical CSS to optimize your site speed whenever your HTML or CSS structure changes. Being on top of this can be tedious and time-consuming.<br><br>Boost’s cloud service can automatically detect when your site needs the Critical CSS regenerated, and perform this function behind the scenes without requiring you to monitor it manually.',
+						content: `<p>It’s essential to regenerate Critical CSS to optimize your site speed whenever your HTML or CSS structure changes. Being on top of this can be tedious and time-consuming.</p>
+								  <p>Boost’s cloud service can automatically detect when your site needs the Critical CSS regenerated, and perform this function behind the scenes without requiring you to monitor it manually.</p>`,
 					},
 				},
 			},
@@ -95,8 +96,8 @@ export const boostProductData = {
 		{
 			name: 'Dedicated email support',
 			info: {
-				content:
-					'Paid customers get dedicated email support from our world-class Happiness Engineers to help with any issue.<br><br>All other questions are handled by our team as quickly as we are able to go through the WordPress support forum.',
+				content: `<p>Paid customers get dedicated email support from our world-class Happiness Engineers to help with any issue.</p>
+					      <p>All other questions are handled by our team as quickly as we are able to go through the WordPress support forum.</p>`,
 			},
 			tiers: {
 				free: {

--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/stories/mock-data.js
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/stories/mock-data.js
@@ -24,9 +24,12 @@ export const boostProductData = {
 					included: false,
 					description: 'Must be done manually',
 					info: {
-						title: '',
-						content: `To enhance the speed of your site, with this plan you will need to optimize CSS by using the Manual Critical CSS generation feature whenever you:
+						title: 'Manual Critical CSS regeneration',
+						content: `To enhance the speed of your site, with this plan you will need to optimize CSS by using the Manual Critical CSS generation feature whenever you:<br><br>
 							<ul>
+								<li>Make theme changes.</li>
+								<li>Write a new post/page.</li>
+								<li>Edit a post/page.</li>
 								<li>Activate, deactivate, or update plugins that impact your site layout or HTML structure.</li>
 								<li>Change settings of plugins that impact your site layout or HTML structure.</li>
 								<li>Upgrade your WordPress version if the new release includes core CSS changes.</li>
@@ -90,7 +93,7 @@ export const boostProductData = {
 			},
 		},
 		{
-			name: 'Dedicated support',
+			name: 'Dedicated email support',
 			info: {
 				content:
 					'Paid customers get dedicated email support from our world-class Happiness Engineers to help with any issue.<br><br>All other questions are handled by our team as quickly as we are able to go through the WordPress support forum.',
@@ -98,7 +101,6 @@ export const boostProductData = {
 			tiers: {
 				free: {
 					included: false,
-					description: 'No dedicated support',
 				},
 				upgraded: {
 					included: true,
@@ -117,7 +119,16 @@ export const boostProductData = {
 				wpcomProductSlug: 'jetpack_boost',
 				currencyCode: 'USD',
 				fullPrice: 240,
-				discountPrice: 240,
+				discountPrice: 120,
+				isIntroductoryOffer: true,
+				introductoryOffer: {
+					intervalUnit: 'year',
+					intervalCount: 1,
+					usageLimit: null,
+					costPerInterval: 167.4,
+					transitionAfterRenewalCount: 0,
+					shouldProrateWhenOfferEnds: false,
+				},
 			},
 		},
 	},

--- a/projects/packages/my-jetpack/changelog/add-boost-pricing-table
+++ b/projects/packages/my-jetpack/changelog/add-boost-pricing-table
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added tier data to the Boost product to support a pricing table interstitial page.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -74,7 +74,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.13.x-dev"
+			"dev-trunk": "2.14.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.13.0",
+	"version": "2.14.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.13.0';
+	const PACKAGE_VERSION = '2.14.0-alpha';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -8,11 +8,16 @@
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\My_Jetpack\Product;
+use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
 /**
  * Class responsible for handling the Boost product
  */
 class Boost extends Product {
+
+	const FREE_TIER_SLUG             = 'free';
+	const UPGRADED_TIER_SLUG         = 'upgraded';
+	const UPGRADED_TIER_PRODUCT_SLUG = 'jetpack_boost_yearly';
 
 	/**
 	 * The product slug
@@ -69,7 +74,7 @@ class Boost extends Product {
 	 * @return string
 	 */
 	public static function get_description() {
-		return __( 'Instant speed and SEO', 'jetpack-my-jetpack' );
+		return __( 'The easiest speed optimization plugin for WordPress', 'jetpack-my-jetpack' );
 	}
 
 	/**
@@ -95,14 +100,167 @@ class Boost extends Product {
 	}
 
 	/**
+	 * Get the product's available tiers
+	 *
+	 * @return string[] Slugs of the available tiers
+	 */
+	public static function get_tiers() {
+		return array(
+			self::UPGRADED_TIER_SLUG,
+			self::FREE_TIER_SLUG,
+		);
+	}
+
+	/**
+	 * Get the internationalized comparison of free vs upgraded features
+	 *
+	 * @return array[] Protect features comparison
+	 */
+	public static function get_features_by_tier() {
+		return array(
+			array(
+				'name'  => __( 'Optimize CSS Loading', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Move important styling information to the start of the page, which helps pages display your content sooner, so your users don’t have to wait for the entire page to load. Commonly referred to as Critical CSS.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array(
+						'included'    => true,
+						'description' => __( 'Must be done manually', 'jetpack-my-jetpack' ),
+						'info'        => array(
+							'title'   => __( 'Manual Critical CSS regeneration', 'jetpack-my-jetpack' ),
+							'content' => __(
+								'To enhance the speed of your site, with this plan you will need to optimize CSS by using the Manual Critical CSS generation feature whenever you:<br><br>
+								<ul>
+									<li>Make theme changes.</li>
+									<li>Write a new post/page.</li>
+									<li>Edit a post/page.</li>
+									<li>Activate, deactivate, or update plugins that impact your site layout or HTML structure.</li>
+									<li>Change settings of plugins that impact your site layout or HTML structure.</li>
+									<li>Upgrade your WordPress version if the new release includes core CSS changes.</li>
+								</ul>',
+								'jetpack-my-jetpack'
+							),
+						),
+					),
+					self::UPGRADED_TIER_SLUG => array(
+						'included'    => true,
+						'description' => __( 'Automatically updated', 'jetpack-my-jetpack' ),
+						'info'        => array(
+							'title'   => __( 'Automatic Critical CSS regeneration', 'jetpack-my-jetpack' ),
+							'content' => __(
+								'It’s essential to regenerate Critical CSS to optimize your site speed whenever your HTML or CSS structure changes. Being on top of this can be tedious and time-consuming.<br><br>Boost’s cloud service can automatically detect when your site needs the Critical CSS regenerated, and perform this function behind the scenes without requiring you to monitor it manually.',
+								'jetpack-my-jetpack'
+							),
+						),
+					),
+				),
+			),
+			array(
+				'name'  => __( 'Defer non-essential JavaScript', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Run non-essential JavaScript after the page has loaded so that styles and images can load more quickly.',
+						'jetpack-my-jetpack'
+					),
+					'link'    => array(
+						'id'    => 'jetpack-boost-defer-js',
+						'title' => 'web.dev',
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => true ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Lazy image loading', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Improve page loading speed by only loading images when they are required.',
+						'jetpack-my-jetpack'
+					),
+					'link'    => array(
+						'id'    => 'jetpack-boost-lazy-load',
+						'title' => 'web.dev',
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array( 'included' => true ),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Image guide', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Discover and fix images with a suboptimal resolution, aspect ratio, or file size, improving user experience and page speed.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array(
+						'included' => true,
+					),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Image CDN', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Deliver images from Jetpack\'s Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array(
+						'included' => true,
+					),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+			array(
+				'name'  => __( 'Dedicated email support', 'jetpack-my-jetpack' ),
+				'info'  => array(
+					'content' => __(
+						'Paid customers get dedicated email support from our world-class Happiness Engineers to help with any issue.<br><br>All other questions are handled by our team as quickly as we are able to go through the WordPress support forum.',
+						'jetpack-my-jetpack'
+					),
+				),
+				'tiers' => array(
+					self::FREE_TIER_SLUG     => array(
+						'included' => false,
+					),
+					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
+				),
+			),
+		);
+	}
+
+	/**
 	 * Get the product princing details
 	 *
 	 * @return array Pricing details
 	 */
 	public static function get_pricing_for_ui() {
 		return array(
-			'available' => true,
-			'is_free'   => true,
+			'tiers' => array(
+				self::FREE_TIER_SLUG     => array(
+					'available' => true,
+					'is_free'   => true,
+				),
+				self::UPGRADED_TIER_SLUG => array_merge(
+					array(
+						'available'          => true,
+						'wpcom_product_slug' => self::UPGRADED_TIER_PRODUCT_SLUG,
+					),
+					Wpcom_Products::get_product_pricing( self::UPGRADED_TIER_PRODUCT_SLUG )
+				),
+			),
 		);
 	}
 
@@ -113,5 +271,26 @@ class Boost extends Product {
 	 */
 	public static function get_manage_url() {
 		return admin_url( 'admin.php?page=jetpack-boost' );
+	}
+
+	/**
+	 * Activates the product by installing and activating its plugin
+	 *
+	 * @param bool|WP_Error $current_result Is the result of the top level activation actions. You probably won't do anything if it is an WP_Error.
+	 * @return boolean|\WP_Error
+	 */
+	public static function do_product_specific_activation( $current_result ) {
+
+		$product_activation = parent::do_product_specific_activation( $current_result );
+
+		if ( is_wp_error( $product_activation ) && 'module_activation_failed' === $product_activation->get_error_code() ) {
+			// A bundle is not a module. There's nothing in the plugin to be activated, so it's ok to fail to activate the module.
+			$product_activation = true;
+		}
+
+		// We just "got started" in My Jetpack, so skip the in-plugin experience.
+		update_option( 'jb_get_started', false );
+
+		return $product_activation;
 	}
 }

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -133,7 +133,7 @@ class Boost extends Product {
 						'info'        => array(
 							'title'   => __( 'Manual Critical CSS regeneration', 'jetpack-my-jetpack' ),
 							'content' => __(
-								'To enhance the speed of your site, with this plan you will need to optimize CSS by using the Manual Critical CSS generation feature whenever you:<br><br>
+								'<p>To enhance the speed of your site, with this plan you will need to optimize CSS by using the Manual Critical CSS generation feature whenever you:</p>
 								<ul>
 									<li>Make theme changes.</li>
 									<li>Write a new post/page.</li>
@@ -152,7 +152,8 @@ class Boost extends Product {
 						'info'        => array(
 							'title'   => __( 'Automatic Critical CSS regeneration', 'jetpack-my-jetpack' ),
 							'content' => __(
-								'It’s essential to regenerate Critical CSS to optimize your site speed whenever your HTML or CSS structure changes. Being on top of this can be tedious and time-consuming.<br><br>Boost’s cloud service can automatically detect when your site needs the Critical CSS regenerated, and perform this function behind the scenes without requiring you to monitor it manually.',
+								'<p>It’s essential to regenerate Critical CSS to optimize your site speed whenever your HTML or CSS structure changes. Being on top of this can be tedious and time-consuming.</p>
+								 <p>Boost’s cloud service can automatically detect when your site needs the Critical CSS regenerated, and perform this function behind the scenes without requiring you to monitor it manually.</p>',
 								'jetpack-my-jetpack'
 							),
 						),
@@ -202,9 +203,7 @@ class Boost extends Product {
 					),
 				),
 				'tiers' => array(
-					self::FREE_TIER_SLUG     => array(
-						'included' => true,
-					),
+					self::FREE_TIER_SLUG     => array( 'included' => true ),
 					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
 				),
 			),
@@ -217,9 +216,7 @@ class Boost extends Product {
 					),
 				),
 				'tiers' => array(
-					self::FREE_TIER_SLUG     => array(
-						'included' => true,
-					),
+					self::FREE_TIER_SLUG     => array( 'included' => true ),
 					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
 				),
 			),
@@ -227,14 +224,13 @@ class Boost extends Product {
 				'name'  => __( 'Dedicated email support', 'jetpack-my-jetpack' ),
 				'info'  => array(
 					'content' => __(
-						'Paid customers get dedicated email support from our world-class Happiness Engineers to help with any issue.<br><br>All other questions are handled by our team as quickly as we are able to go through the WordPress support forum.',
+						'<p>Paid customers get dedicated email support from our world-class Happiness Engineers to help with any issue.</p>
+						 <p>All other questions are handled by our team as quickly as we are able to go through the WordPress support forum.</p>',
 						'jetpack-my-jetpack'
 					),
 				),
 				'tiers' => array(
-					self::FREE_TIER_SLUG     => array(
-						'included' => false,
-					),
+					self::FREE_TIER_SLUG     => array( 'included' => false ),
 					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
 				),
 			),

--- a/projects/plugins/backup/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/backup/changelog/add-my-jetpack-pricing-table-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/backup/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -882,7 +882,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4fea57b68e108ba13b2652967f389dea6f36a23e"
+                "reference": "ebcda0c43475dece868ad5b79f88af134bf0e699"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -912,7 +912,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/boost/changelog/add-my-jetpack-pricing-table-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/boost/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -803,7 +803,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4fea57b68e108ba13b2652967f389dea6f36a23e"
+                "reference": "ebcda0c43475dece868ad5b79f88af134bf0e699"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -833,7 +833,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-pricing-table-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1546,7 +1546,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4fea57b68e108ba13b2652967f389dea6f36a23e"
+                "reference": "ebcda0c43475dece868ad5b79f88af134bf0e699"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1576,7 +1576,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/migration/changelog/add-my-jetpack-pricing-table-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/migration/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -882,7 +882,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4fea57b68e108ba13b2652967f389dea6f36a23e"
+                "reference": "ebcda0c43475dece868ad5b79f88af134bf0e699"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -912,7 +912,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/protect/changelog/add-my-jetpack-pricing-table-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/protect/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -797,7 +797,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4fea57b68e108ba13b2652967f389dea6f36a23e"
+                "reference": "ebcda0c43475dece868ad5b79f88af134bf0e699"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -827,7 +827,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/search/changelog/add-my-jetpack-pricing-table-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/search/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -797,7 +797,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4fea57b68e108ba13b2652967f389dea6f36a23e"
+                "reference": "ebcda0c43475dece868ad5b79f88af134bf0e699"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -827,7 +827,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/social/changelog/add-my-jetpack-pricing-table-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/social/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -797,7 +797,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4fea57b68e108ba13b2652967f389dea6f36a23e"
+                "reference": "ebcda0c43475dece868ad5b79f88af134bf0e699"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -827,7 +827,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/starter-plugin/changelog/add-my-jetpack-pricing-table-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/starter-plugin/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -797,7 +797,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4fea57b68e108ba13b2652967f389dea6f36a23e"
+                "reference": "ebcda0c43475dece868ad5b79f88af134bf0e699"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -827,7 +827,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/videopress/changelog/add-my-jetpack-pricing-table-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/videopress/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -797,7 +797,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "4fea57b68e108ba13b2652967f389dea6f36a23e"
+                "reference": "ebcda0c43475dece868ad5b79f88af134bf0e699"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -827,7 +827,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/29537

Adds the pricing table for Jetpack Boost to the My Jetpack package, so that the plugin can be acquired and activated through a single screen.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add tier data for Boost in My Jetpack, so that it will render the pricing table instead of the current plugin installation prompt.
* Update mock data for `ProductDetailTable` stories, to match the Boost product data.
* Fix post activation redirect in `ProductDetailTable`.
* Update `PricingTable` to use the wide tooltip when both a tooltip title and content is present.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/issues/29537

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get a site running this branch with the Jetpack plugin.
* Go to `/wp-admin/admin.php?page=my-jetpack#/add-boost`
* Test both the free and upgrade paths
* Confirm the pricing table content matches the existing table in the Boost plugin.


## Screenshots

<img width="1147" alt="Screenshot 2023-05-02 at 9 55 11 AM" src="https://user-images.githubusercontent.com/10933065/235719651-7381f654-9250-4322-a2d5-5aa8b825d4ca.png">

<img width="1121" alt="Screenshot 2023-05-02 at 11 30 16 AM" src="https://user-images.githubusercontent.com/10933065/235740614-54d6dae3-0954-47a8-8495-d9a469d38347.png">

