### PR TITLE
Launchpad checklist refactor scaffolding

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-checklist-refactor-scaffolding
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-checklist-refactor-scaffolding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added Launchpad Checklist API scaffolding code

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "1.3.x-dev"
+			"dev-trunk": "1.4.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "1.3.1",
+	"version": "1.4.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '1.3.1';
+	const PACKAGE_VERSION = '1.4.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -203,7 +203,7 @@ function get_checklist_task( $task ) {
  */
 function build_checklist( $checklist_slug ) {
 	$checklist = array();
-	if ( null !== ( CHECKLIST_DEFINITIONS[ $checklist_slug ] ) ) {
+	if ( null == ( CHECKLIST_DEFINITIONS[ $checklist_slug ] ) ) {
 		return $checklist;
 	}
 	foreach ( CHECKLIST_DEFINITIONS[ $checklist_slug ] as $task_id ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -203,7 +203,7 @@ function get_checklist_task( $task ) {
  */
 function build_checklist( $checklist_slug ) {
 	$checklist = array();
-	if ( null == ( CHECKLIST_DEFINITIONS[ $checklist_slug ] ) ) {
+	if ( null === ( CHECKLIST_DEFINITIONS[ $checklist_slug ] ) ) {
 		return $checklist;
 	}
 	foreach ( CHECKLIST_DEFINITIONS[ $checklist_slug ] as $task_id ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Launchpad
+ *
+ * @package A8C\Launchpad
+ */
+
+namespace A8C\Launchpad;
+
+const TASKS = array(
+	array(
+		'id'        => 'setup_newsletter',
+		'completed' => true,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'plan_selected',
+		'completed' => true,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'subscribers_added',
+		'completed' => true,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'first_post_published',
+		'completed' => 'get_checklist_task( first_post_published ).completed',
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'first_post_published_newsletter',
+		'completed' => false,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'design_selected',
+		'completed' => true,
+		'disabled'  => true,
+	),
+	array(
+		'id'        => 'setup_link_in_bio',
+		'completed' => true,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'links_added',
+		'completed' => false,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'link_in_bio_launched',
+		'completed' => false,
+		'disabled'  => true,
+	),
+	array(
+		'id'        => 'videopress_setup',
+		'completed' => true,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'videopress_upload',
+		'completed' => false,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'videopress_launched',
+		'completed' => false,
+		'disabled'  => true,
+	),
+	array(
+		'id'        => 'setup_free',
+		'completed' => true,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'setup_general',
+		'completed' => true,
+		'disabled'  => true,
+	),
+	array(
+		'id'        => 'design_edited',
+		'completed' => false,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'site_launched',
+		'completed' => false,
+		'disabled'  => false,
+	),
+	array(
+		'id'        => 'setup_write',
+		'completed' => true,
+		'disabled'  => true,
+	),
+	array(
+		'id'        => 'domain_upsell',
+		'completed' => false,
+		'disabled'  => false,
+	),
+	array(
+		'id'       => 'verify_email',
+		'complete' => false,
+		'disabled' => true,
+	),
+);
+
+const CHECKLIST_DEFINITIONS = array(
+	'newsletter' => array(
+		'setup_newsletter',
+		'plan_selected',
+		'subscribers_added',
+		'verify_email',
+		'first_post_published_newsletter',
+		'first_post_published',
+	),
+);
+
+/**
+ * Returns launchpad checklist task by task id.
+ *
+ * @param string $task Task id.
+ *
+ * @return array Associative array with task data
+ *               or false if task id is not found.
+ */
+function get_checklist_task( $task ) {
+	$launchpad_checklist_tasks_statuses_option = get_option( 'launchpad_checklist_tasks_statuses' );
+	if ( is_array( $launchpad_checklist_tasks_statuses_option ) && isset( $launchpad_checklist_tasks_statuses_option[ $task ] ) ) {
+			return $launchpad_checklist_tasks_statuses_option[ $task ];
+	}
+
+	return false;
+}
+
+/**
+ * Returns launchpad checklist by checklist slug.
+ *
+ * @param string $checklist_slug Checklist slug.
+ *
+ * @return array Associative array with checklist task
+ *               or empty array if checklist slug is not found.
+ */
+function build_checklist( $checklist_slug ) {
+	$checklist = array();
+	if ( ! isset( CHECKLIST_DEFINITIONS[ $checklist_slug ] ) ) {
+		return $checklist;
+	}
+	foreach ( CHECKLIST_DEFINITIONS[ $checklist_slug ] as $task_id ) {
+		$checklist[] = TASKS[ $task_id ];
+	}
+	return $checklist;
+}
+
+/**
+ * Returns launchpad checklist by checklist slug.
+ *
+ * @param string $checklist_slug Checklist slug.
+ *
+ * @return array Associative array with checklist task data
+ */
+function get_launchpad_checklist_by_checklist_slug( $checklist_slug ) {
+	if ( ! $checklist_slug ) {
+		return array();
+	}
+	return build_checklist( $checklist_slug );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -7,7 +7,7 @@
 
 namespace A8C\Launchpad;
 
-const TASKS = array(
+const TASK_DEFINITIONS = array(
 	'setup_newsletter'
 		=> array(
 			'id'        => 'setup_newsletter',
@@ -125,13 +125,54 @@ const TASKS = array(
 );
 
 const CHECKLIST_DEFINITIONS = array(
-	'newsletter' => array(
+	'build'           => array(
+		'setup_general',
+		'design_selected',
+		'first_post_published',
+		'design_edited',
+		'site_launched',
+	),
+	'free'            => array(
+		'setup_free',
+		'design_selected',
+		'domain_upsell',
+		'first_post_published',
+		'design_edited',
+		'site_launched',
+	),
+	'link-in-bio'     => array(
+		'design_selected',
+		'setup_link_in_bio',
+		'plan_selected',
+		'links_added',
+		'link_in_bio_launched',
+	),
+	'link-in-bio-tld' => array(
+		'design_selected',
+		'setup_link_in_bio',
+		'plan_selected',
+		'links_added',
+		'link_in_bio_launched',
+	),
+	'newsletter'      => array(
 		'setup_newsletter',
 		'plan_selected',
 		'subscribers_added',
 		'verify_email',
 		'first_post_published_newsletter',
 		'first_post_published',
+	),
+	'videopress'      => array(
+		'videopress_setup',
+		'plan_selected',
+		'videopress_upload',
+		'videopress_launched',
+	),
+	'write'           => array(
+		'setup_write',
+		'design_selected',
+		'first_post_published',
+		'site_launched',
 	),
 );
 
@@ -166,7 +207,7 @@ function build_checklist( $checklist_slug ) {
 		return $checklist;
 	}
 	foreach ( CHECKLIST_DEFINITIONS[ $checklist_slug ] as $task_id ) {
-		$checklist[] = TASKS[ $task_id ];
+		$checklist[] = TASK_DEFINITIONS[ $task_id ];
 	}
 	return $checklist;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -203,7 +203,7 @@ function get_checklist_task( $task ) {
  */
 function build_checklist( $checklist_slug ) {
 	$checklist = array();
-	if ( ! isset( CHECKLIST_DEFINITIONS[ $checklist_slug ] ) ) {
+	if ( null !== ( CHECKLIST_DEFINITIONS[ $checklist_slug ] ) ) {
 		return $checklist;
 	}
 	foreach ( CHECKLIST_DEFINITIONS[ $checklist_slug ] as $task_id ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -8,101 +8,120 @@
 namespace A8C\Launchpad;
 
 const TASKS = array(
-	array(
-		'id'        => 'setup_newsletter',
-		'completed' => true,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'plan_selected',
-		'completed' => true,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'subscribers_added',
-		'completed' => true,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'first_post_published',
-		'completed' => 'get_checklist_task( first_post_published ).completed',
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'first_post_published_newsletter',
-		'completed' => false,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'design_selected',
-		'completed' => true,
-		'disabled'  => true,
-	),
-	array(
-		'id'        => 'setup_link_in_bio',
-		'completed' => true,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'links_added',
-		'completed' => false,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'link_in_bio_launched',
-		'completed' => false,
-		'disabled'  => true,
-	),
-	array(
-		'id'        => 'videopress_setup',
-		'completed' => true,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'videopress_upload',
-		'completed' => false,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'videopress_launched',
-		'completed' => false,
-		'disabled'  => true,
-	),
-	array(
-		'id'        => 'setup_free',
-		'completed' => true,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'setup_general',
-		'completed' => true,
-		'disabled'  => true,
-	),
-	array(
-		'id'        => 'design_edited',
-		'completed' => false,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'site_launched',
-		'completed' => false,
-		'disabled'  => false,
-	),
-	array(
-		'id'        => 'setup_write',
-		'completed' => true,
-		'disabled'  => true,
-	),
-	array(
-		'id'        => 'domain_upsell',
-		'completed' => false,
-		'disabled'  => false,
-	),
-	array(
-		'id'       => 'verify_email',
-		'complete' => false,
-		'disabled' => true,
-	),
+	'setup_newsletter'
+		=> array(
+			'id'        => 'setup_newsletter',
+			'completed' => true,
+			'disabled'  => false,
+		),
+	'plan_selected'
+		=> array(
+			'id'        => 'plan_selected',
+			'completed' => true,
+			'disabled'  => false,
+		),
+	'subscribers_added'
+		=> array(
+			'id'        => 'subscribers_added',
+			'completed' => true,
+			'disabled'  => false,
+		),
+	'first_post_published'
+		=> array(
+			'id'        => 'first_post_published',
+			'completed' => 'get_checklist_task( first_post_published ).completed',
+			'disabled'  => false,
+		),
+	'first_post_published_newsletter'
+		=> array(
+			'id'        => 'first_post_published_newsletter',
+			'completed' => false,
+			'disabled'  => false,
+		),
+	'design_selected'
+		=> array(
+			'id'        => 'design_selected',
+			'completed' => true,
+			'disabled'  => true,
+		),
+	'setup_link_in_bio'
+		=> array(
+			'id'        => 'setup_link_in_bio',
+			'completed' => true,
+			'disabled'  => false,
+		),
+	'links_added'
+		=> array(
+			'id'        => 'links_added',
+			'completed' => false,
+			'disabled'  => false,
+		),
+	'link_in_bio_launched'
+		=> array(
+			'id'        => 'link_in_bio_launched',
+			'completed' => false,
+			'disabled'  => true,
+		),
+	'videopress_setup'
+		=> array(
+			'id'        => 'videopress_setup',
+			'completed' => true,
+			'disabled'  => false,
+		),
+	'videopress_upload'
+		=> array(
+			'id'        => 'videopress_upload',
+			'completed' => false,
+			'disabled'  => false,
+		),
+	'videopress_launched'
+		=> array(
+			'id'        => 'videopress_launched',
+			'completed' => false,
+			'disabled'  => true,
+		),
+	'setup_free'
+		=> array(
+			'id'        => 'setup_free',
+			'completed' => true,
+			'disabled'  => false,
+		),
+	'setup_general'
+		=> array(
+			'id'        => 'setup_general',
+			'completed' => true,
+			'disabled'  => true,
+		),
+	'design_edited'
+		=> array(
+			'id'        => 'design_edited',
+			'completed' => false,
+			'disabled'  => false,
+		),
+	'site_launched'
+		=> array(
+			'id'        => 'site_launched',
+			'completed' => false,
+			'disabled'  => false,
+		),
+	'setup_write'
+		=> array(
+			'id'        => 'setup_write',
+			'completed' => true,
+			'disabled'  => true,
+		),
+	'domain_upsell'
+		=> array(
+			'id'        => 'domain_upsell',
+			'completed' => false,
+			'disabled'  => false,
+		),
+	'verify_email'
+		=> array(
+			'id'       => 'verify_email',
+			'complete' => false,
+			'disabled' => true,
+		),
 );
 
 const CHECKLIST_DEFINITIONS = array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Launchpad Checklist API endpoint
+ *
+ * @package automattic/jetpack-mu-wpcom
+ * @since 1.1.0
+ */
+
+/**
+ * Fetches Launchpad checklist data for the site
+ *
+ * @since 1.1.0
+ */
+class WPCOM_REST_API_V2_Endpoint_Launchpad_Checklist extends WP_REST_Controller {
+
+	/**
+	 * Class constructor
+	 */
+	public function __construct() {
+		require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/launchpad/launchpad.php';
+
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'launchpad/checklist';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register our routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_data' ),
+					'permission_callback' => array( $this, 'can_access' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback for the REST route
+	 *
+	 * @return boolean
+	 */
+	public function can_access() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Returns Launchpad-related options
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 *
+	 * @return array Associative array with `site_intent`, `launchpad_screen`,
+	 *               and `launchpad_checklist_tasks_statuses` as `checklist`.
+	 */
+	public function get_data( $request ) {
+		// TODO: Add checklist_slug from request input
+		$checklist_slug = $request['checklist_slug'];
+		return array(
+			'checklist' => get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
+		);
+	}
+
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Launchpad_Checklist' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
@@ -17,7 +17,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Checklist extends WP_REST_Controller 
 	 * Class constructor
 	 */
 	public function __construct() {
-		require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/launchpad/launchpad.php';
+		require_once __DIR__ . '/../launchpad/launchpad.php';
 
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'launchpad/checklist';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
@@ -64,7 +64,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Checklist extends WP_REST_Controller 
 		// TODO: Add checklist_slug from request input
 		$checklist_slug = $request['checklist_slug'];
 		return array(
-			'checklist' => get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
+			'checklist' => A8C\Launchpad\get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
@@ -61,7 +61,6 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Checklist extends WP_REST_Controller 
 	 * @return array Array of launchpad tasks for a given checklist
 	 */
 	public function get_data( $request ) {
-		// TODO: Add checklist_slug from request input
 		$checklist_slug = $request['checklist_slug'];
 		return array(
 			'checklist' => A8C\Launchpad\get_launchpad_checklist_by_checklist_slug( $checklist_slug ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
@@ -58,8 +58,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Checklist extends WP_REST_Controller 
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
-	 * @return array Associative array with `site_intent`, `launchpad_screen`,
-	 *               and `launchpad_checklist_tasks_statuses` as `checklist`.
+	 * @return array Array of launchpad tasks for a given checklist
 	 */
 	public function get_data( $request ) {
 		// TODO: Add checklist_slug from request input

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-checklist-refactor-scaffolding
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-launchpad-checklist-refactor-scaffolding
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_1_1"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_1_2_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "622cd184ab3becd9ae872c469270d6817780ddf4"
+                "reference": "08d42c6140b3860999db350e14f219e68b99c0a2"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "1.3.x-dev"
+                    "dev-trunk": "1.4.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.1.1
+ * Version: 1.1.2-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.1.1",
+	"version": "1.1.2-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

https://github.com/Automattic/wp-calypso/issues/75504

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds a new Launchpad Checklist API to the `jetpack-mu-wpcom` package.
* This new endpoint will allow us to access data related to Launchpad checklists and their status on Simple + Atomic Sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

## Simple Sites

- Checkout this branch.

**METHOD 1:**

- Build the jetpack `mu-wpcom-plugin` : `jetpack build plugins/mu-wpcom-plugin`
- Use the jetpack rsync command in the jetpack project root directory to sync changes to your sandbox 

`jetpack rsync mu-wpcom-plugin {sandbox_here}:~/public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/production`

**METHOD 2:**

- Execute `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-checklist-refactor-scaffolding` on your sandbox.


## Atomic Sites

Create or use an existing WoA site
Use rsync to transfer into (mu-plugins/wpcomsh/vendor/automattic/jetpack-mu-wpcom) OR use the jetpack Beta Tester plugin (https://jetpack.com/download-jetpack-beta/)

---

Finally...

- Use `developer.wordpress.com/docs/api/console/` to make a GET request to the new endpoint (WP REST API: `wpcom/v2/sites/{SITE_SLUG}/launchpad/checklist?checklist_slug=newsletter`)

More details instructions can be found at PCYsg-Osp-p2


<img width="1358" alt="CleanShot 2023-04-11 at 09 46 05@2x" src="https://user-images.githubusercontent.com/10482592/231183085-f252bce8-c0af-48af-aeca-6b52520884d8.png">