### PR TITLE
CRM: Moving the company status selector underneath the ID

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-2957-move-company-status-below-id
+++ b/projects/plugins/crm/changelog/update-crm-2957-move-company-status-below-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Companies: Move status select from Actions to main edit section underneath ID

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
@@ -180,18 +180,36 @@
                     </td></tr>
                     <?php } ?>
 
-                    <?php /* if (has_post_thumbnail( $post->ID ) ): ?>
-                      <?php $image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'single-post-thumbnail' ); ?>
-                      <tr class="wh-large"><th><label><?php echo $this->coOrgLabel; ?> Image:</label></th>
-                                    <td>
-                                        <a href="<?php echo $image[0]; ?>" target="_blank"><img src="<?php echo $image[0]; ?>" alt="<?php echo $this->coOrgLabel; ?> Image" style="max-width:300px;border:0" /></a>
-                                    </td></tr>
-                    <?php endif; */ ?>
+					<?php
+					$potential_statuses = zeroBSCRM_getCompanyStatuses();
+					$current_status     = '';
+					if ( is_array( $company ) && isset( $company['status'] ) ) {
+						$current_status = $company['status'];
+					}
+					?>
+							<tr class="wh-large">
+							<th>
+								<label for="zbsco_status"><?php echo esc_html( $this->coOrgLabel ) . ' ' . esc_html__( 'Status', 'zero-bs-crm' ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase ?>: </label>
+							</th>
+							<td>
+								<select id="zbsco_status" name="zbsco_status">
+					<?php
+					foreach ( $potential_statuses as $status ) {
+						$sel = $status === $current_status ? ' selected' : '';
+						echo '<option value="' .
+						esc_attr( $status ) .
+						'"' .
+						esc_attr( $sel ) .
+						'>' .
+						esc_html( $status ) .
+						'</option>';
+					}
+					?>
+								</select>
+							</td>
+							</tr>
 
-                    <?php /*<tr><td><pre><?php print_r($fields); ?></pre></td></tr> */
-
-            
-
+							<?php
                     #} This global holds "enabled/disabled" for specific fields... ignore unless you're WH or ask
                     global $zbsFieldsEnabled; if ($showSecondAddress == '1') $zbsFieldsEnabled['secondaddress'] = true;
                     
@@ -1121,26 +1139,6 @@ class zeroBS__Metabox_CompanyTags extends zeroBS__Metabox_Tags{
 
             // localise ID & content
             $companyID = -1; if (is_array($company) && isset($company['id'])) $companyID = (int)$company['id'];
-            
-                #} Status either way
-                $potentialStatuses = zeroBSCRM_getCompanyStatuses();
-
-                $status = ''; if (is_array($company) && isset($company['status'])) $status = $company['status'];
-
-                ?>
-                <div>
-                    <label for="zbsco_status"><?php echo esc_html($this->coOrgLabel).' '.esc_html__('Status',"zero-bs-crm"); ?>: </label>
-                    <select id="zbsco_status" name="zbsco_status">
-                            <?php foreach($potentialStatuses as $z){
-                                if($z == $status){$sel = ' selected'; }else{ $sel = '';}
-                                echo '<option value="'. esc_attr( $z ) .'"'. esc_attr( $sel ) .'>'.esc_html__($z,"zero-bs-crm").'</option>';
-                            } ?>
-                    </select>
-                </div>
-
-                <div class="clear"></div>
-                <?php
-
 
                 #} if a saved post...
                 //if (isset($post->post_status) && $post->post_status != "auto-draft"){


### PR DESCRIPTION
## Proposed changes:
* This PR moves the Company Status options from the Company Actions Metabox to underneath the Company ID (on the Company Edit page).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/2957

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the company edit page to create a new company (`wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=company`)
* Go to the company edit page while editing an existing company (e.g. `wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=company&zbsid=1`)

In `trunk` the status select is located in the Company Actions box
![image](https://user-images.githubusercontent.com/37049295/230817370-14cc2633-88e7-4c52-acc0-c4faffbba1db.png)


In `update/crm-2957-move-company-status-below-id` the status select is located underneath the company's ID
![image](https://user-images.githubusercontent.com/37049295/230817311-77179ad5-9bf7-4957-a59f-ffd78f1645f0.png)


