### PR TITLE
Dashboard: Stats bar linking to Calypso Stats for atomic sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -21,6 +21,7 @@ import {
 	isOdysseyStatsEnabled,
 	getInitialStateStatsData,
 	getDateFormat,
+	isAtomicSite,
 } from 'state/initial-state';
 import { isModuleAvailable, getModuleOverride } from 'state/modules';
 import { emptyStatsCardDismissed } from 'state/settings';
@@ -97,12 +98,13 @@ export class DashStats extends Component {
 				nestedValue: null,
 				className: 'statsChartbar',
 				data: {
-					link: isOdysseyStatsEnabled
-						? `${ props.siteAdminUrl }admin.php?page=stats#!/stats/day/${ props.siteRawUrl }?startDate=${ date }`
-						: getRedirectUrl( `calypso-stats-${ unit }`, {
-								site: props.siteRawUrl,
-								query: `startDate=${ date }`,
-						  } ),
+					link:
+						isOdysseyStatsEnabled && ! isAtomicSite
+							? `${ props.siteAdminUrl }admin.php?page=stats#!/stats/day/${ props.siteRawUrl }?startDate=${ date }`
+							: getRedirectUrl( `calypso-stats-${ unit }`, {
+									site: props.siteRawUrl,
+									query: `startDate=${ date }`,
+							  } ),
 				},
 				tooltipData: [
 					{

--- a/projects/plugins/jetpack/changelog/fix-bar-link-for-atomic-sites
+++ b/projects/plugins/jetpack/changelog/fix-bar-link-for-atomic-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: link user to Calypso for atomic sites


### PR DESCRIPTION
## Proposed changes:

The PR changes the link of the bars on dashboard to Calypso Stats for atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p8oabR-1aA-p2#comment-7229

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* This needs to be tested on Atomic  (WoA) sites
* You could test on the at test site with Jetpack beta set to the build of the PR: p8oabR-1aA-p2#comment-7229
* Ensure the bars link to Calypso Stats

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/1425433/234723583-5da1bff7-0e57-42d8-a940-361a1cae01c4.png">
