### PR TITLE
My Jetpack: Add product card action menu for standalone plugin actions

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -1,7 +1,7 @@
 import { Button, Text } from '@automattic/jetpack-components';
 import { Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { external, moreVertical } from '@wordpress/icons';
+import { external, moreVertical, arrowDown } from '@wordpress/icons';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
@@ -18,7 +18,22 @@ const PRODUCT_STATUSES_LABELS = {
 };
 
 /* eslint-disable react/jsx-no-bind */
-const Menu = ( { items = [], onManage } ) => {
+const Menu = ( {
+	items = [],
+	onManage,
+	onInstall,
+	onActivate,
+	hasStandalonePlugin,
+	isStandaloneInstalled,
+	isStandaloneActive,
+} ) => {
+	/**
+	 * Only show standalone related option if plugin is not installed
+	 * or the plugin is not active
+	 */
+	const showStandaloneOption =
+		hasStandalonePlugin && ( ! isStandaloneInstalled || ! isStandaloneActive );
+
 	return (
 		<Dropdown
 			className={ styles.dropdown }
@@ -60,6 +75,39 @@ const Menu = ( { items = [], onManage } ) => {
 					>
 						{ __( 'Manage', 'jetpack-my-jetpack' ) }
 					</Button>
+					{ showStandaloneOption && (
+						<>
+							<hr />
+							{ ! isStandaloneInstalled && (
+								<Button
+									weight="regular"
+									fullWidth
+									variant="tertiary"
+									icon={ arrowDown }
+									onClick={ () => {
+										onClose();
+										onInstall?.();
+									} }
+								>
+									{ __( 'Install plugin', 'jetpack-my-jetpack' ) }
+								</Button>
+							) }
+							{ isStandaloneInstalled && ! isStandaloneActive && (
+								<Button
+									weight="regular"
+									fullWidth
+									variant="tertiary"
+									icon={ external }
+									onClick={ () => {
+										onClose();
+										onActivate?.();
+									} }
+								>
+									{ __( 'Activate plugin', 'jetpack-my-jetpack' ) }
+								</Button>
+							) }
+						</>
+					) }
 				</>
 			) }
 		/>
@@ -82,6 +130,11 @@ const ProductCard = props => {
 		children,
 		showMenu = false,
 		menuItems = [],
+		onInstallStandalone,
+		onActivateStandalone,
+		hasStandalonePlugin = false,
+		isStandaloneInstalled = false,
+		isStandaloneActive = false,
 	} = props;
 	const isActive = status === PRODUCT_STATUSES.ACTIVE;
 	const isError = status === PRODUCT_STATUSES.ERROR;
@@ -176,7 +229,20 @@ const ProductCard = props => {
 					<Text variant="title-medium">{ name }</Text>
 					{ menuIsActive && icon }
 				</div>
-				{ menuIsActive ? <Menu items={ menuItems } onManage={ onManage } /> : icon }
+				{ menuIsActive ? (
+					<Menu
+						status={ status }
+						items={ menuItems }
+						onManage={ onManage }
+						onInstall={ onInstallStandalone }
+						onActivate={ onActivateStandalone }
+						hasStandalonePlugin={ hasStandalonePlugin }
+						isStandaloneActive={ isStandaloneActive }
+						isStandaloneInstalled={ isStandaloneInstalled }
+					/>
+				) : (
+					icon
+				) }
 			</div>
 			{
 				// If is not active, no reason to use children

--- a/projects/packages/my-jetpack/_inc/components/product-card/stories/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/stories/index.jsx
@@ -113,3 +113,20 @@ WithMenu.args = {
 		},
 	],
 };
+
+export const WithMenuForStandalone = Template.bind( {} );
+WithMenuForStandalone.args = {
+	...DefaultArgs,
+	showMenu: true,
+	menuItems: [
+		{
+			label: 'Upload',
+			icon: arrowUp,
+		},
+	],
+	onInstallStandalone: () => alert( 'Installing standalone plugin' ),
+	onActivateStandalone: () => alert( 'Activating standalone plugin' ),
+	hasStandalonePlugin: true,
+	isStandaloneInstalled: false,
+	isStandaloneActive: false,
+};

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-product-card-action-menu-for-standalone-plugin-actions
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-product-card-action-menu-for-standalone-plugin-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add Install/Activate menu actions based on the standalone plugin status.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #29901

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add Install/Activate actions on product card menu based on standalone plugin status

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* We are going to test it on storybook
* Checkout this branch on your local dev environment and run the following commands:

```
cd projects/js-packages/storybook
pnpm run storybook:dev
```

* The storybook will build and then launch a new tab on your browser
* Look for the stories related to My Jetpack

<img width="233" alt="Screen Shot 2023-04-18 at 09 39 39" src="https://user-images.githubusercontent.com/6760046/232780100-1d5ab82c-8958-427c-a87c-63003e8c7084.png">

* Open the group of stories for the Product Card and look for the "With Menu For Standalone" story:

<img width="226" alt="Screen Shot 2023-04-18 at 09 43 26" src="https://user-images.githubusercontent.com/6760046/232780944-e8b84722-fe23-423c-9d35-58d22bfa809a.png">

* Notice that the card will load with some state already:

<img width="446" alt="Screen Shot 2023-04-18 at 09 44 16" src="https://user-images.githubusercontent.com/6760046/232781158-593bc431-ab2d-45ea-84e7-b95c4466156e.png">

* You can play with the values for the standalone flags and check the difference on the rendered menu:

<img width="706" alt="Screen Shot 2023-04-18 at 09 45 43" src="https://user-images.githubusercontent.com/6760046/232781507-bd5819db-6939-4fe7-89a1-8b33cdf7142a.png">

* The expected results for each standalone flag change are the following:

| Standalone plugin status | Expected menu |
| ------------- | ------------- |
| Product does not have a standalone plugin | No action menu added |
| Product has a standalone plugin, but it's not installed | "Install plugin" |
| Product has a standalone plugin, it's installed but is not active | "Activate plugin" |
| Product has a standalone plugin, that is installed and active | No action menu added |

