### PR TITLE
CRM: Resolves 1610 -  translate object names in PDF filename

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-1610-adjust_PDF_names
+++ b/projects/plugins/crm/changelog/fix-crm-1610-adjust_PDF_names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+PDF generator: objects in filenames are translated

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -1519,12 +1519,12 @@ function jpcrm_ajax_quote_send_email() {
 	if ( $attachAsPDF ) {
 
 		// make pdf.
-		$pdf_file = jpcrm_quote_generate_pdf( $quoteID );
+		$pdf_path = jpcrm_quote_generate_pdf( $quoteID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		// attach it
-		if ( $pdf_file !== false ) {
+		if ( $pdf_path !== false ) {
 
-			$attachments[] = array( $pdf_file );
+			$attachments[] = array( $pdf_path );
 
 		}
 
@@ -1590,10 +1590,10 @@ function jpcrm_ajax_quote_send_email() {
 		$sent = zeroBSCRM_mailDelivery_sendMessage( $mailDeliveryMethod, $mailArray );
 
 		// delete any gen'd pdf's
-		if ( $attachAsPDF && $pdf_file !== false ) {
+		if ( $attachAsPDF && $pdf_path !== false ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 			// delete the PDF file once it's been read (i.e. emailed)
-			unlink( $pdf_file );
+			wp_delete_file( $pdf_path );
 
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5969,7 +5969,7 @@ function zeroBSCRM_AJAX_sendInvoiceEmail_v3( $email = '', $invoiceID = -1, $atta
 			if ( $pdfFileLocation !== false ) {
 
 				// attach inv
-				$attachments[] = array( $pdfFileLocation, 'invoice.pdf' );
+				$attachments[] = array( $pdfFileLocation ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 			}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -1524,7 +1524,7 @@ function jpcrm_ajax_quote_send_email() {
 		// attach it
 		if ( $pdf_file !== false ) {
 
-			$attachments[] = array( $pdf_file, 'quote.pdf' );
+			$attachments[] = array( $pdf_file );
 
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5964,12 +5964,12 @@ function zeroBSCRM_AJAX_sendInvoiceEmail_v3( $email = '', $invoiceID = -1, $atta
 			// make pdf.
 
 			// generate the PDF
-			$pdfFileLocation = zeroBSCRM_generateInvoicePDFFile( $invoiceID );
+			$pdf_path = jpcrm_invoice_generate_pdf( $invoiceID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
-			if ( $pdfFileLocation !== false ) {
+			if ( $pdf_path !== false ) {
 
 				// attach inv
-				$attachments[] = array( $pdfFileLocation ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				$attachments[] = array( $pdf_path );
 
 			}
 
@@ -6035,10 +6035,10 @@ function zeroBSCRM_AJAX_sendInvoiceEmail_v3( $email = '', $invoiceID = -1, $atta
 			$sent = zeroBSCRM_mailDelivery_sendMessage( $mailDeliveryMethod, $mailArray );
 
 			// delete any gen'd pdf's
-			if ( $attachAsPDF && $pdfFileLocation !== false ) {
+			if ( $attachAsPDF && $pdf_path !== false ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 				// delete the PDF file once it's been read (i.e. emailed)
-				unlink( $pdfFileLocation );
+				wp_delete_file( $pdf_path );
 
 			}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1504,11 +1504,6 @@ function jetpackcrm_create_zeros_array($start, $end, $zbs_steps = 86400){
    / Dashboard Helpers
    ====================================================== */
 
-
-/* ======================================================
-     YouTube Helpers
-   ====================================================== */
-
 /*
  * Returns a YouTube thumbnail URL of a video
  *
@@ -1557,6 +1552,33 @@ function jpcrm_youtube_url_to_video_id( $video_url ) {
 
 }
 
-/* ======================================================
-   / YouTube Helpers
-   ====================================================== */
+/**
+ * Generates a PDF from provided HTML and returns path to PDF
+ *
+ * @param string $html HTML used for PDF content.
+ * @param string $pdf_filename Name of file where PDF will be stored.
+ *
+ * @returns string|boolean
+ */
+function jpcrm_generate_pdf( $html, $pdf_filename ) {
+	global $zbs;
+
+	$temp_dir = zeroBSCRM_privatisedDirCheckWorks();
+
+	// if tmp dir doesn't exist, die
+	if ( ! $temp_dir ) {
+		return false;
+	}
+
+	$pdf_path = $temp_dir['path'] . '/' . $pdf_filename;
+
+	// build PDF
+	$dompdf = $zbs->pdf_engine();
+	$dompdf->loadHtml( $html, 'UTF-8' );
+	$dompdf->render();
+
+	// save the pdf file on the server
+	file_put_contents( $pdf_path, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+	return $pdf_path;
+}

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -336,10 +336,11 @@ function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
 	$dompdf->loadHtml( $html, 'UTF-8' );
 	$dompdf->render();
 
-	$file_to_save = $temp_dir['path'] . '/' . sanitize_title( __( 'invoice', 'zero-bs-crm' ) ) . '-' . $invoice_id . '.pdf';
+	// normalise translated text to alphanumeric, resulting in a filename like `invoice-321.pdf`
+	$file_to_save = sanitize_title( __( 'invoice', 'zero-bs-crm' ) ) . '-' . $invoice_id . '.pdf';
 
 	// save the pdf file on the server
-	file_put_contents( $file_to_save, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	file_put_contents( $temp_dir['path'] . '/' . $file_to_save, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 
 	return $file_to_save;
 }

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -342,10 +342,10 @@ function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
 	$dompdf->render();
 
 	// normalise translated text to alphanumeric, resulting in a filename like `invoice-321.pdf`
-	$file_to_save = sanitize_title( __( 'invoice', 'zero-bs-crm' ) ) . '-' . $invoice_id . '.pdf';
+	$file_to_save = $temp_dir['path'] . '/' . sanitize_title( __( 'invoice', 'zero-bs-crm' ) ) . '-' . $invoice_id . '.pdf';
 
 	// save the pdf file on the server
-	file_put_contents( $temp_dir['path'] . '/' . $file_to_save, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	file_put_contents( $file_to_save, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 
 	return $file_to_save;
 }

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -333,7 +333,7 @@ function jpcrm_invoice_generate_pdf( $invoice_id = -1 ) {
 	}
 
 	// normalise translated text to alphanumeric, resulting in a filename like `invoice-321.pdf`
-	$pdf_filename = sanitize_title( __( 'invoice', 'zero-bs-crm' ) . '-' . $invoice_id ) . '.pdf';
+	$pdf_filename = sanitize_title( __( 'Invoice', 'zero-bs-crm' ) . '-' . $invoice_id ) . '.pdf';
 
 	// return PDF filename if successful, false if not
 	return jpcrm_generate_pdf( $html, $pdf_filename );

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -313,11 +313,18 @@ function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
 
 	// brutal.
 	if ( ! zeroBSCRM_permsInvoices() ) {
-			return false;
+		return false;
 	}
 
 	// If user has no perms, or id not present, die
 	if ( $invoice_id <= 0 ) {
+		return false;
+	}
+
+	$temp_dir = zeroBSCRM_privatisedDirCheckWorks();
+
+	// if tmp dir doesn't exist, die
+	if ( ! $temp_dir ) {
 		return false;
 	}
 
@@ -329,14 +336,7 @@ function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
 	$dompdf->loadHtml( $html, 'UTF-8' );
 	$dompdf->render();
 
-	$upload_dir  = wp_upload_dir();
-	$invoice_dir = $upload_dir['basedir'] . '/invoices/';
-
-	if ( ! file_exists( $invoice_dir ) ) {
-		wp_mkdir_p( $invoice_dir );
-	}
-
-	$file_to_save = $invoice_dir . $invoice_id . '.pdf';
+	$file_to_save = $temp_dir['path'] . '/' . sanitize_title( __( 'invoice', 'zero-bs-crm' ) ) . '-' . $invoice_id . '.pdf';
 
 	// save the pdf file on the server
 	file_put_contents( $file_to_save, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -278,10 +278,11 @@ function zbs_invoice_generate_pdf(){
 		}
 
 		// generate the PDF
-		$pdf_path     = zeroBSCRM_generateInvoicePDFFile( $invoice_id );
-		$pdf_filename = basename( $pdf_path );
+		$pdf_path = zeroBSCRM_generateInvoicePDFFile( $invoice_id );
 
 		if ( $pdf_path !== false ) {
+
+			$pdf_filename = basename( $pdf_path );
 
 			// print the pdf file to the screen for saving
 			header( 'Content-type: application/pdf' );

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -341,13 +341,21 @@ function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
 	$dompdf->loadHtml( $html, 'UTF-8' );
 	$dompdf->render();
 
+	$invoice = $zbs->DAL->invoices->getInvoice( $invoice_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+	// if invoice has reference number, use instead of ID
+	if ( ! empty( $invoice['id_override'] ) ) {
+		$invoice_id = $invoice['id_override'];
+	}
+
 	// normalise translated text to alphanumeric, resulting in a filename like `invoice-321.pdf`
-	$file_to_save = $temp_dir['path'] . '/' . sanitize_title( __( 'invoice', 'zero-bs-crm' ) ) . '-' . $invoice_id . '.pdf';
+	$pdf_filename = sanitize_title( __( 'invoice', 'zero-bs-crm' ) . '-' . $invoice_id ) . '.pdf';
+	$pdf_path     = $temp_dir['path'] . '/' . $pdf_filename;
 
 	// save the pdf file on the server
-	file_put_contents( $file_to_save, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+	file_put_contents( $pdf_path, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 
-	return $file_to_save;
+	return $pdf_path;
 }
 
 // LEGACY, should now be using zeroBSCRM_invoice_generateInvoiceHTML

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -278,7 +278,7 @@ function zbs_invoice_generate_pdf(){
 		}
 
 		// generate the PDF
-		$pdf_path = zeroBSCRM_generateInvoicePDFFile( $invoice_id );
+		$pdf_path = jpcrm_invoice_generate_pdf( $invoice_id );
 
 		if ( $pdf_path !== false ) {
 
@@ -303,9 +303,13 @@ function zbs_invoice_generate_pdf(){
 // This fires post ZBS init
 add_action( 'zerobscrm_post_init', 'zbs_invoice_generate_pdf' );
 
-#} V3.0 can generate invoice pdf files without sending them
-#} ... used for attaching pdf's to emails etc.
-function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
+/**
+ * Generate PDF file for an invoice
+ *
+ * @param int $invoice_id Invoice ID.
+ * @return str path to PDF file
+ */
+function jpcrm_invoice_generate_pdf( $invoice_id = -1 ) {
 
 	// brutal.
 	if ( ! zeroBSCRM_permsInvoices() ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -270,7 +270,7 @@ function zbs_invoice_generate_pdf(){
 
 		// Check ID
 		$invoice_id = -1;
-		if ( isset( $_POST['zbs_invoice_id'] ) && ! empty( $_POST['zbs_invoice_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! empty( $_POST['zbs_invoice_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$invoice_id = (int) $_POST['zbs_invoice_id']; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		}
 		if ( $invoice_id <= 0 ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -309,42 +309,39 @@ add_action('zerobscrm_post_init','zbs_invoice_generate_pdf');
 #} ... used for attaching pdf's to emails etc.
 function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
 
-    global $zbs;
+	global $zbs;
 
-    // brutal.
-    if ( !zeroBSCRM_permsInvoices() ){
-        return false;
-    }
+	// brutal.
+	if ( ! zeroBSCRM_permsInvoices() ) {
+			return false;
+	}
 
-    // If user has no perms, or id not present, die
-    if ( $invoice_id <= 0 ){
-        
-        return false;
-        
-    }
+	// If user has no perms, or id not present, die
+	if ( $invoice_id <= 0 ) {
+		return false;
+	}
 
-    // Generate html
-    $html = zeroBSCRM_invoice_generateInvoiceHTML( $invoice_id );
+	// Generate html
+	$html = zeroBSCRM_invoice_generateInvoiceHTML( $invoice_id );
 
-    // build PDF
-    $dompdf = $zbs->pdf_engine();
-    $dompdf->loadHtml( $html, 'UTF-8' );
-    $dompdf->render();
+	// build PDF
+	$dompdf = $zbs->pdf_engine();
+	$dompdf->loadHtml( $html, 'UTF-8' );
+	$dompdf->render();
 
-    $upload_dir = wp_upload_dir();        
-    $zbsInvoiceDir = $upload_dir['basedir'].'/invoices/';
+	$upload_dir  = wp_upload_dir();
+	$invoice_dir = $upload_dir['basedir'] . '/invoices/';
 
-    if ( ! file_exists( $zbsInvoiceDir ) ) {
-        wp_mkdir_p( $zbsInvoiceDir );
-    }
-    
-    $file_to_save = $zbsInvoiceDir . $invoice_id . '.pdf';
+	if ( ! file_exists( $invoice_dir ) ) {
+		wp_mkdir_p( $invoice_dir );
+	}
 
-    // save the pdf file on the server
-    file_put_contents( $file_to_save, $dompdf->output() ); 
-    
-    return $file_to_save;
+	$file_to_save = $invoice_dir . $invoice_id . '.pdf';
 
+	// save the pdf file on the server
+	file_put_contents( $file_to_save, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+	return $file_to_save;
 }
 
 // LEGACY, should now be using zeroBSCRM_invoice_generateInvoiceHTML

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -260,50 +260,55 @@ function zeroBSCRM_invoice_generatePortalInvoiceHTML_v3($invoiceID=-1,$return=tr
 
 function zbs_invoice_generate_pdf(){
 
-    global $zbs;
+	global $zbs;
 
-    #} download flag
-    if ( isset($_POST['zbs_invoicing_download_pdf'])  ) {
+	// download flag
+	if ( isset( $_POST['zbs_invoicing_download_pdf'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
-        #} THIS REALLLY needs nonces! For now (1.1.19) added this for you...
-        if (!zeroBSCRM_permsInvoices()) exit();
+		// THIS REALLLY needs nonces! For now (1.1.19) added this for you...
+		if ( ! zeroBSCRM_permsInvoices() ) {
+			exit();
+		}
 
-        #} Check ID
-        $invoiceID = -1;
-        if (isset($_POST['zbs_invoice_id']) && !empty($_POST['zbs_invoice_id'])) $invoiceID = (int)sanitize_text_field($_POST['zbs_invoice_id']);
-        if ($invoiceID <= 0) exit();
+		// Check ID
+		$invoice_id = -1;
+		if ( isset( $_POST['zbs_invoice_id'] ) && ! empty( $_POST['zbs_invoice_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$invoice_id = (int) $_POST['zbs_invoice_id']; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		}
+		if ( $invoice_id <= 0 ) {
+			exit();
+		}
 
-        // generate the PDF
-        $pdfFileLocation = zeroBSCRM_generateInvoicePDFFile($invoiceID);
+		// generate the PDF
+		$pdf_file_location = zeroBSCRM_generateInvoicePDFFile( $invoice_id );
 
-        if ($pdfFileLocation !== false){
+		if ( $pdf_file_location !== false ) {
 
-            $invoice = $zbs->DAL->invoices->getInvoice( $invoiceID );
-            $ref = $invoice[ 'id_override' ];
+			$invoice = $zbs->DAL->invoices->getInvoice( $invoice_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$ref     = $invoice['id_override'];
 
-            if ( empty( $ref ) ) {
-                $ref = $invoiceID;
-            }
+			if ( empty( $ref ) ) {
+				$ref = $invoice_id;
+			}
 
-            //print the pdf file to the screen for saving
-            header('Content-type: application/pdf');
-            header('Content-Disposition: attachment; filename="invoice-' . $ref . '.pdf"' );
-            header('Content-Transfer-Encoding: binary');
-            header('Content-Length: ' . filesize($pdfFileLocation));
-            header('Accept-Ranges: bytes');
-            readfile($pdfFileLocation);
+			// print the pdf file to the screen for saving
+			header( 'Content-type: application/pdf' );
+			header( 'Content-Disposition: attachment; filename="invoice-' . $ref . '.pdf"' );
+			header( 'Content-Transfer-Encoding: binary' );
+			header( 'Content-Length: ' . filesize( $pdf_file_location ) );
+			header( 'Accept-Ranges: bytes' );
+			readfile( $pdf_file_location ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile
 
-            //delete the PDF file once it's been read (i.e. downloaded)
-            unlink($pdfFileLocation); 
+			// delete the PDF file once it's been read (i.e. downloaded)
+			wp_delete_file( $pdf_file_location );
 
-        }
+		}
 
-        exit();
-    }
-
+		exit();
+	}
 }
-#} This fires post ZBS init
-add_action('zerobscrm_post_init','zbs_invoice_generate_pdf');
+// This fires post ZBS init
+add_action( 'zerobscrm_post_init', 'zbs_invoice_generate_pdf' );
 
 #} V3.0 can generate invoice pdf files without sending them
 #} ... used for attaching pdf's to emails etc.

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -306,8 +306,6 @@ add_action( 'zerobscrm_post_init', 'zbs_invoice_generate_pdf' );
 #} ... used for attaching pdf's to emails etc.
 function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
 
-	global $zbs;
-
 	// brutal.
 	if ( ! zeroBSCRM_permsInvoices() ) {
 		return false;
@@ -318,21 +316,10 @@ function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
 		return false;
 	}
 
-	$temp_dir = zeroBSCRM_privatisedDirCheckWorks();
-
-	// if tmp dir doesn't exist, die
-	if ( ! $temp_dir ) {
-		return false;
-	}
-
 	// Generate html
 	$html = zeroBSCRM_invoice_generateInvoiceHTML( $invoice_id );
 
-	// build PDF
-	$dompdf = $zbs->pdf_engine();
-	$dompdf->loadHtml( $html, 'UTF-8' );
-	$dompdf->render();
-
+	global $zbs;
 	$invoice = $zbs->DAL->invoices->getInvoice( $invoice_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 	// if invoice has reference number, use instead of ID
@@ -342,12 +329,9 @@ function zeroBSCRM_generateInvoicePDFFile( $invoice_id = -1 ) {
 
 	// normalise translated text to alphanumeric, resulting in a filename like `invoice-321.pdf`
 	$pdf_filename = sanitize_title( __( 'invoice', 'zero-bs-crm' ) . '-' . $invoice_id ) . '.pdf';
-	$pdf_path     = $temp_dir['path'] . '/' . $pdf_filename;
 
-	// save the pdf file on the server
-	file_put_contents( $pdf_path, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-
-	return $pdf_path;
+	// return PDF filename if successful, false if not
+	return jpcrm_generate_pdf( $html, $pdf_filename );
 }
 
 // LEGACY, should now be using zeroBSCRM_invoice_generateInvoiceHTML

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -260,8 +260,6 @@ function zeroBSCRM_invoice_generatePortalInvoiceHTML_v3($invoiceID=-1,$return=tr
 
 function zbs_invoice_generate_pdf(){
 
-	global $zbs;
-
 	// download flag
 	if ( isset( $_POST['zbs_invoicing_download_pdf'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
@@ -280,27 +278,21 @@ function zbs_invoice_generate_pdf(){
 		}
 
 		// generate the PDF
-		$pdf_file_location = zeroBSCRM_generateInvoicePDFFile( $invoice_id );
+		$pdf_path     = zeroBSCRM_generateInvoicePDFFile( $invoice_id );
+		$pdf_filename = basename( $pdf_path );
 
-		if ( $pdf_file_location !== false ) {
-
-			$invoice = $zbs->DAL->invoices->getInvoice( $invoice_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			$ref     = $invoice['id_override'];
-
-			if ( empty( $ref ) ) {
-				$ref = $invoice_id;
-			}
+		if ( $pdf_path !== false ) {
 
 			// print the pdf file to the screen for saving
 			header( 'Content-type: application/pdf' );
-			header( 'Content-Disposition: attachment; filename="invoice-' . $ref . '.pdf"' );
+			header( 'Content-Disposition: attachment; filename="' . $pdf_filename . '"' );
 			header( 'Content-Transfer-Encoding: binary' );
-			header( 'Content-Length: ' . filesize( $pdf_file_location ) );
+			header( 'Content-Length: ' . filesize( $pdf_path ) );
 			header( 'Accept-Ranges: bytes' );
-			readfile( $pdf_file_location ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile
+			readfile( $pdf_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile
 
 			// delete the PDF file once it's been read (i.e. downloaded)
-			wp_delete_file( $pdf_file_location );
+			wp_delete_file( $pdf_path );
 
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
@@ -1,5 +1,6 @@
-<?php 
-/*!
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+
+/*
  * Jetpack CRM
  * https://jetpackcrm.com
  * V1.20
@@ -9,125 +10,131 @@
  * Date: 01/11/16
  */
 
-/* ======================================================
-  Breaking Checks ( stops direct access )
-   ====================================================== */
-    if ( ! defined( 'ZEROBSCRM_PATH' ) ) exit;
-/* ======================================================
-  / Breaking Checks
-   ====================================================== */
-
+// block direct access
+if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
+	exit;
+}
 
 // This fires post CRM init
-add_action('zerobscrm_post_init','jpcrm_quote_generate_posted_pdf');
+add_action( 'zerobscrm_post_init', 'jpcrm_quote_generate_posted_pdf' );
 
-/*
+/**
  * Catches any quote PDF requests
  *
  * @returns (conditionally) pdf file
  */
-function jpcrm_quote_generate_posted_pdf(){
+function jpcrm_quote_generate_posted_pdf() {
 
-    // download flag
-    if ( isset($_POST['jpcrm_quote_download_pdf'])  ) {
+	// download flag
+	if ( isset( $_POST['jpcrm_quote_download_pdf'] ) ) {
 
-	    // Check nonce
-	    if (!wp_verify_nonce( $_POST['jpcrm_quote_pdf_gen_nonce'], 'jpcrm-quote-pdf-gen' )) exit();
+		// Check nonce
+		if ( ! wp_verify_nonce( $_POST['jpcrm_quote_pdf_gen_nonce'], 'jpcrm-quote-pdf-gen' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			exit();
+		}
 
-	    // check permissions
-	    if (!zeroBSCRM_permsQuotes()) exit();
+		// check permissions
+		if ( ! zeroBSCRM_permsQuotes() ) {
+			exit();
+		}
 
-	    global $zbs;
+		global $zbs;
 
-	    // only 3.0+
-	    if (!$zbs->isDAL3()) exit();
+		// only 3.0+
+		if ( ! $zbs->isDAL3() ) {
+			exit();
+		}
 
-        #} Check ID
-        $quoteID = -1;
-        if (isset($_POST['jpcrm_quote_id']) && !empty($_POST['jpcrm_quote_id'])) $quoteID = (int)sanitize_text_field($_POST['jpcrm_quote_id']);
-        if ($quoteID <= 0) exit();
+		// Check ID
+		$quote_id = -1;
+		if ( ! empty( $_POST['jpcrm_quote_id'] ) ) {
+			$quote_id = (int) $_POST['jpcrm_quote_id'];
+		}
+		if ( $quote_id <= 0 ) {
+			exit();
+		}
 
-        // generate the PDF
-        $pdf_file = jpcrm_quote_generate_pdf($quoteID);
+		// generate the PDF
+		$pdf_file = jpcrm_quote_generate_pdf( $quote_id );
 
-        if ($pdf_file !== false){
+		if ( $pdf_file !== false ) {
 
-            // output the PDF
-            header('Content-type: application/pdf');
-            header('Content-Disposition: attachment; filename="quote-'.$quoteID.'.pdf"');
-            header('Content-Transfer-Encoding: binary');
-            header('Content-Length: ' . filesize($pdf_file));
-            header('Accept-Ranges: bytes');
-            readfile($pdf_file);
+			// output the PDF
+			header( 'Content-type: application/pdf' );
+			header( 'Content-Disposition: attachment; filename="quote-' . $quote_id . '.pdf"' );
+			header( 'Content-Transfer-Encoding: binary' );
+			header( 'Content-Length: ' . filesize( $pdf_file ) );
+			header( 'Accept-Ranges: bytes' );
+			readfile( $pdf_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile
 
-            // delete the PDF file once it's been read (i.e. downloaded)
-            unlink($pdf_file); 
+			// delete the PDF file once it's been read (i.e. downloaded)
+			wp_delete_file( $pdf_file );
 
-        }
+		}
 
-        exit();
-    }
-
-
+		exit();
+	}
 }
 
-
-/*
+/**
  * Generate PDF file for a quote
  *
- * @param int Quote ID
- * @returns str Path to created pdf
+ * @param int $quote_id Quote ID.
+ * @return str $file_to_save path to created pdf
  */
-function jpcrm_quote_generate_pdf( $quoteID = false ){
-    
-    // got permissions?
-    if (!zeroBSCRM_permsQuotes()) return false;
+function jpcrm_quote_generate_pdf( $quote_id = false ) {
 
-	// Check ID	
-	if ($quoteID == false || $quoteID <= 0) return false;
+	// got permissions?
+	if ( ! zeroBSCRM_permsQuotes() ) {
+		return false;
+	}
 
-    // let's build a PDF
-    global $zbs;
+	// Check ID
+	if ( $quote_id === false || $quote_id <= 0 ) {
+		return false;
+	}
 
-    // Discern template and retrieve    
-    $global_quote_pdf_template = zeroBSCRM_getSetting('quote_pdf_template');
-    if ( !empty( $global_quote_pdf_template ) ){
-        $html = jpcrm_retrieve_template( $global_quote_pdf_template, false );
-    }
+	// let's build a PDF
+	global $zbs;
 
-    // fallback to default template
-    if ( !isset( $html ) || empty( $html ) ){
+	// Discern template and retrieve
+	$global_quote_pdf_template = zeroBSCRM_getSetting( 'quote_pdf_template' );
+	if ( ! empty( $global_quote_pdf_template ) ) {
+		$html = jpcrm_retrieve_template( $global_quote_pdf_template, false );
+	}
 
-        // template failed as setting potentially holds out of date (removed) template
-        // so use the default
-        $html = jpcrm_retrieve_template( 'quotes/quote-pdf.html', false );
+	// fallback to default template
+	if ( ! isset( $html ) || empty( $html ) ) {
 
-    }
+		// template failed as setting potentially holds out of date (removed) template
+		// so use the default
+		$html = jpcrm_retrieve_template( 'quotes/quote-pdf.html', false );
 
-    // load templating
-    $placeholder_templating = $zbs->get_templating();
+	}
+
+	// load templating
+	$placeholder_templating = $zbs->get_templating();
 
 	// build HTML
-    $content = zeroBS_getQuoteBuilderContent($quoteID);
-    $html   = $placeholder_templating->replace_single_placeholder( 'quote-content', $content['content'], $html );
+	$content = zeroBS_getQuoteBuilderContent( $quote_id );
+	$html    = $placeholder_templating->replace_single_placeholder( 'quote-content', $content['content'], $html );
 
-    // build PDF
-    $dompdf = $zbs->pdf_engine();
-    $dompdf->loadHtml($html,'UTF-8');
+	// build PDF
+	$dompdf = $zbs->pdf_engine();
+	$dompdf->loadHtml( $html, 'UTF-8' );
 	$dompdf->render();
 
 	// directory & target
 	$upload_dir = wp_upload_dir();
-	$pdf_dir = $upload_dir['basedir'].'/quotes/';
+	$pdf_dir    = $upload_dir['basedir'] . '/quotes/';
 
-        if ( ! file_exists( $pdf_dir ) ) {
-            wp_mkdir_p( $pdf_dir );
-        }       
-    $file_to_save = $pdf_dir.'quote-'.$quoteID.'.pdf';	
-    
+	if ( ! file_exists( $pdf_dir ) ) {
+		wp_mkdir_p( $pdf_dir );
+	}
+	$file_to_save = $pdf_dir . 'quote-' . $quote_id . '.pdf';
+
 	// save the .pdf
-	file_put_contents($file_to_save, $dompdf->output());		
+	file_put_contents( $file_to_save, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 
 	return $file_to_save;
-
 }

--- a/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
@@ -94,9 +94,6 @@ function jpcrm_quote_generate_pdf( $quote_id = false ) {
 		return false;
 	}
 
-	// let's build a PDF
-	global $zbs;
-
 	// Discern template and retrieve
 	$global_quote_pdf_template = zeroBSCRM_getSetting( 'quote_pdf_template' );
 	if ( ! empty( $global_quote_pdf_template ) ) {
@@ -104,7 +101,7 @@ function jpcrm_quote_generate_pdf( $quote_id = false ) {
 	}
 
 	// fallback to default template
-	if ( ! isset( $html ) || empty( $html ) ) {
+	if ( empty( $html ) ) {
 
 		// template failed as setting potentially holds out of date (removed) template
 		// so use the default
@@ -113,28 +110,15 @@ function jpcrm_quote_generate_pdf( $quote_id = false ) {
 	}
 
 	// load templating
+	global $zbs;
 	$placeholder_templating = $zbs->get_templating();
 
 	// build HTML
 	$content = zeroBS_getQuoteBuilderContent( $quote_id );
 	$html    = $placeholder_templating->replace_single_placeholder( 'quote-content', $content['content'], $html );
 
-	// build PDF
-	$dompdf = $zbs->pdf_engine();
-	$dompdf->loadHtml( $html, 'UTF-8' );
-	$dompdf->render();
+	$pdf_filename = 'quote-' . $quote_id . '.pdf';
 
-	// directory & target
-	$upload_dir = wp_upload_dir();
-	$pdf_dir    = $upload_dir['basedir'] . '/quotes/';
-
-	if ( ! file_exists( $pdf_dir ) ) {
-		wp_mkdir_p( $pdf_dir );
-	}
-	$file_to_save = $pdf_dir . 'quote-' . $quote_id . '.pdf';
-
-	// save the .pdf
-	file_put_contents( $file_to_save, $dompdf->output() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-
-	return $file_to_save;
+	// return PDF filename if successful, false if not
+	return jpcrm_generate_pdf( $html, $pdf_filename );
 }

--- a/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
@@ -112,7 +112,8 @@ function jpcrm_quote_generate_pdf( $quote_id = false ) {
 	$content = zeroBS_getQuoteBuilderContent( $quote_id );
 	$html    = $placeholder_templating->replace_single_placeholder( 'quote-content', $content['content'], $html );
 
-	$pdf_filename = 'quote-' . $quote_id . '.pdf';
+	// normalise translated text to alphanumeric, resulting in a filename like `quote-321.pdf`
+	$pdf_filename = sanitize_title( __( 'Quote', 'zero-bs-crm' ) . '-' . $quote_id ) . '.pdf';
 
 	// return PDF filename if successful, false if not
 	return jpcrm_generate_pdf( $html, $pdf_filename );

--- a/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
@@ -55,20 +55,21 @@ function jpcrm_quote_generate_posted_pdf() {
 		}
 
 		// generate the PDF
-		$pdf_file = jpcrm_quote_generate_pdf( $quote_id );
+		$pdf_path = jpcrm_quote_generate_pdf( $quote_id );
 
-		if ( $pdf_file !== false ) {
+		if ( $pdf_path !== false ) {
+			$pdf_filename = basename( $pdf_path );
 
 			// output the PDF
 			header( 'Content-type: application/pdf' );
-			header( 'Content-Disposition: attachment; filename="quote-' . $quote_id . '.pdf"' );
+			header( 'Content-Disposition: attachment; filename="' . $pdf_filename . '"' );
 			header( 'Content-Transfer-Encoding: binary' );
-			header( 'Content-Length: ' . filesize( $pdf_file ) );
+			header( 'Content-Length: ' . filesize( $pdf_path ) );
 			header( 'Accept-Ranges: bytes' );
-			readfile( $pdf_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile
+			readfile( $pdf_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile
 
 			// delete the PDF file once it's been read (i.e. downloaded)
-			wp_delete_file( $pdf_file );
+			wp_delete_file( $pdf_path );
 
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php
@@ -38,18 +38,12 @@ function jpcrm_quote_generate_posted_pdf() {
 			exit();
 		}
 
-		global $zbs;
-
-		// only 3.0+
-		if ( ! $zbs->isDAL3() ) {
-			exit();
-		}
-
 		// Check ID
 		$quote_id = -1;
 		if ( ! empty( $_POST['jpcrm_quote_id'] ) ) {
 			$quote_id = (int) $_POST['jpcrm_quote_id'];
 		}
+
 		if ( $quote_id <= 0 ) {
 			exit();
 		}

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -172,7 +172,6 @@
 	"projects/plugins/crm/includes/ZeroBSCRM.PluginAdminNotices.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.PluginUpdates.ImminentRelease.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.PluginUpdates.php",
-	"projects/plugins/crm/includes/ZeroBSCRM.QuoteBuilder.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.REST.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.ReWriteRules.php",
 	"projects/plugins/crm/includes/ZeroBSCRM.ScreenOptions.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#1610 -  translate object names in PDF filename

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Quote and invoice PDF filenames were inconsistent depending if they were downloaded directly or emailed as an attachment, and always included the object name in English.

This PR fixed the above, and did a fair amount of cleanup around this area, as there was a bunch of redundant code:

* There is now a generic `jpcrm_generate_pdf()` function that handles the generation of code.
* We now properly use the central `wp-content/jpcrm-storage/tmp` folder as a working dir instead of `wp-content/uploads/quotes` and wp-content/uploads/invoices`.
* The same filename is used whether emailed or downloaded directly.
* The object name is now translated in the filename.
* Invoice PDF filenames now consistently use the reference ID instead of the invoice ID if available.

Note that I also cleaned things up per coding standards, which involved updating some var and function names. Filenames are sanitised with `sanitize_title()` to ensure safe alphanumeric names.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Switch your WP install to Spanish: `/wp-admin/options-general.php`
2. Create an invoice.
3. Download the invoice PDF.
4. Email the invoice to a contact with the PDF attached.
5. Add a reference number to the invoice.
6. Download the invoice PDF.
7. Email the invoice to a contact with the PDF attached.
8. Create a quote.
9. Download the quote PDF.
10. Email the quote to a contact with the PDF attached.

In `trunk`, you'll notice the object name in the filename is in English, and there's no consistency between the filenames in invoices. Quotes were consistent but not translated.

In `fix/crm/1610-adjust_PDF_names`, the object name is translated and the filenames are consistent.