### PR TITLE
Repo Gardening: add labels faster when possible

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-add-labels-loop
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-add-labels-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Label management: do not loop through files for labels that do not require it.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -128,13 +128,6 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 			}
 			keywords.add( `[${ prefix }] ${ cleanName( project.groups.pname ) }` );
 
-			// The Image CDN was previously named "Photon".
-			// If we're touching that package, let's add the Photon label too
-			// so we can keep track of changes to the feature.
-			if ( keywords.has( '[Package] Image Cdn' ) ) {
-				keywords.add( 'Photon' );
-			}
-
 			// Extra labels.
 			if ( project.groups.ptype === 'github-actions' ) {
 				keywords.add( 'Actions' );
@@ -249,12 +242,19 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 		if ( anyTestFile ) {
 			keywords.add( '[Tests] Includes Tests' );
 		}
-
-		// Add '[Status] In Progress' for draft PRs
-		if ( isDraft ) {
-			keywords.add( '[Status] In Progress' );
-		}
 	} );
+
+	// The Image CDN was previously named "Photon".
+	// If we're touching that package, let's add the Photon label too
+	// so we can keep track of changes to the feature.
+	if ( keywords.has( '[Package] Image Cdn' ) ) {
+		keywords.add( 'Photon' );
+	}
+
+	// Add '[Status] In Progress' for draft PRs
+	if ( isDraft ) {
+		keywords.add( '[Status] In Progress' );
+	}
 
 	return [ ...keywords ];
 }


### PR DESCRIPTION
## Proposed changes:

Some labels do not directly rely on looping through the files modified in a PR, so let's move the logic for those labels outside of the loop.

See https://github.com/Automattic/jetpack/pull/30340#pullrequestreview-1404695082

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This is better tested in a fork. Check this PR:

https://github.com/jeherve/jetpack/pull/95