### PR TITLE
Social Previews | Update Google Search preview with the latest design

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,8 +652,8 @@ importers:
         specifier: workspace:*
         version: link:../shared-extension-utils
       '@automattic/social-previews':
-        specifier: 1.1.5
-        version: 1.1.5(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.0
+        version: 2.0.0-beta.0(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@wordpress/annotations':
         specifier: 2.32.0
         version: 2.32.0(react@18.2.0)
@@ -3935,6 +3935,34 @@ packages:
       - vite
     dev: false
 
+  /@automattic/social-previews@2.0.0-beta.0(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-O0NFFaZzf3c5cJHChw/2XB+hXjEa9qUn3f5FtQWDNI5cHzT9uZe+b8Nyj1mJbMLRXbMh5zaEu/cB5B2F45FG+w==}
+    peerDependencies:
+      '@babel/runtime': ^7
+      react: ^17.0.2 || ^18
+      react-dom: ^17.0.2 || ^18
+    peerDependenciesMeta:
+      '@babel/runtime':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.21.5
+      '@emotion/react': 11.4.1(@babel/core@7.21.5)(@types/react@18.0.27)(react@18.2.0)
+      '@wordpress/components': 22.1.0(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+      '@wordpress/i18n': 4.32.0
+      classnames: 2.3.2
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/helper-module-imports'
+      - '@babel/types'
+      - '@types/react'
+      - aslemammad-vite-plugin-macro
+      - babel-plugin-macros
+      - vite
+    dev: false
+
   /@automattic/typography@1.0.0:
     resolution: {integrity: sha512-TnT+vPaNUXQYwDsPCPxhNY0d4LnOKvrb0SizUCC5iybo5sfOlX/rYalGDyz6nPQDF0EBaQwMf7qhVsflFR0cBg==}
     dev: false
@@ -6135,6 +6163,53 @@ packages:
       react: 18.2.0
     dev: true
 
+  /@motionone/animation@10.15.1:
+    resolution: {integrity: sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==}
+    dependencies:
+      '@motionone/easing': 10.15.1
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      tslib: 2.5.0
+    dev: false
+
+  /@motionone/dom@10.12.0:
+    resolution: {integrity: sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==}
+    dependencies:
+      '@motionone/animation': 10.15.1
+      '@motionone/generators': 10.15.1
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      hey-listen: 1.0.8
+      tslib: 2.5.0
+    dev: false
+
+  /@motionone/easing@10.15.1:
+    resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
+    dependencies:
+      '@motionone/utils': 10.15.1
+      tslib: 2.5.0
+    dev: false
+
+  /@motionone/generators@10.15.1:
+    resolution: {integrity: sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==}
+    dependencies:
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      tslib: 2.5.0
+    dev: false
+
+  /@motionone/types@10.15.1:
+    resolution: {integrity: sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==}
+    dev: false
+
+  /@motionone/utils@10.15.1:
+    resolution: {integrity: sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==}
+    dependencies:
+      '@motionone/types': 10.15.1
+      hey-listen: 1.0.8
+      tslib: 2.5.0
+    dev: false
+
   /@ndelangen/get-tarball@3.0.7:
     resolution: {integrity: sha512-NqGfTZIZpRFef1GoVaShSSRwDC3vde3ThtTeqFdcYd6ipKqnfEVhjK2hUeHjCQUcptyZr2TONqcloFXM+5QBrQ==}
     dependencies:
@@ -8327,6 +8402,12 @@ packages:
   /@types/range-parser@1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
 
+  /@types/react-dom@17.0.20:
+    resolution: {integrity: sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==}
+    dependencies:
+      '@types/react': 17.0.58
+    dev: false
+
   /@types/react-dom@18.0.10:
     resolution: {integrity: sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==}
     dependencies:
@@ -8346,6 +8427,14 @@ packages:
     dependencies:
       '@types/react': 18.0.27
     dev: true
+
+  /@types/react@17.0.58:
+    resolution: {integrity: sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.3
+      csstype: 3.1.2
+    dev: false
 
   /@types/react@18.0.27:
     resolution: {integrity: sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==}
@@ -9040,6 +9129,66 @@ packages:
     resolution: {integrity: sha512-ff1leg0SseDtBBxDMSTUNCS+1dbUVlQ0a0t/kUZdS3LTd9L71NGMGBA62aXFg2EVf+HT1O2I0mEASqH5fVcilg==}
     engines: {node: '>=14'}
 
+  /@wordpress/components@22.1.0(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Hi3rhfqEjXW+LSj4ibLpSrIthqUn7/fvDlxUeBUXjDwkv+kXGVVFBPw2pin/mJgBF5K90VUFJhwd92VmCZWw0Q==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: ^17.0.0
+      react-dom: ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.21.5
+      '@emotion/cache': 11.10.7
+      '@emotion/css': 11.10.6
+      '@emotion/react': 11.10.6(@types/react@18.0.27)(react@18.2.0)
+      '@emotion/serialize': 1.1.1
+      '@emotion/styled': 11.10.6(@emotion/react@11.10.6)(@types/react@18.0.27)(react@18.2.0)
+      '@emotion/utils': 1.2.0
+      '@floating-ui/react-dom': 1.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@use-gesture/react': 10.2.26(react@18.2.0)
+      '@wordpress/a11y': 3.32.0
+      '@wordpress/compose': 5.20.0(react@18.2.0)
+      '@wordpress/date': 4.32.0
+      '@wordpress/deprecated': 3.32.0
+      '@wordpress/dom': 3.32.0
+      '@wordpress/element': 4.20.0
+      '@wordpress/escape-html': 2.32.0
+      '@wordpress/hooks': 3.32.0
+      '@wordpress/i18n': 4.32.0
+      '@wordpress/icons': 9.23.0
+      '@wordpress/is-shallow-equal': 4.32.0
+      '@wordpress/keycodes': 3.32.0
+      '@wordpress/primitives': 3.30.0
+      '@wordpress/rich-text': 5.20.0(react@18.2.0)
+      '@wordpress/warning': 2.32.0
+      change-case: 4.1.2
+      classnames: 2.3.2
+      colord: 2.9.3
+      date-fns: 2.29.3
+      dom-scroll-into-view: 1.2.1
+      downshift: 6.1.12(react@18.2.0)
+      framer-motion: 6.5.1(react-dom@18.2.0)(react@18.2.0)
+      gradient-parser: 0.1.5
+      highlight-words-core: 1.2.2
+      lodash: 4.17.21
+      memize: 1.1.0
+      re-resizable: 6.9.9(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-colorful: 5.6.1(react-dom@18.2.0)(react@18.2.0)
+      react-dom: 18.2.0(react@18.2.0)
+      reakit: 1.3.11(react-dom@18.2.0)(react@18.2.0)
+      remove-accents: 0.4.4
+      use-lilius: 2.0.3(react-dom@18.2.0)(react@18.2.0)
+      uuid: 8.3.2
+      valtio: 1.7.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/helper-module-imports'
+      - '@babel/types'
+      - '@types/react'
+      - aslemammad-vite-plugin-macro
+      - babel-plugin-macros
+      - vite
+    dev: false
+
   /@wordpress/components@23.9.0(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-hEgzWe6PSWlUXPRcYX8YyQhL5Wp6TRqmzv+jIDJnYKXZH1UvsK/WcfCtdIOx7Q7oaPKDtH3vdv+0twcrHeN/bA==}
     engines: {node: '>=12'}
@@ -9168,6 +9317,27 @@ packages:
       - babel-plugin-macros
       - vite
 
+  /@wordpress/compose@5.20.0(react@18.2.0):
+    resolution: {integrity: sha512-IcmXeAIgZoJUFIO3bxBpPYfAre41H6zxQTC5N6nqhGqpISvbO1SsAIikd6B4AoSHUZmYV5UoTxk9kECqZZGVOw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.21.5
+      '@types/mousetrap': 1.6.11
+      '@wordpress/deprecated': 3.32.0
+      '@wordpress/dom': 3.32.0
+      '@wordpress/element': 4.20.0
+      '@wordpress/is-shallow-equal': 4.32.0
+      '@wordpress/keycodes': 3.32.0
+      '@wordpress/priority-queue': 2.32.0
+      change-case: 4.1.2
+      clipboard: 2.0.11
+      mousetrap: 1.6.5
+      react: 18.2.0
+      use-memo-one: 1.1.3(react@18.2.0)
+    dev: false
+
   /@wordpress/compose@6.9.0(react@18.2.0):
     resolution: {integrity: sha512-5uWC2hzhXtrBBgVsVSO5sjEt2NjgblYpPO99pD6K8zlXni0rs60cQVGcUPmOsusbQen9vJbnfYvoXPnVAbTLRw==}
     engines: {node: '>=12'}
@@ -9212,6 +9382,29 @@ packages:
       react: 18.2.0
       rememo: 4.0.2
       uuid: 8.3.2
+
+  /@wordpress/data@7.6.0(react@18.2.0):
+    resolution: {integrity: sha512-Og+oinEpJzd2rI4cFQGJBtSNzSVEa1sDWje1dYc3Jm7t2/NpkGk/YXn0PlVhkakA7YCGBy2OhX122flgZBuaBw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.21.5
+      '@wordpress/compose': 5.20.0(react@18.2.0)
+      '@wordpress/deprecated': 3.32.0
+      '@wordpress/element': 4.20.0
+      '@wordpress/is-shallow-equal': 4.32.0
+      '@wordpress/priority-queue': 2.32.0
+      '@wordpress/redux-routine': 4.32.0(redux@4.2.1)
+      equivalent-key-map: 0.2.2
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      lodash: 4.17.21
+      react: 18.2.0
+      redux: 4.2.1
+      turbo-combine-reducers: 1.0.2
+      use-memo-one: 1.1.3(react@18.2.0)
+    dev: false
 
   /@wordpress/data@9.2.0(react@18.2.0):
     resolution: {integrity: sha512-7LIklCC9zc9kG8zVQquniEnX0KLL8J5n7WWY/AWYLOHFnjKQR65mzF5KaMl6YX041oWsDGaKBKzLvWOm23KWlA==}
@@ -9480,6 +9673,20 @@ packages:
       - aslemammad-vite-plugin-macro
       - babel-plugin-macros
       - vite
+    dev: false
+
+  /@wordpress/element@4.20.0:
+    resolution: {integrity: sha512-Ou7EoGtGe4FUL6fKALINXJLKoSfyWTBJzkJfN2HzSgM1wira9EuWahl8MQN0HAUaWeOoDqMKPvnglfS+kC8JLA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@babel/runtime': 7.21.5
+      '@types/react': 17.0.58
+      '@types/react-dom': 17.0.20
+      '@wordpress/escape-html': 2.32.0
+      change-case: 4.1.2
+      is-plain-object: 5.0.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@wordpress/element@5.9.0:
@@ -9948,6 +10155,26 @@ packages:
       - aslemammad-vite-plugin-macro
       - babel-plugin-macros
       - vite
+
+  /@wordpress/rich-text@5.20.0(react@18.2.0):
+    resolution: {integrity: sha512-7W4PksJ6/SnQ+KuwvZ0dlKSwbaS6ejvWBm2N8R5S79AzbdmB69BpDCz0U/GUfGDXDhrU9dpzg5NIivoW2LC8Kg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.21.5
+      '@wordpress/a11y': 3.32.0
+      '@wordpress/compose': 5.20.0(react@18.2.0)
+      '@wordpress/data': 7.6.0(react@18.2.0)
+      '@wordpress/deprecated': 3.32.0
+      '@wordpress/element': 4.20.0
+      '@wordpress/escape-html': 2.32.0
+      '@wordpress/i18n': 4.32.0
+      '@wordpress/keycodes': 3.32.0
+      memize: 1.1.0
+      react: 18.2.0
+      rememo: 4.0.1
+    dev: false
 
   /@wordpress/rich-text@6.9.0(react@18.2.0):
     resolution: {integrity: sha512-ejMnW4YCW6/U8Z+9r/2ssHPkMa4HraLVQ/uiT/zU8MgwL5kiOUXX/DSIRzhhZh58031Bf18pIgxeHDQUJGIshw==}
@@ -10601,7 +10828,7 @@ packages:
   /axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -13532,6 +13759,15 @@ packages:
       tabbable: 5.3.3
     dev: false
 
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -13542,6 +13778,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
+    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -13639,6 +13876,30 @@ packages:
       tslib: 2.5.0
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
+
+  /framer-motion@6.5.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==}
+    peerDependencies:
+      react: '>=16.8 || ^17.0.0 || ^18.0.0'
+      react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
+    dependencies:
+      '@motionone/dom': 10.12.0
+      framesync: 6.0.1
+      hey-listen: 1.0.8
+      popmotion: 11.0.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      style-value-types: 5.0.0
+      tslib: 2.5.0
+    optionalDependencies:
+      '@emotion/is-prop-valid': 0.8.8
+    dev: false
+
+  /framesync@6.0.1:
+    resolution: {integrity: sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==}
+    dependencies:
+      tslib: 2.5.0
+    dev: false
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -14125,6 +14386,10 @@ packages:
     dependencies:
       capital-case: 1.0.4
       tslib: 2.5.0
+
+  /hey-listen@1.0.8:
+    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
+    dev: false
 
   /highlight-words-core@1.2.2:
     resolution: {integrity: sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==}
@@ -17473,6 +17738,15 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.5
 
+  /popmotion@11.0.3:
+    resolution: {integrity: sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==}
+    dependencies:
+      framesync: 6.0.1
+      hey-listen: 1.0.8
+      style-value-types: 5.0.0
+      tslib: 2.5.0
+    dev: false
+
   /postcss-calc@8.2.4(postcss@8.4.21):
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
     peerDependencies:
@@ -18242,6 +18516,17 @@ packages:
       - supports-color
     dev: true
 
+  /react-dom@17.0.2(react@17.0.2):
+    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
+    peerDependencies:
+      react: 17.0.2
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react: 17.0.2
+      scheduler: 0.20.2
+    dev: false
+
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
@@ -18516,7 +18801,6 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-    dev: true
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -19336,6 +19620,13 @@ packages:
     dependencies:
       xmlchars: 2.2.0
 
+  /scheduler@0.20.2:
+    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+    dev: false
+
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
@@ -19984,6 +20275,13 @@ packages:
     dependencies:
       webpack: 5.76.0(webpack-cli@4.9.1)
     dev: true
+
+  /style-value-types@5.0.0:
+    resolution: {integrity: sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==}
+    dependencies:
+      hey-listen: 1.0.8
+      tslib: 2.5.0
+    dev: false
 
   /stylehacks@6.0.0(postcss@8.4.21):
     resolution: {integrity: sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,8 +652,8 @@ importers:
         specifier: workspace:*
         version: link:../shared-extension-utils
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.1
-        version: 2.0.0-beta.1(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.2
+        version: 2.0.0-beta.2(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@wordpress/annotations':
         specifier: 2.32.0
         version: 2.32.0(react@18.2.0)
@@ -2687,8 +2687,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.1
-        version: 2.0.0-beta.1(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.2
+        version: 2.0.0-beta.2(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@automattic/viewport':
         specifier: 1.0.0
         version: 1.0.0
@@ -3905,8 +3905,8 @@ packages:
       '@automattic/popup-monitor': 1.0.2
     dev: false
 
-  /@automattic/social-previews@2.0.0-beta.1(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-6+bMhEFhe93RthXkwRKgrMrK180T2rljT1g8VaruoY24KsXs/ly7de3kdekdR9JQ/oH9O6LjfKM9rDSw8+Q1Hw==}
+  /@automattic/social-previews@2.0.0-beta.2(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-lsuZkTNW/58L5GuFDf8cjhXwCXkE1ZD/Fgd5ydIF86MIUQxKjsjMC3mg17m7PU7SYRnDAiHa51rxABLz+AfOpA==}
     peerDependencies:
       '@babel/runtime': ^7
       react: ^17.0.2 || ^18

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,8 +652,8 @@ importers:
         specifier: workspace:*
         version: link:../shared-extension-utils
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.0
-        version: 2.0.0-beta.0(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.1
+        version: 2.0.0-beta.1(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@wordpress/annotations':
         specifier: 2.32.0
         version: 2.32.0(react@18.2.0)
@@ -2687,8 +2687,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@automattic/social-previews':
-        specifier: 1.1.5
-        version: 1.1.5(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.1
+        version: 2.0.0-beta.1(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@automattic/viewport':
         specifier: 1.0.0
         version: 1.0.0
@@ -3905,38 +3905,8 @@ packages:
       '@automattic/popup-monitor': 1.0.2
     dev: false
 
-  /@automattic/social-previews@1.1.5(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-w0fNAeW3UC0rQ8PzOCrf+coO3ym5EAeAUh2q/ruakYK8cZCANDFjFs1dvAwB/rKL/T0WbOMI91pyouLkE5LNmw==}
-    peerDependencies:
-      '@babel/runtime': ^7
-      react: ^17.0.2 || ^18
-      react-dom: ^17.0.2 || ^18
-    peerDependenciesMeta:
-      '@babel/runtime':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.21.5
-      '@emotion/react': 11.4.1(@babel/core@7.21.5)(@types/react@18.0.27)(react@18.2.0)
-      '@wordpress/components': 23.9.0(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
-      '@wordpress/i18n': 4.32.0
-      classnames: 2.3.2
-      lodash: 4.17.21
-      moment: 2.29.4
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/helper-module-imports'
-      - '@babel/types'
-      - '@types/react'
-      - aslemammad-vite-plugin-macro
-      - babel-plugin-macros
-      - vite
-    dev: false
-
-  /@automattic/social-previews@2.0.0-beta.0(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-O0NFFaZzf3c5cJHChw/2XB+hXjEa9qUn3f5FtQWDNI5cHzT9uZe+b8Nyj1mJbMLRXbMh5zaEu/cB5B2F45FG+w==}
+  /@automattic/social-previews@2.0.0-beta.1(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-6+bMhEFhe93RthXkwRKgrMrK180T2rljT1g8VaruoY24KsXs/ly7de3kdekdR9JQ/oH9O6LjfKM9rDSw8+Q1Hw==}
     peerDependencies:
       '@babel/runtime': ^7
       react: ^17.0.2 || ^18
@@ -3953,6 +3923,7 @@ packages:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.5.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/helper-module-imports'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       '@wordpress/hooks':
         specifier: 3.32.0
         version: 3.32.0
+      '@wordpress/html-entities':
+        specifier: 3.30.0
+        version: 3.30.0
       '@wordpress/i18n':
         specifier: 4.32.0
         version: 4.32.0
@@ -9580,6 +9583,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.5
 
+  /@wordpress/html-entities@3.30.0:
+    resolution: {integrity: sha512-Hzqn4WSbL2gYBssMruMadJo9LTrupK+RQLMNO87Zx6sDADu1e4sSLrsfLVvX9hMNmDp3SQxUpt2CHWLxzlVf3g==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@babel/runtime': 7.21.5
+    dev: false
+
   /@wordpress/html-entities@3.32.0:
     resolution: {integrity: sha512-B1PK+F2pJM+0Ido9Ucti/yQxjssm4W6NtJTFcgZA6HJgyfBmRU54LRBCcBt6wCpJERpMn0bm9nFJqc0nvJSfNQ==}
     engines: {node: '>=12'}
@@ -10591,7 +10601,7 @@ packages:
   /axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2(debug@4.3.4)
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -13522,15 +13532,6 @@ packages:
       tabbable: 5.3.3
     dev: false
 
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -13541,7 +13542,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
-    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,8 +652,8 @@ importers:
         specifier: workspace:*
         version: link:../shared-extension-utils
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.2
-        version: 2.0.0-beta.2(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.3
+        version: 2.0.0-beta.3(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@wordpress/annotations':
         specifier: 2.32.0
         version: 2.32.0(react@18.2.0)
@@ -2687,8 +2687,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.2
-        version: 2.0.0-beta.2(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.3
+        version: 2.0.0-beta.3(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@automattic/viewport':
         specifier: 1.0.0
         version: 1.0.0
@@ -3905,8 +3905,8 @@ packages:
       '@automattic/popup-monitor': 1.0.2
     dev: false
 
-  /@automattic/social-previews@2.0.0-beta.2(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-lsuZkTNW/58L5GuFDf8cjhXwCXkE1ZD/Fgd5ydIF86MIUQxKjsjMC3mg17m7PU7SYRnDAiHa51rxABLz+AfOpA==}
+  /@automattic/social-previews@2.0.0-beta.3(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-lG67rwPQH16jN8xFx88wdRtKBv3CZXnRqvb32lkVNA2dQ/QzDrsy/vva2q3lZ6Nt0CLhQMmZUw/f1HqhA3+Q3Q==}
     peerDependencies:
       '@babel/runtime': ^7
       react: ^17.0.2 || ^18

--- a/projects/js-packages/components/changelog/update-social-previews-google
+++ b/projects/js-packages/components/changelog/update-social-previews-google
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed version

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.33.0",
+	"version": "0.33.1-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/publicize-components/changelog/update-social-previews-google
+++ b/projects/js-packages/publicize-components/changelog/update-social-previews-google
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated Google Search preview

--- a/projects/js-packages/publicize-components/jsconfig.json
+++ b/projects/js-packages/publicize-components/jsconfig.json
@@ -4,5 +4,5 @@
 		"jsx": "react"
 	},
 	// List all sources and source-containing subdirs.
-	"include": [ "./index.jsx", "./src" ]
+	"include": [ "./index.js", "./src" ]
 }

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -22,7 +22,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
-		"@automattic/social-previews": "2.0.0-beta.1",
+		"@automattic/social-previews": "2.0.0-beta.2",
 		"@wordpress/annotations": "2.32.0",
 		"@wordpress/api-fetch": "6.29.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -22,7 +22,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
-		"@automattic/social-previews": "^1.1.5",
+		"@automattic/social-previews": "2.0.0-beta.0",
 		"@wordpress/annotations": "2.32.0",
 		"@wordpress/api-fetch": "6.29.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -22,7 +22,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
-		"@automattic/social-previews": "2.0.0-beta.2",
+		"@automattic/social-previews": "2.0.0-beta.3",
 		"@wordpress/annotations": "2.32.0",
 		"@wordpress/api-fetch": "6.29.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.22.0",
+	"version": "0.23.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {
@@ -22,7 +22,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
-		"@automattic/social-previews": "1.1.5",
+		"@automattic/social-previews": "^1.1.5",
 		"@wordpress/annotations": "2.32.0",
 		"@wordpress/api-fetch": "6.29.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -22,7 +22,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
-		"@automattic/social-previews": "2.0.0-beta.0",
+		"@automattic/social-previews": "2.0.0-beta.1",
 		"@wordpress/annotations": "2.32.0",
 		"@wordpress/api-fetch": "6.29.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -33,6 +33,7 @@
 		"@wordpress/editor": "13.9.0",
 		"@wordpress/element": "5.9.0",
 		"@wordpress/hooks": "3.32.0",
+		"@wordpress/html-entities": "3.30.0",
 		"@wordpress/i18n": "4.32.0",
 		"@wordpress/icons": "9.23.0",
 		"@wordpress/notices": "4.0.0",

--- a/projects/js-packages/publicize-components/src/components/social-previews/constants.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/constants.js
@@ -1,5 +1,5 @@
 import { SocialServiceIcon } from '@automattic/jetpack-components';
-import { SearchPreview } from '@automattic/social-previews';
+import { GoogleSearchPreview } from '@automattic/social-previews';
 import { __ } from '@wordpress/i18n';
 import FacebookPreview from '../facebook-preview';
 import TumblrPreview from '../tumblr-preview';
@@ -11,7 +11,7 @@ export const AVAILABLE_SERVICES = [
 		title: __( 'Google Search', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="google" { ...props } />,
 		name: 'google',
-		preview: SearchPreview,
+		preview: GoogleSearchPreview,
 	},
 	{
 		title: __( 'Twitter', 'jetpack' ),

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -6,6 +6,7 @@
 
 import { Modal, TabPanel, Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { AVAILABLE_SERVICES } from './constants';
@@ -22,6 +23,7 @@ const SocialPreviewsModal = function SocialPreviewsModal( {
 	isTweetStorm,
 	tweets,
 	media,
+	siteTitle,
 } ) {
 	return (
 		<Modal
@@ -51,6 +53,7 @@ const SocialPreviewsModal = function SocialPreviewsModal( {
 							isTweetStorm={ isTweetStorm }
 							tweets={ tweets }
 							media={ media }
+							siteTitle={ siteTitle }
 						/>
 					</div>
 				) }
@@ -60,7 +63,7 @@ const SocialPreviewsModal = function SocialPreviewsModal( {
 };
 
 export default withSelect( select => {
-	const { getMedia, getUser } = select( 'core' );
+	const { getMedia, getUser, getEntityRecord } = select( 'core' );
 	const { getCurrentPost, getEditedPostAttribute } = select( 'core/editor' );
 	const { getTweetTemplate, getTweetStorm, getShareMessage, isTweetStorm } =
 		select( 'jetpack/publicize' );
@@ -82,6 +85,7 @@ export default withSelect( select => {
 		url: getEditedPostAttribute( 'link' ),
 		author: user?.name,
 		image: ( !! featuredImageId && getMediaSourceUrl( media ) ) || '',
+		siteTitle: decodeEntities( getEntityRecord( 'root', 'site' ).title ),
 	};
 
 	let tweets = [];

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -1,5 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { FacebookPreview, TwitterPreview, SearchPreview } from '@automattic/social-previews';
+import { FacebookPreview, TwitterPreview, GoogleSearchPreview } from '@automattic/social-previews';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Button from 'components/button';
@@ -65,7 +65,7 @@ export const SEO = withModuleSettingsFormHelpers(
 		};
 
 		SocialPreviewGoogle = siteData => (
-			<SearchPreview
+			<GoogleSearchPreview
 				title={ siteData.title }
 				url={ siteData.url }
 				description={ siteData.frontPageMetaDescription }

--- a/projects/plugins/jetpack/changelog/update-social-previews-google
+++ b/projects/plugins/jetpack/changelog/update-social-previews-google
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+fix version

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -57,7 +57,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/request-external-access": "1.0.0",
-		"@automattic/social-previews": "1.1.5",
+		"@automattic/social-previews": "2.0.0-beta.1",
 		"@automattic/viewport": "1.0.0",
 		"@wordpress/base-styles": "4.23.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -57,7 +57,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/request-external-access": "1.0.0",
-		"@automattic/social-previews": "2.0.0-beta.1",
+		"@automattic/social-previews": "2.0.0-beta.2",
 		"@automattic/viewport": "1.0.0",
 		"@wordpress/base-styles": "4.23.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -57,7 +57,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/request-external-access": "1.0.0",
-		"@automattic/social-previews": "2.0.0-beta.2",
+		"@automattic/social-previews": "2.0.0-beta.3",
 		"@automattic/viewport": "1.0.0",
 		"@wordpress/base-styles": "4.23.0",
 		"@wordpress/block-editor": "12.0.0",


### PR DESCRIPTION
Completes 1203820933396971-as-1204281809108929/f 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the Google Search preview in the Social Previews modal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdrWKz-Ka-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

* Checkout this PR branch and run `pnpn install` in the root directory
* Checkout the latest `trunk` in calypso
* In `wp-calypso/packages/social-previews/` directory, run `pnpm link --global` to expose the package to global `node_modules` for `pnpm`
* In `jetpack/projects/js-packages/publicize-components/` directory, run `pnpm link --global @automattic/social-previews`
* In `wp-calypso` root, run `yarn` and then `yarn workspace @automattic/social-previews run build`
* In Jetpack, run `jetpack build plugins/jetpack --no-pnpm-install`
* Start writing a new post with JT site via Jetpack
* Click Jetpack icon on the top of the sidebar
* Under "Social Previews", click on "Preview"
* Confirm that the preview of Google Search is as expected
* Once you are done, run `pnpm unlink` in Jetpack


| BEFORE | AFTER |
|--------|--------|
| <img width="929" alt="Screenshot 2023-04-28 at 2 42 01 PM" src="https://user-images.githubusercontent.com/18226415/235115060-41daf655-dc13-441d-84f4-687243f8bbba.png"> | <img width="930" alt="Screenshot 2023-04-28 at 2 42 58 PM" src="https://user-images.githubusercontent.com/18226415/235115075-7311ef15-d33b-40d9-9318-91cda40d27b2.png"> |
| | <img width="930" alt="Screenshot 2023-04-28 at 2 44 18 PM" src="https://user-images.githubusercontent.com/18226415/235115261-865c8e5f-b2b6-4de2-85a9-7e5ea1edcbdc.png"> | 

