### PR TITLE
Launchpad API: Address excess queries

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-excess-queries
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-excess-queries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Launchpad API: Address excess queries

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -118,7 +118,10 @@ function can_update_design_selected_task() {
  * @return boolean True if domain upsell task is completed
  */
 function is_domain_upsell_completed() {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	// Adding a 'false' bypass to this for now to unblock Jetpack release.
+	// This was resulting in queries being run on too many requests to wpcom.
+	// Slack context - p1682634633096559/1682634536.650749-slack-C0299DMPG
+	if ( false && defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		if ( class_exists( '\WPCOM_Store_API' ) ) {
 			$plan = \WPCOM_Store_API::get_current_plan( \get_current_blog_id() );
 			return ! $plan['is_free'] || get_checklist_task( 'domain_upsell_deferred' );


### PR DESCRIPTION
## Proposed changes:

It appears some code in our new backend Launchpad logic is resulting in excess queries. As a temporary fix to unblock deployment of other code, we're adding a 'false' bypass to avoid invoking the problematic method call. Once deployed, we'll investigate and push more complete fix. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See p1682634536650749-slack-C0299DMPG

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The behavior of our backend logic and endpoints should be the same except for the return value of the `domain_upsell` task. For this task, 'completed' will now always be false and 'badge_text' will always be Upgrade plan. Other than that, we just want to ensure no regressive breakage.

1. Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/launchpad-text-string-case` to build and sync this branch to your sandbox.
2. Create or use a launchpad enabled site and sandbox the site.
3. Go to https://developer.wordpress.com/docs/api/console/, select Rest API and wpcom/v2, and input the following: `/sites/YOURSITESLUG/launchpad/checklist?checklist_slug=free`. Confirm correct checklist is returned, with correct values above for domain_upsell. 