### PR TITLE
Bypass launchpad domain upsell queries

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-bypass-launch-addomain-upsell-queries
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-bypass-launch-addomain-upsell-queries
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a bypass to a query in the launchpad.php file that was running too often.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -118,7 +118,10 @@ function can_update_design_selected_task() {
  * @return boolean True if domain upsell task is completed
  */
 function is_domain_upsell_completed() {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	// Adding a 'false' bypass to this for now to unblock Jetpack release.
+	// This was resulting in queries being run on too many requests to wpcom.
+	// Slack context - p1682634633096559/1682634536.650749-slack-C0299DMPG
+	if ( false && defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		if ( class_exists( '\WPCOM_Store_API' ) ) {
 			$plan = \WPCOM_Store_API::get_current_plan( \get_current_blog_id() );
 			return ! $plan['is_free'] || get_checklist_task( 'domain_upsell_deferred' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1682634633096559/1682634536.650749-slack-C0299DMPG to unblock jetpack release. We will have to follow up to update how launchpad.php handles these queries.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `false` to the conditional triggering the query.
* This is not yet consumed elsewhere and should be fine to bypass in this manner until we can follow up with a better solution.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*