### PR TITLE
Block editor panels: close by default

### DIFF
--- a/projects/plugins/jetpack/changelog/update-editor-panels-default-open
+++ b/projects/plugins/jetpack/changelog/update-editor-panels-default-open
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Block editor: collapse Jetpack feature panels by default.

--- a/projects/plugins/jetpack/extensions/blocks/shortlinks/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/shortlinks/index.js
@@ -22,7 +22,11 @@ class ShortlinksPanel extends Component {
 
 		return (
 			<JetpackPluginSidebar>
-				<PanelBody title={ __( 'Shortlink', 'jetpack' ) } className="jetpack-shortlinks__panel">
+				<PanelBody
+					title={ __( 'Shortlink', 'jetpack' ) }
+					className="jetpack-shortlinks__panel"
+					initialOpen={ false }
+				>
 					<ClipboardInput link={ shortlink } />
 				</PanelBody>
 			</JetpackPluginSidebar>

--- a/projects/plugins/jetpack/extensions/blocks/social-previews/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/social-previews/index.js
@@ -20,13 +20,14 @@ export const SocialPreviews = function SocialPreviews() {
 		<>
 			{ isOpened && <SocialPreviewsModal onClose={ () => setIsOpened( false ) } /> }
 			<JetpackPluginSidebar>
-				<PanelBody title={ __( 'Social Previews', 'jetpack' ) }>
+				<PanelBody title={ __( 'Social Previews', 'jetpack' ) } initialOpen={ false }>
 					<SocialPreviewsPanel openModal={ () => setIsOpened( true ) } />
 				</PanelBody>
 			</JetpackPluginSidebar>
 			<PluginPrePublishPanel
 				title={ __( 'Social Previews', 'jetpack' ) }
 				icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+				initialOpen={ false }
 			>
 				<SocialPreviewsPanel openModal={ () => setIsOpened( true ) } />
 			</PluginPrePublishPanel>

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -17,6 +17,7 @@ export const settings = {
 			title: __( 'QR Code', 'jetpack' ),
 			className: 'post-publish-qr-post-panel',
 			icon: <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />,
+			initialOpen: false,
 		};
 
 		const isPostPublished = useSelect(

--- a/projects/plugins/jetpack/extensions/shared/jetpack-likes-and-sharing-panel.js
+++ b/projects/plugins/jetpack/extensions/shared/jetpack-likes-and-sharing-panel.js
@@ -18,7 +18,9 @@ registerPlugin( 'jetpack-likes-and-sharing-panel', {
 
 					return (
 						<JetpackPluginSidebar>
-							<PanelBody title={ __( 'Likes and Sharing', 'jetpack' ) }>{ fills }</PanelBody>
+							<PanelBody title={ __( 'Likes and Sharing', 'jetpack' ) } initialOpen={ false }>
+								{ fills }
+							</PanelBody>
 						</JetpackPluginSidebar>
 					);
 				} }


### PR DESCRIPTION
## Proposed changes:

Let's close the QR code, Shortlinks, Social Previews, and Likes and Sharing by default.

<img width="382" alt="image" src="https://user-images.githubusercontent.com/426388/232566665-be822298-cedc-4296-b8bb-dc7a20a4f6d7.png">

<img width="379" alt="image" src="https://user-images.githubusercontent.com/426388/232566750-ab1a0c19-bd25-4683-b520-42e77c6472cc.png">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p9Jlb4-6ZK-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This can be tested once each feature is active (under Jetpack > Settings), and when:

* Creating new posts, in the Jetpack sidebar and the pre/post publish panels.
* Updating existing posts, in the Jetpack sidebar.

For each feature, you will want to ensure the panel is closed by default.
