### PR TITLE
CRM: Change onboarding wizard hint css

### DIFF
--- a/projects/plugins/crm/admin/activation/welcome-to-jpcrm.php
+++ b/projects/plugins/crm/admin/activation/welcome-to-jpcrm.php
@@ -383,7 +383,7 @@ $settings      = $zbs->settings->getAll();
 
 					<label><?php esc_html_e( 'Enable Invoices', 'zero-bs-crm' ); ?></label>
 					<p><?php esc_html_e( "You can run Jetpack CRM with or without Invoicing. We recommend you use this though, as it's very useful (you can invoice online!)", 'zero-bs-crm' ); ?></p>
-					<p class="zbs-extra"><?php esc_html_e( 'Accept online payments with', 'zero-bs-crm' ); ?> <a href="https://jetpackcrm.com/product/invoicing-pro/?utm_content=zbsplugin_welcomewiz" target="_blank">Invoicing Pro</a> <?php esc_html_e( '(Let your clients pay with Stripe or PayPal)', 'zero-bs-crm' ); ?></p>
+					<div class="zbs-extrainfo"><?php esc_html_e( 'Accept online payments with', 'zero-bs-crm' ); ?> <a href="https://jetpackcrm.com/product/invoicing-pro/?utm_content=zbsplugin_welcomewiz" target="_blank" style="color:#0073aa;">Invoicing Pro</a> <?php esc_html_e( '(Let your clients pay with Stripe or PayPal)', 'zero-bs-crm' ); ?></div>
 					
 				</div>
 
@@ -404,7 +404,7 @@ $settings      = $zbs->settings->getAll();
 
 					<label><?php esc_html_e( 'Enable WooSync', 'zero-bs-crm' ); ?></label>
 					<p><?php esc_html_e( 'Automatically import all your customers, transactions, and invoices from WooCommerce, a full-featured eCommerce solution for WordPress.', 'zero-bs-crm' ); ?></p>
-					<p class="zbs-extra"><?php esc_html_e( 'Note that you will also need a site that has the free WooCommerce plugin installed.', 'zero-bs-crm' ); ?></p>
+					<div class="zbs-extrainfo"><?php esc_html_e( 'Note that you will also need a site that has the free WooCommerce plugin installed.', 'zero-bs-crm' ); ?></div>
 					
 
 				</div>
@@ -442,7 +442,7 @@ $settings      = $zbs->settings->getAll();
 				$em    = $current_user->user_email;
 				?>
 				<h3><?php esc_html_e( 'Leverage your new CRM! (BONUSES)', 'zero-bs-crm' ); ?></h3>
-				<p style="font-size:16px;color:#e06d17"><strong><?php esc_html_e( 'Join the Jetpack CRM community today', 'zero-bs-crm' ); ?>:</strong><br />(<?php esc_html_e( 'Bonuses, Critical update notifications', 'zero-bs-crm' ); ?>.)</p>
+				<p style="font-size:16px;color:#000"><label><?php esc_html_e( 'Join the Jetpack CRM community today', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Gain access to exclusive bonuses and critical update notifications.', 'zero-bs-crm' ); ?></p>
 
 				<p style="text-align:center">
 					<input type="hidden" id="zbs_crm_subblogname" name="zbs_crm_subblogname" value="<?php bloginfo( 'name' ); ?>" />

--- a/projects/plugins/crm/changelog/update-crm-2906-change-onboarding-wizard-hint-css
+++ b/projects/plugins/crm/changelog/update-crm-2906-change-onboarding-wizard-hint-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Onboarding: make all hint styles consistent


### PR DESCRIPTION
## Proposed changes:
* This PR ensures that all hint styles are consistent across the onboarding wizard.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/2906

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. t-->

* Open the CRM for the first time
* Alternatively, run the SQL command in your database: ``DELETE FROM `wp_options` WHERE `option_name` = 'zbs_wizard_run';``, and then open the CRM
* Compare the styles from steps 3 and 4 in this branch with trunk

`trunk`
![image](https://user-images.githubusercontent.com/37049295/231298097-3f40f2ce-aefe-4fac-8d2d-177bbc8041fc.png)


`update/crm-2906-change-onboarding-wizard-hint-css`
![image](https://user-images.githubusercontent.com/37049295/231297918-6875128f-8977-418d-8632-5bac12fa7999.png)


`trunk`
![image](https://user-images.githubusercontent.com/37049295/231298126-e80d4035-ee56-4327-b894-01307ae19fe1.png)


`update/crm-2906-change-onboarding-wizard-hint-css`
![image](https://user-images.githubusercontent.com/37049295/231297984-cf965d18-3457-4988-8be2-65a6877e5663.png)

