### PR TITLE
Launchpad: Add checklist to main launchpad endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-videopress-task-definitions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-videopress-task-definitions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Launchpad Checklist API: Update VideoPress tasks

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -163,15 +163,15 @@ function get_task_definitions() {
 			=> array(
 				'id'        => 'videopress_upload',
 				'title'     => __( 'Upload your first video', 'jetpack-mu-wpcom' ),
-				'completed' => get_checklist_task( 'videopress_uploaded' ),
-				'disabled'  => get_checklist_task( 'videopress_uploaded' ),
+				'completed' => get_checklist_task( 'video_uploaded' ),
+				'disabled'  => get_checklist_task( 'video_uploaded' ),
 			),
 		'videopress_launched'
 			=> array(
 				'id'        => 'videopress_launched',
 				'title'     => __( 'Launch site', 'jetpack-mu-wpcom' ),
-				'completed' => false,
-				'disabled'  => ! get_checklist_task( 'videopress_uploaded' ),
+				'completed' => get_checklist_task( 'site_launched' ),
+				'disabled'  => ! get_checklist_task( 'video_uploaded' ),
 			),
 		'setup_free'
 			=> array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -155,20 +155,23 @@ function get_task_definitions() {
 		'videopress_setup'
 			=> array(
 				'id'        => 'videopress_setup',
+				'title'     => __( 'Set up your video site', 'jetpack-mu-wpcom' ),
 				'completed' => true,
 				'disabled'  => false,
 			),
 		'videopress_upload'
 			=> array(
 				'id'        => 'videopress_upload',
-				'completed' => false,
-				'disabled'  => false,
+				'title'     => __( 'Upload your first video', 'jetpack-mu-wpcom' ),
+				'completed' => get_checklist_task( 'videopress_uploaded' ),
+				'disabled'  => get_checklist_task( 'videopress_uploaded' ),
 			),
 		'videopress_launched'
 			=> array(
 				'id'        => 'videopress_launched',
+				'title'     => __( 'Launch site', 'jetpack-mu-wpcom' ),
 				'completed' => false,
-				'disabled'  => true,
+				'disabled'  => ! get_checklist_task( 'videopress_uploaded' ),
 			),
 		'setup_free'
 			=> array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -17,6 +17,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 * Class constructor
 	 */
 	public function __construct() {
+		require_once __DIR__ . '/../launchpad/launchpad.php';
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'launchpad';
 
@@ -37,6 +38,21 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_data' ),
 					'permission_callback' => array( $this, 'can_access' ),
+					'args'                => array(
+						'checklist_slug' => array(
+							'description' => 'Checklist slug',
+							'type'        => 'string',
+							'enum'        => array(
+								'build',
+								'free',
+								'link-in-bio',
+								'link-in-bio-tld',
+								'newsletter',
+								'videopress',
+								'write',
+							),
+						),
+					),
 				),
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
@@ -62,14 +78,19 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	/**
 	 * Returns Launchpad-related options
 	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 *
 	 * @return array Associative array with `site_intent`, `launchpad_screen`,
 	 *               and `launchpad_checklist_tasks_statuses` as `checklist`.
 	 */
-	public function get_data() {
+	public function get_data( $request ) {
+		$checklist_slug = $request['checklist_slug'];
+		$checklist      = $checklist_slug ? get_launchpad_checklist_by_checklist_slug( $checklist_slug ) : null;
 		return array(
 			'site_intent'        => get_option( 'site_intent' ),
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
+			'checklist'          => $checklist,
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:

Rather than require a new endpoint, this PR returns the checklist from the main launchpad endpoint if a checklist_slug is provided, otherwise it provides null for the checklist. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

