### PR TITLE
Stats widget: use Emerald style for footer buttons

### DIFF
--- a/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
+++ b/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
@@ -1,6 +1,6 @@
 @import '@automattic/jetpack-base-styles/root-variables';
 
-@mixin emerald-button() {
+@mixin emerald-button-colors() {
 	background: var(--jp-black);
 	border-color: var(--jp-black);
 	color: var(--jp-white);
@@ -176,7 +176,7 @@
 
 			// Use emerald button style.
 			.wp-core-ui & .button-primary {
-				@include emerald-button();
+				@include emerald-button-colors();
 			}
 		}
 	}
@@ -311,7 +311,7 @@
 		}
 
 		.button {
-			@include emerald-button();
+			@include emerald-button-colors();
 			margin-top: 8px;
 		}
 	}

--- a/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
+++ b/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
@@ -176,7 +176,7 @@
 
 			// Use emerald button style.
 			.wp-core-ui & .button-primary {
-				@include emerald_button();
+				@include emerald-button();
 			}
 		}
 	}
@@ -311,7 +311,7 @@
 		}
 
 		.button {
-			@include emerald_button();
+			@include emerald-button();
 			margin-top: 8px;
 		}
 	}

--- a/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
+++ b/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
@@ -1,5 +1,11 @@
 @import '@automattic/jetpack-base-styles/root-variables';
 
+@mixin emerald-button() {
+	background: var(--jp-black);
+	border-color: var(--jp-black);
+	color: var(--jp-white);
+}
+
 @mixin widget-card-background-container() {
 	background: var(--jp-white-off);
 	padding: 1.5em 1em;
@@ -164,15 +170,13 @@
 			line-height: 30px; // corresponds to .button height.
 			padding: 0;
 		}
-		
+
 		.stats-info-header-right {
 			align-self: center;
 
 			// Use emerald button style.
 			.wp-core-ui & .button-primary {
-				background: var(--jp-black);
-				border-color: var(--jp-black);
-				color: var(--jp-white);
+				@include emerald_button();
 			}
 		}
 	}
@@ -249,46 +253,6 @@
 		}
 	}
 
-	.button-jetpack {
-		background: $green-primary;
-		border-color: darken( $green-primary, 10% );
-		color: $white;
-		box-shadow: inset 0 1px 0 lighten( $green-primary, 15% ), 0 1px 0 rgba(0,0,0,.15);
-
-		&:hover,
-		&:focus {
-			background: darken( $green-primary, 5% );
-			border-color: darken( $green-primary, 15% );
-			color: $white;
-			box-shadow: inset 0 1px 0 lighten( $green-primary, 10% );
-		}
-
-		&:focus {
-			box-shadow: inset 0 1px 0 lighten( $green-primary, 10% ),
-			0 0 0 1px #4f94d4,
-			0 0 2px 1px rgba( 30, 140, 190, .8 );
-		}
-
-		&:active {
-			background: darken( $green-primary, 10% );
-			border-color: darken( $green-primary, 15% );
-			color: $white;
-			box-shadow: inset 0 2px 5px -3px rgba( 0, 0, 0, 0.5 ),
-			0 0 0 1px #4f94d4,
-			0 0 2px 1px rgba( 30, 140, 190, .8 );
-		}
-
-		&[disabled],
-		&:disabled,
-		&.button-primary-disabled,
-		&.disabled {
-			color: hsl( hue( $green-primary ), 10%, 80% ) !important;
-			background: darken( $green-primary, 8% ) !important;
-			border-color: darken( $green-primary, 15% ) !important;
-			text-shadow: none !important;
-		}
-	}
-
 	footer {
 		background: var(--jp-white-off);
 		overflow: hidden;
@@ -346,7 +310,8 @@
 			}
 		}
 
-		.button-jetpack {
+		.button {
+			@include emerald_button();
 			margin-top: 8px;
 		}
 	}

--- a/projects/plugins/jetpack/changelog/fix-stats-widget-footer-buttons
+++ b/projects/plugins/jetpack/changelog/fix-stats-widget-footer-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Stats widget: improve appearance of footer buttons

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -196,8 +196,8 @@ class Jetpack_Stats_Dashboard_Widget {
 						)
 					);
 					?>
-								" class="button button-jetpack" title="<?php esc_attr_e( 'Protect helps to keep you secure from brute-force login attacks.', 'jetpack' ); ?>">
-						<?php esc_html_e( 'Activate brute force attack protection', 'jetpack' ); ?>
+								" class="button button-primary" title="<?php esc_attr_e( 'Protect helps to keep you secure from brute-force login attacks.', 'jetpack' ); ?>">
+						<?php esc_html_e( 'Activate', 'jetpack' ); ?>
 					</a>
 				<?php else : ?>
 					<?php esc_html_e( 'Brute force attack protection is inactive.', 'jetpack' ); ?>
@@ -227,8 +227,8 @@ class Jetpack_Stats_Dashboard_Widget {
 						)
 					);
 					?>
-								" class="button button-jetpack">
-						<?php esc_html_e( 'Activate Anti-spam', 'jetpack' ); ?>
+								" class="button button-primary">
+						<?php esc_html_e( 'Activate', 'jetpack' ); ?>
 					</a>
 				<?php else : ?>
 					<p><a href="<?php echo esc_url( 'https://akismet.com/?utm_source=jetpack&utm_medium=link&utm_campaign=Jetpack%20Dashboard%20Widget%20Footer%20Link' ); ?>"><?php esc_html_e( 'Anti-spam can help to keep your blog safe from spam!', 'jetpack' ); ?></a></p>

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -196,7 +196,7 @@ class Jetpack_Stats_Dashboard_Widget {
 						)
 					);
 					?>
-								" class="button button-primary" title="<?php esc_attr_e( 'Protect helps to keep you secure from brute-force login attacks.', 'jetpack' ); ?>">
+								" class="button button-primary" title="<?php esc_attr_e( 'Jetpack helps to keep you secure from brute-force login attacks.', 'jetpack' ); ?>">
 						<?php esc_html_e( 'Activate', 'jetpack' ); ?>
 					</a>
 				<?php else : ?>


### PR DESCRIPTION
## Proposed changes:
* Use Emerald style for buttons in the stats widget footer (black background, white text).
* Remove the `button-jetpack` styles which are no longer in use.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-lVZ-p2#comment-62557

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Make sure the Akismet plugin is installed on your site but not activated.
2. Apply the PR and ensure the styles are rebuilt (`pnpm jetpack watch plugins/jetpack` will do the trick).
3. Visit the wp-admin dashboard `/wp-admin/index.php` and locate the Jetpack Stats widget.

Before:

<img width="503" alt="Screenshot 2023-04-19 at 2 39 06 PM" src="https://user-images.githubusercontent.com/17325/232952546-794a4ac5-f888-4466-9c12-5a7a6c38565d.png">

After:

<img width="479" alt="Screenshot 2023-04-19 at 11 53 19 AM" src="https://user-images.githubusercontent.com/17325/232952566-b963cd8f-d9a4-4602-919a-e5785f767020.png">




