### PR TITLE
My Jetpack: Add neutral color in contextual card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/contextual-card-info.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/contextual-card-info.jsx
@@ -26,6 +26,7 @@ export const ChangePercentageContext = ( { change, changePercentage } ) => {
 	return (
 		<div
 			className={ classNames( styles[ 'contextual-percentage-change' ], {
+				[ styles.neutral ]: change === 0,
 				[ styles.positive ]: change > 0,
 				[ styles.negative ]: change < 0,
 			} ) }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
@@ -19,6 +19,11 @@
 	display: flex;
 	align-items: baseline;
 
+	&.neutral {
+		color: var( --jp-gray-10 );
+		fill: var( --jp-gray-10 );
+	}
+
 	&.positive {
 		color: var( --jp-green-50 );
 		fill: var( --jp-green-50 );

--- a/projects/packages/my-jetpack/changelog/update-mj-card-stats
+++ b/projects/packages/my-jetpack/changelog/update-mj-card-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add neutral color in contextual card


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #30248 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `neutral` class with `--jp-gray-10` value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `My Jetpack`
* Enable `VideoPress Stats` constant.
* Activate `VideoPress` plugin or module.
* Reload page to see the stats
* It should load the change percentage as gray.

