### PR TITLE
Fix issues with loading placeholders on the forms dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-loading-placeholders
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-loading-placeholders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed buggy behavior of loading placeholders in the forms dashboard.

--- a/projects/packages/forms/src/dashboard/inbox/bulk-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/bulk-actions-menu.js
@@ -62,7 +62,7 @@ const ActionsMenu = ( { currentPage, currentView, selectedResponses, setSelected
 			} );
 			await doBulkAction( selectedResponses, action );
 
-			fetchResponses(
+			await fetchResponses(
 				{
 					...query,
 					limit: RESPONSES_FETCH_LIMIT,
@@ -70,8 +70,8 @@ const ActionsMenu = ( { currentPage, currentView, selectedResponses, setSelected
 				},
 				{ append: true }
 			);
-		} finally {
-			// Prevent getting stuck in loading state if doBulkAction fails
+			setLoading( false );
+		} catch ( error ) {
 			setLoading( false );
 		}
 	};

--- a/projects/packages/forms/src/dashboard/inbox/list.js
+++ b/projects/packages/forms/src/dashboard/inbox/list.js
@@ -65,8 +65,8 @@ const InboxList = ( {
 			const numPlaceholders = totalResponses
 				? Math.min(
 						RESPONSES_FETCH_LIMIT,
-						totalResponses - responses.length - ( currentPage - 1 ) * RESPONSES_FETCH_LIMIT
-				  )
+						totalResponses - ( currentPage - 1 ) * RESPONSES_FETCH_LIMIT
+				  ) - responses.length
 				: 10;
 
 			return items.concat(

--- a/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
@@ -30,13 +30,13 @@ const SingleActionsMenu = ( { id } ) => {
 			} );
 			await doBulkAction( [ id ], action );
 
-			fetchResponses( {
+			await fetchResponses( {
 				...query,
 				limit: RESPONSES_FETCH_LIMIT,
 				offset: ( currentPage - 1 ) * RESPONSES_FETCH_LIMIT,
 			} );
-		} finally {
-			// Prevent getting stuck in loading state if doBulkAction fails
+			setLoading( false );
+		} catch ( error ) {
 			setLoading( false );
 		}
 	};

--- a/projects/packages/forms/src/dashboard/state/reducer.js
+++ b/projects/packages/forms/src/dashboard/state/reducer.js
@@ -56,7 +56,8 @@ const responses = ( state = [], action ) => {
 		action.type === RESPONSES_QUERY_SEARCH_UPDATE ||
 		action.type === RESPONSES_QUERY_STATUS_UPDATE ||
 		action.type === RESPONSES_QUERY_MONTH_UPDATE ||
-		action.type === RESPONSES_QUERY_SOURCE_UPDATE
+		action.type === RESPONSES_QUERY_SOURCE_UPDATE ||
+		action.type === RESPONSES_CURRENT_PAGE_SET
 	) {
 		return [];
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This patch fixes some minor issues introduced with #30213 that I caught while working on other bugs. Namely:

- Fixed the equation that'd still cause an incorrect number of placeholders to be shown in some cases. Particularly when there's multiple pages of responses.
- Updated the handlers for single- and bulk-action menus to ensure they wait for the `fetchResponses` action to finish before setting `loading` to `false`.
- Old responses will now be cleared immediately when changing pages which will prevent unwanted animations in this case.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

While testing you can set `RESPONSES_FETCH_LIMIT` constant to something low which will help notice the issues mentioned above.

- Go to `admin.php?page=jetpack-forms` and make sure there are multiple pages worth of responses.
- Try moving items between different tabs using bulk actions.
- You should always see the exact number of placeholders replace the items you just moved.
- When the placeholders disappear, they should immediately be replaced by responses. Previously there was a noticeable delay.
- There shouldn't be any buggy animations on the response list when switching pages.
