### PR TITLE
Jetpack Visual Refresh: Modules page

### DIFF
--- a/projects/plugins/jetpack/_inc/client/scss/shared/admin-static.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/shared/admin-static.scss
@@ -13,6 +13,24 @@
 	}
 }
 
+.admin_page_jetpack_modules #jp-plugin-container .page-content {
+	max-width: none;
+
+	.frame.top {
+		padding-top: 24px;
+	}
+
+	.table {
+		border-collapse: collapse;
+
+		tr:first-of-type {
+			height: 72px;
+			background: #FFFFFF;
+			border-bottom: 1px solid $gray-5;
+		}
+	}
+}
+
 #jp-plugin-container .wrap {
 	margin: 0 auto;
 	max-width:45rem;

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -149,7 +149,15 @@ abstract class Jetpack_Admin_Page {
 			$this->page_render();
 			return;
 		}
-		self::wrap_ui( array( $this, 'page_render' ) );
+
+		$args = array();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['page'] ) && 'jetpack_modules' === $_GET['page'] ) {
+			$args['is-wide'] = true;
+		}
+
+		self::wrap_ui( array( $this, 'page_render' ), $args );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-visual-refresh-modules
+++ b/projects/plugins/jetpack/changelog/update-visual-refresh-modules
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Visual Refresh: Modules page.


### PR DESCRIPTION
Fixes #29836

## Proposed changes:
* Jetpack Visual Refresh: Modules page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-lJK-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
TBD