### PR TITLE
Odyssey Widget: remove feature gating

### DIFF
--- a/projects/packages/stats-admin/changelog/update-remove-feature-gating
+++ b/projects/packages/stats-admin/changelog/update-remove-feature-gating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats Admin: add minify=false to avoid JS minified by WP.com

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Assets;
 class Odyssey_Assets {
 	// This is a fixed list @see https://github.com/Automattic/wp-calypso/pull/71442/
 	const JS_DEPENDENCIES = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
-	const ODYSSEY_CDN_URL = 'https://widgets.wp.com/odyssey-stats/%s/%s';
+	const ODYSSEY_CDN_URL = 'https://widgets.wp.com/odyssey-stats/%s/%s?minify=false';
 
 	/**
 	 * We bump the asset version when the Jetpack back end is not compatible anymore.

--- a/projects/plugins/jetpack/changelog/update-remove-feature-gating
+++ b/projects/plugins/jetpack/changelog/update-remove-feature-gating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Stats Widget: remove feature gating

--- a/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
+++ b/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats_Admin\WP_Dashboard_Odyssey_Widget as Dashboard_Stats_Widget;
 use Automattic\Jetpack\Status;
 
@@ -63,8 +64,17 @@ class Jetpack_Stats_Dashboard_Widget {
 				__( 'Jetpack Stats', 'jetpack' )
 			);
 
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended
-			if ( ! isset( $_GET['odyssey_widget'] ) ) {
+			if ( Stats_Options::get_option( 'enable_odyssey_stats' ) ) {
+				// New widget implemented in Odyssey Stats.
+				$stats_widget = new Dashboard_Stats_Widget();
+				wp_add_dashboard_widget(
+					'jetpack_summary_widget',
+					$widget_title,
+					array( $stats_widget, 'render' )
+				);
+				$stats_widget->load_admin_scripts();
+			} else {
+				// Legacy widget.
 				wp_add_dashboard_widget(
 					'jetpack_summary_widget',
 					$widget_title,
@@ -80,14 +90,6 @@ class Jetpack_Stats_Dashboard_Widget {
 					JETPACK__VERSION
 				);
 				wp_style_add_data( 'jetpack-dashboard-widget', 'rtl', 'replace' );
-			} else {
-				$stats_widget = new Dashboard_Stats_Widget();
-				wp_add_dashboard_widget(
-					'jetpack_summary_widget',
-					$widget_title,
-					array( $stats_widget, 'render' )
-				);
-				$stats_widget->load_admin_scripts();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #30170 

## Proposed changes:

Removes feature gating from GET param and enable the new widget when Odyssey Stats is enabled.

Adds `minify=false` to walk around WP.com minifier which could break the builds sometimes.

The PR

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Enable Odyssey Stats if you haven't `/wp-admin/admin.php?page=jetpack#/traffic`
* Open WP Admin Dashboard `/wp-admin/admin.php`
* Ensure you see the new Stats Widget
* Disable Odyssey Stats
* Ensure the old widget still works

New:
<img width="585" alt="image" src="https://user-images.githubusercontent.com/1425433/232932875-fa2e6ce6-57f7-4348-b9de-c7dfaca1bee8.png">

Old:
<img width="569" alt="image" src="https://user-images.githubusercontent.com/1425433/232933150-d45585e9-bc61-4a64-9442-77a3f931c301.png">



