### PR TITLE
CRM: Resolves 2920 - use current date if quote date is blank

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-2920-force_default_quote_date
+++ b/projects/plugins/crm/changelog/fix-crm-2920-force_default_quote_date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Quotes: use current date if quote date is blank

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Quotes.php
@@ -1116,6 +1116,10 @@ class zbsDAL_quotes extends zbsDAL_ObjectLayer {
 			// if owner = -1, add current
 			if (!isset($owner) || $owner === -1) { $owner = zeroBSCRM_user(); }
 
+			// if no date is passed, use current date
+			if ( empty( $data['date'] ) ) {
+				$data['date'] = time(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			}
 
 			if (is_array($limitedFields)){ 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#2920- use current date if quote date is blank

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If one left the quote date blank when creating/editing a quote, it would pass a date of epoch 0. This PR forces the current date if the date is blank.

I would've preferred to switch the datepicker to be native as well, but there are other PRs that are touching similar bits of code, so I went for the easy fix at this point.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=quote`
2. Save the quote with no date.
3. Change the date to something else.
4. Save the quote.
5. Blank the date.
6. Save the quote.

In `trunk`, after step 2 and step 6 the date will show epoch 0.

In `fix/crm/2920-force_default_quote_date`, after step 2 and 6 the date will show today's date. After step 4, the date will continue to show the selected date.
