### PR TITLE
CRM: Port back 5.7.0 release changelog, readme and package updates

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.31.6 - 2023-04-19
+### Changed
+- Updated package dependencies. [#30015]
+
+### Removed
+- Remove WordPress 6.0 backwards-compatibility code. [#30126]
+
 ## 0.31.5 - 2023-04-17
 ### Changed
 - Updated package dependencies. [#30019]

--- a/projects/js-packages/components/changelog/renovate-major-storybook-monorepo
+++ b/projects/js-packages/components/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/update-backwards-compat-61
+++ b/projects/js-packages/components/changelog/update-backwards-compat-61
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Remove WordPress 6.0 backwards-compatibility code.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.31.6-alpha",
+	"version": "0.31.6",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -5,6 +5,59 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.7.0] - 2023-04-19
+### Added
+- Menus: Add back to list button on add and edit pages for companies, transactions, invoices, and quotes [#29999]
+- Settings: Remove 'Restore default settings' from the General Settings page, add to settings page menu [#29999]
+- Support Page: Add new support page for customers to submit support requests [#29545]
+
+### Changed
+- API: Add optional parameter to the API to set the external service name, and replace hyphens from the json response to underscores [#29316]
+- Companies: Move status select from Actions to main edit section underneath ID [#29999]
+- Contacts: Change location of save button and add Contact Actions metabox for contacts [#29999]
+- Onboarding: Change onboarding wizard company name description to remove 'as shown below' [#29999]
+- Quotes: Move Quote Status underneath Quote ID [#29999]
+- Menus: Swap the stacked logo to the horizontal one [#30092]
+- CSV Importer: Various UI/UX tweaks [#29851]
+- Dashboard: Align the Latest Contacts and Revenue Chart buttons [#29999]
+- Dashboard: Make spacing between panels more consistent [#29999]
+- Invoices: Fix overflow issue in the edit invoice page [#29999]
+- Invoices: Move status select HTML from Invoice Actions to main edit section under ID [#29999]
+- OAuth: Dependencies are now downloaded to wp-content/jpcrm-storage/packages [#29734]
+- Onboarding: Make all hint styles consistent [#29999]
+- Transactions: Change location of import sub-menu item when CSV Pro is installed and active [#29999]
+- Transactions: Move status select HTML from Transaction Actions to main edit section underneath ID [#29999]
+
+### Removed
+- Onboarding: Remove company name preview from onboarding wizard [#29999]
+
+### Fixed
+- UI: Change fonts to smaller size, and different font family [#29999]
+- UI: Change form placeholder colors to a lighter shade of gray [#29999]
+- Contacts: Fix 403 error if file was uploaded via Client Portal Pro using Apache web server [#29969]
+- Menus: Remove border from top menu [#29999]
+- Dashboard: Adjustments to first-use modals [#30065]
+- Dashboard: Various fixes for the sales funnel [#29995]
+- Email: Caught PHP notices if recipient was deleted [#29747]
+- Exports: Catch PHP notice when exporting a subset of objects [#30111]
+- UI: Fix content overflowing in contact view page [#29999]
+- Support: Fix the Give Feedback link so that it sends to the reviews page on .org [#29873]
+- General: Fix various corrupt JS files [#29705]
+- Onboarding: Get updates (mailing list) changed from opt-out to opt-in in the onboarding wizard [#29999]
+- Importer: Allow import of application/csv mime type
+  Importer: Better parsing of CSV fields [#29822]
+- General: Improved compatibility with PHP 8.1 [#29945]
+- Invoices: Fix ability to remove logo from invoice edit page [#30099]
+- Invoices: Fix PHP notice when sending contact an invoice via email [#30110]
+- General: Fix broken link in bulk actions function in list view [#29623]
+- Mailpoet Sync: Fix an issue where contact images would disappear after synchronization [#30091]
+- Onboarding: Remove outdated YouTube video from welcome overlay [#29999]
+- Quotes: Use current date if quote date is blank [#30032]
+- Settings: Fix broken link on white label installs [#30160]
+- Settings: Allow new tax rates to be added [#29938]
+- Onboarding: Usage tracking changed from opt-out to opt-in in the onboarding wizard [#29999]
+- WooSync: Tag existing contacts with new orders [#30107]
+
 ## [5.6.0] - 2023-03-23
 ### Changed
 - Contacts: Change customer references to contact in all but Woo and commerce contexts [#29267]
@@ -75,5 +128,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved: Security around phone numbers viewing
 - Improved: Added a migration to remove outdated AKA lines
 
-[5.6.0]: https://github.com/Automattic/jetpack-crm/compare/v5.5.4-a.1...v5.6.0
 [5.5.4-a.1]: https://github.com/Automattic/jetpack-crm/compare/v5.5.3...v5.5.4-a.1
+[5.7.0]: https://github.com/Automattic/jetpack-crm/compare/v5.6.0...v5.7.0
+[5.6.0]: https://github.com/Automattic/jetpack-crm/compare/v5.5.4-a.1...v5.6.0

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 5.7.0-alpha
+ * Version: 5.7.0
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/add-crm-add-edit-page-list-button
+++ b/projects/plugins/crm/changelog/add-crm-add-edit-page-list-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-CRM: add back to list button on add and edit pages for companies, transactions, invoices, and quotes.

--- a/projects/plugins/crm/changelog/add-crm-restore-default-settings-link-menu
+++ b/projects/plugins/crm/changelog/add-crm-restore-default-settings-link-menu
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-CRM: add restore default settings menu item to settings page menu

--- a/projects/plugins/crm/changelog/add-package-suggestions
+++ b/projects/plugins/crm/changelog/add-package-suggestions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/changelog/add-package-suggestions#2
+++ b/projects/plugins/crm/changelog/add-package-suggestions#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/changelog/crm-2804-contact-edit-content-overflows
+++ b/projects/plugins/crm/changelog/crm-2804-contact-edit-content-overflows
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix content overflowing in contact view page.

--- a/projects/plugins/crm/changelog/crm-add-support-page
+++ b/projects/plugins/crm/changelog/crm-add-support-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Support Page: A new support page has been added for customers to submit support requests.

--- a/projects/plugins/crm/changelog/crm-change-placeholders-to-lighter-color
+++ b/projects/plugins/crm/changelog/crm-change-placeholders-to-lighter-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Changed form placeholder colors to a lighter shade of gray.

--- a/projects/plugins/crm/changelog/crm-fix-2900-trim_first_use_dashboard_extra_space
+++ b/projects/plugins/crm/changelog/crm-fix-2900-trim_first_use_dashboard_extra_space
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Dashboard: adjustments to first-use modals

--- a/projects/plugins/crm/changelog/crm-fix-feedback-broken-page
+++ b/projects/plugins/crm/changelog/crm-fix-feedback-broken-page
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed the Give Feedback link to send to the reviews on .org

--- a/projects/plugins/crm/changelog/crm-make-form-fonts-smaller
+++ b/projects/plugins/crm/changelog/crm-make-form-fonts-smaller
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Changed fonts to smaller size, and different font family

--- a/projects/plugins/crm/changelog/crm-remove-restore-default-settings-button-from-settings
+++ b/projects/plugins/crm/changelog/crm-remove-restore-default-settings-button-from-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Settings: Remove 'Restore default settings' from the General Settings page

--- a/projects/plugins/crm/changelog/fix-crm-2840-woosync_tag_existing_contacts
+++ b/projects/plugins/crm/changelog/fix-crm-2840-woosync_tag_existing_contacts
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-WooSync: tag existing contacts with new orders

--- a/projects/plugins/crm/changelog/fix-crm-2889_and_2972_unescape_html
+++ b/projects/plugins/crm/changelog/fix-crm-2889_and_2972_unescape_html
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Listview: fixed broken link in bulk actions function

--- a/projects/plugins/crm/changelog/fix-crm-2920-force_default_quote_date
+++ b/projects/plugins/crm/changelog/fix-crm-2920-force_default_quote_date
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Quotes: use current date if quote date is blank

--- a/projects/plugins/crm/changelog/fix-crm-2929-adjust_dashboard_infobox_padding
+++ b/projects/plugins/crm/changelog/fix-crm-2929-adjust_dashboard_infobox_padding
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Adjust padding on dashboard infoboxes
-
-

--- a/projects/plugins/crm/changelog/fix-crm-2930-funnel_glitches
+++ b/projects/plugins/crm/changelog/fix-crm-2930-funnel_glitches
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Dashboard: various fixes for the sales funnel

--- a/projects/plugins/crm/changelog/fix-crm-2951-fix-overflow-in-invoice-edit-page
+++ b/projects/plugins/crm/changelog/fix-crm-2951-fix-overflow-in-invoice-edit-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Invoices: fix overflow issue in the edit invoice page

--- a/projects/plugins/crm/changelog/fix-crm-2979-csv_importer_fixes
+++ b/projects/plugins/crm/changelog/fix-crm-2979-csv_importer_fixes
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-
-Importer: Allow import of application/csv mime type
-Importer: Better parsing of CSV fields

--- a/projects/plugins/crm/changelog/fix-crm-2989-csv_importer_visual_tweaks
+++ b/projects/plugins/crm/changelog/fix-crm-2989-csv_importer_visual_tweaks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-CSV Importer: various UI/UX tweaks

--- a/projects/plugins/crm/changelog/fix-crm-3001-swap-stacked-logo-for-horizontal
+++ b/projects/plugins/crm/changelog/fix-crm-3001-swap-stacked-logo-for-horizontal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-CRM Menu: Swap the stacked logo to the horizontal one

--- a/projects/plugins/crm/changelog/fix-crm-3015-escape_invoice_html
+++ b/projects/plugins/crm/changelog/fix-crm-3015-escape_invoice_html
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3016-remove_htaccess_in_contact_files
+++ b/projects/plugins/crm/changelog/fix-crm-3016-remove_htaccess_in_contact_files
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Contact files: fix 403 if file was uploaded via Client Portal Pro using Apache web server

--- a/projects/plugins/crm/changelog/fix-crm-3020-restore_thirdparty_JS_libs
+++ b/projects/plugins/crm/changelog/fix-crm-3020-restore_thirdparty_JS_libs
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Fixed various corrupt JS files

--- a/projects/plugins/crm/changelog/fix-crm-3021-welcome_wizard_JS_issue
+++ b/projects/plugins/crm/changelog/fix-crm-3021-welcome_wizard_JS_issue
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Allow welcome wizard to work when SCRIPT_DEBUG is true
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3026-move_package_data_folder
+++ b/projects/plugins/crm/changelog/fix-crm-3026-move_package_data_folder
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-OAuth: dependencies are now downloaded to wp-content/jpcrm-storage/packages

--- a/projects/plugins/crm/changelog/fix-crm-3027-catch_php_notices
+++ b/projects/plugins/crm/changelog/fix-crm-3027-catch_php_notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Email: caught PHP notices if recipient was deleted

--- a/projects/plugins/crm/changelog/fix-crm-3030-catch_PHP_8.1_errors
+++ b/projects/plugins/crm/changelog/fix-crm-3030-catch_PHP_8.1_errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improved compatibility with PHP 8.1

--- a/projects/plugins/crm/changelog/fix-crm-3031-catch_PHP_error_on_export
+++ b/projects/plugins/crm/changelog/fix-crm-3031-catch_PHP_error_on_export
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Export: catch PHP notice when exporting a subset of objects

--- a/projects/plugins/crm/changelog/fix-crm-3043-fix_js_esc_functions_on_non_strings
+++ b/projects/plugins/crm/changelog/fix-crm-3043-fix_js_esc_functions_on_non_strings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Tax: new tax rates could not be added

--- a/projects/plugins/crm/changelog/fix-crm-3048-remove_slack_refs
+++ b/projects/plugins/crm/changelog/fix-crm-3048-remove_slack_refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Removed references to Slack community
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3054-mailpoet-sync-removing-avatar
+++ b/projects/plugins/crm/changelog/fix-crm-3054-mailpoet-sync-removing-avatar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Mailpoet Sync: Fixed an issue where contact images would disappear after synchronization.

--- a/projects/plugins/crm/changelog/fix-crm-3059_php-notice_when_sending_invoice
+++ b/projects/plugins/crm/changelog/fix-crm-3059_php-notice_when_sending_invoice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Invoices: PHP notice when sending contact an invoice via email

--- a/projects/plugins/crm/changelog/fix-crm-3063-fix_manage_features_button
+++ b/projects/plugins/crm/changelog/fix-crm-3063-fix_manage_features_button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Settings: fixed broken link on white label installs

--- a/projects/plugins/crm/changelog/fix-crm-invoice-logo-remove
+++ b/projects/plugins/crm/changelog/fix-crm-invoice-logo-remove
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Invoices: fix ability to remove logo from invoice edit page.

--- a/projects/plugins/crm/changelog/fix-crm-onboarding-wizard-change-tracking-to-opt-in
+++ b/projects/plugins/crm/changelog/fix-crm-onboarding-wizard-change-tracking-to-opt-in
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Usage tracking changed from opt-out to opt-in in the onboarding wizard.

--- a/projects/plugins/crm/changelog/fix-crm-onboarding-wizard-change-updates-to-opt-in
+++ b/projects/plugins/crm/changelog/fix-crm-onboarding-wizard-change-updates-to-opt-in
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Get updates (mailing list) changed from opt-out to opt-in in the onboarding wizard.

--- a/projects/plugins/crm/changelog/fix-crm-ui-cohesiveness-remove-youtube-video-from-welcome-overlay
+++ b/projects/plugins/crm/changelog/fix-crm-ui-cohesiveness-remove-youtube-video-from-welcome-overlay
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Outdated YouTube video removed from welcome overlay.

--- a/projects/plugins/crm/changelog/fix-crm-ui-cohesiveness-top-menu-showing-ugly-borders
+++ b/projects/plugins/crm/changelog/fix-crm-ui-cohesiveness-top-menu-showing-ugly-borders
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: remove border from top menu.

--- a/projects/plugins/crm/changelog/fix-crm-webpack-generate-css
+++ b/projects/plugins/crm/changelog/fix-crm-webpack-generate-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Build: change build steps so that CSS files are also generated for production

--- a/projects/plugins/crm/changelog/fix-crm-zapier-integration-using-http-user-agent-global
+++ b/projects/plugins/crm/changelog/fix-crm-zapier-integration-using-http-user-agent-global
@@ -1,6 +1,0 @@
-Significance: patch
-Type: changed
-
-Added optional parameter to the API to set the external service name
-Added optional parameter to the API to replace hyphens from the json response to underscores
-

--- a/projects/plugins/crm/changelog/remove-crm-onboarding-wizard-preview-company-name
+++ b/projects/plugins/crm/changelog/remove-crm-onboarding-wizard-preview-company-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-CRM: remove company name preview from onboarding wizard

--- a/projects/plugins/crm/changelog/renovate-babel-monorepo
+++ b/projects/plugins/crm/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/crm/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/crm/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/crm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/update-crm-2906-change-onboarding-wizard-hint-css
+++ b/projects/plugins/crm/changelog/update-crm-2906-change-onboarding-wizard-hint-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Onboarding: make all hint styles consistent

--- a/projects/plugins/crm/changelog/update-crm-2957-move-company-status-below-id
+++ b/projects/plugins/crm/changelog/update-crm-2957-move-company-status-below-id
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Companies: Move status select from Actions to main edit section underneath ID

--- a/projects/plugins/crm/changelog/update-crm-composer-and-versions
+++ b/projects/plugins/crm/changelog/update-crm-composer-and-versions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/changelog/update-crm-contact-save-button
+++ b/projects/plugins/crm/changelog/update-crm-contact-save-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-CRM: change location of save button and add Contact Actions metabox for contacts

--- a/projects/plugins/crm/changelog/update-crm-dashboard-div-alignment
+++ b/projects/plugins/crm/changelog/update-crm-dashboard-div-alignment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Dashboard: Make spacing between panels more consistent

--- a/projects/plugins/crm/changelog/update-crm-dashboard-revenue-chart-more-button
+++ b/projects/plugins/crm/changelog/update-crm-dashboard-revenue-chart-more-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Dashboard: Aligning the Latest Contacts and Revenue Chart buttons

--- a/projects/plugins/crm/changelog/update-crm-move-invoice-status
+++ b/projects/plugins/crm/changelog/update-crm-move-invoice-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Invoices: move status select html from Invoice Actions to main edit section under ID

--- a/projects/plugins/crm/changelog/update-crm-move-quote-status
+++ b/projects/plugins/crm/changelog/update-crm-move-quote-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-CRM: move Quote Status underneath Quote ID

--- a/projects/plugins/crm/changelog/update-crm-move-transaction-status
+++ b/projects/plugins/crm/changelog/update-crm-move-transaction-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Transactions: move status select html from Transaction Actions to main edit section underneath ID

--- a/projects/plugins/crm/changelog/update-crm-onboarding-wizard-company-name-explanation
+++ b/projects/plugins/crm/changelog/update-crm-onboarding-wizard-company-name-explanation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-CRM: change onboarding wizard company name description to remove 'as shown below'

--- a/projects/plugins/crm/changelog/update-crm-readme-5.6.0
+++ b/projects/plugins/crm/changelog/update-crm-readme-5.6.0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Readme: Update stable tag.

--- a/projects/plugins/crm/changelog/update-crm-transaction-menu-dropdown
+++ b/projects/plugins/crm/changelog/update-crm-transaction-menu-dropdown
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Transactions: change location of import sub-menu item when CSV Pro is installed and active

--- a/projects/plugins/crm/changelog/update-crm-webpack-remove-built-css-and-stray-files
+++ b/projects/plugins/crm/changelog/update-crm-webpack-remove-built-css-and-stray-files
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Tooling: remove CSS from the monorepo but not production and cleaning up gitattibutes and gitignore

--- a/projects/plugins/crm/changelog/update-use-assets-enqueue-stats
+++ b/projects/plugins/crm/changelog/update-use-assets-enqueue-stats
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -37,7 +37,7 @@
 		"platform": {
 			"php": "7.3"
 		},
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_7_0_alpha",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_7_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -24,7 +24,7 @@ final class ZeroBSCRM {
 	 *
 	 * @var string
 	 */
-	public $version = '5.6.0';
+	public $version = '5.7.0';
 
 	/**
 	 * WordPress version tested with.

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "5.7.0-alpha",
+	"version": "5.7.0",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -399,7 +399,61 @@ We offer a full, no-hassle refund within 14 days. You can read more about that, 
 
 
 == Changelog ==
-### 5.6.0 - 2023-03-23
+### 5.7.0 - 2023-04-19
+#### Added
+- Menus: Add back to list button on add and edit pages for companies, transactions, invoices, and quotes
+- Settings: Remove 'Restore default settings' from the General Settings page, add to settings page menu
+- Support Page: Add new support page for customers to submit support requests
+
+#### Changed
+- API: Add optional parameter to the API to set the external service name, and replace hyphens from the json response to underscores
+- Companies: Move status select from Actions to main edit section underneath ID
+- Contacts: Change location of save button and add Contact Actions metabox for contacts
+- Onboarding: Change onboarding wizard company name description to remove 'as shown below'
+- Quotes: Move Quote Status underneath Quote ID
+- Menus: Swap the stacked logo to the horizontal one
+- CSV Importer: Various UI/UX tweaks
+- Dashboard: Align the Latest Contacts and Revenue Chart buttons
+- Dashboard: Make spacing between panels more consistent
+- Invoices: Fix overflow issue in the edit invoice page
+- Invoices: Move status select HTML from Invoice Actions to main edit section under ID
+- OAuth: Dependencies are now downloaded to wp-content/jpcrm-storage/packages
+- Onboarding: Make all hint styles consistent
+- Transactions: Change location of import sub-menu item when CSV Pro is installed and active
+- Transactions: Move status select HTML from Transaction Actions to main edit section underneath ID
+
+#### Removed
+- Onboarding: Remove company name preview from onboarding wizard
+
+#### Fixed
+- UI: Change fonts to smaller size, and different font family
+- UI: Change form placeholder colors to a lighter shade of gray
+- Contacts: Fix 403 error if file was uploaded via Client Portal Pro using Apache web server
+- Menus: Remove border from top menu
+- Dashboard: Adjustments to first-use modals
+- Dashboard: Various fixes for the sales funnel
+- Email: Caught PHP notices if recipient was deleted
+- Exports: Catch PHP notice when exporting a subset of objects
+- UI: Fix content overflowing in contact view page
+- Support: Fix the Give Feedback link so that it sends to the reviews page on .org
+- General: Fix various corrupt JS files
+- Onboarding: Get updates (mailing list) changed from opt-out to opt-in in the onboarding wizard
+- Importer: Allow import of application/csv mime type
+- Importer: Better parsing of CSV fields
+- General: Improved compatibility with PHP 8.1
+- Invoices: Fix ability to remove logo from invoice edit page
+- Invoices: Fix PHP notice when sending contact an invoice via email
+- General: Fix broken link in bulk actions function in list view
+- Mailpoet Sync: Fix an issue where contact images would disappear after synchronization
+- Onboarding: Remove outdated YouTube video from welcome overlay
+- Quotes: Use current date if quote date is blank
+- Settings: Fix broken link on white label installs
+- Settings: Allow new tax rates to be added
+- Onboarding: Usage tracking changed from opt-out to opt-in in the onboarding wizard
+- WooSync: Tag existing contacts with new orders
+
+v5.6.0 - 23 March 2023
+-------------------------
 #### Changed
 - Contacts: Change customer references to contact in all but Woo and commerce contexts
 - Compatibility: Indicate full compatibility with the latest version of WordPress, 6.2


### PR DESCRIPTION

## Proposed changes:

* This PR ports the changelog, readme and package updates for the CRM 5.7.0 release back to trunk

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read - check that versions are as expected.

