### PR TITLE
Jetpack Social: Always render Social Image Generator panel when it is available

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-jetpack-social-render-sig-panel-even-when-disabled-by-default
+++ b/projects/js-packages/publicize-components/changelog/fix-jetpack-social-render-sig-panel-even-when-disabled-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Social: Render Social Image Generator panel even when SIG's default is disabled

--- a/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
@@ -94,6 +94,7 @@ export default function usePublicizeConfig() {
 		numberOfSharesRemaining: sharesData.shares_remaining,
 		hasPaidPlan: !! getJetpackData()?.social?.hasPaidPlan,
 		isEnhancedPublishingEnabled: !! getJetpackData()?.social?.isEnhancedPublishingEnabled,
+		isSocialImageGeneratorAvailable: !! getJetpackData()?.social?.isSocialImageGeneratorAvailable,
 		isSocialImageGeneratorEnabled: !! getJetpackData()?.social?.isSocialImageGeneratorEnabled,
 		connectionsAdminUrl: connectionsRootUrl + getSiteFragment(),
 		adminUrl: getJetpackData()?.social?.adminUrl,

--- a/projects/packages/publicize/changelog/fix-jetpack-social-render-sig-panel-even-when-disabled-by-default
+++ b/projects/packages/publicize/changelog/fix-jetpack-social-render-sig-panel-even-when-disabled-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Social: Render Social Image Generator panel even when SIG's default is disabled

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.25.0",
+	"version": "0.25.1-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/social-image-generator/class-setup.php
+++ b/projects/packages/publicize/src/social-image-generator/class-setup.php
@@ -73,7 +73,9 @@ class Setup {
 			return;
 		}
 
-		if ( ! $publicize->has_social_image_generator_feature() ) {
+		$settings = new Settings();
+
+		if ( ! $settings->is_available() ) {
 			return;
 		}
 
@@ -81,14 +83,12 @@ class Setup {
 			return;
 		}
 
-		if ( ! ( new Settings() )->is_enabled() ) {
-			return;
-		}
-
+		// Set SIG to be enabled by default for new posts if the toggle is on.
 		$post_settings = new Post_Settings( $post_id );
 		if (
 			! $update &&
 			'auto-draft' === $post->post_status &&
+			$settings->is_enabled() &&
 			empty( $post_settings->get_settings( true ) )
 		) {
 			$post_settings->update_setting( 'enabled', true );
@@ -96,6 +96,10 @@ class Setup {
 		}
 
 		if ( $post->post_status === 'auto-draft' ) {
+			return;
+		}
+
+		if ( ! $post_settings->is_enabled() ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/changelog/fix-jetpack-social-render-sig-panel-even-when-disabled-by-default
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-social-render-sig-panel-even-when-disabled-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Social: Render Social Image Ge nerator panel even when SIG's default is disabled

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -757,11 +757,13 @@ class Jetpack_Gutenberg {
 
 		if ( Jetpack::is_module_active( 'publicize' ) && function_exists( 'publicize_init' ) ) {
 			$publicize               = publicize_init();
+			$sig_settings            = new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings();
 			$initial_state['social'] = array(
-				'sharesData'                    => $publicize->get_publicize_shares_info( $blog_id ),
-				'hasPaidPlan'                   => $publicize->has_paid_plan(),
-				'isEnhancedPublishingEnabled'   => $publicize->is_enhanced_publishing_enabled( $blog_id ),
-				'isSocialImageGeneratorEnabled' => ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
+				'sharesData'                      => $publicize->get_publicize_shares_info( $blog_id ),
+				'hasPaidPlan'                     => $publicize->has_paid_plan(),
+				'isEnhancedPublishingEnabled'     => $publicize->is_enhanced_publishing_enabled( $blog_id ),
+				'isSocialImageGeneratorAvailable' => $sig_settings->is_available(),
+				'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
 			);
 		}
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -28,7 +28,7 @@ export const name = 'publicize';
 
 const PublicizeSettings = () => {
 	const { hasEnabledConnections } = useSocialMediaConnections();
-	const { isSocialImageGeneratorEnabled } = usePublicizeConfig();
+	const { isSocialImageGeneratorAvailable } = usePublicizeConfig();
 
 	return (
 		<PostTypeSupportCheck supportKeys="publicize">
@@ -38,7 +38,7 @@ const PublicizeSettings = () => {
 				<PublicizePanel enableTweetStorm={ true }>
 					<UpsellNotice />
 				</PublicizePanel>
-				{ isSocialImageGeneratorEnabled && <SocialImageGeneratorPanel /> }
+				{ isSocialImageGeneratorAvailable && <SocialImageGeneratorPanel /> }
 			</JetpackPluginSidebar>
 
 			<PluginPrePublishPanel
@@ -56,7 +56,7 @@ const PublicizeSettings = () => {
 				</PublicizePanel>
 			</PluginPrePublishPanel>
 
-			{ isSocialImageGeneratorEnabled && (
+			{ isSocialImageGeneratorAvailable && (
 				<PluginPrePublishPanel
 					initialOpen
 					title={ __( 'Social Image Generator', 'jetpack' ) }

--- a/projects/plugins/social/changelog/fix-jetpack-social-render-sig-panel-even-when-disabled-by-default
+++ b/projects/plugins/social/changelog/fix-jetpack-social-render-sig-panel-even-when-disabled-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Social: Render Social Image Generator panel even when SIG's default is disabled

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -308,24 +308,28 @@ class Jetpack_Social {
 		);
 
 		Assets::enqueue_script( 'jetpack-social-editor' );
+
+		$sig_settings = ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() );
+
 		wp_localize_script(
 			'jetpack-social-editor',
 			'Jetpack_Editor_Initial_State',
 			array(
 				'siteFragment' => ( new Status() )->get_site_suffix(),
 				'social'       => array(
-					'adminUrl'                      => esc_url_raw( admin_url( 'admin.php?page=jetpack-social' ) ),
-					'sharesData'                    => $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) ),
-					'reviewRequestDismissed'        => self::is_review_request_dismissed(),
-					'dismissReviewRequestPath'      => '/jetpack/v4/social/review-dismiss',
-					'connectionRefreshPath'         => '/jetpack/v4/publicize/connection-test-results',
-					'resharePath'                   => '/jetpack/v4/publicize/{postId}',
-					'publicizeConnectionsUrl'       => esc_url_raw(
+					'adminUrl'                        => esc_url_raw( admin_url( 'admin.php?page=jetpack-social' ) ),
+					'sharesData'                      => $publicize->get_publicize_shares_info( Jetpack_Options::get_option( 'id' ) ),
+					'reviewRequestDismissed'          => self::is_review_request_dismissed(),
+					'dismissReviewRequestPath'        => '/jetpack/v4/social/review-dismiss',
+					'connectionRefreshPath'           => '/jetpack/v4/publicize/connection-test-results',
+					'resharePath'                     => '/jetpack/v4/publicize/{postId}',
+					'publicizeConnectionsUrl'         => esc_url_raw(
 						'https://jetpack.com/redirect/?source=jetpack-social-connections-block-editor&site='
 					),
-					'hasPaidPlan'                   => $publicize->has_paid_plan(),
-					'isEnhancedPublishingEnabled'   => $publicize->is_enhanced_publishing_enabled( Jetpack_Options::get_option( 'id' ) ),
-					'isSocialImageGeneratorEnabled' => ( new Automattic\Jetpack\Publicize\Social_Image_Generator\Settings() )->is_enabled(),
+					'hasPaidPlan'                     => $publicize->has_paid_plan(),
+					'isEnhancedPublishingEnabled'     => $publicize->is_enhanced_publishing_enabled( Jetpack_Options::get_option( 'id' ) ),
+					'isSocialImageGeneratorAvailable' => $sig_settings->is_available(),
+					'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
 				),
 			)
 		);

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -60,7 +60,7 @@ const JetpackSocialSidebar = () => {
 		isPublicizeEnabled,
 		hidePublicizeFeature,
 		isPostAlreadyShared,
-		isSocialImageGeneratorEnabled,
+		isSocialImageGeneratorAvailable,
 	} = usePublicizeConfig();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 	// Determine if the review request should show right before the post publishes
@@ -111,7 +111,7 @@ const JetpackSocialSidebar = () => {
 				<PublicizePanel>
 					<PanelDescription />
 				</PublicizePanel>
-				{ isSocialImageGeneratorEnabled && <SocialImageGeneratorPanel /> }
+				{ isSocialImageGeneratorAvailable && <SocialImageGeneratorPanel /> }
 				<PanelBody title={ __( 'Social Previews', 'jetpack-social' ) }>
 					<SocialPreviewsPanel openModal={ openModal } />
 				</PanelBody>
@@ -127,7 +127,7 @@ const JetpackSocialSidebar = () => {
 				</PublicizePanel>
 			</PluginPrePublishPanel>
 
-			{ isSocialImageGeneratorEnabled && (
+			{ isSocialImageGeneratorAvailable && (
 				<PluginPrePublishPanel
 					initialOpen
 					title={ __( 'Social Image Generator', 'jetpack-social' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes the Social Image Generator panel to always be rendered when the feature is available. The toggle on the Jetpack Social admin page now simply decides whether or not SIG is enabled by default for new posts.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a new test site with Jetpack and Jetpack Social.
2. Disable Jetpack Social, make sure only Jetpack is enabled.
3. Add Social Image Generator to your site.
4. Go to the "New Post" screen and verify that the SIG panel is visible but toggled off.
5. Do NOT toggle it on and save the post.
6. Verify that SIG is disabled and no token was generated: `wp post meta list POST_ID`.
7. Create a new post, toggle SIG on and verify that a token is generated..
8. Enable Jetpack Social and disable Jetpack.
9. Go to the Social admin page and check that the SIG toggle is off.
10. Repeat steps 4-7.
11. Turn on the SIG toggle on the admin page, create a new post and verify that SIG is toggled on for the post.
12. Save the post and check that SIG meta was added.

