### PR TITLE
CRM: Resolves 3063 - broken link in settings on white label installs

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3063-fix_manage_features_button
+++ b/projects/plugins/crm/changelog/fix-crm-3063-fix_manage_features_button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Settings: fixed broken link on white label installs

--- a/projects/plugins/crm/includes/jpcrm-learn-menu-legacy-functions.php
+++ b/projects/plugins/crm/includes/jpcrm-learn-menu-legacy-functions.php
@@ -763,10 +763,10 @@ function jpcrm_settings_learn_menu(){
 
 	// wh temp hack for mail delivery learn
     $title = __("Settings","zero-bs-crm");
-    
-    if ( current_user_can('admin_zerobs_manage_options') ) {
-        $addNew =  ' <a href="' . zeroBSCRM_getAdminURL($zbs->slugs['extensions'])  . '#free-extensions-tour" class="button ui orange tiny zbs-add-new" id="manage-features">' . __( 'Manage Features',"zero-bs-crm") . '</a>';
-    }
+
+	if ( current_user_can( 'admin_zerobs_manage_options' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+		$addNew = ' <a href="' . zeroBSCRM_getAdminURL( $zbs->slugs['modules'] ) . '" class="button ui orange tiny zbs-add-new" id="manage-features">' . __( 'Manage modules', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	}
 
 	$tab = '';
 	if (isset($_GET['tab']) && $_GET['tab'] == 'maildelivery'){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3063 - broken link in settings on white label installs

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We linked to the extensions page on the settings page, but on white label said page is removed. This PR updates the link to go to the modules page, which was probably the original intent (extensions and modules were originally on the same page), and it also updates the button from "Manage Features" to "Manage modules".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There's not an easy way to test white label, but in this case we're just changing the link to a valid one, so just make sure the new link works on a normal site.

1. Go to the settings page: `/wp-admin/admin.php?page=zerobscrm-plugin-settings`
2. Click on "Manage modules".

It should take you to the modules page.

