### PR TITLE
Change/forms salesforce hook hardening

### DIFF
--- a/projects/plugins/jetpack/3rd-party/class-salesforce-lead-form.php
+++ b/projects/plugins/jetpack/3rd-party/class-salesforce-lead-form.php
@@ -32,6 +32,11 @@ class Salesforce_Lead_Form {
 	 * @return null|void
 	 */
 	public static function process_salesforce_form( $post_id, $fields, $is_spam, $entry_values ) {
+		if ( ! is_array( $fields ) ) {
+			// nothing to do, also prevent hook from processing actions triggered with different args
+			return;
+		}
+
 		// if spam (hinted by akismet?), don't process
 		if ( $is_spam ) {
 			return;

--- a/projects/plugins/jetpack/changelog/change-forms-salesforce-hook-hardening
+++ b/projects/plugins/jetpack/changelog/change-forms-salesforce-hook-hardening
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Make sure the hook receives an array before attempting any process


### PR DESCRIPTION
Mostly janitorial. This PR enforces the argument type of the hook and return early if it doesn't match.

## Proposed changes:
Make sure `$fields` is an array on the Salesforce integration, return otherwise as there is nothing to do.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Nothing to test, if it's not an array, it will just ignore any further processing.