### PR TITLE
My Jetpack: Add endpoint to install the standalone plugin for hybrid products

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-endpoint-to-install-standalone-plugin
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-endpoint-to-install-standalone-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add endpoint to install the standalone plugin for hybrid products.

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -68,6 +68,21 @@ class REST_Products {
 				),
 			)
 		);
+
+		register_rest_route(
+			'my-jetpack/v1',
+			'site/products/(?P<product>[a-z\-]+)/install-standalone',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => __CLASS__ . '::install_standalone',
+					'permission_callback' => __CLASS__ . '::edit_permissions_callback',
+					'args'                => array(
+						'product' => $product_arg,
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -205,4 +220,40 @@ class REST_Products {
 		return rest_ensure_response( Products::get_product( $product_slug ), 200 );
 	}
 
+	/**
+	 * Callback for installing the standalone plugin on a Hybrid Product.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response
+	 */
+	public static function install_standalone( $request ) {
+		$product_slug = $request->get_param( 'product' );
+		$product      = Products::get_product( $product_slug );
+		if ( ! isset( $product['class'] ) ) {
+			return new \WP_Error(
+				'not_implemented',
+				__( 'The product class handler is not implemented', 'jetpack-my-jetpack' ),
+				array( 'status' => 501 )
+			);
+		}
+
+		/**
+		 * If the product is not hybrid, there is no need to deal with a standalone plugin.
+		 */
+		if ( ! is_subclass_of( $product['class'], Hybrid_Product::class ) ) {
+			return new \WP_Error(
+				'not_hybrid',
+				__( 'This product does not have a standalone plugin to install', 'jetpack-my-jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$install_product_result = call_user_func( array( $product['class'], 'install_and_activate_standalone' ) );
+		if ( is_wp_error( $install_product_result ) ) {
+			$install_product_result->add_data( array( 'status' => 400 ) );
+			return $install_product_result;
+		}
+
+		return rest_ensure_response( Products::get_product( $product_slug ), 200 );
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -122,4 +122,42 @@ abstract class Hybrid_Product extends Product {
 		return true;
 	}
 
+	/**
+	 * Install and activate the standalone plugin in the case it's missing.
+	 *
+	 * @return boolean|WP_Error
+	 */
+	final public static function install_and_activate_standalone() {
+		/**
+		 * Check for the presence of the standalone plugin, ignoring Jetpack presence.
+		 *
+		 * If the standalone plugin is not installed and the user can install plugins, proceed with the installation.
+		 */
+		if ( ! parent::is_plugin_installed() ) {
+			/**
+			 * Check for permissions
+			 */
+			if ( ! current_user_can( 'install_plugins' ) ) {
+				return new WP_Error( 'not_allowed', __( 'You are not allowed to install plugins on this site.', 'jetpack-my-jetpack' ) );
+			}
+
+			/**
+			 * Install the plugin
+			 */
+			$installed = Plugins_Installer::install_plugin( static::get_plugin_slug() );
+			if ( is_wp_error( $installed ) ) {
+				return $installed;
+			}
+		}
+
+		/**
+		 * Activate the installed plugin
+		 */
+		$result = static::activate_plugin();
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return true;
+	}
 }

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -39,6 +39,15 @@ abstract class Hybrid_Product extends Product {
 	}
 
 	/**
+	 * Checks whether the standalone plugin for this product is active
+	 *
+	 * @return boolean
+	 */
+	public static function is_standalone_plugin_active() {
+		return parent::is_plugin_active();
+	}
+
+	/**
 	 * Checks whether the plugin is installed
 	 *
 	 * @return boolean

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -23,6 +23,13 @@ use WP_Error;
 abstract class Hybrid_Product extends Product {
 
 	/**
+	 * All hybrid products have a standalone plugin
+	 *
+	 * @var bool
+	 */
+	public static $has_standalone_plugin = true;
+
+	/**
 	 * Checks whether the Product is active
 	 *
 	 * @return boolean

--- a/projects/packages/my-jetpack/tests/php/test-hybrid-product.php
+++ b/projects/packages/my-jetpack/tests/php/test-hybrid-product.php
@@ -178,7 +178,7 @@ class Test_Hybrid_Product extends TestCase {
 		Backup::install_and_activate_standalone();
 
 		// The standalone plugin must be active
-		$this->assertTrue( Backup::is_plugin_active() );
+		$this->assertTrue( Backup::is_standalone_plugin_active() );
 
 		// The Jetpack plugin should not be active
 		$this->assertFalse( Backup::is_jetpack_plugin_active() );

--- a/projects/packages/my-jetpack/tests/php/test-hybrid-product.php
+++ b/projects/packages/my-jetpack/tests/php/test-hybrid-product.php
@@ -164,4 +164,43 @@ class Test_Hybrid_Product extends TestCase {
 		$this->assertSame( '', Backup::get_post_activation_url() );
 	}
 
+	/**
+	 * Tests the activation of the standalone plugin without Jetpack.
+	 *
+	 * We can't test the installation process, but at least we can check
+	 * for the installation and proceed with the activation.
+	 */
+	public function test_install_and_activate_standalone_without_jetpack() {
+		deactivate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Backup::get_installed_plugin_filename() );
+
+		// Trigger the installation + activation of the standalone plugin
+		Backup::install_and_activate_standalone();
+
+		// The standalone plugin must be active
+		$this->assertTrue( Backup::is_plugin_active() );
+
+		// The Jetpack plugin should not be active
+		$this->assertFalse( Backup::is_jetpack_plugin_active() );
+	}
+
+	/**
+	 * Tests the activation of the standalone plugin with Jetpack.
+	 *
+	 * We can't test the installation process, but at least we can check
+	 * for the installation and proceed with the activation.
+	 */
+	public function test_install_and_activate_standalone_with_jetpack() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		deactivate_plugins( Backup::get_installed_plugin_filename() );
+
+		// Trigger the installation + activation of the standalone plugin
+		Backup::install_and_activate_standalone();
+
+		// The standalone plugin must be active
+		$this->assertTrue( Backup::is_standalone_plugin_active() );
+
+		// The Jetpack plugin should not be active
+		$this->assertTrue( Backup::is_jetpack_plugin_active() );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29903. This endpoint will be used from My Jetpack to request the installation of the standalone plugin for a given product, even if we have the module for the product active on Jetpack. 

One examle of usage is the “Install [Product Name] plugin” action menu, for example, that is part of the work to make My Jetpack handle correctly all the product statuses:

![image](https://user-images.githubusercontent.com/6760046/231553766-1a59896c-ceff-4221-8b89-51e34980e1ad.png)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `install_and_activate_standalone` method to hybrid products so we can request the standalone plugin installation + activation
* Register `site/products/$product_slug/install-standalone` endpoint on `my-jetpack/v1` namespace to trigger the standalone plugin installation, when the product is hybrid

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* We are going to test it using some of the hybrid products (`search`, `backup`, `videopress`, `social`)
* Setup a new JN site with only Jetpack running this `add/my-jetpack-endpoint-to-install-standalone-plugin` branch
* Go to `Jetpack > My Jetpack`
* Open your browser console and check the status for one of the hybrid products (examples are for `social`):

```
wp.apiFetch({
  path: "/my-jetpack/v1/site/products/social",
  method: 'GET',
})
.then((data) => console.log(data));
```

* Look for the `standalone_plugin_info` field, you will see something like this:

<img width="333" alt="Screen Shot 2023-04-12 at 15 25 09" src="https://user-images.githubusercontent.com/6760046/231550735-f8b571ad-2c64-4099-9b32-c3d4bba1ecd8.png">

* Now we are going to trigger the installation of the product; to do it, execute a `POST` request to the new endpoint:

```
wp.apiFetch({
  path: "/my-jetpack/v1/site/products/social/install-standalone",
  method: 'POST',
})
.then((data) => console.log(data));
```

* Notice that now the `standalone_plugin_info` is updated:

<img width="462" alt="Screen Shot 2023-04-12 at 15 26 56" src="https://user-images.githubusercontent.com/6760046/231551283-1a954c05-f2bf-479f-b050-f26e5a668914.png">

* Go to `Plugins > Installed Plugins` and confirm that the `Jetpack Social` plugin is now installed and active:

<img width="879" alt="Screen Shot 2023-04-12 at 15 29 05" src="https://user-images.githubusercontent.com/6760046/231551431-f84111fd-bb46-413e-9852-bb18adef2a32.png">

* The status on `Jetpack > My Jetpack` will vary from plugin to plugin, depending on if it needs a purchase or not
* The operation using the `POST` request should work on all scenarios:
   * having or not the Jetpack plugin installed (for example, having only VideoPress standalone and triggering the installation of Social)
   * having or not the module active for the product being installed
   * having or not the plugin already installed (in this case it will only be active)