### PR TITLE
Publicize: Reinstate is_social_image_generator_enabled to avoid fatals

### DIFF
--- a/projects/packages/publicize/changelog/fix-sig-check-fatal
+++ b/projects/packages/publicize/changelog/fix-sig-check-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reinstated is_social_image_generator_enabled for backwards compatibility

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.24.1",
+	"version": "0.24.2-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1619,6 +1619,17 @@ abstract class Publicize_Base {
 	/**
 	 * Check if the social image generator is enabled.
 	 *
+	 * @deprecated $$next-version$$ use Automattic\Jetpack\Publicize\Publicize_Base\has_social_image_generator_feature instead.
+	 * @param int $blog_id The blog ID for the current blog.
+	 * @return bool
+	 */
+	public function is_social_image_generator_enabled( $blog_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $this->has_social_image_generator_feature();
+	}
+
+	/**
+	 * Check if the social image generator is enabled.
+	 *
 	 * @return bool
 	 */
 	public function has_social_image_generator_feature() {


### PR DESCRIPTION
Fixes #29940

## Proposed changes:
When a previous version of Jetpack is active with a newer version of Social, a fatal error would occur when loading the editor.

This is because we removed the is_social_image_generator_enabled method in #29529 and should have left it for backwards compatibility. This change reinstates it as an alias for has_social_image_generator_feature.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Run a site with Jetpack 11.9 and Jetpack Social active
* With Jetpack Social on trunk you will get a fatal error when loading the block editor
<img width="772" alt="image" src="https://user-images.githubusercontent.com/96462/230184197-1fb3b49c-d767-4e86-99b2-5d35eac47ee2.png">

* With Jetpack Social on this branch it should load correctly.

