### PR TITLE
Launchpad Checklist API: Add checklist and task registry

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-registry-for-launchpad-checklists
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-registry-for-launchpad-checklists
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad Checklist API: Adds registry to easily manage Launchpad checklists

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -33,6 +33,7 @@ class Jetpack_Mu_Wpcom {
 		// Coming Soon feature.
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_coming_soon' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_launchpad' ) );
 
 		// Unified navigation fix for changes in WordPress 6.2.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );
@@ -67,6 +68,13 @@ class Jetpack_Mu_Wpcom {
 		) {
 			require_once __DIR__ . '/features/coming-soon/coming-soon.php';
 		}
+	}
+
+	/**
+	 * Load the Launchpad feature.
+	 */
+	public static function load_launchpad() {
+		require_once __DIR__ . '/features/launchpad/launchpad.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -52,9 +52,9 @@ class Launchpad_Task_Lists {
 	/**
 	 * Register a new Launchpad Task List
 	 *
-	 * @param array $task_list Task List definition.
+	 * @param Task_List $task_list Task List definition.
 	 *
-	 * @return bool True if successfully registered.
+	 * @return bool True if successfully registered, false if not.
 	 */
 	public function register_task_list( $task_list = array() ) {
 		if ( ! $this->validate_task_list( $task_list ) ) {
@@ -68,7 +68,7 @@ class Launchpad_Task_Lists {
 	/**
 	 * Register a new Launchpad Task
 	 *
-	 * @param array $task Task definition.
+	 * @param Task $task Task definition.
 	 *
 	 * @return bool True if successful, false if not.
 	 */
@@ -85,7 +85,7 @@ class Launchpad_Task_Lists {
 	/**
 	 * Register a new Launchpad Task
 	 *
-	 * @param array $tasks Collection of task definitions.
+	 * @param Task[] $tasks Collection of task definitions.
 	 *
 	 * @return bool True if successful, false if not.
 	 */
@@ -102,7 +102,7 @@ class Launchpad_Task_Lists {
 		}
 
 		// TODO: Handle duplicate tasks
-		array_merge( $this->task_registry, $tasks_to_register );
+		$this->task_registry = array_merge( $this->task_registry, $tasks_to_register );
 		return true;
 	}
 
@@ -139,7 +139,7 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
-	 * Get a Launchpad Task List
+	 * Get a Launchpad Task List definition
 	 *
 	 * @param string $slug Task List slug.
 	 *
@@ -154,7 +154,7 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
-	 * Get a Launchpad Task
+	 * Get a Launchpad Task definition
 	 *
 	 * @param string $slug Task slug.
 	 *
@@ -173,23 +173,25 @@ class Launchpad_Task_Lists {
 	 *
 	 * @param string $slug Task list slug.
 	 *
-	 * @return Task[] Array of tasks associated with a task list
+	 * @return Task[] Collection of tasks associated with a task list.
 	 */
 	public function build( $slug ) {
-		$task_list            = $this->get_task_list( $slug );
-		$task_list_with_tasks = array();
+		$task_list           = $this->get_task_list( $slug );
+		$tasks_for_task_list = array();
 
+		// Takes a registered task list, looks at its associated task slugs,
+		// and returns a collection of associated tasks.
 		foreach ( $task_list['task_slugs'] as $task_slug => $value ) {
-			$task_list_with_tasks[] = $this->get_task( $task_slug );
+			$tasks_for_task_list[] = $this->get_task( $task_slug );
 		}
 
-		return $task_list_with_tasks;
+		return $tasks_for_task_list;
 	}
 
 	/**
 	 * Validate a Launchpad Task List
 	 *
-	 * @param array $task_list Task List arguments.
+	 * @param Task_List $task_list Task List.
 	 *
 	 * @return bool True if valid, false if not.
 	 */
@@ -212,7 +214,7 @@ class Launchpad_Task_Lists {
 	/**
 	 * Validate a Launchpad Task
 	 *
-	 * @param array $task Task arguments.
+	 * @param Task $task Task.
 	 *
 	 * @return bool True if valid, false if not.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -176,7 +176,6 @@ class Launchpad_Task_Lists {
 	 * @return Task[] Collection of tasks associated with a task list.
 	 */
 	public function build( $id ) {
-		l( $id );
 		$task_list           = $this->get_task_list( $id );
 		$tasks_for_task_list = array();
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -185,7 +185,7 @@ class Launchpad_Task_Lists {
 
 			// if task can't be found don't add anything
 			if ( ! empty( $task ) ) {
-				$tasks_for_task_list[] = $this->get_task( $task_id );
+				$tasks_for_task_list[] = $task;
 			}
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -201,10 +201,7 @@ class Launchpad_Task_Lists {
 		}
 
 		if ( ! isset( $task_list['slug'] ) ) {
-			return false;
-		}
-
-		if ( ! isset( $task_list['title'] ) ) {
+			trigger_error( 'The Launchpad task list being registered requires a "slug" attribute', E_USER_WARNING );
 			return false;
 		}
 
@@ -224,18 +221,22 @@ class Launchpad_Task_Lists {
 		}
 
 		if ( ! isset( $task['slug'] ) ) {
+			trigger_error( 'The Launchpad task being registered requires a "slug" attribute', E_USER_WARNING );
 			return false;
 		}
 
 		if ( ! isset( $task['title'] ) ) {
+			trigger_error( 'The Launchpad task being registered requires a "title" attribute', E_USER_WARNING );
 			return false;
 		}
 
 		if ( ! isset( $task['completed'] ) ) {
+			trigger_error( 'The Launchpad task being registered requires a "completed" attribute', E_USER_WARNING );
 			return false;
 		}
 
 		if ( ! isset( $args['disabled'] ) ) {
+			trigger_error( 'The Launchpad task being registered requires a "disabled" attribute', E_USER_WARNING );
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -111,7 +111,7 @@ class Launchpad_Task_Lists {
 	 *
 	 * @param string $slug Task List slug.
 	 *
-	 * @return bool  True if successfully unregistered, false if not found.
+	 * @return bool True if successfully unregistered, false if not found.
 	 */
 	public function unregister_task_list( $slug ) {
 		if ( ! array_key_exists( $this->task_list_registry, $slug ) ) {
@@ -127,7 +127,7 @@ class Launchpad_Task_Lists {
 	 *
 	 * @param string $slug Task slug.
 	 *
-	 * @return bool  True if successful, false if not.
+	 * @return bool True if successful, false if not.
 	 */
 	public function unregister_task( $slug ) {
 		if ( ! array_key_exists( $this->task_registry, $slug ) ) {
@@ -141,39 +141,49 @@ class Launchpad_Task_Lists {
 	/**
 	 * Get a Launchpad Task List
 	 *
-	 * @param string $id Task List slug.
+	 * @param string $slug Task List slug.
 	 *
-	 * @return array Task List arguments.
+	 * @return Task_List Task List.
 	 */
-	public function get_task_list( $id ) {
-		if ( ! array_key_exists( $this->task_list_registry, $id ) ) {
-			return array();
-		}
-
-		return $this->task_list_registry[ $id ];
-	}
-
-	/**
-	 * Register a new Launchpad Task
-	 *
-	 * @param string $slug Task list slug.
-	 *
-	 * @return array Task List with tasks added
-	 */
-	public function build( $slug ) {
-		$task_list = this->get_task_list( $slug );
+	protected function get_task_list( $slug ) {
 		if ( ! array_key_exists( $this->task_list_registry, $slug ) ) {
 			return array();
 		}
 
-		$task_list = $this->task_list_registry[ $slug ];
-		$result    = array();
+		return $this->task_list_registry[ $slug ];
+	}
 
-		foreach ( $task_list['task_ids'] as $key => $value ) {
-			$result [] = $this->task_registry[ $key ];
+	/**
+	 * Get a Launchpad Task
+	 *
+	 * @param string $slug Task slug.
+	 *
+	 * @return Task Task.
+	 */
+	protected function get_task( $slug ) {
+		if ( ! array_key_exists( $this->task_registry, $slug ) ) {
+			return array();
 		}
 
-		return $result;
+		return $this->task_registry[ $slug ];
+	}
+
+	/**
+	 * Builds a collection of tasks for a given task list
+	 *
+	 * @param string $slug Task list slug.
+	 *
+	 * @return Task[] Array of tasks associated with a task list
+	 */
+	public function build( $slug ) {
+		$task_list            = $this->get_task_list( $slug );
+		$task_list_with_tasks = array();
+
+		foreach ( $task_list['task_slugs'] as $task_slug => $value ) {
+			$task_list_with_tasks[] = $this->get_task( $task_slug );
+		}
+
+		return $task_list_with_tasks;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -205,12 +205,12 @@ class Launchpad_Task_Lists {
 		}
 
 		if ( ! isset( $task_list['id'] ) ) {
-			trigger_error( 'The Launchpad task list being registered requires a "id" attribute', E_USER_WARNING );
+			_doing_it_wrong( 'validate_task_list', 'The Launchpad task list being registered requires a "id" attribute', '6.1' );
 			return false;
 		}
 
 		if ( ! isset( $task_list['task_ids'] ) ) {
-			trigger_error( 'The Launchpad task list being registered requires a "task_ids" attribute', E_USER_WARNING );
+			_doing_it_wrong( 'validate_task_list', 'The Launchpad task list being registered requires a "task_ids" attribute', '6.1' );
 			return false;
 		}
 
@@ -230,22 +230,22 @@ class Launchpad_Task_Lists {
 		}
 
 		if ( ! isset( $task['id'] ) ) {
-			trigger_error( 'The Launchpad task being registered requires a "id" attribute', E_USER_WARNING );
+			_doing_it_wrong( 'validate_task', 'The Launchpad task being registered requires a "id" attribute', '6.1' );
 			return false;
 		}
 
 		if ( ! isset( $task['title'] ) ) {
-			trigger_error( 'The Launchpad task being registered requires a "title" attribute', E_USER_WARNING );
+			_doing_it_wrong( 'validate_task', 'The Launchpad task being registered requires a "title" attribute', '6.1' );
 			return false;
 		}
 
 		if ( ! isset( $task['completed'] ) ) {
-			trigger_error( 'The Launchpad task being registered requires a "completed" attribute', E_USER_WARNING );
+			_doing_it_wrong( 'validate_task', 'The Launchpad task being registered requires a "completed" attribute', '6.1' );
 			return false;
 		}
 
 		if ( ! isset( $task['disabled'] ) ) {
-			trigger_error( 'The Launchpad task being registered requires a "disabled" attribute', E_USER_WARNING );
+			_doing_it_wrong( 'validate_task', 'The Launchpad task being registered requires a "disabled" attribute', '6.1' );
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -61,7 +61,7 @@ class Launchpad_Task_Lists {
 			return false;
 		}
 
-		$this->task_list_registry[] = array( $task_list['id'] => $task_list );
+		$this->task_list_registry[ $task_list['id'] ] = $task_list;
 		return true;
 	}
 
@@ -76,9 +76,8 @@ class Launchpad_Task_Lists {
 		if ( ! $this->validate_task( $task ) ) {
 			return false;
 		}
-
 		// TODO: Handle duplicate tasks
-		$this->task_registry[] = array( $task['id'] => $task );
+		$this->task_registry[ $task['id'] ] = $task;
 		return true;
 	}
 
@@ -98,7 +97,7 @@ class Launchpad_Task_Lists {
 				return false;
 			}
 
-			$tasks_to_register[] = array( $task['id'] => $task );
+			$tasks_to_register[ $task['id'] ] = $task;
 		}
 
 		// TODO: Handle duplicate tasks
@@ -178,10 +177,9 @@ class Launchpad_Task_Lists {
 	public function build( $id ) {
 		$task_list           = $this->get_task_list( $id );
 		$tasks_for_task_list = array();
-
 		// Takes a registered task list, looks at its associated task ids,
 		// and returns a collection of associated tasks.
-		foreach ( $task_list['task_ids'] as $task_id => $value ) {
+		foreach ( $task_list['task_ids'] as $task_id ) {
 			$tasks_for_task_list[] = $this->get_task( $task_id );
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Launchpad Task Lists Registry
+ *
+ * @package automattic/jetpack-mu-wpcom
+ * @since 1.5.0
+ */
+
+/**
+ * Launchpad Task List
+ *
+ * This file provides a Launchpad Task List class that manages the current list
+ * of Launchpad checklists that are available to be used.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+class Launchpad_Task_Lists {
+	/**
+	 * Internal storage for registered Launchpad Task Lists
+	 *
+	 * @var array
+	 */
+	private $registry = array();
+
+	/**
+	 * Singleton instance
+	 *
+	 * @var Launchpad_Task_List
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get the singleton instance
+	 *
+	 * @return Launchpad_Task_Lists
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Register a new Launchpad Task List
+	 *
+	 * @param string $slug Task List slug.
+	 * @param array  $args Task List arguments.
+	 *
+	 * @return bool  True if successfully registered.
+	 */
+	public function register_task_list( $slug, $args ) {
+		if ( ! self::validate_task_list( $args ) ) {
+			return false;
+		}
+
+		self::$registry = array_merge(
+			$this->registry,
+			array( $slug => $args )
+		);
+		return true;
+	}
+
+	/**
+	 * Unregister a Launchpad Task List
+	 *
+	 * @param string $slug Task List slug.
+	 *
+	 * @return bool  True if successfully unregistered, false if not found.
+	 */
+	public function unregister_task_list( $slug ) {
+		if ( ! isset( self::$registry[ $slug ] ) ) {
+			return false;
+		}
+
+		unset( self::$registry[ $slug ] );
+		return true;
+	}
+
+	/**
+	 * Get a Launchpad Task List
+	 *
+	 * @param string $slug Task List slug.
+	 *
+	 * @return array Task List arguments.
+	 */
+	public function get_task_list( $slug ) {
+		if ( ! array_key_exists( self::$registry, $slug ) ) {
+			return array();
+		}
+
+		return self::$registry[ $slug ];
+	}
+
+	/**
+	 * Register a new Launchpad Task
+	 *
+	 * @param string $task_list_slug Task list slug.
+	 * @param array  $args Task List arguments.
+	 *
+	 * @return bool  True if successful
+	 */
+	public function register_task( $task_list_slug, $args = array() ) {
+		if ( ! self::validate_task( $args ) ) {
+			return false;
+		}
+
+		if ( ! array_key_exists( self::$registry, $task_list_slug ) ) {
+			return false;
+		}
+
+		self::$registry[ $task_list_slug ] = array_push( self::$registry[ $task_list_slug ], $args );
+	}
+
+	/**
+	 * Validate a Launchpad Task List
+	 *
+	 * @param array $task_list Task List arguments.
+	 *
+	 * @return bool True if valid, false if not.
+	 */
+	public static function validate_task_list( $task_list ) {
+		if ( ! is_array( $task_list ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate a Launchpad Task
+	 *
+	 * @param array $task Task arguments.
+	 *
+	 * @return bool True if valid, false if not.
+	 */
+	public static function validate_task( $task ) {
+		if ( ! is_array( $task ) ) {
+			return false;
+		}
+
+		if ( ! isset( $task['id'] ) ) {
+			return false;
+		}
+
+		if ( ! isset( $task['title'] ) ) {
+			return false;
+		}
+
+		if ( ! isset( $task['completed'] ) ) {
+			return false;
+		}
+
+		if ( ! isset( $args['disabled'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -203,6 +203,11 @@ class Launchpad_Task_Lists {
 			return false;
 		}
 
+		if ( ! isset( $task_list['task_ids'] ) ) {
+			trigger_error( 'The Launchpad task list being registered requires a "task_ids" attribute', E_USER_WARNING );
+			return false;
+		}
+
 		return true;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -236,7 +236,7 @@ class Launchpad_Task_Lists {
 			return false;
 		}
 
-		if ( ! isset( $args['disabled'] ) ) {
+		if ( ! isset( $task['disabled'] ) ) {
 			trigger_error( 'The Launchpad task being registered requires a "disabled" attribute', E_USER_WARNING );
 			return false;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -114,7 +114,7 @@ class Launchpad_Task_Lists {
 	 * @return bool True if successfully unregistered, false if not found.
 	 */
 	public function unregister_task_list( $id ) {
-		if ( ! array_key_exists( $this->task_list_registry, $id ) ) {
+		if ( ! array_key_exists( $id, $this->task_list_registry ) ) {
 			return false;
 		}
 
@@ -130,7 +130,7 @@ class Launchpad_Task_Lists {
 	 * @return bool True if successful, false if not.
 	 */
 	public function unregister_task( $id ) {
-		if ( ! array_key_exists( $this->task_registry, $id ) ) {
+		if ( ! array_key_exists( $id, $this->task_registry ) ) {
 			return false;
 		}
 
@@ -146,7 +146,7 @@ class Launchpad_Task_Lists {
 	 * @return Task_List Task List.
 	 */
 	protected function get_task_list( $id ) {
-		if ( ! array_key_exists( $this->task_list_registry, $id ) ) {
+		if ( ! array_key_exists( $id, $this->task_list_registry ) ) {
 			return array();
 		}
 
@@ -161,7 +161,7 @@ class Launchpad_Task_Lists {
 	 * @return Task Task.
 	 */
 	protected function get_task( $id ) {
-		if ( ! array_key_exists( $this->task_registry, $id ) ) {
+		if ( ! array_key_exists( $id, $this->task_registry ) ) {
 			return array();
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -90,14 +90,19 @@ class Launchpad_Task_Lists {
 	 * @return bool True if successful, false if not.
 	 */
 	public function register_tasks( $tasks = array() ) {
+		$tasks_to_register = array();
+
 		foreach ( $tasks as $task ) {
+			// Register none of the tasks if any are invalid.
 			if ( ! $this->validate_task( $task ) ) {
 				return false;
 			}
+
+			$tasks_to_register[] = array( $task['slug'] => $task );
 		}
 
 		// TODO: Handle duplicate tasks
-		array_merge( $this->task_registry, $tasks );
+		array_merge( $this->task_registry, $tasks_to_register );
 		return true;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -177,10 +177,16 @@ class Launchpad_Task_Lists {
 	public function build( $id ) {
 		$task_list           = $this->get_task_list( $id );
 		$tasks_for_task_list = array();
+
 		// Takes a registered task list, looks at its associated task ids,
 		// and returns a collection of associated tasks.
 		foreach ( $task_list['task_ids'] as $task_id ) {
-			$tasks_for_task_list[] = $this->get_task( $task_id );
+			$task = $this->get_task( $task_id );
+
+			// if task can't be found don't add anything
+			if ( ! empty( $task ) ) {
+				$tasks_for_task_list[] = $this->get_task( $task_id );
+			}
 		}
 
 		return $tasks_for_task_list;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -61,7 +61,7 @@ class Launchpad_Task_Lists {
 			return false;
 		}
 
-		$this->task_list_registry[] = array( $task_list['slug'] => $task_list );
+		$this->task_list_registry[] = array( $task_list['id'] => $task_list );
 		return true;
 	}
 
@@ -78,7 +78,7 @@ class Launchpad_Task_Lists {
 		}
 
 		// TODO: Handle duplicate tasks
-		$this->task_registry[] = array( $task['slug'] => $task );
+		$this->task_registry[] = array( $task['id'] => $task );
 		return true;
 	}
 
@@ -98,7 +98,7 @@ class Launchpad_Task_Lists {
 				return false;
 			}
 
-			$tasks_to_register[] = array( $task['slug'] => $task );
+			$tasks_to_register[] = array( $task['id'] => $task );
 		}
 
 		// TODO: Handle duplicate tasks
@@ -109,80 +109,81 @@ class Launchpad_Task_Lists {
 	/**
 	 * Unregister a Launchpad Task List
 	 *
-	 * @param string $slug Task List slug.
+	 * @param string $id Task List id.
 	 *
 	 * @return bool True if successfully unregistered, false if not found.
 	 */
-	public function unregister_task_list( $slug ) {
-		if ( ! array_key_exists( $this->task_list_registry, $slug ) ) {
+	public function unregister_task_list( $id ) {
+		if ( ! array_key_exists( $this->task_list_registry, $id ) ) {
 			return false;
 		}
 
-		unset( $this->task_list_registry[ $slug ] );
+		unset( $this->task_list_registry[ $id ] );
 		return true;
 	}
 
 	/**
 	 * Unregister a Launchpad Task
 	 *
-	 * @param string $slug Task slug.
+	 * @param string $id Task id.
 	 *
 	 * @return bool True if successful, false if not.
 	 */
-	public function unregister_task( $slug ) {
-		if ( ! array_key_exists( $this->task_registry, $slug ) ) {
+	public function unregister_task( $id ) {
+		if ( ! array_key_exists( $this->task_registry, $id ) ) {
 			return false;
 		}
 
-		unset( $this->task_registry[ $slug ] );
+		unset( $this->task_registry[ $id ] );
 		return true;
 	}
 
 	/**
 	 * Get a Launchpad Task List definition
 	 *
-	 * @param string $slug Task List slug.
+	 * @param string $id Task List id.
 	 *
 	 * @return Task_List Task List.
 	 */
-	protected function get_task_list( $slug ) {
-		if ( ! array_key_exists( $this->task_list_registry, $slug ) ) {
+	protected function get_task_list( $id ) {
+		if ( ! array_key_exists( $this->task_list_registry, $id ) ) {
 			return array();
 		}
 
-		return $this->task_list_registry[ $slug ];
+		return $this->task_list_registry[ $id ];
 	}
 
 	/**
 	 * Get a Launchpad Task definition
 	 *
-	 * @param string $slug Task slug.
+	 * @param string $id Task id.
 	 *
 	 * @return Task Task.
 	 */
-	protected function get_task( $slug ) {
-		if ( ! array_key_exists( $this->task_registry, $slug ) ) {
+	protected function get_task( $id ) {
+		if ( ! array_key_exists( $this->task_registry, $id ) ) {
 			return array();
 		}
 
-		return $this->task_registry[ $slug ];
+		return $this->task_registry[ $id ];
 	}
 
 	/**
 	 * Builds a collection of tasks for a given task list
 	 *
-	 * @param string $slug Task list slug.
+	 * @param string $id Task list id.
 	 *
 	 * @return Task[] Collection of tasks associated with a task list.
 	 */
-	public function build( $slug ) {
-		$task_list           = $this->get_task_list( $slug );
+	public function build( $id ) {
+		l( $id );
+		$task_list           = $this->get_task_list( $id );
 		$tasks_for_task_list = array();
 
-		// Takes a registered task list, looks at its associated task slugs,
+		// Takes a registered task list, looks at its associated task ids,
 		// and returns a collection of associated tasks.
-		foreach ( $task_list['task_slugs'] as $task_slug => $value ) {
-			$tasks_for_task_list[] = $this->get_task( $task_slug );
+		foreach ( $task_list['task_ids'] as $task_id => $value ) {
+			$tasks_for_task_list[] = $this->get_task( $task_id );
 		}
 
 		return $tasks_for_task_list;
@@ -200,8 +201,8 @@ class Launchpad_Task_Lists {
 			return false;
 		}
 
-		if ( ! isset( $task_list['slug'] ) ) {
-			trigger_error( 'The Launchpad task list being registered requires a "slug" attribute', E_USER_WARNING );
+		if ( ! isset( $task_list['id'] ) ) {
+			trigger_error( 'The Launchpad task list being registered requires a "id" attribute', E_USER_WARNING );
 			return false;
 		}
 
@@ -220,8 +221,8 @@ class Launchpad_Task_Lists {
 			return false;
 		}
 
-		if ( ! isset( $task['slug'] ) ) {
-			trigger_error( 'The Launchpad task being registered requires a "slug" attribute', E_USER_WARNING );
+		if ( ! isset( $task['id'] ) ) {
+			trigger_error( 'The Launchpad task being registered requires a "id" attribute', E_USER_WARNING );
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -58,7 +58,7 @@ function get_checklist_definitions() {
 			),
 		),
 		array(
-			'id'       => 'link-in-bio',
+			'id'       => 'link-in-bio-tld',
 			'title'    => 'Link In Bio',
 			'task_ids' => array(
 				'design_selected',
@@ -91,7 +91,7 @@ function get_checklist_definitions() {
 		),
 		array(
 			'id'       => 'write',
-			'title'    => 'write',
+			'title'    => 'Write',
 			'task_ids' => array(
 				'setup_write',
 				'design_selected',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -14,7 +14,7 @@
  * @since 1.4.0
  */
 
-require_once __DIR__ . '/../launchpad/class-launchpad-task-list.php';
+require_once __DIR__ . '/class-launchpad-task-lists.php';
 
 /**
  * Returns the list of tasks by flow or checklist slug.
@@ -328,14 +328,25 @@ function get_launchpad_checklist_by_checklist_slug( $checklist_slug ) {
 /**
  * Wrapper that registers a launchpad checklist.
  *
- * @param string    $slug Task list slug.
  * @param Task_List $task_list Task list definition.
  *
  * @return bool True if successful, false otherwise.
  */
-function register_launchpad_task_list( $slug, $task_list ) {
+function register_launchpad_task_list( $task_list ) {
 	$launchpad_task_lists = Launchpad_Task_Lists::get_instance();
-	return $launchpad_task_lists->register_task_list( $slug, $task_list );
+	return $launchpad_task_lists->register_task_list( $task_list );
+}
+
+/**
+ * Wrapper that registers a launchpad checklist.
+ *
+ * @param Task $tasks Collection of Task definitions.
+ *
+ * @return bool True if successful, false otherwise.
+ */
+function register_launchpad_tasks( $tasks ) {
+	$launchpad_task_lists = Launchpad_Task_Lists::get_instance();
+	return $launchpad_task_lists->register_task( $tasks );
 }
 
 /**
@@ -354,13 +365,11 @@ function register_launchpad_task( $task ) {
  * Registers all default launchpad checklists
  */
 function register_default_checklists() {
-	$launchpad_task_lists = Launchpad_Task_Lists::get_instance();
-
 	foreach ( get_checklist_definitions() as $checklist ) {
-		$launchpad_task_lists->register_checklist( $checklist );
+		register_launchpad_task_list( $checklist );
 	}
 
-	$launchpad_task_lists->register_tasks( get_task_definitions() );
+	register_launchpad_tasks( get_task_definitions() );
 }
 
 add_action( 'init', 'register_default_checklists' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -321,21 +321,49 @@ function get_launchpad_checklist_by_checklist_slug( $checklist_slug ) {
 	}
 
 	// This won't work yet because tasks aren't registered.
-	$launchpad_task_lists = Launchpad_Task_Lists->getInstance();
+	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
 	return $launchpad_task_lists->get_task_list( $checklist_slug );
+}
+
+// TODO: Write code p2 post or dotcom post
+/**
+ * Wrapper that registers a launchpad checklist without needing
+ * to know about the implementation details.
+ *
+ * @param string $slug Task list slug.
+ * @param array  $task_list Task list definition.
+ *
+ * @return bool True if successful, false otherwise.
+ */
+function register_launchpad_task_list( $slug, $task_list ) {
+	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
+	return $launchpad_task_lists->register_task_list( $slug, $task_list );
+}
+
+/**
+ * Wrapper that registers a launchpad checklist without needing
+ * to know about the implementation details.
+ *
+ * @param array $task Task definition.
+ *
+ * @return bool True if successful, false otherwise.
+ */
+function register_launchpad_task( $task ) {
+	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
+	return $launchpad_task_lists->register_task( $task );
 }
 
 /**
  * Registers all default launchpad checklists
  */
 function register_default_checklists() {
-	$launchpad_task_lists = Launchpad_Task_Lists->getInstance();
+	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
 
 	foreach ( get_checklist_definitions() as $checklist_key => $checklist ) {
 		$launchpad_task_lists->register_checklist( $checklist_key, $checklist );
 	}
 
-	// TODO: Register tasks for task list
+	$launchpad_task_lists->register_tasks( get_task_definitions() );
 }
 
 add_action( 'init', 'register_default_checklists' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -359,8 +359,8 @@ function register_launchpad_task( $task ) {
 function register_default_checklists() {
 	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
 
-	foreach ( get_checklist_definitions() as $checklist_key => $checklist ) {
-		$launchpad_task_lists->register_checklist( $checklist_key, $checklist );
+	foreach ( get_checklist_definitions() as $checklist ) {
+		$launchpad_task_lists->register_checklist( $checklist );
 	}
 
 	$launchpad_task_lists->register_tasks( get_task_definitions() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -336,7 +336,7 @@ function register_launchpad_task_list( $task_list ) {
  */
 function register_launchpad_tasks( $tasks ) {
 	$launchpad_task_lists = Launchpad_Task_Lists::get_instance();
-	return $launchpad_task_lists->register_task( $tasks );
+	return $launchpad_task_lists->register_tasks( $tasks );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -8,7 +8,7 @@
 
 /**
  * This file provides helpers that return the appropriate Launchpad
- * checklist and tasks for a given checklist slug.
+ * checklist and tasks for a given checklist id.
  *
  * @package automattic/jetpack-mu-wpcom
  * @since 1.4.0
@@ -17,16 +17,16 @@
 require_once __DIR__ . '/class-launchpad-task-lists.php';
 
 /**
- * Returns the list of tasks by flow or checklist slug.
+ * Returns the list of tasks by flow or checklist id.
  *
  * @return array Associative array with checklist task data
  */
 function get_checklist_definitions() {
 	return array(
 		array(
-			'slug'       => 'build',
-			'title'      => 'Build',
-			'task_slugs' => array(
+			'id'       => 'build',
+			'title'    => 'Build',
+			'task_ids' => array(
 				'setup_general',
 				'design_selected',
 				'first_post_published',
@@ -35,9 +35,9 @@ function get_checklist_definitions() {
 			),
 		),
 		array(
-			'slug'       => 'free',
-			'title'      => 'Free',
-			'task_slugs' => array(
+			'id'       => 'free',
+			'title'    => 'Free',
+			'task_ids' => array(
 				'setup_free',
 				'design_selected',
 				'domain_upsell',
@@ -47,9 +47,9 @@ function get_checklist_definitions() {
 			),
 		),
 		array(
-			'slug'       => 'link-in-bio',
-			'title'      => 'Link In Bio',
-			'task_slugs' => array(
+			'id'       => 'link-in-bio',
+			'title'    => 'Link In Bio',
+			'task_ids' => array(
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
@@ -58,9 +58,9 @@ function get_checklist_definitions() {
 			),
 		),
 		array(
-			'slug'       => 'link-in-bio',
-			'title'      => 'Link In Bio',
-			'task_slugs' => array(
+			'id'       => 'link-in-bio',
+			'title'    => 'Link In Bio',
+			'task_ids' => array(
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
@@ -69,9 +69,9 @@ function get_checklist_definitions() {
 			),
 		),
 		array(
-			'slug'       => 'newsletter',
-			'title'      => 'Newsletter',
-			'task_slugs' => array(
+			'id'       => 'newsletter',
+			'title'    => 'Newsletter',
+			'task_ids' => array(
 				'setup_newsletter',
 				'plan_selected',
 				'subscribers_added',
@@ -80,9 +80,9 @@ function get_checklist_definitions() {
 			),
 		),
 		array(
-			'slug'       => 'videopress',
-			'title'      => 'Videopress',
-			'task_slugs' => array(
+			'id'       => 'videopress',
+			'title'    => 'Videopress',
+			'task_ids' => array(
 				'videopress_setup',
 				'plan_selected',
 				'videopress_upload',
@@ -90,9 +90,9 @@ function get_checklist_definitions() {
 			),
 		),
 		array(
-			'slug'       => 'write',
-			'title'      => 'write',
-			'task_slugs' => array(
+			'id'       => 'write',
+			'title'    => 'write',
+			'task_ids' => array(
 				'setup_write',
 				'design_selected',
 				'first_post_published',
@@ -161,142 +161,123 @@ function get_domain_upsell_badge_text() {
  */
 function get_task_definitions() {
 	return array(
-		'setup_newsletter'
-			=> array(
-				'id'        => 'setup_newsletter',
-				'title'     => __( 'Personalize Newsletter', 'jetpack-mu-wpcom' ),
-				'completed' => true,
-				'disabled'  => false,
-			),
-		'plan_selected'
-			=> array(
-				'id'        => 'plan_selected',
-				'title'     => __( 'Choose a Plan', 'jetpack-mu-wpcom' ),
-				'subtitle'  => get_plan_selected_subtitle(),
-				'completed' => true,
-				'disabled'  => false,
-			),
-		'subscribers_added'
-			=> array(
-				'id'        => 'subscribers_added',
-				'title'     => __( 'Add Subscribers', 'jetpack-mu-wpcom' ),
-				'completed' => true,
-				'disabled'  => false,
-			),
-		'first_post_published'
-			=> array(
-				'id'        => 'first_post_published',
-				'title'     => __( 'Write your first post', 'jetpack-mu-wpcom' ),
-				'completed' => get_checklist_task( 'first_post_published' ),
-				'disabled'  => false,
-			),
-		'first_post_published_newsletter'
-			=> array(
-				'id'        => 'first_post_published_newsletter',
-				'title'     => __( 'Start writing', 'jetpack-mu-wpcom' ),
-				'completed' => get_checklist_task( 'first_post_published' ),
-				'disabled'  => false,
-			),
-		'design_selected'
-			=> array(
-				'id'        => 'design_selected',
-				'title'     => __( 'Select a design', 'jetpack-mu-wpcom' ),
-				'completed' => true,
-				'disabled'  => ! can_update_design_selected_task(),
-			),
-		'setup_link_in_bio'
-			=> array(
-				'id'        => 'setup_link_in_bio',
-				'title'     => __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' ),
-				'completed' => true,
-				'disabled'  => false,
-			),
-		'links_added'
-			=> array(
-				'id'        => 'links_added',
-				'title'     => __( 'Add links', 'jetpack-mu-wpcom' ),
-				'completed' => get_checklist_task( 'links_edited' ),
-				'disabled'  => false,
-			),
-		'link_in_bio_launched'
-			=> array(
-				'id'        => 'link_in_bio_launched',
-				'title'     => __( 'Launch your site', 'jetpack-mu-wpcom' ),
-				'completed' => get_checklist_task( 'site_launched' ),
-				'disabled'  => ! get_checklist_task( 'links_edited' ),
-			),
-		'videopress_setup'
-			=> array(
-				'id'        => 'videopress_setup',
-				'title'     => __( 'Set up your video site', 'jetpack-mu-wpcom' ),
-				'completed' => true,
-				'disabled'  => false,
-			),
-		'videopress_upload'
-			=> array(
-				'id'        => 'videopress_upload',
-				'title'     => __( 'Upload your first video', 'jetpack-mu-wpcom' ),
-				'completed' => get_checklist_task( 'video_uploaded' ),
-				'disabled'  => get_checklist_task( 'video_uploaded' ),
-			),
-		'videopress_launched'
-			=> array(
-				'id'        => 'videopress_launched',
-				'title'     => __( 'Launch site', 'jetpack-mu-wpcom' ),
-				'completed' => get_checklist_task( 'site_launched' ),
-				'disabled'  => ! get_checklist_task( 'video_uploaded' ),
-			),
-		'setup_free'
-			=> array(
-				'id'        => 'setup_free',
-				'title'     => __( 'Personalize your site', 'jetpack-mu-wpcom' ),
-				'completed' => true,
-				'disabled'  => false,
-			),
-		'setup_general'
-			=> array(
-				'id'        => 'setup_general',
-				'title'     => __( 'Set up your site', 'jetpack-mu-wpcom' ),
-				'completed' => true,
-				'disabled'  => true,
-			),
-		'design_edited'
-			=> array(
-				'id'        => 'design_edited',
-				'title'     => __( 'Edit site design', 'jetpack-mu-wpcom' ),
-				'completed' => get_checklist_task( 'site_edited' ),
-				'disabled'  => false,
-			),
-		'site_launched'
-			=> array(
-				'id'           => 'site_launched',
-				'title'        => __( 'Launch your site', 'jetpack-mu-wpcom' ),
-				'completed'    => get_checklist_task( 'site_launched' ),
-				'disabled'     => false,
-				'isLaunchTask' => true,
-			),
-		'setup_write'
-			=> array(
-				'id'        => 'setup_write',
-				'title'     => __( 'Set up your site', 'jetpack-mu-wpcom' ),
-				'completed' => true,
-				'disabled'  => true,
-			),
-		'domain_upsell'
-			=> array(
-				'id'         => 'domain_upsell',
-				'title'      => __( 'Choose a domain', 'jetpack-mu-wpcom' ),
-				'completed'  => is_domain_upsell_completed(),
-				'disabled'   => false,
-				'badge_text' => get_domain_upsell_badge_text(),
-			),
-		'verify_email'
-			=> array(
-				'id'       => 'verify_email',
-				'title'    => __( 'Confirm Email (Check Your Inbox)', 'jetpack-mu-wpcom' ),
-				'complete' => false,
-				'disabled' => true,
-			),
+		array(
+			'id'        => 'setup_newsletter',
+			'title'     => __( 'Personalize Newsletter', 'jetpack-mu-wpcom' ),
+			'completed' => true,
+			'disabled'  => false,
+		),
+		array(
+			'id'        => 'plan_selected',
+			'title'     => __( 'Choose a Plan', 'jetpack-mu-wpcom' ),
+			'subtitle'  => get_plan_selected_subtitle(),
+			'completed' => true,
+			'disabled'  => false,
+		),
+		array(
+			'id'        => 'subscribers_added',
+			'title'     => __( 'Add Subscribers', 'jetpack-mu-wpcom' ),
+			'completed' => true,
+			'disabled'  => false,
+		),
+		array(
+			'id'        => 'first_post_published',
+			'title'     => __( 'Write your first post', 'jetpack-mu-wpcom' ),
+			'completed' => get_checklist_task( 'first_post_published' ),
+			'disabled'  => false,
+		),
+		array(
+			'id'        => 'first_post_published_newsletter',
+			'title'     => __( 'Start writing', 'jetpack-mu-wpcom' ),
+			'completed' => get_checklist_task( 'first_post_published' ),
+			'disabled'  => false,
+		),
+		array(
+			'id'        => 'design_selected',
+			'title'     => __( 'Select a design', 'jetpack-mu-wpcom' ),
+			'completed' => true,
+			'disabled'  => ! can_update_design_selected_task(),
+		),
+		array(
+			'id'        => 'setup_link_in_bio',
+			'title'     => __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' ),
+			'completed' => true,
+			'disabled'  => false,
+		),
+		array(
+			'id'        => 'links_added',
+			'title'     => __( 'Add links', 'jetpack-mu-wpcom' ),
+			'completed' => get_checklist_task( 'links_edited' ),
+			'disabled'  => false,
+		),
+		array(
+			'id'        => 'link_in_bio_launched',
+			'title'     => __( 'Launch your site', 'jetpack-mu-wpcom' ),
+			'completed' => get_checklist_task( 'site_launched' ),
+			'disabled'  => ! get_checklist_task( 'links_edited' ),
+		),
+		array(
+			'id'        => 'videopress_setup',
+			'title'     => __( 'Set up your video site', 'jetpack-mu-wpcom' ),
+			'completed' => true,
+			'disabled'  => false,
+		),
+		array(
+			'id'        => 'videopress_upload',
+			'title'     => __( 'Upload your first video', 'jetpack-mu-wpcom' ),
+			'completed' => get_checklist_task( 'video_uploaded' ),
+			'disabled'  => get_checklist_task( 'video_uploaded' ),
+		),
+		array(
+			'id'        => 'videopress_launched',
+			'title'     => __( 'Launch site', 'jetpack-mu-wpcom' ),
+			'completed' => get_checklist_task( 'site_launched' ),
+			'disabled'  => ! get_checklist_task( 'video_uploaded' ),
+		),
+		array(
+			'id'        => 'setup_free',
+			'title'     => __( 'Personalize your site', 'jetpack-mu-wpcom' ),
+			'completed' => true,
+			'disabled'  => false,
+		),
+		array(
+			'id'        => 'setup_general',
+			'title'     => __( 'Set up your site', 'jetpack-mu-wpcom' ),
+			'completed' => true,
+			'disabled'  => true,
+		),
+		array(
+			'id'        => 'design_edited',
+			'title'     => __( 'Edit site design', 'jetpack-mu-wpcom' ),
+			'completed' => get_checklist_task( 'site_edited' ),
+			'disabled'  => false,
+		),
+		array(
+			'id'           => 'site_launched',
+			'title'        => __( 'Launch your site', 'jetpack-mu-wpcom' ),
+			'completed'    => get_checklist_task( 'site_launched' ),
+			'disabled'     => false,
+			'isLaunchTask' => true,
+		),
+		array(
+			'id'        => 'setup_write',
+			'title'     => __( 'Set up your site', 'jetpack-mu-wpcom' ),
+			'completed' => true,
+			'disabled'  => true,
+		),
+		array(
+			'id'         => 'domain_upsell',
+			'title'      => __( 'Choose a domain', 'jetpack-mu-wpcom' ),
+			'completed'  => is_domain_upsell_completed(),
+			'disabled'   => false,
+			'badge_text' => get_domain_upsell_badge_text(),
+		),
+		array(
+			'id'       => 'verify_email',
+			'title'    => __( 'Confirm Email (Check Your Inbox)', 'jetpack-mu-wpcom' ),
+			'complete' => false,
+			'disabled' => true,
+		),
 	);
 }
 
@@ -315,25 +296,6 @@ function get_checklist_task( $task ) {
 	}
 
 	return false;
-}
-
-/**
- * Returns launchpad checklist by checklist slug.
- *
- * @param string $checklist_slug Checklist slug.
- *
- * @return array Associative array with checklist task
- *               or empty array if checklist slug is not found.
- */
-function build_checklist( $checklist_slug ) {
-	$checklist = array();
-	if ( null === ( get_checklist_definitions()[ $checklist_slug ] ) ) {
-		return $checklist;
-	}
-	foreach ( get_checklist_definitions()[ $checklist_slug ] as $task_id ) {
-		$checklist[] = get_task_definitions()[ $task_id ];
-	}
-	return $checklist;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -320,9 +320,8 @@ function get_launchpad_checklist_by_checklist_slug( $checklist_slug ) {
 		return array();
 	}
 
-	// This won't work yet because tasks aren't registered.
 	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
-	return $launchpad_task_lists->get_task_list( $checklist_slug );
+	return $launchpad_task_lists->build( $checklist_slug );
 }
 
 // TODO: Write code p2 post or dotcom post

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -273,10 +273,10 @@ function get_task_definitions() {
 			'badge_text' => get_domain_upsell_badge_text(),
 		),
 		array(
-			'id'       => 'verify_email',
-			'title'    => __( 'Confirm Email (Check Your Inbox)', 'jetpack-mu-wpcom' ),
-			'complete' => false,
-			'disabled' => true,
+			'id'        => 'verify_email',
+			'title'     => __( 'Confirm Email (Check Your Inbox)', 'jetpack-mu-wpcom' ),
+			'completed' => false,
+			'disabled'  => true,
 		),
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -313,42 +313,40 @@ function build_checklist( $checklist_slug ) {
  *
  * @param string $checklist_slug Checklist slug.
  *
- * @return array Associative array with checklist task data
+ * @return Task[] Collection of tasks for a given checklist
  */
 function get_launchpad_checklist_by_checklist_slug( $checklist_slug ) {
 	if ( ! $checklist_slug ) {
 		return array();
 	}
 
-	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
+	$launchpad_task_lists = Launchpad_Task_Lists::get_instance();
 	return $launchpad_task_lists->build( $checklist_slug );
 }
 
 // TODO: Write code p2 post or dotcom post
 /**
- * Wrapper that registers a launchpad checklist without needing
- * to know about the implementation details.
+ * Wrapper that registers a launchpad checklist.
  *
- * @param string $slug Task list slug.
- * @param array  $task_list Task list definition.
+ * @param string    $slug Task list slug.
+ * @param Task_List $task_list Task list definition.
  *
  * @return bool True if successful, false otherwise.
  */
 function register_launchpad_task_list( $slug, $task_list ) {
-	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
+	$launchpad_task_lists = Launchpad_Task_Lists::get_instance();
 	return $launchpad_task_lists->register_task_list( $slug, $task_list );
 }
 
 /**
- * Wrapper that registers a launchpad checklist without needing
- * to know about the implementation details.
+ * Wrapper that registers a launchpad checklist.
  *
- * @param array $task Task definition.
+ * @param Task $task Task definition.
  *
  * @return bool True if successful, false otherwise.
  */
 function register_launchpad_task( $task ) {
-	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
+	$launchpad_task_lists = Launchpad_Task_Lists::get_instance();
 	return $launchpad_task_lists->register_task( $task );
 }
 
@@ -356,7 +354,7 @@ function register_launchpad_task( $task ) {
  * Registers all default launchpad checklists
  */
 function register_default_checklists() {
-	$launchpad_task_lists = Launchpad_Task_Lists->get_instance();
+	$launchpad_task_lists = Launchpad_Task_Lists::get_instance();
 
 	foreach ( get_checklist_definitions() as $checklist ) {
 		$launchpad_task_lists->register_checklist( $checklist );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -23,53 +23,81 @@ require_once __DIR__ . '/class-launchpad-task-lists.php';
  */
 function get_checklist_definitions() {
 	return array(
-		'build'           => array(
-			'setup_general',
-			'design_selected',
-			'first_post_published',
-			'design_edited',
-			'site_launched',
+		array(
+			'slug'       => 'build',
+			'title'      => 'Build',
+			'task_slugs' => array(
+				'setup_general',
+				'design_selected',
+				'first_post_published',
+				'design_edited',
+				'site_launched',
+			),
 		),
-		'free'            => array(
-			'setup_free',
-			'design_selected',
-			'domain_upsell',
-			'first_post_published',
-			'design_edited',
-			'site_launched',
+		array(
+			'slug'       => 'free',
+			'title'      => 'Free',
+			'task_slugs' => array(
+				'setup_free',
+				'design_selected',
+				'domain_upsell',
+				'first_post_published',
+				'design_edited',
+				'site_launched',
+			),
 		),
-		'link-in-bio'     => array(
-			'design_selected',
-			'setup_link_in_bio',
-			'plan_selected',
-			'links_added',
-			'link_in_bio_launched',
+		array(
+			'slug'       => 'link-in-bio',
+			'title'      => 'Link In Bio',
+			'task_slugs' => array(
+				'design_selected',
+				'setup_link_in_bio',
+				'plan_selected',
+				'links_added',
+				'link_in_bio_launched',
+			),
 		),
-		'link-in-bio-tld' => array(
-			'design_selected',
-			'setup_link_in_bio',
-			'plan_selected',
-			'links_added',
-			'link_in_bio_launched',
+		array(
+			'slug'       => 'link-in-bio',
+			'title'      => 'Link In Bio',
+			'task_slugs' => array(
+				'design_selected',
+				'setup_link_in_bio',
+				'plan_selected',
+				'links_added',
+				'link_in_bio_launched',
+			),
 		),
-		'newsletter'      => array(
-			'setup_newsletter',
-			'plan_selected',
-			'subscribers_added',
-			'verify_email',
-			'first_post_published_newsletter',
+		array(
+			'slug'       => 'newsletter',
+			'title'      => 'Newsletter',
+			'task_slugs' => array(
+				'setup_newsletter',
+				'plan_selected',
+				'subscribers_added',
+				'verify_email',
+				'first_post_published_newsletter',
+			),
 		),
-		'videopress'      => array(
-			'videopress_setup',
-			'plan_selected',
-			'videopress_upload',
-			'videopress_launched',
+		array(
+			'slug'       => 'videopress',
+			'title'      => 'Videopress',
+			'task_slugs' => array(
+				'videopress_setup',
+				'plan_selected',
+				'videopress_upload',
+				'videopress_launched',
+			),
 		),
-		'write'           => array(
-			'setup_write',
-			'design_selected',
-			'first_post_published',
-			'site_launched',
+		array(
+			'slug'       => 'write',
+			'title'      => 'write',
+			'task_slugs' => array(
+				'setup_write',
+				'design_selected',
+				'first_post_published',
+				'site_launched',
+			),
 		),
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -1,12 +1,20 @@
 <?php
 /**
- * Launchpad
+ * Launchpad Helpers
  *
+ * @package automattic/jetpack-mu-wpcom
+ * @since 1.4.0
+ */
+
+/**
  * This file provides helpers that return the appropriate Launchpad
  * checklist and tasks for a given checklist slug.
  *
- * @package A8C\Launchpad
+ * @package automattic/jetpack-mu-wpcom
+ * @since 1.4.0
  */
+
+require_once __DIR__ . '/../launchpad/class-launchpad-task-list.php';
 
 /**
  * Returns the list of tasks by flow or checklist slug.
@@ -311,5 +319,23 @@ function get_launchpad_checklist_by_checklist_slug( $checklist_slug ) {
 	if ( ! $checklist_slug ) {
 		return array();
 	}
-	return build_checklist( $checklist_slug );
+
+	// This won't work yet because tasks aren't registered.
+	$launchpad_task_lists = Launchpad_Task_Lists->getInstance();
+	return $launchpad_task_lists->get_task_list( $checklist_slug );
 }
+
+/**
+ * Registers all default launchpad checklists
+ */
+function register_default_checklists() {
+	$launchpad_task_lists = Launchpad_Task_Lists->getInstance();
+
+	foreach ( get_checklist_definitions() as $checklist_key => $checklist ) {
+		$launchpad_task_lists->register_checklist( $checklist_key, $checklist );
+	}
+
+	// TODO: Register tasks for task list
+}
+
+add_action( 'init', 'register_default_checklists' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create a centralized registry for Launchpad checklists and Launchpad checklist tasks
* By doing so, we can create easy to use helper methods ( `register_launchpad_task_list`, `register_launchpad_task` ) that will allow other developers to spin up Launchpad checklists quickly
* To elaborate, all of this will allow others to programmatically register Launchpad checklists and tasks wherever is convenient in wpcom rather than hardcoding information in the `jetpack-mu-wpcom` `launchpad.php` file

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/registry-for-launchpad-checklists` to build and sync this branch to your sandbox. 
2. Sandbox a test site and public API
3. Start any new launchpad onboarding site Ex. wordpress.com/setup/free/intro
4. Go to `https://developer.wordpress.com/docs/api/console/`, select Rest API and wpcom/v2, and input the following: `/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=free`. Confirm you get back an appropriate checklist that matches the status of checklist items on Launchpad. 
5. Add the following code to the bottom of the `launchpad.php` file. We are going to verify that the checklist registration logic works properly by programmatically adding an entirely new checklist

```
function register_fake_checklist_and_tasks() {
	$fake_checklist = array(
		'id'          => 'fake_checklist',
		'title'       => 'Fake Checklist',
		'task_ids'       => array(
			'fake_task_1',
			'fake_task_2',
		),
	);

	register_launchpad_task_list( $fake_checklist );

	$fake_tasks = array(
		array(
			'id'        => 'fake_task_1',
			'title'     => 'Fake Task 1',
			'completed' => false,
			'disabled'  => false,
		),
		array(
			'id'        => 'fake_task_2',
			'title'     => 'Fake Task 2',
			'completed' => false,
			'disabled'  => false,
		)
		);

	register_launchpad_tasks( $fake_tasks );
}

add_action( 'init', 'register_fake_checklist_and_tasks' );
```
6. Then add `fake_checklist` as [a whitelisted query param on line 53](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php#L53) of the `class-wpcom-rest-api-v2-endpoint-launchpad-checklist.php` file
7. Verify in the developer console that `/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=fake_checklist` returns a collection of fake tasks that we registered. 

<img width="844" alt="Screenshot 2023-04-20 at 7 01 18 PM" src="https://user-images.githubusercontent.com/5414230/233523239-15094610-5339-44b2-9022-8057adbcde50.png">
