### PR TITLE
Launchpad: Update strings to sentence case

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-text-string-case
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-text-string-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Launchpad: Update text strings.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -163,20 +163,20 @@ function get_task_definitions() {
 	return array(
 		array(
 			'id'        => 'setup_newsletter',
-			'title'     => __( 'Personalize Newsletter', 'jetpack-mu-wpcom' ),
+			'title'     => __( 'Personalize newsletter', 'jetpack-mu-wpcom' ),
 			'completed' => true,
 			'disabled'  => false,
 		),
 		array(
 			'id'        => 'plan_selected',
-			'title'     => __( 'Choose a Plan', 'jetpack-mu-wpcom' ),
+			'title'     => __( 'Choose a plan', 'jetpack-mu-wpcom' ),
 			'subtitle'  => get_plan_selected_subtitle(),
 			'completed' => true,
 			'disabled'  => false,
 		),
 		array(
 			'id'        => 'subscribers_added',
-			'title'     => __( 'Add Subscribers', 'jetpack-mu-wpcom' ),
+			'title'     => __( 'Add subscribers', 'jetpack-mu-wpcom' ),
 			'completed' => true,
 			'disabled'  => false,
 		),
@@ -274,7 +274,7 @@ function get_task_definitions() {
 		),
 		array(
 			'id'        => 'verify_email',
-			'title'     => __( 'Confirm Email (Check Your Inbox)', 'jetpack-mu-wpcom' ),
+			'title'     => __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' ),
 			'completed' => false,
 			'disabled'  => true,
 		),


### PR DESCRIPTION
Resolves: https://github.com/Automattic/wp-calypso/issues/76057

## Proposed changes:
This PR simply updates some text strings to 'sentence case' (only the first letter of a sentence or phrase is capitalized, like 'Personalize newsletter' not 'Personalize Newsletter'. in response to design feedback. We had updated these on the frontend via calypso here https://github.com/Automattic/wp-calypso/pull/75974 and need to duplicate those changes in our new backend code. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

This PR is just text changes, and the backend logic and endpoint should otherwise work the same. So this is mostly a test to confirm no regression or unexpected breakage. 

1. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/launchpad-text-string-case` to build and sync this branch to your sandbox.
2. Create or use a launchpad enabled site and sandbox the site.
3. Go to https://developer.wordpress.com/docs/api/console/, select Rest API and wpcom/v2, and input the following: `/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=newsletter`. Confirm text strings are all sentence case. 
4. Input the following: `/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=link-in-bio`. Confirm text strings are all sentence case except for 'Personalize Link in Bio'.