### PR TITLE
VideoPress: Move out from WPCOM_Stats class

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-stats-endpoint
+++ b/projects/packages/videopress/changelog/update-videopress-stats-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: Move out from Stats class


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #30109 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove usage of `WPCOM_Stats` class.
* Request directly to `WPCOM` using `check_stats_module` parameter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-lHv-p2#comment-62164

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spawn a JN site or run it locally
* Navigate to the `My Jetpack` page (or another page).
* Disable `Jetpack Stats` module (`wp-admin/admin.php?page=jetpack_modules`)
* ~Sandbox `public-api` using this patch: D108216-code~ - Patch Deployed #30108 
* Run: 

```
wp.apiFetch({ path: "/videopress/v1/stats/featured" })
  .then((data) => console.log(data));
```

* It should return stats

_If you stop to sandbox, it should works too, but returning an error message._