### PR TITLE
Add/forms dashboard tab counters

### DIFF
--- a/projects/packages/forms/changelog/add-forms-dashboard-tab-counters
+++ b/projects/packages/forms/changelog/add-forms-dashboard-tab-counters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added counters on the tabs in the Jetpack Forms dashboard

--- a/projects/packages/forms/src/dashboard/inbox/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/index.js
@@ -38,17 +38,17 @@ const RESPONSES_FETCH_LIMIT = 50;
 const TABS = [
 	{
 		name: 'inbox',
-		title: 'Inbox',
+		title: __( 'Inbox', 'jetpack-forms' ),
 		className: 'jp-forms__inbox-tab-item',
 	},
 	{
 		name: 'spam',
-		title: 'Spam',
+		title: __( 'Spam', 'jetpack-forms' ),
 		className: 'jp-forms__inbox-tab-item',
 	},
 	{
 		name: 'trash',
-		title: 'Trash',
+		title: __( 'Trash', 'jetpack-forms' ),
 		className: 'jp-forms__inbox-tab-item',
 	},
 ];
@@ -78,6 +78,7 @@ const Inbox = () => {
 		query,
 		responses,
 		selectedResponses,
+		tabTotals,
 		total,
 	] = useSelect(
 		select => [
@@ -88,6 +89,7 @@ const Inbox = () => {
 			select( STORE_NAME ).getResponsesQuery(),
 			select( STORE_NAME ).getResponses(),
 			select( STORE_NAME ).getSelectedResponseIds(),
+			select( STORE_NAME ).getTabTotals(),
 			select( STORE_NAME ).getTotalResponses(),
 		],
 		[]
@@ -153,6 +155,22 @@ const Inbox = () => {
 	const toggleExportModal = useCallback(
 		() => setShowExportModal( ! showExportModal ),
 		[ showExportModal, setShowExportModal ]
+	);
+
+	const tabs = useMemo(
+		() =>
+			TABS.map( ( { title, ...tab } ) => ( {
+				...tab,
+				title: (
+					<>
+						{ title }
+						{ tabTotals && (
+							<span className="jp-forms__inbox-tab-item-count">{ tabTotals[ tab.name ] || 0 }</span>
+						) }
+					</>
+				),
+			} ) ),
+		[ tabTotals ]
 	);
 
 	const monthList = useMemo( () => {
@@ -236,7 +254,7 @@ const Inbox = () => {
 				className="jp-forms__inbox-tabs"
 				activeClass="active-tab"
 				onSelect={ setStatusQuery }
-				tabs={ TABS }
+				tabs={ tabs }
 			>
 				{ () => (
 					<>

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -94,6 +94,22 @@ $action-bar-height: 88px;
 	}
 }
 
+.jp-forms__inbox-tab-item-count {
+	align-items: center;
+	background: transparent;
+	border: 1px solid #dcdcde;
+	border-radius: 3px;
+	box-sizing: border-box;
+	color: #2C3338;
+	display: inline-flex;
+	font-size: 12px;
+	font-weight: 400;
+	height: 20px;
+	line-height: 18px;
+	margin-left: 10px;
+	padding: 0 6px;
+}
+
 .jp-forms__inbox-content {
 	box-sizing: border-box;
 	display: flex;

--- a/projects/packages/forms/src/dashboard/state/actions.js
+++ b/projects/packages/forms/src/dashboard/state/actions.js
@@ -47,6 +47,7 @@ export function* fetchResponses( query ) {
 			type: RESPONSES_FETCH_RECEIVE,
 			responses: data.responses,
 			total: data.totals[ query.status || 'inbox' ],
+			tabTotals: data.totals,
 			filters: data.filters_available,
 		};
 	} catch ( error ) {

--- a/projects/packages/forms/src/dashboard/state/reducer.js
+++ b/projects/packages/forms/src/dashboard/state/reducer.js
@@ -55,6 +55,14 @@ const responses = ( state = [], action ) => {
 	return state;
 };
 
+const tabTotals = ( state = undefined, action ) => {
+	if ( action.type === RESPONSES_FETCH_RECEIVE ) {
+		return action.tabTotals;
+	}
+
+	return state;
+};
+
 const total = ( state = 0, action ) => {
 	if ( action.type === RESPONSES_FETCH && action.offset === 0 ) {
 		return 0;
@@ -138,5 +146,6 @@ export default combineReducers( {
 	loading,
 	query,
 	responses,
+	tabTotals,
 	total,
 } );

--- a/projects/packages/forms/src/dashboard/state/selectors.js
+++ b/projects/packages/forms/src/dashboard/state/selectors.js
@@ -17,6 +17,8 @@ export const getResponses = state =>
 		};
 	} );
 
+export const getTabTotals = state => state.tabTotals;
+
 export const getTotalResponses = state => state.total;
 
 export const getCurrentPage = state => state.currentPage;

--- a/projects/packages/forms/src/dashboard/style.wpcom.scss
+++ b/projects/packages/forms/src/dashboard/style.wpcom.scss
@@ -59,6 +59,15 @@ body.toplevel_page_jetpack-forms.toplevel_page_jetpack-forms {
 		}
 	}
 
+	.jp-forms__inbox-tab-item-count {
+		background-color: var( --color-neutral-0, #f6f7f7 );
+		border: 0;
+		border-radius: 0;
+		color: var( --color-neutral-80, #2C3338 );
+		line-height: 20px;
+		padding: 0 8px;
+	}
+
 	.jp-forms__inbox.is-response-view .jp-forms__inbox-content-column {
 		@media (max-width: 1024px) {
 			padding-top: 32px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This patch adds counters for the individual tabs on the Jetpack Forms dashboard. The API was already returning the totals so this was just a UI adjustment.

![Screenshot 2023-04-21 at 21 58 59](https://user-images.githubusercontent.com/8056203/233724825-85fc59ae-061f-4fac-b0c8-5e59b34367a6.png)

The counters will update anytime results are fetched.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to `admin.php?page=jetpack-forms`
- You should see the little counters on the tabs in the header once the initial results are loaded.

