### PR TITLE
CRM: Swap stacked logo for horizontal

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3001-swap-stacked-logo-for-horizontal
+++ b/projects/plugins/crm/changelog/fix-crm-3001-swap-stacked-logo-for-horizontal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+CRM Menu: Swap the stacked logo to the horizontal one

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -276,7 +276,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 		<div class="ui mobile tablet only" id="zbs-mobile-nav">
 			<div id="zbs-main-logo-mobile">
 				<div class="zbs-face-1-mobile">
-					<img id="zbs-main-logo-mobby" alt="Jetpack CRM mobile logo" src="<?php echo esc_url( jpcrm_get_logo( true, 'white' ) ); ?>" style="cursor:pointer;">
+					<img id="zbs-main-logo-mobby" alt="Jetpack CRM mobile logo" src="<?php echo esc_url( jpcrm_get_logo( false, 'white' ) ); ?>" style="cursor:pointer;">
 				</div>
 			</div>
 			<?php
@@ -347,7 +347,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 		<div class="item <?php echo esc_attr( $admin_menu_state ); ?> mobile hidden" id="zbs-main-logo-wrap">
 			<div class="zbs-cube" id="zbs-main-logo-cube-wrap">
 				<div class="zbs-face1">
-					<img id="zbs-main-logo" alt="Jetpack CRM logo" src="<?php echo esc_url( jpcrm_get_logo() ); ?>" style="cursor:pointer;">
+					<img id="zbs-main-logo" alt="Jetpack CRM logo" src="<?php echo esc_url( jpcrm_get_logo( false ) ); ?>" style="cursor:pointer;">
 				</div>
 				<div class="zbs-face2">
 					<i class="expand icon fa-flip-horizontal"></i>

--- a/projects/plugins/crm/sass/_JetpackCRM.admin.overrides.scss
+++ b/projects/plugins/crm/sass/_JetpackCRM.admin.overrides.scss
@@ -71,9 +71,9 @@
  }
 
  .zbs-cube{
-	 width:80px !important;
+	 width: 120px !important;
 	 img{
-		 max-width: 80px !important;
+		 max-width: 120px !important;
 	 }
  }
  

--- a/projects/plugins/crm/sass/_ZeroBSCRM.adminmenu.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.adminmenu.scss
@@ -74,7 +74,7 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:a
 // http://cssdeck.com/labs/css3-flipping-cube
 /* Container box to set the sides relative to */
 .zbs-cube {
-	width: 30px;
+	width: 50px;
 	text-align: center;
 	margin: 0 auto;
 	height: 30px;
@@ -86,7 +86,7 @@ ul#adminmenu a.wp-has-current-submenu:after, ul#adminmenu>li.current>a.current:a
 	transform-style: preserve-3d; /* <-NB */
 }
 .zbs-cube img {
-	max-width:30px;
+	max-width:50px;
 }
 .zbs-cube .fa, .zbs-cube .icon {
 	height:30px;width:30px;font-size:30px;

--- a/projects/plugins/crm/sass/_ZeroBSCRM.mobile.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.mobile.scss
@@ -135,7 +135,7 @@
 
         #zbs-main-logo-mobile{
             img{
-                width:45px;
+                width:85px;
                 cursor:pointer;
                 height:auto;
             }
@@ -297,7 +297,7 @@
 @media only screen and (max-width: 600px) {
     #wpcontent {
             #zbs-mobile-nav.ui.mobile.only{
-                padding-top: 40px;
+                padding-top: 55px;
             }
     }
 }
@@ -385,7 +385,7 @@
 
         #zbs-main-logo-mobile{
             img{
-                width:45px;
+                width:85px;
                 cursor:pointer;
                 height:auto;
             }


### PR DESCRIPTION
## Proposed changes:
* This PR changes the CRM's header logo from the stacked one (vertical) to a horizontal one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3001

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Open the dashboard
* Shrink it down to mobile size (we have a different logo for the  mobile version)

In `trunk` the logo for both versions will be the vertical one.

![image](https://user-images.githubusercontent.com/37049295/231877586-14543696-116f-46a6-ba43-faf812a0e19a.png)

![image](https://user-images.githubusercontent.com/37049295/231877655-92e91f3c-1092-488e-a163-f9357cd4b501.png)


In `fix/crm-3001-swap-stacked-logo-for-horizontal` the logo for both versions will be the horizontal one.

![image](https://user-images.githubusercontent.com/37049295/231877106-2a8c20ab-bf92-4520-8394-2fcc1e246d1a.png)

![image](https://user-images.githubusercontent.com/37049295/231877183-c361f011-9411-4216-8a9e-8526812bd28c.png)


