### PR TITLE
Jetpack Boost: Fix flipping toggles

### DIFF
--- a/projects/js-packages/svelte-data-sync-client/changelog/boost-fix-flippin-toggles
+++ b/projects/js-packages/svelte-data-sync-client/changelog/boost-fix-flippin-toggles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Expand the pending state to span multiple requests to help better reflect it in the UI.

--- a/projects/js-packages/svelte-data-sync-client/package.json
+++ b/projects/js-packages/svelte-data-sync-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-svelte-data-sync-client",
-	"version": "0.1.1-alpha",
+	"version": "0.2.0-alpha",
 	"description": "A Svelte.js client for the wp-js-data-sync package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/svelte-data-sync-client/#readme",
 	"type": "module",

--- a/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
@@ -44,7 +44,6 @@ export class SyncedStore< T > {
 		const isPrimitive = this.isPrimitive( initialValue );
 		let prevValue: T;
 		store.subscribe( value => {
-			console.log( 'prevValue', prevValue, isPrimitive, value );
 			// structuredClone may be necessary because using `set` in Svelte will mutate objects.
 			// By the time the value gets to SyncedStore methods it's already mutated,
 			// and so the previous value will be the same as the current value.

--- a/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
@@ -25,44 +25,55 @@ export class SyncedStore< T > {
 		this.pending = this.createPendingStore();
 	}
 
+	private isPrimitive( value: T ): boolean {
+		return (
+			typeof value === 'string' ||
+			typeof value === 'number' ||
+			typeof value === 'boolean' ||
+			value === null ||
+			value === undefined
+		);
+	}
+
 	private createStore( initialValue?: T ): SyncedWritable< T > {
 		const store = writable< T >( initialValue );
 
-		// Send the store value to the API
+		// Track the previous value.
+		// This is used to determine if the value has changed.
+		// If the value has not changed, then the store should not be synchronized.
+		const isPrimitive = this.isPrimitive( initialValue );
+		let prevValue: T;
+		store.subscribe( value => {
+			console.log( 'prevValue', prevValue, isPrimitive, value );
+			// structuredClone may be necessary because using `set` in Svelte will mutate objects.
+			// By the time the value gets to SyncedStore methods it's already mutated,
+			// and so the previous value will be the same as the current value.
+			prevValue = isPrimitive ? value : structuredClone( value );
+		} );
+
+		// `set` is a required method in the Writable interface.
+		// It is called when value is modified using the `store.set` method or `$store = value`.
+		// Set the store value and synchronize it with the API.
 		const set = value => {
-			store.update( prevValue => {
-				// Synchronize is an async function, but is called without await here.
-				// This intentionally prevents the store from waiting for the request to complete.
-				// This is because we want the store to update immediately,
-				// and then the request to happen in the background.
-				this.abortableSynchronize( structuredClone( prevValue ), value );
-				return value;
-			} );
+			// Synchronize is called without await here. This is intentional!
+			// This way the store can be updated immediately without waiting for the API.
+			this.abortableSynchronize( prevValue, value );
+			store.set( value );
 		};
 
+		// Update is an useful utility function in Svelte for updating a value
+		// based on the previous value. This is here only because SyncedStore
+		// aims to have full parity with Svelte's writable store.
 		type SvelteUpdater = typeof store.update;
-		const update: SvelteUpdater = svelteStoreUpdate => {
-			store.update( prevValue => {
-				// Structured Clone is necessary because
-				// the updateCallback function may mutate the value
-				// And debouncedSynchronize may fail an object comparison
-				// because of it.
-				const prevValueClone = structuredClone( prevValue );
-				const value = svelteStoreUpdate( prevValue );
-				this.abortableSynchronize( prevValueClone, value );
-				return value;
-			} );
-		};
-
-		const override = ( value: T ) => {
-			store.update( () => value );
+		const update: SvelteUpdater = updateCallback => {
+			set( updateCallback( prevValue ) );
 		};
 
 		return {
 			subscribe: store.subscribe,
 			set,
 			update,
-			override,
+			override: store.set,
 		};
 	}
 

--- a/projects/js-packages/svelte-data-sync-client/src/index.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/index.ts
@@ -1,4 +1,10 @@
 export { API } from './API';
 export { SyncedStore } from './SyncedStore';
 export { initializeClient } from './initializeClient';
-export type * from './types';
+export type {
+	SyncedStoreCallback,
+	SyncedStoreInterface,
+	ValidatedValue,
+	SyncedWritable,
+	SyncedStoreError,
+} from './types';

--- a/projects/js-packages/svelte-data-sync-client/src/index.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/index.ts
@@ -1,3 +1,4 @@
 export { API } from './API';
 export { SyncedStore } from './SyncedStore';
 export { initializeClient } from './initializeClient';
+export type * from './types';

--- a/projects/plugins/boost/app/assets/src/js/elements/Toggle.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/Toggle.svelte
@@ -6,7 +6,7 @@
 
 <div class="components-base-control components-toggle-control">
 	<div class="components-base-control__field">
-		<span class="components-form-toggle" class:is-checked={checked}>
+		<span class="components-form-toggle" class:is-checked={checked} class:is-disabled={disabled}>
 			<input
 				{id}
 				class="components-form-toggle__input"

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
@@ -8,7 +8,7 @@
 	import Header from '../../sections/Header.svelte';
 	import config, { markGetStartedComplete } from '../../stores/config';
 	import { connection } from '../../stores/connection';
-	import { updateModuleState } from '../../stores/modules';
+	import { modulesState } from '../../stores/modules';
 	import { recordBoostEvent } from '../../utils/analytics';
 	import { getUpgradeURL } from '../../utils/upgrade';
 
@@ -62,8 +62,8 @@
 					markGetStartedComplete();
 
 					// Need to await in this case because the generation request needs to go after the backend has enabled the module.
-					await updateModuleState( 'critical_css', true );
-
+					// @REFACTORING: @TODO: This doesn't work at the moment.
+					$modulesState.critical_css.active = true;
 					navigate( '/' );
 				} catch ( e ) {
 					dismissedSnackbar.set( false );

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -7,7 +7,7 @@
 	import ReactComponent from '../../elements/ReactComponent.svelte';
 	import TemplatedString from '../../elements/TemplatedString.svelte';
 	import { regenerateCriticalCss } from '../../stores/critical-css-state';
-	import { updateModuleState } from '../../stores/modules';
+	import { modulesState } from '../../stores/modules';
 	import Logo from '../../svg/jetpack-green.svg';
 	import externalLinkTemplateVar from '../../utils/external-link-template-var';
 
@@ -17,8 +17,7 @@
 	export let location, navigate;
 
 	onMount( async () => {
-		// Enable cloud-css on a successful upgrade.
-		await updateModuleState( 'cloud_css', true );
+		$modulesState.cloud_css.active = true;
 		await regenerateCriticalCss();
 	} );
 </script>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
 	import Toggle from '../../../elements/Toggle.svelte';
-	import { modulesState, modulesStatePending } from '../../../stores/modules';
+	import { modulesState } from '../../../stores/modules';
 
 	export let slug: string;
 
@@ -27,12 +27,7 @@
 {#if isModuleAvailable}
 	<div class="jb-feature-toggle">
 		<div class="jb-feature-toggle__toggle">
-			<Toggle
-				id={`jb-feature-toggle-${ slug }`}
-				checked={isModuleActive}
-				on:click={handleToggle}
-				disabled={$modulesStatePending}
-			/>
+			<Toggle id={`jb-feature-toggle-${ slug }`} checked={isModuleActive} on:click={handleToggle} />
 		</div>
 		<div class="jb-feature-toggle__content">
 			<slot name="title" />

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
 	import Toggle from '../../../elements/Toggle.svelte';
-	import { modulesState } from '../../../stores/modules';
+	import { modulesState, modulesStatePending } from '../../../stores/modules';
 
 	export let slug: string;
 
@@ -27,7 +27,12 @@
 {#if isModuleAvailable}
 	<div class="jb-feature-toggle">
 		<div class="jb-feature-toggle__toggle">
-			<Toggle id={`jb-feature-toggle-${ slug }`} checked={isModuleActive} on:click={handleToggle} />
+			<Toggle
+				id={`jb-feature-toggle-${ slug }`}
+				checked={isModuleActive}
+				on:click={handleToggle}
+				disabled={$modulesStatePending}
+			/>
 		</div>
 		<div class="jb-feature-toggle__content">
 			<slot name="title" />

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
 	import Toggle from '../../../elements/Toggle.svelte';
-	import { modulesState, modulesStateClient, updateModuleState } from '../../../stores/modules';
+	import { modulesState } from '../../../stores/modules';
 
 	export let slug: string;
 
@@ -10,17 +10,11 @@
 	$: isModuleActive = $modulesState[ slug ].active;
 	$: isModuleAvailable = $modulesState[ slug ].available;
 
-	const isPending = modulesStateClient.pending;
-
 	async function handleToggle() {
-		const previousState = isModuleActive;
-		const result = await updateModuleState( slug, ! isModuleActive );
-		const state = result[ slug ].active;
-
-		if ( previousState !== state ) {
-			const eventName = state === true ? 'enabled' : 'disabled';
-			dispatch( eventName );
-		}
+		const toggledState = ! isModuleActive;
+		$modulesState[ slug ].active = toggledState;
+		const eventName = toggledState === true ? 'enabled' : 'disabled';
+		dispatch( eventName );
 	}
 
 	onMount( async () => {
@@ -33,12 +27,7 @@
 {#if isModuleAvailable}
 	<div class="jb-feature-toggle">
 		<div class="jb-feature-toggle__toggle">
-			<Toggle
-				id={`jb-feature-toggle-${ slug }`}
-				checked={isModuleActive}
-				disabled={$isPending}
-				on:click={handleToggle}
-			/>
+			<Toggle id={`jb-feature-toggle-${ slug }`} checked={isModuleActive} on:click={handleToggle} />
 		</div>
 		<div class="jb-feature-toggle__content">
 			<slot name="title" />

--- a/projects/plugins/boost/app/assets/src/js/stores/modules.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/modules.ts
@@ -63,4 +63,4 @@ export const reloadModulesState = async () => {
 };
 
 export const modulesState = modulesStateClient.store;
-export const modulesIsPending = modulesStateClient.pending;
+export const modulesStatePending = modulesStateClient.pending;

--- a/projects/plugins/boost/app/assets/src/js/stores/modules.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/modules.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line import/no-unresolved
-import { SyncedStoreInterface } from '@automattic/jetpack-svelte-data-sync-client/build/types';
+import { SyncedStoreCallback } from '@automattic/jetpack-svelte-data-sync-client/build/types';
 import { get } from 'svelte/store';
 import { z } from 'zod';
 import { client } from './data-sync-client';
@@ -8,20 +7,54 @@ export type Optimizations = {
 	[ slug: string ]: boolean;
 };
 
-export type ModulesState = SyncedStoreInterface< boolean >;
-
-export const modulesStateClient = client.createAsyncStore(
-	'modules_state',
-	z.record(
-		z.string().min( 1 ),
-		z.object( {
-			active: z.boolean(),
-			available: z.boolean(),
-		} )
-	)
+const modulesStateSchema = z.record(
+	z.string().min( 1 ),
+	z.object( {
+		active: z.boolean(),
+		available: z.boolean(),
+	} )
 );
 
-export const modulesState = modulesStateClient.store;
+type ModulesState = z.infer< typeof modulesStateSchema >;
+const modulesStateClient = client.createAsyncStore( 'modules_state', modulesStateSchema );
+
+/**
+ * This function creates an SyncedStoreCallback.
+ * It's wrapped in a function so that pendingValues can be scoped to this function.
+ */
+function createModulesSyncAction() {
+	// Keep track of the pending values
+	const pendingValues = new Map< string, ModulesState[ string ] >();
+
+	const action: SyncedStoreCallback< ModulesState > = async ( prevValue, newValue, abortSignal ) => {
+		// Extract the keys that have changed
+		const changedKeys = Object.keys( newValue ).filter(
+			key => prevValue[ key ].active !== newValue[ key ].active
+		);
+
+		// Update the pending values that have changed
+		for ( const key of changedKeys ) {
+			pendingValues.set( key, newValue[ key ] );
+		}
+
+		// Reconstruct an object with only the changed keys
+		const updatedValue = Object.fromEntries( pendingValues.entries() );
+
+		// Attempt to merge the pending values
+		const result = await modulesStateClient.endpoint.MERGE( updatedValue, abortSignal );
+
+		// If the request is aborted,
+		// MERGE is going to throw an error that is caught by SyncedStore
+		// Which means that if we get this far, the request was successful
+		// so we can clear the pending values
+		pendingValues.clear();
+		return result;
+	};
+
+	return action;
+}
+
+modulesStateClient.setSyncAction( createModulesSyncAction() );
 
 export const reloadModulesState = async () => {
 	const result = await modulesStateClient.endpoint.GET();
@@ -29,17 +62,5 @@ export const reloadModulesState = async () => {
 	return result;
 };
 
-export async function updateModuleState( slug: string, active: boolean ) {
-	// Update local state first
-	const currentState = get( modulesState );
-	currentState[ slug ].active = active;
-	modulesStateClient.store.override( currentState );
-
-	const result = await modulesStateClient.endpoint.MERGE( {
-		[ slug ]: { active },
-	} );
-
-	// Update local state with the result from the server
-	modulesStateClient.store.override( result );
-	return result;
-}
+export const modulesState = modulesStateClient.store;
+export const modulesIsPending = modulesStateClient.pending;

--- a/projects/plugins/boost/app/assets/src/js/stores/modules.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/modules.ts
@@ -1,7 +1,6 @@
-import { SyncedStoreCallback } from '@automattic/jetpack-svelte-data-sync-client/build/types';
-import { get } from 'svelte/store';
 import { z } from 'zod';
 import { client } from './data-sync-client';
+import type { SyncedStoreCallback } from '@automattic/jetpack-svelte-data-sync-client';
 
 export type Optimizations = {
 	[ slug: string ]: boolean;
@@ -26,7 +25,11 @@ function createModulesSyncAction() {
 	// Keep track of the pending values
 	const pendingValues = new Map< string, ModulesState[ string ] >();
 
-	const action: SyncedStoreCallback< ModulesState > = async ( prevValue, newValue, abortSignal ) => {
+	const action: SyncedStoreCallback< ModulesState > = async (
+		prevValue,
+		newValue,
+		abortSignal
+	) => {
 		// Extract the keys that have changed
 		const changedKeys = Object.keys( newValue ).filter(
 			key => prevValue[ key ].active !== newValue[ key ].active

--- a/projects/plugins/boost/changelog/boost-fix-flippin-toggles
+++ b/projects/plugins/boost/changelog/boost-fix-flippin-toggles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Boost: Module toggles now can handle multiple rapid clicks

--- a/projects/plugins/boost/tests/e2e/specs/score-auto-refresh.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/score-auto-refresh.test.js
@@ -34,13 +34,13 @@ test.describe( 'Auto refresh of speed scores', () => {
 	test( 'Score refresh should debounce between multiple module toggle', async () => {
 		await jetpackBoostPage.waitForScoreLoadingToFinish();
 
-		await jetpackBoostPage.toggleModule( 'lazy_images' );
+		const toggleLazyPromise = jetpackBoostPage.toggleModule( 'lazy_images' );
 
-		// Wait a second after first module is toggled
+		// Wait a second before toggling another.
 		await new Promise( resolve => setTimeout( resolve, 1000 ) );
 
 		// Toggle another module before the automatic score refresh started
-		await jetpackBoostPage.toggleModule( 'render_blocking_js' );
+		const renderBlockingPromise = jetpackBoostPage.toggleModule( 'render_blocking_js' );
 
 		// Wait slightly more than a second after second module is toggled
 		await new Promise( resolve => setTimeout( resolve, 1100 ) );
@@ -51,5 +51,8 @@ test.describe( 'Auto refresh of speed scores', () => {
 		// Score refresh should have started after two seconds of toggling second module
 		await new Promise( resolve => setTimeout( resolve, 1000 ) );
 		expect( await jetpackBoostPage.isScoreLoading(), 'Score should be loading' ).toBeTruthy();
+
+		// Still expect toggling those two modules to succeed.
+		await Promise.all( [ toggleLazyPromise, renderBlockingPromise ] );
 	} );
 } );


### PR DESCRIPTION
This fixes an issue when toggling module switches rapidly their UI state failed to keep up with the backend.

This issue also caused random E2E test failures.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:

1. Don't apply the patch
2. Emulate slow 3G network
3. Flip modules on/off rapidly
4. Observe the UI bug
5. Apply patch
6. Do it again
7. Make sure it's no longer happening

Extra points for:
* Test Critical CSS
* Test Getting Started Flow
* Test Cloud CSS