### PR TITLE
Fix array diff key warnings

### DIFF
--- a/projects/packages/forms/changelog/fix-array-diff-key-warnings
+++ b/projects/packages/forms/changelog/fix-array-diff-key-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure array is provided to array_diff_key to avoid warnings

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -371,7 +371,7 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			$status = wp_update_post(
 				array(
 					'ID'          => $post_id,
-					'post_status' => 'published',
+					'post_status' => 'publish',
 				),
 				false,
 				false

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -175,7 +175,7 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 					'entry_permalink'         => $data['all_fields']['entry_permalink'],
 					'subject'                 => $data['_feedback_subject'],
 					'fields'                  => array_diff_key(
-						$data['all_fields'],
+						empty( $data['all_fields'] ) ? array() : $data['all_fields'],
 						array(
 							'email_marketing_consent' => '',
 							'entry_title'             => '',

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -161,27 +161,29 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			function ( $response ) {
 				$data = \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::parse_fields_from_content( $response->ID );
 
+				$base_fields = array(
+					'email_marketing_consent' => '',
+					'entry_title'             => '',
+					'entry_permalink'         => '',
+					'feedback_id'             => '',
+				);
+				$all_fields  = array_merge( $base_fields, empty( $data['_feedback_all_fields'] ) ? array() : $data['_feedback_all_fields'] );
 				return array(
 					'id'                      => $response->ID,
-					'uid'                     => $data['all_fields']['feedback_id'],
+					'uid'                     => $all_fields['feedback_id'],
 					'date'                    => get_the_date( 'c', $response ),
 					'author_name'             => $data['_feedback_author'],
 					'author_email'            => $data['_feedback_author_email'],
 					'author_url'              => $data['_feedback_author_url'],
 					'author_avatar'           => empty( $data['_feedback_author_email'] ) ? '' : get_avatar_url( $data['_feedback_author_email'] ),
-					'email_marketing_consent' => $data['all_fields']['email_marketing_consent'],
+					'email_marketing_consent' => $all_fields['email_marketing_consent'],
 					'ip'                      => $data['_feedback_ip'],
-					'entry_title'             => $data['all_fields']['entry_title'],
-					'entry_permalink'         => $data['all_fields']['entry_permalink'],
+					'entry_title'             => $all_fields['entry_title'],
+					'entry_permalink'         => $all_fields['entry_permalink'],
 					'subject'                 => $data['_feedback_subject'],
 					'fields'                  => array_diff_key(
-						empty( $data['all_fields'] ) ? array() : $data['all_fields'],
-						array(
-							'email_marketing_consent' => '',
-							'entry_title'             => '',
-							'entry_permalink'         => '',
-							'feedback_id'             => '',
-						)
+						empty( $data['_feedback_all_fields'] ) ? array() : $data['_feedback_all_fields'],
+						$base_fields
 					),
 				);
 			},

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -321,9 +321,18 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 	 */
 	private function bulk_action_mark_as_spam( $post_ids ) {
 		foreach ( $post_ids as $post_id ) {
-			$post              = get_post( $post_id );
-			$post->post_status = 'spam';
-			$status            = wp_insert_post( $post );
+			$post = get_post( $post_id );
+			if ( $post->post_type !== 'feedback' ) {
+				continue;
+			}
+			$status = wp_update_post(
+				array(
+					'ID'          => $post_id,
+					'post_status' => 'spam',
+				),
+				false,
+				false
+			);
 
 			if ( ! $status || is_wp_error( $status ) ) {
 				return $this->error_response(
@@ -355,9 +364,18 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 	 */
 	private function bulk_action_mark_as_not_spam( $post_ids ) {
 		foreach ( $post_ids as $post_id ) {
-			$post              = get_post( $post_id );
-			$post->post_status = 'publish';
-			$status            = wp_insert_post( $post );
+			$post = get_post( $post_id );
+			if ( $post->post_type !== 'feedback' ) {
+				continue;
+			}
+			$status = wp_update_post(
+				array(
+					'ID'          => $post_id,
+					'post_status' => 'published',
+				),
+				false,
+				false
+			);
 
 			if ( ! $status || is_wp_error( $status ) ) {
 				return $this->error_response(

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -717,7 +717,7 @@ class Admin {
 
 		if ( empty( $response_fields ) ) {
 			$chunks = explode( "\nArray", $content );
-			if ( $chunks[1] ) {
+			if ( ! empty( $chunks[1] ) ) {
 				// re-construct the array string
 				$array = 'Array' . $chunks[1];
 				// re-construct the array

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -211,6 +211,7 @@ class Contact_Form_Plugin {
 				'map_meta_cap'          => true,
 			)
 		);
+		add_filter( 'wp_untrash_post_status', array( $this, 'untrash_feedback_status_handler' ), 10, 3 );
 
 		// Add to REST API post type allowed list.
 		add_filter( 'rest_api_allowed_post_types', array( $this, 'allow_feedback_rest_api_type' ) );
@@ -2276,5 +2277,24 @@ class Contact_Form_Plugin {
 
 			return $ret;
 		}
+	}
+
+	/**
+	 * Method untrash_feedback_status_handler
+	 * wp_untrash_post filter handler.
+	 *
+	 * @param string $current_status   The status to be set.
+	 * @param int    $post_id          The post ID.
+	 * @param string $previous_status  The previous status.
+	 */
+	public function untrash_feedback_status_handler( $current_status, $post_id, $previous_status ) {
+		$post = get_post( $post_id );
+		if ( 'feedback' !== $post->post_type ) {
+			if ( in_array( $previous_status, array( 'spam', 'publish' ), true ) ) {
+				return $previous_status;
+			}
+			return 'publish';
+		}
+		return $current_status;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2135,7 +2135,6 @@ class Contact_Form_Plugin {
 		}
 
 		$fields['_feedback_all_fields'] = $all_values;
-		$fields['all_fields']           = $all_values;
 
 		$post_fields[ $post_id ] = $fields;
 

--- a/projects/packages/forms/src/dashboard/inbox/bulk-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/bulk-actions-menu.js
@@ -98,7 +98,7 @@ const ActionsMenu = ( { currentPage, currentView, selectedResponses, setSelected
 
 			{ currentView === TABS.spam && (
 				<Button onClick={ onActionHandler( ACTIONS.markAsNotSpam ) } variant="secondary">
-					{ __( 'Remove from spam', 'jetpack-forms' ) }
+					{ __( 'Not spam', 'jetpack-forms' ) }
 				</Button>
 			) }
 

--- a/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
@@ -56,7 +56,7 @@ const SingleActionsMenu = ( { id } ) => {
 							iconPosition="left"
 							icon={ inbox }
 						>
-							{ __( 'Remove from spam', 'jetpack-forms' ) }
+							{ __( 'Not spam', 'jetpack-forms' ) }
 						</MenuItem>
 					) }
 

--- a/projects/packages/forms/src/dashboard/inbox/util.js
+++ b/projects/packages/forms/src/dashboard/inbox/util.js
@@ -13,9 +13,12 @@ export const getDisplayName = response => {
 };
 
 export const getPath = response => {
-	const url = new URL( response.entry_permalink );
-
-	return url.pathname;
+	try {
+		const url = new URL( response.entry_permalink );
+		return url.pathname;
+	} catch ( error ) {
+		return '';
+	}
 };
 
 export const formatFieldName = fieldName => {


### PR DESCRIPTION
Ensure array is provided for array_diff_key, fix status handling when untrashing.

Fixes #30304 

## Proposed changes:
This PR ensures an array is provided as argument for array_diff_key as we've been seeing warnings about it. ~The underlying cause is still TBD, couldn't reproduce.~

Marking as `spam` was unescaping content, making JSON strings not decodable. This PR changes the use of `wp_insert_post` for `wp_update_post` and canceling any after insert actions. **Should this be a concern?**

It also adds a `wp_untrash_post_status` filter handler, so untrashing a feedback sends it back to where it was before trashing. Defaults to `publish`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Submit responses to some form, make sure to use double quotes `"` and strange characters (tilde is fine, á, ê, ï, etc).
Back at inbox, move those feedbacks to/from inbox/spam/trash.

See that the feedbacks don't break (feedbacks not showing basic properties, like URL or detailed fields).
See that moving out from trash (on legacy view) doesn't turn feedbacks into `drafts` (you can trash your drafts and then untrash to see them go into the inbox)