### PR TITLE
My Jetpack: Connect standalone plugin menu actions

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -63,6 +63,7 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false } ) => 
 			hasStandalonePlugin={ standalonePluginInfo?.hasStandalonePlugin }
 			isStandaloneInstalled={ standalonePluginInfo?.isStandaloneInstalled }
 			isStandaloneActive={ standalonePluginInfo?.isStandaloneActive }
+			isConnected={ isRegistered && isUserConnected }
 		>
 			{ children }
 		</ProductCard>

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -41,30 +41,6 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false } ) => 
 		navigateToConnectionPage,
 	] );
 
-	/*
-	 * Redirect to connection page if the user is not connected
-	 */
-	const handleInstallAndActivateStandalonePlugin = useCallback( () => {
-		if ( ( ! isRegistered || ! isUserConnected ) && requiresUserConnection ) {
-			navigateToConnectionPage();
-			return;
-		}
-
-		/**
-		 * For both installing and activating the plugin, the action is the same
-		 * because the backend endpoint performs both actions
-		 * - installing when is not installed
-		 * - activating when is not active
-		 */
-		installStandalonePlugin();
-	}, [
-		installStandalonePlugin,
-		isRegistered,
-		isUserConnected,
-		requiresUserConnection,
-		navigateToConnectionPage,
-	] );
-
 	const Icon = getIconBySlug( slug );
 
 	return (
@@ -82,8 +58,8 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false } ) => 
 			onManage={ onManage }
 			onFixConnection={ navigateToConnectionPage }
 			showMenu={ showMenu }
-			onInstallStandalone={ handleInstallAndActivateStandalonePlugin }
-			onActivateStandalone={ handleInstallAndActivateStandalonePlugin }
+			onInstallStandalone={ installStandalonePlugin }
+			onActivateStandalone={ installStandalonePlugin }
 			hasStandalonePlugin={ standalonePluginInfo?.hasStandalonePlugin }
 			isStandaloneInstalled={ standalonePluginInfo?.isStandaloneInstalled }
 			isStandaloneActive={ standalonePluginInfo?.isStandaloneActive }

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -6,7 +6,7 @@ import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import { useProduct } from '../../hooks/use-product';
 import ProductCard from '../product-card';
 
-const ConnectedProductCard = ( { admin, slug, children } ) => {
+const ConnectedProductCard = ( { admin, slug, children, showMenu = false } ) => {
 	const { isRegistered, isUserConnected } = useConnection();
 	const { detail, status, activate, deactivate, isFetching, installStandalonePlugin } =
 		useProduct( slug );
@@ -81,6 +81,7 @@ const ConnectedProductCard = ( { admin, slug, children } ) => {
 			onAdd={ navigateToAddProductPage }
 			onManage={ onManage }
 			onFixConnection={ navigateToConnectionPage }
+			showMenu={ showMenu }
 			onInstallStandalone={ handleInstallAndActivateStandalonePlugin }
 			onActivateStandalone={ handleInstallAndActivateStandalonePlugin }
 			hasStandalonePlugin={ standalonePluginInfo?.hasStandalonePlugin }

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -9,7 +9,7 @@ import ProductCard from '../product-card';
 const ConnectedProductCard = ( { admin, slug, children } ) => {
 	const { isRegistered, isUserConnected } = useConnection();
 	const { detail, status, activate, deactivate, isFetching } = useProduct( slug );
-	const { name, description, manageUrl, requiresUserConnection } = detail;
+	const { name, description, manageUrl, requiresUserConnection, standalonePluginInfo } = detail;
 
 	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
 
@@ -56,6 +56,9 @@ const ConnectedProductCard = ( { admin, slug, children } ) => {
 			onAdd={ navigateToAddProductPage }
 			onManage={ onManage }
 			onFixConnection={ navigateToConnectionPage }
+			hasStandalonePlugin={ standalonePluginInfo?.hasStandalonePlugin }
+			isStandaloneInstalled={ standalonePluginInfo?.isStandaloneInstalled }
+			isStandaloneActive={ standalonePluginInfo?.isStandaloneActive }
 		>
 			{ children }
 		</ProductCard>

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -8,7 +8,8 @@ import ProductCard from '../product-card';
 
 const ConnectedProductCard = ( { admin, slug, children } ) => {
 	const { isRegistered, isUserConnected } = useConnection();
-	const { detail, status, activate, deactivate, isFetching } = useProduct( slug );
+	const { detail, status, activate, deactivate, isFetching, installStandalonePlugin } =
+		useProduct( slug );
 	const { name, description, manageUrl, requiresUserConnection, standalonePluginInfo } = detail;
 
 	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
@@ -40,6 +41,30 @@ const ConnectedProductCard = ( { admin, slug, children } ) => {
 		navigateToConnectionPage,
 	] );
 
+	/*
+	 * Redirect to connection page if the user is not connected
+	 */
+	const handleInstallAndActivateStandalonePlugin = useCallback( () => {
+		if ( ( ! isRegistered || ! isUserConnected ) && requiresUserConnection ) {
+			navigateToConnectionPage();
+			return;
+		}
+
+		/**
+		 * For both installing and activating the plugin, the action is the same
+		 * because the backend endpoint performs both actions
+		 * - installing when is not installed
+		 * - activating when is not active
+		 */
+		installStandalonePlugin();
+	}, [
+		installStandalonePlugin,
+		isRegistered,
+		isUserConnected,
+		requiresUserConnection,
+		navigateToConnectionPage,
+	] );
+
 	const Icon = getIconBySlug( slug );
 
 	return (
@@ -56,6 +81,8 @@ const ConnectedProductCard = ( { admin, slug, children } ) => {
 			onAdd={ navigateToAddProductPage }
 			onManage={ onManage }
 			onFixConnection={ navigateToConnectionPage }
+			onInstallStandalone={ handleInstallAndActivateStandalonePlugin }
+			onActivateStandalone={ handleInstallAndActivateStandalonePlugin }
 			hasStandalonePlugin={ standalonePluginInfo?.hasStandalonePlugin }
 			isStandaloneInstalled={ standalonePluginInfo?.isStandaloneInstalled }
 			isStandaloneActive={ standalonePluginInfo?.isStandaloneActive }

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -1,7 +1,7 @@
 import { Button, Text } from '@automattic/jetpack-components';
 import { Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { external, moreVertical, arrowDown } from '@wordpress/icons';
+import { external, moreVertical, download, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
@@ -83,7 +83,7 @@ const Menu = ( {
 									weight="regular"
 									fullWidth
 									variant="tertiary"
-									icon={ arrowDown }
+									icon={ download }
 									onClick={ () => {
 										onClose();
 										onInstall?.();
@@ -97,7 +97,7 @@ const Menu = ( {
 									weight="regular"
 									fullWidth
 									variant="tertiary"
-									icon={ external }
+									icon={ check }
 									onClick={ () => {
 										onClose();
 										onActivate?.();

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -141,6 +141,7 @@ const ProductCard = props => {
 		hasStandalonePlugin = false,
 		isStandaloneInstalled = false,
 		isStandaloneActive = false,
+		isConnected = false,
 	} = props;
 	const isActive = status === PRODUCT_STATUSES.ACTIVE;
 	const isError = status === PRODUCT_STATUSES.ERROR;
@@ -157,6 +158,7 @@ const ProductCard = props => {
 		showMenu && // The menu is enabled for the product AND
 		! isAbsent && // product status is not absent AND
 		! isError && // product status is not error AND
+		isConnected && // the site is connected AND
 		( isActive || // product is active, show at least the Manage option
 			menuItems?.length > 0 || // Show custom menus, if present
 			( hasStandalonePlugin && ( ! isStandaloneActive || ! isStandaloneInstalled ) ) ); // Show install | activate options for standalone plugin

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -156,6 +156,7 @@ const ProductCard = props => {
 	const menuIsActive =
 		showMenu && // The menu is enabled for the product AND
 		! isAbsent && // product status is not absent AND
+		! isError && // product status is not error AND
 		( isActive || // product is active, show at least the Manage option
 			menuItems?.length > 0 || // Show custom menus, if present
 			( hasStandalonePlugin && ( ! isStandaloneActive || ! isStandaloneInstalled ) ) ); // Show install | activate options for standalone plugin

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -35,6 +35,14 @@ const Menu = ( {
 	const showStandaloneOption =
 		hasStandalonePlugin && ( ! isStandaloneInstalled || ! isStandaloneActive );
 
+	if ( productStatus === PRODUCT_STATUSES.ACTIVE ) {
+		items.push( {
+			label: __( 'Manage', 'jetpack-my-jetpack' ),
+			onClick: onManage,
+			icon: external,
+		} );
+	}
+
 	return (
 		<Dropdown
 			className={ styles.dropdown }
@@ -64,20 +72,6 @@ const Menu = ( {
 							{ item?.label }
 						</Button>
 					) ) }
-					{ productStatus === PRODUCT_STATUSES.ACTIVE && (
-						<Button
-							weight="regular"
-							fullWidth
-							variant="tertiary"
-							icon={ external }
-							onClick={ () => {
-								onClose();
-								onManage?.();
-							} }
-						>
-							{ __( 'Manage', 'jetpack-my-jetpack' ) }
-						</Button>
-					) }
 					{ showStandaloneOption && (
 						<>
 							{ ! isStandaloneInstalled && (

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -217,6 +217,26 @@ const ProductCard = props => {
 		onFixConnection();
 	}, [ slug, onFixConnection, recordEvent ] );
 
+	/**
+	 * Use a Tracks event to count a standalone plugin install request
+	 */
+	const installStandaloneHandler = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_product_card_install_standalone_plugin_click', {
+			product: slug,
+		} );
+		onInstallStandalone();
+	}, [ slug, onInstallStandalone, recordEvent ] );
+
+	/**
+	 * Use a Tracks event to count a standalone plugin activation request
+	 */
+	const activateStandaloneHandler = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_product_card_activate_standalone_plugin_click', {
+			product: slug,
+		} );
+		onActivateStandalone();
+	}, [ slug, onActivateStandalone, recordEvent ] );
+
 	const CardWrapper = isAbsent
 		? ( { children: wrapperChildren, ...cardProps } ) => (
 				<a { ...cardProps } href="#" onClick={ addHandler }>
@@ -239,8 +259,8 @@ const ProductCard = props => {
 						status={ status }
 						items={ menuItems }
 						onManage={ onManage }
-						onInstall={ onInstallStandalone }
-						onActivate={ onActivateStandalone }
+						onInstall={ installStandaloneHandler }
+						onActivate={ activateStandaloneHandler }
 						hasStandalonePlugin={ hasStandalonePlugin }
 						isStandaloneActive={ isStandaloneActive }
 						isStandaloneInstalled={ isStandaloneInstalled }

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -35,30 +35,6 @@ const Menu = ( {
 	const showStandaloneOption =
 		hasStandalonePlugin && ( ! isStandaloneInstalled || ! isStandaloneActive );
 
-	if ( productStatus === PRODUCT_STATUSES.ACTIVE ) {
-		items.push( {
-			label: __( 'Manage', 'jetpack-my-jetpack' ),
-			onClick: onManage,
-			icon: external,
-		} );
-	}
-
-	if ( showStandaloneOption && ! isStandaloneInstalled ) {
-		items.push( {
-			label: __( 'Install Plugin', 'jetpack-my-jetpack' ),
-			onClick: onInstall,
-			icon: download,
-		} );
-	}
-
-	if ( showStandaloneOption && isStandaloneInstalled && ! isStandaloneActive ) {
-		items.push( {
-			label: __( 'Activate Plugin', 'jetpack-my-jetpack' ),
-			onClick: onActivate,
-			icon: check,
-		} );
-	}
-
 	return (
 		<Dropdown
 			className={ styles.dropdown }
@@ -88,6 +64,52 @@ const Menu = ( {
 							{ item?.label }
 						</Button>
 					) ) }
+					{ productStatus === PRODUCT_STATUSES.ACTIVE && (
+						<Button
+							weight="regular"
+							fullWidth
+							variant="tertiary"
+							icon={ external }
+							onClick={ () => {
+								onClose();
+								onManage?.();
+							} }
+						>
+							{ __( 'Manage', 'jetpack-my-jetpack' ) }
+						</Button>
+					) }
+					{ showStandaloneOption && (
+						<>
+							{ ! isStandaloneInstalled && (
+								<Button
+									weight="regular"
+									fullWidth
+									variant="tertiary"
+									icon={ download }
+									onClick={ () => {
+										onClose();
+										onInstall?.();
+									} }
+								>
+									{ __( 'Install Plugin', 'jetpack-my-jetpack' ) }
+								</Button>
+							) }
+							{ isStandaloneInstalled && ! isStandaloneActive && (
+								<Button
+									weight="regular"
+									fullWidth
+									variant="tertiary"
+									icon={ check }
+									onClick={ () => {
+										onClose();
+										onActivate?.();
+									} }
+								>
+									{ __( 'Activate Plugin', 'jetpack-my-jetpack' ) }
+								</Button>
+							) }
+						</>
+					) }
 				</>
 			) }
 		/>

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -147,7 +147,12 @@ const ProductCard = props => {
 	const flagLabel = PRODUCT_STATUSES_LABELS[ status ];
 
 	// If status is absent, we disable the menu
-	const menuIsActive = showMenu && ! isAbsent;
+	const menuIsActive =
+		showMenu && // The menu is enabled for the product AND
+		! isAbsent && // product status is not absent AND
+		( isActive || // product is active, show at least the Manage option
+			menuItems?.length > 0 || // Show custom menus, if present
+			( hasStandalonePlugin && ( ! isStandaloneActive || ! isStandaloneInstalled ) ) ); // Show install | activate options for standalone plugin
 
 	const containerClassName = classNames( styles.container, {
 		[ styles.plugin_absent ]: isAbsent,

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -80,6 +80,7 @@ const Menu = ( {
 					) }
 					{ showStandaloneOption && (
 						<>
+							{ ( productStatus === PRODUCT_STATUSES.ACTIVE || items.length > 0 ) && <hr /> }
 							{ ! isStandaloneInstalled && (
 								<Button
 									weight="regular"

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -43,6 +43,22 @@ const Menu = ( {
 		} );
 	}
 
+	if ( showStandaloneOption && ! isStandaloneInstalled ) {
+		items.push( {
+			label: __( 'Install Plugin', 'jetpack-my-jetpack' ),
+			onClick: onInstall,
+			icon: download,
+		} );
+	}
+
+	if ( showStandaloneOption && isStandaloneInstalled && ! isStandaloneActive ) {
+		items.push( {
+			label: __( 'Activate Plugin', 'jetpack-my-jetpack' ),
+			onClick: onActivate,
+			icon: check,
+		} );
+	}
+
 	return (
 		<Dropdown
 			className={ styles.dropdown }
@@ -72,38 +88,6 @@ const Menu = ( {
 							{ item?.label }
 						</Button>
 					) ) }
-					{ showStandaloneOption && (
-						<>
-							{ ! isStandaloneInstalled && (
-								<Button
-									weight="regular"
-									fullWidth
-									variant="tertiary"
-									icon={ download }
-									onClick={ () => {
-										onClose();
-										onInstall?.();
-									} }
-								>
-									{ __( 'Install plugin', 'jetpack-my-jetpack' ) }
-								</Button>
-							) }
-							{ isStandaloneInstalled && ! isStandaloneActive && (
-								<Button
-									weight="regular"
-									fullWidth
-									variant="tertiary"
-									icon={ check }
-									onClick={ () => {
-										onClose();
-										onActivate?.();
-									} }
-								>
-									{ __( 'Activate plugin', 'jetpack-my-jetpack' ) }
-								</Button>
-							) }
-						</>
-					) }
 				</>
 			) }
 		/>

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -19,6 +19,7 @@ const PRODUCT_STATUSES_LABELS = {
 
 /* eslint-disable react/jsx-no-bind */
 const Menu = ( {
+	productStatus,
 	items = [],
 	onManage,
 	onInstall,
@@ -63,21 +64,22 @@ const Menu = ( {
 							{ item?.label }
 						</Button>
 					) ) }
-					<Button
-						weight="regular"
-						fullWidth
-						variant="tertiary"
-						icon={ external }
-						onClick={ () => {
-							onClose();
-							onManage?.();
-						} }
-					>
-						{ __( 'Manage', 'jetpack-my-jetpack' ) }
-					</Button>
+					{ productStatus === PRODUCT_STATUSES.ACTIVE && (
+						<Button
+							weight="regular"
+							fullWidth
+							variant="tertiary"
+							icon={ external }
+							onClick={ () => {
+								onClose();
+								onManage?.();
+							} }
+						>
+							{ __( 'Manage', 'jetpack-my-jetpack' ) }
+						</Button>
+					) }
 					{ showStandaloneOption && (
 						<>
-							<hr />
 							{ ! isStandaloneInstalled && (
 								<Button
 									weight="regular"
@@ -256,7 +258,7 @@ const ProductCard = props => {
 				</div>
 				{ menuIsActive ? (
 					<Menu
-						status={ status }
+						productStatus={ status }
 						items={ menuItems }
 						onManage={ onManage }
 						onInstall={ installStandaloneHandler }

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -30,10 +30,13 @@ const Menu = ( {
 } ) => {
 	/**
 	 * Only show standalone related option if plugin is not installed
-	 * or the plugin is not active
+	 * or the plugin is not active, the product has a standalone plugin
+	 * and there is no connection error.
 	 */
 	const showStandaloneOption =
-		hasStandalonePlugin && ( ! isStandaloneInstalled || ! isStandaloneActive );
+		productStatus !== PRODUCT_STATUSES.ERROR &&
+		hasStandalonePlugin &&
+		( ! isStandaloneInstalled || ! isStandaloneActive );
 
 	return (
 		<Dropdown

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ProductCard from '../connected-product-card';
 
 const VideopressCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="videopress" />;
+	return <ProductCard admin={ admin } slug="videopress" showMenu={ true } />;
 };
 
 VideopressCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
@@ -9,12 +9,14 @@ import { STORE_ID } from '../../state/store';
  * @returns {object}         - Site product data.
  */
 export function useProduct( productId ) {
-	const { activateProduct, deactivateProduct } = useDispatch( STORE_ID );
+	const { activateProduct, deactivateProduct, installStandalonePluginForProduct } =
+		useDispatch( STORE_ID );
 	const detail = useSelect( select => select( STORE_ID ).getProduct( productId ) );
 
 	return {
 		activate: () => activateProduct( productId ),
 		deactivate: () => deactivateProduct( productId ),
+		installStandalonePlugin: () => installStandalonePluginForProduct( productId ),
 		productsList: useSelect( select => select( STORE_ID ).getProducts() ),
 		detail,
 		isActive: detail.status === 'active',

--- a/projects/packages/my-jetpack/_inc/state/selectors.js
+++ b/projects/packages/my-jetpack/_inc/state/selectors.js
@@ -9,6 +9,7 @@ export const getProduct = ( state, productId ) => {
 	const stateProduct = getProducts( state )?.[ productId ] || {};
 
 	const product = mapObjectKeysToCamel( stateProduct, true );
+	product.standalonePluginInfo = mapObjectKeysToCamel( product.standalonePluginInfo || {}, true );
 	product.pricingForUi = mapObjectKeysToCamel( product.pricingForUi || {}, true );
 	product.pricingForUi.introductoryOffer = product.pricingForUi.isIntroductoryOffer
 		? mapObjectKeysToCamel( product.pricingForUi.introductoryOffer, true )

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-menu-actions-for-standalone
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-connect-menu-actions-for-standalone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Connect the standalone plugin menu options so they trigger the installation and activation when clicked.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #29901.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the `use-product` hook to export the standalone plugin installation action
* Create function to handle the call for the installation and pass it to the `ProductCard`
* Fix menu visibility control to consider the standalone plugin status
* Enable the action menu for VideoPress
* Track events related to install and activate standalone plugin

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Testing the installation + activation of a standalone product

* Spin a new JN site with only Jetpack
* Connect the site
* Go to `Jetpack > My Jetpack` and check the VideoPress card; it should show as inactive since we don't activate it yet; it will also show the three dots to open the actions menu:

<img width="369" alt="Screen Shot 2023-04-18 at 18 44 38" src="https://user-images.githubusercontent.com/6760046/232912126-010fa9a7-f69d-4921-ad4d-e508ec37de97.png">

* Click on the action menu icon, on the top right corner of the VideoPress card
* You should see the "Install Plugin" action available:

<img width="363" alt="Screen Shot 2023-04-18 at 18 45 44" src="https://user-images.githubusercontent.com/6760046/232912255-acbfb320-921e-4902-ad78-511d93734162.png">

* Click on "Install Plugin"
* The card will switch to a loading state and then the plugin will be installed and activated
* After the loading state finishes, refresh the page to get the card with the new status; there is a known issue that the install standalone endpoint is returning a stale product status after the installation; I will fix it on a follow up;
* After the refresh, the card is now shown as active and the actions menu only shows the "Manage" option:

<img width="368" alt="Screen Shot 2023-04-18 at 18 48 29" src="https://user-images.githubusercontent.com/6760046/232912735-307e0d4c-6cbb-4821-85ce-a03009cce9a4.png">

* Go to `Plugins > Installed Plugins` and confirm that the VideoPress plugin is now installed:

<img width="349" alt="Screen Shot 2023-04-17 at 18 38 56" src="https://user-images.githubusercontent.com/6760046/232616754-f6ad5412-dd72-46ef-968d-6e41e2cf1027.png">

### Testing the activation of a standalone product

* We are going to disable the plugin to check the action menu again
* On the same test site, go to `Plugins > Installed Plugins` and disable the VideoPress plugin
* Go to `Jetpack > My Jetpack` and confirm that the VideoPress card still show as active (since the module on Jetpack got enable on the prior step):

<img width="358" alt="Screen Shot 2023-04-18 at 18 50 02" src="https://user-images.githubusercontent.com/6760046/232913024-aca77500-e085-4f1b-abf9-78d50b4a60b9.png">

* Click on the action menu icon, on the top right corner of the VideoPress card
* You should see the "Manage" (since the product is active) and "Activate Plugin" (since the plugin is installed but not active) actions available:

<img width="361" alt="Screen Shot 2023-04-18 at 18 51 04" src="https://user-images.githubusercontent.com/6760046/232913191-d1a45bbd-19a6-4b30-a48c-4521ce786e7a.png">

* Click on "Activate Plugin"
* The card will switch to a loading state and then the plugin will be activated on the backend
* After the loading state finishes, the card still shows as active and the actions menu only shows the "Manage" option:

<img width="367" alt="Screen Shot 2023-04-18 at 18 51 37" src="https://user-images.githubusercontent.com/6760046/232913331-10bc508b-0b6c-4162-8056-59a44f45c471.png">

* Go to `Plugins > Installed Plugins` and confirm that the VideoPress plugin is now active again:

<img width="349" alt="Screen Shot 2023-04-17 at 18 38 56" src="https://user-images.githubusercontent.com/6760046/232616754-f6ad5412-dd72-46ef-968d-6e41e2cf1027.png">