### PR TITLE
e2e Performance tests: update with recent Core path changes

### DIFF
--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -8,7 +8,7 @@ jobs:
   block-performance:
     name: "Performance tests"
     runs-on: ubuntu-latest
-    timeout-minutes: 50  # 2021-12-13: Successful runs seem to take 40 minutes
+    timeout-minutes: 60  # 2023-04-18: Some runs exceeded 50 minutes
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -1,6 +1,7 @@
 name: Jetpack block performance
 
 on:
+  pull_request:
   schedule:
     - cron:  '0 */12 * * *'
 

--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -1,7 +1,6 @@
 name: Jetpack block performance
 
 on:
-  pull_request:
   schedule:
     - cron:  '0 */12 * * *'
 

--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -9,7 +9,7 @@ jobs:
   block-performance:
     name: "Performance tests"
     runs-on: ubuntu-latest
-    timeout-minutes: 60  # 2023-04-18: Some runs exceeded 50 minutes
+    timeout-minutes: 90  # 2023-04-18: Some runs exceeded 50 minutes
     steps:
       - uses: actions/checkout@v3
 

--- a/tools/e2e-commons/bin/performance.js
+++ b/tools/e2e-commons/bin/performance.js
@@ -30,7 +30,7 @@ function runTests( type, id ) {
 	execSyncShellCommand( `export WP_BASE_URL=${ siteUrl } &&
 	cd ../../gutenberg &&
 	npm run test:performance packages/e2e-tests/specs/performance/post-editor.test.js &&
-	mv artifacts/post-editor.test.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json` );
+	mv artifacts/post-editor.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json` );
 }
 
 async function testRun( type, id ) {

--- a/tools/e2e-commons/bin/performance.js
+++ b/tools/e2e-commons/bin/performance.js
@@ -34,7 +34,7 @@ async function runTests() {
 
 async function moveResults( type, id ) {
 	execSyncShellCommand(
-		`mv artifacts/post-editor.test.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json`
+		`mv ../../artifacts/post-editor.test.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json`
 	);
 }
 

--- a/tools/e2e-commons/bin/performance.js
+++ b/tools/e2e-commons/bin/performance.js
@@ -30,7 +30,7 @@ function runTests( type, id ) {
 	execSyncShellCommand( `export WP_BASE_URL=${ siteUrl } &&
 	cd ../../gutenberg &&
 	npm run test:performance packages/e2e-tests/specs/performance/post-editor.test.js &&
-	mv packages/e2e-tests/specs/performance/post-editor.test.results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json` );
+	mv artifacts/post-editor.test.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json` );
 }
 
 async function testRun( type, id ) {

--- a/tools/e2e-commons/bin/performance.js
+++ b/tools/e2e-commons/bin/performance.js
@@ -34,7 +34,7 @@ async function runTests() {
 
 async function moveResults( type, id ) {
 	execSyncShellCommand(
-		`mv ../../artifacts/post-editor.test.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json`
+		`mv ../../artifacts/post-editor.test.performance-results.json ./results/${ type }.${ id }.test.results.json`
 	);
 }
 

--- a/tools/e2e-commons/bin/performance.js
+++ b/tools/e2e-commons/bin/performance.js
@@ -24,20 +24,27 @@ async function envSetup( type ) {
 	);
 }
 
-function runTests( type, id ) {
+async function runTests() {
 	const siteUrl = resolveSiteUrl();
 
 	execSyncShellCommand( `export WP_BASE_URL=${ siteUrl } &&
 	cd ../../gutenberg &&
-	npm run test:performance packages/e2e-tests/specs/performance/post-editor.test.js &&
-	mv artifacts/post-editor.test.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json` );
+	npm run test:performance packages/e2e-tests/specs/performance/post-editor.test.js` );
+}
+
+async function moveResults( type, id ) {
+	execSyncShellCommand(
+		`mv artifacts/post-editor.test.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json`
+	);
 }
 
 async function testRun( type, id ) {
 	console.log( `Starting test run #${ id } for ${ type }` );
 	envReset();
 	await envSetup( type );
-	runTests( type, id );
+	await runTests();
+	console.log( `Finished test run #${ id } for ${ type }` );
+	await moveResults( type, id );
 	console.log( `Done with #${ id } for ${ type }` );
 }
 

--- a/tools/e2e-commons/bin/performance.js
+++ b/tools/e2e-commons/bin/performance.js
@@ -28,7 +28,7 @@ async function runTests() {
 	const siteUrl = resolveSiteUrl();
 
 	execSyncShellCommand( `export WP_BASE_URL=${ siteUrl } &&
-	cd ../../gutenberg &&
+	cd ../../gutenberg && mkdir -p artifacts &&
 	npm run test:performance packages/e2e-tests/specs/performance/post-editor.test.js` );
 }
 

--- a/tools/e2e-commons/bin/performance.js
+++ b/tools/e2e-commons/bin/performance.js
@@ -30,7 +30,7 @@ function runTests( type, id ) {
 	execSyncShellCommand( `export WP_BASE_URL=${ siteUrl } &&
 	cd ../../gutenberg &&
 	npm run test:performance packages/e2e-tests/specs/performance/post-editor.test.js &&
-	mv artifacts/post-editor.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json` );
+	mv artifacts/post-editor.test.performance-results.json ../tools/e2e-commons/results/${ type }.${ id }.test.results.json` );
 }
 
 async function testRun( type, id ) {


### PR DESCRIPTION
## Proposed changes:

Let's update our setup following https://github.com/WordPress/gutenberg/pull/48684/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Let's trigger a test on this PR and see the output in CI:
    * https://github.com/Automattic/jetpack/actions/runs/4735476196/jobs/8405757747