### PR TITLE
VideoPress: turn playback "controls" off when pOH feature is enabled

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-turn-controls-off-when-switching-poh-feature
+++ b/projects/packages/videopress/changelog/update-videopress-turn-controls-off-when-switching-poh-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: turn playback "controls" off when pOH feature is enabled

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -454,7 +454,7 @@ export default function PosterPanel( {
 
 			setAttributes( {
 				posterData: newPosterData,
-				controls: ! shouldPreviewOnHover,
+				controls: shouldPreviewOnHover ? false : attributes.controls,
 			} );
 		},
 		[ attributes ]

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -454,6 +454,7 @@ export default function PosterPanel( {
 
 			setAttributes( {
 				posterData: newPosterData,
+				controls: ! shouldPreviewOnHover,
 			} );
 		},
 		[ attributes ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The idea of this PR is to turn off the playback `controls` when the Preview on hover feature is enabled and give a chance to turn it on again.

Fixes https://github.com/Automattic/jetpack/issues/29937

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: turn playback "controls" off when pOH feature is enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a VideoPress video block
* Confirm that, when enabling the pOH feature, the playback ` controls` gets disabled
* Confirm that it's possible to enable it again


https://user-images.githubusercontent.com/77539/230168089-468caa42-b70f-4249-83af-9243cb6b95c3.mov

