### PR TITLE
My Jetpack: Move Search back to a hybrid product

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-search-back-to-hybrid-product
+++ b/projects/packages/my-jetpack/changelog/fix-search-back-to-hybrid-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Turn Search into a hybrid product to handle it as module and as standalone plugin.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.10.0",
+	"version": "2.10.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.10.0';
+	const PACKAGE_VERSION = '2.10.1-alpha';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -9,7 +9,7 @@ namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\My_Jetpack\Product;
+use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Search\Module_Control as Search_Module_Control;
 use Jetpack_Options;
@@ -18,7 +18,7 @@ use WP_Error;
 /**
  * Class responsible for handling the Search product
  */
-class Search extends Product {
+class Search extends Hybrid_Product {
 	/**
 	 * The product slug
 	 *

--- a/projects/packages/my-jetpack/tests/php/test-search-product.php
+++ b/projects/packages/my-jetpack/tests/php/test-search-product.php
@@ -81,7 +81,7 @@ class Test_Search_Product extends TestCase {
 	 */
 	public function test_if_jetpack_active_return_false() {
 		activate_plugin( 'jetpack/jetpack.php' );
-		$this->assertFalse( Search::is_plugin_active() );
+		$this->assertTrue( Search::is_plugin_active() );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #29906. We are moving the products that have standalone plugins back to hybrid products and then enhancing the status handling on them. This way we can mark them as active or not and push the standalone installation or not, on any given state.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Turn Search into a Hybrid product again, so we can manage it's status as a module and also as a standalone product
* Fix related tests to accomodate the hybrid product behavior

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a new Jurassic Ninja site with only Jetpack
* Complete the Jetpack connection setup and choose to proceed with a free Jetpack plan
* Go to `Jetpack > My Jetpack`
* Search will be shown as inactive (the module is not enabled and the plugin is not present), but not absent (greyed):

<img width="350" alt="Screen Shot 2023-04-05 at 15 08 53" src="https://user-images.githubusercontent.com/6760046/230166998-94e9e91a-68d8-4ce6-96d2-2cd8cf530276.png">

* Click `Start for free` and then `Start for free` again and complete the checkout step
   * before this change, this would trigger the standalone plugin installation
   * after this change, this will enable the module without installing the standalone plugin
* Confirm that the Search product shows as active

<img width="369" alt="Screen Shot 2023-04-05 at 15 14 01" src="https://user-images.githubusercontent.com/6760046/230168274-cbaabb60-8927-4485-89e4-fa10a7034c63.png">

* Confirm that the standalone plugin was not installed
* Go to `Jetpack > Jetpack Beta` and activate Jetpack Search from `fix/search-back-to-hybrid-product` feature branch
* Go back to `Jetpack > My Jetpack` and confirm that the Search product still shows as active
* Now disable the Jetpack plugin and keep only the Jetpack Search plugin
* Go to `Jetpack > My Jetpack` again and confirm that the Search product still shows as active