### PR TITLE
CRM: adding dashboard panel spacing consistency

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -477,7 +477,7 @@ if (jQuery('#bar-chart').length){
 	<div class="ten wide column" id="settings_dashboard_latest_contacts_display" 
 	<?php
 	if ( $settings_dashboard_latest_contacts == 'true' ) {
-		echo "style='display:block;margin: 0;padding-left: 0;'";
+		echo "style='display:block;margin: 0;'";
 	} else {
 		echo "style='display:none;'";}
 	?>

--- a/projects/plugins/crm/changelog/update-crm-dashboard-div-alignment
+++ b/projects/plugins/crm/changelog/update-crm-dashboard-div-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Make spacing between panels more consistent

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -369,11 +369,15 @@ background:white;
 }
 
 #settings_dashboard_revenue_chart_display{
-  padding-bottom:0px;
-  .panel{
-    border: 1px solid #ccd0d4 !important;
-    padding-left: 10px;
-  }
+	padding-bottom: 0px;
+	.panel{
+    	border: 1px solid #ccd0d4 !important;
+    	padding-left: 10px;
+  	}
+}
+
+#settings_dashboard_recent_activity_display .panel, #settings_dashboard_latest_contacts_display .panel {
+	height:100%;
 }
 
 .grid{

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -368,6 +368,11 @@ background:white;
   top: -3px;
 }
 
+#settings_dashboard_growth_display {
+	padding-bottom: 14px;
+	padding-top: 24px;
+}
+
 #settings_dashboard_revenue_chart_display{
 	padding-bottom: 0px;
 	.panel{

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -370,7 +370,7 @@ background:white;
 
 #settings_dashboard_growth_display {
 	padding-bottom: 14px;
-	padding-top: 24px;
+	padding-top: 10px;
 }
 
 #settings_dashboard_revenue_chart_display{
@@ -423,7 +423,7 @@ background:white;
 
 /* match padding of other rows on page */
 #crm_summary_numbers_container {
-  padding: 0 1rem;
+  padding: 14px 1rem;
   margin-bottom: 10px;
 }
 


### PR DESCRIPTION
## Proposed changes:

* This PR adds some spacing between the Sales Funnel and Revenue Charts to be consistent with the spacing between the bottom two panels. 
* What it doesn't do is make sure there is space consistency between the Sales Funnel / Revenue Chart panels and the two panels below (vertically), as my CSS skills aren't great and it also looks a little odd to me. But between the remaining panels there should be consistency (vertically).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/2931

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Using the [Jetpack Beta plugin](https://github.com/Automattic/jetpack-beta) on a test site with this branch applied or testing locally with the branch checked out (run `jetpack build plugins/crm` in that case), open up the dashboard and check that the spacing between the Sales Funnel and Revenue Chart panels in particular are consistent across different device screen sizes.

<img width="1654" alt="Screenshot 2023-04-12 at 09 03 45" src="https://user-images.githubusercontent.com/16754605/231392980-53560e46-5761-4d09-bdaf-9d8bf50d6e96.png">

