### PR TITLE
Jetpack Boost: Fix Warnings in PHP 8.2

### DIFF
--- a/projects/packages/wp-js-data-sync/changelog/boost-fix-php-82-warnings
+++ b/projects/packages/wp-js-data-sync/changelog/boost-fix-php-82-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Boost: Fix PHP 8.2 Warnings

--- a/projects/packages/wp-js-data-sync/src/class-data-sync.php
+++ b/projects/packages/wp-js-data-sync/src/class-data-sync.php
@@ -87,6 +87,11 @@ final class Data_Sync {
 	 */
 	private static $instance = array();
 
+	/**
+	 * @var string The namespace to use for the registry.
+	 */
+	private $namespace;
+
 	public function __construct( $namespace ) {
 		$this->namespace = $namespace;
 		$this->registry  = new Registry( $namespace );

--- a/projects/packages/wp-js-data-sync/src/class-data-sync.php
+++ b/projects/packages/wp-js-data-sync/src/class-data-sync.php
@@ -86,7 +86,6 @@ final class Data_Sync {
 	 * @var Data_Sync[]
 	 */
 	private static $instance = array();
-
 	/**
 	 * @var string The namespace to use for the registry.
 	 */

--- a/projects/plugins/boost/app/features/speed-score/Speed_Score.php
+++ b/projects/plugins/boost/app/features/speed-score/Speed_Score.php
@@ -21,7 +21,7 @@ class Speed_Score {
 	 * @var Modules_Setup
 	 */
 	protected $modules;
-	
+
 	public function __construct( Modules_Setup $modules ) {
 		$this->modules = $modules;
 
@@ -284,6 +284,5 @@ class Speed_Score {
 
 		return rest_ensure_response( $response );
 	}
-
 
 }

--- a/projects/plugins/boost/app/features/speed-score/Speed_Score.php
+++ b/projects/plugins/boost/app/features/speed-score/Speed_Score.php
@@ -16,6 +16,12 @@ use Automattic\Jetpack_Boost\Modules\Modules_Setup;
  * Class Speed_Score
  */
 class Speed_Score {
+
+	/**
+	 * @var Modules_Setup
+	 */
+	protected $modules;
+	
 	public function __construct( Modules_Setup $modules ) {
 		$this->modules = $modules;
 
@@ -278,4 +284,6 @@ class Speed_Score {
 
 		return rest_ensure_response( $response );
 	}
+
+
 }

--- a/projects/plugins/boost/changelog/boost-fix-php-82-warnings
+++ b/projects/plugins/boost/changelog/boost-fix-php-82-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Boost: Fix PHP 8.2 Warnings


### PR DESCRIPTION
Fix Warnings in PHP 8.2


### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
Use PHP 8.2 and test the plugin.