### PR TITLE
CRM: Resolves 3030 - catch PHP 8.1 errors

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3030-catch_PHP_8.1_errors
+++ b/projects/plugins/crm/changelog/fix-crm-3030-catch_PHP_8.1_errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved compatibility with PHP 8.1

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -80,9 +80,9 @@ function zeroBSCRM_CSVImporterLiteadmin_menu() {
 	global $zbs,$zeroBSCRM_CSVImporterLiteslugs; // req
 
 	wp_register_style( 'zerobscrm-csvimporter-admcss', ZEROBSCRM_URL . 'css/ZeroBSCRM.admin.csvimporter' . wp_scripts_get_suffix() . '.css', array(), $zbs->version );
-	$csvAdminPage = add_submenu_page( null, 'CSV Importer', 'CSV Importer', 'admin_zerobs_customers', $zbs->slugs['csvlite'], 'zeroBSCRM_CSVImporterLitepages_app', 1 ); // $zeroBSCRM_CSVImporterLiteslugs['app']
-	add_action( "admin_print_styles-{$csvAdminPage}", 'zeroBSCRM_CSVImporter_lite_admin_styles' );
-	add_action( "admin_print_styles-{$csvAdminPage}", 'zeroBSCRM_global_admin_styles' ); // } and this.
+	$csv_admin_page = add_submenu_page( 'jpcrm-hidden', 'CSV Importer', 'CSV Importer', 'admin_zerobs_customers', $zbs->slugs['csvlite'], 'zeroBSCRM_CSVImporterLitepages_app', 1 ); // phpcs:ignore WordPress.WP.Capabilities.Unknown
+	add_action( "admin_print_styles-{$csv_admin_page}", 'zeroBSCRM_CSVImporter_lite_admin_styles' );
+	add_action( "admin_print_styles-{$csv_admin_page}", 'zeroBSCRM_global_admin_styles' ); // } and this.
 }
 add_action( 'zerobs_admin_menu', 'zeroBSCRM_CSVImporterLiteadmin_menu' );
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.WP.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.WP.php
@@ -1263,7 +1263,7 @@ function zeroBSCRM_menu_add_sublevel( $menuItem = -1, $subMenuKey = -1, $subMenu
 
 		// https://developer.wordpress.org/reference/functions/add_submenu_page/
 		$adminSubPage = add_submenu_page(
-			( is_array( $menuItem ) && isset( $menuItem['url'] ) ) ? $menuItem['url'] : null, // parent slug
+			( is_array( $menuItem ) && isset( $menuItem['url'] ) ) ? $menuItem['url'] : 'jpcrm-hidden', // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			$subMenuItem['title'], // __( 'Tags', 'zero-bs-crm' ),
 			$subMenuItem['title'], // __( 'Tags', 'zero-bs-crm' ),
 			$subMenuItem['perms'], // 'admin_zerobs_customers',

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -789,12 +789,16 @@ function zeroBSCRM_wpb_lastlogin($uid ) {
 	    return json_decode(trim($jsonp,'();'), $assoc);
 	}
 
-	// used by DAL2 settings 
-	// https://stackoverflow.com/questions/6041741/fastest-way-to-check-if-a-string-is-json-in-php
-	function zeroBSCRM_isJson($str) {
-	    $json = json_decode($str);
-	    return $json && $str != $json;
+// used by DAL2 settings
+// https://stackoverflow.com/questions/6041741/fastest-way-to-check-if-a-string-is-json-in-php
+// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+function zeroBSCRM_isJson( $str ) {
+	if ( $str === null ) {
+		return false;
 	}
+	$json = json_decode( $str );
+	return $json && $str != $json; // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+}
 
 	// return placeholder img :) DAL2 friendly
 	function zeroBSCRM_getDefaultContactAvatar(){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3030 - catch PHP 8.1 errors

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
While working on Automattic/jetpack-crm-extensions#601, I realised it only occurred in PHP 8.1. As such, I decided to do a quick sweep of our pages on PHP 8.1, and discovered that along with the original CSV importer issue:

* WP menus were broken and headers prematurely sent if debug was output
* Our task system is using `strftime()` (Automattic/zero-bs-crm#2884, see also Automattic/zero-bs-crm#300)

This PR addresses the first item in two ways:

1. While traditionally one could pass `null` as the parent slug of a submenu page, PHP 8.1 no longer allows that. I tried an empty string [as `wordpress-seo` did](https://github.com/Yoast/wordpress-seo/pull/19191/files), which fixed the original issue but resulted in another error with hidden pages + page titles. Thus I used `jpcrm-hidden` as the parent menu slug.
2. When loading settings, we check if a setting is JSON. If the setting value was `null`, PHP 8.1 would complain, so I put a check to return `false` if the value is null.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Enable full PHP logs.
3. Go to any page (JPCRM or otherwise).

On `trunk` one sees dozens of deprecation notices and the WP menus are broken.

On `fix/crm/3030-catch_PHP_8.1_errors` all is well.
