### PR TITLE
VideoPress: autoplay video also when Preview On Hover is enabled

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-run-autoplay-when-poh
+++ b/projects/packages/videopress/changelog/update-videopress-run-autoplay-when-poh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: autoplay video also when Preview On Hover is enabled

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -66,7 +66,11 @@ function previewOnHoverEffect(): void {
 		const iframeApi = window.VideoPressIframeApi( iFrame, () => {
 			iframeApi.status.onPlayerStatusChanged( ( oldStatus, newStatus ) => {
 				if ( oldStatus === 'ready' && newStatus === 'playing' ) {
-					iframeApi.controls.pause();
+					// Do not pause if autoplay is enabled.
+					if ( ! previewOnHoverData.autoplay ) {
+						iframeApi.controls.pause();
+					}
+
 					iframeApi.controls.seek( previewOnHoverData.previewAtTime );
 				}
 			} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR auto plays the video even when the previewOnHover (pOH) effect is activated. Currently, the video doesn't play automatically.

Fixes https://github.com/Automattic/jetpack/issues/30167

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: autoplay video also when Preview On Hover is enabled

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a VideoPress block instance
* Ensure playback `autoplay` is **deactivated**
* Enable pOH
* Save
* View the post in the front-end
* Confirm the video does not play automatically 
* Confirm it play/pause when hovering/leaving
* Go back to the block editor
* Activate playback `autoplay`
* Save
* Go to the front-end
* hard refresh
* Confirm the video auto plays
 
