### PR TITLE
VideoPress: Pause poster preview video when necessary

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-poster-frame-pause
+++ b/projects/packages/videopress/changelog/fix-videopress-poster-frame-pause
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Pause poster preview video when necessary

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.13.8",
+	"version": "0.13.9-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.13.8';
+	const PACKAGE_VERSION = '0.13.9-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -281,9 +281,7 @@ function VideoFramePicker( {
 		}
 	}, [ isGeneratingPoster, pause ] );
 
-	const onFramePickerMouseLeave = useCallback( () => {
-		pause();
-	}, [ pause ] );
+	const onFramePickerMouseLeave = useCallback( pause, [ pause ] );
 
 	const onTimestampDebounceChange = useCallback(
 		iframeTimePosition => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -266,7 +266,7 @@ function VideoFramePicker( {
 		[ setTimestamp, debouncedVideoFrameSelect ]
 	);
 
-	const { playerIsReady } = useVideoPlayer(
+	const { playerIsReady, pause } = useVideoPlayer(
 		playerWrapperRef,
 		isRequestingEmbedPreview,
 		{
@@ -274,6 +274,16 @@ function VideoFramePicker( {
 		},
 		onTimestampUpdateFromPlayer
 	);
+
+	useEffect( () => {
+		if ( isGeneratingPoster ) {
+			pause();
+		}
+	}, [ isGeneratingPoster, pause ] );
+
+	const onFramePickerMouseLeave = useCallback( () => {
+		pause();
+	}, [ pause ] );
 
 	const onTimestampDebounceChange = useCallback(
 		iframeTimePosition => {
@@ -295,6 +305,7 @@ function VideoFramePicker( {
 					'is-player-ready': playerIsReady,
 					'is-generating-poster': isGeneratingPoster,
 				} ) }
+				onMouseLeave={ onFramePickerMouseLeave }
 			>
 				{ ( ! playerIsReady || isGeneratingPoster ) && <Spinner /> }
 				<SandBox html={ html } scripts={ sandboxScripts } />

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
@@ -86,8 +86,12 @@ body.modal-open .poster-panel__dropdown {
 		opacity: 1;
 	}
 
-	&.is-generating-poster .components-sandbox {
-		opacity: 0.5;
+	&.is-generating-poster {
+		pointer-events: none;
+	
+		.components-sandbox {
+			opacity: 0.5;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #30022

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Pauses the video preview on mouseleave and when the poster generation process begins
* Prevents mouse events on the preview when the generation process is in process to ensure the player is paused at the selected frame during the process

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor with a VideoPress video block
* Enable `Pick from video frame` in the `Poster and preview` panel
* Click the player to play it and check that the video pauses on mouse leave
* Save the post and play the video before the poster generation process begins or, alternatively, use `setTimeout( () => wp.data.dispatch( 'core/editor' ).savePost(), 3000 );` in the console to schedule a post save while playing the preview video
* Check that the preview video is paused
* Check that clicking the video while the poster generation process is happening does not play the video 

https://user-images.githubusercontent.com/8486249/232508033-d85a88d6-66da-4dcf-ba6f-5cf27ccb914a.mp4
