### PR TITLE
Fix: Ensure Brute Force Protection Initializes on Atomic and VIP

### DIFF
--- a/projects/packages/waf/changelog/fix-brute-force-on-atomic
+++ b/projects/packages/waf/changelog/fix-brute-force-on-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix brute force protection not initializing on atomic.

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -30,23 +30,23 @@ class Waf_Initializer {
 	public static function init() {
 		// Do not run in unsupported environments
 		add_action( 'jetpack_get_available_modules', __CLASS__ . '::remove_module_on_unsupported_environments' );
-		if ( ! Waf_Runner::is_supported_environment() ) {
-			return;
-		}
-
-		// Update the WAF after installing or upgrading a relevant Jetpack plugin
-		add_action( 'upgrader_process_complete', __CLASS__ . '::update_waf_after_plugin_upgrade', 10, 2 );
-		add_action( 'admin_init', __CLASS__ . '::check_for_waf_update' );
-
-		// Activation/Deactivation hooks
-		add_action( 'jetpack_activate_module_waf', __CLASS__ . '::on_activation' );
-		add_action( 'jetpack_deactivate_module_waf', __CLASS__ . '::on_deactivation' );
 
 		// Ensure backwards compatibility
 		Waf_Compatibility::add_compatibility_hooks();
 
-		// Run the WAF
-		Waf_Runner::initialize();
+		// Run the WAF on supported environments
+		if ( Waf_Runner::is_supported_environment() ) {
+			// Update the WAF after installing or upgrading a relevant Jetpack plugin
+			add_action( 'upgrader_process_complete', __CLASS__ . '::update_waf_after_plugin_upgrade', 10, 2 );
+			add_action( 'admin_init', __CLASS__ . '::check_for_waf_update' );
+
+			// Activation/Deactivation hooks
+			add_action( 'jetpack_activate_module_waf', __CLASS__ . '::on_activation' );
+			add_action( 'jetpack_deactivate_module_waf', __CLASS__ . '::on_deactivation' );
+
+			// Run the WAF
+			Waf_Runner::initialize();
+		}
 
 		// Run brute force protection
 		Brute_Force_Protection::initialize();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

* The logic for brute force protection was recently moved into the `waf` package. 
* The `waf` package includes an `is_supported_environment()` method to prevent the firewall from running on the Atomic and VIP platforms.
* This restriction was not previously applied to brute force protection, and shouldn't have been introduced.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only apply the `is_supported_environment()` gate to the initialization of the firewall, and not brute force protection.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1681512514732049-slack-C04E0KTGW9Z

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this code on a Pressable/Atomic site and validate that you can get blocked by brute force protection.