### PR TITLE
Forms: Update dashboard source column styles and "trash" action label

### DIFF
--- a/projects/packages/forms/changelog/update-dashboard-source-column
+++ b/projects/packages/forms/changelog/update-dashboard-source-column
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update source column styles and trash action label

--- a/projects/packages/forms/src/dashboard/components/search-form/style.scss
+++ b/projects/packages/forms/src/dashboard/components/search-form/style.scss
@@ -1,7 +1,10 @@
 .jp-forms__actions-search {
 	display: flex;
 	flex-direction: row;
-	flex: 1;
+
+	@media (max-width: 600px) {
+		flex: 1;
+	}
 
 	.input-wrapper {
 		min-height: var( --jp-forms-input-wrapper-height );

--- a/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
@@ -13,7 +13,7 @@ const SingleActionsMenu = ( { id } ) => {
 
 	const deleteLabel =
 		currentTab !== TABS.trash
-			? __( 'Delete', 'jetpack-forms' )
+			? __( 'Trash', 'jetpack-forms' )
 			: __( 'Delete permanently', 'jetpack-forms' );
 	const deleteAction = currentTab !== TABS.trash ? ACTIONS.moveToTrash : ACTIONS.delete;
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -189,6 +189,10 @@ $action-bar-height: 88px;
 			&:nth-child(even) {
 				background-color: #f9f9f6;
 			}
+
+			.is-link {
+				text-decoration: underline;
+			}
 		}
 	}
 
@@ -221,11 +225,23 @@ $action-bar-height: 88px;
 		width: 27.5%;
 
 		.is-link {
+			cursor: pointer;
 			display: inline-block;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
 			width: 100%;
+			text-decoration: none;
+
+			 &:hover {
+				 text-decoration: underline;
+			 }
+		}
+	}
+
+	.jp-forms__table-item.is-active {
+		.is-link {
+			text-decoration: underline;
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:

* Update Source column styles
  * The underline should appear only when the row is selected or when hovering the mouse over the link
* Change the Single Action dropdown label from "Delete" to  "Trash"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Enable the jetpack forms package and the new dashboard before testing with:

```
add_filter( 'jetpack_contact_form_use_package', '__return_true' );
add_filter( 'jetpack_forms_dashboard_enable', '__return_true' );
```

- Go to `/wp-admin/admin.php?page=jetpack-forms`
- Check if the changes described above were applied correctly

