### PR TITLE
Stats: revert switch to Core WP methods to add stats pixel

### DIFF
--- a/projects/packages/assets/changelog/update-stats-tracking-pixel-changes
+++ b/projects/packages/assets/changelog/update-stats-tracking-pixel-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Revert previous change to Stats tracking pixel l oading.

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -75,9 +75,8 @@ class Assets {
 	 *
 	 * @param string $script_handle Script handle.
 	 */
-	public static function add_async_script( $script_handle ) {
-		$assets_instance                         = self::instance();
-		$assets_instance->defer_script_handles[] = $script_handle;
+	public function add_async_script( $script_handle ) {
+		$this->defer_script_handles[] = $script_handle;
 	}
 
 	/**

--- a/projects/packages/stats/changelog/update-stats-tracking-pixel-changes
+++ b/projects/packages/stats/changelog/update-stats-tracking-pixel-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Revert previous change to Stats tracking pixel l oading.

--- a/projects/packages/stats/composer.json
+++ b/projects/packages/stats/composer.json
@@ -4,7 +4,6 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-status": "@dev"

--- a/projects/packages/stats/src/class-main.php
+++ b/projects/packages/stats/src/class-main.php
@@ -140,9 +140,8 @@ class Main {
 			return;
 		}
 
-		add_action( 'wp_enqueue_scripts', array( Tracking_Pixel::class, 'enqueue_stats_script' ), 101 );
-		add_action( 'wp_footer', array( Tracking_Pixel::class, 'add_amp_pixel' ), 101 );
-		add_action( 'web_stories_print_analytics', array( Tracking_Pixel::class, 'add_amp_pixel' ), 101 );
+		add_action( 'wp_footer', array( 'Automattic\Jetpack\Stats\Tracking_Pixel', 'add_to_footer' ), 101 );
+		add_action( 'web_stories_print_analytics', array( 'Automattic\Jetpack\Stats\Tracking_Pixel', 'add_to_footer' ), 101 );
 	}
 
 	/**

--- a/projects/packages/stats/tests/php/test-main.php
+++ b/projects/packages/stats/tests/php/test-main.php
@@ -210,7 +210,7 @@ class Test_Main extends StatsBaseTestCase {
 	public function test_template_redirect_adds_wp_footer_hook() {
 		add_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10, 2 );
 		Stats::template_redirect();
-		$has_action = has_action( 'wp_footer', array( Tracking_Pixel::class, 'add_amp_pixel' ) );
+		$has_action = has_action( 'wp_footer', array( 'Automattic\Jetpack\Stats\Tracking_Pixel', 'add_to_footer' ) );
 		remove_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10, 2 );
 		$this->assertSame( 101, $has_action );
 	}
@@ -221,18 +221,7 @@ class Test_Main extends StatsBaseTestCase {
 	public function test_template_redirect_adds_web_stories_print_analytics_hook() {
 		add_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10, 2 );
 		Stats::template_redirect();
-		$has_action = has_action( 'web_stories_print_analytics', array( Tracking_Pixel::class, 'add_amp_pixel' ) );
-		remove_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10, 2 );
-		$this->assertSame( 101, $has_action );
-	}
-
-	/**
-	 * Test Main::template_redirect adds the `wp_enqueue_scripts` hook.
-	 */
-	public function test_template_redirect_adds_wp_enqueue_scripts_hook() {
-		add_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10, 2 );
-		Stats::template_redirect();
-		$has_action = has_action( 'wp_enqueue_scripts', array( Tracking_Pixel::class, 'enqueue_stats_script' ) );
+		$has_action = has_action( 'web_stories_print_analytics', array( 'Automattic\Jetpack\Stats\Tracking_Pixel', 'add_to_footer' ) );
 		remove_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10, 2 );
 		$this->assertSame( 101, $has_action );
 	}

--- a/projects/packages/stats/tests/php/test-tracking-pixel.php
+++ b/projects/packages/stats/tests/php/test-tracking-pixel.php
@@ -30,8 +30,6 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 
 	/**
 	 * Test for Tracking_Pixel::build_view_data with post
-	 *
-	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
 	 */
 	public function test_build_view_data_with_post() {
 		global $wp_the_query;
@@ -50,8 +48,6 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 
 	/**
 	 * Test for Tracking_Pixel::build_view_data with gmt offset
-	 *
-	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_view_data
 	 */
 	public function test_build_view_data_with_gmt_offset() {
 		add_option( 'gmt_offset', '5' );
@@ -67,11 +63,34 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 	}
 
 	/**
-	 * Test for Tracking_Pixel::test_get_footer_to_add for an amp request
-	 *
-	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::get_amp_footer
+	 * Test for Tracking_Pixel::get_footer_to_add
 	 */
-	public function test_get_amp_footer() {
+	public function test_get_footer_to_add() {
+		$data          = array(
+			'v'    => 'ext',
+			'blog' => 1234,
+			'post' => 0,
+			'tz'   => false,
+			'srv'  => 'example.org',
+		);
+		$footer_to_add = Tracking_Pixel::get_footer_to_add( $data );
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$script_url              = 'https://stats.wp.com/e-' . gmdate( 'YW' ) . '.js';
+		$footer_to_add_should_be = <<<END
+	<script src='{$script_url}' defer></script>
+	<script>
+		_stq = window._stq || [];
+		_stq.push([ 'view', {v:'ext',blog:'1234',post:'0',tz:'',srv:'example.org'} ]);
+		_stq.push([ 'clickTrackerInit', '1234', '0' ]);
+	</script>
+END;
+		$this->assertSame( $footer_to_add_should_be, $footer_to_add );
+	}
+
+	/**
+	 * Test for Tracking_Pixel::test_get_footer_to_add for an amp request
+	 */
+	public function test_get_footer_to_add_amp_request() {
 		$_SERVER['HTTP_HOST'] = '127.0.0.1';
 		$data                 = array(
 			'v'    => 'ext',
@@ -81,16 +100,10 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 			'srv'  => 'example.org',
 		);
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
-
-		$method = new \ReflectionMethod( Tracking_Pixel::class, 'get_amp_footer' );
-		$method->setAccessible( true );
-
-		$amp_footer_data = $method->invoke( new Tracking_Pixel(), $data );
-
+		$footer_to_add = Tracking_Pixel::get_footer_to_add( $data );
 		remove_filter( 'jetpack_is_amp_request', '__return_true' );
-
 		$footer_to_add_should_be = '<amp-pixel src="https://pixel.wp.com/g.gif?v=ext&#038;blog=1234&#038;post=0&#038;tz&#038;srv=example.org&#038;host=127.0.0.1&#038;rand=RANDOM&#038;ref=DOCUMENT_REFERRER"></amp-pixel>';
-		$this->assertSame( $footer_to_add_should_be, $amp_footer_data );
+		$this->assertSame( $footer_to_add_should_be, $footer_to_add );
 	}
 
 	/**
@@ -105,28 +118,28 @@ class Test_Tracking_Pixel extends StatsBaseTestCase {
 
 	/**
 	 * Test for Tracking_Pixel::get_footer_to_add to check that stat_array filter is applied
-	 *
-	 * @covers \Automattic\Jetpack\Stats\Tracking_Pixel::build_stats_details
 	 */
 	public function test_get_footer_to_add_applies_filter() {
 		add_filter( 'stats_array', array( $this, 'stats_array_filter_replace_srv' ), 10, 2 );
-		$data = array(
+		$data          = array(
 			'v'    => 'ext',
 			'blog' => 1234,
 			'post' => 0,
 			'tz'   => false,
 			'srv'  => 'example.org',
 		);
-
-		$method = new \ReflectionMethod( Tracking_Pixel::class, 'build_stats_details' );
-		$method->setAccessible( true );
-		$pixel_details = $method->invoke( new Tracking_Pixel(), $data );
-
-		$expected_pixel_details = "_stq = window._stq || [];
-_stq.push([ \"view\", {v:'ext',blog:'1234',post:'0',tz:'',srv:'replaced.com'} ]);
-_stq.push([ \"clickTrackerInit\", \"1234\", \"0\" ]);";
-
+		$footer_to_add = Tracking_Pixel::get_footer_to_add( $data );
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$script_url              = 'https://stats.wp.com/e-' . gmdate( 'YW' ) . '.js';
+		$footer_to_add_should_be = <<<END
+	<script src='{$script_url}' defer></script>
+	<script>
+		_stq = window._stq || [];
+		_stq.push([ 'view', {v:'ext',blog:'1234',post:'0',tz:'',srv:'replaced.com'} ]);
+		_stq.push([ 'clickTrackerInit', '1234', '0' ]);
+	</script>
+END;
 		remove_filter( 'stats_array', array( $this, 'stats_array_filter_replace_srv' ) );
-		$this->assertSame( $expected_pixel_details, $pixel_details );
+		$this->assertSame( $footer_to_add_should_be, $footer_to_add );
 	}
 }

--- a/projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php
+++ b/projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php
@@ -178,7 +178,7 @@ class Jetpack_AMP_Support {
 	 * @since 6.2.1
 	 */
 	public static function add_stats_pixel() {
-		if ( ! has_action( 'wp_footer', array( Stats_Tracking_Pixel::class, 'add_amp_pixel' ) ) ) {
+		if ( ! has_action( 'wp_footer', array( Stats_Tracking_Pixel::class, 'add_to_footer' ) ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/changelog/update-stats-tracking-pixel-changes
+++ b/projects/plugins/jetpack/changelog/update-stats-tracking-pixel-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Stats: revert previous change to stats tracking pixel loading.

--- a/projects/plugins/jetpack/changelog/update-stats-tracking-pixel-changes#2
+++ b/projects/plugins/jetpack/changelog/update-stats-tracking-pixel-changes#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2050,10 +2050,9 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "9f4692f96639eda2306b2c1f140350e907290176"
+                "reference": "f6feacd16949fdadd2edee685ef7d1fc34a4410f"
             },
             "require": {
-                "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-status": "@dev"

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -143,6 +143,42 @@ function stats_build_view_data() {
 }
 
 /**
+ * Stats Footer.
+ *
+ * @deprecated 11.5
+ * @access public
+ * @return void
+ */
+function stats_footer() {
+	_deprecated_function( __METHOD__, 'jetpack-11.5', 'Automattic\Jetpack\Stats\Tracking_Pixel::add_to_footer' );
+	Stats_Tracking_Pixel::add_to_footer();
+}
+
+/**
+ * Render the stats footer
+ *
+ * @deprecated 11.5
+ *
+ * @param array $data Array of data for the JS stats tracker.
+ */
+function stats_render_footer( $data ) {
+	_deprecated_function( __METHOD__, 'jetpack-11.5', 'Automattic\Jetpack\Stats\Tracking_Pixel::render_footer' );
+	Stats_Tracking_Pixel::render_footer( $data );
+}
+
+/**
+ * Render the stats footer for AMP output.
+ *
+ * @deprecated 11.5
+ *
+ * @param array $data Array of data for the AMP pixel tracker.
+ */
+function stats_render_amp_footer( $data ) {
+	_deprecated_function( __METHOD__, 'jetpack-11.5', 'Automattic\Jetpack\Stats\Tracking_Pixel::render_amp_footer' );
+	Stats_Tracking_Pixel::render_amp_footer( $data );
+}
+
+/**
  * Stats Get Options.
  *
  * @deprecated 11.5

--- a/projects/plugins/search/changelog/update-stats-tracking-pixel-changes
+++ b/projects/plugins/search/changelog/update-stats-tracking-pixel-changes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1174,10 +1174,9 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "9f4692f96639eda2306b2c1f140350e907290176"
+                "reference": "f6feacd16949fdadd2edee685ef7d1fc34a4410f"
             },
             "require": {
-                "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-status": "@dev"

--- a/projects/plugins/videopress/changelog/update-stats-tracking-pixel-changes
+++ b/projects/plugins/videopress/changelog/update-stats-tracking-pixel-changes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1155,10 +1155,9 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "9f4692f96639eda2306b2c1f140350e907290176"
+                "reference": "f6feacd16949fdadd2edee685ef7d1fc34a4410f"
             },
             "require": {
-                "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-status": "@dev"


### PR DESCRIPTION
## Proposed changes:

Reverts #29780
This reverts commit 5dcfe76bb621fecb87673f81b8324a68c9740628.

Unfortunately, there are other plugins out there that do not use Jetpack Autoloader and that are loading old versions of the Assets package before Jetpack's version is loaded. This causes Fatal errors.

> **Note**
> We may revert the revert later, based on the conversation in [this forum thread](https://wordpress.org/support/topic/using-jetpack-autoloader/).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1680713232971579-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> **Note**
> See instructions in #29780

Stats should now continue to work as they did before.

