### PR TITLE
Jetpack Boost: Phase 3 of the Image guide dashboard

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/ApiMock.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/ApiMock.ts
@@ -77,12 +77,18 @@ export type ImageMeta = z.infer< typeof ImageMeta >;
 
 const imageMeta = jetpack_boost_ds.createAsyncStore( 'image_size_analysis', ImageSizeAnalysis );
 imageMeta.setSyncAction( async ( prevValue, value, signal ) => {
+	// Only the current page is writable.
+	if ( prevValue.pagination.current === value.pagination.current ) {
+		return prevValue;
+	}
+	// Send a request to the SET endpoint.
 	const fresh = await imageMeta.endpoint.SET( value, signal );
 	if ( signal.aborted ) {
 		return prevValue;
 	}
+	// Override store value without triggering another SET request.
 	imageMeta.store.override( fresh );
-	return value;
+	return fresh;
 } );
 export const imageStore = imageMeta.store;
 export const imagesAreLoading = imageMeta.pending;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/ApiMock.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/ApiMock.ts
@@ -1,7 +1,6 @@
-import { get, writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 import { z } from 'zod';
 import { jetpack_boost_ds } from '../../stores/data-sync-client';
-import { modulesState } from '../../stores/modules';
 
 const Dimensions = z.object( {
 	width: z.number(),

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/ApiMock.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/ApiMock.ts
@@ -1,6 +1,7 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import { z } from 'zod';
 import { jetpack_boost_ds } from '../../stores/data-sync-client';
+import { modulesState } from '../../stores/modules';
 
 const Dimensions = z.object( {
 	width: z.number(),
@@ -30,14 +31,24 @@ const ImageMeta = z.object( {
 	instructions: z.string(),
 } );
 
-const ImageSizeAnalysis = z.object( {
-	pagination: z.object( {
-		current: z.number().catch( 1 ),
-		total: z.number().catch( 1 ),
-	} ),
-	last_updated: z.number(),
-	images: z.array( ImageMeta ),
-} );
+const ImageSizeAnalysis = z
+	.object( {
+		pagination: z.object( {
+			current: z.number().catch( 1 ),
+			total: z.number().catch( 1 ),
+		} ),
+		last_updated: z.number(),
+		images: z.array( ImageMeta ),
+	} )
+	// Prevent fatal error when this module isn't available.
+	.catch( {
+		pagination: {
+			current: 1,
+			total: 1,
+		},
+		last_updated: 0,
+		images: [],
+	} );
 
 type CategoryState = {
 	name: string;
@@ -90,5 +101,6 @@ imageMeta.setSyncAction( async ( prevValue, value, signal ) => {
 	imageMeta.store.override( fresh );
 	return fresh;
 } );
+
 export const imageStore = imageMeta.store;
 export const imagesAreLoading = imageMeta.pending;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/ApiMock.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/ApiMock.ts
@@ -76,13 +76,13 @@ export type Dimensions = { width: number; height: number };
 export type ImageMeta = z.infer< typeof ImageMeta >;
 
 const imageMeta = jetpack_boost_ds.createAsyncStore( 'image_size_analysis', ImageSizeAnalysis );
-// imageMeta.setSyncAction( async ( prevValue, value, signal ) => {
-// 	const fresh = await imageMeta.endpoint.SET( value, signal );
-// 	if ( signal.aborted ) {
-// 		return prevValue;
-// 	}
-// 	imageMeta.store.override( fresh );
-// 	return value;
-// } );
+imageMeta.setSyncAction( async ( prevValue, value, signal ) => {
+	const fresh = await imageMeta.endpoint.SET( value, signal );
+	if ( signal.aborted ) {
+		return prevValue;
+	}
+	imageMeta.store.override( fresh );
+	return value;
+} );
 export const imageStore = imageMeta.store;
 export const imagesAreLoading = imageMeta.pending;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
@@ -4,50 +4,49 @@
 	// "-1" is replaced by "..." when rendering the pagination
 	const MORE_ICON = -1;
 
-	function slidingWindow(pages, currentPage) {
+	function slidingWindow( currentPage, maxPage ) {
 		const windowSize = 8;
 		const first = Math.max(
 			1,
-			Math.min(pages - windowSize, currentPage - Math.floor(windowSize / 2))
+			Math.min( maxPage - windowSize, currentPage - Math.floor( windowSize / 2 ) )
 		);
-		const last = Math.min(pages, first + windowSize);
+		const last = Math.min( maxPage, first + windowSize );
 
-		return new Array(last - first + 1).fill(0).map((_, i) => first + i);
+		return new Array( last - first + 1 ).fill( 0 ).map( ( _, i ) => first + i );
 	}
 
-	function generatePagination(current, total) {
+	function generatePagination( currentPage, maxPage ) {
 		const padding = 2;
-		const pagination = slidingWindow(total, current);
+		const pagination = slidingWindow( currentPage, maxPage );
 
 		// Prepend "1 ..."
-		if (pagination[pagination.length - padding] <= total - padding) {
-			pagination.splice(pagination.length - padding, padding, MORE_ICON, total);
+		if ( pagination[ pagination.length - padding ] <= maxPage - padding ) {
+			pagination.splice( pagination.length - padding, padding, MORE_ICON, maxPage );
 		}
 
 		// Append "... 99"
-		if (pagination[0] - padding >= 0) {
-			pagination.splice(0, padding, 1, MORE_ICON);
+		if ( pagination[ 0 ] - padding >= 0 ) {
+			pagination.splice( 0, padding, 1, MORE_ICON );
 		}
 
 		return pagination;
 	}
 
 	function nextPage() {
-		if (current < total) {
+		if ( current < total ) {
 			$imageStore.pagination.current += 1;
 		}
 	}
 
 	function previousPage() {
-		if (current > 1) {
+		if ( current > 1 ) {
 			$imageStore.pagination.current -= 1;
 		}
 	}
 
 	$: current = $imageStore.pagination.current;
 	$: total = $imageStore.pagination.total;
-	$: pages = generatePagination(current, total);
-
+	$: pages = generatePagination( current, total );
 </script>
 
 <div>
@@ -68,7 +67,7 @@
 				<button
 					class:current={page === current}
 					disabled={page === MORE_ICON}
-					on:click={() => ($imageStore.pagination.current = page)}
+					on:click={() => ( $imageStore.pagination.current = page )}
 				>
 					{#if page === MORE_ICON}
 						...
@@ -103,7 +102,7 @@
 	}
 	.current {
 		background-color: #000;
-		border-radius: var(--border-radius);
+		border-radius: var( --border-radius );
 		color: #fff;
 		cursor: pointer;
 		border: 0;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
@@ -67,6 +67,7 @@
 			<li>
 				<button
 					class:current={page === current}
+					disabled={page === MORE_ICON}
 					on:click={() => ($imageStore.pagination.current = page)}
 				>
 					{#if page === MORE_ICON}
@@ -117,6 +118,11 @@
 		line-height: 1;
 		font-size: 13px;
 		font-weight: 600;
+
+		&[disabled] {
+			cursor: default;
+			color: #000;
+		}
 
 		&.inactive {
 			opacity: 0.25;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
@@ -7,10 +7,7 @@
 
 	// Given a number, this creates an array of page numbers around it
 	// Returns An array of page numbers that are within given range.
-	function slidingWindow( currentPage: number, maxPage: number ): number[] {
-		// The size of the sliding window.
-		const windowSize = 8;
-
+	function slidingWindow( currentPage: number, maxPage: number, windowSize = 8 ): number[] {
 		// Calculate the first page number in the sliding window.
 		const first = Math.max(
 			1,

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
@@ -4,14 +4,24 @@
 	// "-1" is replaced by "..." when rendering the pagination
 	const MORE_ICON = -1;
 
-	function slidingWindow( currentPage, maxPage ) {
+	// Given a number, this creates an array of page numbers around it
+	// Returns An array of page numbers that are within given range.
+	function slidingWindow( currentPage: number, maxPage: number ): number[] {
+		// The size of the sliding window.
 		const windowSize = 8;
+
+		// Calculate the first page number in the sliding window.
 		const first = Math.max(
 			1,
 			Math.min( maxPage - windowSize, currentPage - Math.floor( windowSize / 2 ) )
 		);
+
+		// Calculate the last page number in the sliding window.
 		const last = Math.min( maxPage, first + windowSize );
 
+		// Create an array of page numbers in the sliding window,
+		// initialized with zeros and then replaced with actual values
+		// based on the first and last page numbers.
 		return new Array( last - first + 1 ).fill( 0 ).map( ( _, i ) => first + i );
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+	import ChevronLeft from '../../../svg/chevron-left.svg';
+	import ChevronRight from '../../../svg/chevron-right.svg';
 	import { imageStore } from '../ApiMock';
-
 	// "-1" is replaced by "..." when rendering the pagination
 	const MORE_ICON = -1;
 
@@ -61,14 +62,7 @@
 
 <div>
 	<button class="jb-chevron" class:inactive={current === 1} on:click={previousPage}>
-		<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-			<path
-				fill-rule="evenodd"
-				clip-rule="evenodd"
-				d="M6.44509 13.0045L0.98645 6.99999L6.44509 0.995483L7.555 2.00449L3.01364 6.99999L7.555 11.9955L6.44509 13.0045Z"
-				fill="#1E1E1E"
-			/>
-		</svg>
+		<ChevronLeft />
 	</button>
 
 	<ul>
@@ -90,9 +84,7 @@
 	</ul>
 
 	<button class="jb-chevron" class:inactive={current === total} on:click={nextPage}>
-		<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-			<path d="M1.5 12.5L6.5 6.99998L1.5 1.5" stroke="#1E1E1E" stroke-width="1.5" />
-		</svg>
+		<ChevronRight />
 	</button>
 </div>
 

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { imageStore } from '../ApiMock';
 
-	$: current = $imageStore.pagination.current;
-	$: total = $imageStore.pagination.total;
+	// "-1" is replaced by "..." when rendering the pagination
+	const MORE_ICON = -1;
 
 	function slidingWindow(pages, currentPage) {
 		const windowSize = 8;
@@ -17,7 +17,7 @@
 
 	function generatePagination(current, total) {
 		const padding = 2;
-		const MORE_ICON = -1;
+
 
 		const pagination = slidingWindow(total, current);
 
@@ -32,8 +32,6 @@
 		return pagination;
 	}
 
-	$: pages = generatePagination(current, total);
-
 	function nextPage() {
 		if (current < total) {
 			$imageStore.pagination.current += 1;
@@ -45,6 +43,11 @@
 			$imageStore.pagination.current -= 1;
 		}
 	}
+
+	$: current = $imageStore.pagination.current;
+	$: total = $imageStore.pagination.total;
+	$: pages = generatePagination(current, total);
+
 </script>
 
 <div>
@@ -66,7 +69,7 @@
 					class:current={page === current}
 					on:click={() => ($imageStore.pagination.current = page)}
 				>
-					{#if page === -1}
+					{#if page === MORE_ICON}
 						...
 					{:else}
 						{page}

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
@@ -17,14 +17,14 @@
 
 	function generatePagination(current, total) {
 		const padding = 2;
-
-
 		const pagination = slidingWindow(total, current);
 
+		// Prepend "1 ..."
 		if (pagination[pagination.length - padding] <= total - padding) {
 			pagination.splice(pagination.length - padding, padding, MORE_ICON, total);
 		}
 
+		// Append "... 99"
 		if (pagination[0] - padding >= 0) {
 			pagination.splice(0, padding, 1, MORE_ICON);
 		}

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Pagination.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { imageStore } from '../ApiMock';
+
+	$: current = $imageStore.pagination.current;
+	$: total = $imageStore.pagination.total;
+	$: pages = Array.from( { length: total }, ( _, i ) => i + 1 );
+
+	function nextPage() {
+		if ( current < total ) {
+			$imageStore.pagination.current += 1;
+		}
+	}
+
+	function previousPage() {
+		if ( current > 1 ) {
+			$imageStore.pagination.current -= 1;
+		}
+	}
+</script>
+
+<div>
+	<button class="jb-chevron" class:inactive={current === 1} on:click={previousPage}>
+		<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path
+				fill-rule="evenodd"
+				clip-rule="evenodd"
+				d="M6.44509 13.0045L0.98645 6.99999L6.44509 0.995483L7.555 2.00449L3.01364 6.99999L7.555 11.9955L6.44509 13.0045Z"
+				fill="#1E1E1E"
+			/>
+		</svg>
+	</button>
+
+	<ul>
+		{#each pages as page}
+			<li>
+				<button
+					class:current={page === current}
+					on:click={() => ( $imageStore.pagination.current = page )}>{page}</button
+				>
+			</li>
+		{/each}
+	</ul>
+
+	<button class="jb-chevron" class:inactive={current === total} on:click={nextPage}>
+		<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path d="M1.5 12.5L6.5 6.99998L1.5 1.5" stroke="#1E1E1E" stroke-width="1.5" />
+		</svg>
+	</button>
+</div>
+
+<style lang="scss">
+	div {
+		padding: 48px;
+	}
+	div,
+	ul {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+	li {
+		list-style-type: none;
+		margin: 0;
+	}
+	.current {
+		background-color: #000;
+		border-radius: var( --border-radius );
+		color: #fff;
+		cursor: pointer;
+		border: 0;
+	}
+
+	button {
+		background-color: transparent;
+		border: 0;
+		cursor: pointer;
+		padding: 7px 12px;
+		aspect-ratio: 1;
+		line-height: 1;
+		font-size: 13px;
+		font-weight: 600;
+
+		&.inactive {
+			opacity: 0.25;
+			cursor: not-allowed;
+		}
+	}
+</style>

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Table.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Table.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { imageStore } from '../ApiMock';
+	import { imageStore, imagesAreLoading } from '../ApiMock';
 	import TableRow from './TableRow.svelte';
 </script>
 
-<div class="jb-table">
+<div class="jb-table" class:jb-loading={$imagesAreLoading}>
 	<div class="jb-table-header recommendation-page-grid">
 		<div class="jb-table-header__image">Image</div>
 		<div class="jb-table-header__potential-size">Potential Size</div>
@@ -16,6 +16,10 @@
 </div>
 
 <style lang="scss">
+	.jb-loading {
+		filter: grayscale( 0.5 );
+		opacity: 0.5;
+	}
 	.jb-table-header {
 		font-size: 0.875rem;
 		color: var( --gray-60 );

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
@@ -5,11 +5,14 @@ import api from '../api/api';
 import { startPollingCloudStatus } from '../utils/cloud-css';
 import generateCriticalCss from '../utils/generate-critical-css';
 import { CriticalCssStateSchema } from './critical-css-state-types';
-import { client, JSONObject, suggestRegenerateDS } from './data-sync-client';
+import { jetpack_boost_ds, JSONObject, suggestRegenerateDS } from './data-sync-client';
 import { modulesState } from './modules';
 import type { CriticalCssState, Provider } from './critical-css-state-types';
 
-const stateClient = client.createAsyncStore( 'critical_css_state', CriticalCssStateSchema );
+const stateClient = jetpack_boost_ds.createAsyncStore(
+	'critical_css_state',
+	CriticalCssStateSchema
+);
 const cssStateStore = stateClient.store;
 
 export const criticalCssState = {

--- a/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
@@ -1,7 +1,7 @@
 import { initializeClient } from '@automattic/jetpack-svelte-data-sync-client';
 import { z } from 'zod';
 
-export const client = initializeClient( 'jetpack_boost_ds' );
+export const jetpack_boost_ds = initializeClient( 'jetpack_boost_ds' );
 
 /**
  * Definition for JSON types:
@@ -20,7 +20,7 @@ export const JSONSchema: z.ZodType< JSONValue > = z.lazy( () =>
 /*
  * Data Sync Stores
  */
-export const suggestRegenerateDS = client.createAsyncStore(
+export const suggestRegenerateDS = jetpack_boost_ds.createAsyncStore(
 	'critical_css_suggest_regenerate',
 	z.coerce.boolean().catch( false )
 );

--- a/projects/plugins/boost/app/assets/src/js/stores/modules.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/modules.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { client } from './data-sync-client';
+import { jetpack_boost_ds } from './data-sync-client';
 import type { SyncedStoreCallback } from '@automattic/jetpack-svelte-data-sync-client';
 
 export type Optimizations = {
@@ -15,7 +15,7 @@ const modulesStateSchema = z.record(
 );
 
 type ModulesState = z.infer< typeof modulesStateSchema >;
-const modulesStateClient = client.createAsyncStore( 'modules_state', modulesStateSchema );
+const modulesStateClient = jetpack_boost_ds.createAsyncStore( 'modules_state', modulesStateSchema );
 
 /**
  * This function creates an SyncedStoreCallback.

--- a/projects/plugins/boost/app/assets/src/js/svg/chevron-left.svg
+++ b/projects/plugins/boost/app/assets/src/js/svg/chevron-left.svg
@@ -1,0 +1,8 @@
+<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path
+		fill-rule="evenodd"
+		clip-rule="evenodd"
+		d="M6.44509 13.0045L0.98645 6.99999L6.44509 0.995483L7.555 2.00449L3.01364 6.99999L7.555 11.9955L6.44509 13.0045Z"
+		fill="#1E1E1E"
+	/>
+</svg>

--- a/projects/plugins/boost/app/assets/src/js/svg/chevron-right.svg
+++ b/projects/plugins/boost/app/assets/src/js/svg/chevron-right.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M1.5 12.5L6.5 6.99998L1.5 1.5" stroke="#1E1E1E" stroke-width="1.5" />
+</svg>

--- a/projects/plugins/boost/app/data-sync/Image_Size_Analysis_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Image_Size_Analysis_Entry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Data_Sync;
+
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
+
+class Image_Size_Analysis_Entry implements Entry_Can_Get, Entry_Can_Set {
+
+	private $page = 1;
+
+	private function get_mock_data( $page ) {
+
+		return [
+			'pagination'   => [
+				'current' => $page,
+				'total'   => 3,
+			],
+			'last_updated' => 1682419855474,
+			'images'       => jetpack_boost_mock_api( 10, $page ),
+		];
+	}
+
+	public function get() {
+		return $this->get_mock_data( $this->page );
+	}
+
+	public function set(
+		$value
+	) {
+		$this->page = $value['pagination']['current'];
+		return $this->get();
+	}
+}

--- a/projects/plugins/boost/app/data-sync/Image_Size_Analysis_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Image_Size_Analysis_Entry.php
@@ -11,14 +11,14 @@ class Image_Size_Analysis_Entry implements Entry_Can_Get, Entry_Can_Set {
 
 	private function get_mock_data( $page ) {
 
-		return [
-			'pagination'   => [
+		return array(
+			'pagination'   => array(
 				'current' => $page,
 				'total'   => 3,
-			],
+			),
 			'last_updated' => 1682419855474,
 			'images'       => jetpack_boost_mock_api( 10, $page ),
-		];
+		);
 	}
 
 	public function get() {
@@ -32,3 +32,4 @@ class Image_Size_Analysis_Entry implements Entry_Can_Get, Entry_Can_Set {
 		return $this->get();
 	}
 }
+

--- a/projects/plugins/boost/app/data-sync/Image_Size_Analysis_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Image_Size_Analysis_Entry.php
@@ -25,9 +25,7 @@ class Image_Size_Analysis_Entry implements Entry_Can_Get, Entry_Can_Set {
 		return $this->get_mock_data( $this->page );
 	}
 
-	public function set(
-		$value
-	) {
+	public function set( $value ) {
 		$this->page = $value['pagination']['current'];
 		return $this->get();
 	}

--- a/projects/plugins/boost/app/data-sync/init-image-size-analysis.php
+++ b/projects/plugins/boost/app/data-sync/init-image-size-analysis.php
@@ -1,11 +1,12 @@
 <?php
 // phpcs:ignoreFile
 // This is a temporary file only active when the flag is enabled.
-use Automattic\Jetpack\WP_JS_Data_Sync\Schema\Schema;
 
-function jetpack_boost_mock_api( $count ) {
+use Automattic\Jetpack\WP_JS_Data_Sync\Schema\Schema;
+use Automattic\Jetpack_Boost\Data_Sync\Image_Size_Analysis_Entry;
+
+function jetpack_boost_mock_api( $count, $paged = 1 ) {
 	$image_posts    = array();
-	$offset         = 0;
 	$posts_per_page = 10;
 
 	while ( count( $image_posts ) < $count ) {
@@ -13,7 +14,7 @@ function jetpack_boost_mock_api( $count ) {
 			'post_type'      => 'post',
 			'post_status'    => 'publish',
 			'posts_per_page' => $posts_per_page,
-			'offset'         => $offset,
+			'paged'          => $paged,
 			'orderby'        => 'date',
 			'order'          => 'DESC',
 		);
@@ -42,13 +43,13 @@ function jetpack_boost_mock_api( $count ) {
 				$image_meta['image']['url'] = $image_url;
 
 				// Get image dimensions.
-				list( $width, $height )                        = getimagesize( $image_url );
-				$random                                        = mt_rand( 50, 90 ) / 100;
-				$image_meta['image']['dimensions']['file']     = array(
+				list( $width, $height ) = getimagesize( $image_url );
+				$random                                              = random_int( 50, 90 ) / 100;
+				$image_meta['image']['dimensions']['file']           = array(
 					'width'  => $width,
 					'height' => $height,
 				);
-				$image_meta['image']['dimensions']['expected'] = array(
+				$image_meta['image']['dimensions']['expected']       = array(
 					'width'  => $width * $random,
 					'height' => $height * $random,
 				);
@@ -67,7 +68,7 @@ function jetpack_boost_mock_api( $count ) {
 				$image_meta['page']['url']   = $permalink;
 				$image_meta['page']['title'] = get_the_title( $post->ID );
 
-				$image_meta['device_type'] = mt_rand( 1, 2 ) === 1 ? 'phone' : 'desktop';
+				$image_meta['device_type'] = random_int( 1, 2 ) === 1 ? 'phone' : 'desktop';
 
 				$image_meta['instructions'] = 'Resize the image to the expected dimensions and compress it.';
 
@@ -75,18 +76,18 @@ function jetpack_boost_mock_api( $count ) {
 			}
 		}
 
-		$offset += $posts_per_page;
 	}
 
-	return array(
-		'last_updated' => 1682419855474,
-		'images'       => $image_posts,
-	);
+	return $image_posts;
 }
 
 $image_size_analysis = Schema::as_assoc_array(
 	array(
 		'last_updated' => Schema::as_number(),
+		'pagination'   => Schema::as_assoc_array( [
+			                                          'current' => Schema::as_number(),
+			                                          'total'   => Schema::as_number(),
+		                                          ] ),
 		'images'       => Schema::as_array(
 			Schema::as_assoc_array(
 				array(
@@ -137,6 +138,8 @@ $image_size_analysis = Schema::as_assoc_array(
 			)
 		),
 	)
-)->fallback( jetpack_boost_mock_api( 21 ) );
+);
 
-jetpack_boost_register_option( 'image_size_analysis', $image_size_analysis );
+
+$entry = new Image_Size_Analysis_Entry();
+jetpack_boost_register_option( 'image_size_analysis', $image_size_analysis, $entry );

--- a/projects/plugins/boost/app/data-sync/init-image-size-analysis.php
+++ b/projects/plugins/boost/app/data-sync/init-image-size-analysis.php
@@ -9,7 +9,7 @@ function jetpack_boost_mock_api( $count, $paged = 1 ) {
 	$image_posts    = array();
 	$posts_per_page = 10;
 
-	
+
 	while ( count( $image_posts ) < $count ) {
 		$args = array(
 			'post_type'      => 'post',
@@ -85,10 +85,12 @@ function jetpack_boost_mock_api( $count, $paged = 1 ) {
 $image_size_analysis = Schema::as_assoc_array(
 	array(
 		'last_updated' => Schema::as_number(),
-		'pagination'   => Schema::as_assoc_array( [
-			                                          'current' => Schema::as_number(),
-			                                          'total'   => Schema::as_number(),
-		                                          ] ),
+		'pagination'   => Schema::as_assoc_array(
+			[
+				'current' => Schema::as_number(),
+				'total'   => Schema::as_number(),
+			]
+		),
 		'images'       => Schema::as_array(
 			Schema::as_assoc_array(
 				array(

--- a/projects/plugins/boost/app/data-sync/init-image-size-analysis.php
+++ b/projects/plugins/boost/app/data-sync/init-image-size-analysis.php
@@ -9,6 +9,7 @@ function jetpack_boost_mock_api( $count, $paged = 1 ) {
 	$image_posts    = array();
 	$posts_per_page = 10;
 
+	
 	while ( count( $image_posts ) < $count ) {
 		$args = array(
 			'post_type'      => 'post',

--- a/projects/plugins/boost/changelog/boost-update-igp-phase-3
+++ b/projects/plugins/boost/changelog/boost-update-igp-phase-3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Jetpack Boost: Add image guide pagination


### PR DESCRIPTION
This is a part of a series of pull requests to create an [image guide dashboard](https://github.com/Automattic/boost-cloud/issues/215).

## Proposed changes:
* Add Pagination
* DataSync pagination prototype

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
1. Apply patch
2. composer dump
3. `npm run dev`
4. Enable the feature using setting feature flag: `JETPACK_BOOST_IMAGE_SIZE_ANALYSIS` to true
5. Compare the UI to designs

