### PR TITLE
CRM: Dashboard - aligning Revenue Chart and Latest Contacts main action buttons

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -443,7 +443,7 @@ if (jQuery('#bar-chart').length){
 		>
 	<div class='panel'>
 
-		<div class="panel-heading" style="text-align:center">
+		<div class="panel-heading" style="text-align:center;">
 		<?php $currencyChar = zeroBSCRM_getCurrencyChr(); ?>
 		<h4 class="panel-title text-muted font-light"><?php esc_html_e( 'Revenue Chart', 'zero-bs-crm' ); ?> (<?php echo esc_html( $currencyChar ); ?>)</h4>
 		<?php ##WLREMOVE ?>
@@ -494,7 +494,7 @@ if (jQuery('#bar-chart').length){
 	?>
 	>
 	<div class="panel">
-		<div class="panel-heading" style="text-align:center">
+		<div class="panel-heading jpcrm-recent-activity-heading">
 			<h4 class="panel-title text-muted font-light"><?php esc_html_e( 'Recent Activity', 'zero-bs-crm' ); ?></h4>
 		</div>
 
@@ -583,7 +583,7 @@ if (jQuery('#bar-chart').length){
 	?>
 		>
 	<div class="panel">
-		<div class="panel-heading" style="text-align:center;position:relative">
+		<div class="panel-heading jpcrm-latest-contacts-heading">
 			<h4 class="panel-title text-muted font-light"><?php esc_html_e( 'Latest Contacts', 'zero-bs-crm' ); ?></h4>
 			<span class='upsell'><a href="<?php echo jpcrm_esc_link( $zbs->slugs['managecontacts'] ); ?>"><?php esc_html_e( 'View All', 'zero-bs-crm' ); ?></a></span>
 		</div>

--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -443,7 +443,7 @@ if (jQuery('#bar-chart').length){
 		>
 	<div class='panel'>
 
-		<div class="panel-heading" style="text-align:center;">
+		<div class="panel-heading jpcrm-revenue-chart-heading">
 		<?php $currencyChar = zeroBSCRM_getCurrencyChr(); ?>
 		<h4 class="panel-title text-muted font-light"><?php esc_html_e( 'Revenue Chart', 'zero-bs-crm' ); ?> (<?php echo esc_html( $currencyChar ); ?>)</h4>
 		<?php ##WLREMOVE ?>
@@ -494,7 +494,7 @@ if (jQuery('#bar-chart').length){
 	?>
 	>
 	<div class="panel">
-		<div class="panel-heading jpcrm-recent-activity-heading">
+		<div class="panel-heading" style="text-align:center">
 			<h4 class="panel-title text-muted font-light"><?php esc_html_e( 'Recent Activity', 'zero-bs-crm' ); ?></h4>
 		</div>
 
@@ -583,7 +583,7 @@ if (jQuery('#bar-chart').length){
 	?>
 		>
 	<div class="panel">
-		<div class="panel-heading jpcrm-latest-contacts-heading">
+		<div class="panel-heading" style="text-align:center;position:relative">
 			<h4 class="panel-title text-muted font-light"><?php esc_html_e( 'Latest Contacts', 'zero-bs-crm' ); ?></h4>
 			<span class='upsell'><a href="<?php echo jpcrm_esc_link( $zbs->slugs['managecontacts'] ); ?>"><?php esc_html_e( 'View All', 'zero-bs-crm' ); ?></a></span>
 		</div>

--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -443,7 +443,7 @@ if (jQuery('#bar-chart').length){
 		>
 	<div class='panel'>
 
-		<div class="panel-heading jpcrm-revenue-chart-heading">
+		<div class="panel-heading jpcrm-revenue-chart-heading" style="text-align:center;position:relative">
 		<?php $currencyChar = zeroBSCRM_getCurrencyChr(); ?>
 		<h4 class="panel-title text-muted font-light"><?php esc_html_e( 'Revenue Chart', 'zero-bs-crm' ); ?> (<?php echo esc_html( $currencyChar ); ?>)</h4>
 		<?php ##WLREMOVE ?>
@@ -583,7 +583,7 @@ if (jQuery('#bar-chart').length){
 	?>
 		>
 	<div class="panel">
-		<div class="panel-heading" style="text-align:center;position:relative">
+		<div class="panel-heading jpcrm-latest-contacts-heading" style="text-align:center;position:relative">
 			<h4 class="panel-title text-muted font-light"><?php esc_html_e( 'Latest Contacts', 'zero-bs-crm' ); ?></h4>
 			<span class='upsell'><a href="<?php echo jpcrm_esc_link( $zbs->slugs['managecontacts'] ); ?>"><?php esc_html_e( 'View All', 'zero-bs-crm' ); ?></a></span>
 		</div>

--- a/projects/plugins/crm/changelog/update-crm-dashboard-revenue-chart-more-button
+++ b/projects/plugins/crm/changelog/update-crm-dashboard-revenue-chart-more-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Aligning the Latest Contacts and Revenue Chart buttons

--- a/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
@@ -3217,7 +3217,7 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:focus,a.list-gro
     color:inherit
 }
 
-.jpcrm-latest-contacts-heading, .jpcrm-recent-activity-heading {
+.jpcrm-latest-contacts-heading, .jpcrm-revenue-chart-heading {
 	margin-bottom: 40px;
 	position: relative;
 	text-align: center;

--- a/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
@@ -3217,6 +3217,25 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:focus,a.list-gro
     color:inherit
 }
 
+.jpcrm-latest-contacts-heading, .jpcrm-recent-activity-heading {
+	margin-bottom: 40px;
+	position: relative;
+	text-align: center;
+
+	.panel-title {
+		position: absolute;
+		left: 30%;
+		right: 30%;
+	}
+
+	.upsell {
+		top: 45px;
+		right: 25px;
+	}
+}
+
+
+
 .panel-footer {
     padding:10px 15px;
     background-color:#f5f5f5;

--- a/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
@@ -3217,24 +3217,12 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:focus,a.list-gro
     color:inherit
 }
 
-.jpcrm-latest-contacts-heading,.jpcrm-revenue-chart-heading {
-
-	.panel-title {
-		position: absolute;
-		left: 30%;
-		right: 30%;
-	}
-
-	.upsell {
-		top: 45px;
-	}
-}
-
 .jpcrm-latest-contacts-heading {
 	margin-bottom: 40px;
 
 	.upsell {
 		right: 25px;
+		top: 45px;
 	}
 }
 
@@ -3243,6 +3231,7 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:focus,a.list-gro
 
 	.upsell {
 		right: 20px;
+		top: 45px;
 	}
 }
 

--- a/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
@@ -3217,10 +3217,7 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:focus,a.list-gro
     color:inherit
 }
 
-.jpcrm-latest-contacts-heading, .jpcrm-revenue-chart-heading {
-	margin-bottom: 40px;
-	position: relative;
-	text-align: center;
+.jpcrm-latest-contacts-heading,.jpcrm-revenue-chart-heading {
 
 	.panel-title {
 		position: absolute;
@@ -3230,7 +3227,22 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:focus,a.list-gro
 
 	.upsell {
 		top: 45px;
+	}
+}
+
+.jpcrm-latest-contacts-heading {
+	margin-bottom: 40px;
+
+	.upsell {
 		right: 25px;
+	}
+}
+
+.jpcrm-revenue-chart-heading {
+	margin-bottom: 60px;
+
+	.upsell {
+		right: 20px;
 	}
 }
 


### PR DESCRIPTION

## Proposed changes:

* This PR adds a class to both the Revenue Chart and the Latest Contacts sections on the dashboard. Within this class, the panel headings and upsell buttons have added CSS to make sure they are both responsive, and the buttons aligned to the side of the content below (when there is content to show).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2933

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test, using the [Jetpack Beta plugin](https://github.com/Automattic/jetpack-beta) on a test site with this branch applied or testing locally with the branch checked out, visit the Dashboard: `/wp-admin/admin.php?page=zerobscrm-dash`.
* You should see the  Latest Contacts 'View All' button and the Revenue Charts 'Want More?' button aligned to the content below, and to the right of the panel. The headings should be centred, and there shouldn't be any overlap when viewing from a smaller device.

**Before:**
<img width="729" alt="Screenshot 2023-04-10 at 15 23 34" src="https://user-images.githubusercontent.com/16754605/230920458-e889c7e1-59e1-429e-877c-bfab03f332bc.png">


**After:**
<img width="722" alt="Screenshot 2023-04-10 at 15 23 09" src="https://user-images.githubusercontent.com/16754605/230920480-0fa3e76e-ceeb-4892-afa5-5ee705d9f824.png">
