### PR TITLE
Blogging prompts API: add param to force prompt dates to a specific year

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -190,7 +190,7 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 		global $wpdb;
 		if ( $this->day_of_year_query > 0 ) {
 			$day          = $this->day_of_year_query;
-			$current_year = wp_date( 'Y' );
+			$current_year = $this->force_year ? $this->force_year : wp_date( 'Y' );
 
 			// Grab the current sort order, `ASC` or `DESC`, so we can reuse it.
 			$order = end( explode( ' ', $clauses['orderby'] ) );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -350,7 +350,7 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 				'description'       => __( 'Force the returned prompts to be for a specific year. Returns only one prompt for each day.', 'jetpack' ),
 				'type'              => 'integer',
 				'validate_callback' => function ( $param ) {
-					return is_int( $param ) && $param < 9999;
+					return is_numeric( $param ) && intval( $param ) > 0 && intval( $param ) < 9999;
 				},
 			),
 		);

--- a/projects/plugins/jetpack/changelog/add-blogging-prompts-api-force-year
+++ b/projects/plugins/jetpack/changelog/add-blogging-prompts-api-force-year
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+wpcom/v3/blogging-prompts endpoint: add param to force prompt dates to be a specific year


### PR DESCRIPTION
## Proposed changes:

Adds a `force_year` param to the wpcom/v3/blogging-prompts API endpoint that allows forcing the prompt dates to be for a specific year, with a limit of one prompt per day.

This change was requested to better support the daily writing prompt feature in the Jetpack mobile app.

phpunit tests for this change in wpcom are in D108726-code

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pctCYC-KA-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Apply this change to a wpcom sandbox with `bin/jetpack-downloader test jetpack add/blogging-prompts-api-force-year` and sandbox public-api.wordpress.com
* Use the [API console](https://developer.wordpress.com/docs/api/console/) to make a request like the following: `/sites/150131137/blogging-prompts?after=--04-24&force_year=2023&order=desc`
* You should see the prompt dates use the year 2023, rather than their publish year
* Test that prompts loop to the next year, so that 2023-12-31 is followed by 2024-01-01.
* Test that leaps years (like 2024) include Feb 29th.