### PR TITLE
VideoPress: do not save video block representation

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-do-not-save-html-representation-of-video-block
+++ b/projects/packages/videopress/changelog/update-videopress-do-not-save-html-representation-of-video-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: do not save video block representation

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -188,9 +188,10 @@ class Initializer {
 		global $wp_embed;
 
 		// CSS classes
-		$align       = isset( $block_attributes['align'] ) ? $block_attributes['align'] : null;
-		$align_class = $align ? ' align' . $align : '';
-		$classes     = 'wp-block-jetpack-videopress jetpack-videopress-player' . $align_class;
+		$align        = isset( $block_attributes['align'] ) ? $block_attributes['align'] : null;
+		$align_class  = $align ? ' align' . $align : '';
+		$custom_class = isset( $block_attributes['className'] ) ? ' ' . $block_attributes['className'] : '';
+		$classes      = 'wp-block-jetpack-videopress jetpack-videopress-player' . $custom_class . $align_class;
 
 		// Inline style
 		$style     = '';

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -225,6 +225,12 @@ class Initializer {
 			$figcaption = sprintf( '<figcaption>%s</figcaption>', wp_kses_post( $caption ) );
 		}
 
+		// Custom anchor from block content
+		$id_attribute = '';
+		if ( preg_match( '/<figure[^>]*id="([^"]+)"/', $content, $matches ) ) {
+			$id_attribute = sprintf( 'id="%s"', $matches[1] );
+		}
+
 		// Preview On Hover data
 		$preview_on_hover = '';
 		if (
@@ -245,7 +251,7 @@ class Initializer {
 		}
 
 		$figure_template = '
-		<figure class="%1$s" style="%2$s">			
+		<figure %6$s class="%1$s" style="%2$s">			
 			%3$s
 			%4$s
 			%5$s
@@ -271,7 +277,8 @@ class Initializer {
 			esc_attr( $style ),
 			$preview_on_hover,
 			$video_wrapper,
-			$figcaption
+			$figcaption,
+			$id_attribute
 		);
 	}
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -227,7 +227,12 @@ class Initializer {
 
 		// Custom anchor from block content
 		$id_attribute = '';
-		if ( preg_match( '/<figure[^>]*id="([^"]+)"/', $content, $matches ) ) {
+
+		// Try to get the custom anchor from the block attributes.
+		if ( isset( $block_attributes['anchor'] ) && $block_attributes['anchor'] ) {
+			$id_attribute = sprintf( 'id="%s"', $block_attributes['anchor'] );
+		} elseif ( preg_match( '/<figure[^>]*id="([^"]+)"/', $content, $matches ) ) {
+			// Othwerwise, try to get the custom anchor from the <figure /> element.
 			$id_attribute = sprintf( 'id="%s"', $matches[1] );
 		}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -19,6 +19,9 @@
 		"autoplay": {
 			"type": "boolean"
 		},
+		"anchor": {
+			"type": "string"
+		},
 		"title": {
 			"type": "string"
 		},

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -26,9 +26,7 @@
 			"type": "string"
 		},
 		"caption": {
-			"type": "string",
-			"source": "html",
-			"selector": "figcaption"
+			"type": "string"
 		},
 		"controls": {
 			"type": "boolean",

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/deprecated/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/deprecated/index.tsx
@@ -6,12 +6,12 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { getVideoPressUrl } from '../../../lib/url';
+import { getVideoPressUrl } from '../../../../lib/url';
+import { isVideoFramePosterEnabled } from '../components/poster-panel';
 /**
  * Types
  */
-import { isVideoFramePosterEnabled } from './components/poster-panel';
-import type { VideoBlockAttributes } from './types';
+import type { VideoBlockAttributes } from '../types';
 import type React from 'react';
 
 type videoBlockSaveProps = {
@@ -25,7 +25,7 @@ type videoBlockSaveProps = {
  * @param {object} props.attributes  - Block attributes.
  * @returns {object}                 - React component.
  */
-export default function save( { attributes }: videoBlockSaveProps ): React.ReactNode {
+function save( { attributes }: videoBlockSaveProps ): React.ReactNode {
 	const {
 		align,
 		autoplay,
@@ -91,3 +91,119 @@ export default function save( { attributes }: videoBlockSaveProps ): React.React
 		</figure>
 	);
 }
+
+const attributes = {
+	autoplay: {
+		type: 'boolean',
+	},
+	title: {
+		type: 'string',
+	},
+	description: {
+		type: 'string',
+	},
+	caption: {
+		type: 'string',
+		source: 'html',
+		selector: 'figcaption',
+	},
+	controls: {
+		type: 'boolean',
+		default: true,
+	},
+	loop: {
+		type: 'boolean',
+	},
+	maxWidth: {
+		type: 'string',
+		default: '100%',
+	},
+	muted: {
+		type: 'boolean',
+	},
+	playsinline: {
+		type: 'boolean',
+	},
+	preload: {
+		type: 'string',
+		default: 'metadata',
+	},
+	seekbarPlayedColor: {
+		type: 'string',
+		default: '',
+	},
+	seekbarLoadingColor: {
+		type: 'string',
+		default: '',
+	},
+	seekbarColor: {
+		type: 'string',
+		default: '',
+	},
+	useAverageColor: {
+		type: 'boolean',
+		default: true,
+	},
+	id: {
+		type: 'number',
+	},
+	guid: {
+		type: 'string',
+	},
+	src: {
+		type: 'string',
+	},
+	cacheHtml: {
+		type: 'string',
+		default: '',
+	},
+	poster: {
+		type: 'string',
+	},
+	posterData: {
+		type: 'object',
+		default: {},
+	},
+	videoRatio: {
+		type: 'number',
+	},
+	tracks: {
+		type: 'array',
+		items: {
+			type: 'object',
+		},
+		default: [],
+	},
+	privacySetting: {
+		type: 'number',
+		default: 1,
+	},
+	allowDownload: {
+		type: 'boolean',
+		default: true,
+	},
+	displayEmbed: {
+		type: 'boolean',
+		default: true,
+	},
+	rating: {
+		type: 'string',
+	},
+	isPrivate: {
+		type: 'boolean',
+	},
+	isExample: {
+		type: 'boolean',
+		default: false,
+	},
+	duration: {
+		type: 'number',
+	},
+};
+
+export default [
+	{
+		attributes,
+		save,
+	},
+];

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/deprecated/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/deprecated/index.tsx
@@ -205,6 +205,7 @@ export default [
 	{
 		attributes,
 		supports: {
+			align: true,
 			anchor: true,
 		},
 		save,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/deprecated/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/deprecated/index.tsx
@@ -204,6 +204,9 @@ const attributes = {
 export default [
 	{
 		attributes,
+		supports: {
+			anchor: true,
+		},
 		save,
 	},
 ];

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
@@ -8,8 +8,8 @@ import { registerBlockType } from '@wordpress/blocks';
 import editorImageURL from '../../utils/editor-image-url';
 import metadata from './block.json';
 import { VideoPressIcon as icon } from './components/icons';
+import deprecated from './deprecated';
 import Edit from './edit';
-import save from './save';
 import transforms from './transforms';
 import videoPressBlockExampleImage from './videopress-block-example-image.jpg';
 import './style.scss';
@@ -19,7 +19,7 @@ export const { name, title, description, attributes } = metadata;
 registerBlockType( name, {
 	edit: Edit,
 	title,
-	save,
+	save: () => null,
 	icon,
 	attributes,
 	example: {
@@ -29,4 +29,5 @@ registerBlockType( name, {
 		},
 	},
 	transforms,
+	deprecated,
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Since the block is rendered on the server-side (https://github.com/Automattic/jetpack/pull/30036), saving the block representation is not needed anymore.
This PR adds the changes to stop doing that and handles the block validations issue.

Follow-up of https://github.com/Automattic/jetpack/pull/30036
Fixes https://github.com/Automattic/jetpack/issues/29987

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: do not save video block representation

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Pasting almost the same testing instructions described in the prev [PR](https://github.com/Automattic/jetpack/pull/30036):

In terms of functionality, there should be no changes when using the VideoPress video block between the Jetpack stable version and this branch. Thus

#### Create a VideoPress video block in prod dev-env

* Create a JN site with the Jetpack beta plugin installed
* Disable `beta` extensions
* Start using the Jetpack stable release (the default one)
* Connect the site
* Enable the VideoPress video module
* Go to the block editor and create a VideoPress video block
* Customize the instance (autoplay, control, loop, etc.)
	- [ ] allowDownload
	- [ ] autoplay
	- [ ] caption
	- [ ] controls
	- [ ] description
	- [ ] duration
	- [ ] id
	- [ ] isPrivate
	- [ ] loop
	- [ ] muted
	- [ ] playsinline
	- [ ] poster
	- [ ] preload
	- [ ] privacySetting
	- [ ] rating
	- [ ] seekbarColor
	- [ ] seekbarLoadingColor
	- [ ] seekbarPlayedColor
	- [ ] title
	- [ ] tracks
	- [ ] useAverageColor

* Set block caption, too
* Save the post
* Check the block in the front-end

#### Tesitng this branch

* Switch to this branch by using the Jetpack beta plugin

<img width="600" alt="Screen Shot 2023-04-11 at 16 56 49" src="https://user-images.githubusercontent.com/77539/231274685-8cd61624-0b6e-4315-9620-ae7650b38ec3.png">

* Enable `beta` extensions

<img width="600" alt="Screen Shot 2023-04-11 at 16 58 52" src="https://user-images.githubusercontent.com/77539/231275140-a9739989-4634-4ad7-b9a4-6a1bf819404b.png">

* Go back to the block editor. Same post.
* Hard-refresh
* Confirm you are in the proper branch, taking a look at the Preview On Hover toggle

<img width="600" alt="Screen Shot 2023-04-11 at 17 00 19" src="https://user-images.githubusercontent.com/77539/231275481-fda78e98-e1ea-40cc-adfe-9a244a7f8054.png">

* It should not be any change (no block validation errors, for instance)
* Test in the front-end
* Confirm the previous settings are preserved (autoplay, control, loop, etc)

* Go to the block editor
* Enable Preview On Hover
* Save the post
* Go to the front-end
* Confirm it works as expected 

Repeat the test but for Simple and Atomic sites.