### PR TITLE
 VideoPress: change max duration of the Preview On Hover effect to ten seconds

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-change-poh-max-duration
+++ b/projects/packages/videopress/changelog/update-videopress-change-poh-max-duration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: change max duration of the Preview On Hover effect to ten seconds

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -44,8 +44,8 @@ import type { PosterDataProps, PosterPanelProps, VideoControlProps, VideoGUID } 
 import type React from 'react';
 
 const MIN_LOOP_DURATION = 3 * 1000;
-const MAX_LOOP_DURATION = 30 * 1000;
-const DEFAULT_LOOP_DURATION = 10 * 1000;
+const MAX_LOOP_DURATION = 10 * 1000;
+const DEFAULT_LOOP_DURATION = 5 * 1000;
 
 /*
  * Check whether video frame poster extension is enabled.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -442,7 +442,7 @@ export function VideoHoverPreviewControl( {
 						wait={ 300 }
 						help={ loopDurationHelp }
 						disabled={ disabled || noLoopDurationRange }
-						marksEvery={ 5000 }
+						marksEvery={ 1000 }
 					/>
 				</>
 			) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  VideoPress: change max duration of the Preview On Hover effect to ten seconds

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block edior
* Create/edit a VideoPess video instance
* Enable Preview On Hover

Before | After
-----|------
<img width="282" alt="Screen Shot 2023-04-19 at 08 25 01" src="https://user-images.githubusercontent.com/77539/233065924-a6d6f5ab-d962-4262-8779-3157879fd080.png"> | <img width="284" alt="Screen Shot 2023-04-19 at 08 49 11" src="https://user-images.githubusercontent.com/77539/233065918-f2a00e23-a1e9-4e2d-9831-75167cbf14ef.png">

