### PR TITLE
beta plugin: Fix markdown rendering

### DIFF
--- a/projects/plugins/beta/changelog/fix-beta-plugin-markdown-render
+++ b/projects/plugins/beta/changelog/fix-beta-plugin-markdown-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Disable HTML-style tags in the markdown renderer, the library used doesn't always handle them properly.

--- a/projects/plugins/beta/src/class-utils.php
+++ b/projects/plugins/beta/src/class-utils.php
@@ -177,6 +177,7 @@ class Utils {
 	 */
 	public static function render_markdown( Plugin $plugin, $content ) {
 		return ParsedownExt::instance()
+			->setSafeMode( true )
 			->setPRLinkFormat( "https://github.com/{$plugin->repo()}/pull/%d" )
 			->text( $content );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The markdown library we're using seems to get confused by HTML-style tags and might let some through that shouldn't be let through. Since it has a flag to disable HTML-style tags entirely, and we don't use those much in PR summaries or the relevant bundled .md files, let's set that flag to avoid the problem.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1682615499416869-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Stuff still renders at the bottom of pages like `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack`?