### PR TITLE
Blogging prompts v3 endpoint: fix date ordering when using after param

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blogging-prompts-v3-non-leap-years
+++ b/projects/plugins/jetpack/changelog/fix-blogging-prompts-v3-non-leap-years
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Change only affects endpoint when executed on wpcom
+
+


### PR DESCRIPTION
## Proposed changes:

Fixes response during non-leap years when using after param without year.

| **Before** | **After** |
| - | - |
| <img width="750" alt="Screenshot 2023-04-11 at 09 53 17" src="https://user-images.githubusercontent.com/1699996/231202370-22ec3a6e-6076-4f31-b61c-db172755e115.png"> | <img width="722" alt="Screenshot 2023-04-11 at 09 52 03" src="https://user-images.githubusercontent.com/1699996/231202463-4097222b-af92-46bb-9cec-26bc24b57e50.png"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See pctCYC-KA-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Note, this change must be applied to wpcom to take effect.

* Sandbox public-api.wordpress.com and apply this change to your sandbox with `bin/jetpack-downloader test jetpack fix/blogging-prompts-v3-non-leap-years`
* Use the developer API console to make a request to `wpcom/v3/sites/150131137/blogging-prompts?after=--04-11`
* See that the first prompt is dated `2020-04-11`, not `2020-04-10`
* Make another request using `wpcom/v3/sites/150131137/blogging-prompts?after=--02-28` and see that the prompt for `2020-02-29` is not included.