### PR TITLE
[RNMobile] Ensure VideoPress settings persist following replacement

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-persist-settings-upon-replacement
+++ b/projects/packages/videopress/changelog/rnmobile-persist-settings-upon-replacement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress block: Ensure settings persist following a replacement

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
@@ -89,7 +89,7 @@ export default function VideoPressEdit( {
 		[ setAttributes ]
 	);
 
-	const { videoData } = useSyncMedia( attributes, setAttributes );
+	const { videoData } = useSyncMedia( attributes, setAttributes, isReplacingFile.isReplacing );
 	const { private_enabled_for_site: privateEnabledForSite } = videoData;
 
 	const handleDoneUpload = useCallback(

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-sync-media/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-sync-media/index.native.js
@@ -65,9 +65,10 @@ const invalidateEmbedResolutionFields = [
  *
  * @param {object} attributes		- Block attributes.
  * @param {Function} setAttributes	- Block attributes setter.
+ * @param {boolean} isReplacingFile	- Whether the video is being replaced.
  * @returns {object}				- Hook API object.
  */
-export function useSyncMedia( attributes, setAttributes ) {
+export function useSyncMedia( attributes, setAttributes, isReplacingFile ) {
 	const { id, guid, isPrivate } = attributes;
 	const { videoData, isRequestingVideoData } = useVideoData( {
 		id,
@@ -106,7 +107,7 @@ export function useSyncMedia( attributes, setAttributes ) {
 	 * when the block is mounted.
 	 */
 	useEffect( () => {
-		if ( isRequestingVideoData ) {
+		if ( isRequestingVideoData || isReplacingFile ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/5677

## Proposed changes:

> **Warning**
> As reported in https://github.com/Automattic/jetpack/issues/30233, settings are not currently retained after a replacement on the web, so it may be debated whether this is something that needs to be "fixed" on either platform.

* A check for whether the current video is being replaced is added before syncing changes from the web. If a video _is_ being replaced with a brand new video, then all previously changed settings should persist. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p9ugOq-3mV-p2

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

> **Note**
> The settings should only persist if a new video is uploaded from the device. If a video is uploaded via the media library, then it should retain its original settings. 

* Navigate to a post with a VideoPress block or add a new one. Make sure that a video has been uploaded to the block.
* Edit some of the block's settings that will be synced (e.g. title, description, and the settings under the Privacy and Ratings panel).
* Tap the replace button.
* Select the option to either upload a video from your device or take a new video.
* Open the block settings and verify that the changes persisted.
* Next, tap the replace button again and choose to upload a video from the Media Library.
* Verify that the settings have now changed to match that of the video from the Media Library.