### PR TITLE
Stats Admin: use custom config data names other than all `configData`

### DIFF
--- a/projects/packages/stats-admin/changelog/update-use-custom-config-data-names
+++ b/projects/packages/stats-admin/changelog/update-use-custom-config-data-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats Admin: changed to use custom config data variable name to avoid conflicts with `configData`

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.7.1",
+	"version": "0.7.2-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -126,6 +126,6 @@ class Dashboard {
 	 * Load the admin scripts.
 	 */
 	public function load_admin_scripts() {
-		( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'build.min' );
+		( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'build.min', array( 'config_variable_name' => 'jetpackStatsOdysseyAppConfigData' ) );
 	}
 }

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.7.1';
+	const VERSION = '0.7.2-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -36,6 +36,7 @@ class Odyssey_Assets {
 		$default_options = array(
 			'config_data'          => ( new Odyssey_Config_Data() )->get_data(),
 			'config_variable_name' => 'configData',
+			'enqueue_css'          => true,
 		);
 		$options         = wp_parse_args( $options, $default_options );
 		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.js" ) ) {
@@ -52,12 +53,16 @@ class Odyssey_Assets {
 			Assets::enqueue_script( $asset_handle );
 		} else {
 			// In production, we load the assets from our CDN.
-			$css_url    = $asset_name . ( is_rtl() ? '.rtl' : '' ) . '.css';
-			$css_handle = $asset_handle . '-style';
 			wp_register_script( $asset_handle, sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, "{$asset_name}.js" ), self::JS_DEPENDENCIES, $this->get_cdn_asset_cache_buster(), true );
-			wp_register_style( $css_handle, sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, $css_url ), array(), $this->get_cdn_asset_cache_buster() );
 			wp_enqueue_script( $asset_handle );
-			wp_enqueue_style( $css_handle );
+
+			// Enqueue CSS if needed.
+			if ( $options['enqueue_css'] ) {
+				$css_url    = $asset_name . ( is_rtl() ? '.rtl' : '' ) . '.css';
+				$css_handle = $asset_handle . '-style';
+				wp_register_style( $css_handle, sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, $css_url ), array(), $this->get_cdn_asset_cache_buster() );
+				wp_enqueue_style( $css_handle );
+			}
 		}
 
 		wp_add_inline_script(

--- a/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
+++ b/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
@@ -53,7 +53,7 @@ class WP_Dashboard_Odyssey_Widget {
 			array(
 				'config_variable_name' => 'jetpackStatsOdysseyWidgetConfigData',
 				'config_data'          => $config_data,
-				'css_path'             => false,
+				'enqueue_css'          => false,
 			)
 		);
 	}

--- a/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
+++ b/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
@@ -49,7 +49,13 @@ class WP_Dashboard_Odyssey_Widget {
 		$config_data = ( new Odyssey_Config_Data() )->get_data();
 		// The widget doesn't use redux.
 		unset( $config_data['intial_state'] );
-		// TODO: change `configData` to a more unique name to avoid future conflicts.
-		( new Odyssey_Assets() )->load_admin_scripts( 'jetpack_stats_widget', 'widget-loader.min', 'configData', $config_data );
+		( new Odyssey_Assets() )->load_admin_scripts(
+			'jetpack_stats_widget',
+			'widget-loader.min',
+			array(
+				'config_variable_name' => 'jetpackStatsOdysseyWidgetConfigData',
+				'config_data'          => $config_data,
+			)
+		);
 	}
 }

--- a/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
+++ b/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
@@ -53,6 +53,7 @@ class WP_Dashboard_Odyssey_Widget {
 			array(
 				'config_variable_name' => 'jetpackStatsOdysseyWidgetConfigData',
 				'config_data'          => $config_data,
+				'css_path'             => false,
 			)
 		);
 	}

--- a/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
+++ b/projects/packages/stats-admin/src/class-wp-dashboard-odyssey-widget.php
@@ -47,8 +47,6 @@ class WP_Dashboard_Odyssey_Widget {
 	 */
 	public function load_admin_scripts() {
 		$config_data = ( new Odyssey_Config_Data() )->get_data();
-		// The widget doesn't use redux.
-		unset( $config_data['intial_state'] );
 		( new Odyssey_Assets() )->load_admin_scripts(
 			'jetpack_stats_widget',
 			'widget-loader.min',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/75257

## Proposed changes:

* Renames Odyssey Stats Widget `configData` to `jetpackStatsOdysseyWidgetConfigData`
* Renames Odyssey Stats `configData` to `jetpackStatsOdysseyAppConfigData`
* Stops loading css for Odyssey Widget because it doesn't have one

So that in the future, if we have multiple widgets running on the same page, they wouldn't fight with each other. And it also prevents conflict from other plugins etc.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Test locally with https://github.com/Automattic/wp-calypso/pull/75857
* Ensure Odyssey Stats loads okay
* Ensure Odyssey Widget loads okay

