### PR TITLE
VideoPress: add is_videopress_url() helper method

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-util-videopress-url
+++ b/projects/packages/videopress/changelog/update-videopress-add-util-videopress-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add is_videopress_url() helper function

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -74,7 +74,7 @@ class Utils {
 	 * @return bool True if the URL is a VideoPress URL, false otherwise.
 	 */
 	public static function is_videopress_url( $url ) {
-		$pattern = '/^https?:\/\/(?:(?:v(?:ideo)?\.wordpress\.com|videopress\.com)\/(?:v|embed)|v\.wordpress\.com)\/([a-z\d]{8})(\/|\b)/i';
+		$pattern = '/^https?:\/\/(?:(?:v(?:ideo)?\.wordpress\.com|videopress\.com)\/(?:v|embed)|v\.wordpress\.com)\/([a-z\d]{8})(\/|\b)/i'; // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 		return (bool) preg_match( $pattern, $url );
 	}
 }

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -64,4 +64,17 @@ class Utils {
 		$url = 'https://videopress.com/v/' . $guid;
 		return add_query_arg( $query_args, $url );
 	}
+
+	/**
+	 * Determines if a given URL is a VideoPress URL.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $url The URL to check.
+	 * @return bool True if the URL is a VideoPress URL, false otherwise.
+	 */
+	public static function is_videopress_url( $url ) {
+		$pattern = '/^https?:\/\/(?:(?:v(?:ideo)?\.wordpress\.com|videopress\.com)\/(?:v|embed)|v\.wordpress\.com)\/([a-z\d]{8})(\/|\b)/i';
+		return (bool) preg_match( $pattern, $url );
+	}
 }

--- a/projects/packages/videopress/tests/php/test-class-utils.php
+++ b/projects/packages/videopress/tests/php/test-class-utils.php
@@ -121,4 +121,53 @@ class UtilsTest extends BaseTestCase {
 		$this->assertStringNotContainsString( 'posterUrl', $url_without_poster );
 	}
 
+	/**
+	 * Test the is_videopress_url method.
+	 */
+	public function test_is_videopress_url() {
+		// Test valid VideoPress URLs.
+		$valid_urls = array(
+			'https://videopress.com/v/123abcde',
+			'http://videopress.com/v/123abcde',
+			'https://videopress.com/embed/123abcde',
+			'http://videopress.com/embed/123abcde',
+			'https://video.wordpress.com/v/123abcde',
+			'http://video.wordpress.com/v/123abcde',
+			'https://video.wordpress.com/embed/123abcde',
+			'http://video.wordpress.com/embed/123abcde',
+			'https://v.wordpress.com/123abcde',
+			'http://v.wordpress.com/123abcde',
+		);
+
+		foreach ( $valid_urls as $url ) {
+			$this->assertTrue( Utils::is_videopress_url( $url ) );
+		}
+
+		// Test invalid VideoPress URLs.
+		$invalid_urls = array(
+			// Invalid domain
+			'https://example.com/v/123abcde',
+			'http://example.com/v/123abcde',
+			'https://example.com/embed/123abcde',
+			'http://example.com/embed/123abcde',
+
+			// Missing VideoPress GUID
+			'https://videopress.com/v/',
+			'http://videopress.com/v/',
+			'https://videopress.com/embed/',
+			'http://videopress.com/embed/',
+			'https://video.wordpress.com/v/',
+			'http://video.wordpress.com/v/',
+			'https://video.wordpress.com/embed/',
+			'http://video.wordpress.com/embed/',
+
+			// Missing VideoPress GUID (shortened URL)
+			'https://v.wordpress.com/',
+			'http://v.wordpress.com/',
+		);
+
+		foreach ( $invalid_urls as $url ) {
+			$this->assertFalse( Utils::is_videopress_url( $url ) );
+		}
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the `is_videopress_url()` Util method that we'll use in follow-up janitorial tasks.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add is_videopress_url() helper method

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Since the helper is not used yet:
* Take a look at the function
* Run tests

```cli
jetpack test packages/videopress php -
```

<img width="699" alt="image" src="https://user-images.githubusercontent.com/77539/232610487-c663c985-e3e2-4b9f-8a30-a0eca4d88157.png">



