### PR TITLE
My Jetpack: Reload page after successful license activation

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -54,6 +54,10 @@ export default function AddLicenseScreen() {
 		[ recordEvent, hasActivatedLicense ]
 	);
 
+	const handleActivationSuccess = useCallback( () => {
+		setHasActivatedLicense( true );
+	}, [] );
+
 	return (
 		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
@@ -65,7 +69,7 @@ export default function AddLicenseScreen() {
 						currentRecommendationsStep={ null }
 						availableLicenses={ availableLicenses }
 						fetchingAvailableLicenses={ fetchingAvailableLicenses }
-						onActivationSuccess={ setHasActivatedLicense( true ) }
+						onActivationSuccess={ handleActivationSuccess }
 						siteAdminUrl={ window?.myJetpackInitialState?.adminUrl }
 						siteRawUrl={ window?.myJetpackInitialState?.siteSuffix }
 						displayName={ displayName }

--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -1,8 +1,14 @@
+/*
+ * External dependencies
+ */
 import restApi from '@automattic/jetpack-api';
 import { AdminPage, Container, Col } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { ActivationScreen } from '@automattic/jetpack-licensing';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+/*
+ * Internal dependencies
+ */
 import useAnalytics from '../../hooks/use-analytics';
 import useAvailableLicenses from '../../hooks/use-available-licenses';
 import GoBackLink from '../go-back-link';
@@ -10,7 +16,7 @@ import GoBackLink from '../go-back-link';
 /**
  * The AddLicenseScreen component of the My Jetpack app.
  *
- * @returns {object} The AddLicenseScree component.
+ * @returns {object} The AddLicenseScreen component.
  */
 export default function AddLicenseScreen() {
 	useEffect( () => {
@@ -22,6 +28,8 @@ export default function AddLicenseScreen() {
 	const { recordEvent } = useAnalytics();
 	const { availableLicenses, fetchingAvailableLicenses } = useAvailableLicenses();
 	const { userConnectionData } = useConnection();
+	const [ hasActivatedLicense, setHasActivatedLicense ] = useState( false );
+
 	// They might not have a display name set in wpcom, so fall back to wpcom login or local username.
 	const displayName =
 		userConnectionData?.currentUser?.wpcomUser?.display_name ||
@@ -36,9 +44,14 @@ export default function AddLicenseScreen() {
 				// Prevent default here to minimize page change within the My Jetpack app.
 				event.preventDefault();
 				history.back();
+
+				if ( hasActivatedLicense ) {
+					// Reload the page to reflect the new license in the product card.
+					window.location.reload();
+				}
 			}
 		},
-		[ recordEvent ]
+		[ recordEvent, hasActivatedLicense ]
 	);
 
 	return (
@@ -52,7 +65,7 @@ export default function AddLicenseScreen() {
 						currentRecommendationsStep={ null }
 						availableLicenses={ availableLicenses }
 						fetchingAvailableLicenses={ fetchingAvailableLicenses }
-						onActivationSuccess={ undefined }
+						onActivationSuccess={ setHasActivatedLicense( true ) }
 						siteAdminUrl={ window?.myJetpackInitialState?.adminUrl }
 						siteRawUrl={ window?.myJetpackInitialState?.siteSuffix }
 						displayName={ displayName }

--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -28,7 +28,7 @@ export default function AddLicenseScreen() {
 	const { recordEvent } = useAnalytics();
 	const { availableLicenses, fetchingAvailableLicenses } = useAvailableLicenses();
 	const { userConnectionData } = useConnection();
-	const [ hasActivatedLicense, setHasActivatedLicense ] = useState( true );
+	const [ hasActivatedLicense, setHasActivatedLicense ] = useState( false );
 
 	// They might not have a display name set in wpcom, so fall back to wpcom login or local username.
 	const displayName =
@@ -36,18 +36,9 @@ export default function AddLicenseScreen() {
 		userConnectionData?.currentUser?.wpcomUser?.login ||
 		userConnectionData?.currentUser?.username;
 
-	const onClickGoBack = useCallback(
-		event => {
-			recordEvent( 'jetpack_myjetpack_license_activation_back_link_click' );
-
-			if ( document.referrer.includes( window.location.host ) ) {
-				// Prevent default here to minimize page change within the My Jetpack app.
-				event.preventDefault();
-				history.back();
-			}
-		},
-		[ recordEvent ]
-	);
+	const onClickGoBack = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_license_activation_back_link_click' );
+	}, [ recordEvent ] );
 
 	const handleActivationSuccess = useCallback( () => {
 		setHasActivatedLicense( true );

--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -28,7 +28,7 @@ export default function AddLicenseScreen() {
 	const { recordEvent } = useAnalytics();
 	const { availableLicenses, fetchingAvailableLicenses } = useAvailableLicenses();
 	const { userConnectionData } = useConnection();
-	const [ hasActivatedLicense, setHasActivatedLicense ] = useState( false );
+	const [ hasActivatedLicense, setHasActivatedLicense ] = useState( true );
 
 	// They might not have a display name set in wpcom, so fall back to wpcom login or local username.
 	const displayName =
@@ -44,14 +44,9 @@ export default function AddLicenseScreen() {
 				// Prevent default here to minimize page change within the My Jetpack app.
 				event.preventDefault();
 				history.back();
-
-				if ( hasActivatedLicense ) {
-					// Reload the page to reflect the new license in the product card.
-					window.location.reload();
-				}
 			}
 		},
-		[ recordEvent, hasActivatedLicense ]
+		[ recordEvent ]
 	);
 
 	const handleActivationSuccess = useCallback( () => {
@@ -62,7 +57,7 @@ export default function AddLicenseScreen() {
 		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col>
-					<GoBackLink onClick={ onClickGoBack } />
+					<GoBackLink onClick={ onClickGoBack } reload={ hasActivatedLicense } />
 				</Col>
 				<Col>
 					<ActivationScreen

--- a/projects/packages/my-jetpack/_inc/components/go-back-link/index.js
+++ b/projects/packages/my-jetpack/_inc/components/go-back-link/index.js
@@ -9,11 +9,14 @@ import styles from './styles.module.scss';
  *
  * @param {object} props           - Component props.
  * @param {Function} props.onClick - A callback to execute on click
+ * @param {boolean} props.reload   - Whether to reload the page after going back
  * @returns {object}                 GoBackLink component.
  */
-function GoBackLink( { onClick } ) {
+function GoBackLink( { onClick, reload } ) {
+	const to = reload ? '/?reload=true' : '/';
+
 	return (
-		<Link to="/" className={ styles.link } onClick={ onClick }>
+		<Link to={ to } className={ styles.link } onClick={ onClick }>
 			<Icon icon={ arrowLeft } className={ styles.icon } />
 			{ __( 'Go back', 'jetpack-my-jetpack' ) }
 		</Link>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -1,3 +1,6 @@
+/*
+ * External dependencies
+ */
 import {
 	AdminSection,
 	AdminSectionHero,
@@ -12,7 +15,10 @@ import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-c
 import { Icon, Notice, Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+/*
+ * Internal dependencies
+ */
 import useAnalytics from '../../hooks/use-analytics';
 import useChatAvailability from '../../hooks/use-chat-availability';
 import useConnectionWatcher from '../../hooks/use-connection-watcher';
@@ -81,10 +87,23 @@ export default function MyJetpackScreen() {
 	const shouldShowZendeskChatWidget = ! isFetchingChatAvailability && isAvailable;
 
 	const { recordEvent } = useAnalytics();
+	const [ reloading, setReloading ] = useState( false );
 
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_page_view' );
 	}, [ recordEvent ] );
+
+	if ( window.location.hash.includes( '?reload=true' ) ) {
+		// Clears the query string and reloads the page.
+		window.history.replaceState( null, '', window.location.href.replace( '?reload=true', '' ) );
+		window.location.reload();
+
+		setReloading( true );
+	}
+
+	if ( reloading ) {
+		return null;
+	}
 
 	return (
 		<AdminPage>

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-add-license-reload
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-add-license-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Reload page after successful license activation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28625

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `reload` flag to the `GoBackLink` component to allow page reload after redirection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to https://cloud.jetpack.com/features/comparison and purchase the Jetpack Backup license. Do not attach it to a site.
* Go to My Jetpack
* In the VaultPress Backup card, click on `Purchase`
* Click on `Already have an existing plan or license key? Get started.`
* Select the bought plan and activate it
* Wait for the success message
* Click on the `Go back` link
* Check that you are redirected to the My Jetpack dashboard and that the page is quickly reloaded
* Check that the Backup card shows `Manage` instead of `Purchase`


https://user-images.githubusercontent.com/8486249/235246135-c82a65f2-1c6c-418a-8fa9-16807682b923.mp4
