### PR TITLE
[Boost] Prevent unavailable modules from announcing they are active.

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -24,7 +24,7 @@
 	}
 
 	onMount( async () => {
-		if ( isModuleActive ) {
+		if ( isModuleAvailable && isModuleActive ) {
 			dispatch( 'mountEnabled' );
 		}
 	} );

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -9,11 +9,7 @@
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
 	import ImageSizeAnalysisView from '../../../modules/image-size-analysis/ModuleView.svelte';
 	import { RegenerateCriticalCssSuggestion } from '../../../react-components/RegenerateCriticalCssSuggestion';
-	import {
-		criticalCssState,
-		regenerateLocalCriticalCss,
-		regenerateCriticalCss,
-	} from '../../../stores/critical-css-state';
+	import { criticalCssState, regenerateCriticalCss } from '../../../stores/critical-css-state';
 	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
 	import { isModuleAvailableStore } from '../../../stores/modules';
 	import { startPollingCloudStatus, stopPollingCloudCssStatus } from '../../../utils/cloud-css';
@@ -46,7 +42,6 @@
 		if ( ! $criticalCssState || $criticalCssState.status === 'not_generated' ) {
 			return regenerateCriticalCss();
 		}
-		await regenerateLocalCriticalCss( $criticalCssState );
 	}
 </script>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -9,7 +9,11 @@
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
 	import ImageSizeAnalysisView from '../../../modules/image-size-analysis/ModuleView.svelte';
 	import { RegenerateCriticalCssSuggestion } from '../../../react-components/RegenerateCriticalCssSuggestion';
-	import { criticalCssState, regenerateCriticalCss } from '../../../stores/critical-css-state';
+	import {
+		criticalCssState,
+		regenerateLocalCriticalCss,
+		regenerateCriticalCss,
+	} from '../../../stores/critical-css-state';
 	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
 	import { isModuleAvailableStore } from '../../../stores/modules';
 	import { startPollingCloudStatus, stopPollingCloudCssStatus } from '../../../utils/cloud-css';
@@ -42,6 +46,7 @@
 		if ( ! $criticalCssState || $criticalCssState.status === 'not_generated' ) {
 			return regenerateCriticalCss();
 		}
+		await regenerateLocalCriticalCss( $criticalCssState );
 	}
 </script>
 

--- a/projects/plugins/boost/changelog/boost-dont-run-local-regen
+++ b/projects/plugins/boost/changelog/boost-dont-run-local-regen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't run local regenerate automagically when using cloud css


### PR DESCRIPTION
If you reload the Boost Dashboard while Cloud CSS is generating, a mis-firing event can cause the local Generator to run. This PR fixes the issue by preventing a "mount enabled" event from firing when mounting a Module component for an unavailable module.

## Proposed changes:
* Prevent unavailable modules from announcing themselves enabled.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Generate Cloud CSS
* Reload the page
* Ensure that the local generator doesn't run (check the network tab for signs of it running)
* Generate Local CSS
* Ensure the local generator runs