### PR TITLE
CRM: Resolves 3043 -  fix JS escape functions on non-strings

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3043-fix_js_esc_functions_on_non_strings
+++ b/projects/plugins/crm/changelog/fix-crm-3043-fix_js_esc_functions_on_non_strings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Tax: new tax rates could not be added

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -2755,13 +2755,15 @@ var jpcrm = {
 	// essentially the same as PHP's htmlspecialchars(), which is what WP's esc_attr() primarily uses
 	// https://stackoverflow.com/a/41699140
 	esc_attr( str ) {
-		var map = {
+		const map = {
 			'&': '&amp;',
 			'<': '&lt;',
 			'>': '&gt;',
 			'"': '&quot;',
 			"'": '&#039;',
 		};
+		// ensure it's a string
+		str = '' + str;
 		return str.replace( /[&<>"']/g, function ( m ) {
 			return map[ m ];
 		} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3043 -  fix JS escape functions on non-strings

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We have our `jpcrm.esc_attr()` in JS that escapes output in roughly the same way as WP. However, the function expected a string (as it used `String.replace()`). If a non-string was passed to the function, it failed. Since some numbers were escaped in #29215, this caused an issue.

This PR casts the input to a string, so should work as expected going forward.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=tax`
2. Try to add a new tax rate.

In `trunk`, one cannot add a tax rate and one will get this JS error: `str.replace is not a function`

In `fix/crm/3043-fix_js_esc_functions_on_non_strings`, the tax rate can be added.