### PR TITLE
actions: Improve build and post-build workflows on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,15 @@ jobs:
           # Only need to retain for a day since the beta builder slurps it up to distribute.
           retention-days: 1
 
+      - name: Store plugins.tsv as artifact
+        if: steps.plugins.outputs.any == 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: plugins.tsv
+          path: ${{ env.BUILD_BASE }}/plugins.tsv
+          # We don't really care about this artifact, its presence is a flag to the post-build job.
+          retention-days: 1
+
       - name: Update reminder with testing instructions
         id: update-reminder-comment
         uses: actions/github-script@v6
@@ -248,7 +257,7 @@ jobs:
     name: "Trigger TeamCity build"
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ fromJSON(needs.build.outputs.changed_projects)['plugins/jetpack'] == true }}
+    if: ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Automattic/jetpack' ) && fromJSON(needs.build.outputs.changed_projects)['plugins/jetpack'] == true
 
     steps:
       - name: Trigger TeamCity build

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -117,7 +117,7 @@ jobs:
             echo "$JSON"
             echo "::endgroup::"
             ZIPURL="$(jq -r '.artifacts[] | select( .name == "jetpack-build" ) | .archive_download_url' <<<"$JSON")"
-            PLUGINS="$(jq -r '.artifacts[] | select( .name == "plugins" )' <<<"$JSON")"
+            PLUGINS="$(jq -r '.artifacts[] | select( .name == "plugins.tsv" )' <<<"$JSON")"
             if [[ -n "$ZIPURL" ]]; then
               break
             fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The "Trigger TeamCity build" cannot run on a fork as it needs secrets, so we'll have to skip it.

The post-build workflow is fine to run, but it will think there are no plugins because the "Create artifact for Jetpack Beta plugin" job doesn't run and it looks for that job's artifact to decide if there were plugins. It doesn't actually _use_ it, it just looks for its presence. While we could download and read the zip file instead, it seems easier to just create a dummy artifact to serve as the signal instead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None, spotted the problem while trying to merge #30225.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the post-build workflow run correctly, i.e. it doesn't think "no plugins"?