### PR TITLE
General: update WordPress version requirements to 6.1.

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -39,7 +39,7 @@ case "$WP_BRANCH" in
 	previous)
 		# We hard-code the version here because there's a time near WP releases where
 		# we've dropped the old 'previous' but WP hasn't actually released the new 'latest'
-		TAG=6.0
+		TAG=6.1
 		;;
 	*)
 		echo "Unrecognized value for WP_BRANCH: $WP_BRANCH" >&2

--- a/.phpcs.config.xml
+++ b/.phpcs.config.xml
@@ -2,7 +2,7 @@
 <!-- This file configures everything except the list of rules. -->
 <!-- The separation is so .github/files/phpcompatibility-dev-phpcs.xml can use the same config with a different rule set. -->
 <ruleset>
-	<config name="minimum_supported_wp_version" value="6.0" />
+	<config name="minimum_supported_wp_version" value="6.1" />
 	<config name="testVersion" value="5.6-"/>
 
 	<!-- Use our custom filter for `.phpcsignore` and `.phpcs.dir.xml` support. -->

--- a/projects/plugins/backup/changelog/update-wp-requirements
+++ b/projects/plugins/backup/changelog/update-wp-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack VaultPress Backup ===
 Contributors: automattic, bjorsch, fgiannar, initsogar, jeherve, jwebbdev, kraftbj, macbre, samiff, sermitr, williamvianas
 Tags: jetpack
-Requires at least: 6.0
+Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
 Stable tag: 1.5

--- a/projects/plugins/jetpack/changelog/update-wp-requirements
+++ b/projects/plugins/jetpack/changelog/update-wp-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+General: Jetpack now requires WordPress version 6.1.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -8,7 +8,7 @@
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
- * Requires at least: 6.0
+ * Requires at least: 6.1
  * Requires PHP: 5.6
  *
  * @package automattic/jetpack
@@ -30,7 +30,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '6.0' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '6.1' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
 define( 'JETPACK__VERSION', '12.1-a.6' );
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, batmoo, barry, beaulebens, bindlegirl, biskobe, blobaugh, bjorsch, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, robertbpugh, roccotripaldi, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, wpkaren, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
 Stable tag: 12.0
-Requires at least: 6.0
+Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
 

--- a/projects/plugins/migration/changelog/update-wp-requirements
+++ b/projects/plugins/migration/changelog/update-wp-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/migration/readme.txt
+++ b/projects/plugins/migration/readme.txt
@@ -1,7 +1,7 @@
 === Move to WordPress.com ===
 Contributors: automattic
 Tags: migrate, migration, backup, restore, transfer, move, copy, wordpress.com, automattic, import, importer, hosting
-Requires at least: 6.0
+Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/protect/changelog/update-wp-requirements
+++ b/projects/plugins/protect/changelog/update-wp-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Protect ===
 Contributors: automattic, retrofox, leogermani, renatoagds, bjorsch, ebinnion, fgiannar, zinigor, miguelxavierpenha, dsmart, jeherve, manzoorwanijk, njweller, oskosk, samiff, siddarthan, wpkaren, arsihasi, kraftbj, kev, sermitr, kangzj, pabline, dkmyta
 Tags: jetpack, protect, security, malware, scan
-Requires at least: 6.0
+Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
 Stable tag: 1.3.0

--- a/projects/plugins/search/changelog/update-wp-requirements
+++ b/projects/plugins/search/changelog/update-wp-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Search ===
 Contributors: automattic, annamcphee, bluefuton, kangzj, jsnmoon, robfelty, gibrown, trakos, dognose24, a8ck3n
 Tags: search, filter, woocommerce search, ajax search, product search, free cloud-based search
-Requires at least: 6.0
+Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
 Stable tag: 1.4.0

--- a/projects/plugins/social/changelog/update-wp-requirements
+++ b/projects/plugins/social/changelog/update-wp-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Social  ===
 Contributors: automattic, pabline, danielpost, siddarthan, gmjuhasz
 Tags: social-media, publicize, social-media-manager, social-networking, social marketing, social, social share,  social media scheduling, social media automation, auto post, auto- publish, social share
-Requires at least: 6.0
+Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
 Stable tag: 1.9.0

--- a/projects/plugins/starter-plugin/changelog/update-wp-requirements
+++ b/projects/plugins/starter-plugin/changelog/update-wp-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/starter-plugin/readme.txt
+++ b/projects/plugins/starter-plugin/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Starter Plugin ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.0
+Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/super-cache/changelog/update-wp-requirements
+++ b/projects/plugins/super-cache/changelog/update-wp-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -1,7 +1,7 @@
 === WP Super Cache ===
 Contributors: donncha, automattic, adnan007, mikemayhem3030, ppetrov2c, pyronaur, thingalon
 Tags: performance, caching, wp-cache, wp-super-cache, cache
-Requires at least: 5.9
+Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
 Stable tag: 1.9.3

--- a/projects/plugins/videopress/changelog/update-wp-requirements
+++ b/projects/plugins/videopress/changelog/update-wp-requirements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski, nunyvega, leogermani
 Tags: video, video-hosting, video-player, cdn, vimeo, youtube, video-streaming, mobile-video, jetpack
 
-Requires at least: 6.0
+Requires at least: 6.1
 Tested up to: 6.2
 Stable tag: 1.5
 Requires PHP: 5.6

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -750,7 +750,7 @@ function createReadMeTxt( answers ) {
 		`=== Jetpack ${ answers.name } ===\n` +
 		'Contributors: automattic,\n' +
 		'Tags: jetpack, stuff\n' +
-		'Requires at least: 6.0\n' +
+		'Requires at least: 6.1\n' +
 		'Requires PHP: 5.6\n' +
 		'Tested up to: 6.2\n' +
 		`Stable tag: ${ answers.version }\n` +


### PR DESCRIPTION
See #27795

## Proposed changes:

* Now that WordPress 6.2 is available, let's start requiring n-1.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* #27795
* p9dueE-6vE-p2#comment-9128

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Nothing should change if you run WordPress 6.1 or WP 6.2.
* If you run WordPress 6.0 and had the Jetpack plugin active on your site, you will now see a notice when you load wp-admin.
