### PR TITLE
Launchpad: Update jetpack mu wpcom launchpad feature namespace

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-launchpad-feature-namespace
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-launchpad-feature-namespace
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed namespacing of jetpack-mu-wpcom launchpad feature

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -5,8 +5,6 @@
  * @package A8C\Launchpad
  */
 
-namespace A8C\Launchpad;
-
 const TASK_DEFINITIONS = array(
 	'setup_newsletter'
 		=> array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -5,6 +5,10 @@
  * @package A8C\Launchpad
  */
 
+/**
+ * This file provides helpers that return the appropriate Launchpad
+ * checklist and tasks for a given checklist slug
+ */
 const TASK_DEFINITIONS = array(
 	'setup_newsletter'
 		=> array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php
@@ -63,7 +63,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Checklist extends WP_REST_Controller 
 	public function get_data( $request ) {
 		$checklist_slug = $request['checklist_slug'];
 		return array(
-			'checklist' => A8C\Launchpad\get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
+			'checklist' => get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

p1681249655559939/1681218745.482619-slack-CHN6J22MP

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove namespacing for jetpack-mu-wpcom launchpad feature

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

## Simple Sites

- Checkout this branch.
- **METHOD 1:**
  - Build the jetpack `mu-wpcom-plugin` : `jetpack build plugins/mu-wpcom-plugin`
  - Use the jetpack rsync command in the jetpack project root directory to sync changes to your sandbox 
  - `jetpack rsync mu-wpcom-plugin {sandbox_here}:~/public_html/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/production`
- **METHOD 2:**
  - Execute `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-checklist-refactor-scaffolding` on your sandbox.
- Use `developer.wordpress.com/docs/api/console/` to make a GET request to the new endpoint (WP REST API: `wpcom/v2/sites/{SITE_SLUG}/launchpad/checklist?checklist_slug=newsletter`)