### PR TITLE
e2e tests: fix plan checks to handle new icons

### DIFF
--- a/tools/e2e-commons/pages/wp-admin/jetpack-my-plan.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack-my-plan.js
@@ -10,19 +10,19 @@ export default class JetpackMyPlanPage extends WpPage {
 
 	async isFree() {
 		logger.step( 'Checking if Free plan is active' );
-		const freePlanImage = ".my-plan-card__icon img[src*='free']";
+		const freePlanImage = ".my-plan-card__icon img[alt*='Jetpack Free']";
 		return await this.isElementVisible( freePlanImage );
 	}
 
 	async isComplete() {
 		logger.step( 'Checking if Complete plan is active' );
-		const premiumPlanImage = ".my-plan-card__icon img[src*='complete']";
+		const premiumPlanImage = ".my-plan-card__icon img[alt*='Jetpack Complete']";
 		return await this.isElementVisible( premiumPlanImage );
 	}
 
 	async isSecurity() {
 		logger.step( 'Checking if Security plan is active' );
-		const proPlanImage = ".my-plan-card__icon img[src*='security']";
+		const proPlanImage = ".my-plan-card__icon img[alt*='Jetpack Security']";
 		return await this.isElementVisible( proPlanImage );
 	}
 


### PR DESCRIPTION
## Proposed changes:

Let's update the tests to match the changes introduced in #30259

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1682508237776189-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Is CI happy?
