### PR TITLE
Fix responses endpoint returning the wrong totals when 'offset' is set

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-tab-totals
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-tab-totals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed invalid totals being reported for different tabs in the forms dashboard.

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -118,31 +118,40 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			array( 'post_status' => array( 'draft', 'publish', 'spam', 'trash' ) )
 		);
 
+		$current_query = 'inbox';
+		if ( isset( $request['status'] ) && in_array( $request['status'], array( 'spam', 'trash' ), true ) ) {
+			$current_query = $request['status'];
+		}
+
 		$query = array(
 			'inbox' => new \WP_Query(
 				array_merge(
 					$args,
-					array( 'post_status' => array( 'draft', 'publish' ) )
+					array(
+						'post_status'    => array( 'draft', 'publish' ),
+						'posts_per_page' => $current_query === 'inbox' ? $args['posts_per_page'] : -1,
+					)
 				)
 			),
 			'spam'  => new \WP_Query(
 				array_merge(
 					$args,
-					array( 'post_status' => array( 'spam' ) )
+					array(
+						'post_status'    => array( 'spam' ),
+						'posts_per_page' => $current_query === 'spam' ? $args['posts_per_page'] : -1,
+					)
 				)
 			),
 			'trash' => new \WP_Query(
 				array_merge(
 					$args,
-					array( 'post_status' => array( 'trash' ) )
+					array(
+						'post_status'    => array( 'trash' ),
+						'posts_per_page' => $current_query === 'trash' ? $args['posts_per_page'] : -1,
+					)
 				)
 			),
 		);
-
-		$current_query = 'inbox';
-		if ( isset( $request['status'] ) && in_array( $request['status'], array( 'spam', 'trash' ), true ) ) {
-			$current_query = $request['status'];
-		}
 
 		$source_ids = Contact_Form_Plugin::get_all_parent_post_ids(
 			array_diff_key( $filter_args, array( 'post_parent' => '' ) )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30332.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes an issue where incorrect totals would be reported on the tabs in the forms dashboard when the results contain more than one page and any but the first page is selected.

This was due to `offset` and `limit` properties on the API request being appended to every query, causing it to also offset the numbers for the other tabs.

By setting `posts_per_page` to `-1` for queries where we're only fetching totals, `WP_Query` will ignore the `offset` param as well and return the correct counts.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

While testing you can set `RESPONSES_FETCH_LIMIT` constant to something low which will help notice the issues mentioned above.

- Go to `/wp-admin/admin.php?page=jetpack-forms` and make sure there are multiple pages worth of responses.
- Try switching between different pages using page navigation.
- The totals on the tabs in the header should remain constant regardless of what page you're on.
