### PR TITLE
ci: Run PHP 8.1 and 8.2 against WP latest now

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -55,7 +55,7 @@ $default_matrix_vars = array(
 $matrix = array();
 
 // Add PHP tests.
-foreach ( array( '5.6', '7.0', '7.2', '7.3', '7.4', '8.0' ) as $php ) {
+foreach ( array( '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ) as $php ) {
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP $php WP latest",
 		'script'  => 'test-php',
@@ -64,24 +64,6 @@ foreach ( array( '5.6', '7.0', '7.2', '7.3', '7.4', '8.0' ) as $php ) {
 		'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
 	);
 }
-// Merge this into the above once we decide PHP 8.1 is stable and WP latest works with 8.1.
-$matrix[] = array(
-	'name'                => 'PHP tests: PHP 8.1 WP trunk',
-	'script'              => 'test-php',
-	'php'                 => '8.1',
-	'wp'                  => 'trunk',
-	'timeout'             => 20, // 2022-12-19: The WorDBless WP version bump adds up to ~30s extra per project using it, which adds up.
-	'force-package-tests' => true,
-);
-// Merge this into the above once we decide PHP 8.2 is stable and WP latest works with 8.2.
-$matrix[] = array(
-	'name'                => 'PHP tests: PHP 8.2 WP trunk',
-	'script'              => 'test-php',
-	'php'                 => '8.2',
-	'wp'                  => 'trunk',
-	'timeout'             => 20, // 2022-12-19: The WorDBless WP version bump adds up to ~30s extra per project using it, which adds up.
-	'force-package-tests' => true,
-);
 foreach ( array( 'previous', 'trunk' ) as $wp ) {
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP {$versions['PHP_VERSION']} WP $wp",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Now that 6.2 is latest, run the PHP 8.1 and 8.2 tests against that instead of trunk. This should speed up these tests as packages won't need WrDBless deps bumped.

Note that "PHP tests: PHP 8.1 WP trunk" and "PHP tests: PHP 8.2 WP trunk" no longer run with this PR, so we'll need to un-require them before merging this (and then require the new tests).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy, particularly the new "PHP tests: PHP 8.1 WP latest" and "PHP tests: PHP 8.2 WP latest" tests?