### PR TITLE
VideoPress: iterated over autoplay + PreviewOnHover effect

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-pho-iterate-over-autoplay
+++ b/projects/packages/videopress/changelog/update-videopress-pho-iterate-over-autoplay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: iterated over autoplay + PreviewOnHover effect

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -21,7 +21,10 @@ import type React from 'react';
  * @returns {React.ReactElement}      Playback block sidebar panel
  */
 export default function PlaybackPanel( { attributes, setAttributes }: VideoControlProps ) {
-	const { autoplay, loop, muted, controls, playsinline, preload } = attributes;
+	const { autoplay, loop, muted, controls, playsinline, preload, posterData } = attributes;
+
+	// Is Preview On Hover effect enabled?
+	const isPreviewOnHoverEnabled = posterData?.previewOnHover;
 
 	const handleAttributeChange = useCallback(
 		( attributeName: string, attributeValue?: string ) => {
@@ -37,7 +40,8 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 			<ToggleControl
 				label={ __( 'Autoplay', 'jetpack-videopress-pkg' ) }
 				onChange={ handleAttributeChange( 'autoplay' ) }
-				checked={ autoplay }
+				checked={ autoplay && ! isPreviewOnHoverEnabled }
+				disabled={ isPreviewOnHoverEnabled }
 				help={
 					<>
 						<span className={ styles[ 'help-message' ] }>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -36,6 +36,21 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 	);
 
 	const AutoplayHelp = () => {
+		/*
+		 * If the preview on hover effect is enabled,
+		 * we want to let the user know that the autoplay
+		 */
+		if ( isPreviewOnHoverEnabled ) {
+			return (
+				<span className={ styles[ 'help-message' ] }>
+					{ __(
+						'Autoplay is turned off as the hover preview is active.',
+						'jetpack-videopress-pkg'
+					) }
+				</span>
+			);
+		}
+
 		return (
 			<>
 				<span className={ styles[ 'help-message' ] }>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -35,6 +35,24 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 		[ setAttributes ]
 	);
 
+	const AutoplayHelp = () => {
+		return (
+			<>
+				<span className={ styles[ 'help-message' ] }>
+					{ __( 'Start playing the video as soon as the page loads.', 'jetpack-videopress-pkg' ) }
+				</span>
+				{ autoplay && (
+					<span className={ styles[ 'help-message' ] }>
+						{ __(
+							'Note: Autoplaying videos may cause usability issues for some visitors.',
+							'jetpack-videopress-pkg'
+						) }
+					</span>
+				) }
+			</>
+		);
+	};
+
 	return (
 		<PanelBody title={ __( 'Playback', 'jetpack-videopress-pkg' ) }>
 			<ToggleControl
@@ -42,24 +60,7 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 				onChange={ handleAttributeChange( 'autoplay' ) }
 				checked={ autoplay && ! isPreviewOnHoverEnabled }
 				disabled={ isPreviewOnHoverEnabled }
-				help={
-					<>
-						<span className={ styles[ 'help-message' ] }>
-							{ __(
-								'Start playing the video as soon as the page loads.',
-								'jetpack-videopress-pkg'
-							) }
-						</span>
-						{ autoplay && (
-							<span className={ styles[ 'help-message' ] }>
-								{ __(
-									'Note: Autoplaying videos may cause usability issues for some visitors.',
-									'jetpack-videopress-pkg'
-								) }
-							</span>
-						) }
-					</>
-				}
+				help={ <AutoplayHelp /> }
 			/>
 
 			<ToggleControl

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -39,6 +39,7 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 		/*
 		 * If the preview on hover effect is enabled,
 		 * we want to let the user know that the autoplay
+		 * option is not available.
 		 */
 		if ( isPreviewOnHoverEnabled ) {
 			return (

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.tsx
@@ -44,7 +44,7 @@ export default function PlaybackPanel( { attributes, setAttributes }: VideoContr
 			return (
 				<span className={ styles[ 'help-message' ] }>
 					{ __(
-						'Autoplay is turned off as the hover preview is active.',
+						'Autoplay is turned off as the preview on hover is active.',
 						'jetpack-videopress-pkg'
 					) }
 				</span>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -66,11 +66,7 @@ function previewOnHoverEffect(): void {
 		const iframeApi = window.VideoPressIframeApi( iFrame, () => {
 			iframeApi.status.onPlayerStatusChanged( ( oldStatus, newStatus ) => {
 				if ( oldStatus === 'ready' && newStatus === 'playing' ) {
-					// Do not pause if autoplay is enabled.
-					if ( ! previewOnHoverData.autoplay ) {
-						iframeApi.controls.pause();
-					}
-
+					iframeApi.controls.pause();
 					iframeApi.controls.seek( previewOnHoverData.previewAtTime );
 				}
 			} );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -39,7 +39,7 @@ export const getIframeWindowFromRef = (
 const useVideoPlayer = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
 	isRequestingPreview: boolean,
-	{ initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions,
+	{ initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions
 ): UseVideoPlayer => {
 	const [ playerIsReady, setPlayerIsReady ] = useState( false );
 	const playerState = useRef< PlayerStateProp >( 'not-rendered' );

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -39,7 +39,7 @@ export const getIframeWindowFromRef = (
 const useVideoPlayer = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
 	isRequestingPreview: boolean,
-	{ autoplay, initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions
+	{ initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions,
 ): UseVideoPlayer => {
 	const [ playerIsReady, setPlayerIsReady ] = useState( false );
 	const playerState = useRef< PlayerStateProp >( 'not-rendered' );
@@ -71,13 +71,8 @@ const useVideoPlayer = (
 			playerState.current = 'first-play';
 			debug( 'state: first-play detected' );
 
-			// Pause the video only if the autoplay is disabled.
-			if ( autoplay ) {
-				debug( 'autoplay enabled. Do not pause' );
-			} else {
-				debug( 'pause video' );
-				source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
-			}
+			debug( 'pause video' );
+			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
 
 			// Set position at time if it was provided.
 			if ( typeof initialTimePosition !== 'undefined' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over the playback `autoplay` option with the Preview On Hover (pOH) effect.
If the pOH is enabled, it should deactivate the autoplay and disable the toggle control

Fixes https://github.com/Automattic/jetpack/issues/30202

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: iterated over autoplay + PreviewOnHover effect

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Block editor context

* Go to the block editor
* Create/edit a VideoPress video block instance
* Enable `autoplay` control
* Confirm the video plays right after refreshing
* Enable the pOH feature
* Confirm the `autoplay` control deactivates and disables.
* Confirm the help changes
<img width="263" alt="image" src="https://user-images.githubusercontent.com/77539/233399690-5a317695-f56c-4cfd-b12b-7ad891bdb7b3.png">
* Disable pOH
* Confirm the autoplay control preserves its preview value
* Enable pOH again
* Save the post

### Front-end

* Go to the front end
* Confirm, after hard-refreshing, the video doesn't play automatically


