### PR TITLE
Social Dashboard: fix post editor link on subdirectory installs

### DIFF
--- a/projects/plugins/social/changelog/fix-social-write-post-link-subdirectories
+++ b/projects/plugins/social/changelog/fix-social-write-post-link-subdirectories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: ensure the link to the post editor works, even when WordPress is installed in a subdirectory.

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -19,24 +19,26 @@ import styles from './styles.module.scss';
 
 const Header = () => {
 	const {
-		hasConnections,
-		isModuleEnabled,
 		connectionsAdminUrl,
-		sharesCount,
-		postsCount,
-		isShareLimitEnabled,
+		hasConnections,
 		hasPaidPlan,
+		isModuleEnabled,
+		isShareLimitEnabled,
+		newPostUrl,
+		postsCount,
+		sharesCount,
 		siteSuffix,
 	} = useSelect( select => {
 		const store = select( STORE_ID );
 		return {
-			hasConnections: store.hasConnections(),
-			isModuleEnabled: store.isModuleEnabled(),
 			connectionsAdminUrl: store.getConnectionsAdminUrl(),
-			sharesCount: select( STORE_ID ).getSharesCount(),
-			postsCount: select( STORE_ID ).getPostsCount(),
-			isShareLimitEnabled: select( STORE_ID ).isShareLimitEnabled(),
+			hasConnections: store.hasConnections(),
 			hasPaidPlan: select( STORE_ID ).hasPaidPlan(),
+			isModuleEnabled: store.isModuleEnabled(),
+			isShareLimitEnabled: select( STORE_ID ).isShareLimitEnabled(),
+			newPostUrl: `${ store.getAdminUrl() }post-new.php`,
+			postsCount: select( STORE_ID ).getPostsCount(),
+			sharesCount: select( STORE_ID ).getSharesCount(),
 			siteSuffix: select( STORE_ID ).getSiteSuffix(),
 		};
 	} );
@@ -68,7 +70,7 @@ const Header = () => {
 								{ __( 'Connect accounts', 'jetpack-social' ) }
 							</Button>
 						) }
-						<Button href={ '/wp-admin/post-new.php' } variant="secondary">
+						<Button href={ newPostUrl } variant="secondary">
 							{ __( 'Write a post', 'jetpack-social' ) }
 						</Button>
 					</div>


### PR DESCRIPTION
## Proposed changes:

WordPress [can be installed in a subdirectory](https://wordpress.org/documentation/article/giving-wordpress-its-own-directory/), and in those scenarios the site's block editor lives at a URL like `yoursite.com/subdirectory/wp-admin/post-new.php`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* You'll need a WordPress install where WP lives in a subdirectory while the site is accessible at the root of the domain.
* Install the Social plugin and connect it to WordPress.com.
* Go to Jetpack > Social 
* Click on the "Write a post" button.
