### PR TITLE
e2e tests: update test after changes to full-screen banner

### DIFF
--- a/tools/e2e-commons/pages/wp-admin/plugins.js
+++ b/tools/e2e-commons/pages/wp-admin/plugins.js
@@ -20,8 +20,9 @@ export default class PluginsPage extends WpPage {
 	}
 
 	async isFullScreenPopupShown() {
-		const fullScreenCardSelector = '.jp-connect-full__container-card';
-		const connectButtonSelector = ".jp-connect-full__button-container a[href*='register']";
+		const fullScreenCardSelector = '.jp-connection__portal-contents';
+		const connectButtonSelector =
+			".jp-connection__portal-contents button[aria-label='Set up Jetpack']";
 		const isCardVisible = await this.isElementVisible( fullScreenCardSelector );
 		const isConnectButtonVisible = await this.isElementVisible( connectButtonSelector );
 		return isCardVisible && isConnectButtonVisible;


### PR DESCRIPTION
## Proposed changes:

The selectors changed in #29566

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Is CI happy?
* https://github.com/Automattic/jetpack/actions/runs/4806027856/jobs/8553074484?pr=30297
