### PR TITLE
VideoPress: expose the Preview On Hover data dynamically

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-propagate-pho-data-dynamically
+++ b/projects/packages/videopress/changelog/update-videopress-propagate-pho-data-dynamically
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: expose the Preview On Hover data dynamically

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -178,6 +178,27 @@ class Initializer {
 	}
 
 	/**
+	 * VideoPress video block render method
+	 *
+	 * @param array  $block_attributes - Block attributes.
+	 * @param string $content          - Block markup.
+	 * @return string                    Block markup.
+	 */
+	public static function render_videopress_video_block( $block_attributes, $content ) {
+		// Preview On Hover data
+		if ( ! isset( $block_attributes['posterData']['previewOnHover'] ) || ! $block_attributes['posterData']['previewOnHover'] ) {
+			return sprintf( '<div class="wp-block-jetpack-videopress-container">%s</div>', $content );
+		}
+
+		$preview_on_hover_data = array(
+			'previewAtTime'       => $block_attributes['posterData']['previewAtTime'],
+			'previewLoopDuration' => $block_attributes['posterData']['previewLoopDuration'],
+		);
+
+		return sprintf( '<div class="wp-block-jetpack-videopress-container"><script type="application/json">%s</script>%s</div>', wp_json_encode( $preview_on_hover_data ), $content );
+	}
+
+	/**
 	 * Register the VideoPress block editor block,
 	 * AKA "VideoPress Block v6".
 	 *
@@ -237,6 +258,12 @@ class Initializer {
 		);
 
 		// Register VideoPress video block.
-		register_block_type( $videopress_video_metadata_file );
+		register_block_type(
+			$videopress_video_metadata_file,
+			array(
+				'api_version'     => 2,
+				'render_callback' => array( __CLASS__, 'render_videopress_video_block' ),
+			)
+		);
 	}
 }

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -261,7 +261,6 @@ class Initializer {
 		register_block_type(
 			$videopress_video_metadata_file,
 			array(
-				'api_version'     => 2,
 				'render_callback' => array( __CLASS__, 'render_videopress_video_block' ),
 			)
 		);

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
@@ -45,8 +45,6 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 		posterData,
 	} = attributes;
 
-	const { previewOnHover, previewAtTime, previewLoopDuration } = posterData ?? {};
-
 	const blockProps = useBlockProps.save( {
 		className: classnames( 'wp-block-jetpack-videopress', 'jetpack-videopress-player', {
 			[ `align${ align }` ]: align,
@@ -98,20 +96,9 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 	return (
 		<figure { ...blockProps } style={ style }>
 			{ videoPressUrl && (
-				<>
-					{ previewOnHover && (
-						<span
-							style={ { display: 'none', visibility: 'hidden', position: 'absolute' } }
-							className="videopress-poh"
-						>
-							<span className="videopress-poh__sp">{ previewAtTime }</span>
-							<span className="videopress-poh__duration">{ previewLoopDuration }</span>
-						</span>
-					) }
-					<div className="jetpack-videopress-player__wrapper">
-						{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
-					</div>
-				</>
+				<div className="jetpack-videopress-player__wrapper">
+					{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
+				</div>
 			) }
 
 			{ ! RichText.isEmpty( caption ) && (

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -18,7 +18,7 @@ function previewOnHoverEffect(): void {
 	 * Pick all VideoPress video block intances,
 	 * based on the class name.
 	 */
-	const videoPlayers = document.querySelectorAll( '.wp-block-videopress-video' );
+	const videoPlayers = document.querySelectorAll( '.wp-block-jetpack-videopress-container' );
 	if ( videoPlayers.length === 0 ) {
 		return;
 	}
@@ -30,9 +30,8 @@ function previewOnHoverEffect(): void {
 			return;
 		}
 
-		// Get the data container element.
-		const dataContainer = videoPlayerElement.querySelector( 'span.videopress-poh' );
-		if ( ! dataContainer ) {
+		// If the VideoPress iFrame API is not available, return.
+		if ( ! window?.VideoPressIframeApi ) {
 			return;
 		}
 
@@ -40,20 +39,25 @@ function previewOnHoverEffect(): void {
 		 * Try to pick the POH data from the data container element.
 		 * If it fails, log the error and return.
 		 */
-		const previewOnHoverData = {
-			previewAtTime: Number(
-				dataContainer.querySelector( 'span.videopress-poh__sp' )?.textContent
-			),
-			previewLoopDuration: Number(
-				dataContainer.querySelector( 'span.videopress-poh__duration' )?.textContent
-			),
+		const dataContainer = videoPlayerElement.querySelector( 'script[type="application/json"]' );
+		if ( ! dataContainer ) {
+			return;
+		}
+
+		let previewOnHoverData: {
+			previewAtTime: number;
+			previewLoopDuration: number;
 		};
+
+		try {
+			previewOnHoverData = JSON.parse( dataContainer.innerHTML );
+		} catch ( error ) {
+			console.error( error ); // eslint-disable-line no-console
+			return;
+		}
 
 		// Clean the data container element. It isn't needed anymore.
 		dataContainer.remove();
-		if ( ! window?.VideoPressIframeApi ) {
-			return;
-		}
 
 		const iframeApi = window.VideoPressIframeApi( iFrame, () => {
 			iframeApi.status.onPlayerStatusChanged( ( oldStatus, newStatus ) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Again, this PR iterates how to expose the "Preview On Hover" data to the front end. It handles the block markup dynamically by using a rendering function on the server side.
When the "Preview On Hover" is enabled, the server provides the markup to pick the data in the front-end.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: expose the Preview On Hover data dynamically

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor.
* Create a VideoPress video block
* Enable Preview On Hover feature
* Set Starting point and duration
* Save the post
* View the post in the front-end
* Confirm the pOH feature works as expected: mouseover -> play, mouseleave -> stop

