### PR TITLE
VideoPress: skip PreviewOnHover when user interacts with video player

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-iterate-over-util-fn
+++ b/projects/packages/videopress/changelog/update-videopress-iterate-over-util-fn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix helper VideoPress function when generating URL

--- a/projects/packages/videopress/changelog/update-videopress-skip-poh-when-interacting-with-video
+++ b/projects/packages/videopress/changelog/update-videopress-skip-poh-when-interacting-with-video
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: skip PreviewOnHover when user interacts with video player

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -232,7 +232,13 @@ class Initializer {
 				'previewAtTime'       => $block_attributes['posterData']['previewAtTime'],
 				'previewLoopDuration' => $block_attributes['posterData']['previewLoopDuration'],
 			);
+
+			// Expose the preview on hover data to the client.
 			$preview_on_hover = sprintf( '<div className="jetpack-videopress-player__overlay"></div><script type="application/json">%s</script>', wp_json_encode( $preview_on_hover ) );
+
+			// Set `autoplay` and `muted` attributes to the video element.
+			$block_attributes['autoplay'] = true;
+			$block_attributes['muted']    = true;
 		}
 
 		// VideoPress URL

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -180,10 +180,11 @@ class Initializer {
 	/**
 	 * VideoPress video block render method
 	 *
-	 * @param array $block_attributes - Block attributes.
+	 * @param array  $block_attributes - Block attributes.
+	 * @param string $content          - Block markup.
 	 * @return string                    Block markup.
 	 */
-	public static function render_videopress_video_block( $block_attributes ) {
+	public static function render_videopress_video_block( $block_attributes, $content ) {
 		// VideoPress URL
 		$videopress_url = Utils::get_video_press_url( $block_attributes['guid'], $block_attributes );
 
@@ -197,6 +198,31 @@ class Initializer {
 		$max_width = isset( $block_attributes['maxWidth'] ) ? $block_attributes['maxWidth'] : null;
 		if ( $max_width && $max_width !== '100%' ) {
 			$style = sprintf( 'max-width: %s; margin: auto;', $max_width );
+		}
+
+		/*
+		 * <figcaption /> element
+		 * Caption is stored into the block attributes,
+		 * but also it was stored into the <figcaption /> element,
+		 * meaning that it could be stored in two different places.
+		 */
+		$figcaption = '';
+
+		// Caption from block attributes
+		$caption = isset( $block_attributes['caption'] ) ? $block_attributes['caption'] : null;
+
+		/*
+		 * If the caption is not stored into the block attributes,
+		 * try to get it from the <figcaption /> element.
+		 */
+		if ( $caption === null ) {
+			preg_match( '/<figcaption>(.*?)<\/figcaption>/', $content, $matches );
+			$caption = isset( $matches[1] ) ? $matches[1] : null;
+		}
+
+		// If we have a caption, create the <figcaption /> element.
+		if ( $caption !== null ) {
+			$figcaption = sprintf( '<figcaption>%s</figcaption>', $caption );
 		}
 
 		// Preview On Hover data
@@ -233,14 +259,6 @@ class Initializer {
 			$video_wrapper = sprintf(
 				'<div class="jetpack-videopress-player__wrapper">%s</div>',
 				$oembed_html
-			);
-		}
-
-		$figcaption = '';
-		if ( ! empty( $caption ) ) {
-			$figcaption = sprintf(
-				'<figcaption>%s</figcaption>',
-				$caption
 			);
 		}
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -181,13 +181,10 @@ class Initializer {
 	 * VideoPress video block render method
 	 *
 	 * @param array  $block_attributes - Block attributes.
-	 * @param string $content          - Block markup.
+	 * @param string $content          - Current block markup.
 	 * @return string                    Block markup.
 	 */
 	public static function render_videopress_video_block( $block_attributes, $content ) {
-		// VideoPress URL
-		$videopress_url = Utils::get_video_press_url( $block_attributes['guid'], $block_attributes );
-
 		// CSS classes
 		$align       = isset( $block_attributes['align'] ) ? $block_attributes['align'] : null;
 		$align_class = $align ? ' align' . $align : '';
@@ -222,7 +219,7 @@ class Initializer {
 
 		// If we have a caption, create the <figcaption /> element.
 		if ( $caption !== null ) {
-			$figcaption = sprintf( '<figcaption>%s</figcaption>', $caption );
+			$figcaption = sprintf( '<figcaption>%s</figcaption>', wp_kses_post( $caption ) );
 		}
 
 		// Preview On Hover data
@@ -238,11 +235,11 @@ class Initializer {
 			$preview_on_hover = sprintf( '<div className="jetpack-videopress-player__overlay"></div><script type="application/json">%s</script>', wp_json_encode( $preview_on_hover ) );
 		}
 
+		// VideoPress URL
+		$videopress_url = Utils::get_video_press_url( $block_attributes['guid'], $block_attributes );
 		if ( ! empty( $videopress_url ) ) {
 			$videopress_url = wp_kses_post( $videopress_url );
 		}
-
-		$caption = ! empty( $block_attributes['caption'] ) ? wp_kses_post( $block_attributes['caption'] ) : '';
 
 		$figure_template = '
 		<figure class="%1$s" style="%2$s">			

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -258,7 +258,7 @@ class Initializer {
 		$video_wrapper = '';
 		if ( $videopress_url ) {
 			$wp_embed      = new \WP_Embed();
-			$oembed_html   = $wp_embed->autoembed( $videopress_url );
+			$oembed_html   = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper = sprintf(
 				'<div class="jetpack-videopress-player__wrapper">%s</div>',
 				$oembed_html

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -50,13 +50,16 @@ class Utils {
 			'muted'           => (int) $video_press_url_options['muted'],
 			'persistVolume'   => $video_press_url_options['muted'] ? 0 : 1,
 			'playsinline'     => (int) $video_press_url_options['playsinline'],
-			'posterUrl'       => rawurlencode( $video_press_url_options['poster'] ),
 			'preloadContent'  => $video_press_url_options['preload'],
 			'sbc'             => $video_press_url_options['seekbarColor'],
 			'sbpc'            => $video_press_url_options['seekbarPlayedColor'],
 			'sblc'            => $video_press_url_options['seekbarLoadingColor'],
 			'useAverageColor' => (int) $video_press_url_options['useAverageColor'],
 		);
+
+		if ( ! empty( $video_press_url_options['poster'] ) ) {
+			$query_args['posterUrl'] = rawurlencode( $video_press_url_options['poster'] );
+		}
 
 		$url = 'https://videopress.com/v/' . $guid;
 		return add_query_arg( $query_args, $url );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/deprecated/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/deprecated/index.tsx
@@ -1,0 +1,209 @@
+/**
+ * External dependencies
+ */
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import classnames from 'classnames';
+/**
+ * Internal dependencies
+ */
+import { getVideoPressUrl } from '../../../../lib/url';
+import { isVideoFramePosterEnabled } from '../components/poster-panel';
+/**
+ * Types
+ */
+import type { VideoBlockAttributes } from '../types';
+import type React from 'react';
+
+type videoBlockSaveProps = {
+	attributes: VideoBlockAttributes;
+};
+
+/**
+ * VideoPress block save function
+ *
+ * @param {object} props             - Component props.
+ * @param {object} props.attributes  - Block attributes.
+ * @returns {object}                 - React component.
+ */
+function save( { attributes }: videoBlockSaveProps ): React.ReactNode {
+	const {
+		align,
+		autoplay,
+		caption,
+		loop,
+		muted,
+		controls,
+		playsinline,
+		preload,
+		useAverageColor,
+		seekbarColor,
+		seekbarLoadingColor,
+		seekbarPlayedColor,
+		guid,
+		maxWidth,
+		poster,
+		posterData,
+	} = attributes;
+
+	const blockProps = useBlockProps.save( {
+		className: classnames( 'wp-block-jetpack-videopress', 'jetpack-videopress-player', {
+			[ `align${ align }` ]: align,
+		} ),
+	} );
+
+	const isPreviewOnHoverEnabled = isVideoFramePosterEnabled();
+
+	const autoplayArg = ! isPreviewOnHoverEnabled ? autoplay : autoplay || posterData.previewOnHover;
+	const mutedArg = ! isPreviewOnHoverEnabled ? muted : muted || posterData.previewOnHover;
+
+	const videoPressUrl = getVideoPressUrl( guid, {
+		autoplay: autoplayArg,
+		controls,
+		loop,
+		muted: mutedArg,
+		playsinline,
+		preload,
+		seekbarColor,
+		seekbarLoadingColor,
+		seekbarPlayedColor,
+		useAverageColor,
+		poster,
+	} );
+
+	// Adjust block width based on custom maxWidth.
+	const style: { maxWidth?: string; margin?: string } = {};
+	if ( maxWidth && maxWidth.length > 0 && '100%' !== maxWidth ) {
+		style.maxWidth = maxWidth;
+		style.margin = 'auto';
+	}
+
+	return (
+		<figure { ...blockProps } style={ style }>
+			{ videoPressUrl && (
+				<div className="jetpack-videopress-player__wrapper">
+					{ `\n${ videoPressUrl }\n` /* URL needs to be on its own line. */ }
+				</div>
+			) }
+
+			{ ! RichText.isEmpty( caption ) && (
+				<RichText.Content tagName="figcaption" value={ caption } />
+			) }
+		</figure>
+	);
+}
+
+const attributes = {
+	autoplay: {
+		type: 'boolean',
+	},
+	title: {
+		type: 'string',
+	},
+	description: {
+		type: 'string',
+	},
+	caption: {
+		type: 'string',
+		source: 'html',
+		selector: 'figcaption',
+	},
+	controls: {
+		type: 'boolean',
+		default: true,
+	},
+	loop: {
+		type: 'boolean',
+	},
+	maxWidth: {
+		type: 'string',
+		default: '100%',
+	},
+	muted: {
+		type: 'boolean',
+	},
+	playsinline: {
+		type: 'boolean',
+	},
+	preload: {
+		type: 'string',
+		default: 'metadata',
+	},
+	seekbarPlayedColor: {
+		type: 'string',
+		default: '',
+	},
+	seekbarLoadingColor: {
+		type: 'string',
+		default: '',
+	},
+	seekbarColor: {
+		type: 'string',
+		default: '',
+	},
+	useAverageColor: {
+		type: 'boolean',
+		default: true,
+	},
+	id: {
+		type: 'number',
+	},
+	guid: {
+		type: 'string',
+	},
+	src: {
+		type: 'string',
+	},
+	cacheHtml: {
+		type: 'string',
+		default: '',
+	},
+	poster: {
+		type: 'string',
+	},
+	posterData: {
+		type: 'object',
+		default: {},
+	},
+	videoRatio: {
+		type: 'number',
+	},
+	tracks: {
+		type: 'array',
+		items: {
+			type: 'object',
+		},
+		default: [],
+	},
+	privacySetting: {
+		type: 'number',
+		default: 1,
+	},
+	allowDownload: {
+		type: 'boolean',
+		default: true,
+	},
+	displayEmbed: {
+		type: 'boolean',
+		default: true,
+	},
+	rating: {
+		type: 'string',
+	},
+	isPrivate: {
+		type: 'boolean',
+	},
+	isExample: {
+		type: 'boolean',
+		default: false,
+	},
+	duration: {
+		type: 'number',
+	},
+};
+
+export default [
+	{
+		attributes,
+		save,
+	},
+];

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -18,7 +18,7 @@ function previewOnHoverEffect(): void {
 	 * Pick all VideoPress video block intances,
 	 * based on the class name.
 	 */
-	const videoPlayers = document.querySelectorAll( '.wp-block-jetpack-videopress-container' );
+	const videoPlayers = document.querySelectorAll( '.wp-block-jetpack-videopress' );
 	if ( videoPlayers.length === 0 ) {
 		return;
 	}

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -166,22 +166,6 @@ const useVideoPlayer = (
 		};
 	}, [ isPreviewOnHoverEnabled, wrapperElement, playerIsReady ] );
 
-	// Move the video to the "Starting point" when it changes.
-	useEffect( () => {
-		if ( ! playerIsReady || ! previewOnHover ) {
-			return;
-		}
-
-		if ( ! sandboxIFrameWindow ) {
-			return;
-		}
-
-		sandboxIFrameWindow.postMessage(
-			{ event: 'videopress_action_set_currenttime', currentTime: previewOnHover.atTime / 1000 },
-			{ targetOrigin: '*' }
-		);
-	}, [ previewOnHover?.atTime, playerIsReady, sandboxIFrameWindow ] );
-
 	// Move the video to the "duration" when it changes.
 	useEffect( () => {
 		if ( ! playerIsReady || ! previewOnHover ) {
@@ -201,6 +185,21 @@ const useVideoPlayer = (
 		);
 	}, [ previewOnHover?.duration, playerIsReady, sandboxIFrameWindow ] );
 
+	// Move the video to the "Starting point" when it changes.
+	useEffect( () => {
+		if ( ! playerIsReady || ! previewOnHover ) {
+			return;
+		}
+
+		if ( ! sandboxIFrameWindow ) {
+			return;
+		}
+
+		sandboxIFrameWindow.postMessage(
+			{ event: 'videopress_action_set_currenttime', currentTime: previewOnHover.atTime / 1000 },
+			{ targetOrigin: '*' }
+		);
+	}, [ previewOnHover?.atTime, playerIsReady, sandboxIFrameWindow ] );
 	return {
 		playerIsReady,
 		play,

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -152,7 +152,7 @@ const useVideoPlayer = (
 			return;
 		}
 
-		// Do not play if the effect is disabled.`
+		// Do not play if the effect is disabled.
 		if ( isEffectDisabled ) {
 			return;
 		}
@@ -165,7 +165,7 @@ const useVideoPlayer = (
 			return;
 		}
 
-		// Do not pause if the preview on hover is enabled.
+		// Do not pause if the preview on hover is disabled.
 		if ( isEffectDisabled ) {
 			return;
 		}

--- a/projects/packages/videopress/tests/php/test-class-utils.php
+++ b/projects/packages/videopress/tests/php/test-class-utils.php
@@ -92,4 +92,33 @@ class UtilsTest extends BaseTestCase {
 		$this->assertStringContainsString( 'useAverageColor=0', $url );
 	}
 
+	/**
+	 * Test the get_video_press_url with poster URL.
+	 */
+	public function test_get_video_press_url_posterUrl() {
+		$guid = '3Nq0kSMu';
+
+		// Test with provided poster URL.
+		$attributes_with_poster = array(
+			'poster' => 'http://localhost/wp-content/uploads/2023/03/poster.jpg',
+		);
+
+		$url_with_poster = Utils::get_video_press_url( $guid, $attributes_with_poster );
+		$this->assertStringContainsString( 'posterUrl=' . rawurlencode( $attributes_with_poster['poster'] ), $url_with_poster );
+
+		// Test with provided empty poster URL.
+		$attributes_without_poster = array(
+			'poster' => '',
+		);
+
+		$url_witt_empty_poster = Utils::get_video_press_url( $guid, $attributes_without_poster );
+		$this->assertStringNotContainsString( 'posterUrl', $url_witt_empty_poster );
+
+		// Test without provided poster URL.
+		$attributes_without_poster = array();
+
+		$url_without_poster = Utils::get_video_press_url( $guid, $attributes_without_poster );
+		$this->assertStringNotContainsString( 'posterUrl', $url_without_poster );
+	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR improves the "Preview On Hover" beta feature by enabling users to interact with the video player as they usually would once they engage with it.
In simpler terms, the video will play when the user's cursor enters the player area and pause when it leaves until the user clicks on the player. After that, the video player will function as expected.

Part of https://github.com/Automattic/jetpack/issues/29986
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: skip PreviewOnHover when user interacts with video player

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a VideoPress video block
* Enable and sweet pOH feature.
* Confirm it plays/pauses when mouse entering/mouse leaving
* Confirm after you click on the video, you can pause/play the video
* Confirm the video does not play in pOH loop
* Confirm the play doesn't pay attention to mouse enter/mouse leave events 
