### PR TITLE
CRM: Resolves 3031 - PHP notice when exporting subset of objects

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3031-catch_PHP_error_on_export
+++ b/projects/plugins/crm/changelog/fix-crm-3031-catch_PHP_error_on_export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Export: catch PHP notice when exporting a subset of objects

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
@@ -223,7 +223,7 @@ function jpcrm_export_process_file_export() {
 				(
 					( is_array( $objIDArr ) && count( $objIDArr ) > 0 )
 						|| $extraParams['all']
-						|| $extraParams['segment']
+						|| ( isset( $extraParams['segment'] ) && is_array( $extraParams['segment'] ) ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					)
 			) {
 
@@ -297,7 +297,7 @@ function jpcrm_export_process_file_export() {
 
 					$availObjs = $objDALLayer->getAll( $objIDArr );
 
-				} elseif ( $extraParams['segment'] ) {
+				} elseif ( isset( $extraParams['segment'] ) && is_array( $extraParams['segment'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 					// Retrieve segment.
 					$availObjs = $zbs->DAL->segments->getSegmentAudience(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3031 - PHP notice when exporting subset of objects

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Segment export was introduced in Automattic/zero-bs-crm#2735. Similar to #29482, there were some conditions that weren't accounted for. This PR catches a PHP notice I ran across (line 300), and also mitigates a potential one (line 226). 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Have at least one transaction and enable full debugging.
2. Go to the transaction list: `/wp-admin/admin.php?page=manage-transactions`
3. Select one or more transactions and choose "Export" from the bulk actions dropdown.
4. On the export page, proceed with the export.

On `trunk`, one will get a PHP notice.

On `fix/crm/3031-catch_PHP_error_on_export`, the PHP notice is no more.