### PR TITLE
VideoPress: check guid before to get the VideoPress video url

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-check-guid-before-to-get-url
+++ b/projects/packages/videopress/changelog/update-videopress-check-guid-before-to-get-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: check guid attribute before to get the VideoPress video url

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -252,7 +252,8 @@ class Initializer {
 		';
 
 		// VideoPress URL
-		$videopress_url = Utils::get_video_press_url( $block_attributes['guid'], $block_attributes );
+		$guid           = isset( $block_attributes['guid'] ) ? $block_attributes['guid'] : null;
+		$videopress_url = Utils::get_video_press_url( $guid, $block_attributes );
 
 		$video_wrapper = '';
 		if ( $videopress_url ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue when a new VideoPress video instance is created. On this point, the `guid` is not defined generating a  PHP warning:

```cli
[13-Apr-2023 17:01:52 UTC] PHP Warning:  Undefined array key "guid" in /usr/local/src/jetpack-monorepo/projects/packages/videopress/src/class-initializer.php on line 256
```

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: check guid attribute before to get the VideoPress video url.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a new VideoPress video instance
* Confirm that, on the server side, there is no PHP warning:
```
[13-Apr-2023 17:01:52 UTC] PHP Warning:  Undefined array key "guid" in /usr/local/src/jetpack-monorepo/projects/packages/videopress/src/class-initializer.php on line 256
```

