### PR TITLE
jetpack_debugger_enqueue_site_health_scripts(): Only load full-sync Module on site-health.php

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/debugger/debug-functions.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/debug-functions.php
@@ -124,12 +124,12 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
  * @param string $hook The current admin page hook.
  */
 function jetpack_debugger_enqueue_site_health_scripts( $hook ) {
-	$full_sync_module = Modules::get_module( 'full-sync' );
-	$progress_percent = $full_sync_module ? $full_sync_module->get_sync_progress_percentage() : false;
-
-	$ajax_nonce = wp_create_nonce( 'jetpack-site-health' );
-
 	if ( 'site-health.php' === $hook ) {
+		$full_sync_module = Modules::get_module( 'full-sync' );
+		$progress_percent = $full_sync_module ? $full_sync_module->get_sync_progress_percentage() : false;
+
+		$ajax_nonce = wp_create_nonce( 'jetpack-site-health' );
+
 		$wp_scripts = wp_scripts();
 		wp_enqueue_script( 'jquery-ui-progressbar' );
 		wp_enqueue_script(

--- a/projects/plugins/jetpack/changelog/update-jetpack-debugger-enqueue-site-health-scripts
+++ b/projects/plugins/jetpack/changelog/update-jetpack-debugger-enqueue-site-health-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack_debugger_enqueue_site_health_scripts(): Only load full-sync Module on site-health.php


### PR DESCRIPTION
## Proposed changes:

* In profiling edit.php on a local site, I saw 2-3ms being spent inside jetpack_debugger_enqueue_site_health_scripts(), even though it only does work on site-health.php.
  * Changed it to only load the full-sync module on the site-health.php page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Site health page should continue to show a progress bar indicating sync status
  * **Can someone please verify this since I don't have a working JP environment.** :)  
* Verify the `$full_sync_module`, `$progress_percent`, and `$ajax_nonce` variables are used only inside the `if ( 'site-health.php' === $hook ) {` block.
  *   [Trunk code for function](https://github.com/Automattic/jetpack/blob/d4db4c83c59ba0e0895cfff869d682d94591901a/projects/plugins/jetpack/_inc/lib/debugger/debug-functions.php#L126). 

