### PR TITLE
Social: Fix upgrade nudges not showing

### DIFF
--- a/projects/plugins/social/changelog/fix-upgrade-nudges-not-showing
+++ b/projects/plugins/social/changelog/fix-upgrade-nudges-not-showing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Temporarily removed review prompts to fix the plugin's UI state.

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -112,7 +112,6 @@ class Jetpack_Social {
 
 		// Add block editor assets
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_scripts' ) );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_review_prompt' ) );
 
 		// Add meta tags.
 		add_action( 'wp_head', array( new Automattic\Jetpack\Social\Meta_Tags(), 'render_tags' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Jetpack Social's paid features are broken on the trunk branch currently. When you don't have a paid plan, the upgrade nudges don't show up. Along with that, the initial state of the plugin isn't set up correctly. This was inadvertently introduced in https://github.com/Automattic/jetpack/pull/29910  through this bit of code https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/social/src/class-jetpack-social.php#L361-L372, which overrides the initial state in https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/social/src/class-jetpack-social.php#L316. 

This is the [PR](https://github.com/Automattic/jetpack/pull/27917) which originally added the review prompts. But this [line](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/social/src/class-jetpack-social.php#L295) sets the state for the Social plugin only if the Jetpack plugin is not active which leads to https://github.com/Automattic/jetpack/pull/29910 being created, I presume. That accidentally stomped over the plugin's initial state. 

I am not entirely sure how to go about fixing the review prompts when both the plugins are active, requires a bit of thinking I would reckon, but to restore the plugin to a working state I have the code that enqueues the review prompt-related script. I wonder if we can revert https://github.com/Automattic/jetpack/pull/29910 to reinstate the user reviews at least in the case where only the social plugin is active. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Remove any paid plans on your test site and boot up your Jetpack Site on **trunk**.  You won't see the upgrade nudge for Jetpack Social in the sidebar. 
<img width="259" alt="Screenshot 2023-04-14 at 16 53 48" src="https://user-images.githubusercontent.com/6594561/232031247-48a41f47-93e1-4b51-afb5-e27e0c030042.png">

* Switch to this branch and you will see that the nudge shows up. 

