### PR TITLE
VideoPress: Add fallback for experimental features for hover preview

### DIFF
--- a/projects/js-packages/svelte-data-sync-client/changelog/update-videopress-preview-on-hover-import-fallback
+++ b/projects/js-packages/svelte-data-sync-client/changelog/update-videopress-preview-on-hover-import-fallback
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Version bump
+
+

--- a/projects/js-packages/svelte-data-sync-client/package.json
+++ b/projects/js-packages/svelte-data-sync-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-svelte-data-sync-client",
-	"version": "0.1.0",
+	"version": "0.1.1-alpha",
 	"description": "A Svelte.js client for the wp-js-data-sync package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/svelte-data-sync-client/#readme",
 	"type": "module",

--- a/projects/packages/videopress/changelog/update-videopress-preview-on-hover-import-fallback
+++ b/projects/packages/videopress/changelog/update-videopress-preview-on-hover-import-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add falback for experimental features for hover preview

--- a/projects/packages/videopress/changelog/update-videopress-preview-on-hover-import-fallback
+++ b/projects/packages/videopress/changelog/update-videopress-preview-on-hover-import-fallback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-VideoPress: Add falback for experimental features for hover preview
+VideoPress: Add fallback for experimental features for hover preview

--- a/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
+++ b/projects/packages/videopress/src/client/components/timestamp-control/style.module.scss
@@ -49,6 +49,19 @@
 		&:last-child{
 			margin-bottom: 0;
 		}
+
+		/* For TextControl fallback */
+		:global {
+			.components-base-control__field {
+				margin-bottom: 0;
+
+				.components-text-control__input {
+					border: none;
+					text-align: center;
+					padding: 0;
+				}
+			}
+		}
 	}
 
 	:global {

--- a/projects/packages/wp-js-data-sync/changelog/update-videopress-preview-on-hover-import-fallback
+++ b/projects/packages/wp-js-data-sync/changelog/update-videopress-preview-on-hover-import-fallback
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Version bump
+
+

--- a/projects/packages/wp-js-data-sync/package.json
+++ b/projects/packages/wp-js-data-sync/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wp-js-data-sync",
-	"version": "0.1.0",
+	"version": "0.1.1-alpha",
 	"description": "A package to setup REST API and script localization to pass data to a JavaScript client.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wp-js-data-sync/#readme",
 	"bugs": {

--- a/projects/packages/wp-js-data-sync/src/class-data-sync.php
+++ b/projects/packages/wp-js-data-sync/src/class-data-sync.php
@@ -68,7 +68,7 @@ use Automattic\Jetpack\WP_JS_Data_Sync\Schema\Schema;
 
 final class Data_Sync {
 
-	const PACKAGE_VERSION = '0.1.0';
+	const PACKAGE_VERSION = '0.1.1-alpha';
 
 	/**
 	 * @var Registry


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29687

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds fallbacks for `useBaseControlProps` and `__experimentalNumberControl` in case the user has an old version of Gutenberg

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This one is tricky to test.
* One way would be to install an old version of Gutenberg. Or, locally, change the imports of `__experimentalNumberControl` and `useBaseControlProps` to wrong names to ensure they fail and return `undefined`
* Go to the block editor
* Add a VideoPress video block
* Go the the `Poster and preview` panel
* Turn the `Video preview on hover` toggle on
* Check that the controls, labels and help text work. The input is not a 1-to-1 replacement, lacking change on scroll, for instance, but it should be usable, without console warnings

Original | Fallback
-|-
![2023-04-06_15-42-43-original](https://user-images.githubusercontent.com/8486249/230471154-8df85d77-eb64-4959-b8b7-1ddef314fbdc.png) | ![2023-04-06_15-42-59-fallback](https://user-images.githubusercontent.com/8486249/230471172-f63d8027-fa08-4ef6-99c2-b2f43aa65655.png)
