### PR TITLE
CRM: Fix overflow in invoice edit page

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-2951-fix-overflow-in-invoice-edit-page
+++ b/projects/plugins/crm/changelog/fix-crm-2951-fix-overflow-in-invoice-edit-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Invoices: fix overflow issue in the edit invoice page

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
@@ -295,13 +295,13 @@
 		.zbs-invoice-topper{
 			width:50%;
 			float:right;
+			min-width: 335px;
 			input, select{
 				// WH: changed for symmetry with rest of page width:80%;
 				width:100%;
 				float:left;
 			}
 			th{
-			    vertical-align: middle;
 			    text-align:right;
 			}
 		}
@@ -380,9 +380,9 @@
 		font-weight:100;
 		.fa{
 			color: #428bca;
-		    margin-right: 10px;
-		    font-size: 20px;
-		    font-weight: 100;
+		   margin-right: 10px;
+		   font-size: 20px;
+		   font-weight: 100;
 		}
 	}
 	#zbs-business-info-wrapper{
@@ -759,6 +759,7 @@
 	    .fa{
 	    	color: #428bca;
 	    	margin-right:5px;
+			margin-bottom:10px;
 	    	font-size:40px;
 	    	font-weight:100;
 	    }
@@ -769,6 +770,8 @@
 		    margin-left: 20px;
 		    position: absolute;
 		    top: 63px;
+		    display: contents;
+		    white-space: nowrap;
 	    }
 	}
 }
@@ -911,5 +914,11 @@
 	}
 	label {
 		margin-bottom:0;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	div.zbs-invoice-topper th {
+		text-align:left !important;
 	}
 }

--- a/projects/plugins/crm/sass/_ZeroBSCRM.adminpages.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.adminpages.scss
@@ -872,3 +872,9 @@ table#zbsFilesTable td {
 .swal-wider{
     width:850px !important;
 }
+
+@media only screen and (min-width: 768px) and (max-width: 960px) {
+  #zbs-admin-top-bar {
+    margin-left: 0px !important;
+  }
+}


### PR DESCRIPTION
## Proposed changes:
* This PR addresses an issue with content overflowing between divs on smaller screens by making CSS adjustments.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/2951

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the edit page for invoices (e.g. add a new invoice: `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=invoice`)
* Make the size of the screen smaller.

In `trunk` contents will overflow between divs.

![image](https://user-images.githubusercontent.com/37049295/231039344-81763802-6a3b-4eb6-b643-3da5397eb235.png)

In `fix/crm-2951-fix-overflow-in-invoice-edit-page` no content will overflow between divs, and responsiveness for small screens was improved.

![image](https://user-images.githubusercontent.com/37049295/231039208-73a72454-6884-4e71-a25f-9a761e72d67a.png)


Small screens in `trunk`:

![image](https://user-images.githubusercontent.com/37049295/231039451-0116be38-7eb9-4846-a358-c31502693ea6.png)

Small screens in `fix/crm-2951-fix-overflow-in-invoice-edit-page`:

![image](https://user-images.githubusercontent.com/37049295/231039664-965c4625-4652-49fb-857c-127152cf7077.png)
