### PR TITLE
My Jetpack: Reload page after standalone install/activation

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -41,6 +41,12 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false } ) => 
 		navigateToConnectionPage,
 	] );
 
+	const handleInstallStandalone = useCallback( () => {
+		installStandalonePlugin().then( () => {
+			window?.location?.reload();
+		} );
+	}, [ installStandalonePlugin ] );
+
 	const Icon = getIconBySlug( slug );
 
 	return (
@@ -58,8 +64,8 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false } ) => 
 			onManage={ onManage }
 			onFixConnection={ navigateToConnectionPage }
 			showMenu={ showMenu }
-			onInstallStandalone={ installStandalonePlugin }
-			onActivateStandalone={ installStandalonePlugin }
+			onInstallStandalone={ handleInstallStandalone }
+			onActivateStandalone={ handleInstallStandalone }
 			hasStandalonePlugin={ standalonePluginInfo?.hasStandalonePlugin }
 			isStandaloneInstalled={ standalonePluginInfo?.isStandaloneInstalled }
 			isStandaloneActive={ standalonePluginInfo?.isStandaloneActive }

--- a/projects/packages/my-jetpack/changelog/update-mj-reload-after-standalone-install
+++ b/projects/packages/my-jetpack/changelog/update-mj-reload-after-standalone-install
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Reload page after standalone action


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #30220 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `handleInstallStandalone` who calls `window.location.reload` after success.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Navigate to My Jetpack page.
* Make sure that you have Jetpack core plugin installed and VideoPress standalone not installed or active.
* Open VideoPress card menu and install/activate plugin.
* The page should be reload after success.

