### PR TITLE
Revert "Anchor: Remove Anchor.fm from the post-publish sidebar"

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-anchor-post-publish-sidebar
+++ b/projects/plugins/jetpack/changelog/remove-anchor-post-publish-sidebar
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Remove the Anchor.fm component on the post-publish sidebar

--- a/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/anchor-fm/editor.js
@@ -1,6 +1,13 @@
+import { JetpackLogo } from '@automattic/jetpack-components';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { Button, PanelRow } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
+import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
+import { external, Icon } from '@wordpress/icons';
+import { registerPlugin } from '@wordpress/plugins';
 import { castArray } from 'lodash';
+import { useEffect, useCallback } from 'react';
 import '@wordpress/notices';
 import { waitForEditor } from '../../shared/wait-for-editor';
 import { basicTemplate, spotifyBadgeTemplate } from './templates';
@@ -34,6 +41,52 @@ async function setEpisodeTitle( { title } ) {
 	}
 	await waitForEditor();
 	dispatch( 'core/editor' ).editPost( { title } );
+}
+
+const ConvertToAudio = () => {
+	const { tracks } = useAnalytics();
+
+	useEffect( () => {
+		tracks.recordEvent( 'jetpack_editor_block_anchor_fm_post_publish_impression' );
+	}, [ tracks ] );
+	const handleClick = useCallback(
+		() => tracks.recordEvent( 'jetpack_editor_block_anchor_fm_post_publish_click' ),
+		[ tracks ]
+	);
+	return (
+		<PluginPostPublishPanel
+			className="anchor-post-publish-outbound-link"
+			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+			title={ __( 'Convert to audio', 'jetpack' ) }
+		>
+			<PanelRow>
+				<p>
+					{ __(
+						'Seamlessly turn this post into a podcast episode with Anchor - and let readers listen to your post.',
+						'jetpack'
+					) }
+				</p>
+			</PanelRow>
+			<div
+				role="link"
+				className="post-publish-panel__postpublish-buttons"
+				tabIndex={ 0 }
+				onClick={ handleClick }
+				onKeyDown={ handleClick }
+			>
+				<Button variant="secondary" href="https://anchor.fm/wordpressdotcom" target="_top">
+					{ __( 'Create a podcast episode', 'jetpack' ) }{ ' ' }
+					<Icon icon={ external } className="anchor-post-publish-outbound-link__external_icon" />
+				</Button>
+			</div>
+		</PluginPostPublishPanel>
+	);
+};
+
+function showPostPublishOutboundLink() {
+	registerPlugin( 'anchor-post-publish-outbound-link', {
+		render: ConvertToAudio,
+	} );
 }
 
 function createEpisodeErrorNotice( params ) {
@@ -74,6 +127,9 @@ function initAnchor() {
 				break;
 			case 'insert-episode-template':
 				insertTemplate( { ...actionParams, tpl: 'basicEpisode' } );
+				break;
+			case 'show-post-publish-outbound-link':
+				showPostPublishOutboundLink();
 				break;
 			case 'set-episode-title':
 				setEpisodeTitle( actionParams );


### PR DESCRIPTION
Reverts Automattic/jetpack#29944

This was prematurely deployed, we should wait for the appropriate date to start deploying the work related to the Anchor.fm discontinuation.

More details: p1681153857744349/1681152439.286669-slack-C0Q664T29

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p7fD6U-9EZ-p2#comment-22954
Slack discussion about the revert: p1681153857744349/1681152439.286669-slack-C0Q664T29

## Does this pull request change what data or activity we track or use?

Yes, the following tracks event will added back.
* jetpack_editor_block_anchor_fm_post_publish_impression
* jetpack_editor_block_anchor_fm_post_publish_click

## Testing instructions:

Read the guide for more information on how to test WordPress.com: PCYsg-eg0-p2

* Select a simple site on which you want to test
* Sandbox the site(not the public-api)
* Run the following command on your sandbox to apply these changes to your sandbox:
```
bin/jetpack-downloader test jetpack revert-29944-remove/anchor-component-sidebar
```
* Start editing one of your posts `/post/{YOUR-SITE-SLUG}/{POST-ID}`
* Ensure the post is not published. You can convert the post back to a draft.
* Publish the post again
* You should **see** the Anchor.fm component on the post-publish sidebar: "Convert to audio"