### PR TITLE
VideoPress: fix setting front-end css file issue for the VideoPress video block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-video-block-style-handle
+++ b/projects/packages/videopress/changelog/update-videopress-fix-video-block-style-handle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix setting front-end css file issue for the VideoPress video block

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -126,6 +126,6 @@
 	"textdomain": "jetpack-videopress",
 	"editorScript": "jetpack-videopress-video-block",
 	"editorStyle": "jetpack-videopress-video-block",
-	"style": "file:style-index.css",
+	"style": "jetpack-videopress-video-block-view",
 	"viewScript": "jetpack-videopress-video-block-view"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR correctly defines the CSS handle, which will be served either in the frontend as well as in the block editor context, replacing the file path for the `jetpack-videopress-video-block-view` style handle.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix setting front-end css file issue for the VideoPress video block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add/edit a VideoPress video block
* Save the post
* Go to the frontend
* Open the network tab of your favorite browser ;-)
* Show `all` files
* filter the files by `block-editor/blocks/video`
* **BEFORE**, confirm there is only one JS file shown in the files list
* **AFERTE**,  confirm there are two JS and CSS files

Before | After
-------|-------
<img width="537" alt="Screen Shot 2023-04-10 at 14 56 09" src="https://user-images.githubusercontent.com/77539/230962319-ae6d39c3-442b-4af2-bb1c-4dea012b3691.png"> | <img width="534" alt="image" src="https://user-images.githubusercontent.com/77539/230962295-38273891-2ecf-49e0-8032-77cb91a29a7d.png">

Particularly the file server to both sides (style.scss) only applies styles to the video caption: thus:
* Add a caption to the video block
* Save the post
* Go to the frontend
* Confirm, now, it looks properly

Before | After
------|------
<img width="748" alt="Screen Shot 2023-04-10 at 15 01 06" src="https://user-images.githubusercontent.com/77539/230962935-5b97c2b8-74a9-4a3f-b7fb-50031c8edf44.png"> | <img width="771" alt="Screen Shot 2023-04-10 at 15 00 39" src="https://user-images.githubusercontent.com/77539/230962939-ec66062b-de6e-4e72-b94c-e305fb732361.png">




