### PR TITLE
Staging Sites: Hide jetpack backups for wpcom staging site

### DIFF
--- a/projects/plugins/jetpack/changelog/update-hide-jetpack-backups-for-wpcom-staging-site
+++ b/projects/plugins/jetpack/changelog/update-hide-jetpack-backups-for-wpcom-staging-site
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove Backup menu for staging sites

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -412,7 +412,10 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 
 		add_submenu_page( 'jetpack', esc_attr__( 'Activity Log', 'jetpack' ), __( 'Activity Log', 'jetpack' ), 'manage_options', 'https://wordpress.com/activity-log/' . $this->domain, null, 2 );
-		add_submenu_page( 'jetpack', esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 3 );
+
+		if ( ! get_option( 'wpcom_is_staging_site' ) ) {
+			add_submenu_page( 'jetpack', esc_attr__( 'Backup', 'jetpack' ), __( 'Backup', 'jetpack' ), 'manage_options', 'https://wordpress.com/backup/' . $this->domain, null, 3 );
+		}
 
 		$this->hide_submenu_page( 'jetpack', 'jetpack#/settings' );
 		$this->hide_submenu_page( 'jetpack', 'stats' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/1880

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In this diff, I propose to hide Backup link for WPCOM staging sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a WoA dev blog and enable SSH
2. Build and sync this PR to the site.

```
jetpack rsync jetpack <ssh URL>:~/htdocs/wp-content/plugins/jetpack
```

3. Modify WoA dev blog to make it a staging site (see https://github.com/Automattic/dotcom-forge/issues/1880#issuecomment-1521936175)

4. Confirm that menu doesn't include Backup link anymore

<img width="454" alt="Screenshot 2023-04-25 at 16 48 31" src="https://user-images.githubusercontent.com/727413/234315100-89282fd3-7989-4437-9247-f2187ff6ba6a.png">

