### PR TITLE
Launchpad: Add link-in-bio task logic to endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-link-in-bio-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-link-in-bio-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Launchpad: Add link-in-bio task logic to endpoint

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -95,7 +95,7 @@ function get_task_definitions() {
 		'first_post_published'
 			=> array(
 				'id'        => 'first_post_published',
-				'completed' => get_checklist_task( first_post_published ),
+				'completed' => get_checklist_task( 'first_post_published' ),
 				'disabled'  => false,
 			),
 		'first_post_published_newsletter'

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -95,7 +95,7 @@ function get_task_definitions() {
 		'first_post_published'
 			=> array(
 				'id'        => 'first_post_published',
-				'completed' => get_checklist_task( first_post_published ) . completed,
+				'completed' => get_checklist_task( first_post_published ),
 				'disabled'  => false,
 			),
 		'first_post_published_newsletter'
@@ -113,20 +113,23 @@ function get_task_definitions() {
 		'setup_link_in_bio'
 			=> array(
 				'id'        => 'setup_link_in_bio',
+				'title'     => __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' ),
 				'completed' => true,
 				'disabled'  => false,
 			),
 		'links_added'
 			=> array(
 				'id'        => 'links_added',
-				'completed' => false,
+				'title'     => __( 'Add links', 'jetpack-mu-wpcom' ),
+				'completed' => get_checklist_task( 'links_edited' ),
 				'disabled'  => false,
 			),
 		'link_in_bio_launched'
 			=> array(
 				'id'        => 'link_in_bio_launched',
-				'completed' => false,
-				'disabled'  => true,
+				'title'     => __( 'Launch your site', 'jetpack-mu-wpcom' ),
+				'completed' => get_checklist_task( 'site_launched' ),
+				'disabled'  => ! get_checklist_task( 'links_added' ),
 			),
 		'videopress_setup'
 			=> array(


### PR DESCRIPTION
## Proposed Changes

This PR ensures we return correct title, complete status, and enabled status for link-in-bio tasks from the new launchpad endpoint. 

## Testing instructions:

1. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-link-in-bio-logic` to build and sync this branch to your sandbox. 
2. Sandbox a test site. 
3. Start a new link in bio site from https://wordpress.com/setup/link-in-bio/intro, and proceed to launchpad. 
4. Go to `https://developer.wordpress.com/docs/api/console/`, select Rest API and wpcom/v2, and input the following: `/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=link-in-bio`. Confirm you get back an appropriate checklist that matches the status of checklist items on Launchpad. 
5. Go back to the frontend launchpad screen from Step 3, and try completing one or more tasks. After each step, re-run the test in Step 4. You should alway see the correct task status in the developer console, matching the status of tasks on the frontend Launchpad. 

## Does this pull request change what data or activity we track or use?

No.