### PR TITLE
Jetpack Social: Use image from Media Picker for OpenGraph image

### DIFF
--- a/projects/js-packages/publicize-components/changelog/change-jetpack-social-use-media-picker-for-og-image
+++ b/projects/js-packages/publicize-components/changelog/change-jetpack-social-use-media-picker-for-og-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use attached media for the OpenGraph image

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.20.2",
+	"version": "0.21.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -181,7 +181,6 @@ export default function PublicizeForm( {
 
 					{ isPublicizeEnabled && connections.some( connection => connection.enabled ) && (
 						<>
-							{ isEnhancedPublishingEnabled && <MediaSection /> }
 							<MessageBoxControl
 								maxLength={ maxLength }
 								onChange={ updateMessage }
@@ -189,6 +188,7 @@ export default function PublicizeForm( {
 							/>
 						</>
 					) }
+					{ isEnhancedPublishingEnabled && <MediaSection /> }
 				</Fragment>
 			) }
 		</Wrapper>

--- a/projects/packages/publicize/changelog/change-jetpack-social-use-media-picker-for-og-image
+++ b/projects/packages/publicize/changelog/change-jetpack-social-use-media-picker-for-og-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use attached media for the OpenGraph image

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -62,7 +62,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.24.x-dev"
+			"dev-trunk": "0.25.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.24.2",
+	"version": "0.25.0-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -217,7 +217,7 @@ abstract class Publicize_Base {
 
 		// Default checkbox state for each Connection.
 		add_filter( 'publicize_checkbox_default', array( $this, 'publicize_checkbox_default' ), 10, 2 );
-		add_filter( 'jetpack_open_graph_tags', array( $this, 'get_sig_image_for_post' ), 10, 1 );
+		add_filter( 'jetpack_open_graph_tags', array( $this, 'add_jetpack_social_og_images' ), 12, 1 ); // $priority = 12, to run after Jetpack adds the tags in the Jetpack_Twitter_Cards class.
 
 		// Alter the "Post Publish" admin notice to mention the Connections we Publicized to.
 		add_filter( 'post_updated_messages', array( $this, 'update_published_message' ), 20, 1 );
@@ -1487,23 +1487,104 @@ abstract class Publicize_Base {
 	}
 
 	/**
-	 * Adds the sig image to the meta tags array.
+	 * Get the attached image for a post.
+	 *
+	 * @param int $post_id ID of the post to get attached media for.
+	 * @return array {
+	 *     Array of image data, or empty array if no image is available.
+	 *
+	 *     @type string $url Image source URL.
+	 *     @type int    $width Image width in pixels.
+	 *     @type int    $height Image height in pixels.
+	 * }
+	 */
+	public function get_attached_media_image( $post_id ) {
+		$options = get_post_meta( $post_id, self::POST_JETPACK_SOCIAL_OPTIONS, true );
+
+		if ( ! is_array( $options ) || empty( $options['attached_media'] ) || empty( $options['attached_media'][0]['id'] ) ) {
+			return array();
+		}
+
+		$media_id = $options['attached_media'][0]['id'];
+
+		if ( ! wp_attachment_is_image( $media_id ) ) {
+			return array();
+		}
+
+		$image = wp_get_attachment_image_src( $media_id, array( 1200 ) );
+
+		if ( ! $image ) {
+			return array();
+		}
+
+		return array(
+			'url'    => $image[0],
+			'width'  => $image[1],
+			'height' => $image[2],
+		);
+	}
+
+	/**
+	 * Get the OpenGraph image for a post.
+	 *
+	 * @param int $post_id ID of the post to get OpenGraph image for.
+	 * @return array {
+	 *     Array of image data, or empty array if no image is available.
+	 *
+	 *     @type string $url Image source URL.
+	 *     @type int    $width Image width in pixels.
+	 *     @type int    $height Image height in pixels.
+	 * }
+	 */
+	public function get_social_opengraph_image( $post_id ) {
+		$attached_media = $this->get_attached_media_image( $post_id );
+
+		if ( $attached_media ) {
+			return $attached_media;
+		}
+
+		$generated_image_url = Social_Image_Generator\get_image_url( $post_id );
+
+		if ( ! empty( $generated_image_url ) ) {
+			return array(
+				'url'    => $generated_image_url,
+				'width'  => 1200,
+				'height' => 630,
+			);
+		}
+
+		return array();
+	}
+
+	/**
+	 * Add the Jetpack Social images (attached media, SIG image) to the OpenGraph tags.
 	 *
 	 * @param array $tags Current tags.
 	 */
-	public function get_sig_image_for_post( $tags ) {
-		$generated_image_url = Social_Image_Generator\get_image_url( get_the_ID() );
-		if ( ! empty( $generated_image_url ) ) {
-			$tags = array_merge(
-				$tags,
-				array(
-					'og:image'        => $generated_image_url,
-					'og:image:width'  => 1200,
-					'og:image:height' => 630,
-				)
-			);
+	public function add_jetpack_social_og_images( $tags ) {
+		$opengraph_image = $this->get_social_opengraph_image( get_the_ID() );
+
+		if ( empty( $opengraph_image ) ) {
+			return $tags;
 		}
-		return $tags;
+
+		// If this code is running in Jetpack, we need to add Twitter cards.
+		// Some active plugins disable Jetpack's Twitter Cards, so we need
+		// to check if the class was instantiated before adding the cards.
+		$needs_twitter_cards = class_exists( 'Jetpack_Twitter_Cards' );
+
+		return array_merge(
+			$tags,
+			array(
+				'og:image'        => $opengraph_image['url'],
+				'og:image:width'  => $opengraph_image['width'],
+				'og:image:height' => $opengraph_image['height'],
+			),
+			$needs_twitter_cards ? array(
+				'twitter:image' => $opengraph_image['url'],
+				'twitter:card'  => 'summary_large_image',
+			) : array()
+		);
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1537,12 +1537,6 @@ abstract class Publicize_Base {
 	 * }
 	 */
 	public function get_social_opengraph_image( $post_id ) {
-		$attached_media = $this->get_attached_media_image( $post_id );
-
-		if ( $attached_media ) {
-			return $attached_media;
-		}
-
 		$generated_image_url = Social_Image_Generator\get_image_url( $post_id );
 
 		if ( ! empty( $generated_image_url ) ) {
@@ -1551,6 +1545,12 @@ abstract class Publicize_Base {
 				'width'  => 1200,
 				'height' => 630,
 			);
+		}
+
+		$attached_media = $this->get_attached_media_image( $post_id );
+
+		if ( $attached_media ) {
+			return $attached_media;
 		}
 
 		return array();

--- a/projects/plugins/jetpack/changelog/change-jetpack-social-use-media-picker-for-og-image
+++ b/projects/plugins/jetpack/changelog/change-jetpack-social-use-media-picker-for-og-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Publicize: Use attached media for the OpenGraph image

--- a/projects/plugins/jetpack/changelog/change-jetpack-social-use-media-picker-for-og-image#2
+++ b/projects/plugins/jetpack/changelog/change-jetpack-social-use-media-picker-for-og-image#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1898,7 +1898,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "e44d34d615737fa61a3f4f4e3da2e29b969cc197"
+                "reference": "5cd27d4f7e22c3f213ab5631d9797d9ed1985eb3"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1925,7 +1925,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.24.x-dev"
+                    "dev-trunk": "0.25.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/change-jetpack-social-use-media-picker-for-og-image
+++ b/projects/plugins/social/changelog/change-jetpack-social-use-media-picker-for-og-image
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1113,7 +1113,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "e44d34d615737fa61a3f4f4e3da2e29b969cc197"
+                "reference": "5cd27d4f7e22c3f213ab5631d9797d9ed1985eb3"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1140,7 +1140,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.24.x-dev"
+                    "dev-trunk": "0.25.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR changes the behavior of the Media Picker (part of Jetpack Social's Advanced Plan). With this PR, the Media Picker not just sets the image that gets uploaded during Publicize, but also sets the OpenGraph image that's used whenever a post gets shared.

It also changed the Media Picker to always be visible in the sidebar, since it now has a use even when no Publicize connections are toggled on.

As a bonus, it also fixes 1202583289493814-as-1204345803096704/f.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1202583289493814-as-1204411041263280/f
1202583289493814-as-1204345803096704/f

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add the Jetpack Social Advanced plan to your site.
* Create a new post and pick an image from the media picker.
* Publish the post.
* View the post's source code and verify that `og:image` and `twitter:image` are set to the URL of the image you picked.
* Verify that `twitter:card` is set to `summary_large_image`.
* Add a featured image and verify that `og:image` and `twitter:image` are still set to the image from the media picker.
* Remove the image from the media picker and check that and `og:image` and `twitter:image` are set to the featured image.

**With Social Image Generator:**
* Add Social Image Generator to your site.
* Verify that `og:image` and `twitter:image` use the image from the media picker if set, and use the SIG image if not.
* Verify that `twitter:card` is set to `summary_large_image` in both cases.