### PR TITLE
RNA: Fix button box-shadow radius on Linux build of Firefox

### DIFF
--- a/projects/js-packages/components/changelog/fix-rna-button-box-shadow-firefox-linux
+++ b/projects/js-packages/components/changelog/fix-rna-button-box-shadow-firefox-linux
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RNA: Fix button box-shadow radius on Linux build of Firefox

--- a/projects/js-packages/components/components/button/style.module.scss
+++ b/projects/js-packages/components/components/button/style.module.scss
@@ -2,6 +2,7 @@
 	--wp-admin-theme-color: var(--jp-black);
 	--wp-admin-theme-color-darker-10: var(--jp-black-80);
 	--wp-admin-theme-color-darker-20: var(--jp-black-80);
+	// 1.51px to avoid subpixel rendering issues on Firefox/Linux
 	--wp-admin-border-width-focus: 1.51px;
 
 	border-radius: var(--jp-border-radius);
@@ -81,6 +82,7 @@
 	// Only Secondary
 	&:global(.is-secondary) {
 		background: var(--jp-white);
+		// 1.51px to avoid subpixel rendering issues on Firefox/Linux
 		box-shadow: inset 0 0 0 1.51px var(--jp-black);
 
 		// Hover & Active

--- a/projects/js-packages/components/components/button/style.module.scss
+++ b/projects/js-packages/components/components/button/style.module.scss
@@ -2,7 +2,7 @@
 	--wp-admin-theme-color: var(--jp-black);
 	--wp-admin-theme-color-darker-10: var(--jp-black-80);
 	--wp-admin-theme-color-darker-20: var(--jp-black-80);
-	--wp-admin-border-width-focus: 1.5px;
+	--wp-admin-border-width-focus: 1.51px;
 
 	border-radius: var(--jp-border-radius);
 	justify-content: center;
@@ -81,7 +81,7 @@
 	// Only Secondary
 	&:global(.is-secondary) {
 		background: var(--jp-white);
-		box-shadow: inset 0 0 0 1.5px var(--jp-black);
+		box-shadow: inset 0 0 0 1.51px var(--jp-black);
 
 		// Hover & Active
 		&:active:not(:disabled),

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.31.6",
+	"version": "0.31.7-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30245

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `0.01px` to the box-shadow radius. It seems that `1.5px` rounds up in one position, but rounds down in the other, causing the visual issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `( cd projects/js-packages/storybook && pnpm run storybook:dev )`
* Go to JS Packages > Components > Button > Button Secondary (http://localhost:50240/?path=/story/js-packages-components-button--button-secondary)
* Check that the box-shadow is fixed and both sides have the same width

Before | After
-|-
![2023-04-21_14-36-40](https://user-images.githubusercontent.com/8486249/233710784-915aeeb2-43fe-4ee8-9d14-73161f1ad3b3.png) | ![2023-04-21_15-37-41](https://user-images.githubusercontent.com/8486249/233710946-6972ae7e-b0d1-4d73-b24a-8d444afc5b97.png)
