### PR TITLE
Launchpad Checklist API: Update VideoPress tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-videopress-task-definitions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-videopress-task-definitions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Launchpad Checklist API: Update VideoPress tasks

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -163,15 +163,15 @@ function get_task_definitions() {
 			=> array(
 				'id'        => 'videopress_upload',
 				'title'     => __( 'Upload your first video', 'jetpack-mu-wpcom' ),
-				'completed' => get_checklist_task( 'videopress_uploaded' ),
-				'disabled'  => get_checklist_task( 'videopress_uploaded' ),
+				'completed' => get_checklist_task( 'video_uploaded' ),
+				'disabled'  => get_checklist_task( 'video_uploaded' ),
 			),
 		'videopress_launched'
 			=> array(
 				'id'        => 'videopress_launched',
 				'title'     => __( 'Launch site', 'jetpack-mu-wpcom' ),
-				'completed' => false,
-				'disabled'  => ! get_checklist_task( 'videopress_uploaded' ),
+				'completed' => get_checklist_task( 'site_launched' ),
+				'disabled'  => ! get_checklist_task( 'video_uploaded' ),
 			),
 		'setup_free'
 			=> array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -155,20 +155,23 @@ function get_task_definitions() {
 		'videopress_setup'
 			=> array(
 				'id'        => 'videopress_setup',
+				'title'     => __( 'Set up your video site', 'jetpack-mu-wpcom' ),
 				'completed' => true,
 				'disabled'  => false,
 			),
 		'videopress_upload'
 			=> array(
 				'id'        => 'videopress_upload',
-				'completed' => false,
-				'disabled'  => false,
+				'title'     => __( 'Upload your first video', 'jetpack-mu-wpcom' ),
+				'completed' => get_checklist_task( 'videopress_uploaded' ),
+				'disabled'  => get_checklist_task( 'videopress_uploaded' ),
 			),
 		'videopress_launched'
 			=> array(
 				'id'        => 'videopress_launched',
+				'title'     => __( 'Launch site', 'jetpack-mu-wpcom' ),
 				'completed' => false,
-				'disabled'  => true,
+				'disabled'  => ! get_checklist_task( 'videopress_uploaded' ),
 			),
 		'setup_free'
 			=> array(


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/30040

## Proposed changes:
* Updates the task definitions for VideoPress tasks for Launchpad and the Launchpad checklist endpoint. 
* **Not Included**: In our current front end logic, the video upload task also depends on the status of `planHasFeature( productSlug as string, FEATURE_VIDEO_UPLOADS )`. See [this line](https://github.com/Automattic/wp-calypso/blob/5ed748aac2f18a28367ac9db3fedf5874e36fe6d/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.ts#L68). This is complicated to re-create on the backend because the logic for defining features and associating them with plans is all done on the front end [here](https://github.com/Automattic/wp-calypso/blob/trunk/client/lib/plans/features-list.tsx). So we're going to create a separate issue and handle this in a follow up. 

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/launchpad-videopress-task-definitions` to build and sync this branch to your sandbox.
2. Create a new VideoPress site at `https://wordpress.com/setup/videopress/intro`, continue to Launchpad, and then sandbox the site.
3. Go to https://developer.wordpress.com/docs/api/console/, select Rest API and wpcom/v2, and input the following: `/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=videopress`. 
4. TEST: Confirm the correct initial task list and statuses are returned from the endpoint. 
5. TEST: From Launchpad, complete the video upload task, and then retest the endpoint in the dev console and confirm that task is now complete. 
6. TEST: From Launchpad, launch your site, and then retest the endpoint in the dev console and confirm that site_launched is now complete. 