### PR TITLE
VideoPress: Do not force enable Stats module on VideoPress

### DIFF
--- a/projects/packages/videopress/changelog/fix-do-not-force-enable-stats-on-videopress
+++ b/projects/packages/videopress/changelog/fix-do-not-force-enable-stats-on-videopress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Do not force-enable the Stats module inside the VideoPress plugin.

--- a/projects/packages/videopress/src/class-module-control.php
+++ b/projects/packages/videopress/src/class-module-control.php
@@ -20,9 +20,8 @@ class Module_Control {
 	public static function init() {
 		add_filter( 'jetpack_get_available_standalone_modules', array( __CLASS__, 'add_videopress_to_array' ), 10, 1 );
 		if ( Status::is_standalone_plugin_active() ) {
-			// If the stand-alone plugin is active, videopress module will always be considered active; same for the stats module
+			// If the stand-alone plugin is active, videopress module will always be considered active
 			add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_videopress_to_array' ), 10, 2 );
-			add_filter( 'jetpack_active_modules', array( __CLASS__, 'add_stats_to_array' ), 10, 2 );
 		}
 	}
 
@@ -34,15 +33,5 @@ class Module_Control {
 	 */
 	public static function add_videopress_to_array( $modules ) {
 		return array_merge( array( 'videopress' ), $modules );
-	}
-
-	/**
-	 * Adds stats to the list of available/active modules
-	 *
-	 * @param array $modules Array with modules slugs.
-	 * @return array
-	 */
-	public static function add_stats_to_array( $modules ) {
-		return array_merge( array( 'stats' ), $modules );
 	}
 }

--- a/projects/plugins/videopress/changelog/fix-do-not-force-enable-stats-on-videopress
+++ b/projects/plugins/videopress/changelog/fix-do-not-force-enable-stats-on-videopress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Do not force-enable the Stats module inside the VideoPress plugin.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -13,8 +13,7 @@
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-plugins-installer": "@dev",
-		"automattic/jetpack-videopress": "@dev",
-		"automattic/jetpack-stats": "@dev"
+		"automattic/jetpack-videopress": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.0.4",

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "367ce04c2aecfbe718ec9eda8e27c64f",
+    "content-hash": "75db4a73a2d94f740076bc5f6ec284ae",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1145,64 +1145,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Utilities, related with user roles and capabilities.",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-stats",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/stats",
-                "reference": "9f4692f96639eda2306b2c1f140350e907290176"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-status": "@dev"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/wordbless": "dev-master",
-                "yoast/phpunit-polyfills": "1.0.4"
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-stats",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.6.x-dev"
-                },
-                "textdomain": "jetpack-stats"
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "post-install-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "post-update-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Collect valuable traffic stats and insights.",
             "transport-options": {
                 "relative": true
             }
@@ -4262,7 +4204,6 @@
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-plugins-installer": 20,
         "automattic/jetpack-videopress": 20,
-        "automattic/jetpack-stats": 20,
         "automattic/jetpack-changelogger": 20
     },
     "prefer-stable": true,

--- a/projects/plugins/videopress/jetpack-videopress.php
+++ b/projects/plugins/videopress/jetpack-videopress.php
@@ -116,7 +116,6 @@ add_filter(
 );
 
 register_deactivation_hook( __FILE__, array( 'Jetpack_VideoPress_Plugin', 'plugin_deactivation' ) );
-register_activation_hook( __FILE__, array( 'Jetpack_VideoPress_Plugin', 'plugin_activation' ) );
 
 // Main plugin class.
 new Jetpack_VideoPress_Plugin();

--- a/projects/plugins/videopress/src/class-jetpack-videopress-plugin.php
+++ b/projects/plugins/videopress/src/class-jetpack-videopress-plugin.php
@@ -11,7 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
-use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Pkg_Initializer;
 
@@ -51,9 +50,6 @@ class Jetpack_VideoPress_Plugin {
 					'videopress',
 					array( 'admin_ui' => true )
 				);
-
-				// Stats package.
-				$config->ensure( 'stats' );
 			},
 			1
 		);
@@ -76,15 +72,6 @@ class Jetpack_VideoPress_Plugin {
 	public static function plugin_deactivation() {
 		$manager = new Connection_Manager( 'jetpack-videopress' );
 		$manager->remove_connection();
-	}
-
-	/**
-	 * Activation hook. Enables the Stats module since it's required
-	 * for getting stats.
-	 */
-	public static function plugin_activation() {
-		// Enable the Stats module
-		( new Modules() )->activate( 'stats', false, false );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29960.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed Stats package from the list of dependencies for the VideoPress plugin
* Removed the Stats module from the list of enabled modules on VideoPress plugin

This is a revert for #29668. We need to figure out a better way to include stats on standalone plugins to prevent the issue #29960 from happening.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1680772469476929-slack-C03TA48NSUX

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch a site with Jetpack and VideoPress
* Confirm that Stats are not auto-enabled
* Confirm that you can enable and disable Stats from Jetpack settings