### PR TITLE
CRM: Resolves 2840 - tag existing contacts with WooSync

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-2840-woosync_tag_existing_contacts
+++ b/projects/plugins/crm/changelog/fix-crm-2840-woosync_tag_existing_contacts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+WooSync: tag existing contacts with new orders

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -846,6 +846,14 @@ class Woo_Sync_Background_Sync_Job {
 
 			$this->debug( 'Contact added/updated #' . $contact_id );
 
+			$zbs->DAL->contacts->addUpdateContactTags( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				array(
+					'id'        => $contact_id,
+					'tag_input' => $crm_object_data['contact']['tags'],
+					'mode'      => 'append',
+				)
+			);
+
 			// contact logs
 			if ( is_array( $crm_object_data['contact_logs'] ) ) {
 
@@ -1716,8 +1724,7 @@ class Woo_Sync_Background_Sync_Job {
 		// tags (contact)
 		if ( $tag_contact_with_item ) {
 
-			$data['contact']['tags']     = $order_tags;
-			$data['contact']['tag_mode'] = 'append';
+			$data['contact']['tags'] = $order_tags;
 
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#2840 - tag existing contacts with WooSync

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
TL;DR: we captured order tags, but tags weren't updated on existing contacts, because we used `addUpdateContact()` with `do_not_update_blanks`, which converts things to `limitedFields` without blanks or arrays. The `tags` param is an array, so is removed. Confused? It's messy.

This PR calls `$zbs->DAL->contacts->addUpdateContactTags()` directly to add any new tags.

Notes:
* This does NOT affect invoices or transactions, which have different logic in the DAL.
* If one deletes a tag, then saves/resyncs a WooCommerce order, the tag will be added back. I don't see this as a problem.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create an order with a product.
2. Save.
3. Verify the contact's profile was tagged with the product.
4. Add another product to the order (or create a new order for the same user).
5. Save.

In `trunk`, the contact is tagged with the original product but not subsequent ones.

In `fix/crm/2840-woosync_tag_existing_contacts`, the contact is tagged with the additional products as well.