### PR TITLE
jetpack: Move i18n of module tags closer to the output

### DIFF
--- a/projects/packages/status/changelog/update-jetpack-module-tags-i18n
+++ b/projects/packages/status/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+When Jetpack is available, `Modules::get()` no longer translates `module_tags`. Use Jetpack's `jetpack_get_module_i18n_tag()` function if you need translations.

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -46,7 +46,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.16.x-dev"
+			"dev-trunk": "1.17.x-dev"
 		}
 	}
 }

--- a/projects/packages/status/src/class-modules.php
+++ b/projects/packages/status/src/class-modules.php
@@ -80,9 +80,8 @@ class Modules {
 			if ( $mod['module_tags'] ) {
 				$mod['module_tags'] = explode( ',', $mod['module_tags'] );
 				$mod['module_tags'] = array_map( 'trim', $mod['module_tags'] );
-				$mod['module_tags'] = array_map( 'jetpack_get_module_i18n_tag', $mod['module_tags'] );
 			} else {
-				$mod['module_tags'] = array( jetpack_get_module_i18n_tag( 'Other' ) );
+				$mod['module_tags'] = array( 'Other' );
 			}
 
 			if ( $mod['plan_classes'] ) {
@@ -96,7 +95,7 @@ class Modules {
 				$mod['feature'] = explode( ',', $mod['feature'] );
 				$mod['feature'] = array_map( 'trim', $mod['feature'] );
 			} else {
-				$mod['feature'] = array( jetpack_get_module_i18n_tag( 'Other' ) );
+				$mod['feature'] = array( 'Other' );
 			}
 
 			$modules_details[ $module ] = $mod;

--- a/projects/plugins/backup/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/backup/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1233,7 +1233,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "92d026aa0316ac90edeb4adcef68fce1e0f10578"
+                "reference": "8254f98df9bf989973d102a2901b2328e51775c0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1255,7 +1255,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.16.x-dev"
+                    "dev-trunk": "1.17.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/boost/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1163,7 +1163,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "92d026aa0316ac90edeb4adcef68fce1e0f10578"
+                "reference": "8254f98df9bf989973d102a2901b2328e51775c0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1185,7 +1185,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.16.x-dev"
+                    "dev-trunk": "1.17.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -410,6 +410,9 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				$module['description']       = $i18n['description'];
 				$module['short_description'] = $i18n['description'];
 			}
+			if ( isset( $module['module_tags'] ) ) {
+				$module['module_tags'] = array_map( 'jetpack_get_module_i18n_tag', $module['module_tags'] );
+			}
 
 			return Jetpack_Core_Json_Api_Endpoints::prepare_modules_for_response( $module );
 		}

--- a/projects/plugins/jetpack/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/jetpack/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Move i18n of module tags closer to the output.

--- a/projects/plugins/jetpack/changelog/update-jetpack-module-tags-i18n#2
+++ b/projects/plugins/jetpack/changelog/update-jetpack-module-tags-i18n#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -162,6 +162,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		$modules              = apply_filters( 'jetpack_modules_list_table_items', Jetpack_Admin::init()->get_modules() );
 		$array_of_module_tags = wp_list_pluck( $modules, 'module_tags' );
 		$module_tags          = array_merge( ...array_values( $array_of_module_tags ) );
+		$module_tags          = array_map( 'jetpack_get_module_i18n_tag', $module_tags );
 		$module_tags_unique   = array_count_values( $module_tags );
 		ksort( $module_tags_unique );
 
@@ -224,7 +225,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		if ( ! empty( $_REQUEST['module_tag'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a view, not a model or controller.
 			$module_tag = sanitize_text_field( wp_unslash( $_REQUEST['module_tag'] ) );
-			if ( ! in_array( $module_tag, $module['module_tags'], true ) ) {
+			if ( ! in_array( $module_tag, array_map( 'jetpack_get_module_i18n_tag', $module['module_tags'] ), true ) ) {
 				return false;
 			}
 		}
@@ -417,7 +418,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	 */
 	public function column_module_tags( $item ) {
 		$module_tags = array();
-		foreach ( $item['module_tags'] as $module_tag ) {
+		foreach ( array_map( 'jetpack_get_module_i18n_tag', $item['module_tags'] ) as $module_tag ) {
 			$module_tags[] = sprintf( '<a href="%3$s" data-title="%2$s">%1$s</a>', esc_html( $module_tag ), esc_attr( $module_tag ), esc_url( add_query_arg( 'module_tag', rawurlencode( $module_tag ) ) ) );
 		}
 		return implode( ', ', $module_tags );

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2407,6 +2407,9 @@ class Jetpack {
 				$modules[ $index ]['description']       = $i18n_module['description'];
 				$modules[ $index ]['short_description'] = $i18n_module['description'];
 			}
+			if ( isset( $module['module_tags'] ) ) {
+				$modules[ $index ]['module_tags'] = array_map( 'jetpack_get_module_i18n_tag', $module['module_tags'] );
+			}
 		}
 		return $modules;
 	}

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2281,7 +2281,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "92d026aa0316ac90edeb4adcef68fce1e0f10578"
+                "reference": "8254f98df9bf989973d102a2901b2328e51775c0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -2303,7 +2303,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.16.x-dev"
+                    "dev-trunk": "1.17.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-endpoint.php
@@ -120,7 +120,7 @@ abstract class Jetpack_JSON_API_Modules_Endpoint extends Jetpack_JSON_API_Endpoi
 		$module['introduced']        = $module_data['introduced'];
 		$module['changed']           = $module_data['changed'];
 		$module['free']              = $module_data['free'];
-		$module['module_tags']       = $module_data['module_tags'];
+		$module['module_tags']       = array_map( 'jetpack_get_module_i18n_tag', $module_data['module_tags'] );
 
 		$overrides_instance = Jetpack_Modules_Overrides::instance();
 		$module['override'] = $overrides_instance->get_module_override( $module_slug );

--- a/projects/plugins/migration/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/migration/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1148,7 +1148,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "92d026aa0316ac90edeb4adcef68fce1e0f10578"
+                "reference": "8254f98df9bf989973d102a2901b2328e51775c0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1170,7 +1170,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.16.x-dev"
+                    "dev-trunk": "1.17.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/protect/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1212,7 +1212,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "92d026aa0316ac90edeb4adcef68fce1e0f10578"
+                "reference": "8254f98df9bf989973d102a2901b2328e51775c0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1234,7 +1234,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.16.x-dev"
+                    "dev-trunk": "1.17.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/search/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1292,7 +1292,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "92d026aa0316ac90edeb4adcef68fce1e0f10578"
+                "reference": "8254f98df9bf989973d102a2901b2328e51775c0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1314,7 +1314,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.16.x-dev"
+                    "dev-trunk": "1.17.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/social/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1284,7 +1284,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "92d026aa0316ac90edeb4adcef68fce1e0f10578"
+                "reference": "8254f98df9bf989973d102a2901b2328e51775c0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1306,7 +1306,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.16.x-dev"
+                    "dev-trunk": "1.17.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/starter-plugin/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1148,7 +1148,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "92d026aa0316ac90edeb4adcef68fce1e0f10578"
+                "reference": "8254f98df9bf989973d102a2901b2328e51775c0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1170,7 +1170,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.16.x-dev"
+                    "dev-trunk": "1.17.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/videopress/changelog/update-jetpack-module-tags-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1212,7 +1212,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "92d026aa0316ac90edeb4adcef68fce1e0f10578"
+                "reference": "8254f98df9bf989973d102a2901b2328e51775c0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -1234,7 +1234,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.16.x-dev"
+                    "dev-trunk": "1.17.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Most of the code paths that wind up calling `Modules::get()` don't seem to care about the tags at all. It's a waste of time to translate them there.

Instead, let's move the i18n closer to the output. I see only a few such places:
* The module list in the Jetpack dashboard.
* A few module-related API endpoints.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-lOi-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the modules page in the dashboard with a non-English locale.
* Check the REST API output for module-related endpoints (e.g. `jetpack/v4/module/all`) with a non-English locale.
* Check the public-api.wordpress.com module-related endpoints (e.g. `v1/sites/$site/jetpack/modules`) with a non-English locale.
* Anything else?