### PR TITLE
Stats: higher contrast for dashboard stats popover

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/chart/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/chart/style.scss
@@ -365,9 +365,12 @@
 
 // Chart tooltip
 
-.dops-chart__tooltip {
+.dops-chart__tooltip.dops-chart__tooltip {
 
 	.dops-popover__inner {
+		color: var(--color-text-inverted);
+		background: var(--color-neutral-100);
+
 		width: 230px;
 		text-align: left;
 
@@ -380,7 +383,7 @@
 			li {
 				font-size: 11px;
 				text-transform: uppercase;
-				font-weight: 100;
+				font-weight: 500;
 				height: 24px;
 				letter-spacing: 0.1em;
 				border: 0;
@@ -397,7 +400,7 @@
 					text-align: right;
 					float: right;
 					min-width: 22px;
-					color: lighten( $gray, 20% );
+					color: inherit;
 				}
 
 				.label {

--- a/projects/plugins/jetpack/changelog/fix-higher-contrast-for-dashboard-stats-popover
+++ b/projects/plugins/jetpack/changelog/fix-higher-contrast-for-dashboard-stats-popover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: improved contrast for Stats chart tooltip


### PR DESCRIPTION
## Proposed changes:

- Increase font weight to 500
- Foreground color is set to white
- Background color is set to black

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p8oabR-1aA-p2#comment-7228

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
- Open on a JN site `/wp-admin/admin.php?page=jetpack#/dashboard`
- Ensure the tooltip has better contrast

<img width="804" alt="image" src="https://user-images.githubusercontent.com/1425433/234720389-e81d1c02-7bda-4dcd-a240-547d0e03e149.png">
