### PR TITLE
VideoPress: integrate video poster with Preview On Hover effect

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-handle-cover-in-poh
+++ b/projects/packages/videopress/changelog/update-videopress-handle-cover-in-poh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: integrate video poster with Preview On Hover effect

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -248,6 +248,7 @@ class Initializer {
 
 		$autoplay = isset( $block_attributes['autoplay'] ) ? $block_attributes['autoplay'] : false;
 		$controls = isset( $block_attributes['controls'] ) ? $block_attributes['controls'] : false;
+		$poster   = isset( $block_attributes['posterData']['url'] ) ? $block_attributes['posterData']['url'] : null;
 
 		$preview_on_hover = '';
 		if ( $is_poh_enabled ) {
@@ -258,8 +259,22 @@ class Initializer {
 				'showControls'        => $controls,
 			);
 
+			// Create inlione style in case video has a custom poster.
+			$inline_style = '';
+			if ( $poster ) {
+				$inline_style = sprintf(
+					'style="background-image: url(%s); background-size: cover;
+				background-position: center center;"',
+					$poster
+				);
+			}
+
 			// Expose the preview on hover data to the client.
-			$preview_on_hover = sprintf( '<div class="jetpack-videopress-player__overlay"></div><script type="application/json">%s</script>', wp_json_encode( $preview_on_hover ) );
+			$preview_on_hover = sprintf(
+				'<div class="jetpack-videopress-player__overlay" %s></div><script type="application/json">%s</script>',
+				$inline_style,
+				wp_json_encode( $preview_on_hover )
+			);
 
 			// Set `autoplay` and `muted` attributes to the video element.
 			$block_attributes['autoplay'] = true;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -19,5 +19,11 @@
 		height: 100%;
 		background-color: transparent;
 		z-index: 10;
+		opacity: 1;
+		transition: opacity 300ms ease-in-out;
+
+		&:hover {
+			opacity: 0;
+		}
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -9,6 +9,7 @@
 
 	.jetpack-videopress-player__wrapper {
 		position: relative;
+		display: flex;
 	}
 
 	.jetpack-videopress-player__overlay {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If a video has a cover image, the video player will display the cover image by default when the video is not being interacted with.
When a user moves their mouse cursor over the video, the cover image will be hidden, revealing the video content underneath. 
Once the user moves their mouse cursor away from the video, the cover image will reappear, covering the video content again. The video will be paused.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: integrate video poster with Preview On Hover effect

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Created/edit a VideoPress video block
* Add a cover image

<img width="370" alt="image" src="https://user-images.githubusercontent.com/77539/233072270-cca42f5b-7601-49db-94ef-fd3ed53b49c2.png">

<img width="909" alt="image" src="https://user-images.githubusercontent.com/77539/233073194-2747f5ad-6c0d-4a5f-ab1d-ccfac14b4d92.png">

_Disclaimer: there is an issue when setting the cover using an image. It's on our radar and can be addressed in a different PR._

* Enable Preview On Hover effect
* Save the post
* View the post in the front-end
* Confirm the player shows the cover
* Confirm it shows the video once the user moves their mouse cursor over the video
* Confirm it shows up on the cover again when leaving the video

https://user-images.githubusercontent.com/77539/233076177-7118813c-a6d8-4aba-94af-52203ae2f81e.mov
