### PR TITLE
Jetpack Plugin Visual Refresh: add renew subscription link

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/product-activated/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/product-activated/index.jsx
@@ -3,11 +3,18 @@ import React from 'react';
 
 import './style.scss';
 
-const ProductActivated = () => {
+const ProductActivated = ( { type } ) => {
+	if ( type === 'product-expired' ) {
+		return (
+			<div className="jp-product-activated-label expired">
+				<span className="jp-product-expired-label__text">{ __( 'Expired', 'jetpack' ) }</span>
+			</div>
+		);
+	}
 	return (
 		<div className="jp-product-activated-label">
 			<span className="jp-product-activated-label__text">
-				{ __( 'Subscription activated', 'jetpack' ) }
+				{ __( 'Subscription active', 'jetpack' ) }
 			</span>
 		</div>
 	);

--- a/projects/plugins/jetpack/_inc/client/components/product-activated/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/product-activated/style.scss
@@ -7,6 +7,14 @@
 	color: $green-primary;
 	padding: 0 0 8px 0;
 
+  	&.expired {
+	  color: $alert-red;
+
+	  ::before {
+	    background: $alert-red;
+	  }
+	}
+
   	::before {
 	  content: "";
 	  display: inline-block;

--- a/projects/plugins/jetpack/_inc/client/components/product-expiration/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/product-expiration/index.jsx
@@ -1,4 +1,7 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { dateI18n, isInTheFuture } from '@wordpress/date';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -19,7 +22,7 @@ class ProductExpiration extends React.PureComponent {
 	};
 
 	render() {
-		const { expiryDate, purchaseDate, isRefundable, dateFormat, isGift } = this.props;
+		const { expiryDate, purchaseDate, isRefundable, dateFormat, isGift, purchaseID } = this.props;
 
 		// Return null if we don't have any dates.
 		if ( ! expiryDate && ! purchaseDate ) {
@@ -54,6 +57,7 @@ class ProductExpiration extends React.PureComponent {
 		}
 
 		const expiryDateObj = new Date( expiryDate );
+		const path = purchaseID;
 
 		// Return null if date is not parsable.
 		if ( expiryDateObj.toString() === 'Invalid Date' ) {
@@ -62,10 +66,25 @@ class ProductExpiration extends React.PureComponent {
 
 		// If the expiry date is in the past, show the expiration date.
 		if ( ! isInTheFuture( expiryDateObj ) ) {
-			return sprintf(
-				/* translators: placeholder is a date. */
-				__( 'Expired on %s.', 'jetpack' ),
-				dateI18n( dateFormat, expiryDateObj )
+			return createInterpolateElement(
+				sprintf(
+					/* translators: %d is a count of how many new (unread) recommendations are available. */
+					__( '<span>Expired on %s.</span> <renewLink />', 'jetpack' ),
+					dateI18n( dateFormat, expiryDateObj )
+				),
+				{
+					span: <span className="my-plan-card__expired" />,
+					renewLink: (
+						<span className={ 'my-plan-card__renew' }>
+							<ExternalLink
+								href={ getRedirectUrl( 'jetpack-subscription-renew', { path } ) }
+								className="my-plan-card__renew"
+							>
+								{ __( 'Renew subscription', 'jetpack' ) }
+							</ExternalLink>
+						</span>
+					),
+				}
 			);
 		}
 

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-card/style.scss
@@ -126,6 +126,11 @@
 .my-plan-card__details {
 	padding: 8px 0 16px;
 	color: $gray-darken-10;
+  	display: contents;
+
+	@include breakpoint( '<960px' ) {
+	  display: block;
+	}
 
 	@include breakpoint( '>480px' ) {
 		white-space: nowrap;
@@ -138,13 +143,53 @@
 	&.is-error {
 		color: $alert-red;
 	}
+
+	a.my-plan-card__renew {
+	  text-decoration: underline;
+	  margin-top: 8px;
+
+	  &:hover {
+		text-decoration-thickness: 3px;
+		color: $black;
+	  }
+
+	  &:focus {
+		text-decoration-line: none;
+		border-radius: 2px;
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) black;
+		outline: 3px solid transparent;
+		color: $black;
+	  }
+
+	  &:active {
+		color: $black;
+	  }
+	}
 }
 
 .my-plan-card__action {
 	padding-top: 8px;
 	white-space: nowrap;
 
-	.has-action-only & {
-		padding-top: 0;
+	  .has-action-only & {
+		  padding-top: 0;
+	  }
+}
+
+.my-plan-card__expired {
+	color: $alert-red;
+}
+.my-plan-card__renew {
+	display: flex;
+	justify-content: flex-end;
+	color: $black;
+
+	.components-external-link__icon {
+	  align-self: center;
+	}
+
+	@include breakpoint( '<960px' ) {
+	  justify-content: flex-start;
 	}
 }
+

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -1,5 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
+import { isInTheFuture } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
@@ -62,10 +63,18 @@ class MyPlanHeader extends React.Component {
 					purchaseDate={ purchase.subscribed_date }
 					isRefundable={ purchase.is_refundable }
 					isGift={ containsGiftedPlanOrProduct( purchase.product_slug ) }
+					purchaseID={ purchase.ID }
 				/>
 			);
-
-			activation = purchase.active === '1' ? <ProductActivated key="product-activated" /> : null;
+			if ( purchase.active === '1' ) {
+				if ( ! isInTheFuture( purchase.expiry_date ) ) {
+					activation = <ProductActivated key="product-expired" type="product-expired" />;
+				} else {
+					activation = <ProductActivated key="product-activated" />;
+				}
+			} else {
+				activation = null;
+			}
 		}
 
 		switch ( getPlanClass( productSlug ) ) {

--- a/projects/plugins/jetpack/changelog/refresh-expired-subscription
+++ b/projects/plugins/jetpack/changelog/refresh-expired-subscription
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Admin dashboard: add link to renew expired subscription.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Improved styling for expired subscriptions on My Plan page.
Added renewal link for expired subscriptions.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed CSS
* Expanded Product Activated component and added logic to Product expired

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Plan page
* Add a subscription and use tools to edit the expire date. Should look like this: 

<img width="930" alt="Screenshot 2023-04-28 at 13 09 38" src="https://user-images.githubusercontent.com/1242807/235132593-1d1690f0-7c19-43ea-8d31-c69936a60b0c.png">
