### PR TITLE
VideoPress: change the message when the Jetpack module is not active

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-message-when-module-is-not-connected
+++ b/projects/packages/videopress/changelog/update-videopress-fix-message-when-module-is-not-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: change the connection message when the Jetpack VideoPress module is not active

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
@@ -15,6 +15,7 @@ import type React from 'react';
 type ConnectBannerProps = {
 	isConnected: boolean;
 	isConnecting: boolean;
+	isModuleActive: boolean;
 	onConnect: () => void;
 };
 
@@ -26,6 +27,7 @@ type ConnectBannerProps = {
  */
 export default function ConnectBanner( {
 	onConnect,
+	isModuleActive,
 	isConnected,
 	isConnecting,
 }: ConnectBannerProps ): React.ReactElement {
@@ -37,6 +39,10 @@ export default function ConnectBanner( {
 	if ( isConnecting ) {
 		connectButtonText = __( 'Redirecting…', 'jetpack-videopress-pkg' );
 	}
+
+	const buttonText = ! isModuleActive
+		? __( 'Enable Jetpack module to continue using VideoPress', 'jetpack-videopress-pkg' )
+		: __( 'Connect your account to continue using VideoPress', 'jetpack-videopress-pkg' );
 
 	return (
 		<Banner
@@ -51,7 +57,7 @@ export default function ConnectBanner( {
 				</Button>
 			}
 		>
-			{ __( 'Connect your account to continue using VideoPress', 'jetpack-videopress-pkg' ) }
+			{ buttonText }
 		</Banner>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
@@ -40,9 +40,14 @@ export default function ConnectBanner( {
 		connectButtonText = __( 'Redirecting…', 'jetpack-videopress-pkg' );
 	}
 
-	const buttonText = ! isModuleActive
-		? __( 'Enable Jetpack module to continue using VideoPress', 'jetpack-videopress-pkg' )
-		: __( 'Connect your account to continue using VideoPress', 'jetpack-videopress-pkg' );
+	const connectYourAccountMessage = __(
+		'Connect your account to continue using VideoPress',
+		'jetpack-videopress-pkg'
+	);
+	const connectJetpackModuleMessage = __(
+		'Enable Jetpack module to continue using VideoPress',
+		'jetpack-videopress-pkg'
+	);
 
 	return (
 		<Banner
@@ -57,7 +62,7 @@ export default function ConnectBanner( {
 				</Button>
 			}
 		>
-			{ buttonText }
+			{ isModuleActive ? connectYourAccountMessage : connectJetpackModuleMessage }
 		</Banner>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -20,7 +20,11 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { isStandaloneActive, isVideoPressActive } from '../../../lib/connection';
+import {
+	isStandaloneActive,
+	isVideoPressActive,
+	isVideoPressModuleActive,
+} from '../../../lib/connection';
 import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
 import { usePreview } from '../../hooks/use-preview';
 import { useSyncMedia } from '../../hooks/use-sync-media';
@@ -54,6 +58,7 @@ const { myJetpackConnectUrl, jetpackVideoPressSettingUrl } = window?.videoPressE
  */
 const isStandalonePluginActive = isStandaloneActive();
 const isActive = isVideoPressActive();
+const isModuleActive = isVideoPressModuleActive();
 
 const VIDEO_PREVIEW_ATTEMPTS_LIMIT = 10;
 
@@ -356,6 +361,7 @@ export default function VideoPressEdit( {
 				<>
 					<ConnectBanner
 						isConnected={ isActive }
+						isModuleActive={ isModuleActive }
 						isConnecting={ isRedirectingToMyJetpack }
 						onConnect={ () => {
 							setIsRedirectingToMyJetpack( true );
@@ -547,6 +553,7 @@ export default function VideoPressEdit( {
 			</InspectorControls>
 
 			<ConnectBanner
+				isModuleActive={ isModuleActive }
 				isConnected={ isActive }
 				isConnecting={ isRedirectingToMyJetpack }
 				onConnect={ () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #29806

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: change the connection message when the Jetpack VideoPress module is not active

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disconnect your testing site
* Go to the block editor
* Create a VideoPress video block instance
* Confirm the block has **a message about the site connection**
* Connect the site
* Do not activate the standalone plugin
* Do not activate the VideoPress module
* Go back to the block editor
* Hard refresh
* Confirm the block **a message about the Jetpack module**
* Connect the module
* Confirm the block doesn't show any banner

**Site disconnected**

<img width="611" alt="image" src="https://user-images.githubusercontent.com/77539/234963654-f6b26f1c-512f-4c82-b19e-0642db592aa3.png">

**Connected with module not activated** 

<img width="611" alt="image" src="https://user-images.githubusercontent.com/77539/234963699-0acf97fc-6906-417f-a907-b94bc1d64ba1.png">

**Connected and module activated**

<img width="609" alt="image" src="https://user-images.githubusercontent.com/77539/234963761-e57f37ff-eac4-4b1e-93e6-8159c912e09a.png">


