### PR TITLE
Extensions: Add new blogroll scaffolding

### DIFF
--- a/projects/plugins/jetpack/changelog/add-new_blogroll
+++ b/projects/plugins/jetpack/changelog/add-new_blogroll
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add initial scaffold for new blogroll block

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/attributes.js
@@ -1,0 +1,3 @@
+export default {
+	// @TODO - Add block attributes here
+};

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/author-recommendation.php
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/author-recommendation.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Author-recommendation Block.
+ *
+ * @since 12.1
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\AuthorRecommendation;
+
+use Automattic\Jetpack\Blocks;
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'author-recommendation';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	Blocks::jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Author-recommendation block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Author-recommendation block attributes.
+ * @param string $content String containing the Author-recommendation block content.
+ *
+ * @return string
+ */
+function load_assets( $attr, $content ) {
+	/*
+	 * Enqueue necessary scripts and styles.
+	 */
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
+
+	return sprintf(
+		'<div class="%1$s">%2$s</div>',
+		esc_attr( Blocks::classes( FEATURE_NAME, $attr ) ),
+		$content
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/edit.js
@@ -1,0 +1,28 @@
+import { BlockIcon } from '@wordpress/block-editor';
+import { Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import './editor.scss';
+import icon from './icon';
+
+function AuthorRecommendationEdit( { className, noticeUI } ) {
+	/**
+	 * Write the block editor UI.
+	 *
+	 * @returns {object} The UI displayed when user edits this block.
+	 */
+
+	return (
+		<div className={ className }>
+			<Placeholder
+				label={ __( 'Author-recommendation', 'jetpack' ) }
+				instructions={ __( 'Instructions go here.', 'jetpack' ) }
+				icon={ <BlockIcon icon={ icon } /> }
+				notices={ noticeUI }
+			>
+				{ __( 'User input goes here?', 'jetpack' ) }
+			</Placeholder>
+		</div>
+	);
+}
+
+export default AuthorRecommendationEdit;

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/editor.js
@@ -1,0 +1,4 @@
+import registerJetpackBlock from '../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/editor.scss
@@ -1,0 +1,5 @@
+/**
+ * Editor styles for Author-recommendation
+ */
+
+.wp-block-jetpack-author-recommendation { }

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/icon.js
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/icon.js
@@ -1,0 +1,8 @@
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
+	<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
+	</SVG>
+);

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/index.js
@@ -1,0 +1,54 @@
+import { __ } from '@wordpress/i18n';
+import { getIconColor } from '../../shared/block-icons';
+import attributes from './attributes';
+import edit from './edit';
+import icon from './icon';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
+
+export const name = 'author-recommendation';
+export const title = __( 'Author-recommendation', 'jetpack' );
+export const settings = {
+	title,
+	description: __( 'Author-recommendation', 'jetpack' ),
+	icon: {
+		src: icon,
+		foreground: getIconColor(),
+	},
+	category: 'grow',
+	keywords: [],
+	supports: {
+		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
+		align: false /* if set to true, the 'align' option below can be used*/,
+		// Pick which alignment options to display.
+		/*align: [ 'left', 'right', 'full' ],*/
+		// Support for wide alignment, that requires additional support in themes.
+		alignWide: true,
+		// When true, a new field in the block sidebar allows to define an id for the block and a button to copy the direct link.
+		anchor: false,
+		// When true, a new field in the block sidebar allows to define a custom className for the block’s wrapper.
+		customClassName: true,
+		// When false, Gutenberg won't add a class like .wp-block-your-block-name to the root element of your saved markup
+		className: true,
+		// Setting this to false suppress the ability to edit a block’s markup individually. We often set this to false in Jetpack blocks.
+		html: false,
+		// Passing false hides this block in Gutenberg's visual inserter.
+		/*inserter: true,*/
+		// When false, user will only be able to insert the block once per post.
+		multiple: true,
+		// When false, the block won't be available to be converted into a reusable block.
+		reusable: true,
+	},
+	edit,
+	/* @TODO Write the block editor output */
+	save: () => null,
+	attributes,
+	example: {
+		attributes: {
+			// @TODO: Add default values for block attributes, for generating the block preview.
+		},
+	},
+};

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -58,7 +58,8 @@
 		"post-publish-promote-post-panel",
 		"recipe",
 		"v6-video-frame-poster",
-		"videopress/video-chapters"
+		"videopress/video-chapters",
+		"author-recommendation"
 	],
 	"experimental": [ "ai-image", "ai-paragraph", "anchor-fm", "premium-content" ],
 	"no-post-editor": [


### PR DESCRIPTION
## Proposed changes:
This PR creates a scaffolding structure for the new `blogroll` block that will be implemented by team Vertex. This is to make our PRs small and easy to review. The code was generated by `jetpack docker wp jetpack scaffold block author-recommendation`. We are uncertain if blogroll will be renamed, this might change but should not be an issue.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- [1721-gh-Automattic/dotcom-forge](https://href.li/?https://github.com/Automattic/dotcom-forge/issues/1721)
- p1682499893280729-slack-C02T4NVL4JJ 

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This is just a basic scaffolding
* Pull and run this branch
* Open the editor
* Add the new block `author-recommendation` 
<img width="379" alt="image" src="https://user-images.githubusercontent.com/2653810/235191976-555c9e2c-36f8-45fd-a0e2-e076e8fbc953.png">

@jeherve Thank you for explaining the [scaffold command](https://github.com/Automattic/jetpack/pull/30328#pullrequestreview-1403675151).
