### PR TITLE
Gardening: don't trigger automated triage during triage

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-triage-priority-handling-events
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-triage-priority-handling-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Triage: ensure we do not trigger triaging on events when a laabel that would impact our automated triage is already being added.


### PR DESCRIPTION
## Proposed changes:

The Triage Issues task runs when new issues are being created, but also when issues are labeled.
We do not want to start adding labels automatically (doing our own automated triage) when the action that triggered this was someone making changes to labels that would impact our automated triage.

So our automated triage must be aware of labels being added to the issue right now, in addition of being aware of issues already existing on the issue.

See p1681411170005189/1681404941.879739-slack-C04TRTZUSP9 where this was discovered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1681411170005189/1681404941.879739-slack-C04TRTZUSP9

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This will need to be tested on a fork. I will add links below.

* High priority issue created here:
    * https://github.com/jeherve/jetpack/issues/91
    * The high priority label is properly added, along the escalated label
    * It gets posted to Slack: p1681474075427179-slack-CN2FSK7L4
    * Nothing happens when posting a comment
    * Adding a Priority label and removing the Escalated label doesn't cause the Escalated label to be added again => This was happening before this patch, see this issue for an example of the bug: https://github.com/Automattic/wp-calypso/issues/75728#event-9000969272
 * No Priority bug created here:
     * https://github.com/jeherve/jetpack/issues/93
     * The TBD Priority label gets added, and a Slack notification will get posted
     * p1681475305686649-slack-CN2FSK7L4
     * After adding a high priority label manually, it gets escalated:
     * p1681475441999579-slack-CN2FSK7L4