### PR TITLE
codesniffer: Fix test configs for PHP 8.1+

### DIFF
--- a/projects/packages/codesniffer/changelog/update-codesniffer-tests-ok-on-8.2-now
+++ b/projects/packages/codesniffer/changelog/update-codesniffer-tests-ok-on-8.2-now
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Run CI tests with PHP 8.1+ after adjusting test configs to avoid the deprecation warnings.
+
+

--- a/projects/packages/codesniffer/tests/action-skip-test-php.sh
+++ b/projects/packages/codesniffer/tests/action-skip-test-php.sh
@@ -4,9 +4,3 @@ if php -r 'exit( version_compare( PHP_VERSION, "7.4.0", "<" ) ? 0 : 1 );'; then
 	echo "PHP version is too old to run tests. 7.4 is required, but $(php -r 'echo PHP_VERSION;') is installed. Skipping.";
 	exit 3
 fi
-
-# PHPCompatibility currently fails in 8.1.
-if php -r 'exit( version_compare( PHP_VERSION, "8.0.9999999", ">" ) ? 0 : 1 );'; then
-	echo "PHP version is too new to run tests (some upstream deps don't support it). 8.0 or earlier is required, but $(php -r 'echo PHP_VERSION;') is installed. Skipping.";
-	exit 3
-fi

--- a/projects/packages/codesniffer/tests/php/tests/files/default.xml
+++ b/projects/packages/codesniffer/tests/php/tests/files/default.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <ruleset>
 
+	<config name="minimum_supported_wp_version" value="6.0" />
+	<config name="testVersion" value="5.6-"/>
+
 	<!-- Ruleset under test. -->
 	<rule ref="../../../../Jetpack/ruleset.xml" />
 

--- a/projects/packages/codesniffer/tests/php/tests/files/i18n-text_domain-default.php.ruleset.xml
+++ b/projects/packages/codesniffer/tests/php/tests/files/i18n-text_domain-default.php.ruleset.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <ruleset>
 
+	<config name="minimum_supported_wp_version" value="6.0" />
+	<config name="testVersion" value="5.6-"/>
+
 	<!-- Ruleset under test. -->
 	<rule ref="../../../../Jetpack/ruleset.xml" />
 

--- a/projects/packages/codesniffer/tests/php/tests/files/i18n-text_domain-not-set.php.ruleset.xml
+++ b/projects/packages/codesniffer/tests/php/tests/files/i18n-text_domain-not-set.php.ruleset.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <ruleset>
 
+	<config name="minimum_supported_wp_version" value="6.0" />
+	<config name="testVersion" value="5.6-"/>
+
 	<!-- Ruleset under test. -->
 	<rule ref="../../../../Jetpack/ruleset.xml" />
 

--- a/projects/packages/codesniffer/tests/php/tests/files/i18n.php.report
+++ b/projects/packages/codesniffer/tests/php/tests/files/i18n.php.report
@@ -1,13 +1,13 @@
+ 14 | ERROR | [ ] Unicode codepoint escape sequences are not supported in PHP 5.6 or earlier. Found: \u{0061}
+    |       |     (PHPCompatibility.TextStrings.NewUnicodeEscapeSequence.Found)
  17 | ERROR | [x] Mismatched text domain. Expected 'domain' but got 'wrongdomain'. (Jetpack.Functions.I18n.TextDomainMismatch)
  18 | ERROR | [x] Mismatched text domain. Expected 'domain' but got 'wrongdomain'. (Jetpack.Functions.I18n.TextDomainMismatch)
  21 | ERROR | [x] Missing domain arg. (Jetpack.Functions.I18n.MissingDomain)
  22 | ERROR | [x] Missing domain arg. (Jetpack.Functions.I18n.MissingDomain)
  25 | ERROR | [ ] Missing domain arg. (Jetpack.Functions.I18n.MissingDomain)
  26 | ERROR | [ ] Domain is not a string literal. (Jetpack.Functions.I18n.DomainNotLiteral)
- 29 | ERROR | [ ] The domain must not contain interpolated variables. Found $domain.
-    |       |     (Jetpack.Functions.I18n.InterpolatedVariable)
- 30 | ERROR | [ ] The domain must not contain interpolated variables. Found $domain.
-    |       |     (Jetpack.Functions.I18n.InterpolatedVariable)
+ 29 | ERROR | [ ] The domain must not contain interpolated variables. Found $domain. (Jetpack.Functions.I18n.InterpolatedVariable)
+ 30 | ERROR | [ ] The domain must not contain interpolated variables. Found $domain. (Jetpack.Functions.I18n.InterpolatedVariable)
  33 | ERROR | [x] Mismatched text domain. Expected 'domain' but got 'a $domain'. (Jetpack.Functions.I18n.TextDomainMismatch)
  44 | ERROR | [x] Short array syntax is not allowed (Universal.Arrays.DisallowShortArraySyntax.Found)
  45 | ERROR | [x] Short array syntax is not allowed (Universal.Arrays.DisallowShortArraySyntax.Found)
@@ -22,5 +22,4 @@
  64 | ERROR | [x] Mismatched text domain. Expected 'domain' but got 'wrongdomain'. (Jetpack.Functions.I18n.TextDomainMismatch)
  65 | ERROR | [x] Mismatched text domain. Expected 'domain' but got 'wrongdomain'. (Jetpack.Functions.I18n.TextDomainMismatch)
  72 | ERROR | [x] Mismatched text domain. Expected 'domain' but got 'wrongdomain'. (Jetpack.Functions.I18n.TextDomainMismatch)
- 77 | ERROR | [ ] The domain must not contain interpolated variables. Found $domain.
-    |       |     (Jetpack.Functions.I18n.InterpolatedVariable)
+ 77 | ERROR | [ ] The domain must not contain interpolated variables. Found $domain. (Jetpack.Functions.I18n.InterpolatedVariable)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We added the skipping a while back because PHPCompatibility didn't work with 8.1 at the time, throwing deprecation warnings. It turns out we can avoid those deprecation warnings by setting the config entries it's trying to read, so let's do that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
