### PR TITLE
Social: Add option to flag post as social post

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-is-social-post-option
+++ b/projects/js-packages/publicize-components/changelog/add-is-social-post-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added new option for flagging a post as social post

--- a/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
@@ -2,6 +2,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
 
+const PUBLICIZE_STORE = 'jetpack/publicize';
+
 /**
  * @typedef {object} AttachedMediaHook
  * @property {Array} attachedMedia - List of media with ID, URL, and metadata.
@@ -18,11 +20,11 @@ import { useCallback } from '@wordpress/element';
 export default function useAttachedMedia() {
 	const { editPost } = useDispatch( editorStore );
 
-	const isSocialPost = useSelect( select => select( 'jetpack/publicize' ).isSocialPost() );
-	const attachedMedia = useSelect( select => select( 'jetpack/publicize' ).getAttachedMedia() );
-	const currentOptions = useSelect( select =>
-		select( 'jetpack/publicize' ).getJetpackSocialOptions()
-	);
+	const { isSocialPost, attachedMedia, currentOptions } = useSelect( select => ( {
+		isSocialPost: select( PUBLICIZE_STORE ).isSocialPost(),
+		attachedMedia: select( PUBLICIZE_STORE ).getAttachedMedia(),
+		currentOptions: select( PUBLICIZE_STORE ).getJetpackSocialOptions(),
+	} ) );
 
 	const updateAttachedMedia = useCallback(
 		medias => {

--- a/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
@@ -21,7 +21,7 @@ export default function useAttachedMedia() {
 	const { editPost } = useDispatch( editorStore );
 
 	const { shouldUploadAttachedMedia, attachedMedia, currentOptions } = useSelect( select => ( {
-		shouldUploadAttachedMedia: select( PUBLICIZE_STORE ).isSocialPost(),
+		shouldUploadAttachedMedia: select( PUBLICIZE_STORE ).shouldUploadAttachedMedia(),
 		attachedMedia: select( PUBLICIZE_STORE ).getAttachedMedia(),
 		currentOptions: select( PUBLICIZE_STORE ).getJetpackSocialOptions(),
 	} ) );

--- a/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
@@ -5,17 +5,20 @@ import { useCallback } from '@wordpress/element';
 /**
  * @typedef {object} AttachedMediaHook
  * @property {Array} attachedMedia - List of media with ID, URL, and metadata.
+ * @property {boolean} isSocialPost - Whether the post is a social post.
  * @property {Function} updateAttachedMedia - Callback used to update the attached media.
+ * @property {Function} updateIsSocialPost - Callback used to update the isSocialPost value.
  */
 
 /**
- * Hook to handle storing the attached media.
+ * Hook to handle storing the attached media, choosing whether it is a social post.
  *
  * @returns {AttachedMediaHook} - An object with the attached media hook properties set.
  */
 export default function useAttachedMedia() {
 	const { editPost } = useDispatch( editorStore );
 
+	const isSocialPost = useSelect( select => select( 'jetpack/publicize' ).isSocialPost() );
 	const attachedMedia = useSelect( select => select( 'jetpack/publicize' ).getAttachedMedia() );
 	const currentOptions = useSelect( select =>
 		select( 'jetpack/publicize' ).getJetpackSocialOptions()
@@ -32,8 +35,21 @@ export default function useAttachedMedia() {
 		[ currentOptions, editPost ]
 	);
 
+	const updateIsSocialPost = useCallback(
+		option => {
+			editPost( {
+				meta: {
+					jetpack_social_options: { ...currentOptions, is_social_post: option },
+				},
+			} );
+		},
+		[ currentOptions, editPost ]
+	);
+
 	return {
 		attachedMedia,
+		isSocialPost,
 		updateAttachedMedia,
+		updateIsSocialPost,
 	};
 }

--- a/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
@@ -7,9 +7,9 @@ const PUBLICIZE_STORE = 'jetpack/publicize';
 /**
  * @typedef {object} AttachedMediaHook
  * @property {Array} attachedMedia - List of media with ID, URL, and metadata.
- * @property {boolean} isSocialPost - Whether the post is a social post.
+ * @property {boolean} shouldUploadAttachedMedia - Whether the post is a social post and we upload the media.
  * @property {Function} updateAttachedMedia - Callback used to update the attached media.
- * @property {Function} updateIsSocialPost - Callback used to update the isSocialPost value.
+ * @property {Function} updateShouldUploadAttachedMedia - Callback used to update the shouldUploadAttachedMedia value.
  */
 
 /**
@@ -20,28 +20,17 @@ const PUBLICIZE_STORE = 'jetpack/publicize';
 export default function useAttachedMedia() {
 	const { editPost } = useDispatch( editorStore );
 
-	const { isSocialPost, attachedMedia, currentOptions } = useSelect( select => ( {
-		isSocialPost: select( PUBLICIZE_STORE ).isSocialPost(),
+	const { shouldUploadAttachedMedia, attachedMedia, currentOptions } = useSelect( select => ( {
+		shouldUploadAttachedMedia: select( PUBLICIZE_STORE ).isSocialPost(),
 		attachedMedia: select( PUBLICIZE_STORE ).getAttachedMedia(),
 		currentOptions: select( PUBLICIZE_STORE ).getJetpackSocialOptions(),
 	} ) );
 
-	const updateAttachedMedia = useCallback(
-		medias => {
+	const updateJetpackSocialOptions = useCallback(
+		( key, value ) => {
 			editPost( {
 				meta: {
-					jetpack_social_options: { ...currentOptions, attached_media: medias },
-				},
-			} );
-		},
-		[ currentOptions, editPost ]
-	);
-
-	const updateIsSocialPost = useCallback(
-		option => {
-			editPost( {
-				meta: {
-					jetpack_social_options: { ...currentOptions, is_social_post: option },
+					jetpack_social_options: { ...currentOptions, [ key ]: value },
 				},
 			} );
 		},
@@ -50,8 +39,9 @@ export default function useAttachedMedia() {
 
 	return {
 		attachedMedia,
-		isSocialPost,
-		updateAttachedMedia,
-		updateIsSocialPost,
+		shouldUploadAttachedMedia,
+		updateAttachedMedia: media => updateJetpackSocialOptions( 'attached_media', media ),
+		updateShouldUploadAttachedMedia: option =>
+			updateJetpackSocialOptions( 'should_upload_attached_media', option ),
 	};
 }

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -572,6 +572,15 @@ export function getAttachedMedia() {
 }
 
 /**
+ * Checks if the post is a social post.
+ *
+ * @returns {boolean} Whether the post is a social post.
+ */
+export function isSocialPost() {
+	return getJetpackSocialOptions()?.is_social_post ?? false;
+}
+
+/**
  * Get a list of all image generator settings for a post.
  *
  * @returns {Array} An array of image generator settings.

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -576,7 +576,7 @@ export function getAttachedMedia() {
  *
  * @returns {boolean} Whether the post is a social post.
  */
-export function isSocialPost() {
+export function shouldUploadAttachedMedia() {
 	return getJetpackSocialOptions()?.should_upload_attached_media ?? false;
 }
 

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -577,7 +577,7 @@ export function getAttachedMedia() {
  * @returns {boolean} Whether the post is a social post.
  */
 export function isSocialPost() {
-	return getJetpackSocialOptions()?.is_social_post ?? false;
+	return getJetpackSocialOptions()?.should_upload_attached_media ?? false;
 }
 
 /**

--- a/projects/packages/publicize/changelog/add-is-social-post-option
+++ b/projects/packages/publicize/changelog/add-is-social-post-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added new option for flagging a post as social post

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1086,6 +1086,9 @@ abstract class Publicize_Base {
 								),
 							),
 						),
+						'is_social_post'           => array(
+							'type' => 'boolean',
+						),
 						'image_generator_settings' => array(
 							'type'       => 'object',
 							'properties' => array(

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1072,7 +1072,7 @@ abstract class Publicize_Base {
 				'schema' => array(
 					'type'       => 'object',
 					'properties' => array(
-						'attached_media'           => array(
+						'attached_media'               => array(
 							'type'  => 'array',
 							'items' => array(
 								'type'       => 'object',
@@ -1086,10 +1086,10 @@ abstract class Publicize_Base {
 								),
 							),
 						),
-						'is_social_post'           => array(
+						'should_upload_attached_media' => array(
 							'type' => 'boolean',
 						),
-						'image_generator_settings' => array(
+						'image_generator_settings'     => array(
 							'type'       => 'object',
 							'properties' => array(
 								'enabled'     => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This change adds a new option to our `jetpack_social_options` array, which is used to flag a post whether it is a social post

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added new option to meta
* Extended `useAttachedMedia` hook to be able to get/set this option.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1204272127368434-as-1204411047112874
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* in `projects/js-packages/publicize-components/src/components/media-section/index.js` import `isSocialPost` and `updateIsSocialPost` from the `useAttachedMedia` hook.
* Console log out `isSocialPost`.
* Open a new post, and check the logs, it should log out `false`.
* Refresh the page with `updateIsSocialPost( true );` called, and save as draft.
* Log out `isSocialPost` again, now it should be true for this post even after refresh 
* Saving attachedMedia should work as before - select a media with the media picker, save post, refresh, and media should be selected