### PR TITLE
Repo Gardening: automatically add legacy Photon label

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-photon-legacy-label
+++ b/projects/github-actions/repo-gardening/changelog/add-photon-legacy-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the legacy Photon label for PRs that make changes to the Image CDN package.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -128,6 +128,13 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 			}
 			keywords.add( `[${ prefix }] ${ cleanName( project.groups.pname ) }` );
 
+			// The Image CDN was previously named "Photon".
+			// If we're touching that package, let's add the Photon label too
+			// so we can keep track of changes to the feature.
+			if ( keywords.has( '[Package] Image Cdn' ) ) {
+				keywords.add( 'Photon' );
+			}
+
 			// Extra labels.
 			if ( project.groups.ptype === 'github-actions' ) {
 				keywords.add( 'Actions' );


### PR DESCRIPTION
## Proposed changes:

Photon now lives on in the Image CDN package. We can use the new "[Package] Image CDN" label to look for changes to the feature, but the existing Photon label is still widely used. Let's add that legacy label to PRs that touch the package, so we can continue to use the Photon label for sorting through issues and PRs in the repo.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This is better tested in a fork of this repo. I'll add a link below:

* https://github.com/jeherve/jetpack/pull/94
