### PR TITLE
My Jetpack: Add flags in initial state

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-mj-stats-flag
+++ b/projects/packages/my-jetpack/changelog/add-mj-stats-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add flags field in initial state

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Connection\Client as Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\JITMS\JITM as JITM;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Plugins_Installer;
@@ -165,6 +166,7 @@ class Initializer {
 				'topJetpackMenuItemUrl' => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'            => ( new Status() )->get_site_suffix(),
 				'myJetpackVersion'      => self::PACKAGE_VERSION,
+				'myJetpackFlags'        => self::get_my_jetpack_flags(),
 				'fileSystemWriteAccess' => self::has_file_system_write_access(),
 				'loadAddLicenseScreen'  => self::is_licensing_ui_enabled(),
 				'adminUrl'              => esc_url( admin_url() ),
@@ -187,6 +189,19 @@ class Initializer {
 		if ( self::can_use_analytics() ) {
 			Tracking::register_tracks_functions_scripts( true );
 		}
+	}
+
+	/**
+	 *  Build flags for My Jetpack UI
+	 *
+	 *  @return array
+	 */
+	public static function get_my_jetpack_flags() {
+		$flags = array(
+			'stats' => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_STATS_ENABLED' ),
+		);
+
+		return $flags;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -198,7 +198,7 @@ class Initializer {
 	 */
 	public static function get_my_jetpack_flags() {
 		$flags = array(
-			'stats' => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_STATS_ENABLED' ),
+			'videoPressStats' => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
 		);
 
 		return $flags;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Close #30242 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `myJetpackFlags` field in the initial state.
* Define first flag `videoPressStats`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run it locally
* Open `My Jetpack` page.
* Run in console `window.myJetpackInitialState.myJetpackFlags`.
* You should see `videoPressStats` as `false`.
* Open `tools/docker/wordpress/wp-config.php` and define `JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED`
* Reload the page and rerun the console.
* You should see `videoPressStats` as `true`.