### PR TITLE
Add import package end endpoint

### DIFF
--- a/projects/packages/import/changelog/add-uimp-end-endpoint
+++ b/projects/packages/import/changelog/add-uimp-end-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added Unified Importer end endpoint

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-import",
-	"version": "0.7.0-alpha",
+	"version": "0.7.1-alpha",
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
 	"bugs": {

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-import",
-	"version": "0.7.1-alpha",
+	"version": "0.7.0-alpha",
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
 	"bugs": {

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -69,6 +69,7 @@ class Main {
 			'categories'     => new Endpoints\Category(),
 			'comments'       => new Endpoints\Comment(),
 			'custom-css'     => new Endpoints\Custom_CSS(),
+			'end'            => new Endpoints\End(),
 			'global-styles'  => new Endpoints\Global_Style(),
 			'media'          => new Endpoints\Attachment(),
 			'menu-items'     => new Endpoints\Menu_Item(),
@@ -78,8 +79,8 @@ class Main {
 			'posts'          => new Endpoints\Post(),
 			'start'          => new Endpoints\Start(),
 			'tags'           => new Endpoints\Tag(),
-			'templates'      => new Endpoints\Template(),
 			'template-parts' => new Endpoints\Template_Part(),
+			'templates'      => new Endpoints\Template(),
 		);
 
 		/**

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.7.1-alpha';
+	const PACKAGE_VERSION = '0.7.0-alpha';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.7.0-alpha';
+	const PACKAGE_VERSION = '0.7.1-alpha';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/import/src/endpoints/class-end.php
+++ b/projects/packages/import/src/endpoints/class-end.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * End REST route
+ *
+ * @package automattic/jetpack-import
+ */
+
+namespace Automattic\Jetpack\Import\Endpoints;
+
+/**
+ * Class End
+ *
+ * This class is used to start the import process.
+ */
+class End extends \WP_REST_Controller {
+
+	/**
+	 * Base class
+	 */
+	use Import;
+
+	/**
+	 * The Import ID add a new item to the schema.
+	 */
+	use Import_ID;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->rest_base = 'end';
+	}
+
+	/**
+	 * Get the register route options.
+	 *
+	 * @see register_rest_route()
+	 *
+	 * @return array The options.
+	 */
+	protected function get_route_options() {
+		return array(
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'cleanup_database' ),
+				'permission_callback' => array( $this, 'import_permissions_callback' ),
+				'args'                => array(),
+			),
+			'schema' => array( $this, 'get_public_item_schema' ),
+		);
+	}
+
+	/**
+	 * Retrieves the start values schema, conforming to JSON Schema.
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'import-end',
+			'type'       => 'object',
+			'properties' => array(
+				'commentmeta_count' => array(
+					'description' => __( 'Comment meta deleted count.', 'jetpack-import' ),
+					'type'        => 'integer',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'postmeta_count'    => array(
+					'description' => __( 'Post meta deleted count.', 'jetpack-import' ),
+					'type'        => 'integer',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'termmeta_count'    => array(
+					'description' => __( 'Term meta deleted count.', 'jetpack-import' ),
+					'type'        => 'integer',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		$this->schema = $schema;
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+
+	/**
+	 * Delete all meta values from database.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or error object on failure.
+	 */
+	public function cleanup_database( $request ) {
+		global $wpdb;
+
+		$where = array( 'meta_key' => $this->import_id_field_name );
+
+		return array(
+			'commentmeta_count' => $wpdb->delete( $wpdb->commentmeta, $where ),
+			'postmeta_count'    => $wpdb->delete( $wpdb->postmeta, $where ),
+			'termmeta_count'    => $wpdb->delete( $wpdb->termmeta, $where ),
+		);
+	}
+}

--- a/projects/packages/import/src/endpoints/class-end.php
+++ b/projects/packages/import/src/endpoints/class-end.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 /**
  * End REST route
  *
@@ -96,6 +96,8 @@ class End extends \WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or error object on failure.
+	 *
+	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	 */
 	public function cleanup_database( $request ) {
 		global $wpdb;


### PR DESCRIPTION
This PR adds an end start endpoint to the Unified Importer, that cleanup up all the importer artifacts.

See https://github.com/Automattic/dotcom-forge/issues/2041 for additional information.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new `jetpack/v4/import/end` endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See D107810-code for detailed instructions.