### PR TITLE
Actions: remove the teamcity_trigger job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,30 +253,6 @@ jobs:
             --form-string "plugins=$PLUGIN_DATA" \
             --form-string "secret=$SECRET"
 
-  teamcity_trigger:
-    name: "Trigger TeamCity build"
-    runs-on: ubuntu-latest
-    needs: build
-    if: ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Automattic/jetpack' ) && fromJSON(needs.build.outputs.changed_projects)['plugins/jetpack'] == true
-
-    steps:
-      - name: Trigger TeamCity build
-        env:
-          SECRET: ${{ secrets.JETPACK__GITHUB_TEAMCITY_TOKEN }}
-          URL: ${{ secrets.TEAMCITY_TRIGGER_ENDPOINT }}
-          PR: ${{ github.event_name == 'push' && github.ref_name || github.event.number }}
-          SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
-        run: |
-          response=$(curl --fail -L \
-            --url "$URL" \
-            --form-string "pr-number=$PR" \
-            --form-string "sha=$SHA" \
-            --form-string "secret=$SECRET")
-
-          echo "The TeamCity build has been triggered. Details: /viewQueued.html?itemId=$response"
-          echo
-          echo "If you would like to restart the tests, please re-run this job."
-
   update_mirrors:
     name: Push to mirror repos
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed changes:

Remove the teamcity_trigger job. This TeamCity job will be triggered via the beta builder server now, see internal: 32-gh-Automattic/jetpack-builder

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Part of PT: p9dueE-6So-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Once the preflight tests are being run via the beta builder server, this PR can be merged.

## Todo:

- [x] After merging, remove unused secrets.
- [x] After merging, cleanup the MC callback file.