### PR TITLE
Repo Gardening: add Docs label for PRs touching .md files

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-labeling-docs
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-labeling-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add the Docs label whenever markdown files are edited.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -162,7 +162,7 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 			keywords.add( '[Tools] Development CLI' );
 		}
 
-		const docs = file.match( /^docs\// );
+		const docs = file.match( /^docs\/|\.md$/ );
 		if ( docs !== null ) {
 			keywords.add( 'Docs' );
 		}

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -162,7 +162,7 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 			keywords.add( '[Tools] Development CLI' );
 		}
 
-		const docs = file.match( /^docs\/|\.md$/ );
+		const docs = file.match( /^docs\/|\.md$/ ) && ! file.match( /\/CHANGELOG\.md$/ );
 		if ( docs !== null ) {
 			keywords.add( 'Docs' );
 		}


### PR DESCRIPTION
## Proposed changes:

Following a suggestion from @sergeymitr, I'd like to be able to better track the PRs that make changes to markdown files.

Granted, there may be times when we make changes to .md files without really improving our docs, but I think overall, this should offer a good insight as to the number of doc changes we make.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here apart from the validity of the regex; once this is merged, any PR that makes changes to an .md should get the "Docs" label added automatically.
