### PR TITLE
 VideoPress: return the player control after user interaction

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-return-player-control
+++ b/projects/packages/videopress/changelog/update-videopress-return-player-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: return the player control after user interaction

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -256,7 +256,7 @@ class Initializer {
 			);
 
 			// Expose the preview on hover data to the client.
-			$preview_on_hover = sprintf( '<div className="jetpack-videopress-player__overlay"></div><script type="application/json">%s</script>', wp_json_encode( $preview_on_hover ) );
+			$preview_on_hover = sprintf( '<div class="jetpack-videopress-player__overlay"></div><script type="application/json">%s</script>', wp_json_encode( $preview_on_hover ) );
 
 			// Set `autoplay` and `muted` attributes to the video element.
 			$block_attributes['autoplay'] = true;

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -242,14 +242,17 @@ class Initializer {
 		}
 
 		// Preview On Hover data
-		$preview_on_hover = '';
-		if (
+		$is_poh_enabled =
 			isset( $block_attributes['posterData']['previewOnHover'] ) &&
-			$block_attributes['posterData']['previewOnHover']
-		) {
+			$block_attributes['posterData']['previewOnHover'];
+
+		$preview_on_hover = '';
+		if ( $is_poh_enabled ) {
 			$preview_on_hover = array(
 				'previewAtTime'       => $block_attributes['posterData']['previewAtTime'],
 				'previewLoopDuration' => $block_attributes['posterData']['previewLoopDuration'],
+				'autoplay'            => (bool) $block_attributes['autoplay'],
+				'showControls'        => (bool) $block_attributes['controls'],
 			);
 
 			// Expose the preview on hover data to the client.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -246,13 +246,16 @@ class Initializer {
 			isset( $block_attributes['posterData']['previewOnHover'] ) &&
 			$block_attributes['posterData']['previewOnHover'];
 
+		$autoplay = isset( $block_attributes['autoplay'] ) ? $block_attributes['autoplay'] : false;
+		$controls = isset( $block_attributes['controls'] ) ? $block_attributes['controls'] : false;
+
 		$preview_on_hover = '';
 		if ( $is_poh_enabled ) {
 			$preview_on_hover = array(
 				'previewAtTime'       => $block_attributes['posterData']['previewAtTime'],
 				'previewLoopDuration' => $block_attributes['posterData']['previewLoopDuration'],
-				'autoplay'            => (bool) $block_attributes['autoplay'],
-				'showControls'        => (bool) $block_attributes['controls'],
+				'autoplay'            => $autoplay,
+				'showControls'        => $controls,
 			);
 
 			// Expose the preview on hover data to the client.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -1,7 +1,23 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .wp-block-jetpack-videopress {
+	position: relative;
+
 	figcaption {
 		@include caption-style-theme();
+	}
+
+	.jetpack-videopress-player__wrapper {
+		position: relative;
+	}
+
+	.jetpack-videopress-player__overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background-color: transparent;
+		z-index: 10;
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -47,6 +47,8 @@ function previewOnHoverEffect(): void {
 		let previewOnHoverData: {
 			previewAtTime: number;
 			previewLoopDuration: number;
+			autoplay: boolean;
+			showControls: boolean;
 		};
 
 		try {
@@ -81,6 +83,19 @@ function previewOnHoverEffect(): void {
 		const overlay = videoPlayerElement.querySelector( '.jetpack-videopress-player__overlay' );
 		if ( ! overlay ) {
 			return;
+		}
+
+		/*
+		 * Disable PreviewOnHover (pOH) when the player
+		 * should show the controls and
+		 * once the user clicks on the video (overlay).
+		 */
+		if ( previewOnHoverData.showControls ) {
+			overlay.addEventListener( 'click', () => {
+				// Delete overlay element.
+				overlay.remove();
+				setTimeout( iframeApi.controls.pause, 100 ); // Hack; without this, the video will not pause.
+			} );
 		}
 
 		overlay.addEventListener( 'mouseenter', iframeApi.controls.play );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -61,6 +61,8 @@ function previewOnHoverEffect(): void {
 		// Clean the data container element. It isn't needed anymore.
 		dataContainer.remove();
 
+		let userHasInteracted = false;
+
 		const iframeApi = window.VideoPressIframeApi( iFrame, () => {
 			iframeApi.status.onPlayerStatusChanged( ( oldStatus, newStatus ) => {
 				if ( oldStatus === 'ready' && newStatus === 'playing' ) {
@@ -70,6 +72,10 @@ function previewOnHoverEffect(): void {
 			} );
 
 			iframeApi.status.onTimeUpdate( playbackTime => {
+				if ( userHasInteracted ) {
+					return;
+				}
+
 				const playback = playbackTime * 1000;
 				const start = previewOnHoverData.previewAtTime;
 				const end = start + previewOnHoverData.previewLoopDuration;
@@ -92,8 +98,13 @@ function previewOnHoverEffect(): void {
 		 */
 		if ( previewOnHoverData.showControls ) {
 			overlay.addEventListener( 'click', () => {
+				// Set the userHasInteracted flag to true.
+				userHasInteracted = true;
+
 				// Delete overlay element.
 				overlay.remove();
+
+				// Pause when user clicks on the video.
 				setTimeout( iframeApi.controls.pause, 100 ); // Hack; without this, the video will not pause.
 			} );
 		}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -78,8 +78,13 @@ function previewOnHoverEffect(): void {
 			} );
 		} );
 
-		videoPlayerElement.addEventListener( 'mouseenter', iframeApi.controls.play );
-		videoPlayerElement.addEventListener( 'mouseleave', iframeApi.controls.pause );
+		const overlay = videoPlayerElement.querySelector( '.jetpack-videopress-player__overlay' );
+		if ( ! overlay ) {
+			return;
+		}
+
+		overlay.addEventListener( 'mouseenter', iframeApi.controls.play );
+		overlay.addEventListener( 'mouseleave', iframeApi.controls.pause );
 	} );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This Pull Request (PR) makes improvements to the "Preview On Hover" (pOH) effect of the VideoPress video block. In summary, when the video player has both controls and the pOH feature enabled, we expect the following behavior:

The video will play when the mouse pointer enters the video player area and pause when it leaves.
The pOH effect will be disabled once the user interacts with the video (by clicking on it)

Fixes https://github.com/Automattic/jetpack/issues/29986

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  VideoPress: return the player control after user interaction

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a VideoPress video block instance
* Enable and set the pOH effect
* Do not enable the playback controls

<img width="511" alt="Screen Shot 2023-04-18 at 16 07 47" src="https://user-images.githubusercontent.com/77539/232880270-c80d1615-2e0e-4d4b-bea9-1a8215190912.png">

* Save the post
* View the post in the front-end
* Confirm it works as expected
* Confirm when the user clicks on the video, nothing happens. pOH keeps working and playing in a loop.

* Go back to the editor
* Enable playback `controls` option
* Save the post
* Go to the front end
* Hard refresh
* Confirm pOH keeps working
* Confirm that, after clicking on the video, pOH is disabled 
* Confirm you can use the player controls
* Confirm the video doesn't play in a loop anymore

https://user-images.githubusercontent.com/77539/232883618-78de1f63-6331-4d2d-99fd-52ba08402a9c.mov
