### PR TITLE
Social Previews | Update Twitter preview with multiple view type sections

### DIFF
--- a/projects/js-packages/publicize-components/src/components/social-previews/constants.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/constants.js
@@ -1,6 +1,7 @@
 import { SocialServiceIcon } from '@automattic/jetpack-components';
-import { FacebookPreview, TwitterPreview, SearchPreview } from '@automattic/social-previews';
+import { FacebookPreview, SearchPreview } from '@automattic/social-previews';
 import { __ } from '@wordpress/i18n';
+import { Twitter } from './twitter';
 
 export const AVAILABLE_SERVICES = [
 	{
@@ -13,7 +14,7 @@ export const AVAILABLE_SERVICES = [
 		title: __( 'Twitter', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="twitter" { ...props } />,
 		name: 'twitter',
-		preview: props => <TwitterPreview { ...props } />,
+		preview: props => <Twitter { ...props } />,
 	},
 	{
 		title: __( 'Facebook', 'jetpack' ),

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -21,6 +21,7 @@ const SocialPreviewsModal = function SocialPreviewsModal( {
 	author,
 	isTweetStorm,
 	tweets,
+	media,
 } ) {
 	return (
 		<Modal
@@ -49,6 +50,7 @@ const SocialPreviewsModal = function SocialPreviewsModal( {
 							image={ image }
 							isTweetStorm={ isTweetStorm }
 							tweets={ tweets }
+							media={ media }
 						/>
 					</div>
 				) }
@@ -67,6 +69,8 @@ export default withSelect( select => {
 	const authorId = getEditedPostAttribute( 'author' );
 	const user = authorId && getUser( authorId );
 
+	const media = getMedia( featuredImageId );
+
 	const postData = {
 		post: getCurrentPost(),
 		title:
@@ -78,7 +82,7 @@ export default withSelect( select => {
 			__( 'Visit the post for more.', 'jetpack' ),
 		url: getEditedPostAttribute( 'link' ),
 		author: user?.name,
-		image: !! featuredImageId && getMediaSourceUrl( getMedia( featuredImageId ) ),
+		image: !! featuredImageId && getMediaSourceUrl( media ),
 	};
 
 	let tweets = [];
@@ -98,6 +102,15 @@ export default withSelect( select => {
 	return {
 		...postData,
 		tweets,
+		media: media
+			? [
+					{
+						type: media.mime_type,
+						url: getMediaSourceUrl( media ),
+						alt: media.alt_text,
+					},
+			  ]
+			: null,
 		isTweetStorm: isTweetStorm(),
 	};
 } )( SocialPreviewsModal );

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
@@ -182,3 +182,14 @@ $highlight-color: #3858e9;
 		}
 	}
 }
+
+.twitter-preview-tab {
+	header{
+		padding-inline-start: 37px;
+		padding-inline-end: 20px;
+		width: 635px;
+	}
+	p.description {
+		font-size: 1rem;
+	}
+}

--- a/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
@@ -1,0 +1,77 @@
+import { TwitterPreview } from '@automattic/social-previews';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+import { getTweetTemplate } from '../../store/selectors';
+import { getAutoSharedTweetText } from './utils';
+
+/**
+ * The twitter tab component.
+ *
+ * @param {object} props - The props.
+ * @param {boolean} props.isTweetStorm  - Whether it's a tweetstorm.
+ * @param {object[]} props.tweets - The tweets.
+ * @param {object} props.media - The media.
+ * @returns {React.ReactNode} The twitter tab component.
+ */
+export function Twitter( { isTweetStorm, tweets, media } ) {
+	const template = getTweetTemplate( { connections: [] } );
+
+	const linkTweet = { ...tweets[ 0 ], ...template, text: '' };
+
+	const autoSharedTweet = {
+		...tweets[ 0 ],
+		media,
+		card: undefined,
+		text: getAutoSharedTweetText( { ...tweets[ 0 ], ...tweets[ 0 ]?.card } ),
+	};
+
+	return (
+		<div className="twitter-preview-tab">
+			<section>
+				<header>
+					<h2>{ __( 'Auto-shared', 'jetpack' ) }</h2>
+					<p className="description">
+						{ __( 'This is how it will look like when auto-shared', 'jetpack' ) }
+					</p>
+				</header>
+				<TwitterPreview
+					isTweetStorm={ isTweetStorm }
+					tweets={ isTweetStorm ? tweets : [ autoSharedTweet ] }
+				/>
+			</section>
+			<section>
+				<header>
+					<h2>{ __( 'Your post', 'jetpack' ) }</h2>
+					<p className="description">
+						{ __( 'This is what your social post will look like on Twitter', 'jetpack' ) }
+					</p>
+				</header>
+				<TwitterPreview tweets={ [ tweets[ 0 ] ] } />
+			</section>
+			<section>
+				<header>
+					<h2>{ __( 'Link preview', 'jetpack' ) }</h2>
+					<p className="description">
+						{ createInterpolateElement(
+							__(
+								'This is what it will look like when someone shares the link to your WordPress post on Twitter. <LearnMoreLink>Learn more about links</LearnMoreLink>',
+								'jetpack'
+							),
+							{
+								LearnMoreLink: (
+									<a
+										href={ 'https://jetpack.com/support/jetpack-social/twitter/' }
+										rel="noopener noreferrer"
+										target="_blank"
+									/>
+								),
+							}
+						) }
+					</p>
+				</header>
+				<TwitterPreview tweets={ [ linkTweet ] } />
+			</section>
+		</div>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/social-previews/utils.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/utils.js
@@ -12,3 +12,29 @@ export function getMediaSourceUrl( media ) {
 	// Try getting the large size (1024px width) and fallback to the full size.
 	return media.media_details?.sizes?.large?.source_url || media.source_url;
 }
+
+/**
+ * Get the text for the auto-shared tweet.
+ *
+ * @param {object} params - The params.
+ * @param {string} params.title - The title.
+ * @param {string} params.url 	- The url.
+ * @param {string} params.text 	- The text.
+ * @returns {string} The text for the auto-shared tweet.
+ */
+export function getAutoSharedTweetText( { title, url, text } ) {
+	let content = ( text || title || '' ).trim();
+
+	// 24 is the length of the URL and 2 is for the space and the ellipsis.
+	const maxTweetLength = 280 - ( 24 + 2 );
+
+	if ( content.length > maxTweetLength ) {
+		// Get the limited number of characters without breaking words.
+		content =
+			content.match( new RegExp( '.{1,' + maxTweetLength + '}(?:\\s|$)', 'u' ) )?.[ 0 ]?.trim() ||
+			'';
+		content += '…';
+	}
+
+	return `${ content } ${ url }`;
+}

--- a/projects/js-packages/publicize-components/src/store/test/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/test/selectors.js
@@ -117,7 +117,7 @@ describe( 'getTweetStorm', () => {
 			name: 'Account Name',
 			profileImage:
 				'https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png',
-			screenName: '',
+			screenName: '@account',
 		};
 
 		const tweets = getTweetstormHelper( state );


### PR DESCRIPTION
Completes 1203820933396971-as-1204281809108915/f and 1203820933396971-as-1204281809108923/f

## Proposed Changes

This PR updates the Twitter preview component to the latest design from Twitter

## Testing instructions:

* Checkout this PR branch
* Checkout https://github.com/Automattic/wp-calypso/pull/75544 in calypso
* In `wp-calypso/packages/social-previews/` directory, run `pnpm link --global` to expose the package to global `node_modules` for `pnpm`
* In `jetpack/projects/js-packages/publicize-components/` directory, run `pnpm link --global @automattic/social-previews`
* In `wp-calypso` root, run `yarn` and then `yarn workspace @automattic/social-previews run build`
* In Jetpack, run `jetpack build plugins/jetpack --no-pnpm-install`
* Start writing a new post with JT site via Jetpack
* Click Jetpack icon on the top of the sidebar
* Under "Social Previews", click on "Preview"
* Confirm that the preview of Twitter is as per the design
* Once you are done, run `pnpm unlink` in Jetpack


Single Tweet
<img width="1411" alt="Screenshot 2023-04-11 at 3 55 06 PM" src="https://user-images.githubusercontent.com/18226415/231136960-33a1f62d-83a3-4468-b399-d2c9df4d3042.png">
<img width="1410" alt="Screenshot 2023-04-11 at 3 55 40 PM" src="https://user-images.githubusercontent.com/18226415/231136971-3f37b6ee-b1b5-48ba-b448-7580787bbe06.png">

Twitter Thread
<img width="1410" alt="Screenshot 2023-04-11 at 3 56 57 PM" src="https://user-images.githubusercontent.com/18226415/231136978-ae2c78e9-456b-43c2-8134-b70826e56bc2.png">
<img width="1412" alt="Screenshot 2023-04-11 at 3 57 22 PM" src="https://user-images.githubusercontent.com/18226415/231136981-0c81868f-78e0-4be9-92cf-e53d800c05f9.png">
<img width="1413" alt="Screenshot 2023-04-11 at 3 57 42 PM" src="https://user-images.githubusercontent.com/18226415/231136986-8e6cbc6f-cec4-4c8a-b7b9-f9f47a33b9fd.png">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1204281809108923