### PR TITLE
Jetpack: allow disabling dismissal of full-screen banner

### DIFF
--- a/projects/plugins/jetpack/_inc/client/portals/activation-modal.jsx
+++ b/projects/plugins/jetpack/_inc/client/portals/activation-modal.jsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { connect } from 'react-redux';
 import {
+	arePreConnectionHelpersEnabled,
 	getApiRootUrl,
 	getApiNonce,
 	getRegistrationNonce,
@@ -26,7 +27,7 @@ import './activation-modal.scss';
  * @returns {React.Component} - The ActivationModal component.
  */
 const ActivationModal = props => {
-	const { apiRoot, apiNonce, pluginBaseUrl, registrationNonce } = props;
+	const { apiRoot, apiNonce, pluginBaseUrl, preConnectionHelpers, registrationNonce } = props;
 	const [ modalDismissed, setModalDismissed ] = useState( false );
 
 	const dismissModal = useCallback( () => {
@@ -62,9 +63,9 @@ const ActivationModal = props => {
 					labelledby: 'jp-action-button--button',
 				} }
 				className="jp-connection__portal-contents"
-				shouldCloseOnClickOutside={ true }
-				shouldCloseOnEsc={ true }
-				isDismissible={ true }
+				shouldCloseOnClickOutside={ ! preConnectionHelpers }
+				shouldCloseOnEsc={ ! preConnectionHelpers }
+				isDismissible={ ! preConnectionHelpers }
 				onRequestClose={ dismissModal }
 			>
 				<ConnectScreen
@@ -100,6 +101,7 @@ export default connect( state => {
 	return {
 		apiRoot: getApiRootUrl( state ),
 		apiNonce: getApiNonce( state ),
+		preConnectionHelpers: arePreConnectionHelpersEnabled( state ),
 		pluginBaseUrl: getPluginBaseUrl( state ),
 		registrationNonce: getRegistrationNonce( state ),
 	};

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -649,3 +649,13 @@ export function getJetpackCloudUrl( state, slug ) {
 export function isOdysseyStatsEnabled( state ) {
 	return !! state.jetpack.initialState.isOdysseyStatsEnabled;
 }
+
+/**
+ * Returns true if Jetpack's Pre-connection helpers are enabled.
+ *
+ * @param {object} state - Global state tree.
+ * @returns {boolean} True if pre-connection helpers are enabled.
+ */
+export function arePreConnectionHelpersEnabled( state ) {
+	return !! state.jetpack.initialState.preConnectionHelpers;
+}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -33,10 +33,12 @@ class Jetpack_Redux_State_Helper {
 	 */
 	public static function get_minimal_state() {
 		return array(
-			'pluginBaseUrl'     => plugins_url( '', JETPACK__PLUGIN_FILE ),
-			'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
-			'WP_API_root'       => esc_url_raw( rest_url() ),
-			'WP_API_nonce'      => wp_create_nonce( 'wp_rest' ),
+			'pluginBaseUrl'        => plugins_url( '', JETPACK__PLUGIN_FILE ),
+			/* This filter is documented in class.jetpack-connection-banner.php */
+			'preConnectionHelpers' => apply_filters( 'jetpack_pre_connection_prompt_helpers', false ),
+			'registrationNonce'    => wp_create_nonce( 'jetpack-registration-nonce' ),
+			'WP_API_root'          => esc_url_raw( rest_url() ),
+			'WP_API_nonce'         => wp_create_nonce( 'wp_rest' ),
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/update-full-connect-banner-support-non-dismissible
+++ b/projects/plugins/jetpack/changelog/update-full-connect-banner-support-non-dismissible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Connection banner: support existing filter to disable dismisasals.


### PR DESCRIPTION
## Proposed changes:

Follow-up from #29566

By default, anyone can dismiss the full-screen connection banner. However, in the legacy banner we had an option to remove the dismissal icon when a specific filter is set.
This commit brings that option to the new banner as well.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

1. Start by adding the following code snippet to a brand new site that is not yet connected to WordPress.com:

```php
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```

2. SSH in to the site, and run the following command:

```
wp transient set activated_jetpack true
```

3. Go to the main dashboard page (`/wp-admin/index.php`)
4. You should see the full-screen connection banner with no dismiss icon in the top right corner.
5. Now remove the code snippet you had added.
6. Run the command to create the transient again.
7. Refresh the dashboard page.
8. The full-screen connection banner should appear again, but with a dismiss icon this time.
