### PR TITLE
Remove builds on `pnpm install`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -8,3 +8,6 @@ engine-strict = true
 # No hoisting by default.
 hoist-pattern=[]
 public-hoist-pattern=[]
+
+# @automattic/jetpack-webpack-config looks for this.
+jetpack-webpack-config-resolve-conditions=jetpack:src

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3722,6 +3722,9 @@ importers:
       eslint-config-prettier:
         specifier: 8.8.0
         version: 8.8.0(eslint@8.39.0)
+      eslint-import-resolver-exports:
+        specifier: 1.0.0-beta.5
+        version: 1.0.0-beta.5(eslint-plugin-import@2.27.5)(eslint@8.39.0)
       eslint-plugin-es:
         specifier: 4.1.0
         version: 4.1.0(eslint@8.39.0)
@@ -12739,6 +12742,17 @@ packages:
       eslint: '>=7.0.0'
     dependencies:
       eslint: 8.39.0
+    dev: true
+
+  /eslint-import-resolver-exports@1.0.0-beta.5(eslint-plugin-import@2.27.5)(eslint@8.39.0):
+    resolution: {integrity: sha512-o6t0w7muUpXr7MkUVzD5igQoDfAQvTmcPp8HEAJdNF8eOuAO+yn6I/TTyMxz9ecCwzX7e02vzlkHURoScUuidg==}
+    peerDependencies:
+      eslint: '*'
+      eslint-plugin-import: '*'
+    dependencies:
+      eslint: 8.39.0
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.0)(eslint@8.39.0)
+      resolve.exports: 2.0.2
     dev: true
 
   /eslint-import-resolver-node@0.3.7:

--- a/projects/js-packages/image-guide/changelog/remove-builds-on-pnpm-install
+++ b/projects/js-packages/image-guide/changelog/remove-builds-on-pnpm-install
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Set `exports` in package.json. This will break directly requiring files from within the package in environments that respect `exports`.

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-image-guide",
-	"version": "0.2.2-alpha",
+	"version": "0.3.0-alpha",
 	"description": "Go through the dom to analyze image size on screen vs actual file size.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/image-guide/#readme",
 	"type": "module",
@@ -15,7 +15,6 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"prepare": "[ -e ./build/index.js ] || pnpm build",
 		"build": "pnpm run clean && webpack",
 		"clean": "rm -rf build/",
 		"watch": "pnpm run build && pnpm webpack watch",
@@ -34,6 +33,13 @@
 	"engines": {
 		"node": "^18.13.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	},
+	"exports": {
+		".": {
+			"jetpack:src": "./src/index.ts",
+			"types": "./build/index.d.ts",
+			"default": "./build/index.js"
+		}
 	},
 	"main": "./build/index.js",
 	"types": "./build/index.d.ts"

--- a/projects/js-packages/svelte-data-sync-client/changelog/remove-builds-on-pnpm-install
+++ b/projects/js-packages/svelte-data-sync-client/changelog/remove-builds-on-pnpm-install
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Set `exports` in package.json. This will break directly requiring files from within the package in environments that respect `exports`.

--- a/projects/js-packages/svelte-data-sync-client/package.json
+++ b/projects/js-packages/svelte-data-sync-client/package.json
@@ -16,7 +16,6 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"prepare": "[ -e ./build/index.js ] || pnpm build",
 		"build": "pnpm run clean && webpack",
 		"clean": "rm -rf build/",
 		"watch": "pnpm run build && pnpm webpack watch",
@@ -40,6 +39,13 @@
 	"engines": {
 		"node": "^18.13.0",
 		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	},
+	"exports": {
+		".": {
+			"jetpack:src": "./src/index.ts",
+			"types": "./build/index.d.ts",
+			"default": "./build/index.js"
+		}
 	},
 	"main": "./build/index.js",
 	"types": "./build/index.d.ts"

--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -119,7 +119,8 @@ This provides an instance of [css-minimizer-webpack-plugin](https://www.npmjs.co
 
 This is an object suitable for spreading some defaults into Webpack's `resolve` setting.
 
-Currently we only set `extensions` to add `.jsx`, `.ts`, and `.tsx` to Webpack's defaults.
+* For `extensions`, we add `.jsx`, `.ts`, and `.tsx` to Webpack's defaults.
+* If `npm_config_jetpack_webpack_config_resolve_conditions` is set in the environment (e.g. by setting `jetpack-webpack-config-resolve-conditions` in `.npmrc`), [`conditionNames`](https://webpack.js.org/configuration/resolve/#resolveconditionnames) will be set to add the values (comma-separated) to Webpack's defaults.
 
 #### Plugins
 

--- a/projects/js-packages/webpack-config/changelog/remove-builds-on-pnpm-install
+++ b/projects/js-packages/webpack-config/changelog/remove-builds-on-pnpm-install
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Webpack's `.resolve.conditionNames` may now be set from `.npmrc` or the corresponding environment variable.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.4.5",
+	"version": "1.5.0-alpha",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -36,6 +36,12 @@ const optimization = {
 };
 const resolve = {
 	extensions: [ '.js', '.jsx', '.ts', '.tsx', '...' ],
+	conditionNames: [
+		...( process.env.npm_config_jetpack_webpack_config_resolve_conditions
+			? process.env.npm_config_jetpack_webpack_config_resolve_conditions.split( ',' )
+			: [] ),
+		'...',
+	],
 };
 
 /****** Plugins ******/

--- a/projects/plugins/boost/changelog/remove-builds-on-pnpm-install
+++ b/projects/plugins/boost/changelog/remove-builds-on-pnpm-install
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update build to make use of `jetpack:src` in image-guide and svelte-data-sync-client
+
+

--- a/projects/plugins/boost/rollup-tsconfig.json
+++ b/projects/plugins/boost/rollup-tsconfig.json
@@ -2,6 +2,8 @@
 	"extends": "./tsconfig.json",
 	"include": [
 		"../../js-packages/components/**/*",
+		"../../js-packages/image-guide/**/*",
+		"../../js-packages/svelte-data-sync-client/**/*",
 		"app/assets/src/js/**/*",
 		"app/modules/image-guide/src/**/*"
 	],

--- a/projects/plugins/boost/rollup.config.js
+++ b/projects/plugins/boost/rollup.config.js
@@ -21,6 +21,10 @@ const cssGenPath = path.dirname(
 const production = ! process.env.ROLLUP_WATCH;
 const runServer = !! process.env.SERVE;
 
+const exportConditions = process.env.npm_config_jetpack_webpack_config_resolve_conditions
+	? process.env.npm_config_jetpack_webpack_config_resolve_conditions.split( ',' )
+	: [];
+
 // eslint-disable-next-line jsdoc/require-jsdoc
 function serve() {
 	let server;
@@ -105,6 +109,7 @@ export default [
 				browser: true,
 				preferBuiltins: false,
 				dedupe: [ 'svelte' ],
+				exportConditions,
 			} ),
 
 			commonjs(),
@@ -235,6 +240,7 @@ export default [
 				browser: true,
 				preferBuiltins: false,
 				dedupe: [ 'svelte' ],
+				exportConditions,
 			} ),
 
 			commonjs(),

--- a/tools/js-tools/eslintrc/base.js
+++ b/tools/js-tools/eslintrc/base.js
@@ -41,6 +41,19 @@ module.exports = {
 		requireConfigFile: false,
 	},
 	settings: {
+		'import/resolver': {
+			// Check package.json exports. See https://github.com/import-js/eslint-plugin-import/issues/1810.
+			[ require.resolve( 'eslint-import-resolver-exports' ) ]: {
+				extensions: [ '.js', '.jsx', '.ts', '.tsx' ],
+				conditions: process.env.npm_config_jetpack_webpack_config_resolve_conditions
+					? process.env.npm_config_jetpack_webpack_config_resolve_conditions.split( ',' )
+					: [],
+			},
+			// Check normal node file resolution.
+			node: {
+				extensions: [ '.js', '.jsx', '.ts', '.tsx' ],
+			},
+		},
 		jsdoc: {
 			preferredTypes: {
 				// Override wpcalypso, we'd rather follow jsdoc and typescript in this.

--- a/tools/js-tools/jest/config.base.js
+++ b/tools/js-tools/jest/config.base.js
@@ -2,6 +2,15 @@ const path = require( 'path' );
 
 module.exports = {
 	testEnvironment: 'jsdom',
+	testEnvironmentOptions: {
+		// Note we need to repeat the environment's default conditions here too, sigh.
+		customExportConditions: [
+			'browser',
+			...( process.env.npm_config_jetpack_webpack_config_resolve_conditions
+				? process.env.npm_config_jetpack_webpack_config_resolve_conditions.split( ',' )
+				: [] ),
+		],
+	},
 	transform: {
 		'\\.(gif|jpg|jpeg|png|svg|scss|sass|css|ttf|woff|woff2)$': path.join(
 			__dirname,

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -29,6 +29,7 @@
 		"debug": "4.3.4",
 		"eslint": "8.39.0",
 		"eslint-config-prettier": "8.8.0",
+		"eslint-import-resolver-exports": "1.0.0-beta.5",
 		"eslint-plugin-es": "4.1.0",
 		"eslint-plugin-import": "2.27.5",
 		"eslint-plugin-inclusive-language": "2.2.0",

--- a/tools/js-tools/tsconfig.base.json
+++ b/tools/js-tools/tsconfig.base.json
@@ -1,12 +1,13 @@
 {
 	"compilerOptions": {
 		"allowJs": true,
+		"customConditions": [ "jetpack:src" ],
 		"esModuleInterop": true,
 		"isolatedModules": true,
 		"jsx": "react-jsx",
 		"lib": [ "DOM", "ESNext" ],
 		"module": "esnext",
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"noEmit": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It's annoying to have to build these on `pnpm install`, and slows down the install unnecessarily if the built packages aren't going to be used. Let's fix that.

To keep the actual npmjs packages usable, we still need external users to get the built versions while getting the sources within the monorepo. package.json exports custom conditions are a way to do that: we specify a custom condition "jetpack:src" first pointing at the source index file, then "types" for the index.d.ts where appropriate, then "default" for the built index.js.

Then we have to configure tooling inside the monorepo to look for that "jetpack:src" condition:

* Webpack uses `.resolve.conditionNames`. But in case we ever publish our webpack-config package, let's avoid the problem we had with calypso-build and their "calypso:src" condition by setting an environment variable via `.npmrc` and using that instead of hard-coding 'jetpack:src'.
  * Unlike Calypso, we're not going to also set `.resolve.mainFields`. Exports are the modern way to do things like this.
* Typescript's tsc uses `.compilerOptions.customConditions`. Plus we also have to set `.compilerOptions.moduleResolution` to "bundler" for it to pay attention to exports at all (or "nodenext", but that has a lot of other side effects).
* Jest (at least for the jsdom and node environments) uses `.testEnvironmentOptions.customExportConditions`.
* Eslint's `eslint-plugin-import` needs a custom resolver (sigh).
* Rollup uses `exportConditions` in the options for `@rollup/plugin-node-resolve`.

Then, for good measure, let's also have the cli strip the "jetpack:src" from the mirror repos to make it even less likely that some external user gets confused by it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None, but p1671775119411749-slack-C01U2KGS2PQ is relevant.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a fresh checkout, run `pnpm install`. There should be no building of js-packages/image-guide or js-packages/svelte-data-sync-client anymore.
* In that same checkout, run `pnpm lint-required`. It should pass.
* In that same checkout, run `jetpack build -v plugins/boost`. It should succeed.
* Check that the CI linting job is happy.
* Check the build artifacts, the ones for image-guide and svelte-data-sync-client should not contain "jetpack:src" entries in package.json exports.