### PR TITLE
[Boost] Fix weird rounding on pricing.

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumCTA.svelte
@@ -21,7 +21,7 @@
 	}
 
 	$: currencyObjectAfter = getCurrencyObject(
-		$config.pricing.yearly.priceAfter,
+		$config.pricing.yearly.priceAfter / 12,
 		$config.pricing.yearly.currencyCode
 	);
 </script>
@@ -33,7 +33,7 @@
 			{sprintf(
 				/* translators: %s is the price including the currency symbol in front. */
 				__( `Upgrade now only %s`, 'jetpack-boost' ),
-				currencyObjectAfter.symbol + currencyObjectAfter.integer / 12
+				currencyObjectAfter.symbol + currencyObjectAfter.integer + currencyObjectAfter.fraction
 			)}
 		</p>
 	</div>

--- a/projects/plugins/boost/changelog/boost-fix-pricing
+++ b/projects/plugins/boost/changelog/boost-fix-pricing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix pricing display, getting cherry-picked to 1.8.0 w/o changelog
+
+


### PR DESCRIPTION
We were showing weird prices like this:

![image](https://user-images.githubusercontent.com/1369626/232425124-df4e84a4-efdc-4876-81ff-8e8b05010cdb.png)

This PR fixes the issue by calculating the monthly cost of the annual plan _before_ calling `getCurrencyObject` to format it - instead of after. :) 

## Proposed changes:
* Fix weird formatting of pricing.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
* Check the Boost dashboard without any upgrades but Critical CSS turned on
* Ensure the displayed price looks right.

