### PR TITLE
MyJetpack: set the Social standalone page as the default admin one

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-set-social-standalone-page-default-admin
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-set-social-standalone-page-default-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+MyJetpack: set the Social standalone page as the default admin one

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -128,15 +128,19 @@ class Social extends Hybrid_Product {
 	}
 
 	/**
-	 * Get the URL where the user manages the product
+	 * Get the URL where the user manages the product.
+	 *
+	 * If the standalone plugin is active,
+	 * it will redirect to the standalone plugin settings page.
+	 * Otherwise, it will redirect to the Jetpack settings page.
 	 *
 	 * @return string
 	 */
 	public static function get_manage_url() {
-		if ( static::is_jetpack_plugin_active() ) {
-			return admin_url( 'admin.php?page=jetpack#/settings?term=publicize' );
-		} elseif ( static::is_plugin_active() ) {
+		if ( static::is_standalone_plugin_active() ) {
 			return admin_url( 'admin.php?page=jetpack-social' );
 		}
+
+		return admin_url( 'admin.php?page=jetpack#/settings?term=publicize' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* MyJetpack: set the Social standalone page as the default admin one

### Other information:

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect Jetpack plugin
* Do not activate Social standalone plugin
* Go to My Jetpack
* Confirm the `manage` button of the Social card leads to the Jetpack Social settings page

Manage button | Jetpack Social settings page
--------|------
<img width="364" alt="image" src="https://user-images.githubusercontent.com/77539/233140452-71b1f4a5-22c4-4e98-b091-8966b50ba966.png"> | <img width="1160" alt="image" src="https://user-images.githubusercontent.com/77539/233140586-d46b77c0-0b0e-4882-8666-a735fbdedabe.png">

* Active the Jetpack Social plugin
<img width="289" alt="Screen Shot 2023-04-19 at 13 31 34" src="https://user-images.githubusercontent.com/77539/233140857-fa246d3b-c2dd-4fcf-9a84-1df6f211cd53.png">

* Go back to the MyJetpack dashboard
* Confirm that,.now, the manage button leads to the Social standalone plugin page

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/77539/233141104-c92893e6-a6cc-4f17-9796-09f922f5b1a2.png">





