### PR TITLE
VideoPress: Fix auto-enabling of video frame poster

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-poster-frame-auto-select
+++ b/projects/packages/videopress/changelog/fix-videopress-poster-frame-auto-select
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix auto-enabling of video frame poster


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30157 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks if the feature is enabled when reacting to timestamp update events
* Guarantees that the default timestamp (0) is added to the state when first enabling the feature

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable `beta` features and go to the block editor
* Add a VideoPress video block
* Go to the `Poster and preview` panel
* Check that the `Pick from video frame` toggle is not automatically enabled after 2 seconds
* Check that the feature still works as intended

https://user-images.githubusercontent.com/8486249/233197087-db5c614c-0e50-4ce6-8a0e-650ea405cf0c.mp4
