### PR TITLE
[Boost] Add Image CDN to the pricing table.

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/icon-tooltip.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/icon-tooltip.scss
@@ -1,12 +1,24 @@
-.icon-tooltip-wrapper.wide-tooltip .icon-tooltip-helper .components-popover__content {
-	width: 440px;
+.icon-tooltip-wrapper.wide-tooltip {
+	// Widen tooltips marked as "wide".
+	.icon-tooltip-helper .components-popover__content {
+		width: 440px;
+	}
+
+	// Allow bulleted lists in wide tooltips.
+	ul {
+		margin: 0 0 0 30px;
+		list-style-type: disc;
+	}
+
+	// Remove bottom margin from last list item.
+	ul li:last-child {
+		margin-bottom: 0;
+	}
 }
 
-.icon-tooltip-wrapper.wide-tooltip ul {
-	margin: 0 0 0 30px;
-	list-style-type: disc;
-}
-
-.icon-tooltip-wrapper.wide-tooltip ul li:last-child {
-	margin-bottom: 0;
+// Narrow down tooltips that are not marked as "wide".
+.icon-tooltip-wrapper:not( .wide-tooltip ) {
+	.icon-tooltip-helper .components-popover__content {
+		width: 250px;
+	}
 }

--- a/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
@@ -58,6 +58,11 @@ const automaticallyUpdatedContext = (
 	</span>
 );
 
+const imageCdnContext = __(
+	`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
+	'jetpack-boost'
+);
+
 const manuallyUpdatedContext = (
 	<span>
 		{ __(
@@ -127,6 +132,10 @@ export const BoostPricingTable = ( {
 					tooltipInfo: imageGuideContext,
 				},
 				{
+					name: __( 'Image CDN', 'jetpack-boost' ),
+					tooltipInfo: imageCdnContext,
+				},
+				{
 					name: __( 'Dedicated email support', 'jetpack-boost' ),
 					tooltipInfo: <span dangerouslySetInnerHTML={ { __html: supportContext } }></span>,
 				},
@@ -161,6 +170,7 @@ export const BoostPricingTable = ( {
 				<PricingTableItem isIncluded={ true } />
 				<PricingTableItem isIncluded={ true } />
 				<PricingTableItem isIncluded={ true } />
+				<PricingTableItem isIncluded={ true } />
 			</PricingTableColumn>
 			<PricingTableColumn>
 				<PricingTableHeader>
@@ -187,6 +197,7 @@ export const BoostPricingTable = ( {
 					tooltipInfo={ manuallyUpdatedContext }
 					tooltipClassName="wide-tooltip"
 				/>
+				<PricingTableItem isIncluded={ true } />
 				<PricingTableItem isIncluded={ true } />
 				<PricingTableItem isIncluded={ true } />
 				<PricingTableItem isIncluded={ true } />

--- a/projects/plugins/boost/changelog/boost-add-image-cdn-pricing-table
+++ b/projects/plugins/boost/changelog/boost-add-image-cdn-pricing-table
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added Image CDN to the pricing table. Being cherry-picked to 1.8.0 so it shouldn't go into the 1.9 changelog
+
+


### PR DESCRIPTION
Add the Image CDN to the pricing table. Also tweaks the styling on the info popups to prevent them from going off the edge of the page.

## Proposed changes:
* Add Image CDN to the pricing table.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Look at the getting started page.

