### PR TITLE
VideoPress: add marksEvery to the TimestampControl component

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-tweak-timestamp-controls-poh
+++ b/projects/packages/videopress/changelog/update-videopress-tweak-timestamp-controls-poh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add marksEvery to the TimestampControl component

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -400,6 +400,7 @@ export function VideoHoverPreviewControl( {
 						wait={ 100 }
 						help={ loopDurationHelp }
 						disabled={ disabled || noLoopDurationRange }
+						marksEvery={ 5000 }
 					/>
 				</>
 			) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -372,8 +372,7 @@ export function VideoHoverPreviewControl( {
 					<TimestampControl
 						label={ __( 'Starting point', 'jetpack-videopress-pkg' ) }
 						max={ maxStartingPoint }
-						fineAdjustment={ 1 }
-						decimalPlaces={ 2 }
+						fineAdjustment={ 100 }
 						value={ previewAtTime }
 						onDebounceChange={ timestamp => {
 							onPreviewAtTimeChange( timestamp );
@@ -394,8 +393,7 @@ export function VideoHoverPreviewControl( {
 					<TimestampControl
 						max={ maxLoopDuration }
 						min={ MIN_LOOP_DURATION }
-						fineAdjustment={ 1 }
-						decimalPlaces={ 2 }
+						fineAdjustment={ 100 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
 						value={ loopDuration }
 						onDebounceChange={ onLoopDurationChange }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -347,7 +347,7 @@ export function VideoHoverPreviewControl( {
 	const loopDurationHelp = createInterpolateElement(
 		sprintf(
 			/* translators: placeholder is the maximum lapse duration for the previewOnHover */
-			__( 'Minimum value: <em>3s</em>. Maximum value: <em>%s</em>s.', 'jetpack-videopress-pkg' ),
+			__( 'Minimum: <em>3s</em>. Maximum: <em>%s</em>s.', 'jetpack-videopress-pkg' ),
 			( ( maxLoopDuration / 10 ) | 0 ) / 100
 		),
 		{
@@ -372,7 +372,7 @@ export function VideoHoverPreviewControl( {
 					<TimestampControl
 						label={ __( 'Starting point', 'jetpack-videopress-pkg' ) }
 						max={ maxStartingPoint }
-						fineAdjustment={ 100 }
+						fineAdjustment={ 1 }
 						value={ previewAtTime }
 						onDebounceChange={ timestamp => {
 							onPreviewAtTimeChange( timestamp );
@@ -393,7 +393,7 @@ export function VideoHoverPreviewControl( {
 					<TimestampControl
 						max={ maxLoopDuration }
 						min={ MIN_LOOP_DURATION }
-						fineAdjustment={ 100 }
+						fineAdjustment={ 1 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
 						value={ loopDuration }
 						onDebounceChange={ onLoopDurationChange }

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -245,6 +245,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 		fineAdjustment = 50,
 		autoHideTimeInput = true,
 		decimalPlaces,
+		marksEvery,
 	} = props;
 
 	const debounceTimer = useRef< NodeJS.Timeout >();
@@ -276,6 +277,13 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 		[ onDebounceChange, onChange, max, min, wait ]
 	);
 
+	const marks: Array< { value: number; label: string } > = [];
+	if ( marksEvery ) {
+		for ( let i = min; i <= max; i += marksEvery ) {
+			marks.push( { value: i, label: null } );
+		}
+	}
+
 	return (
 		<BaseControl { ...baseControlProps }>
 			<div className={ styles[ 'timestamp-control__controls-wrapper' ] }>
@@ -301,6 +309,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 					showTooltip={ false }
 					withInputField={ false }
 					onChange={ onChangeHandler }
+					marks={ marksEvery ? marks : undefined }
 				/>
 			</div>
 		</BaseControl>

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
@@ -77,7 +77,7 @@ Also, if it's bigger than one hour, the hour input will be rendered into the Tim
 
 The decimalPlaces property is used to add fractions of a second.
 This property allows the user to specify the number of digits to be displayed after the seconds separator,
-thus allowing for a customizable level of precision.
+thus allowpackages-videopress-timestamp-control--with-marksing for a customizable level of precision.
 
 <Canvas withSource="open">
   <Story id="packages-videopress-timestamp-control--decimal-places" />
@@ -96,6 +96,17 @@ Time, in milliseconds, for every step of the Range control.
 
 - type: `boolean`
 - default: `True`
+
+### marksEvery
+
+- type: `number`
+- optional
+
+Pass a time value, in milliseconds, to generate a mark set to add to the Range control.
+
+<Canvas>
+  <Story id="packages-videopress-timestamp-control--with-marks" />
+</Canvas>
 
 ## Handling the value property
 

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
@@ -60,6 +60,14 @@ disabled.args = {
 	disabled: true,
 };
 
+export const withMarks = Template.bind( {} );
+withMarks.args = {
+	value: 3500, // 3.5 seconds
+	max: 1000 * 5, // five seconds
+	decimalPlaces: 2,
+	marksEvery: 1000,
+};
+
 const ChangingValueTemplate: ComponentStory< typeof TimestampControl > = args => {
 	const [ value, setValue ] = useState( args.value );
 

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
@@ -63,9 +63,9 @@ disabled.args = {
 export const withMarks = Template.bind( {} );
 withMarks.args = {
 	value: 3500, // 3.5 seconds
-	max: 1000 * 5, // five seconds
-	decimalPlaces: 2,
-	marksEvery: 1000,
+	max: 1000 * 10, // ten seconds
+	marksEvery: 1000, // a mark every second
+	fineAdjustment: 200,
 };
 
 const ChangingValueTemplate: ComponentStory< typeof TimestampControl > = args => {

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -9,9 +9,16 @@
 		margin-bottom: 0;
 		flex-grow: 2;
 
-		:global .components-base-control__field {
-			margin-bottom: 0;
+		:global {
+			.components-base-control__field {
+				margin-bottom: 0;
+			}
+
+			.components-range-control__wrapper {
+				margin-bottom: 0;
+			}
 		}
+
 	}
 	
 	:global {

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -12,7 +12,13 @@
 		:global .components-base-control__field {
 			margin-bottom: 0;
 		}
-	} 
+	}
+	
+	:global {
+		.components-range-control__marks {
+			top: 13px;
+		}
+	}
 }
 
 .timestamp-input-wrapper {

--- a/projects/packages/videopress/src/client/components/timestamp-control/types.ts
+++ b/projects/packages/videopress/src/client/components/timestamp-control/types.ts
@@ -20,5 +20,6 @@ export type TimestampControlProps = TimestampInputProps & {
 	label?: ReactNode;
 	help?: ReactNode;
 	wait?: number;
+	marksEvery?: number;
 	onDebounceChange?: ( ms: number ) => void;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR tweaks the TimestampControl and the PosterPanel components:

* Add `markeEvery` prop (TimestampControl)
* Remove decimal places for the Stating point and Duration TimestampControls of the pOH panel section
* Adjust Range control visual issues

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add marksEvery to the TimestampControl component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### With storybook

* Run Storybook

```cli
 cd projects/js-packages/storybook
```

```cli
pnpm run storybook:dev
```

* Go to the TimestampControl story doc
* Go to the [marksEvery prop section](http://localhost:50240/?path=/docs/packages-videopress-timestamp-control--with-marks#marksevery)
* Confirm it works and looks as expected
<img width="608" alt="image" src="https://user-images.githubusercontent.com/77539/230217897-821616f2-5b0f-4806-a85f-8ac1399a7eb1.png">

#### Block editor context

* Go to the block editor
* Create/edit a VideoPress video block
* Enable Preview On Hover feature
* Take a look at the Panel:
  * Confirm the duration control has marks 
  * Confirm the marks update according to the max duration time


https://user-images.githubusercontent.com/77539/230218567-3a5a5e49-d933-451f-9f00-36552a68a39c.mov

