### PR TITLE
Auto-labeling: update task to use newer label.

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-compat
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Auto-labeling: update logic to use new [Focus] label.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -228,7 +228,7 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 			/^(projects\/plugins\/boost\/compatibility|projects\/plugins\/jetpack\/3rd-party)\//
 		);
 		if ( compat ) {
-			keywords.add( 'Compatibility' );
+			keywords.add( '[Focus] Compatibility' );
 		}
 
 		// E2E tests.


### PR DESCRIPTION
## Proposed changes:

We now use "[Focus] Compatibility" instead of "Compatibility".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here, we'll see it in future PRs that get created and auto-labeled.
