### PR TITLE
My Jetpack: Add side-effect action to trigger standalone plugin installation

### DIFF
--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -192,7 +192,7 @@ const installStandalonePluginForProduct = productId => async store => {
 			.catch( error => {
 				const { name } = select.getProduct( productId );
 				const message = sprintf(
-					// translators: %$1s: Jetpack Product name
+					// translators: %$1s: Jetpack Product name; %$2s: Original error message
 					__(
 						'Failed to install standalone plugin for %1$s: %2$s. Please try again',
 						'jetpack-my-jetpack'

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -152,6 +152,63 @@ const activateProduct = productId => async store => {
 	return await requestProductStatus( productId, { activate: true }, store );
 };
 
+/**
+ * Side effect action that will trigger
+ * the standalone plugin installation on the server.
+ *
+ * @param {string} productId - My Jetpack product ID.
+ * @returns {Promise}        - Promise which resolves when the product plugin is installed.
+ */
+const installStandalonePluginForProduct = productId => async store => {
+	const { select, dispatch, registry } = store;
+	return await new Promise( ( resolve, reject ) => {
+		// Check valid product.
+		const isValid = select.isValidProduct( productId );
+
+		if ( ! isValid ) {
+			const message = __( 'Invalid product name', 'jetpack-my-jetpack' );
+			const error = new Error( message );
+
+			dispatch( setRequestProductError( productId, error ) );
+			dispatch( setGlobalNotice( message, { status: 'error', isDismissible: true } ) );
+			reject( error );
+			return;
+		}
+
+		/** Processing... */
+		dispatch( setIsFetchingProduct( productId, true ) );
+
+		// Install product standalone plugin.
+		return apiFetch( {
+			path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }/install-standalone`,
+			method: 'POST',
+		} )
+			.then( freshProduct => {
+				dispatch( setIsFetchingProduct( productId, false ) );
+				dispatch( setProduct( freshProduct ) );
+				registry.dispatch( CONNECTION_STORE_ID ).refreshConnectedPlugins();
+				resolve( freshProduct?.standalone_plugin_info );
+			} )
+			.catch( error => {
+				const { name } = select.getProduct( productId );
+				const message = sprintf(
+					// translators: %$1s: Jetpack Product name
+					__(
+						'Failed to install standalone plugin for %1$s: %2$s. Please try again',
+						'jetpack-my-jetpack'
+					),
+					name,
+					error.message
+				);
+
+				dispatch( setIsFetchingProduct( productId, false ) );
+				dispatch( setRequestProductError( productId, error ) );
+				dispatch( setGlobalNotice( message, { status: 'error', isDismissible: true } ) );
+				reject( error );
+			} );
+	} );
+};
+
 const setProductStats = ( productId, stats ) => {
 	return { type: SET_PRODUCT_STATS, productId, stats };
 };
@@ -163,6 +220,7 @@ const setIsFetchingProductStats = ( productId, isFetching ) => {
 const productActions = {
 	setProduct,
 	activateProduct,
+	installStandalonePluginForProduct,
 	setIsFetchingProduct,
 	setRequestProductError,
 	setProductStatus,

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-action-to-trigger-standalone-plugin-installation
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-action-to-trigger-standalone-plugin-installation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add side-effect action to request the standalone plugin installation on the backend.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.10.2",
+	"version": "2.10.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -30,7 +30,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.10.2';
+	const PACKAGE_VERSION = '2.10.3-alpha';
 
 	/**
 	 * Initialize My Jetpack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #29901.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `installStandalonePluginForProduct` action to trigger a request to the `site/products/$product_slug/install-standalone` endpoint, causing the installation and activation of the standalone plugin for a given product

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin a new JN site with only Jetpack
* Connect the site
* Go to`Jetpack > My Jetpack` and open the browser's console
* Inspect the standalone state for some hybrid product (`videopress`, `backup`, `social`, `search`); example for VideoPress:

```
myJetpackInitialState.products.items.videopress.standalone_plugin_info
```

* Expected result:

<img width="657" alt="Screen Shot 2023-04-17 at 18 30 57" src="https://user-images.githubusercontent.com/6760046/232615204-79412a51-1ee7-43f3-9361-52b12b22b9c4.png">

* Confirm that the VideoPress standalone plugin is not installed on `Plugins > Installed Plugins`
* Now we are going to dispatch the action that will install the standalone plugin
* Go to `Jetpack > My Jetpack` and open the browser's console again
* Run the following code:

```
wp.data.dispatch( 'my-jetpack' ).installStandalonePluginForProduct( 'videopress' ).then((result) => console.log(result));
```

* This will trigger the endpoint call and returns the new standalone status information:

<img width="834" alt="Screen Shot 2023-04-17 at 18 34 54" src="https://user-images.githubusercontent.com/6760046/232615989-dc580650-5ba5-4a19-bf49-a0254d5a1668.png">

* This wil also update the product information on the My Jetpack state with the info returned by the endpoint
* Check the "Network" tab of the console for a `POST` call to `site/products/videopress/install-standalone`:

<img width="536" alt="Screen Shot 2023-04-17 at 18 37 31" src="https://user-images.githubusercontent.com/6760046/232616467-09b7925b-2403-45aa-ac73-1b9b4cdc0a09.png">

* Go to `Plugins > Installed Plugins` and confirm that VideoPress plugin is now installed:

<img width="349" alt="Screen Shot 2023-04-17 at 18 38 56" src="https://user-images.githubusercontent.com/6760046/232616754-f6ad5412-dd72-46ef-968d-6e41e2cf1027.png">

* Confirm that VideoPress shows as active on My Jetpack:

<img width="368" alt="Screen Shot 2023-04-17 at 18 38 17" src="https://user-images.githubusercontent.com/6760046/232616679-0e122d9e-ae1a-499d-b450-d42a9bb575dd.png">

* Try running the action again for a product that is not a hybrid product, like "CRM", to confirm that nothing will happen in this case:

```
wp.data.dispatch( 'my-jetpack' ).installStandalonePluginForProduct( 'crm' ).then((result) => console.log(result));
```

<img width="788" alt="Screen Shot 2023-04-17 at 18 41 30" src="https://user-images.githubusercontent.com/6760046/232617191-84b6c3bd-e1d7-40fe-bd35-40ef79733bcc.png">

* Notice the friendly warning at the top of My Jetpack page:

<img width="1111" alt="Screen Shot 2023-04-17 at 18 41 39" src="https://user-images.githubusercontent.com/6760046/232617218-86793965-549b-47d8-8699-ae50753c3f14.png">

---

**Known issue**

- right after dispatching the action, the card goes to a loading state (correct) but when it finishes the card is still showing as "inactive" (wrong); this is due to the endpoint returning a stale state for the product and I plan to fix it; if you refresh the page, the active is state is now visible