### PR TITLE
Dashboard: Remove "Click to view" from stats tooltip

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -116,7 +116,6 @@ export class DashStats extends Component {
 						),
 						className: 'tooltip class',
 					},
-					{ label: __( 'Click to view Jetpack Stats.', 'jetpack' ) },
 				],
 			} );
 		} );

--- a/projects/plugins/jetpack/changelog/remove-dashboard-click-to-view-jetpack-stats-text
+++ b/projects/plugins/jetpack/changelog/remove-dashboard-click-to-view-jetpack-stats-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Dashboard: Remove confusing "Click to view" stats CTA


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the "Click to view Jetpack Stats" call-to-action from the tooltip shown when hovering the Jetpack Stats chart in the Jetpack Dashboard.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p8oabR-1aA-p2#comment-7229

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your site and navigate to the Jetpack Dashboard (`/wp-admin/admin.php?page=jetpack#/dashboard`).
* Hover over any bar and ensure the "Click to view Jetpack Stats." CTA is no longer shown.

<img width="330" alt="image" src="https://user-images.githubusercontent.com/4044428/234952960-3b39d516-ba38-460d-b268-fa504d5c1aa7.png">
