### PR TITLE
 VideoPress: fix helper VideoPress function when generating URL

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-iterate-over-util-fn
+++ b/projects/packages/videopress/changelog/update-videopress-iterate-over-util-fn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: fix helper VideoPress function when generating URL

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -50,13 +50,16 @@ class Utils {
 			'muted'           => (int) $video_press_url_options['muted'],
 			'persistVolume'   => $video_press_url_options['muted'] ? 0 : 1,
 			'playsinline'     => (int) $video_press_url_options['playsinline'],
-			'posterUrl'       => rawurlencode( $video_press_url_options['poster'] ),
 			'preloadContent'  => $video_press_url_options['preload'],
 			'sbc'             => $video_press_url_options['seekbarColor'],
 			'sbpc'            => $video_press_url_options['seekbarPlayedColor'],
 			'sblc'            => $video_press_url_options['seekbarLoadingColor'],
 			'useAverageColor' => (int) $video_press_url_options['useAverageColor'],
 		);
+
+		if ( ! empty( $video_press_url_options['poster'] ) ) {
+			$query_args['posterUrl'] = rawurlencode( $video_press_url_options['poster'] );
+		}
 
 		$url = 'https://videopress.com/v/' . $guid;
 		return add_query_arg( $query_args, $url );

--- a/projects/packages/videopress/tests/php/test-class-utils.php
+++ b/projects/packages/videopress/tests/php/test-class-utils.php
@@ -111,8 +111,8 @@ class UtilsTest extends BaseTestCase {
 			'poster' => '',
 		);
 
-		$url_witt_empty_poster = Utils::get_video_press_url( $guid, $attributes_without_poster );
-		$this->assertStringNotContainsString( 'posterUrl', $url_witt_empty_poster );
+		$url_with_empty_poster = Utils::get_video_press_url( $guid, $attributes_without_poster );
+		$this->assertStringNotContainsString( 'posterUrl', $url_with_empty_poster );
 
 		// Test without provided poster URL.
 		$attributes_without_poster = array();

--- a/projects/packages/videopress/tests/php/test-class-utils.php
+++ b/projects/packages/videopress/tests/php/test-class-utils.php
@@ -92,4 +92,33 @@ class UtilsTest extends BaseTestCase {
 		$this->assertStringContainsString( 'useAverageColor=0', $url );
 	}
 
+	/**
+	 * Test the get_video_press_url with poster URL.
+	 */
+	public function test_get_video_press_url_posterUrl() {
+		$guid = '3Nq0kSMu';
+
+		// Test with provided poster URL.
+		$attributes_with_poster = array(
+			'poster' => 'http://localhost/wp-content/uploads/2023/03/poster.jpg',
+		);
+
+		$url_with_poster = Utils::get_video_press_url( $guid, $attributes_with_poster );
+		$this->assertStringContainsString( 'posterUrl=' . rawurlencode( $attributes_with_poster['poster'] ), $url_with_poster );
+
+		// Test with provided empty poster URL.
+		$attributes_without_poster = array(
+			'poster' => '',
+		);
+
+		$url_witt_empty_poster = Utils::get_video_press_url( $guid, $attributes_without_poster );
+		$this->assertStringNotContainsString( 'posterUrl', $url_witt_empty_poster );
+
+		// Test without provided poster URL.
+		$attributes_without_poster = array();
+
+		$url_without_poster = Utils::get_video_press_url( $guid, $attributes_without_poster );
+		$this->assertStringNotContainsString( 'posterUrl', $url_without_poster );
+	}
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue in the `get_video_press_url()` when the `poster` attribute is not defined. In short, the function added the `posterUrl` parameter even when the block attribute was not defined.
Now, it doesn't add the parameter when the attribute is not defined.
The test added explains the idea :-)

Follow-up of https://github.com/Automattic/jetpack/pull/30033

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  VideoPress: fix helper VideoPress function when generating URL

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Take a look at the code
* Run tests

