### PR TITLE
[RNMobile] Stop saving HTML markup representation

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-fix-stop-saving-html-markup
+++ b/projects/packages/videopress/changelog/rnmobile-fix-stop-saving-html-markup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress block: Stop saving HTML markup representation.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.13.8",
+	"version": "0.13.9-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.13.8';
+	const PACKAGE_VERSION = '0.13.9-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.native.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.native.ts
@@ -8,8 +8,8 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import metadata from './block.json';
 import { VideoPressIcon as icon } from './components/icons';
+import deprecated from './deprecated';
 import Edit from './edit';
-import save from './save';
 import transforms from './transforms';
 import './style.scss';
 
@@ -35,10 +35,11 @@ export default function registerVideoPressBlock() {
 	const result = registerBlockType( name, {
 		edit: Edit,
 		title,
-		save,
+		save: () => null,
 		icon,
 		attributes,
 		transforms,
+		deprecated,
 	} );
 
 	// eslint-disable-next-line no-console


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5671.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Following the changes introduced https://github.com/Automattic/jetpack/pull/30081 in the web version, we apply the same approach in the native version.
* The main change is that the block doesn't contain HTML markup representation:

**Before:**
```
<!-- wp:videopress/video {"title":"Planet video","description":"Video description.","id":21,"guid":"AbcDe","cacheHtml":"<cache-html>","videoRatio":56.333333333333336,"allowDownload":false,"displayEmbed":false,"rating":"PG-13","isPrivate":true,"duration":1673} -->
<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">
    <div class="jetpack-videopress-player__wrapper">
        https://videopress.com/v/AbcDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
    </div>
</figure>
<!-- /wp:videopress/video -->
```

**After:**

```
<!-- wp:videopress/video {"title":"Planet video","description":"Video description.","caption":"","loop":true,"playsinline":true,"id":21,"guid":"AbcDe","cacheHtml":"<cache-html","posterData":{},"videoRatio":56.333333333333336,"tracks":[],"allowDownload":false,"displayEmbed":false,"rating":"PG-13","isPrivate":true,"duration":1673} /-->
```

⚠️ Once this PR is merged, we'd need to update the upload processors to reflect this change:
- https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/WordPress/src/main/java/org/wordpress/android/ui/posts/mediauploadcompletionprocessors/VideoPressBlockProcessor.kt
- https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1681483252176389-slack-C04LWMHSGLC

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Preparation:** 
The changes introduced in https://github.com/Automattic/jetpack/pull/30081 are not yet in WPCOM, so we need to test this using sandbox:
* Sandbox a Simple site and use changes from this PR ([instructions](https://github.com/Automattic/jetpack/pull/30134#issuecomment-1511630945)).

**Steps:**
* On the browser, navigate to the Simple site and create/open a post.
* Add a VideoPress block.
* Add a video.
* Switch to the code editor and check that the block doesn't contain HTML markup.
* Save the post.
* On the app, open the post.
* Observe that the block is properly rendered and that the video can be played.
* Switch to the HTML mode and check that the block doesn't contain HTML markup.
* Remove the block and add a new VideoPress block.
* Add a video.
* Switch to the HTML mode and check that the block doesn't contain HTML markup.
* Save the post.
* One the browser, open the post.
* Observe that the block is properly rendered and that the video can be played.
* Switch to the code editor and check that the block doesn't contain HTML markup.