### PR TITLE
CRM: fix logo removal on Invoice Edit page

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-invoice-logo-remove
+++ b/projects/plugins/crm/changelog/fix-crm-invoice-logo-remove
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Invoices: fix ability to remove logo from invoice edit page.

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -1972,6 +1972,7 @@ function zbscrm_JS_bind_invoice_actions() {
 			jQuery( '#wh-logo-set-img' ).attr( 'src', '' ).hide();
 			jQuery( '#zbs_invoice_logo' ).val( '' );
 			jQuery( '.wh-logo' ).removeClass( 'hide' ).show();
+			jQuery( '.wh-logo-set input' ).val( '' );
 			jQuery( '.wh-logo-set' ).hide();
 		} );
 	jQuery( '.business-info-toggle' )


### PR DESCRIPTION

## Proposed changes:

* This PR makes sure that the invoice bind actions when removing a logo include setting the logo input value to empty. After removing a logo on the Invoice Edit page and then clicking 'Update', any logo added manually (or automatically if the logo was set on the Business Info page - `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=bizinfo`) will be removed and that removal will be respected.
* It looks like not having the ability to remove the logo (despite having a remove button) has been the case as far back as the ability to add the logo appears to have been there (for example testing back down to the 2.* versions).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3058

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Testing on trunk (or any most other prior stable versions of Jetpack CRM), create a new invoice and add a new logo to it.
* Click on 'Save', then on the edit invoice page attempt to remove the logo using the 'Remove' link visible when hovering over the logo. The logo should be removed on this pre-saved page. 
* Click on 'Update' and the logo will re-appear.
* Try adding a logo to the Business Info page - `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=bizinfo` and then create a new Invoice. Follow the same steps to try and remove that logo - it should re-appear.
* Using the [Jetpack Beta plugin](https://github.com/Automattic/jetpack-beta) on a test site with this branch applied or testing locally with the branch checked out, follow the same steps as above. Whenever removing a logo, the logo removal should now be respected.


