### PR TITLE
VideoPress: remove duplicated code when saving video block 

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-render-video-block-dynamically
+++ b/projects/packages/videopress/changelog/update-videopress-render-video-block-dynamically
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: remove duplicated code when saving video block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/save.tsx
@@ -77,22 +77,6 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 		style.margin = 'auto';
 	}
 
-	if ( ! isVideoFramePosterEnabled() ) {
-		return (
-			<figure { ...blockProps } style={ style }>
-				{ videoPressUrl && (
-					<div className="jetpack-videopress-player__wrapper">
-						{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
-					</div>
-				) }
-
-				{ ! RichText.isEmpty( caption ) && (
-					<RichText.Content tagName="figcaption" value={ caption } />
-				) }
-			</figure>
-		);
-	}
-
 	return (
 		<figure { ...blockProps } style={ style }>
 			{ videoPressUrl && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The block renders its content dynamically on the server-side (https://github.com/Automattic/jetpack/pull/29939). Whit this, we shouldn't take care of the block validation errors.  This PR removes the code that, in short, doesn't change anything.
This is a janitorial PR.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: remove duplicated code when saving video block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test in the block editor
* Create a block with an old version of the VideoPress video block (Jetpack production)
* Switch to this version using the Jetpack `beta` plugin
* Confirm there is not any block validation error
* Confirm it works as usual


