### PR TITLE
VideoPress: add help to the "Starting point" range control

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-time-to-starting-point-range-control
+++ b/projects/packages/videopress/changelog/update-videopress-add-time-to-starting-point-range-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add help to the "Starting point" range control

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -28,6 +28,7 @@ import classnames from 'classnames';
  */
 import TimestampControl from '../../../../../components/timestamp-control';
 import { getVideoPressUrl } from '../../../../../lib/url';
+import { millisecondsToClockTime } from '../../../../../utils/video-chapters/generate-chapters-file';
 import { usePreview } from '../../../../hooks/use-preview';
 import useVideoPlayer from '../../../../hooks/use-video-player';
 import { VIDEO_POSTER_ALLOWED_MEDIA_TYPES } from '../../constants';
@@ -332,6 +333,17 @@ export function VideoHoverPreviewControl( {
 		Math.min( MAX_LOOP_DURATION, videoDuration - previewAtTime )
 	);
 
+	const startingPointHelp = createInterpolateElement(
+		sprintf(
+			/* translators: placeholder is video duration */
+			__( 'Video duration: <em>%s</em>.', 'jetpack-videopress-pkg' ),
+			millisecondsToClockTime( maxStartingPoint )
+		),
+		{
+			em: <em />,
+		}
+	);
+
 	const loopDurationHelp = createInterpolateElement(
 		sprintf(
 			/* translators: placeholder is the maximum lapse duration for the previewOnHover */
@@ -376,6 +388,7 @@ export function VideoHoverPreviewControl( {
 						} }
 						wait={ 100 }
 						disabled={ disabled }
+						help={ startingPointHelp }
 					/>
 
 					<TimestampControl

--- a/projects/packages/videopress/src/client/utils/video-chapters/generate-chapters-file/index.ts
+++ b/projects/packages/videopress/src/client/utils/video-chapters/generate-chapters-file/index.ts
@@ -6,7 +6,7 @@ import { extractVideoChapters } from '../extract-video-chapters';
  * @param {number} milliseconds - The duration in milliseconds
  * @returns {string}             - The formatted time
  */
-function millisecondsToClockTime( milliseconds: number ) {
+function millisecondsToClockTime( milliseconds: number ): string {
 	const hours = Math.floor( milliseconds / 3600000 );
 	let remaining = milliseconds - hours * 3600000;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/orgs/Automattic/projects/460/views/33?pane=issue&itemId=24896414

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add help to the "Starting point" range control

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a VideoPress video block
* Enable Preview On Hover feature
* Confirm you see the help just below of the "Starting point" range control
* Confirm the value is correct

<img width="328" alt="Screen Shot 2023-04-05 at 15 44 21" src="https://user-images.githubusercontent.com/77539/230175513-a21a9d46-81dc-4723-9b8e-4fb2bc923f52.png">
