### PR TITLE
 VideoPress: fix visual issue in the poster integration with Preview On Hover

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-poster-in-poh
+++ b/projects/packages/videopress/changelog/fix-videopress-poster-in-poh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: fix visual issue in the poster integration with Preview On Hover

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -282,8 +282,7 @@ class Initializer {
 		}
 
 		$figure_template = '
-		<figure %6$s class="%1$s" style="%2$s">			
-			%3$s
+		<figure class="%1$s" style="%2$s" %3$s>
 			%4$s
 			%5$s
 		</figure>
@@ -298,7 +297,8 @@ class Initializer {
 			$videopress_url = wp_kses_post( $videopress_url );
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
-				'<div class="jetpack-videopress-player__wrapper">%s</div>',
+				'<div class="jetpack-videopress-player__wrapper">%s %s</div>',
+				$preview_on_hover,
 				$oembed_html
 			);
 		}
@@ -307,10 +307,9 @@ class Initializer {
 			$figure_template,
 			esc_attr( $classes ),
 			esc_attr( $style ),
-			$preview_on_hover,
+			$id_attribute,
 			$video_wrapper,
-			$figcaption,
-			$id_attribute
+			$figcaption
 		);
 	}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -4,6 +4,8 @@
 	position: relative;
 
 	figcaption {
+		margin-bottom: 1em;
+    	margin-top: 0.5em;
 		@include caption-style-theme();
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes a visual issue when setting the custom poster image and enabling the Preview On Hover feature. In short, the poster image covers the area that includes the caption (when it's defined).

https://user-images.githubusercontent.com/77539/233206396-565c15dd-90ef-49d1-b35c-c84cc29bf120.mov

In the video above, the poster covers the caption, something not desired.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  VideoPress: fix visual issue in the poster integration with Preview On Hover

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Create/edit a VideoPress video post
* Set a caption
* Set poster image
* Enable pOH
* Save the post
* View the post in the front-end
* **before**, the poster covers the whole area (caption included)
* **after**, the poster covers only the player


before | after
--------|-------
<img width="839" alt="image" src="https://user-images.githubusercontent.com/77539/233206296-92c45f07-5f2a-4063-b314-d69ce82328cd.png"> | <img width="834" alt="image" src="https://user-images.githubusercontent.com/77539/233206231-d58f560a-4436-4a76-8736-692cbf6e5bdd.png">
