### PR TITLE
Repo Gardening: automatically label PRs touching the CRM plugin

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-labels-crm
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-labels-crm
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Auto labeling: add labels for common elements of the CRM plugin.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -182,7 +182,7 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 
 		// React Dashboard and Boost Admin.
 		const reactAdmin = file.match(
-			/^(projects\/plugins\/boost\/app\/admin|projects\/plugins\/jetpack\/_inc\/client)\//
+			/^(projects\/plugins\/(crm|boost\/app)\/admin|projects\/plugins\/jetpack\/_inc\/client)\//
 		);
 		if ( reactAdmin !== null ) {
 			keywords.add( 'Admin Page' );
@@ -200,6 +200,18 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 		const wpcomApi = file.match( /^projects\/plugins\/jetpack\/json-endpoints\// );
 		if ( wpcomApi !== null ) {
 			keywords.add( 'WPCOM API' );
+		}
+
+		// CRM elements.
+		const crmModules = file.match( /^projects\/plugins\/crm\/modules\/(?<crmModule>[^/]*)\// );
+		const crmModuleName = crmModules && crmModules.groups.crmModule;
+		if ( crmModuleName ) {
+			keywords.add( `[CRM] ${ cleanName( crmModuleName ) } Module` );
+		}
+
+		const crmApi = file.match( /^projects\/plugins\/crm\/api\// );
+		if ( crmApi !== null ) {
+			keywords.add( '[CRM] API' );
 		}
 
 		// Boost Critical CSS.


### PR DESCRIPTION
## Proposed changes:

Let's start adding labels to CRM PRs when they touch common parts of the plugin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This is better tested in a fork of this repo. Make changes to files in the CRM plugin, open a PR, and see the labels being added.
