### PR TITLE
CRM: Fixes Mailpoet Sync removing avatar

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3054-mailpoet-sync-removing-avatar
+++ b/projects/plugins/crm/changelog/fix-crm-3054-mailpoet-sync-removing-avatar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Mailpoet Sync: Fixed an issue where contact images would disappear after synchronization.

--- a/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-background-sync-job.php
+++ b/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-background-sync-job.php
@@ -506,8 +506,12 @@ class Mailpoet_Background_Sync_Job {
 		//$this->debug( 'Add/Update contact: <pre>' . var_export( $contact_args ) . '</pre>' );
 
 		// Add/update the contact & return id
-		return $zbs->DAL->contacts->addUpdateContact( $contact_args );
-
+		return $zbs->DAL->contacts->addUpdateContact( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			array(
+				'data'                 => $contact_args['data'],
+				'do_not_update_blanks' => true,
+			)
+		);
 	}
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

* This PR fixes an issue where contact images would disappear after synchronization.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3054

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate Mailpoet
* Activate Mailpoet Sync in the CRM core modules (`/wp-admin/admin.php?page=zerobscrm-modules`)
* In General Settings (`/wp-admin/admin.php?page=zerobscrm-plugin-settings`), set `Contact Image Mode:` to `Custom Images`.
* Add a contact with a custom image (`wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=contact`)
* Do a Mailpoet Sync (`wp-admin/admin.php?page=crm-mail-poet-hub`)

In `trunk` the contact's image will be removed
In `fix/crm-3054-mailpoet-sync-removing-avatar` the contact's image will be preserved




