### PR TITLE
CRM: Resolves 2930, 2088, 2932 - various fixes for sales funnel

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -315,7 +315,7 @@ if (jQuery('#bar-chart').length){
 </div>
 
 <div class="ui grid narrow">
-	<div class="six wide column zbs-funnel"  id="settings_dashboard_sales_funnel_display" 
+	<div class="six wide column" id="settings_dashboard_sales_funnel_display" 
 	<?php
 	if ( $settings_dashboard_sales_funnel == 'true' ) {
 		echo "style='display:block;'";

--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -560,9 +560,9 @@ if (jQuery('#bar-chart').length){
 </div>
 <script>
 // build sales funnel
-element = document.getElementById('jpcrm_sales_funnel');
-funnel_data = <?php echo wp_json_encode( $funnel_data ); ?>;
-jpcrm_build_funnel(funnel_data,element);
+let funnel_element = document.getElementById('jpcrm_sales_funnel');
+let funnel_data = <?php echo wp_json_encode( $funnel_data ); ?>;
+jpcrm_build_funnel(funnel_data,funnel_element);
 </script>
 	<?php
 

--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -67,6 +67,43 @@ function jpcrm_render_dashboard_page() {
 		$settings_dashboard_latest_contacts = 'true';
 	}
 
+	// process data for use in sales funnel
+	$funnel_data = array();
+
+	$funnel_status_str = zeroBSCRM_getSetting( 'zbsfunnel' );
+
+	// if no setting exists, grab it from the init config
+	if ( empty( $funnel_status_str ) ) {
+		global $zeroBSCRM_Conf_Setup; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$funnel_status_str = $zeroBSCRM_Conf_Setup['conf_defaults']['zbsfunnel']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	}
+
+	$funnel_statuses = explode( ',', $funnel_status_str );
+
+	$backfill_count = 0;
+
+	// reverse for backfill purposes
+	foreach ( array_reverse( $funnel_statuses ) as $contact_status ) {
+
+		// number of contacts in a given status
+		$count = zeroBS_customerCountByStatus( $contact_status );
+
+		// number of contacts in this status plus later statuses
+		$backfill_count += $count;
+
+		// The funnel supports links, so we could link to the contact list filtered by statuses,
+		// for example...however, there's no predefined list of status filters and the current
+		// conversion methods indicate they're not entirely i18n-safe and/or tested.
+		$funnel_data[] = array(
+			'count'          => $count,
+			'backfill_count' => $backfill_count,
+			'contact_status' => $contact_status,
+			'link'           => false,
+		);
+	}
+
+	$funnel_data = array_reverse( $funnel_data );
+
 	?>
 
 
@@ -171,77 +208,6 @@ function jpcrm_render_dashboard_page() {
 <!--- the contacts over time comes in next - PHP below is for the funnel -->
 <div class="ui grid narrow">
 
-
-
-	<?php
-
-	$zbsFunnelStr = zeroBSCRM_getSetting( 'zbsfunnel' );
-
-	// } Defaults:
-	$zbsFunnelArr  = array();
-	$zbsFunnelArrN = array();
-
-	// } Unpack.. if present
-	if ( ! empty( $zbsFunnelStr ) ) {
-
-		if ( strpos( $zbsFunnelStr, ',' ) > -1 ) {
-
-			// csv
-			$zbsFunnelArrN = explode( ',', $zbsFunnelStr );
-			$zbsFunnelArr  = array_reverse( $zbsFunnelArrN );
-
-		} else {
-
-			// single str
-			$zbsFunnelArr  = array( $zbsFunnelStr );
-			$zbsFunnelArrN = array( $zbsFunnelStr );
-
-		}
-	}
-
-	$i   = 0;
-	$tot = 0;
-	$n   = count( $zbsFunnelArr );
-	// wh added these to stop php notices?
-	$func = array();
-	foreach ( $zbsFunnelArr as $Funnel ) {
-		// hack for demo site
-		$fun[ $i ]  = zeroBS_customerCountByStatus( $Funnel );
-		$func[ $i ] = $fun[ $i ] + $tot;
-		$tot        = $func[ $i ];
-		++$i;
-	}
-
-	$values = array_reverse( $func );
-
-	// WH note: added second set of SAME colours here - as was PHP NOTICE for users with more than 6 in setting below
-	$colors  = array( '#00a0d2', '#0073aa', '#035d88', '#333', '#222', '#000', '#00a0d2', '#0073aa', '#035d88', '#333', '#222', '#000' );
-	$colorsR = array_reverse( $colors );
-
-	$i    = 0;
-	$data = '';
-	$n    = count( $zbsFunnelArr ) - 1;
-
-	// WH added - to stop 0 0 funnels
-	$someDataInData = false;
-
-	for ( $j = $n; $j >= 0;  $j-- ) {
-
-		$val = (int) $func[ $j ];
-
-		if ( $val > 0 ) {
-			$someDataInData = true;
-		}
-
-		$data     .= '{';
-			$data .= 'value: ' . $val . ',';
-			$data .= "color: '" . $colors[ $j ] . "',";
-			$data .= "labelstr: '" . $func[ $j ] . "'";
-		$data     .= '},';
-	}
-
-	?>
-
 	<?php
 
 	/* Transactions - Revenue Chart data gen */
@@ -297,44 +263,7 @@ function jpcrm_render_dashboard_page() {
 <script type="text/javascript">
 jQuery(function(){
 
-	funnel_height = jQuery('#bar-chart').height();
-	jQuery('.zbs-funnel').height(funnel_height);
 
-	jQuery('.learn')
-	.popup({
-		inline: false,
-		on:'click',
-		lastResort: 'bottom right',
-	});
-
-	<?php if ( strlen( $data ) > 0 ) { ?>
-	window.funnelData = [<?php echo $data; ?>];
-	<?php } else { ?>
-	window.funnelData = '';
-	<?php } ?>
-
-	if (funnelData != '') jQuery('#funnel-container').drawFunnel(funnelData, {
-
-
-	width: jQuery('.zbs-funnel').width() - 50, 
-	height: jQuery('.zbs-funnel').height() -50,  
-
-	// Padding between segments, in pixels
-	padding: 1, 
-
-	// Render only a half funnel
-	half: false,  
-
-	// Width of a segment can't be smaller than this, in pixels
-	minSegmentSize: 30,  
-
-	// label: function () { return "Label!"; } 
-
-
-	label: function (obj) {
-		return obj;
-	}
-	});
 
 
 // WH added: don't draw if not there :)
@@ -399,36 +328,7 @@ if (jQuery('#bar-chart').length){
 		<div class="panel-heading" style="text-align:center">
 		<h4 class="panel-title text-muted font-light"><?php esc_html_e( 'Sales Funnel', 'zero-bs-crm' ); ?></h4>
 		</div>
-		<?php
-		if (
-			( is_array( $data ) && count( $data ) == 0 )
-			||
-			( is_string( $data ) && strlen( $data ) == 0 )
-			||
-			! $someDataInData
-			) {
-			?>
-		<div class='ui message blue' style="text-align:center;margin-bottom:50px;">
-				<?php esc_html_e( 'You do not have any contacts. Make sure you have contacts in each stage of your funnel.', 'zero-bs-crm' ); ?> 
-				<?php ##WLREMOVE ?><br/><br/>
-			<a class="button ui blue" href="<?php echo esc_url( $zbs->urls['kbcrmdashboard'] ); ?>"><?php esc_html_e( 'Read Guide', 'zero-bs-crm' ); ?></a>
-				<?php ##/WLREMOVE ?>
-		</div>
-		<?php } else { ?>
-		<div id="funnel-container"></div>
-		<?php } ?>
-
-		<div class='funnel-legend'>
-			<?php
-			$i             = 0;
-			$zbsFunnelArrR = array_reverse( $zbsFunnelArr );
-			$j             = count( $zbsFunnelArrR );
-			foreach ( $zbsFunnelArrR as $Funnel ) {
-				echo '<div class="zbs-legend" style="background:' . esc_attr( $colors[ $j - $i - 1 ] ) . '"></div><div class="zbs-label">  ' . esc_html( $Funnel ) . '</div>';
-				++$i;
-			}
-			?>
-		</div>
+		<div id="jpcrm_sales_funnel"></div>
 
 	</div>
 	</div>
@@ -658,6 +558,12 @@ if (jQuery('#bar-chart').length){
 		</div>
 	</div>
 </div>
+<script>
+// build sales funnel
+element = document.getElementById('jpcrm_sales_funnel');
+funnel_data = <?php echo wp_json_encode( $funnel_data ); ?>;
+jpcrm_build_funnel(funnel_data,element);
+</script>
 	<?php
 
 	// First use dashboard

--- a/projects/plugins/crm/admin/settings/field-options.page.php
+++ b/projects/plugins/crm/admin/settings/field-options.page.php
@@ -460,12 +460,12 @@ if ( isset( $sbupdated ) ) {
 
 								if ( empty( $zbsFunnelStr ) ) {
 									// } Defaults:
-									$zbsFunnelStr = 'Lead,Contacted,Customer,Upsell'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+									$zbsFunnelStr = 'Lead,Customer'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 								}
 
 								?>
 								<input type="text" name="zbs-funnel" id="zbs-funnel" value="<?php echo esc_attr( $zbsFunnelStr ); ?>" class="form-control" />
-								<p style="margin-top:4px"><?php esc_html_e( 'Enter which statuses you want to display in the funnel. Starting at the top of the funnel', 'zero-bs-crm' ); ?>. e.g. Lead,Contacted,Customer,Upsell as a CSV value</p>
+								<p style="margin-top:4px"><?php esc_html_e( 'Enter which statuses you want to display in the funnel. Starting at the top of the funnel', 'zero-bs-crm' ); ?>. e.g. Lead,Customer as a CSV value</p>
 							</td>
 						</tr>
 

--- a/projects/plugins/crm/changelog/fix-crm-2930-funnel_glitches
+++ b/projects/plugins/crm/changelog/fix-crm-2930-funnel_glitches
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Dashboard: various fixes for the sales funnel

--- a/projects/plugins/crm/includes/ZeroBSCRM.ScriptsStyles.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.ScriptsStyles.php
@@ -561,6 +561,9 @@ function zeroBSCRM_admin_styles_homedash(){
 	zeroBSCRM_enqueue_libs_js_momentdatepicker();
 	wp_register_script('zerobscrmjs-dash' , ZEROBSCRM_URL .'js/ZeroBSCRM.admin.dash'.wp_scripts_get_suffix().'.js', array('jquery'), $zbs->version);
 	wp_enqueue_script( 'zerobscrmjs-dash');
+
+	wp_enqueue_script( 'jpcrm-funnel-js', ZEROBSCRM_URL . 'js/jpcrm-admin-funnel' . wp_scripts_get_suffix() . '.js', array(), $zbs->version, false );
+	wp_enqueue_style( 'jpcrm-funnel-css', ZEROBSCRM_URL . 'css/jpcrm-admin-funnel' . wp_scripts_get_suffix() . '.css', array(), $zbs->version );
 	
 }
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.dash.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.dash.js
@@ -70,9 +70,6 @@ jQuery( function ( $ ) {
 		} );
 	}
 
-	funnel_height = jQuery( '#bar-chart' ).height();
-	jQuery( '.zbs-funnel' ).height( funnel_height );
-
 	jQuery( '.dashboard-customiser' ).on( 'click', function ( e ) {
 		jQuery( '.dashboard-custom-choices' ).toggle();
 	} );
@@ -218,34 +215,6 @@ function jetpackcrm_draw_contact_chart( data ) {
 	window.contactChart.data.datasets[ 0 ].data = data.data;
 	window.contactChart.update();
 }
-
-//handle window resizing + charts
-jQuery( window ).on( 'resize', function () {
-	jQuery( '#funnel-container' ).html( '' );
-
-	funnel_height = jQuery( '#bar-chart' ).height();
-	jQuery( '.zbs-funnel' ).height( funnel_height );
-
-	jQuery( '#funnel-container' ).drawFunnel( window.funnelData, {
-		width: jQuery( '.zbs-funnel' ).width() - 50,
-		height: jQuery( '.zbs-funnel' ).height() - 50,
-
-		// Padding between segments, in pixels
-		padding: 1,
-
-		// Render only a half funnel
-		half: false,
-
-		// Width of a segment can't be smaller than this, in pixels
-		minSegmentSize: 30,
-
-		// label: function () { return "Label!"; }
-
-		label: function ( obj ) {
-			return obj;
-		},
-	} );
-} );
 
 if ( typeof module !== 'undefined' ) {
     module.exports = {  jetpackcrm_draw_contact_chart  };

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -3,7 +3,7 @@
  * 
  * Inspired in part by https://codepen.io/tylerlwsmith/pen/RwNZKgp
  * 
- * @param funnel_data array of funnel data (value and color)
+ * @param funnel_data array of funnel data (count, backfill_count, contact_status, and link)
  * @element HTML element to turn into a funnel
  **/
 

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -1,4 +1,31 @@
 /**
+ * Gets an array of funnel segment colors
+ * 
+ * @param num_segments the number of segments to generate colors for
+ * 
+ * @returns an array of colors
+ **/
+function jpcrm_get_segment_colors(num_segments) {
+	let colors = [ '#68b3e8', '#399ce3', '#1689db', '#0675c4', '#055d9c', '#044b7a', '#02395c', '#01283d', '#001621', '#000000' ];
+
+	if (num_segments === colors.length) {
+		// use full set of colors
+		return colors;
+	} else if (num_segments < colors.length) {
+		// use a middle subset of colors
+		let mid_point = Math.floor(colors.length/2);
+		let start_index = Math.floor(mid_point - num_segments/2);
+		return colors.slice(start_index,start_index+num_segments);
+	}
+
+	// use full set of colors, repeated
+	while (num_segments > colors.length) {
+		colors = colors.concat(colors);
+	}
+	return colors.slice(0,num_segments);
+}
+
+/**
  * Draws a simple funnel
  * 
  * Inspired in part by https://codepen.io/tylerlwsmith/pen/RwNZKgp
@@ -11,8 +38,6 @@ function jpcrm_build_funnel(funnel_data, funnel_element) {
 	// something's wrong, so stop
 	if (!funnel_element || !funnel_data) return;
 
-	const COLORS = [ '#000', '#222', '#333', '#035d88', '#0073aa', '#00a0d2' ];
-
 	// show legend if desired
 	const SHOW_FUNNEL_LEGEND = false;
 
@@ -22,6 +47,9 @@ function jpcrm_build_funnel(funnel_data, funnel_element) {
 	// height of each section
 	const SECTION_HEIGHT = 50;
 
+	// colors to use
+	const SEGMENT_COLORS = jpcrm_get_segment_colors(NUM_FUNNEL_SECTIONS);
+
 	let funnel_html = `<div class="jpcrm_funnel" style="height: ${SECTION_HEIGHT * NUM_FUNNEL_SECTIONS}px">`;
 	let legend_html = '';
 	
@@ -29,7 +57,7 @@ function jpcrm_build_funnel(funnel_data, funnel_element) {
 		legend_html = '<div class="jpcrm_funnel_legend">';
 	}
 	for (var i=0; i<NUM_FUNNEL_SECTIONS; i++) {
-		let section_color = COLORS[i%COLORS.length];
+		let section_color = SEGMENT_COLORS[i];
 		funnel_html += `<a
 			${funnel_data[i]['link']?'href='+funnel_data[i]['link']:''}
 			class="funnel_section"
@@ -52,7 +80,6 @@ function jpcrm_build_funnel(funnel_data, funnel_element) {
 		funnel_html += '<br>' + legend_html;
 	}
 	funnel_element.innerHTML = funnel_html + '<br>';
-
 }
 
 if ( typeof module !== 'undefined' ) {

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -30,14 +30,13 @@ function jpcrm_build_funnel(funnel_data, funnel_element) {
 	}
 	for (var i=0; i<NUM_FUNNEL_SECTIONS; i++) {
 		let section_color = COLORS[i%COLORS.length];
-		let section_html = `<a
+		funnel_html += `<a
 			${funnel_data[i]['link']?'href='+funnel_data[i]['link']:''}
 			class="funnel_section"
 			data-hover="${funnel_data[i]['contact_status'] + ': \u00a0'}"
 			alt="${funnel_data[i]['contact_status']}: ${funnel_data[i]['backfill_count']}"
 			style="background-color: ${section_color};"
 			>${funnel_data[i]['backfill_count']}</a>`;
-		funnel_html += section_html;
 
 		if (SHOW_FUNNEL_LEGEND) {
 			legend_html += `<div class="legend-color" style="background-color: ${section_color}"></div><div class="legend-label">${funnel_data[i]['contact_status']}</div>`;

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -6,23 +6,24 @@
  * @returns an array of colors
  **/
 function jpcrm_get_segment_colors(num_segments) {
-	let colors = [ '#68b3e8', '#399ce3', '#1689db', '#0675c4', '#055d9c', '#044b7a', '#02395c', '#01283d', '#001621', '#000000' ];
+	const COLORS = [ '#68b3e8', '#399ce3', '#1689db', '#0675c4', '#055d9c', '#044b7a', '#02395c', '#01283d', '#001621', '#000000' ];
 
-	if (num_segments === colors.length) {
+	if (num_segments === COLORS.length) {
 		// use full set of colors
 		return colors;
-	} else if (num_segments < colors.length) {
+	} else if (num_segments < COLORS.length) {
 		// use a middle subset of colors
-		let mid_point = Math.floor(colors.length/2);
-		let start_index = Math.floor(mid_point - num_segments/2);
-		return colors.slice(start_index,start_index+num_segments);
+		let midpoint = Math.floor(COLORS.length/2);
+		let start_index = Math.floor(midpoint - num_segments/2);
+		return COLORS.slice(start_index,start_index+num_segments);
 	}
 
-	// use full set of colors, repeated
-	while (num_segments > colors.length) {
-		colors = colors.concat(colors);
+	// use full set of colors, repeated and variably reversed
+	let lotsa_colors = COLORS.slice();
+	while (num_segments > lotsa_colors.length) {
+		lotsa_colors = lotsa_colors.concat(COLORS.reverse().slice(1));
 	}
-	return colors.slice(0,num_segments);
+	return lotsa_colors.slice(0,num_segments);
 }
 
 /**

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -10,7 +10,7 @@ function jpcrm_get_segment_colors(num_segments) {
 
 	if (num_segments === COLORS.length) {
 		// use full set of colors
-		return colors;
+		return COLORS;
 	} else if (num_segments < COLORS.length) {
 		// use a middle subset of colors
 		let midpoint = Math.floor(COLORS.length/2);

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -1,0 +1,57 @@
+/**
+ * Draws a simple funnel
+ * 
+ * Inspired in part by https://codepen.io/tylerlwsmith/pen/RwNZKgp
+ * 
+ * @param funnel_data array of funnel data (value and color)
+ * @element HTML element to turn into a funnel
+ **/
+
+function jpcrm_build_funnel(data, funnel_element) {
+	// something's wrong, so stop
+	if (!element || !data) return;
+
+	const COLORS = [ '#00a0d2', '#0073aa', '#035d88', '#333', '#222', '#000' ];
+
+	// show legend if desired
+	const SHOW_FUNNEL_LEGEND = false;
+
+	num_of_funnel_sections = data.length;
+	funnel_height = num_of_funnel_sections * 50;
+	let funnel_html = `<div class="jpcrm_funnel" style="height: ${funnel_height}px">`;
+	let legend_html = '';
+	
+	if (SHOW_FUNNEL_LEGEND) {
+		legend_html = '<div class="jpcrm_funnel_legend">';
+	}
+	for (var i=0; i<num_of_funnel_sections; i++) {
+		let section_color = COLORS[i%COLORS.length];
+		let section_html = `<a
+			${data[i]['link']?'href='+data[i]['link']:''}
+			class="funnel_section"
+			data-hover="${data[i]['contact_status'] + ': \u00a0'}"
+			alt="${data[i]['contact_status']}: ${data[i]['backfill_count']}"
+			style="background-color: ${section_color};"
+			>${data[i]['backfill_count']}</a>`;
+		funnel_html += section_html;
+
+		if (SHOW_FUNNEL_LEGEND) {
+			legend_html += `<div class="legend-color" style="background-color: ${section_color}"></div><div class="legend-label">${data[i]['contact_status']}</div>`;
+		}
+	}
+	funnel_html += '</div>';
+
+	if (SHOW_FUNNEL_LEGEND) {
+		legend_html += '</div>';
+	}
+
+	if (SHOW_FUNNEL_LEGEND) {
+		funnel_html += '<br>' + legend_html;
+	}
+	funnel_element.innerHTML = funnel_html + '<br>';
+
+}
+
+if ( typeof module !== 'undefined' ) {
+	module.exports = { jpcrm_build_funnel };
+}

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -16,15 +16,19 @@ function jpcrm_build_funnel(funnel_data, funnel_element) {
 	// show legend if desired
 	const SHOW_FUNNEL_LEGEND = false;
 
-	num_of_funnel_sections = funnel_data.length;
-	funnel_height = num_of_funnel_sections * 50;
-	let funnel_html = `<div class="jpcrm_funnel" style="height: ${funnel_height}px">`;
+	// number of funnel sections
+	const NUM_FUNNEL_SECTIONS = funnel_data.length;
+
+	// height of each section
+	const SECTION_HEIGHT = 50;
+
+	let funnel_html = `<div class="jpcrm_funnel" style="height: ${SECTION_HEIGHT * NUM_FUNNEL_SECTIONS}px">`;
 	let legend_html = '';
 	
 	if (SHOW_FUNNEL_LEGEND) {
 		legend_html = '<div class="jpcrm_funnel_legend">';
 	}
-	for (var i=0; i<num_of_funnel_sections; i++) {
+	for (var i=0; i<NUM_FUNNEL_SECTIONS; i++) {
 		let section_color = COLORS[i%COLORS.length];
 		let section_html = `<a
 			${funnel_data[i]['link']?'href='+funnel_data[i]['link']:''}

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -11,7 +11,7 @@ function jpcrm_build_funnel(data, funnel_element) {
 	// something's wrong, so stop
 	if (!element || !data) return;
 
-	const COLORS = [ '#00a0d2', '#0073aa', '#035d88', '#333', '#222', '#000' ];
+	const COLORS = [ '#000', '#222', '#333', '#035d88', '#0073aa', '#00a0d2' ];
 
 	// show legend if desired
 	const SHOW_FUNNEL_LEGEND = false;

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -7,16 +7,16 @@
  * @element HTML element to turn into a funnel
  **/
 
-function jpcrm_build_funnel(data, funnel_element) {
+function jpcrm_build_funnel(funnel_data, funnel_element) {
 	// something's wrong, so stop
-	if (!element || !data) return;
+	if (!element || !funnel_data) return;
 
 	const COLORS = [ '#000', '#222', '#333', '#035d88', '#0073aa', '#00a0d2' ];
 
 	// show legend if desired
 	const SHOW_FUNNEL_LEGEND = false;
 
-	num_of_funnel_sections = data.length;
+	num_of_funnel_sections = funnel_data.length;
 	funnel_height = num_of_funnel_sections * 50;
 	let funnel_html = `<div class="jpcrm_funnel" style="height: ${funnel_height}px">`;
 	let legend_html = '';
@@ -27,16 +27,16 @@ function jpcrm_build_funnel(data, funnel_element) {
 	for (var i=0; i<num_of_funnel_sections; i++) {
 		let section_color = COLORS[i%COLORS.length];
 		let section_html = `<a
-			${data[i]['link']?'href='+data[i]['link']:''}
+			${funnel_data[i]['link']?'href='+funnel_data[i]['link']:''}
 			class="funnel_section"
-			data-hover="${data[i]['contact_status'] + ': \u00a0'}"
-			alt="${data[i]['contact_status']}: ${data[i]['backfill_count']}"
+			data-hover="${funnel_data[i]['contact_status'] + ': \u00a0'}"
+			alt="${funnel_data[i]['contact_status']}: ${funnel_data[i]['backfill_count']}"
 			style="background-color: ${section_color};"
-			>${data[i]['backfill_count']}</a>`;
+			>${funnel_data[i]['backfill_count']}</a>`;
 		funnel_html += section_html;
 
 		if (SHOW_FUNNEL_LEGEND) {
-			legend_html += `<div class="legend-color" style="background-color: ${section_color}"></div><div class="legend-label">${data[i]['contact_status']}</div>`;
+			legend_html += `<div class="legend-color" style="background-color: ${section_color}"></div><div class="legend-label">${funnel_data[i]['contact_status']}</div>`;
 		}
 	}
 	funnel_html += '</div>';

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -4,12 +4,12 @@
  * Inspired in part by https://codepen.io/tylerlwsmith/pen/RwNZKgp
  * 
  * @param funnel_data array of funnel data (count, backfill_count, contact_status, and link)
- * @element HTML element to turn into a funnel
+ * @funnel_element HTML element to turn into a funnel
  **/
 
 function jpcrm_build_funnel(funnel_data, funnel_element) {
 	// something's wrong, so stop
-	if (!element || !funnel_data) return;
+	if (!funnel_element || !funnel_data) return;
 
 	const COLORS = [ '#000', '#222', '#333', '#035d88', '#0073aa', '#00a0d2' ];
 

--- a/projects/plugins/crm/js/jpcrm-admin-funnel.js
+++ b/projects/plugins/crm/js/jpcrm-admin-funnel.js
@@ -4,7 +4,7 @@
  * Inspired in part by https://codepen.io/tylerlwsmith/pen/RwNZKgp
  * 
  * @param funnel_data array of funnel data (count, backfill_count, contact_status, and link)
- * @funnel_element HTML element to turn into a funnel
+ * @param funnel_element HTML element to turn into a funnel
  **/
 
 function jpcrm_build_funnel(funnel_data, funnel_element) {

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -147,26 +147,6 @@ h1, h2, h3, h4, h5, h6 {
     margin-bottom:20px;
 }
 
-#funnel-container{
-  position:relative;
-  padding:20px;
-  padding-bottom: 96px;
-}
-
-.zbs-funnel{
-  position:relative;
-}
-
-.zbs-funnel .panel{
-  margin-bottom:0px !important;
-  -webkit-box-shadow: 0 0px 0px rgba(0,0,0,0.05);
-   box-shadow: 0 0px 0px rgba(0,0,0,0.05);
-}
-.zbs-funnel .funnel-label{
-  color:white;
-  font-weight:900;
-}
-
 .progress {
     -webkit-box-shadow: none !important;
     background-color: #f5f5f5;
@@ -192,24 +172,9 @@ h1, h2, h3, h4, h5, h6 {
   cursor:pointer;
 }
 
-.zbs-legend{
-  width:15px;
-  height:15px;
-  margin-right:5px;
-  float:left;
-}
-
 .zbs-label{
   float:left;
   margin-right:5px;
-}
-
-.funnel-legend{
-    float: left;
-    margin-right: 6px;
-    margin-bottom: 5px;
-    position: absolute;
-    bottom: 22px;
 }
 
 .upsell a, .upsell a:hover{
@@ -403,17 +368,12 @@ background:white;
   top: -3px;
 }
 
-#settings_dashboard_sales_funnel_display, #settings_dashboard_revenue_chart_display{
+#settings_dashboard_revenue_chart_display{
   padding-bottom:0px;
   .panel{
     border: 1px solid #ccd0d4 !important;
     padding-left: 10px;
   }
-}
-
-#settings_dashboard_sales_funnel_display{
-  margin-bottom:15px;
-  padding-bottom:68px;
 }
 
 .grid{

--- a/projects/plugins/crm/sass/_JetpackCRM.admin.overrides.scss
+++ b/projects/plugins/crm/sass/_JetpackCRM.admin.overrides.scss
@@ -36,7 +36,7 @@
 	@include jetpackBox;
 
 }
-#settings_dashboard_sales_funnel_display .panel,
+
 #settings_dashboard_revenue_chart_display .panel {
 	box-shadow: none !important;
 }

--- a/projects/plugins/crm/sass/jpcrm-admin-funnel.scss
+++ b/projects/plugins/crm/sass/jpcrm-admin-funnel.scss
@@ -1,0 +1,40 @@
+.jpcrm_funnel {
+	margin: auto;
+	width: 90%;
+	display: flex;
+	flex-direction: column;
+	clip-path: polygon(0 0, 100% 0, 80% 100%, 20% 100%);
+}
+
+.jpcrm_funnel > .funnel_section {
+	color: #ffffff;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 1 1 100%;
+	margin-bottom: 2px;
+}
+
+.jpcrm_funnel > .funnel_section:hover {
+	/* https://stackoverflow.com/a/16910152 */
+	box-shadow: inset 0 0 0 99999px rgba(255,255,255,0.2);
+}
+
+.jpcrm_funnel > .funnel_section:hover::before {
+	content: attr(data-hover);
+}
+
+.jpcrm_funnel_legend {
+	text-align: center;
+}
+
+.jpcrm_funnel_legend > div {
+	display: inline-block;
+	margin-right: 5px;
+	vertical-align: middle;
+}
+
+.jpcrm_funnel_legend > .legend-color {
+	width: 15px;
+	height: 15px;
+}

--- a/projects/plugins/crm/sass/jpcrm-admin-funnel.scss
+++ b/projects/plugins/crm/sass/jpcrm-admin-funnel.scss
@@ -4,37 +4,37 @@
 	display: flex;
 	flex-direction: column;
 	clip-path: polygon(0 0, 100% 0, 80% 100%, 20% 100%);
-}
 
-.jpcrm_funnel > .funnel_section {
-	color: #ffffff;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	flex: 1 1 100%;
-	margin-bottom: 2px;
-}
+	>.funnel_section {
+		color: #ffffff;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex: 1 1 100%;
+		margin-bottom: 2px;
+	}
 
-.jpcrm_funnel > .funnel_section:hover {
-	/* https://stackoverflow.com/a/16910152 */
-	box-shadow: inset 0 0 0 99999px rgba(255,255,255,0.2);
-}
+	>.funnel_section:hover {
+		/* https://stackoverflow.com/a/16910152 */
+		box-shadow: inset 0 0 0 99999px rgba(255,255,255,0.2);
+	}
 
-.jpcrm_funnel > .funnel_section:hover::before {
-	content: attr(data-hover);
+	>.funnel_section:hover::before {
+		content: attr(data-hover);
+	}
 }
 
 .jpcrm_funnel_legend {
 	text-align: center;
-}
 
-.jpcrm_funnel_legend > div {
-	display: inline-block;
-	margin-right: 5px;
-	vertical-align: middle;
-}
+	>div {
+		display: inline-block;
+		margin-right: 5px;
+		vertical-align: middle;
+	}
 
-.jpcrm_funnel_legend > .legend-color {
-	width: 15px;
-	height: 15px;
+	>.legend-color {
+		width: 15px;
+		height: 15px;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#2930, Automattic/zero-bs-crm#2088, Automattic/zero-bs-crm#2932 - various fixes for sales funnel

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
TL;DR the funnel library we use is defunct and has plenty of edge-case bugs. I looked into a few options, most of which were outdated or incompatible with our included outdated libraries. As such, I decided to build our own lightweight funnel.

Changes/fixes include:
* The funnel will show properly (based on init settings) if the funnel status setting is blank
* Having 0 contacts in later statuses no longer breaks things.
* Having the same number of contacts in later statuses no longer breaks things
* Sometimes status counts didn't show
* The legend was misplaced
* Screen resizing is a bit more robust
* Lots of code cleanup
* We now use `Lead,Customer` as the default statuses used if settings were blank instead of `Lead,Contacted,Customer,Upsell`

Additions:
* The funnel will show even when there are no contacts
* Hovering over a funnel section will show which status it belongs to
* There's now an `alt` attribute on each funnel section
* Funnel sections support links (not currently used)
* The funnel logic should easily allow for multiple funnels on the same page, as well as easy adaptation when moving to React

For consideration:
* Should we swap out for JP colors? If we do, this might clash with other charts.
* Is there anything that needs escaping? I think we're safe, as it's going through `wp_json_encode()`.
* I've disabled the legend for now with a simple constant, but can add it back if we think that's better.

One can build a funnel like so:

```
// build sales funnel
element = document.getElementById('jpcrm_sales_funnel');
funnel_data = [{"count":"1828","backfill_count":1968,"contact_status":"Lead","link":false},{"count":"131","backfill_count":140,"contact_status":"Customer","link":false},{"count":"4","backfill_count":9,"contact_status":"Blacklisted","link":false},{"count":"5","backfill_count":5,"contact_status":"Refused","link":false},{"count":"0","backfill_count":0,"contact_status":"a","link":false},{"count":"0","backfill_count":0,"contact_status":"b","link":false},{"count":"0","backfill_count":0,"contact_status":"c","link":false},{"count":"0","backfill_count":0,"contact_status":"d","link":false}];
jpcrm_build_funnel(funnel_data,element);
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Play with various circumstances, including:

* 0 contacts in status 1, 2, and 3, but 2 contacts in status 4
* 0 funnel statuses
* 1 funnel status
* LOTS of funnel statuses
* Window resizing
* 1 contact in status 1 and 0 contacts in status 2
* Hiding the panel (dashboard setting in upper right)

Ensure that nothing is worse than it was, and that most things are better.