### PR TITLE
Repo gardening: standardize how PRs with tests are tracked

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-triage-test-prs
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-triage-test-prs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Automated labeling: standardize how we track PRs with tests.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -134,15 +134,10 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 		}
 
 		// Modules.
-		const module = file.match(
-			/^projects\/plugins\/jetpack\/?(?<test>tests\/php\/)?modules\/(?<module>[^/]*)\//
-		);
+		const module = file.match( /^projects\/plugins\/jetpack\/modules\/(?<module>[^/]*)\// );
 		const moduleName = module && module.groups.module;
 		if ( moduleName ) {
 			keywords.add( `${ cleanName( moduleName ) }` );
-		}
-		if ( module && module.groups.test ) {
-			keywords.add( 'Unit Tests' );
 		}
 
 		// Actions.
@@ -225,9 +220,10 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 			keywords.add( 'E2E Tests' );
 		}
 
-		const anyTestFile = file.match( /\/tests\// );
+		// Tests.
+		const anyTestFile = file.match( /\/tests?\// );
 		if ( anyTestFile ) {
-			keywords.add( '[Status] Needs Test Review' );
+			keywords.add( '[Tests] Includes Tests' );
 		}
 
 		// Add '[Status] In Progress' for draft PRs


### PR DESCRIPTION
## Proposed changes:

This is a follow-up to #26585.

* Instead of adding a status label (no team watches for PRs with that label anymore), we include a label that shows that there are tests in that PR.
* We add that label when files are in a test/ directory too.
* We stop adding a "Unit Tests" label to files in the Jetpack plugin, to favor the new label instead.
* That new label ("[Tests] Includes Tests") matches the one already in use in the Calypso repo.

In the future, watching for all PRs with that label should help us better track PRs that include tests. We can also extend on that label by adding a "[Tests] No tests" label if we ever need it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* This idea comes out of this post, where I mentioned wanting to better track PRs with tests: pdWQjU-hr-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This is better tested in a fork of this repo. Open a PR that modifies any file in a `test/` or / and `tests/` directory and see what happens.
