### PR TITLE
VideoPress: Remove poster frame update on preview play

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-remove-poster-frame-from-preview-play
+++ b/projects/packages/videopress/changelog/update-videopress-remove-poster-frame-from-preview-play
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+VideoPress: Remove poster frame update on preview play

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/style.scss
@@ -86,12 +86,8 @@ body.modal-open .poster-panel__dropdown {
 		opacity: 1;
 	}
 
-	&.is-generating-poster {
-		pointer-events: none;
-	
-		.components-sandbox {
-			opacity: 0.5;
-		}
+	&.is-generating-poster .components-sandbox {
+		opacity: 0.5;
 	}
 }
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -34,14 +34,12 @@ export const getIframeWindowFromRef = (
  * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - useRef of the sandbox wrapper.
  * @param {boolean} isRequestingPreview                        - Whether the preview is being requested.
  * @param {UseVideoPlayerOptions} options                      - Options object.
- * @param {Function} onTimeUpdate                              - Callback function to be called when the time is updated.
  * @returns {UseVideoPlayer}                                     playerIsReady and playerState
  */
 const useVideoPlayer = (
 	iFrameRef: React.MutableRefObject< HTMLDivElement >,
 	isRequestingPreview: boolean,
-	{ autoplay, initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions,
-	onTimeUpdate?: ( currentTime: number ) => void
+	{ autoplay, initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions
 ): UseVideoPlayer => {
 	const [ playerIsReady, setPlayerIsReady ] = useState( false );
 	const playerState = useRef< PlayerStateProp >( 'not-rendered' );
@@ -95,22 +93,18 @@ const useVideoPlayer = (
 			playerState.current = 'ready';
 		}
 
-		if ( eventName === 'videopress_timeupdate' ) {
+		if ( eventName === 'videopress_timeupdate' && previewOnHover ) {
 			const currentTime = eventData.currentTimeMs;
-			onTimeUpdate?.( currentTime );
-
-			if ( previewOnHover ) {
-				const startLimit = previewOnHover.atTime;
-				const endLimit = previewOnHover.atTime + previewOnHover.duration;
-				if (
-					currentTime < startLimit || // Before the start limit.
-					currentTime > endLimit // After the end limit.
-				) {
-					source.postMessage(
-						{ event: 'videopress_action_set_currenttime', currentTime: startLimit / 1000 },
-						{ targetOrigin: '*' }
-					);
-				}
+			const startLimit = previewOnHover.atTime;
+			const endLimit = previewOnHover.atTime + previewOnHover.duration;
+			if (
+				currentTime < startLimit || // Before the start limit.
+				currentTime > endLimit // After the end limit.
+			) {
+				source.postMessage(
+					{ event: 'videopress_action_set_currenttime', currentTime: startLimit / 1000 },
+					{ targetOrigin: '*' }
+				);
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #30157

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Removes the feature for now. React hooks do not play well with the player API events, causing some issues. We can iterate over the feature later.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With `beta` extensions enabled, go to the block editor
* Add a VideoPress video block
* Go to the `Poster and preview` panel
* Check that the poster timestamp does not change when playing the preview video
