### PR TITLE
VideoPress: playback at beginning when Preview On Hover is enabled

### DIFF
--- a/projects/packages/videopress/changelog/update-vidopress-playback-from-start-when-control-and-poh
+++ b/projects/packages/videopress/changelog/update-vidopress-playback-from-start-when-control-and-poh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: playback at beginning when Preview On Hover is enabled

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/style.scss
@@ -58,13 +58,8 @@
 		background: url( data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjIiIHZpZXdCb3g9IjAgMCAyMiAyMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KCTxwYXRoCgkJZD0iTTYuMjU3MjUgMS4wNzVDNi4xMDI3OSAwLjk3NzQ0OSA1LjkxMDQxIDAuOTc0ODg5IDUuNzUzNjUgMS4wNjgzMkM1LjU5Njg5IDEuMTYxNzQgNS41IDEuMzM2NyA1LjUgMS41MjYzMlYyMC40NzM3QzUuNSAyMC42NjMzIDUuNTk2ODkgMjAuODM4MyA1Ljc1MzY1IDIwLjkzMTdDNS45MTA0MSAyMS4wMjUxIDYuMTAyNzkgMjEuMDIyNiA2LjI1NzI1IDIwLjkyNUwyMS4yNTczIDExLjQ1MTNDMjEuNDA3OSAxMS4zNTYyIDIxLjUgMTEuMTg0OSAyMS41IDExQzIxLjUgMTAuODE1MSAyMS40MDc5IDEwLjY0MzggMjEuMjU3MyAxMC41NDg3TDYuMjU3MjUgMS4wNzVaIgoJCWZpbGw9IndoaXRlIgoJLz4KPC9zdmc+ );
 		background-size: var( --big-play-button-size ) var( --big-play-button-size );
 
-		/* Transition properties for mouse-leave */
-		transition-property: opacity;
-		transition-duration: 0.3s;
-		transition-delay: 0.5s;
-
 		&.is-behind {
 			z-index: 8;
 		}
-	}	
+	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/view.ts
@@ -109,8 +109,8 @@ function previewOnHoverEffect(): void {
 				overlay.remove();
 				playButton?.remove();
 
-				// Pause when user clicks on the video.
-				setTimeout( iframeApi.controls.pause, 100 ); // Hack; without this, the video will not pause.
+				// Playback the video from the beginning.
+				iframeApi.controls.seek( 0 );
 			} );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/30231

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: playback at beginning when Preview On Hover is enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a VideoPress video block
* `Show controls`
* Enable pOH
* Save the post
* Go to the front-end
* Confirm that, after clicking on the video, it playbacks at the beginning of the video



