### PR TITLE
Launchpad: Fix variable scope issue in endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-variable-scope-issue
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-variable-scope-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Launchpad: Fixed variable scope issue with endpoint

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -2,181 +2,194 @@
 /**
  * Launchpad
  *
+ * This file provides helpers that return the appropriate Launchpad
+ * checklist and tasks for a given checklist slug.
+ *
  * @package A8C\Launchpad
  */
 
 /**
- * This file provides helpers that return the appropriate Launchpad
- * checklist and tasks for a given checklist slug
+ * Returns the list of tasks by flow or checklist slug.
+ *
+ * @return array Associative array with checklist task data
  */
-const TASK_DEFINITIONS = array(
-	'setup_newsletter'
-		=> array(
-			'id'        => 'setup_newsletter',
-			'completed' => true,
-			'disabled'  => false,
+function get_checklist_definitions() {
+	return array(
+		'build'           => array(
+			'setup_general',
+			'design_selected',
+			'first_post_published',
+			'design_edited',
+			'site_launched',
 		),
-	'plan_selected'
-		=> array(
-			'id'        => 'plan_selected',
-			'completed' => true,
-			'disabled'  => false,
+		'free'            => array(
+			'setup_free',
+			'design_selected',
+			'domain_upsell',
+			'first_post_published',
+			'design_edited',
+			'site_launched',
 		),
-	'subscribers_added'
-		=> array(
-			'id'        => 'subscribers_added',
-			'completed' => true,
-			'disabled'  => false,
+		'link-in-bio'     => array(
+			'design_selected',
+			'setup_link_in_bio',
+			'plan_selected',
+			'links_added',
+			'link_in_bio_launched',
 		),
-	'first_post_published'
-		=> array(
-			'id'        => 'first_post_published',
-			'completed' => 'get_checklist_task( first_post_published ).completed',
-			'disabled'  => false,
+		'link-in-bio-tld' => array(
+			'design_selected',
+			'setup_link_in_bio',
+			'plan_selected',
+			'links_added',
+			'link_in_bio_launched',
 		),
-	'first_post_published_newsletter'
-		=> array(
-			'id'        => 'first_post_published_newsletter',
-			'completed' => false,
-			'disabled'  => false,
+		'newsletter'      => array(
+			'setup_newsletter',
+			'plan_selected',
+			'subscribers_added',
+			'verify_email',
+			'first_post_published_newsletter',
+			'first_post_published',
 		),
-	'design_selected'
-		=> array(
-			'id'        => 'design_selected',
-			'completed' => true,
-			'disabled'  => true,
+		'videopress'      => array(
+			'videopress_setup',
+			'plan_selected',
+			'videopress_upload',
+			'videopress_launched',
 		),
-	'setup_link_in_bio'
-		=> array(
-			'id'        => 'setup_link_in_bio',
-			'completed' => true,
-			'disabled'  => false,
+		'write'           => array(
+			'setup_write',
+			'design_selected',
+			'first_post_published',
+			'site_launched',
 		),
-	'links_added'
-		=> array(
-			'id'        => 'links_added',
-			'completed' => false,
-			'disabled'  => false,
-		),
-	'link_in_bio_launched'
-		=> array(
-			'id'        => 'link_in_bio_launched',
-			'completed' => false,
-			'disabled'  => true,
-		),
-	'videopress_setup'
-		=> array(
-			'id'        => 'videopress_setup',
-			'completed' => true,
-			'disabled'  => false,
-		),
-	'videopress_upload'
-		=> array(
-			'id'        => 'videopress_upload',
-			'completed' => false,
-			'disabled'  => false,
-		),
-	'videopress_launched'
-		=> array(
-			'id'        => 'videopress_launched',
-			'completed' => false,
-			'disabled'  => true,
-		),
-	'setup_free'
-		=> array(
-			'id'        => 'setup_free',
-			'completed' => true,
-			'disabled'  => false,
-		),
-	'setup_general'
-		=> array(
-			'id'        => 'setup_general',
-			'completed' => true,
-			'disabled'  => true,
-		),
-	'design_edited'
-		=> array(
-			'id'        => 'design_edited',
-			'completed' => false,
-			'disabled'  => false,
-		),
-	'site_launched'
-		=> array(
-			'id'        => 'site_launched',
-			'completed' => false,
-			'disabled'  => false,
-		),
-	'setup_write'
-		=> array(
-			'id'        => 'setup_write',
-			'completed' => true,
-			'disabled'  => true,
-		),
-	'domain_upsell'
-		=> array(
-			'id'        => 'domain_upsell',
-			'completed' => false,
-			'disabled'  => false,
-		),
-	'verify_email'
-		=> array(
-			'id'       => 'verify_email',
-			'complete' => false,
-			'disabled' => true,
-		),
-);
+	);
+}
 
-const CHECKLIST_DEFINITIONS = array(
-	'build'           => array(
-		'setup_general',
-		'design_selected',
-		'first_post_published',
-		'design_edited',
-		'site_launched',
-	),
-	'free'            => array(
-		'setup_free',
-		'design_selected',
-		'domain_upsell',
-		'first_post_published',
-		'design_edited',
-		'site_launched',
-	),
-	'link-in-bio'     => array(
-		'design_selected',
-		'setup_link_in_bio',
-		'plan_selected',
-		'links_added',
-		'link_in_bio_launched',
-	),
-	'link-in-bio-tld' => array(
-		'design_selected',
-		'setup_link_in_bio',
-		'plan_selected',
-		'links_added',
-		'link_in_bio_launched',
-	),
-	'newsletter'      => array(
-		'setup_newsletter',
-		'plan_selected',
-		'subscribers_added',
-		'verify_email',
-		'first_post_published_newsletter',
-		'first_post_published',
-	),
-	'videopress'      => array(
-		'videopress_setup',
-		'plan_selected',
-		'videopress_upload',
-		'videopress_launched',
-	),
-	'write'           => array(
-		'setup_write',
-		'design_selected',
-		'first_post_published',
-		'site_launched',
-	),
-);
+/**
+ * Returns the checklist task definitions.
+ *
+ * @return array Associative array with checklist task data
+ */
+function get_task_definitions() {
+	return array(
+		'setup_newsletter'
+			=> array(
+				'id'        => 'setup_newsletter',
+				'completed' => true,
+				'disabled'  => false,
+			),
+		'plan_selected'
+			=> array(
+				'id'        => 'plan_selected',
+				'completed' => true,
+				'disabled'  => false,
+			),
+		'subscribers_added'
+			=> array(
+				'id'        => 'subscribers_added',
+				'completed' => true,
+				'disabled'  => false,
+			),
+		'first_post_published'
+			=> array(
+				'id'        => 'first_post_published',
+				'completed' => get_checklist_task( first_post_published ) . completed,
+				'disabled'  => false,
+			),
+		'first_post_published_newsletter'
+			=> array(
+				'id'        => 'first_post_published_newsletter',
+				'completed' => false,
+				'disabled'  => false,
+			),
+		'design_selected'
+			=> array(
+				'id'        => 'design_selected',
+				'completed' => true,
+				'disabled'  => true,
+			),
+		'setup_link_in_bio'
+			=> array(
+				'id'        => 'setup_link_in_bio',
+				'completed' => true,
+				'disabled'  => false,
+			),
+		'links_added'
+			=> array(
+				'id'        => 'links_added',
+				'completed' => false,
+				'disabled'  => false,
+			),
+		'link_in_bio_launched'
+			=> array(
+				'id'        => 'link_in_bio_launched',
+				'completed' => false,
+				'disabled'  => true,
+			),
+		'videopress_setup'
+			=> array(
+				'id'        => 'videopress_setup',
+				'completed' => true,
+				'disabled'  => false,
+			),
+		'videopress_upload'
+			=> array(
+				'id'        => 'videopress_upload',
+				'completed' => false,
+				'disabled'  => false,
+			),
+		'videopress_launched'
+			=> array(
+				'id'        => 'videopress_launched',
+				'completed' => false,
+				'disabled'  => true,
+			),
+		'setup_free'
+			=> array(
+				'id'        => 'setup_free',
+				'completed' => true,
+				'disabled'  => false,
+			),
+		'setup_general'
+			=> array(
+				'id'        => 'setup_general',
+				'completed' => true,
+				'disabled'  => true,
+			),
+		'design_edited'
+			=> array(
+				'id'        => 'design_edited',
+				'completed' => false,
+				'disabled'  => false,
+			),
+		'site_launched'
+			=> array(
+				'id'        => 'site_launched',
+				'completed' => false,
+				'disabled'  => false,
+			),
+		'setup_write'
+			=> array(
+				'id'        => 'setup_write',
+				'completed' => true,
+				'disabled'  => true,
+			),
+		'domain_upsell'
+			=> array(
+				'id'        => 'domain_upsell',
+				'completed' => false,
+				'disabled'  => false,
+			),
+		'verify_email'
+			=> array(
+				'id'       => 'verify_email',
+				'complete' => false,
+				'disabled' => true,
+			),
+	);
+}
 
 /**
  * Returns launchpad checklist task by task id.
@@ -205,11 +218,11 @@ function get_checklist_task( $task ) {
  */
 function build_checklist( $checklist_slug ) {
 	$checklist = array();
-	if ( null === ( CHECKLIST_DEFINITIONS[ $checklist_slug ] ) ) {
+	if ( null === ( get_checklist_definitions()[ $checklist_slug ] ) ) {
 		return $checklist;
 	}
-	foreach ( CHECKLIST_DEFINITIONS[ $checklist_slug ] as $task_id ) {
-		$checklist[] = TASK_DEFINITIONS[ $task_id ];
+	foreach ( get_checklist_definitions()[ $checklist_slug ] as $task_id ) {
+		$checklist[] = get_task_definitions()[ $task_id ];
 	}
 	return $checklist;
 }


### PR DESCRIPTION
Co-author: @jeyip 

## Proposed Changes:

We were defining CHECKLIST_DEFINTIONS and TASK_DEFINITIONS as constants in the launchpad.php file. This precludes adding dynamics content to those values. But if we change the constants to variables, there are PHP variable scope issues. So we've put these values inside helper functions. 

We also fixed a related issue where we were outputting a string for `get_checklist_task( first_post_published ).completed`.

## Testing instructions:

1. Checkout this branch
2. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/launchpad-variable-scope-issue` to build and sync this branch to your sandbox. 
3. Sandbox a test site as well. 
4. Go to https://developer.wordpress.com/docs/api/console/, select Rest API and wpcom/v2, and input the following: 
`/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=newsletter` and confirm you get back an appropriate checklist. 

## Does this pull request change what data or activity we track or use?

No.
