### PR TITLE
General: remove backwards-compatibility WP 6.0 code

### DIFF
--- a/projects/js-packages/components/changelog/update-backwards-compat-61
+++ b/projects/js-packages/components/changelog/update-backwards-compat-61
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove WordPress 6.0 backwards-compatibility code.

--- a/projects/js-packages/components/lib/locale/index.ts
+++ b/projects/js-packages/components/lib/locale/index.ts
@@ -1,8 +1,4 @@
-import * as wpdate from '@wordpress/date';
-
-// @wordpress/date now provides getSettings in preference to __experimentalGetSettings,
-// but we still have to support WP 6.0 that doesn't have that yet.
-const getSettings = wpdate.getSettings || wpdate.__experimentalGetSettings;
+import { getSettings } from '@wordpress/date';
 
 /**
  * Clean up WP locale so it matches the format expected by browsers.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.31.5",
+	"version": "0.31.6-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/plugins/jetpack/changelog/update-backwards-compat-61
+++ b/projects/plugins/jetpack/changelog/update-backwards-compat-61
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+General: remove WordPress 6.0 backwards-compatibility code, now that Jetpack requires WordPress 6.1

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/edit.js
@@ -1,16 +1,12 @@
 import apiFetch from '@wordpress/api-fetch';
 import { Placeholder } from '@wordpress/components';
-import * as wpdate from '@wordpress/date';
+import { getSettings } from '@wordpress/date';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import DayEdit from './components/day-edit';
 import DayPreview from './components/day-preview';
 import { icon } from '.';
-
-// @wordpress/date now provides getSettings in preference to __experimentalGetSettings,
-// but we still have to support WP 6.0 that doesn't have that yet.
-const getSettings = wpdate.getSettings || wpdate.__experimentalGetSettings;
 
 export const defaultLocalization = {
 	days: {

--- a/projects/plugins/jetpack/modules/shortcodes/others.php
+++ b/projects/plugins/jetpack/modules/shortcodes/others.php
@@ -36,14 +36,5 @@ function jetpack_oembed_timeout_override( $timeout, $url ) {
 // TODO: Remove this. This should hopefully be a temporary hack since Apple's oEmbed often seems to take more than 5 seconds to respond. 10 is an arbitrary number of seconds that seems to work better.
 add_filter( 'http_request_timeout', 'jetpack_oembed_timeout_override', 10, 2 );
 
-/**
- * Conditionally add PocketCasts as an oEmbed provider in advanced of its inclusion in WP 6.1.
- *
- * @todo Remove when WordPress 6.1 is the minimum supported version.
- */
-global $wp_version;
-if ( version_compare( $wp_version, '6.1-alpha-53744', '<' ) ) {
-	wp_oembed_add_provider( '#https?://pca\.st/.+#i', 'https://pca.st/oembed.json', true );
-}
 // WordPress core only registers pca.st, not pcast.pocketcasts.net.
 wp_oembed_add_provider( '#https?://pcast\.pocketcasts\.net/.+#i', 'https://pcast.pocketcasts.net/oembed.json', true );

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-oembed-pocketcasts.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-oembed-pocketcasts.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Tests PocketCasts oEmbed.
- *
- * @todo Remove when WordPress 6.1 is the minimum version.
  */
 
 require_once __DIR__ . '/trait.http-request-cache.php';
@@ -10,7 +8,6 @@ require_once __DIR__ . '/trait.http-request-cache.php';
 class WP_Test_Jetpack_Shortcodes_PocketCasts extends WP_UnitTestCase {
 	use Automattic\Jetpack\Tests\HttpRequestCacheTrait;
 
-	const POCKETCASTS_TEST_URL      = 'https://pca.st/6934i7iw';
 	const POCKETCASTS_BETA_TEST_URL = 'https://pcast.pocketcasts.net/drtlaf9s';
 
 	/**
@@ -48,40 +45,16 @@ class WP_Test_Jetpack_Shortcodes_PocketCasts extends WP_UnitTestCase {
 		$api_query_args = null;
 		wp_parse_str( $api_query, $api_query_args );
 
-		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		switch ( $api_query_args['url'] ) {
-			case self::POCKETCASTS_TEST_URL:
-				$response['body'] = '{"type":"rich","version":"1.0","provider_name":"Pocket Casts","provider_url":"https://pocketcasts.com/","title":"Episode 29: Dylan Field, Figma Co-founder, Talks Design, Digital Economy, and Remote Culture with Host Connie Yang - Distributed, with Matt Mullenweg","author_name":"Distributed, with Matt Mullenweg","author_url":"https://distributed.blog","html":"\u003cdiv style=\"width: 100%; max-width: 1200px; max-height: 100%; position: relative;\"\u003e\n    \u003cdiv style=\"padding-bottom: 42.857142857142854%;\"\u003e\u003c/div\u003e\n    \u003ciframe src=\"https://pca.st/embed/6934i7iw\" width=\"1200\" height=\"514.2857142857142\" style=\"border: 0; border-radius: 8px; position: absolute; top: 0; left: 0; width: 100%; height: 100%;\"\u003e\u003c/iframe\u003e\n\u003c/div\u003e","width":1200,"height":514.2857142857142}';
-				break;
-
-			case self::POCKETCASTS_BETA_TEST_URL:
-				$response['body'] = '{"type":"rich","version":"1.0","provider_name":"Pocket Casts","provider_url":"https://pocketcasts.com/","title":"Tom - Dead Eyes","author_name":"Dead Eyes","author_url":"https://art19.com/shows/dead-eyes","html":"\u003cdiv style=\"width: 100%; max-width: 1200px; max-height: 100%; position: relative;\"\u003e\n    \u003cdiv style=\"padding-bottom: 42.857142857142854%;\"\u003e\u003c/div\u003e\n    \u003ciframe src=\"https://pcast.pocketcasts.net/embed/drtlaf9s\" width=\"1200\" height=\"514.2857142857142\" style=\"border: 0; border-radius: 8px; position: absolute; top: 0; left: 0; width: 100%; height: 100%;\" allowfullscreen=\"true\" frameborder=\"0\" sandbox=\"allow-scripts allow-same-origin allow-presentation\"\u003e\u003c/iframe\u003e\n\u003c/div\u003e\n","width":1200,"height":514.2857142857142}';
-				break;
-			default:
+		if (
+			! isset( $api_query_args['url'] )
+			|| self::POCKETCASTS_BETA_TEST_URL !== $api_query_args['url']
+		) {
 				return new WP_Error( 'unexpected-http-request', 'Test is making an unexpected HTTP request.' );
 		}
-		// phpcs:enable
+
+		$response['body'] = '{"type":"rich","version":"1.0","provider_name":"Pocket Casts","provider_url":"https://pocketcasts.com/","title":"Tom - Dead Eyes","author_name":"Dead Eyes","author_url":"https://art19.com/shows/dead-eyes","html":"\u003cdiv style=\"width: 100%; max-width: 1200px; max-height: 100%; position: relative;\"\u003e\n    \u003cdiv style=\"padding-bottom: 42.857142857142854%;\"\u003e\u003c/div\u003e\n    \u003ciframe src=\"https://pcast.pocketcasts.net/embed/drtlaf9s\" width=\"1200\" height=\"514.2857142857142\" style=\"border: 0; border-radius: 8px; position: absolute; top: 0; left: 0; width: 100%; height: 100%;\" allowfullscreen=\"true\" frameborder=\"0\" sandbox=\"allow-scripts allow-same-origin allow-presentation\"\u003e\u003c/iframe\u003e\n\u003c/div\u003e\n","width":1200,"height":514.2857142857142}';
 
 		return $response;
-	}
-
-	/**
-	 * Test Pocket Casts oEmbed endpoint.
-	 */
-	public function test_pocketcasts_oembed_fetch_url() {
-
-		$wp_embed = new WP_Embed();
-		$actual   = $wp_embed->autoembed( self::POCKETCASTS_TEST_URL );
-
-		/*
-			$actual contains this:
-			<div style="width: 100%; max-width: 1200px; max-height: 100%; position: relative;">    <div style="padding-bottom: 42.857142857142854%;"></div>    <iframe title="Episode 29: Dylan Field, Figma Co-founder, Talks Design, Digital Economy, and Remote Culture with Host Connie Yang - Distributed, with Matt Mullenweg" src="https://pca.st/embed/6934i7iw" width="1200" height="514.2857142857142" style="border: 0; border-radius: 8px; position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
-		*/
-
-		$this->assertStringContainsString(
-			'src="https://pca.st/embed/6934i7iw"',
-			$actual
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

Following #30120, let's remove code that was only in there to keep backwards-compatibility with WP 6.0.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See #27795

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Check impacted files, those features should keep working.
    * Go to Posts > Add New, and add a new Business Hours block
    * It should work with no js errors in the console, and regardless of your site language.
