### PR TITLE
AI Chat Block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-chat-add-api-links
+++ b/projects/plugins/jetpack/changelog/update-ai-chat-add-api-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Plumbed in the WPcom API links to the beta ai-chat block so it can be can be tested against a real blog.

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/loading.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/loading.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Circle } from '@wordpress/components';
+export default function Loading() {
+	return (
+		<SVG width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+			<Circle cx="4" cy="12" r="3" opacity="1">
+				<animate
+					id="spinner_qYjJ"
+					begin="0;spinner_t4KZ.end-0.25s"
+					attributeName="opacity"
+					dur="0.75s"
+					values="1;.2"
+					fill="freeze"
+				/>
+			</Circle>
+			<Circle cx="12" cy="12" r="3" opacity=".4">
+				<animate
+					begin="spinner_qYjJ.begin+0.15s"
+					attributeName="opacity"
+					dur="0.75s"
+					values="1;.2"
+					fill="freeze"
+				/>
+			</Circle>
+			<Circle cx="20" cy="12" r="3" opacity=".3">
+				<animate
+					id="spinner_t4KZ"
+					begin="spinner_qYjJ.begin+0.3s"
+					attributeName="opacity"
+					dur="0.75s"
+					values="1;.2"
+					fill="freeze"
+				/>
+			</Circle>
+		</SVG>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
@@ -1,18 +1,13 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	TextControl,
-	Spinner,
-	KeyboardShortcuts,
-	ExternalLink,
-} from '@wordpress/components';
+import { Button, TextControl, KeyboardShortcuts, ExternalLink } from '@wordpress/components';
 import { RawHTML, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import Loading from './loading';
 import useSubmitQuestion from './use-submit-question';
 
 // This component displays the text word by word if show animation is true
@@ -89,7 +84,7 @@ export default function QuestionAnswer() {
 				<div className="jetpack-ai-chat-answer-container">
 					{ isLoading ? (
 						<>
-							<Spinner />
+							<Loading />
 							{ waitString }
 						</>
 					) : (

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
@@ -15,12 +15,6 @@ import { __ } from '@wordpress/i18n';
  */
 import useSubmitQuestion from './use-submit-question';
 
-const waitStrings = [
-	__( 'Good question, give me a moment to think about that 🤔', 'jetpack' ),
-	__( 'Let me work out the answer to that, back soon!', 'jetpack' ),
-	__( '🤔 Thinking, thinking, will be back with an answer soon', 'jetpack' ),
-];
-
 // This component displays the text word by word if show animation is true
 function ShowLittleByLittle( { html, showAnimation, onAnimationDone } ) {
 	// This is the HTML to be displayed.
@@ -56,22 +50,20 @@ function ShowLittleByLittle( { html, showAnimation, onAnimationDone } ) {
 	);
 }
 export default function QuestionAnswer() {
-	const { question, setQuestion, answer, isLoading, submitQuestion, references } =
+	const { question, setQuestion, answer, isLoading, submitQuestion, references, waitString } =
 		useSubmitQuestion();
 
 	const [ animationDone, setAnimationDone ] = useState( false );
-	const [ showReferences, setShowReferences ] = useState( false );
 
 	const handleSubmitQuestion = () => {
 		setAnimationDone( false );
-		setShowReferences( false );
 		submitQuestion();
 	};
 
 	const handleSetAnimationDone = () => {
 		setAnimationDone( true );
-		setShowReferences( true );
 	};
+
 	return (
 		<>
 			<KeyboardShortcuts
@@ -98,7 +90,7 @@ export default function QuestionAnswer() {
 					{ isLoading ? (
 						<>
 							<Spinner />
-							{ waitStrings[ Math.floor( Math.random() * 3 ) ] }
+							{ waitString }
 						</>
 					) : (
 						// eslint-disable-next-line react/no-danger
@@ -109,9 +101,9 @@ export default function QuestionAnswer() {
 						/>
 					) }
 				</div>
-				{ references && references.length > 0 && showReferences && (
+				{ references && references.length > 0 && (
 					<div className="jetpack-ai-chat-answer-references">
-						<div>{ __( 'Additional resources:', 'jetpack' ) }</div>
+						<div>{ __( 'Related resources:', 'jetpack' ) }</div>
 
 						<ul>
 							{ references.map( ( reference, index ) => (

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
@@ -45,8 +45,16 @@ function ShowLittleByLittle( { html, showAnimation, onAnimationDone } ) {
 	);
 }
 export default function QuestionAnswer() {
-	const { question, setQuestion, answer, isLoading, submitQuestion, references, waitString } =
-		useSubmitQuestion();
+	const {
+		question,
+		setQuestion,
+		answer,
+		isLoading,
+		submitQuestion,
+		references,
+		waitString,
+		error,
+	} = useSubmitQuestion();
 
 	const [ animationDone, setAnimationDone ] = useState( false );
 
@@ -82,6 +90,7 @@ export default function QuestionAnswer() {
 			</KeyboardShortcuts>
 			<div>
 				<div className="jetpack-ai-chat-answer-container">
+					{ error && <div className="jetpack-ai-chat-error">{ error }</div> }
 					{ isLoading ? (
 						<>
 							<Loading />

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
@@ -10,61 +10,21 @@ import { __ } from '@wordpress/i18n';
 import Loading from './loading';
 import useSubmitQuestion from './use-submit-question';
 
-// This component displays the text word by word if show animation is true
-function ShowLittleByLittle( { html, showAnimation, onAnimationDone } ) {
-	// This is the HTML to be displayed.
-	const [ displayedRawHTML, setDisplayedRawHTML ] = useState( '' );
-
-	useEffect(
-		() => {
-			// That will only happen once
-			if ( showAnimation && html ) {
-				// This is to animate text input. I think this will give an idea of a "better" AI.
-				// At this point this is an established pattern.
-				const tokens = html.split( ' ' );
-				for ( let i = 1; i < tokens.length; i++ ) {
-					const output = tokens.slice( 0, i ).join( ' ' );
-					setTimeout( () => setDisplayedRawHTML( output ), 50 * i );
-				}
-				setTimeout( () => {
-					setDisplayedRawHTML( html );
-					onAnimationDone();
-				}, 50 * tokens.length );
-			} else {
-				setDisplayedRawHTML( html );
-			}
-		},
-		// eslint-disable-next-line
-		[]
-	);
-
-	return (
-		<div className="content">
-			<RawHTML>{ displayedRawHTML }</RawHTML>
-		</div>
-	);
-}
 export default function QuestionAnswer() {
-	const {
-		question,
-		setQuestion,
-		answer,
-		isLoading,
-		submitQuestion,
-		references,
-		waitString,
-		error,
-	} = useSubmitQuestion();
+	const [ answer, setAnswer ] = useState( '' );
+	const [ aiResponse, setAiResponse ] = useState( '' );
 
-	const [ animationDone, setAnimationDone ] = useState( false );
+	useEffect( () => {
+		if ( aiResponse !== '' && aiResponse !== undefined ) {
+			setAnswer( `${ answer }${ aiResponse }` );
+		}
+	}, [ aiResponse ] );
+
+	const { question, setQuestion, isLoading, submitQuestion, references, waitString, error } =
+		useSubmitQuestion( setAiResponse );
 
 	const handleSubmitQuestion = () => {
-		setAnimationDone( false );
 		submitQuestion();
-	};
-
-	const handleSetAnimationDone = () => {
-		setAnimationDone( true );
 	};
 
 	return (
@@ -97,12 +57,9 @@ export default function QuestionAnswer() {
 							{ <div className="jetpack-ai-chat-wait-string">{ waitString } </div> }
 						</>
 					) : (
-						// eslint-disable-next-line react/no-danger
-						<ShowLittleByLittle
-							showAnimation={ ! animationDone }
-							onAnimationDone={ handleSetAnimationDone }
-							html={ answer }
-						/>
+						<div className="content">
+							<RawHTML>{ answer }</RawHTML>
+						</div>
 					) }
 				</div>
 				{ references && references.length > 0 && (

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
@@ -94,7 +94,7 @@ export default function QuestionAnswer() {
 					{ isLoading ? (
 						<>
 							<Loading />
-							{ waitString }
+							{ <div className="jetpack-ai-chat-wait-string">{ waitString } </div> }
 						</>
 					) : (
 						// eslint-disable-next-line react/no-danger

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/question-answer.js
@@ -4,6 +4,7 @@
 import { Button, TextControl, KeyboardShortcuts, ExternalLink } from '@wordpress/components';
 import { RawHTML, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import MarkdownIt from 'markdown-it';
 /**
  * Internal dependencies
  */
@@ -14,9 +15,15 @@ export default function QuestionAnswer() {
 	const [ answer, setAnswer ] = useState( '' );
 	const [ aiResponse, setAiResponse ] = useState( '' );
 
+	const markdownConverter = new MarkdownIt( { html: true } );
+
 	useEffect( () => {
 		if ( aiResponse !== '' && aiResponse !== undefined ) {
-			setAnswer( `${ answer }${ aiResponse }` );
+			if ( aiResponse === '[DONE]' ) {
+				setAnswer( markdownConverter.render( `${ answer }` ) );
+			} else {
+				setAnswer( markdownConverter.renderInline( `${ answer }${ aiResponse }` ) );
+			}
 		}
 	}, [ aiResponse ] );
 
@@ -24,6 +31,7 @@ export default function QuestionAnswer() {
 		useSubmitQuestion( setAiResponse );
 
 	const handleSubmitQuestion = () => {
+		setAnswer( '' );
 		submitQuestion();
 	};
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/response-strings.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/response-strings.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const initialWaitTexts = [
+	__( 'Let me see what I can find, back soon', 'jetpack' ),
+	__( 'Let me think about that for a moment', 'jetpack' ),
+	__( 'Great question, give me a few moments to think about that', 'jetpack' ),
+	__( 'Hmm, let me see what I can find about that', 'jetpack' ),
+	__( 'That rings a bell, give me a moment', 'jetpack' ),
+];
+
+export const referenceTexts = [
+	__(
+		'I found the following documents. Bear with me while I try and summarise them for you',
+		'jetpack'
+	),
+	__(
+		'The following documents look useful, but stick around while I summarise them for you',
+		'jetpack'
+	),
+	__(
+		'The following documents might have the answers, give me a moment to read and summarize them for you',
+		'jetpack'
+	),
+	__(
+		'I have a good feeling about these documents, but let me have a quick read and give you a summary',
+		'jetpack'
+	),
+	__(
+		"These documents look useful, but don't waste your time reading them, let me do that for you",
+		'jetpack'
+	),
+];

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
@@ -3,7 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 const blogId = '9619154';
@@ -30,21 +30,6 @@ export default function useSubmitQuestion() {
 		setIsLoading( true );
 		setWaitString( __( 'Let me think about that for a moment.', 'jetpack' ) );
 		const encoded = encodeURIComponent( question );
-
-		const termsResponse = await apiFetch( {
-			path: addQueryArgs( `wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {
-				stop_at: 'terms',
-				query: encoded,
-			} ),
-		} ).catch( handleAPIError );
-
-		setWaitString(
-			sprintf(
-				/* translators: %1$s: A list of terms being searched for. */
-				__( 'Sit tight, I am going to search for %1$s', 'jetpack' ),
-				termsResponse.terms.join( ', ' )
-			)
-		);
 
 		const urlsResponse = await apiFetch( {
 			path: addQueryArgs( `/wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 /**
@@ -12,21 +12,54 @@ import { referenceTexts, initialWaitTexts } from './response-strings';
 
 const blogId = '9619154';
 
-export default function useSubmitQuestion() {
+export default function useSubmitQuestion( setAiResponse ) {
 	const [ question, setQuestion ] = useState( '' );
-
-	const [ answer, setAnswer ] = useState();
 	const [ references, setReferences ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ waitString, setWaitString ] = useState( '' );
+	const [ callOpenAI, setCallOpenAI ] = useState( false );
 	const [ error, setError ] = useState();
 
 	const handleAPIError = () => {
 		setReferences( [] );
-		setAnswer( undefined );
+		setAiResponse( undefined );
 		setIsLoading( false );
 		setError( __( 'I seem to have encountered a problem. Please try again.', 'jetpack' ) );
 	};
+
+	useEffect( () => {
+		let source;
+		if ( callOpenAI === true ) {
+			const encoded = encodeURIComponent( question );
+			const path = addQueryArgs(
+				`https://public-api.wordpress.com/wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`,
+				{
+					stop_at: 'response',
+					query: encoded,
+					stream: true,
+				}
+			);
+			source = new EventSource( path );
+
+			source.addEventListener( 'open', () => {
+				setIsLoading( false );
+			} );
+
+			source.addEventListener( 'message', e => {
+				if ( e.data === '[DONE]' ) {
+					source.close();
+					setCallOpenAI( false );
+					return;
+				}
+				const data = JSON.parse( e.data );
+
+				setAiResponse( data.choices[ 0 ]?.delta?.content );
+			} );
+		}
+		return () => {
+			source?.close();
+		};
+	}, [ callOpenAI ] );
 
 	const submitQuestion = async () => {
 		setReferences( [] );
@@ -39,27 +72,19 @@ export default function useSubmitQuestion() {
 			path: addQueryArgs( `/wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {
 				stop_at: 'urls',
 				query: encoded,
+				stream: true,
 			} ),
 		} ).catch( handleAPIError );
 
 		setReferences( urlsResponse.urls );
 		setWaitString( referenceTexts[ Math.floor( Math.random() * referenceTexts.length ) ] );
 
-		const answerResponse = await apiFetch( {
-			path: addQueryArgs( `/wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {
-				stop_at: 'response',
-				query: encoded,
-			} ),
-		} ).catch( handleAPIError );
-
-		setAnswer( answerResponse.response );
-		setIsLoading( false );
+		setCallOpenAI( true );
 	};
 
 	return {
 		question,
 		setQuestion,
-		answer,
 		isLoading,
 		submitQuestion,
 		references,

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
@@ -47,6 +47,7 @@ export default function useSubmitQuestion( setAiResponse ) {
 
 			source.addEventListener( 'message', e => {
 				if ( e.data === '[DONE]' ) {
+					setAiResponse( '[DONE]' );
 					source.close();
 					setCallOpenAI( false );
 					return;

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
@@ -5,6 +5,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+/**
+ * Internal dependencies
+ */
+import { referenceTexts, initialWaitTexts } from './response-strings';
 
 const blogId = '9619154';
 
@@ -28,7 +32,7 @@ export default function useSubmitQuestion() {
 		setReferences( [] );
 		setError();
 		setIsLoading( true );
-		setWaitString( __( 'Let me think about that for a moment.', 'jetpack' ) );
+		setWaitString( initialWaitTexts[ Math.floor( Math.random() * initialWaitTexts.length ) ] );
 		const encoded = encodeURIComponent( question );
 
 		const urlsResponse = await apiFetch( {
@@ -39,12 +43,7 @@ export default function useSubmitQuestion() {
 		} ).catch( handleAPIError );
 
 		setReferences( urlsResponse.urls );
-		setWaitString(
-			__(
-				'I have found the following documents. Bear with me while I try and summarise them for you',
-				'jetpack'
-			)
-		);
+		setWaitString( referenceTexts[ Math.floor( Math.random() * referenceTexts.length ) ] );
 
 		const answerResponse = await apiFetch( {
 			path: addQueryArgs( `/wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/use-submit-question.js
@@ -19,48 +19,48 @@ export default function useSubmitQuestion() {
 	const submitQuestion = async () => {
 		setReferences( [] );
 		setIsLoading( true );
+		setWaitString( __( 'Let me think about that for a moment.', 'jetpack' ) );
 		const encoded = encodeURIComponent( question );
-		apiFetch( {
+
+		const { terms } = await apiFetch( {
 			path: addQueryArgs( `wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {
 				stop_at: 'terms',
 				query: encoded,
 			} ),
-		} )
-			.then( response => {
-				setWaitString(
-					sprintf(
-						/* translators: %1$s: A list of terms being searched for. */
-						__( 'Site tight, I am going to search for %1$s', 'jetpack' ),
-						response.terms.join( ', ' )
-					)
-				);
-				return apiFetch( {
-					path: addQueryArgs( `/wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {
-						stop_at: 'urls',
-						query: encoded,
-					} ),
-				} );
-			} )
-			.then( response => {
-				setReferences( response.urls );
-				setWaitString(
-					__(
-						'I have found the following documents. Bear with me while I try and summarise them for you',
-						'jetpack'
-					)
-				);
+		} );
 
-				return apiFetch( {
-					path: addQueryArgs( `/wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {
-						stop_at: 'response',
-						query: encoded,
-					} ),
-				} );
-			} )
-			.then( response => {
-				setAnswer( response.response );
-				setIsLoading( false );
-			} );
+		setWaitString(
+			sprintf(
+				/* translators: %1$s: A list of terms being searched for. */
+				__( 'Sit tight, I am going to search for %1$s', 'jetpack' ),
+				terms.join( ', ' )
+			)
+		);
+
+		const { urls } = await apiFetch( {
+			path: addQueryArgs( `/wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {
+				stop_at: 'urls',
+				query: encoded,
+			} ),
+		} );
+
+		setReferences( urls );
+		setWaitString(
+			__(
+				'I have found the following documents. Bear with me while I try and summarise them for you',
+				'jetpack'
+			)
+		);
+
+		const { response } = await apiFetch( {
+			path: addQueryArgs( `/wpcom/v2/sites/${ blogId }/jetpack-search/ai/search`, {
+				stop_at: 'response',
+				query: encoded,
+			} ),
+		} );
+
+		setAnswer( response );
+		setIsLoading( false );
 	};
 
 	return { question, setQuestion, answer, isLoading, submitQuestion, references, waitString };

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
@@ -31,6 +31,21 @@
 		}
 
 	}
+	.jetpack-ai-chat-answer-container {
+		display: flex;
+		align-items: center;
+		font-size: 1.2rem;
+
+		p { 
+			font-size: 1.2rem;
+		}
+
+		svg {
+			width: 40px;
+			height: 40px;
+			margin-right: 12px;
+		}
+	}
 	.jetpack-ai-chat-answer-references {
 		margin-top: 12px;
 		font-size: 1rem;

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
@@ -45,7 +45,12 @@
 			height: 40px;
 			margin-right: 12px;
 		}
+
+		.jetpack-ai-chat-wait-string {
+			font-size: 1rem;
+		}
 	}
+
 	.jetpack-ai-chat-answer-references {
 		margin-top: 12px;
 		font-size: 1rem;

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
@@ -49,6 +49,10 @@
 		.jetpack-ai-chat-wait-string {
 			font-size: 1rem;
 		}
+
+		.content div p:first-of-type {
+			margin-top: 0;
+		}
 	}
 
 	.jetpack-ai-chat-answer-references {


### PR DESCRIPTION
## Proposed changes:

* Wires in the AI Chat beta block into the search API so it can be tested against live content.

### Other information:

 - Still a beta block, so no tests added yet - will add some when more of structure finalised.

## Jetpack product discussion
Some background discussion here peGwbA-2b-p2

## Does this pull request change what data or activity we track or use?
No

## Todo

- [ ] Work out how to pass in the blog id to search - probably just the current blog id for starters, and needs to be limitied to public blogs only so private blog data is not passed out to OpenAI API 
- [ ] Add the option to specify default questions to choose from
- [ ] Add a little more design finesse, some fade-in, fade-out of text changes, etc.
- [ ] There is a CORs error when using the block on the frontend of sandbox server
- [ ] Work out how the block can be restricted to only sites with Jetpack search subs and how summarization of results will be metered

## Testing instructions:

* Sync PR to sandbox and add the AI Chat block to a post and try asking a WPcom related question

https://user-images.githubusercontent.com/3629020/236056356-f266b146-4f74-4e12-98c3-0562a7ab36d0.mp4


