### PR TITLE
Dashboard: hide Akismet 'learn more' link for Atomic sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -17,7 +17,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { getAkismetData } from 'state/at-a-glance';
 import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
-import { getApiNonce } from 'state/initial-state';
+import { getApiNonce, isAtomicSite } from 'state/initial-state';
 import { siteHasFeature } from 'state/site';
 
 class DashAkismet extends Component {
@@ -94,7 +94,8 @@ class DashAkismet extends Component {
 				'Jetpack Anti-spam powered by Akismet. Comments and contact form submissions are checked against our global database of spam.',
 				'jetpack'
 			),
-			link: 'https://akismet.com/',
+			// Hide the action link from Atomic sites because it promotes purchase of Jetpack product
+			link: this.props.isAtomicSite ? null : 'https://akismet.com/',
 			privacyLink: 'https://automattic.com/privacy/',
 		};
 
@@ -169,7 +170,7 @@ class DashAkismet extends Component {
 				<div className="jp-dash-item__recently-activated">
 					<p className="jp-dash-item__description">
 						{ __(
-							'Jetpack and its Anti-spam currently monitor all comments on your site. Data will display here soon!',
+							'Akismet is now monitoring all comments on your site. Data will display here soon!',
 							'jetpack'
 						) }
 					</p>
@@ -265,6 +266,7 @@ export default connect(
 	state => {
 		return {
 			akismetData: getAkismetData( state ),
+			isAtomicSite: isAtomicSite( state ),
 			isOfflineMode: isOfflineMode( state ),
 			upgradeUrl: getProductDescriptionUrl( state, 'akismet' ),
 			nonce: getApiNonce( state ),

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
@@ -147,7 +147,7 @@ export class DashItem extends Component {
 				) : (
 					<Card className="jp-dash-item__card" href={ this.props.href }>
 						<div className="jp-dash-item__content">
-							{ this.props.support.link && (
+							{ this.props.support.text && (
 								<SupportInfo module={ module } { ...this.props.support } />
 							) }
 							{ this.props.children }

--- a/projects/plugins/jetpack/_inc/client/components/support-info/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-info/index.jsx
@@ -72,15 +72,17 @@ export default class SupportInfo extends Component {
 					screenReaderText={ __( 'Learn more', 'jetpack' ) }
 				>
 					{ text + ' ' }
-					<span className="jp-support-info__learn-more">
-						<ExternalLink
-							href={ link }
-							onClick={ this.trackLearnMoreClick }
-							rel="noopener noreferrer"
-						>
-							{ __( 'Learn more', 'jetpack' ) }
-						</ExternalLink>
-					</span>
+					{ link && (
+						<span className="jp-support-info__learn-more">
+							<ExternalLink
+								href={ link }
+								onClick={ this.trackLearnMoreClick }
+								rel="noopener noreferrer"
+							>
+								{ __( 'Learn more', 'jetpack' ) }
+							</ExternalLink>
+						</span>
+					) }
 					<span className="jp-support-info__privacy">
 						<ExternalLink
 							href={ privacyLink }

--- a/projects/plugins/jetpack/changelog/hide-akismet-learn-more-link-atomic
+++ b/projects/plugins/jetpack/changelog/hide-akismet-learn-more-link-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Dashboard: hide Akismet 'learn more' link for Atomic sites


### PR DESCRIPTION
## Proposed changes:
During Jetpack 12.1 testing, @ash1eygrace noted:

> The tooltip [Learn more](https://akismet.com/) flow link takes me to a page with a button that says, “Get started with Akismet”, when clicked it encourages me to buy a plan. WordPress.com includes and manages the Akismet plugin, so this is super confusing for .com users.

Ideally we would send users to either a page in the WordPress.com docs, or a dedicated section on akismet.com. In the meantime, this PR turns off the 'Learn more' link for Atomic users only.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p8oabR-1aA-p2#comment-7230

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. On a Jetpack site with an active Anti-spam subscription, navigate to `/wp-admin/admin.php?page=jetpack#/dashboard` and find the Akismet module. Click the 'info' icon and ensure the content contains a 'Learn more' link which links to akismet.com:

<img width="535" alt="Screenshot 2023-04-27 at 2 07 33 PM" src="https://user-images.githubusercontent.com/17325/234741888-c79c96ea-db66-4eb9-99f9-9c2dac4a27be.png">

2. Repeat the process using an Atomic test site by using the Jetpack Beta plugin to switch to the feature branch `hide/akismet-learn-more-link-atomic`. Ensure that the 'info' icon still works, but the 'Learn more' link is absent, like this:

<img width="509" alt="Screenshot 2023-04-27 at 2 51 07 PM" src="https://user-images.githubusercontent.com/17325/234747600-c7804fa7-9be2-4357-b818-d8a085119a27.png">


