### PR TITLE
VideoPress: enqueue IFrame API file based on the embed_oembed_html filter

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-iterate-checking-videopress-url
+++ b/projects/packages/videopress/changelog/update-videopress-iterate-checking-videopress-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: enqueue IFrame API file based on the embed_oembed_html filter

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -16,6 +16,7 @@ class Initializer {
 
 	const JETPACK_VIDEOPRESS_VIDEO_HANDLER      = 'jetpack-videopress-video-block';
 	const JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER = 'jetpack-videopress-video-block-view';
+	const JETPACK_VIDEOPRESS_IFRAME_API_HANDLER = 'jetpack-videopress-iframe-api';
 
 	/**
 	 * Initialization optinos
@@ -339,13 +340,8 @@ class Initializer {
 			)
 		);
 
-		wp_enqueue_script(
-			self::JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER . '-iframe-api',
-			'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
-			array(),
-			gmdate( 'YW' ),
-			false
-		);
+		// Handle enqueuing of the VideoPress Iframe API script in the front-end.
+		add_filter( 'embed_oembed_html', array( __CLASS__, 'enqueue_videopress_iframe_api_script' ), 10, 4 );
 
 		// Register VideoPress video block.
 		register_block_type(
@@ -354,5 +350,31 @@ class Initializer {
 				'render_callback' => array( __CLASS__, 'render_videopress_video_block' ),
 			)
 		);
+	}
+
+	/**
+	 * Enqueue the VideoPress Iframe API script
+	 * when the URL of oEmbed HTML is a VideoPress URL.
+	 *
+	 * @param string|false $cache   The cached HTML result, stored in post meta.
+	 * @param string       $url     The attempted embed URL.
+	 * @param array        $attr    An array of shortcode attributes.
+	 * @param int          $post_ID Post ID.
+	 *
+	 * @return string|false
+	 */
+	public static function enqueue_videopress_iframe_api_script( $cache, $url, $attr, $post_ID ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( Utils::is_videopress_url( $url ) ) {
+			// Enqueue the VideoPress IFrame API in the front-end.
+			wp_enqueue_script(
+				self::JETPACK_VIDEOPRESS_IFRAME_API_HANDLER,
+				'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
+				array(),
+				gmdate( 'YW' ),
+				false
+			);
+		}
+
+		return $cache;
 	}
 }

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -129,6 +129,10 @@ class Initializer {
 		XMLRPC::init();
 		Block_Editor_Content::init();
 		self::register_oembed_providers();
+
+		// Enqueuethe VideoPress Iframe API script in the front-end.
+		add_filter( 'embed_oembed_html', array( __CLASS__, 'enqueue_videopress_iframe_api_script' ), 10, 4 );
+
 		if ( self::should_initialize_admin_ui() ) {
 			Admin_UI::init();
 		}
@@ -339,9 +343,6 @@ class Initializer {
 				'textdomain' => 'jetpack-videopress-pkg',
 			)
 		);
-
-		// Handle enqueuing of the VideoPress Iframe API script in the front-end.
-		add_filter( 'embed_oembed_html', array( __CLASS__, 'enqueue_videopress_iframe_api_script' ), 10, 4 );
 
 		// Register VideoPress video block.
 		register_block_type(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR handles how the VideoPress IFrame API file is enqueued. Relevant changes:

* **It is not enqueued in the wp-admin**.
  It has yet to be used.
* **It is enqueued in the front end only when required.**
  It is enqueued by hooking to the `embed_oembed_html` filter, meaning the file will be enqueued if the site has a VideoPress video oEmbed instance.

Fixes https://github.com/Automattic/jetpack/issues/29934

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: enqueue IFrame API file based on the embed_oembed_html filter

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to any wp-admin page
* Open the network tab
* Filter by JS files and by the `iframe-api` string
* **Before**, confirm the file is enqueued and thus loaded by the client 

<img width="593" alt="Screen Shot 2023-04-18 at 10 04 07" src="https://user-images.githubusercontent.com/77539/232786308-c8244010-8579-4507-87d6-52ab026d918b.png">

* **After**, confirm the file is not enqueued.

* Go to the block editor
* Add a VideoPress video instance
<img width="626" alt="image" src="https://user-images.githubusercontent.com/77539/232788774-4459a23f-c683-4894-aa48-968c5d442032.png">

* First of all, confirm the `videopress-iframe-api.js` is not enqueued or loaded in the client

* Go to the front end, and confirm that without setting the video source for the, the `videopress-iframe-api.js` is not loaded in the client
* GO back to the editor
* Set a video source for the video block
* Save the post
* Go to the front end again
* Hard refresh
* Confirm that, now, the iframe API is enqueued.

<img width="1325" alt="Screen Shot 2023-04-18 at 10 18 59" src="https://user-images.githubusercontent.com/77539/232789967-a45ac04a-241a-4bff-b4a8-0d165d3f8608.png">
