### PR TITLE
Fix html entities not displaying correctly in the forms dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-html-entities
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-html-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed html entities not displaying correctly in the forms dashboard

--- a/projects/packages/forms/src/dashboard/data/responses.js
+++ b/projects/packages/forms/src/dashboard/data/responses.js
@@ -1,5 +1,9 @@
+/**
+ * External dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
-import { isNil, omitBy, pick } from 'lodash';
+import { decodeEntities } from '@wordpress/html-entities';
+import { isNil, mapValues, omitBy, pick } from 'lodash';
 
 /**
  * Fetches responses from backend (API)
@@ -16,7 +20,15 @@ export const fetchResponses = query => {
 		pick( omitBy( query, isNil ), [ 'limit', 'offset', 'search', 'status', 'parent_id', 'month' ] )
 	).toString();
 
-	return apiFetch( { path: `/wpcom/v2/forms/responses?${ queryString }` } );
+	return apiFetch( { path: `/wpcom/v2/forms/responses?${ queryString }` } ).then( data => ( {
+		...data,
+		responses: data.responses.map( response => ( {
+			...response,
+			author_name: decodeEntities( response.author_name ),
+			entry_title: decodeEntities( response.entry_title ),
+			fields: mapValues( response.fields, value => decodeEntities( value ) ),
+		} ) ),
+	} ) );
 };
 
 /**

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -85,16 +85,14 @@ const InboxResponse = ( { loading, response } ) => {
 			<div className="jp-forms__inbox-response-separator" />
 
 			<div className="jp-forms__inbox-response-data">
-				{ map( response.fields, ( value, key ) => {
-					return (
-						<div key={ key } className="jp-forms__inbox-response-item">
-							<div className="jp-forms__inbox-response-data-label">{ formatFieldName( key ) }:</div>
-							<div className="jp-forms__inbox-response-data-value">
-								{ isEmpty( value ) ? '-' : value }
-							</div>
+				{ map( response.fields, ( value, key ) => (
+					<div key={ key } className="jp-forms__inbox-response-item">
+						<div className="jp-forms__inbox-response-data-label">{ formatFieldName( key ) }:</div>
+						<div className="jp-forms__inbox-response-data-value">
+							{ isEmpty( value ) ? '-' : value }
 						</div>
-					);
-				} ) }
+					</div>
+				) ) }
 			</div>
 		</SwitchTransition>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This patch fixes HTML entities not being rendered correctly on the forms dashboard. Instead of applying the fix in every place we render a piece of information, I just added an additional step to when a response comes in to make sure the data is already in the correct format before it goes into the store. I think this will also help prevent accidental regressions in the future.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Create a post with a contact form.
- Respond to the created contact form and make sure to include some special characters inside the name or message field. `&` or `<` are good first candidates.
- Go to `admin.php?page=jetpack-forms` and view the new response.
- All response values should be rendered correctly in both list and response views.