### PR TITLE
Jetpack Plugin Visual Refresh: fix responsive css on about and my plan pages

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
@@ -200,6 +200,10 @@ $color__back-link: #787c82;
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	grid-gap: 24px;
+
+	@include breakpoint( "<960px" ) {
+	  display: block;
+	}
 }
 
 .jetpack-about__plugin {
@@ -256,5 +260,9 @@ $color__back-link: #787c82;
 				margin-bottom: 0;
 			}
 		}
+	}
+
+	@include breakpoint( "<960px" ) {
+	  margin-bottom: 24px;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/my-plan/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/style.scss
@@ -14,6 +14,10 @@
 	.dops-card.is-compact {
 	  margin-bottom: 0;
 	  border-bottom: 1px solid var(--jp-gray);
+
+	  	@include breakpoint( "<960px" ) {
+		border-bottom: 0;
+	  	}
 	}
 
   	.dops-card:first-child {

--- a/projects/plugins/jetpack/_inc/client/my-plan/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/style.scss
@@ -87,7 +87,7 @@
 		}
 
 		@include breakpoint( "<660px" ) {
-			justify-content: space-between;
+		  	flex-direction: unset;
 			flex: 1;
 		}
 
@@ -104,6 +104,13 @@
 
 	.jp-landing__licensing-actions-item.no-licenses {
 		justify-content: flex-end;
+
+		@include breakpoint( "<660px" ) {
+		  justify-content: space-around;
+		  a {
+			margin: 0;
+		  }
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/client/my-plan/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/style.scss
@@ -109,6 +109,10 @@
 		  justify-content: space-around;
 		  a {
 			margin: 0;
+
+			&.is-compact {
+			  width: 48%;
+			}
 		  }
 		}
 	}

--- a/projects/plugins/jetpack/changelog/refresh-fix-about-plans-2
+++ b/projects/plugins/jetpack/changelog/refresh-fix-about-plans-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Minor CSS updates for visual refresh project


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addressing issues from #30293
https://github.com/Automattic/jetpack/pull/30293#issuecomment-1526359331

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix About us page plugin dsplay on small screens
* Fix "View all purchases" & "Activate a product" buttons on small screens 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Plan and shrink it to mobile width. Buttons should stay on the same line and 
get evenly spaced.
* Go to About us page and view it on mobile width. Plugin boxes shouldn't display in a 
grid. 

Expected look:
<img width="630" alt="Screenshot 2023-04-28 at 15 26 07" src="https://user-images.githubusercontent.com/1242807/235159960-3944a9cd-bb45-4ada-80fe-c9a83caa0665.png">


<img width="483" alt="Screenshot 2023-04-28 at 15 26 41" src="https://user-images.githubusercontent.com/1242807/235160099-704bf702-1361-4945-8de9-1136e8f0c32e.png">


