### PR TITLE
Launchpad Checklist API: Update free flow task definitions

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-free-flow-task-definitions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-free-flow-task-definitions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+SLaunchpad Checklist API: add task definitions for the Launchpad free flow

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -67,6 +67,32 @@ function get_checklist_definitions() {
 }
 
 /**
+ * Determines whether or not design selected task is enabled
+ *
+ * @return boolean True if design selected task is enabled
+ */
+function can_update_design_selected_task() {
+	$site_intent = get_option( 'site_intent' );
+	return $site_intent === 'free' || $site_intent === 'build' || $site_intent === 'write';
+}
+
+/**
+ * Determines whether or not domain upsell task is completed
+ *
+ * @return boolean True if domain upsell task is completed
+ */
+function is_domain_upsell_completed() {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		if ( class_exists( '\WPCOM_Store_API' ) ) {
+			$plan = \WPCOM_Store_API::get_current_plan( \get_current_blog_id() );
+			return ! $plan['is_free'] || get_checklist_task( 'domain_upsell_deferred' );
+		}
+	}
+
+	return get_checklist_task( 'domain_upsell_deferred' );
+}
+
+/**
  * Returns the subtitle for the plan selected task
  *
  * @return string Subtitle text
@@ -84,13 +110,12 @@ function get_plan_selected_subtitle() {
 }
 
 /**
- * Determines whether or not design selected task is enabled
+ * Returns the badge text for the plan selected task
  *
- * @return boolean True if design selected task is enabled
+ * @return string Badge text
  */
-function can_update_design_selected_task() {
-	$site_intent = get_option( 'site_intent' );
-	return $site_intent === 'free' || $site_intent === 'build' || $site_intent === 'write';
+function get_domain_upsell_badge_text() {
+	return is_domain_upsell_completed() ? '' : __( 'Upgrade plan', 'jetpack-mu-wpcom' );
 }
 
 /**
@@ -185,6 +210,7 @@ function get_task_definitions() {
 		'setup_free'
 			=> array(
 				'id'        => 'setup_free',
+				'title'     => __( 'Personalize your site', 'jetpack-mu-wpcom' ),
 				'completed' => true,
 				'disabled'  => false,
 			),
@@ -219,9 +245,11 @@ function get_task_definitions() {
 			),
 		'domain_upsell'
 			=> array(
-				'id'        => 'domain_upsell',
-				'completed' => false,
-				'disabled'  => false,
+				'id'         => 'domain_upsell',
+				'title'      => __( 'Choose a domain', 'jetpack-mu-wpcom' ),
+				'completed'  => is_domain_upsell_completed(),
+				'disabled'   => false,
+				'badge_text' => get_domain_upsell_badge_text(),
 			),
 		'verify_email'
 			=> array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

- Fixes https://github.com/Automattic/jetpack/issues/30042 and https://github.com/Automattic/wp-calypso/issues/75504

## Estimated Time to Test / Review:
- Test -> Short
- Review -> Short

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add task definitions to Launchpad Checklist API for free flow

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/launchpad-free-flow-task-definitions` to build and sync this branch to your sandbox. 
2. Sandbox a test site and public api. 
3. Start a new free onboarding site from https://wordpress.com/setup/free/intro and proceed to launchpad. 
4. Go to `https://developer.wordpress.com/docs/api/console/`, select Rest API and wpcom/v2, and input the following: `/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=free`. Confirm you get back an appropriate checklist that matches the status of checklist items on Launchpad.
5. Verify that the `domain_upsell` task is completed if a non-free plan is purchased or the "choose a domain later" link is clicked during the custom domains flow

<img width="1496" alt="Screenshot 2023-04-17 at 7 42 06 PM" src="https://user-images.githubusercontent.com/5414230/232656841-f29d19f6-88fa-4bf0-84ac-1e900309018d.png">

6. Go back to the frontend launchpad screen from Step 3, and try completing one or more tasks. After each step, re-run the test in Step 4. You should alway see the correct task status in the developer console, matching the status of tasks on the frontend Launchpad. 

