### PR TITLE
[RNMobile] Update native player viewport

### DIFF
--- a/projects/packages/videopress/changelog/update-native-player-viewport
+++ b/projects/packages/videopress/changelog/update-native-player-viewport
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disable zoom on native player

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
@@ -31,7 +31,7 @@ export default function Player( { html, isRequestingEmbedPreview, isSelected } )
 	return (
 		<View style={ [ style[ 'videopress-player' ], loadingStyle ] }>
 			{ ! isSelected && <View style={ style[ 'videopress-player__overlay' ] } /> }
-			{ ! isRequestingEmbedPreview && <SandBox html={ html } /> }
+			{ ! isRequestingEmbedPreview && <SandBox html={ html } viewportProps="user-scalable=0" /> }
 			{ ! html && <Text>{ __( 'Loading…', 'jetpack-videopress-pkg' ) }</Text> }
 		</View>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/orgs/wordpress-mobile/projects/166/views/1?pane=issue&itemId=25021141
Depends on https://github.com/WordPress/gutenberg/pull/49699

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds the viewport prop `user-scalable=0` to the native player to avoid zooming in after focusing on the age gate form.
Note: This does disable the ability to zoom in on all videos in the VideoPress native player. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Add an age restriction to a VideoPress block. 
- Save the post and reload the mobile editor.
- Focus on any DOB input field.
- Notice that the video zoom level does not change.
- Fill in the DOB with a valid age and submit the form.
- Notice that the video is not zoomed in or cropped.

