### PR TITLE
Social Previews | Add LinkedIn preview

### DIFF
--- a/projects/js-packages/publicize-components/src/components/social-previews/constants.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/constants.js
@@ -1,6 +1,7 @@
 import { SocialServiceIcon } from '@automattic/jetpack-components';
 import { FacebookPreview, SearchPreview } from '@automattic/social-previews';
 import { __ } from '@wordpress/i18n';
+import { LinkedIn } from './linkedin';
 import { Twitter } from './twitter';
 
 export const AVAILABLE_SERVICES = [
@@ -32,7 +33,7 @@ export const AVAILABLE_SERVICES = [
 		title: __( 'LinkedIn', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="linkedin" { ...props } />,
 		name: 'linkedin',
-		preview: () => null,
+		preview: props => <LinkedIn { ...props } />,
 	},
 	{
 		title: __( 'Tumblr', 'jetpack' ),

--- a/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
@@ -1,3 +1,4 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { LinkedInPreview, FEED_TEXT_MAX_LENGTH } from '@automattic/social-previews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -69,7 +70,7 @@ export function LinkedIn( props ) {
 							{
 								LearnMoreLink: (
 									<a
-										href={ 'https://jetpack.com/support/jetpack-social-image-generator' }
+										href={ getRedirectUrl( 'jetpack-social-image-generator' ) }
 										rel="noopener noreferrer"
 										target="_blank"
 									/>

--- a/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
@@ -1,0 +1,91 @@
+import { LinkedInPreview, FEED_TEXT_MAX_LENGTH } from '@automattic/social-previews';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+import { getLinkedInDetails, getTextForLinkedIn } from '../../store/selectors';
+
+/**
+ * The linkedin tab component.
+ *
+ * @param {object} props - The props.
+ * @returns {React.ReactNode} The linkedin tab component.
+ */
+export function LinkedIn( props ) {
+	const { title, url, image } = props;
+
+	const { name, profileImage } = getLinkedInDetails();
+
+	const text = getTextForLinkedIn();
+
+	const autoSharedText = text
+		.substring( 0, FEED_TEXT_MAX_LENGTH )
+		// Subtract the length of the URL and the space before it.
+		.slice( 0, -( url.length + 1 ) );
+
+	return (
+		<div className="linked-preview-tab">
+			<section>
+				<header>
+					<h2>{ __( 'Auto-shared', 'jetpack' ) }</h2>
+					<p className="description">
+						{ __( 'This is how it will look like when auto-shared', 'jetpack' ) }
+					</p>
+				</header>
+				<LinkedInPreview
+					jobTitle="Job Title (Company Name)"
+					image={ image }
+					name={ name }
+					profileImage={ profileImage }
+					title={ title }
+					text={ `${ autoSharedText } ${ url }` }
+				/>
+			</section>
+			<section>
+				<header>
+					<h2>{ __( 'Your post', 'jetpack' ) }</h2>
+					<p className="description">
+						{ __( 'This is what your social post will look like on LinkedIn', 'jetpack' ) }
+					</p>
+				</header>
+				<LinkedInPreview
+					jobTitle="Job Title (Company Name)"
+					image={ image }
+					name={ name }
+					profileImage={ profileImage }
+					title={ title }
+					text={ text }
+					url={ url }
+				/>
+			</section>
+			<section>
+				<header>
+					<h2>{ __( 'Link preview', 'jetpack' ) }</h2>
+					<p className="description">
+						{ createInterpolateElement(
+							__(
+								'This is what it will look like when someone shares the link to your WordPress post on LinkedIn. <LearnMoreLink>Learn more about links</LearnMoreLink>',
+								'jetpack'
+							),
+							{
+								LearnMoreLink: (
+									<a
+										href={ 'https://jetpack.com/support/jetpack-social-image-generator' }
+										rel="noopener noreferrer"
+										target="_blank"
+									/>
+								),
+							}
+						) }
+					</p>
+				</header>
+				<LinkedInPreview
+					jobTitle="Job Title (Company Name)"
+					image={ image }
+					title={ title }
+					url={ url }
+					{ ...getLinkedInDetails( { forceDefaults: true } ) }
+				/>
+			</section>
+		</div>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
@@ -3,7 +3,8 @@ import { LinkedInPreview, FEED_TEXT_MAX_LENGTH } from '@automattic/social-previe
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
-import { getLinkedInDetails, getTextForLinkedIn } from '../../store/selectors';
+import useSocialMediaMessage from '../../hooks/use-social-media-message';
+import { getLinkedInDetails } from '../../store/selectors';
 
 /**
  * The linkedin tab component.
@@ -16,7 +17,7 @@ export function LinkedIn( props ) {
 
 	const { name, profileImage } = getLinkedInDetails();
 
-	const text = getTextForLinkedIn();
+	const { message: text } = useSocialMediaMessage();
 
 	const autoSharedText = text
 		.substring( 0, FEED_TEXT_MAX_LENGTH )

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -82,7 +82,7 @@ export default withSelect( select => {
 			__( 'Visit the post for more.', 'jetpack' ),
 		url: getEditedPostAttribute( 'link' ),
 		author: user?.name,
-		image: !! featuredImageId && getMediaSourceUrl( media ),
+		image: ( !! featuredImageId && getMediaSourceUrl( media ) ) || '',
 	};
 
 	let tweets = [];

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
@@ -193,3 +193,15 @@ $highlight-color: #3858e9;
 		font-size: 1rem;
 	}
 }
+
+.linked-preview-tab {
+	header {
+		width: 555px;
+	}
+	p.description {
+		font-size: 1rem;
+	}
+	.linkedin-preview {
+		margin: 1.25rem 0 3rem;
+	}
+}

--- a/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
@@ -1,3 +1,4 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { TwitterPreview } from '@automattic/social-previews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -61,7 +62,7 @@ export function Twitter( { isTweetStorm, tweets, media } ) {
 							{
 								LearnMoreLink: (
 									<a
-										href={ 'https://jetpack.com/support/jetpack-social-image-generator' }
+										href={ getRedirectUrl( 'jetpack-social-image-generator' ) }
 										rel="noopener noreferrer"
 										target="_blank"
 									/>

--- a/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
@@ -61,7 +61,7 @@ export function Twitter( { isTweetStorm, tweets, media } ) {
 							{
 								LearnMoreLink: (
 									<a
-										href={ 'https://jetpack.com/support/jetpack-social/twitter/' }
+										href={ 'https://jetpack.com/support/jetpack-social-image-generator' }
 										rel="noopener noreferrer"
 										target="_blank"
 									/>

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -37,6 +37,31 @@ export function getMustReauthConnections() {
 }
 
 /**
+ * Returns a template for linkedIn data, based on the first linkedin account found.
+ *
+ * @param {object} args - Arguments.
+ * @param {boolean} args.forceDefaults - Whether to use default values.
+ * @returns {object} The linkedin account data.
+ */
+export function getLinkedInDetails( { forceDefaults = false } = {} ) {
+	if ( ! forceDefaults ) {
+		const connection = getConnections().find( ( { service_name } ) => 'linkedin' === service_name );
+
+		if ( connection ) {
+			return {
+				name: connection.display_name,
+				profileImage: connection.profile_picture,
+			};
+		}
+	}
+
+	return {
+		name: __( 'Account Name', 'jetpack' ),
+		profileImage: 'https://static.licdn.com/sc/h/1c5u578iilxfi4m4dvc4q810q',
+	};
+}
+
+/**
  * Returns a template for tweet data, based on the first Twitter account found.
  *
  * @param {object} state - State object.
@@ -235,6 +260,19 @@ export function getTwitterCardForURLs( state, urls ) {
  */
 export function twitterCardIsCached( state, url ) {
 	return !! state.twitterCards[ url ];
+}
+
+/**
+ * Gets the text that will be used when sharing this post on LinkedIn.
+ *
+ * @returns {string} The share message.
+ */
+export function getTextForLinkedIn() {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const meta = getEditedPostAttribute( 'meta' );
+	const text = meta?.jetpack_publicize_message || getEditedPostAttribute( 'title' ) || '';
+
+	return text;
 }
 
 /**

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -263,19 +263,6 @@ export function twitterCardIsCached( state, url ) {
 }
 
 /**
- * Gets the text that will be used when sharing this post on LinkedIn.
- *
- * @returns {string} The share message.
- */
-export function getTextForLinkedIn() {
-	const { getEditedPostAttribute } = select( 'core/editor' );
-	const meta = getEditedPostAttribute( 'meta' );
-	const text = meta?.jetpack_publicize_message || getEditedPostAttribute( 'title' ) || '';
-
-	return text;
-}
-
-/**
  * Gets the message that will be used hen sharing this post.
  *
  * @returns {string} The share message.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Completes 1203820933396971-as-1204281809108917/f and 1203820933396971-as-1204281809108921/f

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds the LinkedIn preview to the Social Previews modal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdrWKz-Ka-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

* Checkout this PR branch
* Checkout the latest `trunk` in calypso
* In `wp-calypso/packages/social-previews/` directory, run `pnpm link --global` to expose the package to global `node_modules` for `pnpm`
* In `jetpack/projects/js-packages/publicize-components/` directory, run `pnpm link --global @automattic/social-previews`
* In `wp-calypso` root, run `yarn` and then `yarn workspace @automattic/social-previews run build`
* In Jetpack, run `jetpack build plugins/jetpack --no-pnpm-install`
* Start writing a new post with JT site via Jetpack
* Click Jetpack icon on the top of the sidebar
* Under "Social Previews", click on "Preview"
* Confirm that the preview of LinkedIn is as expected
* Once you are done, run `pnpm unlink` in Jetpack

<img width="1327" alt="Screenshot 2023-04-18 at 4 13 51 PM" src="https://user-images.githubusercontent.com/18226415/232755418-e9da6df4-1caa-4b3d-b5eb-232912c660cd.png">
<img width="1467" alt="Screenshot 2023-04-18 at 4 14 16 PM" src="https://user-images.githubusercontent.com/18226415/232755451-0992dbbf-f2a3-44dd-8cab-bafdc787b1e6.png">
<img width="1468" alt="Screenshot 2023-04-18 at 4 14 28 PM" src="https://user-images.githubusercontent.com/18226415/232755461-826872b2-59e6-4ca9-8c22-fe98adc8aaae.png">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1204281809108917
  - 0-as-1204281809108921