### PR TITLE
VideoPress: render VideoPress video block 100% dynamically

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-render-video-block-100-dynamically
+++ b/projects/packages/videopress/changelog/update-videopress-render-video-block-100-dynamically
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: render VideoPress video block 100% dynamically

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -232,7 +232,13 @@ class Initializer {
 				'previewAtTime'       => $block_attributes['posterData']['previewAtTime'],
 				'previewLoopDuration' => $block_attributes['posterData']['previewLoopDuration'],
 			);
+
+			// Expose the preview on hover data to the client.
 			$preview_on_hover = sprintf( '<div className="jetpack-videopress-player__overlay"></div><script type="application/json">%s</script>', wp_json_encode( $preview_on_hover ) );
+
+			// Set `autoplay` and `muted` attributes to the video element.
+			$block_attributes['autoplay'] = true;
+			$block_attributes['muted']    = true;
 		}
 
 		// VideoPress URL

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -180,10 +180,11 @@ class Initializer {
 	/**
 	 * VideoPress video block render method
 	 *
-	 * @param array $block_attributes - Block attributes.
+	 * @param array  $block_attributes - Block attributes.
+	 * @param string $content          - Block markup.
 	 * @return string                    Block markup.
 	 */
-	public static function render_videopress_video_block( $block_attributes ) {
+	public static function render_videopress_video_block( $block_attributes, $content ) {
 		// VideoPress URL
 		$videopress_url = Utils::get_video_press_url( $block_attributes['guid'], $block_attributes );
 
@@ -197,6 +198,31 @@ class Initializer {
 		$max_width = isset( $block_attributes['maxWidth'] ) ? $block_attributes['maxWidth'] : null;
 		if ( $max_width && $max_width !== '100%' ) {
 			$style = sprintf( 'max-width: %s; margin: auto;', $max_width );
+		}
+
+		/*
+		 * <figcaption /> element
+		 * Caption is stored into the block attributes,
+		 * but also it was stored into the <figcaption /> element,
+		 * meaning that it could be stored in two different places.
+		 */
+		$figcaption = '';
+
+		// Caption from block attributes
+		$caption = isset( $block_attributes['caption'] ) ? $block_attributes['caption'] : null;
+
+		/*
+		 * If the caption is not stored into the block attributes,
+		 * try to get it from the <figcaption /> element.
+		 */
+		if ( $caption === null ) {
+			preg_match( '/<figcaption>(.*?)<\/figcaption>/', $content, $matches );
+			$caption = isset( $matches[1] ) ? $matches[1] : null;
+		}
+
+		// If we have a caption, create the <figcaption /> element.
+		if ( $caption !== null ) {
+			$figcaption = sprintf( '<figcaption>%s</figcaption>', $caption );
 		}
 
 		// Preview On Hover data
@@ -233,14 +259,6 @@ class Initializer {
 			$video_wrapper = sprintf(
 				'<div class="jetpack-videopress-player__wrapper">%s</div>',
 				$oembed_html
-			);
-		}
-
-		$figcaption = '';
-		if ( ! empty( $caption ) ) {
-			$figcaption = sprintf(
-				'<figcaption>%s</figcaption>',
-				$caption
 			);
 		}
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -241,12 +241,6 @@ class Initializer {
 			$block_attributes['muted']    = true;
 		}
 
-		// VideoPress URL
-		$videopress_url = Utils::get_video_press_url( $block_attributes['guid'], $block_attributes );
-		if ( ! empty( $videopress_url ) ) {
-			$videopress_url = wp_kses_post( $videopress_url );
-		}
-
 		$figure_template = '
 		<figure class="%1$s" style="%2$s">			
 			%3$s
@@ -255,11 +249,15 @@ class Initializer {
 		</figure>
 		';
 
+		// VideoPress URL
+		$videopress_url = Utils::get_video_press_url( $block_attributes['guid'], $block_attributes );
+
 		$video_wrapper = '';
 		if ( $videopress_url ) {
-			$wp_embed      = new \WP_Embed();
-			$oembed_html   = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
-			$video_wrapper = sprintf(
+			$videopress_url = wp_kses_post( $videopress_url );
+			$wp_embed       = new \WP_Embed();
+			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
+			$video_wrapper  = sprintf(
 				'<div class="jetpack-videopress-player__wrapper">%s</div>',
 				$oembed_html
 			);

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -185,6 +185,8 @@ class Initializer {
 	 * @return string                    Block markup.
 	 */
 	public static function render_videopress_video_block( $block_attributes, $content ) {
+		global $wp_embed;
+
 		// CSS classes
 		$align       = isset( $block_attributes['align'] ) ? $block_attributes['align'] : null;
 		$align_class = $align ? ' align' . $align : '';
@@ -255,7 +257,6 @@ class Initializer {
 		$video_wrapper = '';
 		if ( $videopress_url ) {
 			$videopress_url = wp_kses_post( $videopress_url );
-			$wp_embed       = new \WP_Embed();
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
 				'<div class="jetpack-videopress-player__wrapper">%s</div>',

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -181,13 +181,10 @@ class Initializer {
 	 * VideoPress video block render method
 	 *
 	 * @param array  $block_attributes - Block attributes.
-	 * @param string $content          - Block markup.
+	 * @param string $content          - Current block markup.
 	 * @return string                    Block markup.
 	 */
 	public static function render_videopress_video_block( $block_attributes, $content ) {
-		// VideoPress URL
-		$videopress_url = Utils::get_video_press_url( $block_attributes['guid'], $block_attributes );
-
 		// CSS classes
 		$align       = isset( $block_attributes['align'] ) ? $block_attributes['align'] : null;
 		$align_class = $align ? ' align' . $align : '';
@@ -222,7 +219,7 @@ class Initializer {
 
 		// If we have a caption, create the <figcaption /> element.
 		if ( $caption !== null ) {
-			$figcaption = sprintf( '<figcaption>%s</figcaption>', $caption );
+			$figcaption = sprintf( '<figcaption>%s</figcaption>', wp_kses_post( $caption ) );
 		}
 
 		// Preview On Hover data
@@ -238,11 +235,11 @@ class Initializer {
 			$preview_on_hover = sprintf( '<div className="jetpack-videopress-player__overlay"></div><script type="application/json">%s</script>', wp_json_encode( $preview_on_hover ) );
 		}
 
+		// VideoPress URL
+		$videopress_url = Utils::get_video_press_url( $block_attributes['guid'], $block_attributes );
 		if ( ! empty( $videopress_url ) ) {
 			$videopress_url = wp_kses_post( $videopress_url );
 		}
-
-		$caption = ! empty( $block_attributes['caption'] ) ? wp_kses_post( $block_attributes['caption'] ) : '';
 
 		$figure_template = '
 		<figure class="%1$s" style="%2$s">			

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -258,7 +258,7 @@ class Initializer {
 		$video_wrapper = '';
 		if ( $videopress_url ) {
 			$wp_embed      = new \WP_Embed();
-			$oembed_html   = $wp_embed->autoembed( $videopress_url );
+			$oembed_html   = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper = sprintf(
 				'<div class="jetpack-videopress-player__wrapper">%s</div>',
 				$oembed_html

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -18,7 +18,7 @@ function previewOnHoverEffect(): void {
 	 * Pick all VideoPress video block intances,
 	 * based on the class name.
 	 */
-	const videoPlayers = document.querySelectorAll( '.wp-block-jetpack-videopress-container' );
+	const videoPlayers = document.querySelectorAll( '.wp-block-jetpack-videopress' );
 	if ( videoPlayers.length === 0 ) {
 		return;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/issues/29987
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: render VideoPress video block 100% dynamically

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In terms of functionality, there should be no changes when using the VideoPress video block between the Jetpack stable version and this branch. Thus

* Create a JN site with the Jetpack beta plugin installed
* Start using the Jetpack stable release (the default one)
* Connect the site
* Enable the VideoPress video module
* Go to the block editor and create a VideoPress video block
* Customize the instance (autoplay, control, loop, etc.)
* Set block caption, too
* Save the post
* Check the block in the front-end

* Switch to this branch by using the Jetpack beta plugin

<img width="600" alt="Screen Shot 2023-04-11 at 16 56 49" src="https://user-images.githubusercontent.com/77539/231274685-8cd61624-0b6e-4315-9620-ae7650b38ec3.png">

* Enable `beta` extensions

<img width="600" alt="Screen Shot 2023-04-11 at 16 58 52" src="https://user-images.githubusercontent.com/77539/231275140-a9739989-4634-4ad7-b9a4-6a1bf819404b.png">

* Go back to the block editor. Same post.
* Hard-refresh
* Confirm you are in the proper branch, taking a look at the Preview On Hover toggle

<img width="600" alt="Screen Shot 2023-04-11 at 17 00 19" src="https://user-images.githubusercontent.com/77539/231275481-fda78e98-e1ea-40cc-adfe-9a244a7f8054.png">

* It should not be any change (no block validation errors, for instance)
* Test in the front-end
* Confirm the previous settings are preserved (autoplay, control, loop, etc)

* Go to the block editor
* Enable Preview On Hover
* Save the post
* Go to the front-end
* Confirm it works as expected 

Repeat the test but for Simple and Atomic sites