### PR TITLE
VideoPress: support tooltip in TimestampControl component

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-time-tooltip-to-timestamp-control
+++ b/projects/packages/videopress/changelog/update-videopress-add-time-tooltip-to-timestamp-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: support tooltip in TimestampControl component

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -372,7 +372,7 @@ export function VideoHoverPreviewControl( {
 					<TimestampControl
 						label={ __( 'Starting point', 'jetpack-videopress-pkg' ) }
 						max={ maxStartingPoint }
-						fineAdjustment={ 10 }
+						fineAdjustment={ 50 }
 						value={ previewAtTime }
 						onDebounceChange={ timestamp => {
 							onPreviewAtTimeChange( timestamp );
@@ -393,7 +393,7 @@ export function VideoHoverPreviewControl( {
 					<TimestampControl
 						max={ maxLoopDuration }
 						min={ MIN_LOOP_DURATION }
-						fineAdjustment={ 10 }
+						fineAdjustment={ 50 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
 						value={ loopDuration }
 						onDebounceChange={ onLoopDurationChange }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -372,7 +372,7 @@ export function VideoHoverPreviewControl( {
 					<TimestampControl
 						label={ __( 'Starting point', 'jetpack-videopress-pkg' ) }
 						max={ maxStartingPoint }
-						fineAdjustment={ 1 }
+						fineAdjustment={ 10 }
 						value={ previewAtTime }
 						onDebounceChange={ timestamp => {
 							onPreviewAtTimeChange( timestamp );
@@ -393,7 +393,7 @@ export function VideoHoverPreviewControl( {
 					<TimestampControl
 						max={ maxLoopDuration }
 						min={ MIN_LOOP_DURATION }
-						fineAdjustment={ 1 }
+						fineAdjustment={ 10 }
 						label={ __( 'Loop duration', 'jetpack-videopress-pkg' ) }
 						value={ loopDuration }
 						onDebounceChange={ onLoopDurationChange }

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -316,6 +316,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 					onChange={ onChangeHandler }
 					marks={ marksEvery ? marks : undefined }
 					renderTooltipContent={ renderTooltipHandler }
+					{ ...( renderTooltip === false ? { showTooltip: false } : {} ) }
 				/>
 			</div>
 		</BaseControl>

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { formatTime } from '../../utils/time';
 import styles from './style.module.scss';
 /**
  * Types
@@ -306,7 +307,9 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 					initialPosition={ controledValue }
 					value={ controledValue }
 					max={ max }
-					showTooltip={ false }
+					renderTooltipContent={ ( time: number ) => {
+						return formatTime( time );
+					} }
 					withInputField={ false }
 					onChange={ onChangeHandler }
 					marks={ marksEvery ? marks : undefined }

--- a/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/index.tsx
@@ -247,6 +247,7 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 		autoHideTimeInput = true,
 		decimalPlaces,
 		marksEvery,
+		renderTooltip,
 	} = props;
 
 	const debounceTimer = useRef< NodeJS.Timeout >();
@@ -285,6 +286,10 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 		}
 	}
 
+	// Provides a default function to render the tooltip content.
+	const renderTooltipHandler =
+		typeof renderTooltip === 'function' ? renderTooltip : ( time: number ) => formatTime( time );
+
 	return (
 		<BaseControl { ...baseControlProps }>
 			<div className={ styles[ 'timestamp-control__controls-wrapper' ] }>
@@ -307,12 +312,10 @@ export const TimestampControl = ( props: TimestampControlProps ): React.ReactEle
 					initialPosition={ controledValue }
 					value={ controledValue }
 					max={ max }
-					renderTooltipContent={ ( time: number ) => {
-						return formatTime( time );
-					} }
 					withInputField={ false }
 					onChange={ onChangeHandler }
 					marks={ marksEvery ? marks : undefined }
+					renderTooltipContent={ renderTooltipHandler }
 				/>
 			</div>
 		</BaseControl>

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/TimestampControl.mdx
@@ -97,6 +97,23 @@ Time, in milliseconds, for every step of the Range control.
 - type: `boolean`
 - default: `True`
 
+### renderTooltip
+
+- type: `function`
+- optional
+
+Optional option that when True renders a tooltip in the Range control, with a default time format.
+
+<Canvas>
+  <Story id="packages-videopress-timestamp-control--show-tooltip" />
+</Canvas>
+
+It also accepts a function. The example below shows how to customize what the tooltip shows.
+
+<Canvas>
+  <Story id="packages-videopress-timestamp-control--custom-tooltip" />
+</Canvas>
+
 ### marksEvery
 
 - type: `number`

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
@@ -72,7 +72,7 @@ export const showTooltip = Template.bind( {} );
 showTooltip.args = {
 	value: 80000, // 1 minute 20 seconds
 	max: 1000 * 100, // 100 seconds
-	showTooltip: true,
+	renderTooltip: true,
 };
 
 export const customTooltip = Template.bind( {} );

--- a/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
+++ b/projects/packages/videopress/src/client/components/timestamp-control/stories/index.tsx
@@ -68,6 +68,23 @@ withMarks.args = {
 	fineAdjustment: 200,
 };
 
+export const showTooltip = Template.bind( {} );
+showTooltip.args = {
+	value: 80000, // 1 minute 20 seconds
+	max: 1000 * 100, // 100 seconds
+	showTooltip: true,
+};
+
+export const customTooltip = Template.bind( {} );
+customTooltip.args = {
+	value: 1000 * 50, // 3.5 seconds
+	max: 1000 * 80, // ten seconds
+	fineAdjustment: 200,
+	renderTooltip: ( value: number ) => {
+		return <span>{ value / 1000 } seconds</span>;
+	},
+};
+
 const ChangingValueTemplate: ComponentStory< typeof TimestampControl > = args => {
 	const [ value, setValue ] = useState( args.value );
 

--- a/projects/packages/videopress/src/client/components/timestamp-control/types.ts
+++ b/projects/packages/videopress/src/client/components/timestamp-control/types.ts
@@ -21,6 +21,6 @@ export type TimestampControlProps = TimestampInputProps & {
 	help?: ReactNode;
 	wait?: number;
 	marksEvery?: number;
-	renderTooltip: boolean;
+	renderTooltip?: boolean;
 	onDebounceChange?: ( ms: number ) => void;
 };

--- a/projects/packages/videopress/src/client/components/timestamp-control/types.ts
+++ b/projects/packages/videopress/src/client/components/timestamp-control/types.ts
@@ -21,5 +21,6 @@ export type TimestampControlProps = TimestampInputProps & {
 	help?: ReactNode;
 	wait?: number;
 	marksEvery?: number;
+	renderTooltip: boolean;
 	onDebounceChange?: ( ms: number ) => void;
 };

--- a/projects/packages/videopress/src/client/utils/time/index.ts
+++ b/projects/packages/videopress/src/client/utils/time/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Formats the given time in milliseconds into a string with the format HH:MM:SS.DD,
+ * adding hours and minutes only when needed.
+ *
+ * @param {number} ms - The time in milliseconds to format.
+ * @returns {string} The formatted time string.
+ * @example
+ * const formattedTime1 = formatTime(1234567); // Returns "20:34.56"
+ * const formattedTime2 = formatTime(45123);   // Returns "45.12"
+ */
+export function formatTime( ms: number ): string {
+	const hours = Math.floor( ms / 3600000 );
+	const minutes = Math.floor( ms / 60000 ) % 60;
+	const seconds = Math.floor( ms / 1000 ) % 60;
+	const deciseconds = Math.floor( ms / 10 ) % 100;
+
+	const parts = [
+		hours > 0 ? hours.toString().padStart( 2, '0' ) + ':' : '',
+		hours > 0 || minutes > 0 ? minutes.toString().padStart( 2, '0' ) + ':' : '',
+		seconds.toString().padStart( 2, '0' ),
+		'.' + deciseconds.toString().padStart( 2, '0' ),
+	];
+
+	return parts.join( '' );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR introduces the `renderTooltip` property to the `<TimestampControl />` to be used by the `<PosterPanel />` component, to show the selected time in the TimestampControl instances.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: support tooltip in TimestampControl component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


#### Use storybook


* Run Storybook

```cli
 cd projects/js-packages/storybook
```

```cli
pnpm run storybook:dev
```

* Go to the TimestampControl story doc
* Go to the [renderTooltip prop section](http://localhost:50240/?path=/docs/packages-videopress-timestamp-control--show-tooltip#rendertooltip)
* Confirm it works and looks as expected
* Confirm you can change the time by typing DOWN/UP LEFT/RIGHT when the range control is focused 

<img width="682" alt="image" src="https://user-images.githubusercontent.com/77539/230418083-37f4e4bd-57de-458a-91d2-9b1a16b4cc6f.png">


#### Block editor context

* Go to the block editor
* Create/edit a VideoPress video block
* Enable Preview On Hover feature
* Confirm the Timestamp controls show the selected



https://user-images.githubusercontent.com/77539/230418684-29aa7493-acb5-4bc0-8f6c-43f73516e951.mov

#### DISCLAIMER

There is an issue when changing the time by using the inputs. The decimal part gets lost. Going to address this in a follow-up.