### PR TITLE
Staging Sites: Use our custom function instead of blog sticker

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-staging-sites-avoid-blog-sticker
+++ b/projects/plugins/jetpack/changelog/improve-staging-sites-avoid-blog-sticker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Switches `is_wpcom_staging_site()` to our custom function instead of a blog sticker.

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -483,8 +483,8 @@ abstract class SAL_Site {
 	 * @return bool
 	 */
 	public function is_wpcom_staging_site() {
-		if ( function_exists( 'has_blog_sticker' ) ) {
-			return has_blog_sticker( 'staging_site' );
+		if ( function_exists( 'is_blog_wpcom_staging' ) ) {
+			return is_blog_wpcom_staging( $this->blog_id );
 		}
 		return false;
 	}


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/2163
See D107842-code

## Proposed changes:

Switches to `is_blog_wpcom_staging()` as the source of truth, instead of a blog sticker.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

N/A

## Testing instructions:

See D107842-code