### PR TITLE
Blocks: update CLI to only input strings in descriptions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-block-skeleton
+++ b/projects/plugins/jetpack/changelog/update-block-skeleton
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: update block cli structure to only use strings in descriptions

--- a/projects/plugins/jetpack/wp-cli-templates/block-index-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-index-js.mustache
@@ -15,12 +15,7 @@ export const name = '{{ slug }}';
 export const title = __( '{{ title }}', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( '{{ description }}', 'jetpack' ) }</p>
-			<ExternalLink href="#">{ __( 'Learn more about {{ title }}', 'jetpack' ) }</ExternalLink>
-		</Fragment>
-	),
+	description: __( '{{ description }}', 'jetpack' ),
 	icon: {
 		src: icon,
 		foreground: getIconColor(),

--- a/projects/plugins/jetpack/wp-cli-templates/block-register-php.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-register-php.mustache
@@ -2,7 +2,7 @@
 /**
  * {{ title }} Block.
  *
- * @since 11.9
+ * @since $$next-version$$
  *
  * @package automattic/jetpack
  */


### PR DESCRIPTION
See #26792

## Proposed changes:

Let's not encourage the use of non-strings in block descriptions; only strings should be used from now on.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here, but you could try to run `jetpack docker wp jetpack scaffold block something` and check the files being created.

