### PR TITLE
[Boost] Fix Defer JS on short pages

### DIFF
--- a/projects/plugins/boost/app/lib/class-output-filter.php
+++ b/projects/plugins/boost/app/lib/class-output-filter.php
@@ -97,6 +97,9 @@ class Output_Filter {
 		}
 
 		// Check if this the first or last buffer. Use the $phase bitmask to figure it out.
+		// $phase can contain multiple PHP_OUTPUT_HANDLER_* constants.
+		// e.g.: PHP_OUTPUT_HANDLER_END = 8 (binary 1000), PHP_OUTPUT_HANDLER_START = 1 (binary 0001). Both = 9 (binary 1001).
+		// Use bitwise AND to read individual flags from $phase.
 		$is_first_chunk = ( $phase & PHP_OUTPUT_HANDLER_START ) > 0;
 		$is_last_chunk  = ( $phase & PHP_OUTPUT_HANDLER_END ) > 0;
 

--- a/projects/plugins/boost/changelog/boost-fix-short-defers
+++ b/projects/plugins/boost/changelog/boost-fix-short-defers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Deferred JS: Fix for some extremely short pages (such as WooCommerce Box Office tickets being printed) from resulting in a blank page


### PR DESCRIPTION
Fixes #30008

The Defer JS feature uses output filtering to shift scripts to the bottom of the page. PHP output buffering is handled in "chunks" - page renders typically have multiple chunks to process.

However, when a page is extremely tiny - such as when printing a ticket in Woocommerce Box Office - only one chunk gets filtered. This PR implements fixes for the output filtering code to ensure it works whether there is one chunk, or more.

## Proposed changes:
* Fix output filtering to ensure single-chunk pages get output properly.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Follow the testing instructions on https://github.com/Automattic/jetpack/issues/30008

