### PR TITLE
[RNMobile] Add empty native version of `PosterPanel` component

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-videopress-fix-poster-panel
+++ b/projects/packages/videopress/changelog/rnmobile-videopress-fix-poster-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Add empty native version of `PosterPanel` component.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.native.js
@@ -1,0 +1,11 @@
+export const isVideoFramePosterEnabled = () =>
+	!! window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'v6-video-frame-poster' ];
+
+/**
+ * Sidebar Control component.
+ *
+ * @returns {import('react').ReactElement}    Component template
+ */
+export default function PosterPanel() {
+	return null;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addresses an issue in the native version introduced in https://github.com/Automattic/jetpack/pull/29926 (internal reference: p1680713090062799-slack-C04LWMHSGLC).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* https://github.com/Automattic/jetpack/commit/52abc1f49e3020339befeab2e486c983f3dfaa4d: Implement the native version of `poster-panel` component in order to avoid importing the stylesheet which causes an error in the native version. The function `isVideoFramePosterEnabled` has been copied over, but the rest of the components except `PosterPanel` are not included. For the latter, we are returning an empty component since it's not being used in the native version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the app with local Metro server connected.
* Add a VideoPress block.
* Observe the no error is displayed, e.g.:
```
9 │ @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
  stdin 9:9  root stylesheet
```