### PR TITLE
Update README.md to point to jetpack-autoloader v2.x

### DIFF
--- a/projects/packages/autoloader/README.md
+++ b/projects/packages/autoloader/README.md
@@ -21,7 +21,7 @@ In your project's `composer.json`, add the following lines:
 ```json
 {
     "require-dev": {
-        "automattic/jetpack-autoloader": "^1"
+        "automattic/jetpack-autoloader": "^2"
     }
 }
 ```

--- a/projects/packages/autoloader/changelog/nextgenthemes-patch-2
+++ b/projects/packages/autoloader/changelog/nextgenthemes-patch-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix example in README


### PR DESCRIPTION
Version 1 has a unsolvable deps issue in my case.

Is this thing ready for public use in plugins in general outside of Jetpack? The idea seems pretty cool. Seems version 2 is the one that should be used.