### PR TITLE
Docs: Updating the docs/coding-guidelines.md with a deprecation example

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -26,10 +26,32 @@ When deprecating code in Jetpack (removing / renaming files, classes, functions,
 For these reasons, here are a few guidelines you can follow:
 
 - Instead of deleting files, mark them as deprecated first with `_deprecated_file`.
-- Deprecate classes, functions, and methods in the same way, while still returning its replacement if there is one.
+- Deprecate classes, [functions](https://developer.wordpress.org/reference/functions/_deprecated_function/), and methods in the same way, while still returning its replacement if there is one.
 - Deprecated code should remain in Jetpack for 6 months, so third-parties have time to find out about the deprecations and update their codebase.
 - If possible, reach out to partners who rely on deprecated code to let them know when the code will be removed, and how they can update.
 - If necessary, you can publish an update guide on developer.jetpack.com to help people update.
+
+Example usage for deprecating a function:
+
+```
+/**
+ * This is an example function.
+ *
+ * @deprecated $$next-version$$ Give an explanation about what function to use instead.
+ *
+ * @return string
+ */
+function example_function( ) {
+ 
+    if ( function_exists( '_deprecated_function' ) ) {
+        _deprecated_function( __FUNCTION__, '{plugin/package}-$$next-version$$' );
+    }
+ 
+   return 'example';
+}
+```
+
+For more information on how to use `$$next-version`, please see the [packages README](../packages/README.md#package-version-annotations) (relevant for plugins as well).
 
 ## Widgets
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -43,15 +43,13 @@ Example usage for deprecating a function:
  */
 function example_function( ) {
  
-    if ( function_exists( '_deprecated_function' ) ) {
-        _deprecated_function( __FUNCTION__, '{plugin/package}-$$next-version$$' );
-    }
+    _deprecated_function( __FUNCTION__, '{plugin/package}-$$next-version$$' );
  
    return 'example';
 }
 ```
 
-For more information on how to use `$$next-version`, please see the [packages README](../packages/README.md#package-version-annotations) (relevant for plugins as well).
+For more information on how to use `$$next-version$$`, please see the [packages README](../projects/packages/README.md#package-version-annotations) (relevant for plugins as well).
 
 ## Widgets
 


### PR DESCRIPTION
## Proposed changes:

* This PR adds an example of how to deprecate a function in the Jetpack monorepo to the coding-guidelines.md doc.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

This came up after looking into deprecations in CRM (post here - pbhBOz-3vv-p2 )

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read. You can also check the `$$next-version$$` usage by running `tools/replace-next-version-tag.sh {plugins/package} {version}` from the monorepo root, if you add an example deprecated function locally to test that out.
* Q: Should there be more information about `$$next-version$$` specifically or is the link enough - perhaps there is existing context as to why that's not covered for plugins?