### PR TITLE
admin-menu: Use .getAttribute('aria-expanded') instead of .ariaExpanded

### DIFF
--- a/projects/plugins/jetpack/changelog/update-admin-menu-collapse-button
+++ b/projects/plugins/jetpack/changelog/update-admin-menu-collapse-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix firefox not detecting the collapsed state of the sidebar properly

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.js
@@ -55,7 +55,7 @@
 				collapseButton.addEventListener( 'click', function ( event ) {
 					// Let's the core event listener be triggered first.
 					setTimeout( function () {
-						saveSidebarIsExpanded( event.target.parentNode.ariaExpanded );
+						saveSidebarIsExpanded( event.target.parentNode.getAttribute( 'aria-expanded' ) );
 					}, 50 );
 				} );
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Just a minor compatibility fix for firefox:

It seems that `.ariaExpanded` doesn't work in firefox:

![2023-04-21_09-07](https://user-images.githubusercontent.com/937354/233662268-64394a63-1f2a-49f5-975c-023ce20c5530.png)

https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaExpanded

![2023-04-20_15-10](https://user-images.githubusercontent.com/937354/233662309-4c419ded-db1b-4e63-8c14-52158f01169f.png)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visit wp-admin 
* Check `console.log( document.getElementById("collapse-button").ariaExpanded ); ` in both Chrome and FF
* Check `console.log( document.getElementById("collapse-button").getAttribute('aria-expanded' ) ); ` in both Chrome and FF
* If you have a full setup, you can expand/collapse the bar and watch the ajax requests going out
![2023-04-21_09-23](https://user-images.githubusercontent.com/937354/233662797-7bb3e212-1ccf-45cf-9c60-cb11e1fd3461.png)
* "Expanded" should no longer be undefined in FF

