### PR TITLE
Visual Refresh: Update SectionHeader with RNA styles

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
@@ -7,7 +7,6 @@
 	.dops-section-header__actions {
 		.form-toggle__label {
 			position: relative;
-			top: 6px;
 			right: 0;
 		}
 		.form-toggle__label-content {
@@ -107,7 +106,6 @@
 }
 .jp-dash-item__active-label {
 	display: inline-block;
-	padding: rem( 6px ) 0 0;
 	color: darken( $gray, 10% );
 	color: $gray;
 	font-size: rem( 12px );

--- a/projects/plugins/jetpack/_inc/client/components/section-header/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/section-header/style.scss
@@ -7,9 +7,9 @@
 	display: flex;
 	flex-wrap: wrap;
 	max-width: 100%;
-	padding-top: rem( 11px );
-	padding-bottom: rem( 11px );
 	position: relative;
+	border-bottom: 1px solid #DCDCDE;
+	margin-bottom: 0;
 
 	&:after {
 		content: '';
@@ -18,13 +18,14 @@
 
 .dops-section-header__label {
 	display: flex;
-		align-items: center;
+	align-items: center;
 	flex-grow: 1;
 	min-width: 0; // weird fix for overflowing items
-	line-height: rem( 28px );
+	line-height: rem( 30px );
 	position: relative;
-	color: $gray-dark;
-	font-size: rem( 14px );
+	color: $black;
+	font-size: rem( 20px );
+	font-weight: 500;
 
 	.dops-count {
 		margin-left: rem( 8px );
@@ -49,17 +50,8 @@
 }
 
 .dops-section-header__actions {
+	align-items: center;
+	display: flex;
 	flex-grow: 0;
 	position: relative;
-
-	@include clear-fix;
-}
-
-.section-header__actions .button {
-	float: left;
-	margin-right: rem( 8px );
-
-	&:last-child {
-		margin-right: 0;
-	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In support of https://github.com/Automattic/jetpack/issues/29832 and https://github.com/Automattic/jetpack/issues/29835

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Applies RNA styling to the `SectionHeader` component.
* Removes `6px` offsets from dash item controls, as controls are now centered with flex.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

C051H2TQR54-p1682038255452449

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review the Jetpack dashboard and settings screens, validating the new styles are present.

## Screenshots

<img width="888" alt="Screenshot 2023-04-22 at 1 34 29 PM" src="https://user-images.githubusercontent.com/10933065/233803458-83b8738f-6f1b-466f-a789-29bb03d954d2.png">
<img width="594" alt="Screenshot 2023-04-22 at 1 06 15 PM" src="https://user-images.githubusercontent.com/10933065/233803460-84a87fe4-716f-45a2-8472-8fd05172d8f6.png">
<img width="597" alt="Screenshot 2023-04-22 at 1 06 07 PM" src="https://user-images.githubusercontent.com/10933065/233803462-1390a25b-74ff-4535-b020-bc951a8a7ab2.png">
