### PR TITLE
CRM: Fixes 3016 - remove `.htaccess` when not needed

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3016-remove_htaccess_in_contact_files
+++ b/projects/plugins/crm/changelog/fix-crm-3016-remove_htaccess_in_contact_files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact files: fix 403 if file was uploaded via Client Portal Pro using Apache web server

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1422,6 +1422,8 @@ function jpcrm_create_and_secure_dir_from_external_access( $directory_path = '',
 			'file'    => '.htaccess',
 			'content' => 'DirectoryIndex index.php index.html' . PHP_EOL . 'deny from all',
 		);
+	} elseif ( file_exists( trailingslashit( $directory_path ) . '.htaccess' ) ) {
+		wp_delete_file( trailingslashit( $directory_path ) . '.htaccess' );
 	}
 
 	foreach ( $files as $file ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/zero-bs-crm#3016 - remove `.htaccess` when not needed

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When `$include_htaccess` was set to `false` in `jpcrm_create_and_secure_dir_from_external_access()`, it didn't create a `.htaccess`, but if there was one errantly present (e.g. Automattic/jetpack-crm-extensions#647), it wasn't removed.

This PR removes the `.htaccess` if it exists but shouldn't.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
This is best tested with Automattic/jetpack-crm-extensions#656. To test it standalone on an Apache server:

1. Upload a file to a contact.
2. Manually add a `.htaccess` in the contact's file folder (e.g. `/Users/tmb/local_sites/apachecrm/app/public/wp-content/jpcrm-storage/contacts/some_contact_hash/files/`).
3. Try to view the file via the contact's profile.
4. Upload a new file to the contact.
5. Try to view either file. The `.htaccess` has been removed, so files can now be viewed.