### PR TITLE
Boost: Fix module status

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -18,7 +18,6 @@
 	export let generateMoreText = '';
 	const { navigate } = routerHistory;
 
-	$: cloudCssAvailable = $modulesState.cloud_css.available;
 	$: successCount = $criticalCssState.providers.filter(
 		provider => provider.status === 'success'
 	).length;
@@ -38,7 +37,7 @@
 				{#if $criticalCssState.updated}
 					<TimeAgo time={new Date( $criticalCssState.updated * 1000 )} />.
 				{/if}
-				{#if ! cloudCssAvailable}
+				{#if ! $modulesState.cloud_css?.available}
 					{__(
 						'Remember to regenerate each time you make changes that affect your HTML or CSS structure.',
 						'jetpack-boost'

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -8,7 +8,7 @@
 		regenerateCriticalCss,
 	} from '../../../stores/critical-css-state';
 	import { criticalCssIssues } from '../../../stores/critical-css-state-errors';
-	import { isModuleAvailableStore } from '../../../stores/modules';
+	import { modulesState } from '../../../stores/modules';
 	import InfoIcon from '../../../svg/info.svg';
 	import RefreshIcon from '../../../svg/refresh.svg';
 	import actionLinkTemplateVar from '../../../utils/action-link-template-var';
@@ -18,7 +18,7 @@
 	export let generateMoreText = '';
 	const { navigate } = routerHistory;
 
-	const cloudCssAvailable = isModuleAvailableStore( 'cloud_css' );
+	$: cloudCssAvailable = $modulesState.cloud_css.available;
 	$: successCount = $criticalCssState.providers.filter(
 		provider => provider.status === 'success'
 	).length;
@@ -38,7 +38,7 @@
 				{#if $criticalCssState.updated}
 					<TimeAgo time={new Date( $criticalCssState.updated * 1000 )} />.
 				{/if}
-				{#if ! $cloudCssAvailable}
+				{#if ! cloudCssAvailable}
 					{__(
 						'Remember to regenerate each time you make changes that affect your HTML or CSS structure.',
 						'jetpack-boost'

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -15,7 +15,6 @@
 		regenerateCriticalCss,
 	} from '../../../stores/critical-css-state';
 	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
-	import { isModuleAvailableStore } from '../../../stores/modules';
 	import { startPollingCloudStatus, stopPollingCloudCssStatus } from '../../../utils/cloud-css';
 	import externalLinkTemplateVar from '../../../utils/external-link-template-var';
 	import CloudCssMeta from '../elements/CloudCssMeta.svelte';
@@ -34,7 +33,6 @@
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
 
-	$: cloudCssAvailable = isModuleAvailableStore( 'cloud_css' );
 	const suggestRegenerate = suggestRegenerateDS.store;
 
 	async function resume() {
@@ -99,9 +97,7 @@
 		</div>
 
 		<div slot="cta">
-			{#if ! $cloudCssAvailable}
-				<PremiumCTA />
-			{/if}
+			<PremiumCTA />
 		</div>
 	</Module>
 

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
@@ -6,7 +6,7 @@ import { startPollingCloudStatus } from '../utils/cloud-css';
 import generateCriticalCss from '../utils/generate-critical-css';
 import { CriticalCssStateSchema } from './critical-css-state-types';
 import { client, JSONObject, suggestRegenerateDS } from './data-sync-client';
-import { isModuleEnabledStore } from './modules';
+import { modulesState } from './modules';
 import type { CriticalCssState, Provider } from './critical-css-state-types';
 
 const stateClient = client.createAsyncStore( 'critical_css_state', CriticalCssStateSchema );
@@ -59,11 +59,14 @@ export const isFatalError = derived(
 );
 
 export const isGenerating = derived(
-	[ cssStateStore, isModuleEnabledStore( 'critical_css' ), isModuleEnabledStore( 'cloud_css' ) ],
-	( [ $criticalCssState, $criticalCssEnabled, $cloudCssEnabled ] ) => {
+	[ cssStateStore, modulesState ],
+	( [ $criticalCssState, $modulesState ] ) => {
 		const statusIsRequesting = $criticalCssState.status === 'pending';
 
-		return statusIsRequesting && ( $criticalCssEnabled || $cloudCssEnabled );
+		return (
+			statusIsRequesting &&
+			( $modulesState.cloud_css.active || $modulesState.critical_css.available )
+		);
 	}
 );
 
@@ -162,7 +165,7 @@ export const regenerateCriticalCss = async () => {
 	// This will update the store without triggering a save back to the server.
 	cssStateStore.override( freshState );
 
-	const $isCloudCssEnabled = get( isModuleEnabledStore( 'cloud_css' ) ) || false;
+	const $isCloudCssEnabled = get( modulesState ).cloud_css?.active || false;
 
 	if ( $isCloudCssEnabled ) {
 		startPollingCloudStatus();

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
@@ -165,9 +165,9 @@ export const regenerateCriticalCss = async () => {
 	// This will update the store without triggering a save back to the server.
 	cssStateStore.override( freshState );
 
-	const $isCloudCssEnabled = get( modulesState ).cloud_css?.active || false;
+	const isCloudCssEnabled = get( modulesState ).cloud_css?.active || false;
 
-	if ( $isCloudCssEnabled ) {
+	if ( isCloudCssEnabled ) {
 		startPollingCloudStatus();
 	} else {
 		await regenerateLocalCriticalCss( freshState );

--- a/projects/plugins/boost/app/assets/src/js/stores/modules.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/modules.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
 import { SyncedStoreInterface } from '@automattic/jetpack-svelte-data-sync-client/build/types';
-import { derived } from 'svelte/store';
+import { derived, get } from 'svelte/store';
 import { z } from 'zod';
 import { client } from './data-sync-client';
 
@@ -33,9 +33,16 @@ export const isModuleAvailableStore = ( slug: string ) =>
 	derived( modulesState, $modulesState => $modulesState[ slug ].available );
 
 export async function updateModuleState( slug: string, active: boolean ) {
+	// Update local state first
+	const currentState = get( modulesState );
+	currentState[ slug ].active = active;
+	modulesStateClient.store.override( currentState );
+
 	const result = await modulesStateClient.endpoint.MERGE( {
 		[ slug ]: { active },
 	} );
+
+	// Update local state with the result from the server
 	modulesStateClient.store.override( result );
 	return result;
 }

--- a/projects/plugins/boost/app/assets/src/js/stores/modules.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/modules.ts
@@ -29,9 +29,6 @@ export const reloadModulesState = async () => {
 	return result;
 };
 
-export const isModuleAvailableStore = ( slug: string ) =>
-	derived( modulesState, $modulesState => $modulesState[ slug ].available );
-
 export async function updateModuleState( slug: string, active: boolean ) {
 	// Update local state first
 	const currentState = get( modulesState );

--- a/projects/plugins/boost/app/assets/src/js/stores/modules.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/modules.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
 import { SyncedStoreInterface } from '@automattic/jetpack-svelte-data-sync-client/build/types';
-import { derived, get } from 'svelte/store';
+import { get } from 'svelte/store';
 import { z } from 'zod';
 import { client } from './data-sync-client';
 
@@ -43,9 +43,3 @@ export async function updateModuleState( slug: string, active: boolean ) {
 	modulesStateClient.store.override( result );
 	return result;
 }
-
-export const isModuleEnabledStore = ( slug: string ) =>
-	derived(
-		modulesState,
-		$modulesState => $modulesState[ slug ].available && $modulesState[ slug ].active
-	);

--- a/projects/plugins/boost/app/assets/src/js/utils/connection.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/connection.ts
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store';
 import config from '../stores/config';
 import { regenerateCriticalCss } from '../stores/critical-css-state';
-import { isModuleEnabledStore } from '../stores/modules';
+import { modulesState } from '../stores/modules';
 
 /**
  * Run all the tasks to be performed upon connection completion.
@@ -10,7 +10,7 @@ export async function onConnectionComplete(): Promise< void > {
 	await config.refresh();
 
 	// Request fresh Cloud CSS if cloud_css is enabled
-	if ( get( isModuleEnabledStore( 'cloud_css' ) ) ) {
+	if ( get( modulesState ).cloud_css?.active ) {
 		await regenerateCriticalCss();
 	}
 }

--- a/projects/plugins/boost/app/data-sync/Modules_State_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Modules_State_Entry.php
@@ -6,7 +6,7 @@ use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Merge;
 use Automattic\Jetpack_Boost\Modules\Modules_Index;
 
-class Modules_Status_Entry implements Entry_Can_Get, Entry_Can_Merge {
+class Modules_State_Entry implements Entry_Can_Get, Entry_Can_Merge {
 	public function get() {
 		$modules = Modules_Index::MODULES;
 

--- a/projects/plugins/boost/app/data-sync/Modules_Status_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Modules_Status_Entry.php
@@ -22,7 +22,7 @@ class Modules_Status_Entry implements Entry_Can_Get, Entry_Can_Merge {
 			$option_name = $this->get_module_option_name( $slug );
 
 			$modules_state[ $slug ] = array(
-				'active'    => get_option( $option_name, false ),
+				'active'    => isset( $available_modules[ $slug ] ) && get_option( $option_name, false ),
 				'available' => isset( $available_modules[ $slug ] ),
 			);
 		}

--- a/projects/plugins/boost/changelog/update-module-status
+++ b/projects/plugins/boost/changelog/update-module-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue causing reactiveness of module toggle if the state failed to update

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -134,5 +134,5 @@ $modules_state_schema = Schema::as_array(
 	)
 )->fallback( array() );
 
-$entry = new Modules_Status_Entry( JETPACK_BOOST_DATASYNC_NAMESPACE, 'modules_state' );
+$entry = new Modules_Status_Entry();
 jetpack_boost_register_option( 'modules_state', $modules_state_schema, $entry );

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -3,7 +3,7 @@
 use Automattic\Jetpack\WP_JS_Data_Sync\Data_Sync;
 use Automattic\Jetpack\WP_JS_Data_Sync\Data_Sync_Entry;
 use Automattic\Jetpack\WP_JS_Data_Sync\Schema\Schema;
-use Automattic\Jetpack_Boost\Data_Sync\Modules_Status_Entry;
+use Automattic\Jetpack_Boost\Data_Sync\Modules_State_Entry;
 
 if ( ! defined( 'JETPACK_BOOST_DATASYNC_NAMESPACE' ) ) {
 	define( 'JETPACK_BOOST_DATASYNC_NAMESPACE', 'jetpack_boost_ds' );
@@ -134,5 +134,5 @@ $modules_state_schema = Schema::as_array(
 	)
 )->fallback( array() );
 
-$entry = new Modules_Status_Entry();
+$entry = new Modules_State_Entry();
 jetpack_boost_register_option( 'modules_state', $modules_state_schema, $entry );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Some cleanup
* Prevent UI from going out of sync if state failed to update

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The PR shouldn't change anything functionality other than fixing a small bug. If the module did not toggle in the backend the UI would go out of sync. To reproduce this issue use the following example:

Use the following code to force disable image-guide:

```php
<?php
add_filter( 'option_jetpack_boost_status_image-guide', '__return_false', 11, 2 );
add_filter( 'default_option_jetpack_boost_status_image-guide', '__return_false', 11, 2 );
```

Now, open boost dashboard and toggle image-guide to on. The result of the toggle from server would be that image-guide is not active, but the switch would remain active.

Now, try to toggle any other module, image-guide still does not update and remains active in the UI.

This PR fixes the above issue and keeps the toggle reactive.