### PR TITLE
Dashboard: Fix href for stats chart click

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -50,8 +50,11 @@ export class DashStats extends Component {
 	barClick = bar => {
 		if ( bar.data.link ) {
 			analytics.tracks.recordJetpackClick( 'stats_bar' );
-			// Open the link in the same tab if the user is on a non-Atomic Jetpack site.
-			window.open( bar.data.link, this.shouldLinkToWpcomStats() ? '_blank' : '_self' );
+			// Open the link in the same tab if the user has Odyssey enabled or is on at Atomic site.
+			window.open(
+				bar.data.link,
+				this.props.isOdysseyStatsEnabled || this.props.isAtomicSite ? '_self' : '_blank'
+			);
 		}
 	};
 

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -43,12 +43,16 @@ export class DashStats extends Component {
 		};
 	}
 
-	barClick( bar ) {
+	shouldLinkToWpcomStats() {
+		return ! this.props.isOdysseyStatsEnabled || this.props.isAtomicSite;
+	}
+
+	barClick = bar => {
 		if ( bar.data.link ) {
 			analytics.tracks.recordJetpackClick( 'stats_bar' );
 			window.open( bar.data.link, '_blank' );
 		}
-	}
+	};
 
 	statsChart( unit ) {
 		const props = this.props,
@@ -391,6 +395,8 @@ export default connect(
 			: getStatsData( state ),
 		isEmptyStatsCardDismissed: emptyStatsCardDismissed( state ),
 		getModuleOverride: module_name => getModuleOverride( state, module_name ),
+		isOdysseyStatsEnabled: isOdysseyStatsEnabled( state ),
+		isAtomicSite: isAtomicSite( state ),
 	} ),
 	dispatch => ( {
 		switchView: tab => dispatch( statsSwitchTab( tab ) ),

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -50,12 +50,13 @@ export class DashStats extends Component {
 	barClick = bar => {
 		if ( bar.data.link ) {
 			analytics.tracks.recordJetpackClick( 'stats_bar' );
-			window.open( bar.data.link, '_blank' );
+			// Open the link in the same tab if the user is on a non-Atomic Jetpack site.
+			window.open( bar.data.link, this.shouldLinkToWpcomStats() ? '_blank' : '_self' );
 		}
 	};
 
 	statsChart( unit ) {
-		const props = this.props,
+		const { siteAdminUrl, siteRawUrl, statsData } = this.props,
 			s = [];
 
 		let totalViews = 0;
@@ -67,11 +68,11 @@ export class DashStats extends Component {
 			/* translators: long month/year format, such as: January, 2021. */
 			longMonthYearFormat = __( 'F Y', 'jetpack' );
 
-		if ( 'object' !== typeof props.statsData[ unit ] ) {
+		if ( 'object' !== typeof statsData[ unit ] ) {
 			return { chartData: s, totalViews: false };
 		}
 
-		forEach( props.statsData[ unit ].data, function ( v ) {
+		forEach( statsData[ unit ].data, v => {
 			const views = v[ 1 ];
 			let date = v[ 0 ],
 				chartLabel = '',
@@ -102,13 +103,12 @@ export class DashStats extends Component {
 				nestedValue: null,
 				className: 'statsChartbar',
 				data: {
-					link:
-						isOdysseyStatsEnabled && ! isAtomicSite
-							? `${ props.siteAdminUrl }admin.php?page=stats#!/stats/day/${ props.siteRawUrl }?startDate=${ date }`
-							: getRedirectUrl( `calypso-stats-${ unit }`, {
-									site: props.siteRawUrl,
-									query: `startDate=${ date }`,
-							  } ),
+					link: ! this.shouldLinkToWpcomStats()
+						? `${ siteAdminUrl }admin.php?page=stats#!/stats/day/${ siteRawUrl }?startDate=${ date }`
+						: getRedirectUrl( `calypso-stats-${ unit }`, {
+								site: siteRawUrl,
+								query: `startDate=${ date }`,
+						  } ),
 				},
 				tooltipData: [
 					{

--- a/projects/plugins/jetpack/changelog/follow-up-30322
+++ b/projects/plugins/jetpack/changelog/follow-up-30322
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: Fix href for stats chart clicks for all sites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #30322.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the incorrect conditional that was evaluating the selector function instead of the output of the selector function.
* Tweaks the click behavior to open a new window only if the target is external on non-atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p8oabR-1aA-p2#comment-7229

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On your local WordPress test site:
* Enable Odyssey Stats via `/wp-admin/admin.php?page=jetpack#/traffic?term=jetpack%20stats`.
* Go to `/wp-admin/admin.php?page=jetpack#/dashboard`.
* Click on any of the bars.
* Ensure that you've navigated to the Jetpack Stats page on wp-admin on the same window.
* Disable Odyssey Stats and repeat.
* Ensure that you've navigated to Calypso Stats page on a new window.

On an Atomic test site:
* Go to `/wp-admin/admin.php?page=jetpack#/dashboard`.
* Click on any of the bars.
* Ensure that you've navigated to Calypso Stats page on the same window.