### PR TITLE
Make the Donation Block Stipe Connect Link the Primary Color

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fix-stripe-connect-button-styles
+++ b/projects/plugins/jetpack/changelog/fix-fix-stripe-connect-button-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Make the Donation block "Connect" link the primary color

--- a/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
@@ -33,6 +33,7 @@ export default function BlockNudge( {
 						onClick={ handleClick }
 						target="_top"
 						variant="secondary"
+						className="jetpack-stripe-nudge__link"
 					>
 						{ buttonLabel }
 					</Button>,

--- a/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
@@ -16,6 +16,6 @@
 	padding: 6px;
 }
 
-..jetpack-stripe-nudge__banner span a.jetpack-stripe-nudge__link {
+.jetpack-stripe-nudge__banner span a.jetpack-stripe-nudge__link {
 	color: var( --color-primary ) !important;
 }

--- a/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
@@ -16,6 +16,6 @@
 	padding: 6px;
 }
 
-.jetpack-stripe-nudge__banner span.block-editor-warning__action a {
-	color: var( --color-primary );
+.jetpack-stripe-nudge__banner .jetpack-stripe-nudge__link {
+	color: #0675c4 !important;
 }

--- a/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
@@ -17,5 +17,5 @@
 }
 
 .jetpack-stripe-nudge__banner span a.jetpack-stripe-nudge__link {
-	color: var( --color-primary ) !important;
+	color: var( --color-primary );
 }

--- a/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
@@ -16,6 +16,6 @@
 	padding: 6px;
 }
 
-.jetpack-stripe-nudge__banner .jetpack-stripe-nudge__link {
+..jetpack-stripe-nudge__banner span a.jetpack-stripe-nudge__link {
 	color: var( --color-primary ) !important;
 }

--- a/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
@@ -17,5 +17,5 @@
 }
 
 .jetpack-stripe-nudge__banner .jetpack-stripe-nudge__link {
-	color: #0675c4 !important;
+	color: var( --color-primary ) !important;
 }

--- a/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/style.scss
@@ -15,3 +15,7 @@
 	margin-right: 16px;
 	padding: 6px;
 }
+
+.jetpack-stripe-nudge__banner span.block-editor-warning__action a {
+	color: var( --color-primary );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/30300

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make the Donation Block Stipe Connect Link the Primary Color

| Before | After |
| ------------- | ------------- |
| <img width="623" alt="Screenshot 2023-04-26 at 5 40 25 PM" src="https://user-images.githubusercontent.com/7076981/234718062-c91d320f-a4a2-4076-8abc-dc13d26f01fd.png"> | <img width="568" alt="Screenshot 2023-04-26 at 5 33 15 PM" src="https://user-images.githubusercontent.com/7076981/234717747-ac1d9804-c09f-4ce6-a4a5-a438764e2452.png"> |



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync changes to WPCOM
* Sandbox `romarioraffearn.wordpress.com`
* Go to https://wordpress.com/page/romarioraffearn.wordpress.com/242, edit the post and verify the Stripe "Connect" link is visible for both instances of the Donation block on the page

