### PR TITLE
Prevent critical css state set on page load

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
@@ -178,6 +178,9 @@ export const regenerateCriticalCss = async () => {
  * @param state
  */
 export async function regenerateLocalCriticalCss( state: CriticalCssState ) {
+	if ( state.status === 'generated' ) {
+		return;
+	}
 	const generatingSucceeded = await generateCriticalCss( state );
 	const status = generatingSucceeded ? 'generated' : 'error';
 	replaceCssState( { status } );

--- a/projects/plugins/boost/changelog/boost-fix-dont-update-css-state-on-pageload
+++ b/projects/plugins/boost/changelog/boost-fix-dont-update-css-state-on-pageload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Boost: Fix Critical CSS Requests on page load


### PR DESCRIPTION
This fixes an issue where `critical-css-status/set` endpoint would be POSTed to on every page load.


### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
1. Apply patch
2. Inspect network requests when Critical CSS is active
3. Ensure that a POST request isn't issued on page load
4. Ensure that critical css both cloud and local generation works and is able to resume