### PR TITLE
CRM: Fix Contact content overflows

### DIFF
--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -139,10 +139,13 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 					<?php
 
 				} else {
-
-					// normal, 2 column 'contact card'
+					/*
+					 * We are setting a min-width of 125px to match the size of the
+					 * edit button since Semantic UI does not handle the button
+					 * resizing well when the screen is too small.
+					 */
 					?>
-					<div class="three wide column" style="text-align:center">
+					<div class="three wide column" style="text-align:center; min-width:125px;">
 						<?php echo $avatar; ?>
 						<a class="ui button green" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link( 'edit', $id, 'zerobs_customer', false ); ?>">
 							<?php esc_html_e( 'Edit Contact', 'zero-bs-crm' ); ?>

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -176,6 +176,20 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 						<input type="hidden" id="email" value="<?php echo esc_attr( $contact_email ); ?>" />
 						</p>
 
+					<?php
+					$statusStr = ''; //phpcs:ignore  WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					if ( isset( $contact ) && isset( $contact['status'] ) && ! empty( $contact['status'] ) ) {
+						$statusStr = $contact['status']; //phpcs:ignore  WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					}
+
+					if ( ! empty( $statusStr ) ) { //phpcs:ignore  WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+						?>
+					<p>
+						<?php esc_html_e( 'Status', 'zero-bs-crm' ); ?>: 
+						<b><?php echo esc_html( $statusStr ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?></b>
+					</p>
+					<?php } ?>
+
 						<div class="zbs-social-buttons">
 							<?php
 							if ( count( $zbsSocialAccountTypes ) > 0 && count( $contact_socials ) > 0 ) {
@@ -260,12 +274,6 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 				<!-- customer vitals -->
 				<?php
 
-				// prep
-				$statusStr = '';
-				if ( isset( $contact ) && isset( $contact['status'] ) && ! empty( $contact['status'] ) ) {
-					$statusStr = $contact['status'];
-				}
-
 				// compiled addr str
 				$addrStr = '';
 				if ( isset( $contact ) ) {
@@ -321,16 +329,8 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 					?>
 					item">
 														<?php
-
-															// custom title e.g. Lead Vitals
-														if ( ! empty( $statusStr ) ) {
-															echo esc_html( $statusStr );
-														} else {
 															esc_html_e( 'Contact', 'zero-bs-crm' );
-														}
-
 															echo ' ' . esc_html__( 'Vitals', 'zero-bs-crm' );
-
 														?>
 						</div>
 					<?php if ( count( $zbsSocialAccountTypes ) > 0 && count( $contact_socials ) > 0 ) { ?>
@@ -367,12 +367,6 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 						}
 					}
 					?>
-					<?php if ( ! empty( $statusStr ) ) { ?>
-					<div class="right menu item">
-						<?php esc_html_e( 'Status', 'zero-bs-crm' ); ?>: 
-					<span class="ui green label"><?php echo esc_html( $statusStr ); ?></span>
-					</div>
-					<?php } ?>
 				</div>
 
 				<div class="ui bottom attached active tab segment" data-tab="vitals" id="zbs-contact-view-vitals">

--- a/projects/plugins/crm/changelog/crm-2804-contact-edit-content-overflows
+++ b/projects/plugins/crm/changelog/crm-2804-contact-edit-content-overflows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix content overflowing in contact view page.

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.singleview.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.singleview.scss
@@ -239,7 +239,7 @@ display:none !important;
 }
 .zbs-view-card .zbs-sentence{
 padding-left:0px;
-color: #b4b4c5;
+color: #000;
 margin-top:5px;
 font-size:14px;
 }

--- a/projects/plugins/crm/sass/_ZeroBSCRM.mobile.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.mobile.scss
@@ -191,11 +191,6 @@
             width: 95% !important;
         }
 
-        .zbs-view-card{
-            text-align:center;
-        }
-
-
         #zbs-edit-table-wrap, #zbs-edit-sidebar-wrap, #zbs-side-sortables{
             padding-right:0px !important;
         }
@@ -435,12 +430,6 @@
         #zbs-list-table-wrap, #zbs-list-sidebar-wrap{
             padding-right: 0;
         }
-
-
-        .zbs-view-card{
-            text-align:center;
-        }
-
 
         #zbs-edit-table-wrap, #zbs-edit-sidebar-wrap, #zbs-side-sortables{
             padding-right:0px !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
This PR fixes the issue of content overflowing on the contact view page.

## Proposed changes:
* The status was moved up, inside the contact's 'information card'.
* The prefix before the first tab, which was previously '[STATUS] Vitals', has been changed to 'Contact Vitals'.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/2804

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the view page for any contact.
* Make the page's width smaller by reducing the window size, from large to small.

In `trunk`, the information overflows in a weird way.

![image](https://user-images.githubusercontent.com/37049295/230812920-fd9717bc-014f-4b1f-aa50-8d0823af2814.png)


In `fix/crm-2804-contact-edit-content-overflows` the information is displayed correctly.


![image](https://user-images.githubusercontent.com/37049295/230812713-3855fc08-5cd6-49fd-a86d-45dfc7d1cb1b.png)
