### PR TITLE
VideoPress: add play button when the video block show controls and Preview On Hover is enabled

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-play-button
+++ b/projects/packages/videopress/changelog/update-videopress-add-play-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add play button when the video block show controls and Preview On Hovwer is enabled

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -251,6 +251,8 @@ class Initializer {
 		$poster   = isset( $block_attributes['posterData']['url'] ) ? $block_attributes['posterData']['url'] : null;
 
 		$preview_on_hover = '';
+		$play_button      = '';
+
 		if ( $is_poh_enabled ) {
 			$preview_on_hover = array(
 				'previewAtTime'       => $block_attributes['posterData']['previewAtTime'],
@@ -267,6 +269,14 @@ class Initializer {
 				background-position: center center;"',
 					$poster
 				);
+			}
+
+			/*
+			 * Add a child element to show the play button
+			 * when the controls is enabled
+			 */
+			if ( $controls ) {
+				$play_button = '<div class="jetpack-videopress-player__play-button"></div>';
 			}
 
 			// Expose the preview on hover data to the client.
@@ -297,7 +307,8 @@ class Initializer {
 			$videopress_url = wp_kses_post( $videopress_url );
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
-				'<div class="jetpack-videopress-player__wrapper">%s %s</div>',
+				'<div class="jetpack-videopress-player__wrapper">%s %s %s</div>',
+				$play_button,
 				$preview_on_hover,
 				$oembed_html
 			);

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -302,12 +302,18 @@ class Initializer {
 		$guid           = isset( $block_attributes['guid'] ) ? $block_attributes['guid'] : null;
 		$videopress_url = Utils::get_video_press_url( $guid, $block_attributes );
 
-		$video_wrapper = '';
+		$video_wrapper         = '';
+		$video_wrapper_classes = 'jetpack-videopress-player__wrapper';
+		if ( $controls ) {
+			$video_wrapper_classes .= ' has-controls';
+		}
+
 		if ( $videopress_url ) {
 			$videopress_url = wp_kses_post( $videopress_url );
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
-				'<div class="jetpack-videopress-player__wrapper">%s %s %s</div>',
+				'<div class="%s">%s %s %s</div>',
+				$video_wrapper_classes,
 				$play_button,
 				$preview_on_hover,
 				$oembed_html

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -19,6 +19,10 @@
 		position: relative;
 		display: flex;
 
+		&.has-controls .jetpack-videopress-player__overlay {
+			cursor: pointer;
+		}
+
 		&:hover {
 			.jetpack-videopress-player__play-button {
 				transition-property: opacity;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -22,15 +22,6 @@
 		&.has-controls .jetpack-videopress-player__overlay {
 			cursor: pointer;
 		}
-
-		&:hover {
-			.jetpack-videopress-player__play-button {
-				transition-property: opacity;
-  				transition-duration: 0.3s;
-  				transition-delay: 0.5s;
-				opacity: 0;
-			}
-		}
 	}
 
 	.jetpack-videopress-player__overlay {
@@ -71,7 +62,6 @@
 		transition-property: opacity;
 		transition-duration: 0.3s;
 		transition-delay: 0.5s;
-		opacity: 1;
 
 		&.is-behind {
 			z-index: 8;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -1,5 +1,11 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
+:root {
+	// var picked from VideoPress .jetpack-videopress-player__overlay
+	
+	--big-play-button-size: min( max( calc( 100vw / 8 ), 60px ), 90px );
+}
+
 .wp-block-jetpack-videopress {
 	position: relative;
 
@@ -16,6 +22,7 @@
 
 	.jetpack-videopress-player__overlay {
 		position: absolute;
+		z-index: 0;
 		top: 0;
 		left: 0;
 		width: 100%;
@@ -29,4 +36,22 @@
 			opacity: 0;
 		}
 	}
+
+	.jetpack-videopress-player__play-button {
+		border: none;
+		padding: 0;
+		margin: 0;
+		height: var( --big-play-button-size );
+		width: var( --big-play-button-size );
+	
+		display: block;
+		position: absolute;
+		z-index: 20;
+		top: 50%;
+		left: 50%;
+
+		transform: translate( -50%, -50% );	
+		background: url( data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyMiAyMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxwYXRoCgkJZD0iTTYuMjU3MjUgMS4wNzVDNi4xMDI3OSAwLjk3NzQ0OSA1LjkxMDQxIDAuOTc0ODg5IDUuNzUzNjUgMS4wNjgzMkM1LjU5Njg5IDEuMTYxNzQgNS41IDEuMzM2NyA1LjUgMS41MjYzMlYyMC40NzM3QzUuNSAyMC42NjMzIDUuNTk2ODkgMjAuODM4MyA1Ljc1MzY1IDIwLjkzMTdDNS45MTA0MSAyMS4wMjUxIDYuMTAyNzkgMjEuMDIyNiA2LjI1NzI1IDIwLjkyNUwyMS4yNTczIDExLjQ1MTNDMjEuNDA3OSAxMS4zNTYyIDIxLjUgMTEuMTg0OSAyMS41IDExQzIxLjUgMTAuODE1MSAyMS40MDc5IDEwLjY0MzggMjEuMjU3MyAxMC41NDg3TDYuMjU3MjUgMS4wNzVaIgoJCWZpbGw9IndoaXRlIgoJLz4KPC9zdmc+ );
+		background-size: var( --big-play-button-size ) var( --big-play-button-size );
+	}	
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -18,6 +18,15 @@
 	.jetpack-videopress-player__wrapper {
 		position: relative;
 		display: flex;
+
+		&:hover {
+			.jetpack-videopress-player__play-button {
+				transition-property: opacity;
+  				transition-duration: 0.3s;
+  				transition-delay: 0.5s;
+				opacity: 0;
+			}
+		}
 	}
 
 	.jetpack-videopress-player__overlay {
@@ -53,6 +62,12 @@
 		transform: translate( -50%, -50% );	
 		background: url( data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyMiAyMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxwYXRoCgkJZD0iTTYuMjU3MjUgMS4wNzVDNi4xMDI3OSAwLjk3NzQ0OSA1LjkxMDQxIDAuOTc0ODg5IDUuNzUzNjUgMS4wNjgzMkM1LjU5Njg5IDEuMTYxNzQgNS41IDEuMzM2NyA1LjUgMS41MjYzMlYyMC40NzM3QzUuNSAyMC42NjMzIDUuNTk2ODkgMjAuODM4MyA1Ljc1MzY1IDIwLjkzMTdDNS45MTA0MSAyMS4wMjUxIDYuMTAyNzkgMjEuMDIyNiA2LjI1NzI1IDIwLjkyNUwyMS4yNTczIDExLjQ1MTNDMjEuNDA3OSAxMS4zNTYyIDIxLjUgMTEuMTg0OSAyMS41IDExQzIxLjUgMTAuODE1MSAyMS40MDc5IDEwLjY0MzggMjEuMjU3MyAxMC41NDg3TDYuMjU3MjUgMS4wNzVaIgoJCWZpbGw9IndoaXRlIgoJLz4KPC9zdmc+ );
 		background-size: var( --big-play-button-size ) var( --big-play-button-size );
+
+		/* Transition properties for mouse-leave */
+		transition-property: opacity;
+		transition-duration: 0.3s;
+		transition-delay: 0.5s;
+		opacity: 1;
 
 		&.is-behind {
 			z-index: 8;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -53,5 +53,9 @@
 		transform: translate( -50%, -50% );	
 		background: url( data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyMiAyMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxwYXRoCgkJZD0iTTYuMjU3MjUgMS4wNzVDNi4xMDI3OSAwLjk3NzQ0OSA1LjkxMDQxIDAuOTc0ODg5IDUuNzUzNjUgMS4wNjgzMkM1LjU5Njg5IDEuMTYxNzQgNS41IDEuMzM2NyA1LjUgMS41MjYzMlYyMC40NzM3QzUuNSAyMC42NjMzIDUuNTk2ODkgMjAuODM4MyA1Ljc1MzY1IDIwLjkzMTdDNS45MTA0MSAyMS4wMjUxIDYuMTAyNzkgMjEuMDIyNiA2LjI1NzI1IDIwLjkyNUwyMS4yNTczIDExLjQ1MTNDMjEuNDA3OSAxMS4zNTYyIDIxLjUgMTEuMTg0OSAyMS41IDExQzIxLjUgMTAuODE1MSAyMS40MDc5IDEwLjY0MzggMjEuMjU3MyAxMC41NDg3TDYuMjU3MjUgMS4wNzVaIgoJCWZpbGw9IndoaXRlIgoJLz4KPC9zdmc+ );
 		background-size: var( --big-play-button-size ) var( --big-play-button-size );
+
+		&.is-behind {
+			z-index: 8;
+		}
 	}	
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -118,8 +118,15 @@ function previewOnHoverEffect(): void {
 			} );
 		}
 
-		overlay.addEventListener( 'mouseenter', iframeApi.controls.play );
-		overlay.addEventListener( 'mouseleave', iframeApi.controls.pause );
+		overlay.addEventListener( 'mouseenter', () => {
+			playButton?.classList.add( 'is-behind' );
+			iframeApi.controls.play();
+		} );
+
+		overlay.addEventListener( 'mouseleave', () => {
+			playButton?.classList.remove( 'is-behind' );
+			iframeApi.controls.pause();
+		} );
 	} );
 }
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -119,7 +119,8 @@ function previewOnHoverEffect(): void {
 		}
 
 		overlay.addEventListener( 'mouseenter', () => {
-			playButton?.classList.add( 'is-behind' );
+			// Adding a delay to do not overlap the client fade-in animation.
+			setTimeout( () => playButton?.classList.add( 'is-behind' ), 500 );
 			iframeApi.controls.play();
 		} );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -95,6 +95,10 @@ function previewOnHoverEffect(): void {
 			return;
 		}
 
+		const playButton = videoPlayerElement.querySelector(
+			'.jetpack-videopress-player__play-button'
+		);
+
 		/*
 		 * Disable PreviewOnHover (pOH) when the player
 		 * should show the controls and
@@ -105,8 +109,9 @@ function previewOnHoverEffect(): void {
 				// Set the userHasInteracted flag to true.
 				userHasInteracted = true;
 
-				// Delete overlay element.
+				// Delete overlay and play button elements.
 				overlay.remove();
+				playButton?.remove();
 
 				// Pause when user clicks on the video.
 				setTimeout( iframeApi.controls.pause, 100 ); // Hack; without this, the video will not pause.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a Play button to the VideoPress video block when:
* Preview On Hover (pOH) effect is enabled, AND
* Show `controls` is enabled.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: add play button when the video block show controls and Preview On Hovwer is enabled

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a VideoPress video block
* `Show controls`
* Enable pOH effect
* Save the post
* View the post in the front end.
* Confirm the player initially shows the `play` button
* ~Confirm the player plays when mouse hovering~
* ~Confirm the play button disappear while the video keeps playing~
* Confirm the player stops when leaving it
* ~Confirm the play button shows up~
* Confirm Preview On Hover disables when user interacts (clicks) the player

