### PR TITLE
Launchpad: Update text strings

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-text-strings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-text-strings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just minor changes to text strings.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -128,14 +128,14 @@ function get_task_definitions() {
 		'setup_newsletter'
 			=> array(
 				'id'        => 'setup_newsletter',
-				'title'     => __( 'Personalize Newsletter', 'jetpack-mu-wpcom' ),
+				'title'     => __( 'Personalize newsletter', 'jetpack-mu-wpcom' ),
 				'completed' => true,
 				'disabled'  => false,
 			),
 		'plan_selected'
 			=> array(
 				'id'        => 'plan_selected',
-				'title'     => __( 'Choose a Plan', 'jetpack-mu-wpcom' ),
+				'title'     => __( 'Choose a plan', 'jetpack-mu-wpcom' ),
 				'subtitle'  => get_plan_selected_subtitle(),
 				'completed' => true,
 				'disabled'  => false,
@@ -143,7 +143,7 @@ function get_task_definitions() {
 		'subscribers_added'
 			=> array(
 				'id'        => 'subscribers_added',
-				'title'     => __( 'Add Subscribers', 'jetpack-mu-wpcom' ),
+				'title'     => __( 'Add subscribers', 'jetpack-mu-wpcom' ),
 				'completed' => true,
 				'disabled'  => false,
 			),
@@ -257,7 +257,7 @@ function get_task_definitions() {
 		'verify_email'
 			=> array(
 				'id'       => 'verify_email',
-				'title'    => __( 'Confirm Email (Check Your Inbox)', 'jetpack-mu-wpcom' ),
+				'title'    => __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' ),
 				'complete' => false,
 				'disabled' => true,
 			),


### PR DESCRIPTION
## Proposed changes:
This PR simply updates some text strings to 'sentence case' in response to design feedback. We had updated these on the frontend via calypso here https://github.com/Automattic/wp-calypso/pull/75974 and need to duplicate those changes in our new backend code. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

This PR is just text changes, and the backend logic and endpoint should otherwise work the same. So this is mostly a test to confirm no regression or unexpected breakage. 

1. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/launchpad-text-strings` to build and sync this branch to your sandbox.
2. Create or use a launchpad enabled site and sandbox the site.
3. Go to https://developer.wordpress.com/docs/api/console/, select Rest API and wpcom/v2, and input the following: `/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=free`. You can replace free with any valid flow name.  