### PR TITLE
Staging Sites: Add a 'Staging' badge to wp-admin

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-staging-sites-badge
+++ b/projects/plugins/jetpack/changelog/improve-staging-sites-badge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adds a 'Staging' badge to the wp-admin nav menu when the site is a WordPress.com staging site.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -267,6 +267,11 @@
 	padding: 1px 10px;
 }
 
+.site__info > .site__badge.site__badge-staging {
+	background-color: #f0c930;
+	color: #4f3500;
+}
+
 /**
  * Inline text in a menu title
  */

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -206,6 +206,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$is_coming_soon = ( new Status() )->is_coming_soon();
 
 		$badge = '';
+
+		if ( get_option( 'wpcom_is_staging_site' ) ) {
+			$badge .= '<span class="site__badge site__badge-staging">' . esc_html__( 'Staging', 'jetpack' ) . '</span>';
+		}
+
 		if ( ( function_exists( 'site_is_private' ) && site_is_private() ) || $is_coming_soon ) {
 			$badge .= sprintf(
 				'<span class="site__badge site__badge-private">%s</span>',


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/1954

## Proposed changes:

Adds a 'Staging' badge to wp-admin when the site is a WordPress.com staging site.

<img width="443" alt="image" src="https://user-images.githubusercontent.com/36432/234416440-93fe5308-46ec-417b-aa2d-6bfc9463b357.png">

<img width="473" alt="image" src="https://user-images.githubusercontent.com/36432/234416398-20156f8b-4e52-42b2-b8e8-0b2f76c5f760.png">

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

N/A

## Testing instructions:

1. Create a new Business site, mark it as a WoA Developer Blog, and take it Atomic.
2. Install the Jetpack Beta Tester plugin and check out this branch on the site.
3. Visit `/wp-admin/` and verify no 'Staging' badge appears.
4. SSH into the site and run `wp option update wpcom_is_staging_site 1`.
5. Visit `/wp-admin/` and verify the 'Staging' badge appears as expected.