### PR TITLE
SEO: remove "Jetpack" from the feature name.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-seo-panel-name
+++ b/projects/plugins/jetpack/changelog/update-seo-panel-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO: update panel name in block editor.

--- a/projects/plugins/jetpack/extensions/blocks/seo/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/seo/index.js
@@ -15,12 +15,12 @@ export const name = 'seo';
 export const settings = {
 	render: () => {
 		const jetpackSeoPanelProps = {
-			title: __( 'Jetpack SEO', 'jetpack' ),
+			title: __( 'SEO', 'jetpack' ),
 		};
 
 		const jetpackSeoPrePublishPanelProps = {
 			icon: <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />,
-			title: __( 'Jetpack SEO', 'jetpack' ),
+			title: __( 'SEO', 'jetpack' ),
 		};
 
 		return (


### PR DESCRIPTION
## Proposed changes:

The panel is already part of the "Jetpack" sidebar, we may not need an extra "jetpack" in the name.

<img width="342" alt="Screenshot 2023-04-17 at 19 16 44" src="https://user-images.githubusercontent.com/426388/232560965-14e1c8ce-8906-432b-9246-9156fabd8d98.png">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p9Jlb4-6ZK-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > settings > Traffic
* Enable the SEO feature
* Go to Posts > Add New
* Open the Jetpack sidebar
* You should see the SEO panel with the "SEO" title.
