### PR TITLE
backup, videopress: Plugin changelog should not mention semver

### DIFF
--- a/projects/plugins/backup/CHANGELOG.md
+++ b/projects/plugins/backup/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 1.6 - 2023-04-04
 ### Changed

--- a/projects/plugins/backup/changelog/fix-non-semver-plugins-changelog-claiming-semver
+++ b/projects/plugins/backup/changelog/fix-non-semver-plugins-changelog-claiming-semver
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove mention of semver from changelog header, this plugin does not use semver.
+
+

--- a/projects/plugins/videopress/CHANGELOG.md
+++ b/projects/plugins/videopress/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 1.5 - 2023-03-22
 ### Added

--- a/projects/plugins/videopress/changelog/fix-non-semver-plugins-changelog-claiming-semver
+++ b/projects/plugins/videopress/changelog/fix-non-semver-plugins-changelog-claiming-semver
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove mention of semver from changelog header, this plugin does not use semver.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The Backup and VideoPress plugins use WP-style versioning rather than semver. Their changelogs should therefore not claim that they use semver.

Also, let's add some linting checks to catch this if any plugins switch to WP-style in the future, as the default changelog includes that note.

Also let's lint to restrict non-semver versioning to plugins as other project types exist in ecosystems that strongly assume semver is in use.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Revert the plugin changes in this PR. Does the linting script catch them?
* Configure some non-plugin to use non-semver versioning. Does the linting script catch that?
