### PR TITLE
Form responses inbox focus visual feedback

### DIFF
--- a/projects/packages/forms/changelog/change-inbox-focus-visual-feedback
+++ b/projects/packages/forms/changelog/change-inbox-focus-visual-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add a unified/consistent visual aid for focused elements

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.19.10",
+	"version": "0.19.11-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.19.10';
+	const PACKAGE_VERSION = '0.19.11-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/dashboard/components/search-form/style.scss
+++ b/projects/packages/forms/src/dashboard/components/search-form/style.scss
@@ -1,6 +1,12 @@
 .jp-forms__actions-search {
 	display: flex;
 	flex-direction: row;
+	border-radius: 4px;
+
+	// visual aid for focus
+	&:focus-within {
+		box-shadow: var( --jp-forms-focus-shadow );
+	}
 
 	@media (max-width: 600px) {
 		flex: 1;
@@ -28,7 +34,8 @@
 		}
 
 		&:focus-within {
-			box-shadow: 0 0 0 1px var( --jp-black ) inset;
+			// visual aid for focus in the wrapper element, remove border when focused
+			border-color: transparent;
 		}
 
 		&.disabled {

--- a/projects/packages/forms/src/dashboard/components/table/style.scss
+++ b/projects/packages/forms/src/dashboard/components/table/style.scss
@@ -115,6 +115,11 @@ input[type="checkbox"].jp-forms__table-checkbox {
 		width: 16px;
 	}
 
+	// visual aid for focus
+	&:focus::before {
+		box-shadow: var( --jp-forms-focus-shadow );
+	}
+
 	&:checked::before {
 		background: #000;
 		border-color: #000;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -16,6 +16,11 @@ $action-bar-height: 88px;
 		}
 	}
 
+	// visual aid for focus, currently only export button
+	.button-primary.export-button:focus {
+		box-shadow: var( --jp-forms-focus-shadow );
+	}
+
 	.components-dropdown-menu {
 		.components-menu-item__button {
 			font-size: var(--jp-forms-font-size-regular);
@@ -302,6 +307,11 @@ $action-bar-height: 88px;
 			> svg {
 				width: 32px;
 				height: 32px;
+			}
+
+			// visual aid for focus
+			&:focus {
+				box-shadow: var( --jp-forms-focus-shadow );
 			}
 		}
 

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -11,6 +11,8 @@
 	--jp-forms-color-darker-10: var( --jp-black-80, #2c3338 );
 	--jp-forms-color-darker-20: var( --jp-black-80, #2c3338 );
 
+	--jp-forms-focus-shadow: 0 0 0 1px var( --jp-forms-white ), 0 0 0 3px var( --jp-forms-color-darker-10 );// jetpack color would be nicer: #0b9e08;
+
 	// finally, re-write
 	--wp-admin-theme-color: var( --jp-forms-black );
 	--wp-admin-theme-color--rgb: 0, 0, 0;


### PR DESCRIPTION
This PR simply adds some visual aid for focused elements

## Proposed changes:
Add a CSS variable for a box-shadow definition, similar to the one used throughout other components so to have a consistent visual feedback of the focused element.

![focus](https://user-images.githubusercontent.com/157240/233426851-ca8a62c8-d78a-4a38-b24c-a224aa4c96df.gif)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the Feedback section using the sidebar menu. If you haven't, select the new inbox view from the top-right view options:
<img width="245" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/8728ec33-2b25-400f-b206-65e4d15e0582">

Focus on the search box of the inbox, then use "tab" key to cycle through elements on the responses inbox. On focus, all elements should show the same "outline" as visual aid/feedback.
