### PR TITLE
VideoPress: disable PreviewOnHover when user clicks on the video

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-disable-pho-when-user-clicks
+++ b/projects/packages/videopress/changelog/update-videopress-disable-pho-when-user-clicks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: enable video control once user interacts with the video (poh)

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -247,6 +247,7 @@ class Initializer {
 				'previewAtTime'       => $block_attributes['posterData']['previewAtTime'],
 				'previewLoopDuration' => $block_attributes['posterData']['previewLoopDuration'],
 				'autoplay'            => (bool) $block_attributes['autoplay'],
+				'showControls'        => (bool) $block_attributes['controls'],
 			);
 
 			// Expose the preview on hover data to the client.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -246,6 +246,7 @@ class Initializer {
 			$preview_on_hover = array(
 				'previewAtTime'       => $block_attributes['posterData']['previewAtTime'],
 				'previewLoopDuration' => $block_attributes['posterData']['previewLoopDuration'],
+				'autoplay'            => (bool) $block_attributes['autoplay'],
 			);
 
 			// Expose the preview on hover data to the client.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -237,11 +237,12 @@ class Initializer {
 		}
 
 		// Preview On Hover data
-		$preview_on_hover = '';
-		if (
+		$is_poh_enabled =
 			isset( $block_attributes['posterData']['previewOnHover'] ) &&
-			$block_attributes['posterData']['previewOnHover']
-		) {
+			$block_attributes['posterData']['previewOnHover'];
+
+		$preview_on_hover = '';
+		if ( $is_poh_enabled ) {
 			$preview_on_hover = array(
 				'previewAtTime'       => $block_attributes['posterData']['previewAtTime'],
 				'previewLoopDuration' => $block_attributes['posterData']['previewLoopDuration'],
@@ -272,7 +273,9 @@ class Initializer {
 			$videopress_url = wp_kses_post( $videopress_url );
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
-				'<div class="jetpack-videopress-player__wrapper"><div class="jetpack-videopress-player__overlay"></div>%s</div>',
+				$is_poh_enabled
+					? '<div class="jetpack-videopress-player__wrapper"><div class="jetpack-videopress-player__overlay"></div>%s</div>'
+					: '<div class="jetpack-videopress-player__wrapper">%s</div>',
 				$oembed_html
 			);
 		}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -248,7 +248,7 @@ class Initializer {
 			);
 
 			// Expose the preview on hover data to the client.
-			$preview_on_hover = sprintf( '<div className="jetpack-videopress-player__overlay"></div><script type="application/json">%s</script>', wp_json_encode( $preview_on_hover ) );
+			$preview_on_hover = sprintf( '<script type="application/json">%s</script>', wp_json_encode( $preview_on_hover ) );
 
 			// Set `autoplay` and `muted` attributes to the video element.
 			$block_attributes['autoplay'] = true;
@@ -272,7 +272,7 @@ class Initializer {
 			$videopress_url = wp_kses_post( $videopress_url );
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
-				'<div class="jetpack-videopress-player__wrapper">%s</div>',
+				'<div class="jetpack-videopress-player__wrapper"><div class="jetpack-videopress-player__overlay"></div>%s</div>',
 				$oembed_html
 			);
 		}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -44,8 +44,8 @@ import type { PosterDataProps, PosterPanelProps, VideoControlProps, VideoGUID } 
 import type React from 'react';
 
 const MIN_LOOP_DURATION = 3 * 1000;
-const MAX_LOOP_DURATION = 30 * 1000;
-const DEFAULT_LOOP_DURATION = 10 * 1000;
+const MAX_LOOP_DURATION = 10 * 1000;
+const DEFAULT_LOOP_DURATION = 5 * 1000;
 
 /*
  * Check whether video frame poster extension is enabled.
@@ -433,7 +433,7 @@ export function VideoHoverPreviewControl( {
 						wait={ 300 }
 						help={ loopDurationHelp }
 						disabled={ disabled || noLoopDurationRange }
-						marksEvery={ 5000 }
+						marksEvery={ 1000 }
 					/>
 				</>
 			) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/editor.scss
@@ -1,7 +1,6 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .wp-block-jetpack-videopress {
-	position: relative;
 
 	.jetpack-videopress-player {
 		margin: 0;
@@ -9,16 +8,6 @@
 
 	&.is-updating-preview {
 		opacity: 0.5; // @todo: consider improve this state in the UI
-	}
-
-	.jetpack-videopress-player__overlay {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		background-color: transparent;
-		z-index: 10;
 	}
 
 	.jetpack-videopress-player__wrapper {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -1,7 +1,23 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .wp-block-jetpack-videopress {
+	position: relative;
+
 	figcaption {
 		@include caption-style-theme();
+	}
+
+	.jetpack-videopress-player__wrapper {
+		position: relative;
+	}
+
+	.jetpack-videopress-player__overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background-color: transparent;
+		z-index: 10;
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -16,11 +16,16 @@ declare global {
 				onInfoUpdated: ( fn: () => void ) => void;
 			};
 			status: {
+				onFullscreenChanged: ( fn: ( isFullscreen: boolean ) => void ) => void;
 				onPlayerStatusChanged: (
 					fn: ( oldStatus: playerStatuses, newStatus: playerStatuses ) => void
 				) => void;
 				onPlaybackTimeUpdated: ( fn: ( playbackTime: number ) => void ) => void;
 				onTimeUpdate: ( fn: ( playbackTime: number ) => void ) => void;
+				onChaptersChapterChanged: ( fn: ( chapter: number ) => void ) => void;
+				onChaptersTrackChanged: ( fn: ( track: number ) => void ) => void;
+				onBorderColorsChanged: ( fn: ( colors: string[] ) => void ) => void;
+				onError: ( fn: ( code: number, message: string ) => void ) => void;
 			};
 			controls: {
 				play: () => void;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -78,8 +78,20 @@ function previewOnHoverEffect(): void {
 			} );
 		} );
 
-		videoPlayerElement.addEventListener( 'mouseenter', iframeApi.controls.play );
-		videoPlayerElement.addEventListener( 'mouseleave', iframeApi.controls.pause );
+		const overlay = videoPlayerElement.querySelector( '.jetpack-videopress-player__overlay' );
+		if ( ! overlay ) {
+			return;
+		}
+
+		// Disable pOH when the user clicks on the video (overlay).
+		overlay.addEventListener( 'click', () => {
+			overlay.remove();
+			// Delete overlay element.
+			setTimeout( iframeApi.controls.pause, 100 ); // Hack; without this, the video will not pause.
+		} );
+
+		overlay.addEventListener( 'mouseenter', iframeApi.controls.play );
+		overlay.addEventListener( 'mouseleave', iframeApi.controls.pause );
 	} );
 }
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -59,6 +59,7 @@ function previewOnHoverEffect(): void {
 		// Clean the data container element. It isn't needed anymore.
 		dataContainer.remove();
 
+		let userHasInteracted = false;
 		const iframeApi = window.VideoPressIframeApi( iFrame, () => {
 			iframeApi.status.onPlayerStatusChanged( ( oldStatus, newStatus ) => {
 				if ( oldStatus === 'ready' && newStatus === 'playing' ) {
@@ -68,6 +69,10 @@ function previewOnHoverEffect(): void {
 			} );
 
 			iframeApi.status.onTimeUpdate( playbackTime => {
+				if ( userHasInteracted ) {
+					return;
+				}
+
 				const playback = playbackTime * 1000;
 				const start = previewOnHoverData.previewAtTime;
 				const end = start + previewOnHoverData.previewLoopDuration;
@@ -85,6 +90,7 @@ function previewOnHoverEffect(): void {
 
 		// Disable pOH when the user clicks on the video (overlay).
 		overlay.addEventListener( 'click', () => {
+			userHasInteracted = true;
 			overlay.remove();
 			// Delete overlay element.
 			setTimeout( iframeApi.controls.pause, 100 ); // Hack; without this, the video will not pause.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -48,6 +48,7 @@ function previewOnHoverEffect(): void {
 			previewAtTime: number;
 			previewLoopDuration: number;
 			autoplay: boolean;
+			showControls: boolean;
 		};
 
 		try {
@@ -92,13 +93,19 @@ function previewOnHoverEffect(): void {
 			return;
 		}
 
-		// Disable pOH when the user clicks on the video (overlay).
-		overlay.addEventListener( 'click', () => {
-			userHasInteracted = true;
-			overlay.remove();
-			// Delete overlay element.
-			setTimeout( iframeApi.controls.pause, 100 ); // Hack; without this, the video will not pause.
-		} );
+		/*
+		 * Disable PreviewOnHover (pOH) when the player
+		 * should show the controls and
+		 * once the user clicks on the video (overlay).
+		 */
+		if ( previewOnHoverData.showControls ) {
+			overlay.addEventListener( 'click', () => {
+				userHasInteracted = true;
+				overlay.remove();
+				// Delete overlay element.
+				setTimeout( iframeApi.controls.pause, 100 ); // Hack; without this, the video will not pause.
+			} );
+		}
 
 		overlay.addEventListener( 'mouseenter', iframeApi.controls.play );
 		overlay.addEventListener( 'mouseleave', iframeApi.controls.pause );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -47,6 +47,7 @@ function previewOnHoverEffect(): void {
 		let previewOnHoverData: {
 			previewAtTime: number;
 			previewLoopDuration: number;
+			autoplay: boolean;
 		};
 
 		try {
@@ -63,7 +64,10 @@ function previewOnHoverEffect(): void {
 		const iframeApi = window.VideoPressIframeApi( iFrame, () => {
 			iframeApi.status.onPlayerStatusChanged( ( oldStatus, newStatus ) => {
 				if ( oldStatus === 'ready' && newStatus === 'playing' ) {
-					iframeApi.controls.pause();
+					if ( ! previewOnHoverData.autoplay ) {
+						iframeApi.controls.pause();
+					}
+
 					iframeApi.controls.seek( previewOnHoverData.previewAtTime );
 				}
 			} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: disable PreviewOnHover when user clicks on the video

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD...
*

