### PR TITLE
cli: Add `--no-dev` option to `jetpack dependencies`

### DIFF
--- a/tools/cli/commands/dependencies.js
+++ b/tools/cli/commands/dependencies.js
@@ -73,6 +73,10 @@ export function builder( yargs ) {
 			describe: 'Ignore the monorepo root.',
 			type: 'boolean',
 		} )
+		.option( 'no-dev', {
+			describe: 'Do not consider dev dependencies.',
+			type: 'boolean',
+		} )
 		.option( 'pretty', {
 			describe: 'Pretty-print JSON or build-order output.',
 			type: 'boolean',
@@ -85,7 +89,7 @@ export function builder( yargs ) {
  * @param {object} argv - the arguments passed.
  */
 export async function handler( argv ) {
-	let deps = await getDependencies( process.cwd(), argv.extra );
+	let deps = await getDependencies( process.cwd(), argv.extra, argv.dev === false );
 
 	if ( argv.ignoreRoot ) {
 		deps.delete( 'monorepo' );

--- a/tools/cli/helpers/dependencyAnalysis.js
+++ b/tools/cli/helpers/dependencyAnalysis.js
@@ -7,9 +7,10 @@ import glob from 'glob';
  *
  * @param {string} root - Monorepo root directory.
  * @param {string|null} extra - Extra deps to include, "build" or "test".
+ * @param {boolean} noDev - Exclude dev dependencies.
  * @returns {Map} Key is the project slug, value is a Set of slugs depended on.
  */
-export async function getDependencies( root, extra = null ) {
+export async function getDependencies( root, extra = null, noDev = false ) {
 	const ret = new Map();
 
 	// Collect all project slugs.
@@ -60,7 +61,7 @@ export async function getDependencies( root, extra = null ) {
 		// Collect composer require, require-dev, and .extra.dependencies.
 		let json = JSON.parse( await fs.readFile( path + '/composer.json', { encoding: 'utf8' } ) );
 		for ( const [ pkg, pkgslug ] of packageMap.entries() ) {
-			if ( json.require?.[ pkg ] || json[ 'require-dev' ]?.[ pkg ] ) {
+			if ( json.require?.[ pkg ] || ( json[ 'require-dev' ]?.[ pkg ] && ! noDev ) ) {
 				deps.push( pkgslug );
 			}
 		}
@@ -72,7 +73,7 @@ export async function getDependencies( root, extra = null ) {
 		if ( ( await fs.access( path + '/package.json' ).catch( () => false ) ) !== false ) {
 			json = JSON.parse( await fs.readFile( path + '/package.json', { encoding: 'utf8' } ) );
 			for ( const [ pkg, pkgslug ] of jsPackageMap.entries() ) {
-				if ( json.dependencies?.[ pkg ] || json.devDependencies?.[ pkg ] ) {
+				if ( json.dependencies?.[ pkg ] || ( json.devDependencies?.[ pkg ] && ! noDev ) ) {
 					deps.push( pkgslug );
 				}
 			}

--- a/tools/cli/tests/unit/helpers/dependencyAnalysis.test.js
+++ b/tools/cli/tests/unit/helpers/dependencyAnalysis.test.js
@@ -68,6 +68,19 @@ describe( 'dependencyAnalysis', () => {
 			} );
 		} );
 
+		test( 'monorepo, no dev deps', async () => {
+			const ret = await getDependencies( dataDir + '/monorepo', null, true );
+			expect( ret ).toMatchDeps( {
+				monorepo: [ 'packages/a' ],
+				'packages/a': [],
+				'packages/b': [ 'packages/a' ],
+				'packages/c': [ 'js-packages/d', 'packages/a' ],
+				'js-packages/d': [],
+				'js-packages/e': [],
+				'js-packages/f': [],
+			} );
+		} );
+
 		test( 'monorepo, build deps', async () => {
 			const ret = await getDependencies( dataDir + '/monorepo', 'build' );
 			expect( ret ).toMatchDeps( {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Useful in certain cases where you want to know which plugins actually bundle a PHP package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Compare the output of `jetpack dependencies list --add-dependents packages/logo` and `jetpack dependencies list --add-dependents --no-dev packages/logo`, for example. The latter should omit things like plugins/beta that have no non-dev dependency on the package.
