### PR TITLE
Forms: Fix Forms styles when inside Cover blocks

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-inside-cover-block
+++ b/projects/packages/forms/changelog/fix-forms-inside-cover-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: Fix Forms styles when inside Cover blocks

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -18,7 +18,7 @@ import {
 } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment, useEffect, useState } from '@wordpress/element';
+import { forwardRef, Fragment, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { filter, get, isArray, map } from 'lodash';
@@ -62,250 +62,264 @@ const ALLOWED_BLOCKS = [
 const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 const CUSTOMIZING_FORMS_URL = 'https://jetpack.com/support/jetpack-blocks/contact-form/';
 
-export function JetpackContactFormEdit( {
-	attributes,
-	setAttributes,
-	siteTitle,
-	postTitle,
-	postAuthorEmail,
-	hasInnerBlocks,
-	replaceInnerBlocks,
-	selectBlock,
-	clientId,
-	instanceId,
-	className,
-	blockType,
-	variations,
-	defaultVariation,
-	canUserInstallPlugins,
-	style,
-} ) {
-	const {
-		to,
-		subject,
-		customThankyou,
-		customThankyouHeading,
-		customThankyouMessage,
-		customThankyouRedirect,
-		jetpackCRM,
-		formTitle,
-		salesforceData,
-	} = attributes;
+const JetpackContactFormEdit = forwardRef(
+	(
+		{
+			attributes,
+			setAttributes,
+			siteTitle,
+			postTitle,
+			postAuthorEmail,
+			hasInnerBlocks,
+			replaceInnerBlocks,
+			selectBlock,
+			clientId,
+			instanceId,
+			className,
+			blockType,
+			variations,
+			defaultVariation,
+			canUserInstallPlugins,
+			style,
+		},
+		ref
+	) => {
+		const {
+			to,
+			subject,
+			customThankyou,
+			customThankyouHeading,
+			customThankyouMessage,
+			customThankyouRedirect,
+			jetpackCRM,
+			formTitle,
+			salesforceData,
+		} = attributes;
 
-	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
+		const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
 
-	const formClassnames = classnames( className, 'jetpack-contact-form', {
-		'is-placeholder': ! hasInnerBlocks && registerBlockVariation,
-	} );
-	const isSalesForceExtensionEnabled =
-		!! window?.Jetpack_Editor_Initial_State?.available_blocks[
-			'contact-form/salesforce-lead-form'
-		];
+		const formClassnames = classnames( className, 'jetpack-contact-form', {
+			'is-placeholder': ! hasInnerBlocks && registerBlockVariation,
+		} );
+		const isSalesForceExtensionEnabled =
+			!! window?.Jetpack_Editor_Initial_State?.available_blocks[
+				'contact-form/salesforce-lead-form'
+			];
 
-	if ( isSalesForceExtensionEnabled ) {
-		variations = [ ...variations, salesforceLeadFormVariation ];
-	}
-
-	const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
-		const blocks = map( innerBlocksTemplate, ( [ name, attr, innerBlocks = [] ] ) =>
-			createBlock( name, attr, createBlocksFromInnerBlocksTemplate( innerBlocks ) )
-		);
-
-		return blocks;
-	};
-
-	const setVariation = variation => {
-		if ( variation.attributes ) {
-			setAttributes( variation.attributes );
+		if ( isSalesForceExtensionEnabled ) {
+			variations = [ ...variations, salesforceLeadFormVariation ];
 		}
 
-		if ( variation.innerBlocks ) {
-			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( variation.innerBlocks ) );
+		const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
+			const blocks = map( innerBlocksTemplate, ( [ name, attr, innerBlocks = [] ] ) =>
+				createBlock( name, attr, createBlocksFromInnerBlocksTemplate( innerBlocks ) )
+			);
+
+			return blocks;
+		};
+
+		const setVariation = variation => {
+			if ( variation.attributes ) {
+				setAttributes( variation.attributes );
+			}
+
+			if ( variation.innerBlocks ) {
+				replaceInnerBlocks(
+					clientId,
+					createBlocksFromInnerBlocksTemplate( variation.innerBlocks )
+				);
+			}
+
+			selectBlock( clientId );
+		};
+
+		useEffect( () => {
+			// Populate default variation on older versions of WP or GB that don't support variations.
+			if ( ! hasInnerBlocks && ! registerBlockVariation ) {
+				setVariation( defaultVariations[ 0 ] );
+			}
+		} );
+
+		useEffect( () => {
+			if ( to === undefined && postAuthorEmail ) {
+				setAttributes( { to: postAuthorEmail } );
+			}
+
+			if ( subject === undefined && siteTitle !== undefined && postTitle !== undefined ) {
+				const emailSubject = '[' + siteTitle + '] ' + postTitle;
+				setAttributes( { subject: emailSubject } );
+			}
+		}, [ to, postAuthorEmail, subject, siteTitle, postTitle, setAttributes ] );
+
+		const renderSubmissionSettings = () => {
+			return (
+				<>
+					<InspectorHint>
+						{ __( 'Customize the view after form submission:', 'jetpack-forms' ) }
+					</InspectorHint>
+					<SelectControl
+						label={ __( 'On Submission', 'jetpack-forms' ) }
+						value={ customThankyou }
+						options={ [
+							{ label: __( 'Show a summary of submitted fields', 'jetpack-forms' ), value: '' },
+							{ label: __( 'Show a custom text message', 'jetpack-forms' ), value: 'message' },
+							{ label: __( 'Redirect to another webpage', 'jetpack-forms' ), value: 'redirect' },
+						] }
+						onChange={ newMessage => setAttributes( { customThankyou: newMessage } ) }
+					/>
+
+					{ 'redirect' !== customThankyou && (
+						<TextControl
+							label={ __( 'Message Heading', 'jetpack-forms' ) }
+							value={ customThankyouHeading }
+							placeholder={ __( 'Your message has been sent', 'jetpack-forms' ) }
+							onChange={ newHeading => setAttributes( { customThankyouHeading: newHeading } ) }
+						/>
+					) }
+
+					{ 'message' === customThankyou && (
+						<TextareaControl
+							label={ __( 'Message Text', 'jetpack-forms' ) }
+							value={ customThankyouMessage }
+							placeholder={ __( 'Thank you for your submission!', 'jetpack-forms' ) }
+							onChange={ newMessage => setAttributes( { customThankyouMessage: newMessage } ) }
+						/>
+					) }
+
+					{ 'redirect' === customThankyou && (
+						<BaseControl
+							label={ __( 'Redirect Address', 'jetpack-forms' ) }
+							id={ `contact-form-${ instanceId }-thankyou-url` }
+						>
+							<URLInput
+								id={ `contact-form-${ instanceId }-thankyou-url` }
+								value={ customThankyouRedirect }
+								className="jetpack-contact-form__thankyou-redirect-url"
+								onChange={ newURL => setAttributes( { customThankyouRedirect: newURL } ) }
+							/>
+						</BaseControl>
+					) }
+				</>
+			);
+		};
+
+		const renderVariationPicker = () => {
+			return (
+				<div className={ formClassnames }>
+					<BlockVariationPicker
+						icon={ get( blockType, [ 'icon', 'src' ] ) }
+						label={ get( blockType, [ 'title' ] ) }
+						instructions={ __(
+							'Start building a form by selecting one of these form templates, or search in the patterns library for more forms:',
+							'jetpack-forms'
+						) }
+						variations={ filter( variations, v => ! v.hiddenFromPicker ) }
+						onSelect={ ( nextVariation = defaultVariation ) => {
+							setVariation( nextVariation );
+						} }
+					/>
+					<div className="form-placeholder__footer">
+						<Button variant="secondary" onClick={ () => setIsPatternsModalOpen( true ) }>
+							{ __( 'Explore Form Patterns', 'jetpack-forms' ) }
+						</Button>
+						<div className="form-placeholder__footer-links">
+							<Button
+								variant="link"
+								className="form-placeholder__external-link"
+								href={ CUSTOMIZING_FORMS_URL }
+								target="_blank"
+							>
+								{ __( 'Learn more about customizing forms', 'jetpack-forms' ) }
+							</Button>
+							<Button
+								variant="link"
+								className="form-placeholder__external-link"
+								href={ RESPONSES_PATH }
+								target="_blank"
+							>
+								{ __( 'View and export your form responses here', 'jetpack-forms' ) }
+							</Button>
+						</div>
+					</div>
+					{ isPatternsModalOpen && (
+						<Modal
+							className="form-placeholder__patterns-modal"
+							title={ __( 'Choose a pattern', 'jetpack-forms' ) }
+							closeLabel={ __( 'Cancel', 'jetpack-forms' ) }
+							onRequestClose={ () => setIsPatternsModalOpen( false ) }
+						>
+							<BlockPatternSetup
+								filterPatternsFn={ pattern => {
+									return pattern.content.indexOf( 'jetpack/contact-form' ) !== -1;
+								} }
+								clientId={ clientId }
+							/>
+						</Modal>
+					) }
+				</div>
+			);
+		};
+
+		if ( ! hasInnerBlocks && registerBlockVariation ) {
+			return renderVariationPicker();
 		}
 
-		selectBlock( clientId );
-	};
-
-	useEffect( () => {
-		// Populate default variation on older versions of WP or GB that don't support variations.
-		if ( ! hasInnerBlocks && ! registerBlockVariation ) {
-			setVariation( defaultVariations[ 0 ] );
-		}
-	} );
-
-	useEffect( () => {
-		if ( to === undefined && postAuthorEmail ) {
-			setAttributes( { to: postAuthorEmail } );
-		}
-
-		if ( subject === undefined && siteTitle !== undefined && postTitle !== undefined ) {
-			const emailSubject = '[' + siteTitle + '] ' + postTitle;
-			setAttributes( { subject: emailSubject } );
-		}
-	}, [ to, postAuthorEmail, subject, siteTitle, postTitle, setAttributes ] );
-
-	const renderSubmissionSettings = () => {
 		return (
 			<>
-				<InspectorHint>
-					{ __( 'Customize the view after form submission:', 'jetpack-forms' ) }
-				</InspectorHint>
-				<SelectControl
-					label={ __( 'On Submission', 'jetpack-forms' ) }
-					value={ customThankyou }
-					options={ [
-						{ label: __( 'Show a summary of submitted fields', 'jetpack-forms' ), value: '' },
-						{ label: __( 'Show a custom text message', 'jetpack-forms' ), value: 'message' },
-						{ label: __( 'Redirect to another webpage', 'jetpack-forms' ), value: 'redirect' },
-					] }
-					onChange={ newMessage => setAttributes( { customThankyou: newMessage } ) }
-				/>
-
-				{ 'redirect' !== customThankyou && (
-					<TextControl
-						label={ __( 'Message Heading', 'jetpack-forms' ) }
-						value={ customThankyouHeading }
-						placeholder={ __( 'Your message has been sent', 'jetpack-forms' ) }
-						onChange={ newHeading => setAttributes( { customThankyouHeading: newHeading } ) }
-					/>
-				) }
-
-				{ 'message' === customThankyou && (
-					<TextareaControl
-						label={ __( 'Message Text', 'jetpack-forms' ) }
-						value={ customThankyouMessage }
-						placeholder={ __( 'Thank you for your submission!', 'jetpack-forms' ) }
-						onChange={ newMessage => setAttributes( { customThankyouMessage: newMessage } ) }
-					/>
-				) }
-
-				{ 'redirect' === customThankyou && (
-					<BaseControl
-						label={ __( 'Redirect Address', 'jetpack-forms' ) }
-						id={ `contact-form-${ instanceId }-thankyou-url` }
-					>
-						<URLInput
-							id={ `contact-form-${ instanceId }-thankyou-url` }
-							value={ customThankyouRedirect }
-							className="jetpack-contact-form__thankyou-redirect-url"
-							onChange={ newURL => setAttributes( { customThankyouRedirect: newURL } ) }
+				<InspectorControls>
+					<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
+						<JetpackManageResponsesSettings
+							formTitle={ formTitle }
+							setAttributes={ setAttributes }
 						/>
-					</BaseControl>
-				) }
+					</PanelBody>
+					<PanelBody title={ __( 'Submission Settings', 'jetpack-forms' ) } initialOpen={ false }>
+						{ renderSubmissionSettings() }
+					</PanelBody>
+					<PanelBody title={ __( 'Email Connection', 'jetpack-forms' ) }>
+						<JetpackEmailConnectionSettings
+							emailAddress={ to }
+							emailSubject={ subject }
+							instanceId={ instanceId }
+							postAuthorEmail={ postAuthorEmail }
+							setAttributes={ setAttributes }
+						/>
+					</PanelBody>
+
+					{ isSalesForceExtensionEnabled && salesforceData?.sendToSalesforce && (
+						<SalesforceLeadFormSettings
+							salesforceData={ salesforceData }
+							setAttributes={ setAttributes }
+							instanceId={ instanceId }
+						/>
+					) }
+					{ ! isSimpleSite() && (
+						<Fragment>
+							{ canUserInstallPlugins && (
+								<PanelBody title={ __( 'CRM Connection', 'jetpack-forms' ) } initialOpen={ false }>
+									<CRMIntegrationSettings
+										jetpackCRM={ jetpackCRM }
+										setAttributes={ setAttributes }
+									/>
+								</PanelBody>
+							) }
+							<PanelBody
+								title={ __( 'Newsletter Connection', 'jetpack-forms' ) }
+								initialOpen={ false }
+							>
+								<NewsletterIntegrationSettings />
+							</PanelBody>
+						</Fragment>
+					) }
+				</InspectorControls>
+
+				<div className={ formClassnames } style={ style } ref={ ref }>
+					<InnerBlocks allowedBlocks={ ALLOWED_BLOCKS } templateInsertUpdatesSelection={ false } />
+				</div>
 			</>
 		);
-	};
-
-	const renderVariationPicker = () => {
-		return (
-			<div className={ formClassnames }>
-				<BlockVariationPicker
-					icon={ get( blockType, [ 'icon', 'src' ] ) }
-					label={ get( blockType, [ 'title' ] ) }
-					instructions={ __(
-						'Start building a form by selecting one of these form templates, or search in the patterns library for more forms:',
-						'jetpack-forms'
-					) }
-					variations={ filter( variations, v => ! v.hiddenFromPicker ) }
-					onSelect={ ( nextVariation = defaultVariation ) => {
-						setVariation( nextVariation );
-					} }
-				/>
-				<div className="form-placeholder__footer">
-					<Button variant="secondary" onClick={ () => setIsPatternsModalOpen( true ) }>
-						{ __( 'Explore Form Patterns', 'jetpack-forms' ) }
-					</Button>
-					<div className="form-placeholder__footer-links">
-						<Button
-							variant="link"
-							className="form-placeholder__external-link"
-							href={ CUSTOMIZING_FORMS_URL }
-							target="_blank"
-						>
-							{ __( 'Learn more about customizing forms', 'jetpack-forms' ) }
-						</Button>
-						<Button
-							variant="link"
-							className="form-placeholder__external-link"
-							href={ RESPONSES_PATH }
-							target="_blank"
-						>
-							{ __( 'View and export your form responses here', 'jetpack-forms' ) }
-						</Button>
-					</div>
-				</div>
-				{ isPatternsModalOpen && (
-					<Modal
-						className="form-placeholder__patterns-modal"
-						title={ __( 'Choose a pattern', 'jetpack-forms' ) }
-						closeLabel={ __( 'Cancel', 'jetpack-forms' ) }
-						onRequestClose={ () => setIsPatternsModalOpen( false ) }
-					>
-						<BlockPatternSetup
-							filterPatternsFn={ pattern => {
-								return pattern.content.indexOf( 'jetpack/contact-form' ) !== -1;
-							} }
-							clientId={ clientId }
-						/>
-					</Modal>
-				) }
-			</div>
-		);
-	};
-
-	if ( ! hasInnerBlocks && registerBlockVariation ) {
-		return renderVariationPicker();
 	}
-
-	return (
-		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
-					<JetpackManageResponsesSettings formTitle={ formTitle } setAttributes={ setAttributes } />
-				</PanelBody>
-				<PanelBody title={ __( 'Submission Settings', 'jetpack-forms' ) } initialOpen={ false }>
-					{ renderSubmissionSettings() }
-				</PanelBody>
-				<PanelBody title={ __( 'Email Connection', 'jetpack-forms' ) }>
-					<JetpackEmailConnectionSettings
-						emailAddress={ to }
-						emailSubject={ subject }
-						instanceId={ instanceId }
-						postAuthorEmail={ postAuthorEmail }
-						setAttributes={ setAttributes }
-					/>
-				</PanelBody>
-
-				{ isSalesForceExtensionEnabled && salesforceData?.sendToSalesforce && (
-					<SalesforceLeadFormSettings
-						salesforceData={ salesforceData }
-						setAttributes={ setAttributes }
-						instanceId={ instanceId }
-					/>
-				) }
-				{ ! isSimpleSite() && (
-					<Fragment>
-						{ canUserInstallPlugins && (
-							<PanelBody title={ __( 'CRM Connection', 'jetpack-forms' ) } initialOpen={ false }>
-								<CRMIntegrationSettings jetpackCRM={ jetpackCRM } setAttributes={ setAttributes } />
-							</PanelBody>
-						) }
-						<PanelBody
-							title={ __( 'Newsletter Connection', 'jetpack-forms' ) }
-							initialOpen={ false }
-						>
-							<NewsletterIntegrationSettings />
-						</PanelBody>
-					</Fragment>
-				) }
-			</InspectorControls>
-
-			<div className={ formClassnames } style={ style }>
-				<InnerBlocks allowedBlocks={ ALLOWED_BLOCKS } templateInsertUpdatesSelection={ false } />
-			</div>
-		</>
-	);
-}
+);
 
 export default compose( [
 	withSelect( ( select, props ) => {
@@ -343,6 +357,5 @@ export default compose( [
 		const { replaceInnerBlocks, selectBlock } = dispatch( 'core/block-editor' );
 		return { replaceInnerBlocks, selectBlock };
 	} ),
-	withStyleVariables,
 	withInstanceId,
-] )( JetpackContactFormEdit );
+] )( withStyleVariables( JetpackContactFormEdit ) );

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -62,7 +62,7 @@ const ALLOWED_BLOCKS = [
 const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 const CUSTOMIZING_FORMS_URL = 'https://jetpack.com/support/jetpack-blocks/contact-form/';
 
-const JetpackContactFormEdit = forwardRef(
+export const JetpackContactFormEdit = forwardRef(
 	(
 		{
 			attributes,

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -610,7 +610,6 @@
 	&:not(.is-style-outlined):not(.is-style-animated) {
 		.jetpack-field.jetpack-field-multiple {
 			.jetpack-field-multiple__list {
-				//background-color: var(--jetpack--contact-form--input-background);
 				border-radius: var(--jetpack--contact-form--border-radius);
 				border-color: var(--jetpack--contact-form--border-color);
 				border-style: var(--jetpack--contact-form--border-style);

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -610,7 +610,7 @@
 	&:not(.is-style-outlined):not(.is-style-animated) {
 		.jetpack-field.jetpack-field-multiple {
 			.jetpack-field-multiple__list {
-				background-color: var(--jetpack--contact-form--input-background);
+				//background-color: var(--jetpack--contact-form--input-background);
 				border-radius: var(--jetpack--contact-form--border-radius);
 				border-color: var(--jetpack--contact-form--border-color);
 				border-style: var(--jetpack--contact-form--border-style);

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -8,12 +8,21 @@ window.jetpackForms.getBackgroundColor = function ( backgroundColorNode ) {
 		backgroundColorNode.parentNode.nodeType === window.Node.ELEMENT_NODE
 	) {
 		backgroundColorNode = backgroundColorNode.parentNode;
+
+		if ( backgroundColorNode.className === 'wp-block-cover' ) {
+			const coverBackgroundNode = backgroundColorNode.querySelector(
+				'.wp-block-cover__background'
+			);
+			backgroundColor = window.getComputedStyle( coverBackgroundNode ).backgroundColor;
+			continue;
+		}
+
 		backgroundColor = window.getComputedStyle( backgroundColorNode ).backgroundColor;
 	}
 	return backgroundColor;
 };
 
-window.jetpackForms.generateStyleVariables = function ( selector ) {
+window.jetpackForms.generateStyleVariables = function ( formNode ) {
 	const STYLE_PROBE_CLASS = 'contact-form__style-probe';
 	const STYLE_PROBE_STYLE =
 		'position: absolute; z-index: -1; width: 1px; height: 1px; visibility: hidden';
@@ -31,7 +40,7 @@ window.jetpackForms.generateStyleVariables = function ( selector ) {
 	const _document = window[ 'editor-canvas' ] ? window[ 'editor-canvas' ].document : document;
 	const bodyNode = _document.querySelector( 'body' );
 
-	if ( ! _document.querySelectorAll( selector ).length ) {
+	if ( ! formNode ) {
 		return;
 	}
 
@@ -40,14 +49,14 @@ window.jetpackForms.generateStyleVariables = function ( selector ) {
 	styleProbe.style = STYLE_PROBE_STYLE;
 	styleProbe.innerHTML = HTML;
 
-	const container = _document.querySelector( selector );
-	container.appendChild( styleProbe );
+	formNode.appendChild( styleProbe );
 
 	const buttonNode = styleProbe.querySelector( '.wp-block-button__link' );
 	const inputNode = styleProbe.querySelector( 'input[type="text"]' );
 
 	const backgroundColor = window.jetpackForms.getBackgroundColor( bodyNode );
-	const inputBackground = window.jetpackForms.getBackgroundColor( inputNode );
+	const inputBackgroundFallback = window.jetpackForms.getBackgroundColor( inputNode );
+	const inputBackground = window.getComputedStyle( inputNode ).backgroundColor;
 	const primaryColor = window.getComputedStyle( buttonNode ).borderColor;
 
 	const {
@@ -77,6 +86,7 @@ window.jetpackForms.generateStyleVariables = function ( selector ) {
 		'--jetpack--contact-form--border-style': borderStyle,
 		'--jetpack--contact-form--border-radius': borderRadius,
 		'--jetpack--contact-form--input-background': inputBackground,
+		'--jetpack--contact-form--input-background-fallback': inputBackgroundFallback,
 		'--jetpack--contact-form--input-padding': inputPadding,
 		'--jetpack--contact-form--input-padding-top': inputPaddingTop,
 		'--jetpack--contact-form--input-padding-left': inputPaddingLeft,

--- a/projects/packages/forms/src/blocks/contact-form/util/with-style-variables.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/with-style-variables.js
@@ -1,8 +1,15 @@
 import './form-styles.js';
+import { useRef } from '@wordpress/element';
 
 export const withStyleVariables = WrappedComponent => props => {
-	const EDITOR_SELECTOR = '[data-type="jetpack/contact-form"]';
 	const { generateStyleVariables } = window.jetpackForms;
+	const componentRef = useRef();
 
-	return <WrappedComponent style={ generateStyleVariables( EDITOR_SELECTOR ) } { ...props } />;
+	return (
+		<WrappedComponent
+			style={ generateStyleVariables( componentRef?.current ) }
+			{ ...props }
+			ref={ componentRef }
+		/>
+	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/view.js
+++ b/projects/packages/forms/src/blocks/contact-form/view.js
@@ -14,14 +14,17 @@ window.addEventListener( 'load', () => {
 } );
 
 function handleFormStyles() {
-	const styleVariables = generateStyleVariables( FRONTEND_SELECTOR );
+	const formNodes = document.querySelectorAll( FRONTEND_SELECTOR );
 
-	if ( ! styleVariables ) {
-		return;
-	}
+	for ( const formNode of formNodes ) {
+		const styleVariables = generateStyleVariables( formNode );
 
-	const outputContainer = document.querySelector( FRONTEND_SELECTOR );
-	for ( const styleVariablesKey in styleVariables ) {
-		outputContainer.style.setProperty( styleVariablesKey, styleVariables[ styleVariablesKey ] );
+		if ( ! styleVariables ) {
+			return;
+		}
+
+		for ( const styleVariablesKey in styleVariables ) {
+			formNode.style.setProperty( styleVariablesKey, styleVariables[ styleVariablesKey ] );
+		}
 	}
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -192,6 +192,7 @@
 
 .wp-block-jetpack-contact-form > * {
 	flex: 0 0 100%;
+	box-sizing: border-box;
 }
 
 /* Added circa Nov 2022: container class assigned to topmost block div */
@@ -331,7 +332,7 @@
 	border-style: var(--jetpack--contact-form--border-style);
 	border-width: var(--jetpack--contact-form--border-size);
 	border-radius: var(--jetpack--contact-form--border-radius);
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--input-background-fallback);
 	color: var(--jetpack--contact-form--text-color);
 	font-size: var(--jetpack--contact-form--font-size);
 	font-family: var(--jetpack--contact-form--font-family);
@@ -353,7 +354,7 @@
 .contact-form .contact-form-dropdown__menu .ui-menu .ui-menu-item-wrapper.ui-state-active {
 	position: relative;
 	border: none;
-	color: var(--jetpack--contact-form--input-background);
+	color: var(--jetpack--contact-form--input-background-fallback);
 	background-color: var(--jetpack--contact-form--text-color);
 }
 
@@ -383,7 +384,7 @@
 
 .contact-form :not(.is-style-outlined):not(.is-style-animated) .grunion-field-wrap .grunion-checkbox-multiple-options,
 .contact-form :not(.is-style-outlined):not(.is-style-animated) .grunion-field-wrap .grunion-radio-options {
-	background-color: var(--jetpack--contact-form--input-background);
+	/*background-color: var(--jetpack--contact-form--input-background);*/
 	border-radius: var(--jetpack--contact-form--border-radius);
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -384,7 +384,6 @@
 
 .contact-form :not(.is-style-outlined):not(.is-style-animated) .grunion-field-wrap .grunion-checkbox-multiple-options,
 .contact-form :not(.is-style-outlined):not(.is-style-animated) .grunion-field-wrap .grunion-radio-options {
-	/*background-color: var(--jetpack--contact-form--input-background);*/
 	border-radius: var(--jetpack--contact-form--border-radius);
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);

--- a/projects/plugins/jetpack/changelog/fix-forms-inside-cover-block
+++ b/projects/plugins/jetpack/changelog/fix-forms-inside-cover-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Forms: Fix Forms styles when inside Cover blocks

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -18,7 +18,7 @@ import {
 } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment, useEffect, useState } from '@wordpress/element';
+import { forwardRef, Fragment, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { filter, get, isArray, map } from 'lodash';
@@ -62,247 +62,261 @@ const ALLOWED_BLOCKS = [
 const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 const CUSTOMIZING_FORMS_URL = 'https://jetpack.com/support/jetpack-blocks/contact-form/';
 
-export function JetpackContactFormEdit( {
-	attributes,
-	setAttributes,
-	siteTitle,
-	postTitle,
-	postAuthorEmail,
-	hasInnerBlocks,
-	replaceInnerBlocks,
-	selectBlock,
-	clientId,
-	instanceId,
-	className,
-	blockType,
-	variations,
-	defaultVariation,
-	canUserInstallPlugins,
-	style,
-} ) {
-	const {
-		to,
-		subject,
-		customThankyou,
-		customThankyouHeading,
-		customThankyouMessage,
-		customThankyouRedirect,
-		jetpackCRM,
-		formTitle,
-		salesforceData,
-	} = attributes;
+const JetpackContactFormEdit = forwardRef(
+	(
+		{
+			attributes,
+			setAttributes,
+			siteTitle,
+			postTitle,
+			postAuthorEmail,
+			hasInnerBlocks,
+			replaceInnerBlocks,
+			selectBlock,
+			clientId,
+			instanceId,
+			className,
+			blockType,
+			variations,
+			defaultVariation,
+			canUserInstallPlugins,
+			style,
+		},
+		ref
+	) => {
+		const {
+			to,
+			subject,
+			customThankyou,
+			customThankyouHeading,
+			customThankyouMessage,
+			customThankyouRedirect,
+			jetpackCRM,
+			formTitle,
+			salesforceData,
+		} = attributes;
 
-	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
+		const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
 
-	const formClassnames = classnames( className, 'jetpack-contact-form', {
-		'is-placeholder': ! hasInnerBlocks && registerBlockVariation,
-	} );
-	const isSalesForceExtensionEnabled =
-		!! window?.Jetpack_Editor_Initial_State?.available_blocks[
-			'contact-form/salesforce-lead-form'
-		];
+		const formClassnames = classnames( className, 'jetpack-contact-form', {
+			'is-placeholder': ! hasInnerBlocks && registerBlockVariation,
+		} );
+		const isSalesForceExtensionEnabled =
+			!! window?.Jetpack_Editor_Initial_State?.available_blocks[
+				'contact-form/salesforce-lead-form'
+			];
 
-	if ( isSalesForceExtensionEnabled ) {
-		variations = [ ...variations, salesforceLeadFormVariation ];
-	}
-
-	const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
-		const blocks = map( innerBlocksTemplate, ( [ name, attr, innerBlocks = [] ] ) =>
-			createBlock( name, attr, createBlocksFromInnerBlocksTemplate( innerBlocks ) )
-		);
-
-		return blocks;
-	};
-
-	const setVariation = variation => {
-		if ( variation.attributes ) {
-			setAttributes( variation.attributes );
+		if ( isSalesForceExtensionEnabled ) {
+			variations = [ ...variations, salesforceLeadFormVariation ];
 		}
 
-		if ( variation.innerBlocks ) {
-			replaceInnerBlocks( clientId, createBlocksFromInnerBlocksTemplate( variation.innerBlocks ) );
+		const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
+			const blocks = map( innerBlocksTemplate, ( [ name, attr, innerBlocks = [] ] ) =>
+				createBlock( name, attr, createBlocksFromInnerBlocksTemplate( innerBlocks ) )
+			);
+
+			return blocks;
+		};
+
+		const setVariation = variation => {
+			if ( variation.attributes ) {
+				setAttributes( variation.attributes );
+			}
+
+			if ( variation.innerBlocks ) {
+				replaceInnerBlocks(
+					clientId,
+					createBlocksFromInnerBlocksTemplate( variation.innerBlocks )
+				);
+			}
+
+			selectBlock( clientId );
+		};
+
+		useEffect( () => {
+			// Populate default variation on older versions of WP or GB that don't support variations.
+			if ( ! hasInnerBlocks && ! registerBlockVariation ) {
+				setVariation( defaultVariations[ 0 ] );
+			}
+		} );
+
+		useEffect( () => {
+			if ( to === undefined && postAuthorEmail ) {
+				setAttributes( { to: postAuthorEmail } );
+			}
+
+			if ( subject === undefined && siteTitle !== undefined && postTitle !== undefined ) {
+				const emailSubject = '[' + siteTitle + '] ' + postTitle;
+				setAttributes( { subject: emailSubject } );
+			}
+		}, [ to, postAuthorEmail, subject, siteTitle, postTitle, setAttributes ] );
+
+		const renderSubmissionSettings = () => {
+			return (
+				<>
+					<InspectorHint>
+						{ __( 'Customize the view after form submission:', 'jetpack' ) }
+					</InspectorHint>
+					<SelectControl
+						label={ __( 'On Submission', 'jetpack' ) }
+						value={ customThankyou }
+						options={ [
+							{ label: __( 'Show a summary of submitted fields', 'jetpack' ), value: '' },
+							{ label: __( 'Show a custom text message', 'jetpack' ), value: 'message' },
+							{ label: __( 'Redirect to another webpage', 'jetpack' ), value: 'redirect' },
+						] }
+						onChange={ newMessage => setAttributes( { customThankyou: newMessage } ) }
+					/>
+
+					{ 'redirect' !== customThankyou && (
+						<TextControl
+							label={ __( 'Message Heading', 'jetpack' ) }
+							value={ customThankyouHeading }
+							placeholder={ __( 'Your message has been sent', 'jetpack' ) }
+							onChange={ newHeading => setAttributes( { customThankyouHeading: newHeading } ) }
+						/>
+					) }
+
+					{ 'message' === customThankyou && (
+						<TextareaControl
+							label={ __( 'Message Text', 'jetpack' ) }
+							value={ customThankyouMessage }
+							placeholder={ __( 'Thank you for your submission!', 'jetpack' ) }
+							onChange={ newMessage => setAttributes( { customThankyouMessage: newMessage } ) }
+						/>
+					) }
+
+					{ 'redirect' === customThankyou && (
+						<BaseControl
+							label={ __( 'Redirect Address', 'jetpack' ) }
+							id={ `contact-form-${ instanceId }-thankyou-url` }
+						>
+							<URLInput
+								id={ `contact-form-${ instanceId }-thankyou-url` }
+								value={ customThankyouRedirect }
+								className="jetpack-contact-form__thankyou-redirect-url"
+								onChange={ newURL => setAttributes( { customThankyouRedirect: newURL } ) }
+							/>
+						</BaseControl>
+					) }
+				</>
+			);
+		};
+
+		const renderVariationPicker = () => {
+			return (
+				<div className={ formClassnames }>
+					<BlockVariationPicker
+						icon={ get( blockType, [ 'icon', 'src' ] ) }
+						label={ get( blockType, [ 'title' ] ) }
+						instructions={ __(
+							'Start building a form by selecting one of these form templates, or search in the patterns library for more forms:',
+							'jetpack'
+						) }
+						variations={ filter( variations, v => ! v.hiddenFromPicker ) }
+						onSelect={ ( nextVariation = defaultVariation ) => {
+							setVariation( nextVariation );
+						} }
+					/>
+					<div className="form-placeholder__footer">
+						<Button variant="secondary" onClick={ () => setIsPatternsModalOpen( true ) }>
+							{ __( 'Explore Form Patterns', 'jetpack' ) }
+						</Button>
+						<div className="form-placeholder__footer-links">
+							<Button
+								variant="link"
+								className="form-placeholder__external-link"
+								href={ CUSTOMIZING_FORMS_URL }
+								target="_blank"
+							>
+								{ __( 'Learn more about customizing forms', 'jetpack' ) }
+							</Button>
+							<Button
+								variant="link"
+								className="form-placeholder__external-link"
+								href={ RESPONSES_PATH }
+								target="_blank"
+							>
+								{ __( 'View and export your form responses here', 'jetpack' ) }
+							</Button>
+						</div>
+					</div>
+					{ isPatternsModalOpen && (
+						<Modal
+							className="form-placeholder__patterns-modal"
+							title={ __( 'Choose a pattern', 'jetpack' ) }
+							closeLabel={ __( 'Cancel', 'jetpack' ) }
+							onRequestClose={ () => setIsPatternsModalOpen( false ) }
+						>
+							<BlockPatternSetup
+								filterPatternsFn={ pattern => {
+									return pattern.content.indexOf( 'jetpack/contact-form' ) !== -1;
+								} }
+								clientId={ clientId }
+							/>
+						</Modal>
+					) }
+				</div>
+			);
+		};
+
+		if ( ! hasInnerBlocks && registerBlockVariation ) {
+			return renderVariationPicker();
 		}
 
-		selectBlock( clientId );
-	};
-
-	useEffect( () => {
-		// Populate default variation on older versions of WP or GB that don't support variations.
-		if ( ! hasInnerBlocks && ! registerBlockVariation ) {
-			setVariation( defaultVariations[ 0 ] );
-		}
-	} );
-
-	useEffect( () => {
-		if ( to === undefined && postAuthorEmail ) {
-			setAttributes( { to: postAuthorEmail } );
-		}
-
-		if ( subject === undefined && siteTitle !== undefined && postTitle !== undefined ) {
-			const emailSubject = '[' + siteTitle + '] ' + postTitle;
-			setAttributes( { subject: emailSubject } );
-		}
-	}, [ to, postAuthorEmail, subject, siteTitle, postTitle, setAttributes ] );
-
-	const renderSubmissionSettings = () => {
 		return (
 			<>
-				<InspectorHint>
-					{ __( 'Customize the view after form submission:', 'jetpack' ) }
-				</InspectorHint>
-				<SelectControl
-					label={ __( 'On Submission', 'jetpack' ) }
-					value={ customThankyou }
-					options={ [
-						{ label: __( 'Show a summary of submitted fields', 'jetpack' ), value: '' },
-						{ label: __( 'Show a custom text message', 'jetpack' ), value: 'message' },
-						{ label: __( 'Redirect to another webpage', 'jetpack' ), value: 'redirect' },
-					] }
-					onChange={ newMessage => setAttributes( { customThankyou: newMessage } ) }
-				/>
-
-				{ 'redirect' !== customThankyou && (
-					<TextControl
-						label={ __( 'Message Heading', 'jetpack' ) }
-						value={ customThankyouHeading }
-						placeholder={ __( 'Your message has been sent', 'jetpack' ) }
-						onChange={ newHeading => setAttributes( { customThankyouHeading: newHeading } ) }
-					/>
-				) }
-
-				{ 'message' === customThankyou && (
-					<TextareaControl
-						label={ __( 'Message Text', 'jetpack' ) }
-						value={ customThankyouMessage }
-						placeholder={ __( 'Thank you for your submission!', 'jetpack' ) }
-						onChange={ newMessage => setAttributes( { customThankyouMessage: newMessage } ) }
-					/>
-				) }
-
-				{ 'redirect' === customThankyou && (
-					<BaseControl
-						label={ __( 'Redirect Address', 'jetpack' ) }
-						id={ `contact-form-${ instanceId }-thankyou-url` }
-					>
-						<URLInput
-							id={ `contact-form-${ instanceId }-thankyou-url` }
-							value={ customThankyouRedirect }
-							className="jetpack-contact-form__thankyou-redirect-url"
-							onChange={ newURL => setAttributes( { customThankyouRedirect: newURL } ) }
+				<InspectorControls>
+					<PanelBody title={ __( 'Manage Responses', 'jetpack' ) }>
+						<JetpackManageResponsesSettings
+							formTitle={ formTitle }
+							setAttributes={ setAttributes }
 						/>
-					</BaseControl>
-				) }
+					</PanelBody>
+					<PanelBody title={ __( 'Submission Settings', 'jetpack' ) } initialOpen={ false }>
+						{ renderSubmissionSettings() }
+					</PanelBody>
+					<PanelBody title={ __( 'Email Connection', 'jetpack' ) }>
+						<JetpackEmailConnectionSettings
+							emailAddress={ to }
+							emailSubject={ subject }
+							instanceId={ instanceId }
+							postAuthorEmail={ postAuthorEmail }
+							setAttributes={ setAttributes }
+						/>
+					</PanelBody>
+
+					{ isSalesForceExtensionEnabled && salesforceData?.sendToSalesforce && (
+						<SalesforceLeadFormSettings
+							salesforceData={ salesforceData }
+							setAttributes={ setAttributes }
+							instanceId={ instanceId }
+						/>
+					) }
+					{ ! isSimpleSite() && (
+						<Fragment>
+							{ canUserInstallPlugins && (
+								<PanelBody title={ __( 'CRM Connection', 'jetpack' ) } initialOpen={ false }>
+									<CRMIntegrationSettings
+										jetpackCRM={ jetpackCRM }
+										setAttributes={ setAttributes }
+									/>
+								</PanelBody>
+							) }
+							<PanelBody title={ __( 'Newsletter Connection', 'jetpack' ) } initialOpen={ false }>
+								<NewsletterIntegrationSettings />
+							</PanelBody>
+						</Fragment>
+					) }
+				</InspectorControls>
+
+				<div className={ formClassnames } style={ style } ref={ ref }>
+					<InnerBlocks allowedBlocks={ ALLOWED_BLOCKS } templateInsertUpdatesSelection={ false } />
+				</div>
 			</>
 		);
-	};
-
-	const renderVariationPicker = () => {
-		return (
-			<div className={ formClassnames }>
-				<BlockVariationPicker
-					icon={ get( blockType, [ 'icon', 'src' ] ) }
-					label={ get( blockType, [ 'title' ] ) }
-					instructions={ __(
-						'Start building a form by selecting one of these form templates, or search in the patterns library for more forms:',
-						'jetpack'
-					) }
-					variations={ filter( variations, v => ! v.hiddenFromPicker ) }
-					onSelect={ ( nextVariation = defaultVariation ) => {
-						setVariation( nextVariation );
-					} }
-				/>
-				<div className="form-placeholder__footer">
-					<Button variant="secondary" onClick={ () => setIsPatternsModalOpen( true ) }>
-						{ __( 'Explore Form Patterns', 'jetpack' ) }
-					</Button>
-					<div className="form-placeholder__footer-links">
-						<Button
-							variant="link"
-							className="form-placeholder__external-link"
-							href={ CUSTOMIZING_FORMS_URL }
-							target="_blank"
-						>
-							{ __( 'Learn more about customizing forms', 'jetpack' ) }
-						</Button>
-						<Button
-							variant="link"
-							className="form-placeholder__external-link"
-							href={ RESPONSES_PATH }
-							target="_blank"
-						>
-							{ __( 'View and export your form responses here', 'jetpack' ) }
-						</Button>
-					</div>
-				</div>
-				{ isPatternsModalOpen && (
-					<Modal
-						className="form-placeholder__patterns-modal"
-						title={ __( 'Choose a pattern', 'jetpack' ) }
-						closeLabel={ __( 'Cancel', 'jetpack' ) }
-						onRequestClose={ () => setIsPatternsModalOpen( false ) }
-					>
-						<BlockPatternSetup
-							filterPatternsFn={ pattern => {
-								return pattern.content.indexOf( 'jetpack/contact-form' ) !== -1;
-							} }
-							clientId={ clientId }
-						/>
-					</Modal>
-				) }
-			</div>
-		);
-	};
-
-	if ( ! hasInnerBlocks && registerBlockVariation ) {
-		return renderVariationPicker();
 	}
-
-	return (
-		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Manage Responses', 'jetpack' ) }>
-					<JetpackManageResponsesSettings formTitle={ formTitle } setAttributes={ setAttributes } />
-				</PanelBody>
-				<PanelBody title={ __( 'Submission Settings', 'jetpack' ) } initialOpen={ false }>
-					{ renderSubmissionSettings() }
-				</PanelBody>
-				<PanelBody title={ __( 'Email Connection', 'jetpack' ) }>
-					<JetpackEmailConnectionSettings
-						emailAddress={ to }
-						emailSubject={ subject }
-						instanceId={ instanceId }
-						postAuthorEmail={ postAuthorEmail }
-						setAttributes={ setAttributes }
-					/>
-				</PanelBody>
-
-				{ isSalesForceExtensionEnabled && salesforceData?.sendToSalesforce && (
-					<SalesforceLeadFormSettings
-						salesforceData={ salesforceData }
-						setAttributes={ setAttributes }
-						instanceId={ instanceId }
-					/>
-				) }
-				{ ! isSimpleSite() && (
-					<Fragment>
-						{ canUserInstallPlugins && (
-							<PanelBody title={ __( 'CRM Connection', 'jetpack' ) } initialOpen={ false }>
-								<CRMIntegrationSettings jetpackCRM={ jetpackCRM } setAttributes={ setAttributes } />
-							</PanelBody>
-						) }
-						<PanelBody title={ __( 'Newsletter Connection', 'jetpack' ) } initialOpen={ false }>
-							<NewsletterIntegrationSettings />
-						</PanelBody>
-					</Fragment>
-				) }
-			</InspectorControls>
-
-			<div className={ formClassnames } style={ style }>
-				<InnerBlocks allowedBlocks={ ALLOWED_BLOCKS } templateInsertUpdatesSelection={ false } />
-			</div>
-		</>
-	);
-}
+);
 
 export default compose( [
 	withSelect( ( select, props ) => {
@@ -340,6 +354,5 @@ export default compose( [
 		const { replaceInnerBlocks, selectBlock } = dispatch( 'core/block-editor' );
 		return { replaceInnerBlocks, selectBlock };
 	} ),
-	withStyleVariables,
 	withInstanceId,
-] )( JetpackContactFormEdit );
+] )( withStyleVariables( JetpackContactFormEdit ) );

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/edit.js
@@ -62,7 +62,7 @@ const ALLOWED_BLOCKS = [
 const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;
 const CUSTOMIZING_FORMS_URL = 'https://jetpack.com/support/jetpack-blocks/contact-form/';
 
-const JetpackContactFormEdit = forwardRef(
+export const JetpackContactFormEdit = forwardRef(
 	(
 		{
 			attributes,

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/editor.scss
@@ -610,7 +610,6 @@
 	&:not(.is-style-outlined):not(.is-style-animated) {
 		.jetpack-field.jetpack-field-multiple {
 			.jetpack-field-multiple__list {
-				background-color: var(--jetpack--contact-form--input-background);
 				border-radius: var(--jetpack--contact-form--border-radius);
 				border-color: var(--jetpack--contact-form--border-color);
 				border-style: var(--jetpack--contact-form--border-style);

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/util/form-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/util/form-styles.js
@@ -8,12 +8,21 @@ window.jetpackForms.getBackgroundColor = function ( backgroundColorNode ) {
 		backgroundColorNode.parentNode.nodeType === window.Node.ELEMENT_NODE
 	) {
 		backgroundColorNode = backgroundColorNode.parentNode;
+
+		if ( backgroundColorNode.className === 'wp-block-cover' ) {
+			const coverBackgroundNode = backgroundColorNode.querySelector(
+				'.wp-block-cover__background'
+			);
+			backgroundColor = window.getComputedStyle( coverBackgroundNode ).backgroundColor;
+			continue;
+		}
+
 		backgroundColor = window.getComputedStyle( backgroundColorNode ).backgroundColor;
 	}
 	return backgroundColor;
 };
 
-window.jetpackForms.generateStyleVariables = function ( selector ) {
+window.jetpackForms.generateStyleVariables = function ( formNode ) {
 	const STYLE_PROBE_CLASS = 'contact-form__style-probe';
 	const STYLE_PROBE_STYLE =
 		'position: absolute; z-index: -1; width: 1px; height: 1px; visibility: hidden';
@@ -31,7 +40,7 @@ window.jetpackForms.generateStyleVariables = function ( selector ) {
 	const _document = window[ 'editor-canvas' ] ? window[ 'editor-canvas' ].document : document;
 	const bodyNode = _document.querySelector( 'body' );
 
-	if ( ! _document.querySelectorAll( selector ).length ) {
+	if ( ! formNode ) {
 		return;
 	}
 
@@ -40,14 +49,14 @@ window.jetpackForms.generateStyleVariables = function ( selector ) {
 	styleProbe.style = STYLE_PROBE_STYLE;
 	styleProbe.innerHTML = HTML;
 
-	const container = _document.querySelector( selector );
-	container.appendChild( styleProbe );
+	formNode.appendChild( styleProbe );
 
 	const buttonNode = styleProbe.querySelector( '.wp-block-button__link' );
 	const inputNode = styleProbe.querySelector( 'input[type="text"]' );
 
 	const backgroundColor = window.jetpackForms.getBackgroundColor( bodyNode );
-	const inputBackground = window.jetpackForms.getBackgroundColor( inputNode );
+	const inputBackgroundFallback = window.jetpackForms.getBackgroundColor( inputNode );
+	const inputBackground = window.getComputedStyle( inputNode ).backgroundColor;
 	const primaryColor = window.getComputedStyle( buttonNode ).borderColor;
 
 	const {
@@ -77,6 +86,7 @@ window.jetpackForms.generateStyleVariables = function ( selector ) {
 		'--jetpack--contact-form--border-style': borderStyle,
 		'--jetpack--contact-form--border-radius': borderRadius,
 		'--jetpack--contact-form--input-background': inputBackground,
+		'--jetpack--contact-form--input-background-fallback': inputBackgroundFallback,
 		'--jetpack--contact-form--input-padding': inputPadding,
 		'--jetpack--contact-form--input-padding-top': inputPaddingTop,
 		'--jetpack--contact-form--input-padding-left': inputPaddingLeft,

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/util/with-style-variables.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/util/with-style-variables.js
@@ -1,8 +1,15 @@
 import './form-styles.js';
+import { useRef } from '@wordpress/element';
 
 export const withStyleVariables = WrappedComponent => props => {
-	const EDITOR_SELECTOR = '[data-type="jetpack/contact-form"]';
 	const { generateStyleVariables } = window.jetpackForms;
+	const componentRef = useRef();
 
-	return <WrappedComponent style={ generateStyleVariables( EDITOR_SELECTOR ) } { ...props } />;
+	return (
+		<WrappedComponent
+			style={ generateStyleVariables( componentRef?.current ) }
+			{ ...props }
+			ref={ componentRef }
+		/>
+	);
 };

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/view.js
@@ -14,14 +14,17 @@ window.addEventListener( 'load', () => {
 } );
 
 function handleFormStyles() {
-	const styleVariables = generateStyleVariables( FRONTEND_SELECTOR );
+	const formNodes = document.querySelectorAll( FRONTEND_SELECTOR );
 
-	if ( ! styleVariables ) {
-		return;
-	}
+	for ( const formNode of formNodes ) {
+		const styleVariables = generateStyleVariables( formNode );
 
-	const outputContainer = document.querySelector( FRONTEND_SELECTOR );
-	for ( const styleVariablesKey in styleVariables ) {
-		outputContainer.style.setProperty( styleVariablesKey, styleVariables[ styleVariablesKey ] );
+		if ( ! styleVariables ) {
+			return;
+		}
+
+		for ( const styleVariablesKey in styleVariables ) {
+			formNode.style.setProperty( styleVariablesKey, styleVariables[ styleVariablesKey ] );
+		}
 	}
 }

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -195,6 +195,7 @@
 
 .wp-block-jetpack-contact-form > * {
 	flex: 0 0 100%;
+	box-sizing: border-box;
 }
 
 /* Added circa Nov 2022: container class assigned to topmost block div */
@@ -334,7 +335,7 @@
 	border-style: var(--jetpack--contact-form--border-style);
 	border-width: var(--jetpack--contact-form--border-size);
 	border-radius: var(--jetpack--contact-form--border-radius);
-	background-color: var(--jetpack--contact-form--input-background);
+	background-color: var(--jetpack--contact-form--input-background-fallback);
 	color: var(--jetpack--contact-form--text-color);
 	font-size: var(--jetpack--contact-form--font-size);
 	font-family: var(--jetpack--contact-form--font-family);
@@ -362,7 +363,7 @@
 .contact-form .contact-form-dropdown__menu .ui-menu .ui-menu-item-wrapper.ui-state-active {
 	position: relative;
 	border: none;
-	color: var(--jetpack--contact-form--input-background);
+	color: var(--jetpack--contact-form--input-background-fallback);
 	background-color: var(--jetpack--contact-form--text-color);
 }
 
@@ -392,7 +393,6 @@
 
 .contact-form :not(.is-style-outlined):not(.is-style-animated) .grunion-field-wrap .grunion-checkbox-multiple-options,
 .contact-form :not(.is-style-outlined):not(.is-style-animated) .grunion-field-wrap .grunion-radio-options {
-	background-color: var(--jetpack--contact-form--input-background);
 	border-radius: var(--jetpack--contact-form--border-radius);
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/74001

## Proposed changes:

* Fix Forms styles when inside Cover blocks. More context in the issue above

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Follow the steps described in the issue above
* You shouldn't be able to reproduce the issue

