### PR TITLE
Menu icon: avoid error when used with older version of Logo

### DIFF
--- a/projects/packages/admin-ui/changelog/fix-method-admin-ui
+++ b/projects/packages/admin-ui/changelog/fix-method-admin-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid errors when used in combination with an older version of the Assets package.

--- a/projects/packages/admin-ui/changelog/fix-method-admin-ui
+++ b/projects/packages/admin-ui/changelog/fix-method-admin-ui
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Avoid errors when used in combination with an older version of the Assets package.
+Avoid errors when used in combination with an older version of the Logo package.

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.2.19",
+	"version": "0.2.20-alpha",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.2.19';
+	const PACKAGE_VERSION = '0.2.20-alpha';
 
 	/**
 	 * Whether this class has been initialized
@@ -73,7 +73,7 @@ class Admin_Menu {
 	public static function admin_menu_hook_callback() {
 		$can_see_toplevel_menu  = true;
 		$jetpack_plugin_present = class_exists( 'Jetpack_React_Page' );
-		$icon                   = class_exists( '\Automattic\Jetpack\Assets\Logo' )
+		$icon                   = method_exists( '\Automattic\Jetpack\Assets\Logo', 'get_base64_logo' )
 			? ( new \Automattic\Jetpack\Assets\Logo() )->get_base64_logo()
 			: 'dashicons-admin-plugins';
 


### PR DESCRIPTION
## Proposed changes:

Avoid fatal errors when combining multiple plugins with different package versions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1681747330884549-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This is a bit involved (see Slack discussion). It relies on using an old version of the Logo package, alongside this branch. You can achieve that by using the Jetpack plugin with this branch alongside another plugin that relies on an old version of the Logo package, like the VaultPress plugin I believe.
