### PR TITLE
 VideoPress: set video player position according to "starting point" and "duration"

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-change-video-position-when-editing-poh
+++ b/projects/packages/videopress/changelog/update-videopress-change-video-position-when-editing-poh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: set video player position according to "starting point" and "duration"

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -386,7 +386,7 @@ export function VideoHoverPreviewControl( {
 								onLoopDurationChange( max );
 							}
 						} }
-						wait={ 100 }
+						wait={ 300 }
 						disabled={ disabled }
 						help={ startingPointHelp }
 					/>
@@ -399,7 +399,7 @@ export function VideoHoverPreviewControl( {
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
 						value={ loopDuration }
 						onDebounceChange={ onLoopDurationChange }
-						wait={ 100 }
+						wait={ 300 }
 						help={ loopDurationHelp }
 						disabled={ disabled || noLoopDurationRange }
 					/>

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -167,6 +167,23 @@ const useVideoPlayer = (
 		};
 	}, [ isPreviewOnHoverEnabled, wrapperElement, playerIsReady ] );
 
+	// Move the video to the "Starting point" when it changes.
+	useEffect( () => {
+		if ( ! playerIsReady || ! previewOnHover ) {
+			return;
+		}
+
+		const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
+		if ( ! sandboxIFrameWindow ) {
+			return;
+		}
+
+		sandboxIFrameWindow.postMessage(
+			{ event: 'videopress_action_set_currenttime', currentTime: previewOnHover.atTime / 1000 },
+			{ targetOrigin: '*' }
+		);
+	}, [ previewOnHover, playerIsReady ] );
+
 	return {
 		playerIsReady,
 		play,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/29951

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: set video player position according to "starting point" and "duration"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a VideoPress video block
* Enable the Preview On Hover feature
* Confirm that when you change the "starting point," the player sets the position to the proper frame
* Confirm that when you change the "loop duration", the player sets the position to the proper frame


https://user-images.githubusercontent.com/77539/230192467-92876fb3-e192-48f1-b7e7-5c335ecec2d1.mov
