### PR TITLE
[RNMobile] Refactor native player to handle the embed preview

### DIFF
--- a/projects/packages/videopress/changelog/update-native-player
+++ b/projects/packages/videopress/changelog/update-native-player
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Refactor native Player component to handle the embed preview

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { SandBox } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
@@ -10,18 +11,61 @@ import { View, Text } from 'react-native';
 /**
  * Internal dependencies
  */
+import getMediaToken from '../../../../../lib/get-media-token/index.native';
+import { getVideoPressUrl } from '../../../../../lib/url';
+import { usePreview } from '../../../../hooks/use-preview';
+import addTokenIntoIframeSource from '../../../../utils/add-token-iframe-source';
 import style from './style.scss';
 
 /**
  * VideoPlayer react component
  *
  * @param {object} props - Component props.
- * @param {string} props.html - HTML markup for the player.
- * @param {boolean} props.isRequestingEmbedPreview - Whether the preview is being requested.
+ * @param {object} props.attributes - Block attributes.
  * @param {boolean} props.isSelected - Whether the block is selected.
  * @returns {import('react').ReactElement} - React component.
  */
-export default function Player( { html, isRequestingEmbedPreview, isSelected } ) {
+export default function Player( { isSelected, attributes } ) {
+	const {
+		controls,
+		guid,
+		loop,
+		muted,
+		playsinline,
+		poster,
+		preload,
+		seekbarColor,
+		seekbarLoadingColor,
+		seekbarPlayedColor,
+	} = attributes;
+
+	const [ token, setToken ] = useState();
+
+	// Fetch token for a VideoPress GUID
+	useEffect( () => {
+		if ( guid ) {
+			getMediaToken( 'playback', { guid } ).then( tokenData => {
+				setToken( tokenData.token );
+			} );
+		}
+	}, [ guid ] );
+
+	const videoPressUrl = getVideoPressUrl( guid, {
+		autoplay: false, // Note: Autoplay is disabled to prevent the video from playing fullscreen when loading the editor.
+		controls,
+		loop,
+		muted,
+		playsinline,
+		preload,
+		seekbarColor,
+		seekbarLoadingColor,
+		seekbarPlayedColor,
+		poster,
+	} );
+
+	const { preview, isRequestingEmbedPreview } = usePreview( videoPressUrl );
+	const html = addTokenIntoIframeSource( preview?.html, token );
+
 	// Set up style for when the player is loading.
 	const loadingStyle = {};
 	if ( ! html || isRequestingEmbedPreview ) {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
@@ -20,10 +20,7 @@ import { View } from 'react-native';
 /**
  * Internal dependencies
  */
-import getMediaToken from '../../../lib/get-media-token/index.native';
-import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
-import { usePreview } from '../../hooks/use-preview';
-import addTokenIntoIframeSource from '../../utils/add-token-iframe-source';
+import { buildVideoPressURL } from '../../../lib/url';
 import isLocalFile from '../../utils/is-local-file';
 import ColorPanel from './components/color-panel';
 import DetailsPanel from './components/details-panel';
@@ -54,18 +51,7 @@ export default function VideoPressEdit( {
 	onFocus,
 	insertBlocksAfter,
 } ) {
-	const {
-		controls,
-		guid,
-		loop,
-		muted,
-		playsinline,
-		poster,
-		preload,
-		seekbarColor,
-		seekbarLoadingColor,
-		seekbarPlayedColor,
-	} = attributes;
+	const { guid } = attributes;
 
 	const [ isUploadingFile, setIsUploadingFile ] = useState( ! guid );
 	const [ fileToUpload, setFileToUpload ] = useState( null );
@@ -73,16 +59,6 @@ export default function VideoPressEdit( {
 		isReplacing: false,
 		prevAttrs: {},
 	} );
-	const [ token, setToken ] = useState();
-
-	// Fetch token for a VideoPress GUID
-	useEffect( () => {
-		if ( guid ) {
-			getMediaToken( 'playback', { guid } ).then( tokenData => {
-				setToken( tokenData.token );
-			} );
-		}
-	}, [ guid ] );
 
 	const [ showReplaceControl, setShowReplaceControl ] = useState( true );
 
@@ -92,22 +68,6 @@ export default function VideoPressEdit( {
 	);
 	const { replaceBlock } = useDispatch( blockEditorStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
-
-	const videoPressUrl = getVideoPressUrl( guid, {
-		autoplay: false, // Note: Autoplay is disabled to prevent the video from playing fullscreen when loading the editor.
-		controls,
-		loop,
-		muted,
-		playsinline,
-		preload,
-		seekbarColor,
-		seekbarLoadingColor,
-		seekbarPlayedColor,
-		poster,
-	} );
-
-	const { preview, isRequestingEmbedPreview } = usePreview( videoPressUrl );
-	const previewHTML = addTokenIntoIframeSource( preview?.html, token );
 
 	// Display upload progress in case the editor is closed and re-opened
 	// while the upload is in progress.
@@ -255,11 +215,7 @@ export default function VideoPressEdit( {
 				</InspectorControls>
 			) }
 
-			<Player
-				html={ previewHTML }
-				isRequestingEmbedPreview={ isRequestingEmbedPreview }
-				isSelected={ isSelected }
-			/>
+			<Player { ...{ attributes, isSelected } } />
 
 			<BlockCaption
 				clientId={ clientId }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Foundation work to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/5603

The `Player` component will receive messages from the embed client player noting when the video preview is available. When a video is uploaded, the embed displays a processing screen. After processing however, the preview is not completely ready to render since it often does not include video dimensions. To account for this we need to repeat the preview requests until the preview is fully ready ( usually within a few seconds )

As of now we would have to pass callbacks and add multiple local state variables between the `Edit` and `Player` component. A simpler solution is to have the `Player` component own the preview code and let the `Edit` component handle file processing. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refactors the native `Player` component to handle the embed preview.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
There are no new behavioral changes in this PR.
Testing should look out for any regressions by verifying the following:
- Check that posts with existing VP blocks load as expected
- Check that private videos load as expected
- Check that uploading and replacing videos work as expected *.

* Note: https://github.com/wordpress-mobile/gutenberg-mobile/issues/5603 is still an open issue which is not fixed in the PR.

