### PR TITLE
VideoPress: enqueue iframe api when registering video block

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-enqueue-iframe-api-when-registering-block
+++ b/projects/packages/videopress/changelog/update-videopress-enqueue-iframe-api-when-registering-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: enqueue iframe api when registering video block

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -318,8 +318,7 @@ class Initializer {
 	}
 
 	/**
-	 * Register the VideoPress block editor block,
-	 * AKA "VideoPress Block v6".
+	 * Register the VideoPress video block.
 	 *
 	 * @return void
 	 */
@@ -367,6 +366,20 @@ class Initializer {
 				'textdomain' => 'jetpack-videopress-pkg',
 			)
 		);
+
+		/*
+		 * Enqueue the VideoPress Iframe API script
+		 * only when the plugin/Jetpack module is active.
+		 */
+		if ( Status::is_active() ) {
+			wp_enqueue_script(
+				self::JETPACK_VIDEOPRESS_IFRAME_API_HANDLER,
+				'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
+				array(),
+				gmdate( 'YW' ),
+				false
+			);
+		}
 
 		// Register VideoPress video block.
 		register_block_type(

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -372,13 +372,7 @@ class Initializer {
 		 * only when the plugin/Jetpack module is active.
 		 */
 		if ( Status::is_active() ) {
-			wp_enqueue_script(
-				self::JETPACK_VIDEOPRESS_IFRAME_API_HANDLER,
-				'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
-				array(),
-				gmdate( 'YW' ),
-				false
-			);
+			add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_videopress_iframe_api_script_in_block_editor' ), 1 );
 		}
 
 		// Register VideoPress video block.
@@ -414,5 +408,18 @@ class Initializer {
 		}
 
 		return $cache;
+	}
+
+	/**
+	 * Enqueue the VideoPress Iframe API script
+	 */
+	public static function enqueue_videopress_iframe_api_script_in_block_editor() {
+		wp_enqueue_script(
+			self::JETPACK_VIDEOPRESS_IFRAME_API_HANDLER,
+			'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js',
+			array(),
+			gmdate( 'YW' ),
+			false
+		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This pull request implements modifications to enqueue the Iframe API file in the registration of the VideoPress video block and when the standalone plugin/Jetpack module is/are activated.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: enqueue iframe api when registering video block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to ...
*

