### PR TITLE
Update/sync jetpack launchpad with wpcom

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-sync-jetpack-launchpad-with-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-sync-jetpack-launchpad-with-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync WPCOM launchpad changes with Jetpack launchpad code

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -219,14 +219,12 @@ class Launchpad_Task_Lists {
 	 * @return bool True if completed, false if not.
 	 */
 	public function get_task_completion_status( $task ) {
-		if ( isset( $task['completed'] ) ) {
-			if ( array_key_exists( $task['id'], $this->launchpad_task_completion_status_mapping ) ) {
-				$task_status_mapped_value = $this->launchpad_task_completion_status_mapping[ $task['id'] ];
-				if ( is_callable( $task_status_mapped_value ) ) {
-					return call_user_func( $task_status_mapped_value );
-				} elseif ( is_string( $task_status_mapped_value ) ) {
-					return get_checklist_task( $task_status_mapped_value );
-				}
+		if ( array_key_exists( $task['id'], $this->launchpad_task_completion_status_mapping ) ) {
+			$task_status_mapped_value = $this->launchpad_task_completion_status_mapping[ $task['id'] ];
+			if ( is_callable( $task_status_mapped_value ) ) {
+				return call_user_func( $task_status_mapped_value );
+			} elseif ( is_string( $task_status_mapped_value ) ) {
+				return get_checklist_task( $task_status_mapped_value );
 			}
 		}
 		return $task['completed'];

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -238,13 +238,13 @@ function get_task_definitions() {
 		array(
 			'id'        => 'first_post_published',
 			'title'     => __( 'Write your first post', 'jetpack-mu-wpcom' ),
-			'completed' => get_checklist_task( 'first_post_published' ),
+			'completed' => false,
 			'disabled'  => false,
 		),
 		array(
 			'id'        => 'first_post_published_newsletter',
 			'title'     => __( 'Start writing', 'jetpack-mu-wpcom' ),
-			'completed' => get_checklist_task( 'first_post_published' ),
+			'completed' => false,
 			'disabled'  => false,
 		),
 		array(
@@ -262,13 +262,13 @@ function get_task_definitions() {
 		array(
 			'id'        => 'links_added',
 			'title'     => __( 'Add links', 'jetpack-mu-wpcom' ),
-			'completed' => get_checklist_task( 'links_edited' ),
+			'completed' => false,
 			'disabled'  => false,
 		),
 		array(
 			'id'        => 'link_in_bio_launched',
 			'title'     => __( 'Launch your site', 'jetpack-mu-wpcom' ),
-			'completed' => get_checklist_task( 'site_launched' ),
+			'completed' => false,
 			'disabled'  => ! get_checklist_task( 'links_edited' ),
 		),
 		array(
@@ -280,13 +280,13 @@ function get_task_definitions() {
 		array(
 			'id'        => 'videopress_upload',
 			'title'     => __( 'Upload your first video', 'jetpack-mu-wpcom' ),
-			'completed' => get_checklist_task( 'video_uploaded' ),
+			'completed' => false,
 			'disabled'  => get_checklist_task( 'video_uploaded' ),
 		),
 		array(
 			'id'        => 'videopress_launched',
 			'title'     => __( 'Launch site', 'jetpack-mu-wpcom' ),
-			'completed' => get_checklist_task( 'site_launched' ),
+			'completed' => false,
 			'disabled'  => ! get_checklist_task( 'video_uploaded' ),
 		),
 		array(
@@ -304,13 +304,13 @@ function get_task_definitions() {
 		array(
 			'id'        => 'design_edited',
 			'title'     => __( 'Edit site design', 'jetpack-mu-wpcom' ),
-			'completed' => get_checklist_task( 'site_edited' ),
+			'completed' => false,
 			'disabled'  => false,
 		),
 		array(
 			'id'           => 'site_launched',
 			'title'        => __( 'Launch your site', 'jetpack-mu-wpcom' ),
-			'completed'    => get_checklist_task( 'site_launched' ),
+			'completed'    => false,
 			'disabled'     => false,
 			'isLaunchTask' => true,
 		),
@@ -323,7 +323,7 @@ function get_task_definitions() {
 		array(
 			'id'         => 'domain_upsell',
 			'title'      => __( 'Choose a domain', 'jetpack-mu-wpcom' ),
-			'completed'  => is_domain_upsell_completed(),
+			'completed'  => false,
 			'disabled'   => false,
 			'badge_text' => get_domain_upsell_badge_text(),
 		),
@@ -669,19 +669,16 @@ add_action( 'init', 'register_default_checklists' );
 add_action( 'load-site-editor.php', 'track_edit_site_task', 10 );
 add_action( 'wp_head', 'maybe_preview_with_no_interactions', PHP_INT_MAX );
 add_action( 'publish_post', 'track_publish_first_post_task', 10 );
-
-// WIP ( Need to test )
-// add_action( 'add_attachment', 'track_video_uploaded_task', 10, 1 );
-// add_action( 'wpcom_site_launched', 'track_site_launch_task', 10 );
+add_action( 'wpcom_site_launched', 'track_site_launch_task', 10 );
+add_action( 'add_attachment', 'track_video_uploaded_task', 10, 1 );
 // Atomic Only
-// if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
-// add_action( 'update_option_blog_public', 'maybe_track_site_launch', 10, 2 );
-// } else {
-// WPCOM only - relies on blog stickers
-// add_filter( 'option_launchpad_screen', 'maybe_disable_for_difm' );
-// }
-
+if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+	add_action( 'update_option_blog_public', 'maybe_track_site_launch', 10, 2 );
+} else {
+	// WPCOM only - relies on blog stickers
+	add_filter( 'option_launchpad_screen', 'maybe_disable_for_difm' );
+}
 // Temporarily log information to debug intermittent launchpad errors for e2e tests
-// if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-// add_action( 'add_option_launchpad_screen', 'log_launchpad_being_enabled_for_test_sites', 10, 2 );
-// }
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	add_action( 'add_option_launchpad_screen', 'log_launchpad_being_enabled_for_test_sites', 10, 2 );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/76058

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sync WPCOM Launchpad code with Jetpack
* Use with https://github.com/Automattic/wp-calypso/pull/76402 to use launchpad checklist API on Calypso

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout Calypso PR with updated launchpad checklist API changes (https://github.com/Automattic/wp-calypso/pull/76402)
* Sandbox public api and your test site(s).
* Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/sync-jetpack-launchpad-with-wpcom` on your sandbox.
* Test the different launchpad flows (newsletter, link-in-bio, write, build, free, videopress) and ensure that the launchpad checklist tasks are marked as completed correctly when you go through them.
* Verify that you cannot interact with your blog links/input fields/etc. when you add the `do_preview_no_interactions=true` query parameter to blog url : `https://TEST_SITE.com/?do_preview_no_interactions=true`
* Verify you are not navigated to the launchpad screen when `difm-lite-in-progress` blog sticker is enabled and you `/home`. Disabled the blog sticker and verify you are navigated to the launchpad screen when you visit `/home`.

