### PR TITLE
Launchpad: Return checklist from main endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-checklist-to-launchpad-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-checklist-to-launchpad-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Launchpad: Return checklist from main endpoint.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -17,7 +17,6 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 * Class constructor
 	 */
 	public function __construct() {
-		require_once __DIR__ . '/../launchpad/launchpad.php';
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'launchpad';
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -17,6 +17,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 * Class constructor
 	 */
 	public function __construct() {
+		require_once __DIR__ . '/../launchpad/launchpad.php';
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'launchpad';
 
@@ -35,6 +36,21 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_data' ),
 					'permission_callback' => array( $this, 'can_access' ),
+					'args'                => array(
+						'checklist_slug' => array(
+							'description' => 'Checklist slug',
+							'type'        => 'string',
+							'enum'        => array(
+								'build',
+								'free',
+								'link-in-bio',
+								'link-in-bio-tld',
+								'newsletter',
+								'videopress',
+								'write',
+							),
+						),
+					),
 				),
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
@@ -95,14 +111,19 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	/**
 	 * Returns Launchpad-related options.
 	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 *
 	 * @return array Associative array with `site_intent`, `launchpad_screen`,
 	 *               and `launchpad_checklist_tasks_statuses` as `checklist`.
 	 */
-	public function get_data() {
+	public function get_data( $request ) {
+		$checklist_slug = $request['checklist_slug'];
+		$checklist      = $checklist_slug ? get_launchpad_checklist_by_checklist_slug( $checklist_slug ) : null;
 		return array(
 			'site_intent'        => get_option( 'site_intent' ),
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
+			'checklist'          => $checklist,
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -114,7 +114,8 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return array Associative array with `site_intent`, `launchpad_screen`,
-	 *               `launchpad_checklist_tasks_statuses`, and `checklist`.
+	 *               `launchpad_checklist_tasks_statuses` as `checklist_statuses`,
+	 *               and `checklist`.
 	 */
 	public function get_data( $request ) {
 		$checklist_slug = $request['checklist_slug'];

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -117,12 +117,11 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 */
 	public function get_data( $request ) {
 		$checklist_slug = $request['checklist_slug'];
-		$checklist      = $checklist_slug ? get_launchpad_checklist_by_checklist_slug( $checklist_slug ) : null;
 		return array(
 			'site_intent'        => get_option( 'site_intent' ),
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
-			'checklist'          => $checklist,
+			'checklist'          => get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -113,7 +113,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 *
 	 * @return array Associative array with `site_intent`, `launchpad_screen`,
-	 *               and `launchpad_checklist_tasks_statuses` as `checklist`.
+	 *               `launchpad_checklist_tasks_statuses`, and `checklist`.
 	 */
 	public function get_data( $request ) {
 		$checklist_slug = $request['checklist_slug'];

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -17,6 +17,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 * Class constructor
 	 */
 	public function __construct() {
+		require_once __DIR__ . '/../launchpad/launchpad.php';
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'launchpad';
 


### PR DESCRIPTION
### Proposed changes

We recently added a new backend launchpad/checklist endpoint to fetch Launchpad checklists. But we already have an existing Launchpad endpoint, and it's a very small change to just have our existing Launchpad endpoint also return a checklist if requested. This PR updated the main Launchpad endpoint to that end. 

Specific changes: 
   - Allows us to append a ?checklist=checklist_slug to the /launchpad endpoint to retrieve a checklist
   - Adds relevant query args with validation/sanitization to the end point definition
  
How it now works: 
   - `/sites/SITESLUG/launchpad` (ie, no checklist_slug param) will return the long-standing values from the endpoint PLUS `null` for 'checklist'.  **UPDATE**: Based on subsequent changes, this will now return an empty array for checklist.
   - `/sites/SITESLUG/launchpad?checklist_slug=CHECKLISTSLUG` will return the long-standing values from the endpoint PLUS the checklist matching CHECKLISTSLUG. Example: using 'free' for the checklist slug will return the free flow checklist. 
   - `/sites/SITESLUG/launchpad?checklist_slug=`  will give an error (this mimics the behavior of the new launchpad/checklist endpoint based on the same validations rules)
   - `/sites/SITESLUG/launchpad?checklist_slug=asdkfadf` will give an error (this mimics the behavior of the new launchpad/checklist endpoint based on the same validations rules)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See slack conversations: p1682021017500299-slack-CHN6J22MP and p1682447527337119/1682441914.846989-slack-CHN6J22MP

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/add-checklist-to-launchpad-endpoint` to build and sync this branch to your sandbox.
2. Create or use a launchpad-enabled site. Sandbox that site and public API.
3. Go to https://developer.wordpress.com/docs/api/console/, select Rest API and wpcom/v2. 
4. TEST: Input `/sites/SITESLUG/launchpad` (ie, no checklist_slug param) and confirm you get back long-standing values for launchpad_screen and checklist_statuses, as well as `null` for 'checklist'
5. TEST: Input `/sites/SITESLUG/launchpad?checklist_slug=free` and confirm you get back long-standing values for launchpad_screen and checklist_statuses, as well as the correct `free` checklist. 
6. TEST: Input `/sites/SITESLUG/launchpad?checklist_slug=newsletter` and confirm you get back long-standing values for launchpad_screen and checklist_statuses, as well as the correct `newsletter` checklist. 
8. Feel free to test any other flows like link-in-bio, write, or build if desired. 
9. TEST: Input `/sites/SITESLUG/launchpad?checklist_slug=` (empty checklist_slug) and confirm you receive an error from the endpoint.
10. TEST: Input `/sites/SITESLUG/launchpad?checklist_slug=asdkfadf` (any malformed/invalid checklist_slug) and confirm you receive an error from the endpoint.
