### PR TITLE
[RNMobile] Fix blocking state when stopping the upload

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-videopress-fix-stop-upload
+++ b/projects/packages/videopress/changelog/rnmobile-videopress-fix-stop-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress block: Fix blocking state when stopping an upload

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.native.js
@@ -22,10 +22,9 @@ const VideoPressUploader = ( {
 	fileToUpload,
 	handleDoneUpload,
 	isInteractionDisabled,
-	isReplacing,
 	onFocus,
-	onReplaceCancel,
 	onStartUpload,
+	onStopUpload,
 } ) => {
 	const [ uploadFile, setFile ] = useState( null );
 	const [ isUploadingInProgress, setIsUploadingInProgress ] = useState( false );
@@ -83,9 +82,7 @@ const VideoPressUploader = ( {
 
 	const onResetUpload = useCallback( () => {
 		setIsUploadingInProgress( false );
-		if ( isReplacing ) {
-			onReplaceCancel();
-		}
+		onStopUpload();
 	}, [] );
 
 	if ( isUploadingInProgress ) {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
@@ -132,7 +132,7 @@ export default function VideoPressEdit( {
 			setAttributes( { guid: null } );
 			setFileToUpload( media );
 		},
-		[ setIsReplacingFile, setIsUploadingFile, setFileToUpload ]
+		[ attributes, setIsReplacingFile, setIsUploadingFile, setFileToUpload ]
 	);
 
 	const onReplaceSelectFromLibrary = useCallback(

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
@@ -114,10 +114,14 @@ export default function VideoPressEdit( {
 		[ setIsUploadingFile, setAttributes ]
 	);
 
-	const cancelReplacingVideoFile = useCallback( () => {
-		setAttributes( isReplacingFile.prevAttrs );
-		setIsReplacingFile( { isReplacing: false, prevAttrs: {} } );
-		setIsUploadingFile( false );
+	const onStopUpload = useCallback( () => {
+		if ( isReplacingFile?.isReplacing ) {
+			setAttributes( isReplacingFile.prevAttrs );
+			setIsReplacingFile( { isReplacing: false, prevAttrs: {} } );
+			setIsUploadingFile( false );
+		} else {
+			setAttributes( { id: undefined, src: undefined } );
+		}
 	}, [ isReplacingFile, setAttributes, setIsReplacingFile, setIsUploadingFile ] );
 
 	// Handlers of `ReplaceControl`
@@ -188,10 +192,9 @@ export default function VideoPressEdit( {
 				fileToUpload={ fileToUpload }
 				handleDoneUpload={ handleDoneUpload }
 				isInteractionDisabled={ ! isSelected }
-				isReplacing={ isReplacingFile?.isReplacing }
 				onFocus={ onFocus }
-				onReplaceCancel={ cancelReplacingVideoFile }
 				onStartUpload={ onStartUpload }
+				onStopUpload={ onStopUpload }
 			/>
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5693.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the handler when an upload is stopped to `edit` component.
* In case the upload isn't replacing another video, reset the block attributes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Stop upload on the first video

1. Create/open a post.
2. Add a VideoPress block.
3. Add a video.
4. Select the "Choose from device" option.
5. Select a video.
6. Observe that a progress bar is displayed while the upload is in progress.
7. Before the upload finishes, tap on the block.
8. Tap on "Stop upload".
9. Observe that the upload is stopped and that the block displays the empty state.
<img width="372" alt="Screenshot 2023-04-21 at 18 01 40" src="https://user-images.githubusercontent.com/14905380/233682509-b391e8cb-4aeb-4540-bb83-03d7175f6330.png">

10. Tapping on the block again shows the media options to upload.
11. Save the post.
12. Observe that the block remains in the empty state.

### Stop upload when replacing a video

1. Create/open a post.
2. Add a VideoPress block.
3. Add a video.
4. Tap on the <img width="32" src="https://user-images.githubusercontent.com/14905380/227274533-b434d785-eaa5-4486-aa67-44ffa23f4555.png"> button to replace the video.
5. Select the "Choose from device" option.
6. Select a video.
7. Observe that a progress bar is displayed while the upload is in progress.
8. Before the upload finishes, tap on the block.
9. Tap on "Stop upload".
13. Observe that the upload is stopped and that the block displays the previous video.