### PR TITLE
stats: Workaround broken plugins on Atomic

### DIFF
--- a/projects/packages/stats/changelog/workaround-broken-crap-on-atomic
+++ b/projects/packages/stats/changelog/workaround-broken-crap-on-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Change a method call to avoid fatals when broken plugins on a few Atomic sites force the use of an outdated version of the Assets package.
+
+

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -107,7 +107,7 @@ _stq.push([ "clickTrackerInit", "%2$s", "%3$s" ]);',
 		);
 
 		// Make sure the script loads asynchronously (add a defer attribute).
-		Assets::add_async_script( 'jetpack-stats' );
+		Assets::instance()->add_async_script( 'jetpack-stats' );
 
 		$data = self::build_view_data();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Apparently some plugins are embedding our assets package, without using our autoloader or any other method to avoid the problems that arise when multiple plugins bundle different versions of the same Composer package. And apparently these plugins are being used on a few Atomic sites, causing fatals when Jetpack is updated there.

Atomic sysops are refusing to allow Jetpack to be updated because of this, blocking our updates that have already been blocked for a week because (as far as I'm aware) of other non-Jetpack stuff breaking. Sigh.

Let's update our code in a way that should avoid breaking with the incorrectly-loaded older versions of the package so we can stop having everyone else asking us when their other code in Jetpack is going to get updated on Atomic and Simple.

This sort of thing will probably happen again in the future when we do some similar minor change in packages used by such plugins, but maybe by then the plugins will have gotten fixed to avoid this (and will have gotten updated on the relevant Atomic sites too).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1680713232971579-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Hack your site to load v1.17.34 of the Assets package, and see whether things still fatal.