### PR TITLE
Jetpack Debugger: minor improvements

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
@@ -91,7 +91,7 @@ class Jetpack_Debugger {
 								echo sprintf(
 									wp_kses(
 										/* translators: URLs to Jetpack support pages. */
-										__( 'Some themes and plugins have <a href="%1$s" target="_blank">known conflicts</a> with Jetpack – check the <a href="%2$s" target="_blank">list</a>. (You can also browse the <a href="%3$s" target="_blank">Jetpack support pages</a> or <a href="%4$s" target="_blank">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ),
+										__( 'Some themes and plugins have <a href="%1$s" target="_blank">known conflicts</a> with Jetpack – check the list. (You can also browse the <a href="%2$s" target="_blank">Jetpack support pages</a> or <a href="%3$s" target="_blank">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ),
 										array(
 											'a' => array(
 												'href'   => array(),
@@ -99,7 +99,6 @@ class Jetpack_Debugger {
 											),
 										)
 									),
-									esc_url( Redirect::get_url( 'jetpack-contact-support-known-issues' ) ),
 									esc_url( Redirect::get_url( 'jetpack-contact-support-known-issues' ) ),
 									esc_url( Redirect::get_url( 'jetpack-support' ) ),
 									esc_url( Redirect::get_url( 'wporg-support-plugin-jetpack' ) )

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
@@ -270,6 +270,10 @@ class Jetpack_Debugger {
 				margin: 8px 0;
 			}
 
+			#connected-user-details p strong {
+				word-break: break-all;
+			}
+
 			.jetpack-tests-succeed {
 				font-size: large;
 				color: #069E08;

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
@@ -91,11 +91,12 @@ class Jetpack_Debugger {
 								echo sprintf(
 									wp_kses(
 										/* translators: URLs to Jetpack support pages. */
-										__( 'Some themes and plugins have <a href="%1$s" target="_blank">known conflicts</a> with Jetpack – check the list. (You can also browse the <a href="%2$s" target="_blank">Jetpack support pages</a> or <a href="%3$s" target="_blank">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ),
+										__( 'Some themes and plugins have <a href="%1$s" target="_blank" rel="noopener noreferrer">known conflicts</a> with Jetpack – check the list. (You can also browse the <a href="%2$s" target="_blank" rel="noopener noreferrer">Jetpack support pages</a> or <a href="%3$s" target="_blank" rel="noopener noreferrer">Jetpack support forum</a> to see if others have experienced and solved the problem.)', 'jetpack' ),
 										array(
 											'a' => array(
 												'href'   => array(),
 												'target' => array(),
+												'rel'    => array(),
 											),
 										)
 									),

--- a/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/projects/plugins/jetpack/_inc/lib/debugger/class-jetpack-debugger.php
@@ -124,12 +124,12 @@ class Jetpack_Debugger {
 								<?php esc_html_e( "If this solves the problem, something in your theme is probably broken – let the theme's author know.", 'jetpack' ); ?>
 							</li>
 							<li>
-								<?php esc_html_e( 'A problem with your XMLRPC file.', 'jetpack' ); ?>
+								<?php esc_html_e( 'A problem with your XML-RPC file.', 'jetpack' ); ?>
 								<?php
 								echo sprintf(
 									wp_kses(
 										/* translators: The URL to the site's xmlrpc.php file. */
-										__( 'Load your <a href="%s">XMLRPC file</a>. It should say “XML-RPC server accepts POST requests only.” on a line by itself.', 'jetpack' ),
+										__( 'Load your <a href="%s">XML-RPC file</a>. It should say “XML-RPC server accepts POST requests only.” on a line by itself.', 'jetpack' ),
 										array( 'a' => array( 'href' => array() ) )
 									),
 									esc_attr( site_url( 'xmlrpc.php' ) )
@@ -137,7 +137,7 @@ class Jetpack_Debugger {
 								?>
 								<ul>
 									<li><?php esc_html_e( "If it's not by itself, a theme or plugin is displaying extra characters. Try steps 2 and 3.", 'jetpack' ); ?></li>
-									<li><?php esc_html_e( 'If you get a 404 message, contact your web host. Their security may block XMLRPC.', 'jetpack' ); ?></li>
+									<li><?php esc_html_e( 'If you get a 404 message, contact your web host. Their security may block the XML-RPC file.', 'jetpack' ); ?></li>
 								</ul>
 							</li>
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-debugger-minor-issues
+++ b/projects/plugins/jetpack/changelog/update-jetpack-debugger-minor-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Minor changes on the Jetpack debugger page content.

--- a/projects/plugins/jetpack/changelog/update-jetpack-debugger-remove-excessive-link
+++ b/projects/plugins/jetpack/changelog/update-jetpack-debugger-remove-excessive-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Debugger: remove duplicated "known issues" link.

--- a/projects/plugins/jetpack/changelog/update-jetpack-debugger-remove-excessive-link
+++ b/projects/plugins/jetpack/changelog/update-jetpack-debugger-remove-excessive-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Debugger: remove duplicated "known issues" link.


### PR DESCRIPTION
## Proposed changes:
* Remove duplicated link to the "known issues" page.
* Replace XMLRPC with XML-RPC.
* Fix overflowing for long email addresses.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p8oabR-1aA-p2#comment-7222

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Visit Jetpack Debugger (`/wp-admin/admin.php?page=jetpack-debugger`)
2. Confirm all the links in `1. A known issue...` lead to correct pages.