### PR TITLE
CRM: Moving the transaction status selector underneath the ID

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-move-transaction-status
+++ b/projects/plugins/crm/changelog/update-crm-move-transaction-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Transactions: move status select html from Transaction Actions to main edit section underneath ID

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
@@ -216,6 +216,41 @@
 						<td colspan="2"><hr /></td>
 					</tr>
 
+					<?php
+
+					// Transaction Status
+					$potential_statuses = zeroBSCRM_getTransactionsStatuses( true );
+					$current_status     = '';
+				if ( is_array( $transaction ) && isset( $transaction['status'] ) ) {
+						$current_status = $transaction['status'];
+				}
+				?>
+					<tr class="wh-large">
+						<th><label for="zbst_status"><?php echo esc_html( __( 'Transaction Status:', 'zero-bs-crm' ) ); ?></label>
+						</th>
+						<td>
+						<select id="zbst_status" name="zbst_status">
+							<?php
+						foreach ( $potential_statuses as $status ) {
+							$sel = $status === $current_status ? ' selected' : '';
+							echo '<option value="' .
+							esc_attr( $status ) .
+							'"' .
+							esc_attr( $sel ) .
+							'>' .
+							esc_html(
+								sprintf(
+									/* Translators: placeholder is the name of the transaction status */
+									__( '%s', 'zero-bs-crm' ), // phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
+									$status
+								)
+							) .
+							'</option>';
+						}
+						?>
+						</select>
+					</tr>
+
 					<tr class="wh-large">
 						<th><label for="title"><?php echo esc_html( __( 'Transaction Name:', 'zero-bs-crm' ) ); ?></label>
 							<span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'If possible, keep these the same if you routinely use common products here (they are used in the transaction index)', 'zero-bs-crm' ) );?></span>
@@ -671,26 +706,6 @@ class zeroBS__Metabox_TransactionTags extends zeroBS__Metabox_Tags{
 
             // localise ID & content
             $transactionID = -1; if (is_array($transaction) && isset($transaction['id'])) $transactionID = (int)$transaction['id'];
-            
-            	#} Status either way
-                $potentialStatuses = zeroBSCRM_getTransactionsStatuses(true);
-
-            	$status = ''; if (is_array($transaction) && isset($transaction['status'])) $status = $transaction['status'];
-
-                ?>
-                <div>
-                    <label for="zbst_status"><?php echo esc_html( __( 'Status', 'zero-bs-crm' ) ); ?>: </label>
-                    <select id="zbst_status" name="zbst_status">
-                            <?php foreach($potentialStatuses as $z){
-                                if($z == $status){$sel = ' selected'; }else{ $sel = '';}
-                                echo '<option value="'.esc_attr( $z ).'"'. esc_attr( $sel ) .'>'.esc_html__($z,"zero-bs-crm").'</option>';
-                            } ?>
-                    </select>
-                </div>
-
-                <div class="clear"></div>
-                <?php
-
 
                 #} if a saved post...
                 //if (isset($post->post_status) && $post->post_status != "auto-draft"){

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
@@ -238,13 +238,7 @@
 							'"' .
 							esc_attr( $sel ) .
 							'>' .
-							esc_html(
-								sprintf(
-									/* Translators: placeholder is the name of the transaction status */
-									__( '%s', 'zero-bs-crm' ), // phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
-									$status
-								)
-							) .
+							esc_html( $status ) .
 							'</option>';
 						}
 						?>


### PR DESCRIPTION

## Proposed changes:

* This PR moves the Transaction Status options from the Transaction Actions Metabox to underneath the Transaction ID (on the Transaction Edit page).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2952

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test this, using the Jetpack Beta plugin on a test site with this branch applied or testing locally with the branch checked out, visit the 'Edit' Transaction page for a Transaction: `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=invoice&zbsid={quoteid}`.
* Underneath the Transaction ID you should see a Transaction Status label, with a dropdown for the available statuses.
* Try changing the status and saving - the change should save and the status should be visible on the 'View All' Transactions page.
* The Status dropdown should no longer be visible in the Transaction Actions metabox.

**Before:**
<img width="1991" alt="Screenshot 2023-04-05 at 13 25 09" src="https://user-images.githubusercontent.com/16754605/230079928-b1bb76a3-1df8-4c1a-a4d9-be3be603ca67.png">



**After:**

<img width="1981" alt="Screenshot 2023-04-05 at 13 26 50" src="https://user-images.githubusercontent.com/16754605/230080119-1d76a890-84b7-4321-b4da-6fa24660b407.png">

