### PR TITLE
 Add is_block_theme field to the wp/v2/themes endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/theme-fields-is-block-theme.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/theme-fields-is-block-theme.php
@@ -34,9 +34,22 @@ class WPCOM_REST_API_V2_Theme_Fields_Is_Block_Theme extends WPCOM_REST_API_V2_Fi
 	 * @return bool
 	 */
 	public function get_permission_check( $object_data, $request ) {
-		// Allow access to the field if user alraedy has permission to view the theme,
-		// as checked by WP_REST_Themes_Controller.
+		// Allow access to the field if user already has permission to view the theme,
+		// as checked by the WP_REST_Themes_Controller.
 		return true;
+	}
+
+	/**
+	 * Get the value of the field.
+	 *
+	 * @param array           $object_data The theme data.
+	 * @param WP_REST_Request $request     WP API request.
+	 *
+	 * @return bool Whether the theme is a block-based theme.
+	 */
+	public function get( $object_data, $request ) {
+		$theme = wp_get_theme( $object_data['stylesheet'] );
+		return $theme->exists() ? $theme->is_block_theme() : false;
 	}
 
 	/**
@@ -52,19 +65,6 @@ class WPCOM_REST_API_V2_Theme_Fields_Is_Block_Theme extends WPCOM_REST_API_V2_Fi
 	 */
 	public function update_permission_check( $value, $object_data, $request ) {
 		return false;
-	}
-
-	/**
-	 * Get the value of the field.
-	 *
-	 * @param array           $object_data The theme data.
-	 * @param WP_REST_Request $request     WP API request.
-	 *
-	 * @return bool Whether the theme is a block-based theme.
-	 */
-	public function get( $object_data, $request ) {
-		$theme = wp_get_theme( $object_data['stylesheet'] );
-		return $theme->exists() ? $theme->is_block_theme() : false;
 	}
 
 	/**
@@ -96,6 +96,6 @@ class WPCOM_REST_API_V2_Theme_Fields_Is_Block_Theme extends WPCOM_REST_API_V2_Fi
 	}
 }
 
-// TODO: add conditional to only load this if it ends up being included in Core.
+// TODO: If this field is also added to Core, add a conditional to load only when using an older version of WordPress.
 // See https://core.trac.wordpress.org/ticket/58123
 wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Theme_Fields_Is_Block_Theme' );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/theme-fields-is-block-theme.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/theme-fields-is-block-theme.php
@@ -9,11 +9,13 @@
  * Field controller for adding the is_block_theme field to the themes endpoint.
  */
 class WPCOM_REST_API_V2_Theme_Fields_Is_Block_Theme extends WPCOM_REST_API_V2_Field_Controller {
-		/**
-		 * Array of post types that can handle Publicize.
-		 *
-		 * @var array
-		 */
+	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- extended methods must have the same signatures, even if paramaters are unused.
+
+	/**
+	 * Array of post types that can handle Publicize.
+	 *
+	 * @var array
+	 */
 	protected $object_type = array( 'theme' );
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/theme-fields-is-block-theme.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/theme-fields-is-block-theme.php
@@ -1,0 +1,99 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Themes API: add is_block_theme field to the themes endpoint.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Field controller for adding the is_block_theme field to the themes endpoint.
+ */
+class WPCOM_REST_API_V2_Theme_Fields_Is_Block_Theme extends WPCOM_REST_API_V2_Field_Controller {
+		/**
+		 * Array of post types that can handle Publicize.
+		 *
+		 * @var array
+		 */
+	protected $object_type = array( 'theme' );
+
+	/**
+	 * Field name
+	 *
+	 * @var string
+	 */
+	protected $field_name = 'is_block_theme';
+
+	/**
+	 * Permission check when getting the field.
+	 *
+	 * @param array           $object_data The theme data.
+	 * @param WP_REST_Request $request     WP API request.
+	 *
+	 * @return bool
+	 */
+	public function get_permission_check( $object_data, $request ) {
+		// Allow access to the field if user alraedy has permission to view the theme,
+		// as checked by WP_REST_Themes_Controller.
+		return true;
+	}
+
+	/**
+	 * Permission check when updating the field.
+	 *
+	 * This is not used because themes can't be updated using the API.
+	 *
+	 * @param bool            $value       The new value of the field.
+	 * @param array           $object_data The theme data.
+	 * @param WP_REST_Request $request     WP API request.
+	 *
+	 * @return bool
+	 */
+	public function update_permission_check( $value, $object_data, $request ) {
+		return false;
+	}
+
+	/**
+	 * Get the value of the field.
+	 *
+	 * @param array           $object_data The theme data.
+	 * @param WP_REST_Request $request     WP API request.
+	 *
+	 * @return bool Whether the theme is a block-based theme.
+	 */
+	public function get( $object_data, $request ) {
+		$theme = wp_get_theme( $object_data['stylesheet'] );
+		return $theme->exists() ? $theme->is_block_theme() : false;
+	}
+
+	/**
+	 * Update the field.
+	 *
+	 * This is not used because themes can't be updated using the API.
+	 *
+	 * @param mixed           $value The new value for the field.
+	 * @param mixed           $object_data The theme data.
+	 * @param WP_REST_Request $request     WP API request.
+	 *
+	 * @return WP_Error
+	 */
+	public function update( $value, $object_data, $request ) {
+		return new WP_Error( 'not_implemeted', __( 'Themes cannot be updated using the REST API.', 'jetpack' ), array( 'status' => 501 ) );
+	}
+
+	/**
+	 * Schema for the field.
+	 *
+	 * @return array
+	 */
+	public function get_schema() {
+		return array(
+			'description' => __( 'Whether the theme is a block-based theme.', 'jetpack' ),
+			'type'        => 'boolean',
+			'readonly'    => true,
+		);
+	}
+}
+
+// TODO: add conditional to only load this if it ends up being included in Core.
+// See https://core.trac.wordpress.org/ticket/58123
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Theme_Fields_Is_Block_Theme' );

--- a/projects/plugins/jetpack/changelog/add-themes-is-block-theme-field
+++ b/projects/plugins/jetpack/changelog/add-themes-is-block-theme-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add is_block_theme field to the wp/v2/themes endpoint to indicate it the theme is a block-based theme.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-class-theme-fields-is-block-theme.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-class-theme-fields-is-block-theme.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @group rest-api
+ */
+class Test_WPCOM_REST_API_V2_Theme_Fields_Is_Block_Theme extends WP_Test_Jetpack_REST_Testcase {
+	protected static $admin_id;
+
+	public static function set_up_before_class() {
+		self::$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public function test_theme_is_block_theme() {
+		switch_theme( 'block-theme' );
+
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+
+		$this->assertTrue( isset( $result[0]['is_block_theme'] ) );
+		$this->assertTrue( $result[0]['is_block_theme'] );
+	}
+
+	public function test_theme_is_not_block_theme() {
+		switch_theme( 'rest-api' );
+
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+
+		$this->assertTrue( isset( $result[0]['is_block_theme'] ) );
+		$this->assertFalse( $result[0]['is_block_theme'] );
+	}
+
+	/**
+	 * Performs a REST API request for the active theme.
+	 *
+	 * @return WP_REST_Response The request's response.
+	 */
+	protected function perform_active_theme_request() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/themes' );
+		$request->set_param( 'status', 'active' );
+
+		return rest_get_server()->dispatch( $request );
+	}
+}


### PR DESCRIPTION
First step in fixing https://github.com/Automattic/wp-calypso/issues/62755

## Proposed changes:

Adds the `is_block_theme` field to the `wp/v2/themes` endpoint, to indicate if each theme is a block-based theme, or not.

Note that I've [proposed adding this field in Core](https://core.trac.wordpress.org/ticket/58123#ticket), but am also adding it here to to make the change available sooner to WP.com sites and in case it's not desired in Core.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See https://github.com/Automattic/wp-calypso/issues/62755

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

**Jetpack sites**

* Install Jetpack Debug Tools and enable the REST API Tester (`/wp-admin/admin.php?page=jetpack-debug-tools`) 
* Use the REST API Tester to make a request to `/wp/v2/themes`
* See that the `is_block_theme` field is added to each theme and properly indicates if the theme is block-based.

**wpcom**

- Apply D108111-code, patch your sandbox with `bin/jetpack-downloader test jetpack add/themes-is-block-theme-field` and sandbox public-api.wordpress.com
- Use the API console to make a request to `/wp/v2/themes?status=active`
- See that the `is_block_theme` field is added and properly indicates if the theme is block-based.

