### PR TITLE
Use wp_date in blogging-prompts v3 endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -179,7 +179,7 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 		global $wpdb;
 		if ( $this->day_of_year_query > 0 ) {
 			$day          = $this->day_of_year_query;
-			$current_year = gmdate( 'Y' );
+			$current_year = wp_date( 'Y' );
 
 			// Grab the current sort order, `ASC` or `DESC`, so we can reuse it.
 			$order = end( explode( ' ', $clauses['orderby'] ) );

--- a/projects/plugins/jetpack/changelog/fix-blogging-prompts-v3-wp-date
+++ b/projects/plugins/jetpack/changelog/fix-blogging-prompts-v3-wp-date
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Small change to wpcom only functionality
+
+


### PR DESCRIPTION
## Proposed changes:

Small follow-up to https://github.com/Automattic/jetpack/pull/30034 that uses wp_date instead of gmdate to get the current year.

- Ensures the site timezone is used
- Makes the date filterable for tests (see D107601-code)

### Other information:

- [x] Have you written new tests for your changes, if applicable? (on wpcom)
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See pctCYC-KA-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

See testing instructions from https://github.com/Automattic/jetpack/pull/30034