### PR TITLE
My Jetpack: Keep product card action button disabled while installing standalone plugin

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -1,7 +1,13 @@
+/**
+ * External dependencies
+ */
 import { getIconBySlug } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import PropTypes from 'prop-types';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
+/**
+ * Internal dependencies
+ */
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import { useProduct } from '../../hooks/use-product';
 import ProductCard, { PRODUCT_STATUSES } from '../product-card';
@@ -12,6 +18,7 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 	const { detail, status, activate, deactivate, isFetching, installStandalonePlugin } =
 		useProduct( slug );
 	const { name, description, manageUrl, requiresUserConnection, standalonePluginInfo } = detail;
+	const [ installingStandalone, setInstallingStandalone ] = useState( false );
 
 	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
 	const navigateToAddProductPage = useMyJetpackNavigate( `add-${ slug }` );
@@ -62,9 +69,15 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 	] );
 
 	const handleInstallStandalone = useCallback( () => {
-		installStandalonePlugin().then( () => {
-			window?.location?.reload();
-		} );
+		setInstallingStandalone( true );
+
+		installStandalonePlugin()
+			.then( () => {
+				window?.location?.reload();
+			} )
+			.catch( () => {
+				setInstallingStandalone( false );
+			} );
 	}, [ installStandalonePlugin ] );
 
 	const Icon = getIconBySlug( slug );
@@ -77,6 +90,7 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 			icon={ <Icon opacity={ 0.4 } /> }
 			admin={ admin }
 			isFetching={ isFetching }
+			isInstallingStandalone={ installingStandalone }
 			onDeactivate={ deactivate }
 			slug={ slug }
 			onActivate={ handleActivate }

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
@@ -20,6 +20,7 @@ const ActionButton = ( {
 	onManage,
 	onFixConnection,
 	isFetching,
+	isInstallingStandalone,
 	className,
 	onAdd,
 } ) => {
@@ -34,9 +35,11 @@ const ActionButton = ( {
 		);
 	}
 
+	const isBusy = isFetching || isInstallingStandalone;
+
 	const buttonState = {
-		variant: ! isFetching ? 'primary' : undefined,
-		disabled: isFetching,
+		variant: ! isBusy ? 'primary' : undefined,
+		disabled: isBusy,
 		className,
 	};
 

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -116,6 +116,7 @@ const ProductCard = props => {
 		onFixConnection,
 		onManage,
 		isFetching,
+		isInstallingStandalone,
 		slug,
 		children,
 		// Menu Related
@@ -150,7 +151,7 @@ const ProductCard = props => {
 		[ styles.active ]: isActive,
 		[ styles.inactive ]: isInactive || isPurchaseRequired,
 		[ styles.error ]: isError,
-		[ styles[ 'is-fetching' ] ]: isFetching,
+		[ styles[ 'is-fetching' ] ]: isFetching || isInstallingStandalone,
 	} );
 
 	const { recordEvent } = useAnalytics();
@@ -289,6 +290,7 @@ ProductCard.propTypes = {
 	icon: PropTypes.element,
 	admin: PropTypes.bool.isRequired,
 	isFetching: PropTypes.bool,
+	isInstallingStandalone: PropTypes.bool,
 	onManage: PropTypes.func,
 	onFixConnection: PropTypes.func,
 	onActivate: PropTypes.func,
@@ -308,6 +310,7 @@ ProductCard.propTypes = {
 ProductCard.defaultProps = {
 	icon: null,
 	isFetching: false,
+	isInstallingStandalone: false,
 	onManage: () => {},
 	onFixConnection: () => {},
 	onActivate: () => {},

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-installing-state
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-installing-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Keep product card action button disabled while installing standalone plugin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30223

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a local state flag to know when a standalone plugin is installing to keep the button disabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* In any card representing a plugin that is not installed and has the actions menu, use it to install the plugin:
![2023-04-27_17-45-29](https://user-images.githubusercontent.com/8486249/234986981-fba03778-867a-4a9d-bb08-70256e9b2f84.png)
* Check that the `Manage` button is disabled until the page refresh

Before: https://github.com/Automattic/jetpack/issues/30223
After:

https://user-images.githubusercontent.com/8486249/234987296-5d379c6d-72ad-47b0-8cb3-70a8a15d1f2b.mp4




