### PR TITLE
Whitelist `_jetpack_newsletter_access` post meta

### DIFF
--- a/projects/plugins/jetpack/changelog/add-whitelist-jetpack-newsletter-access-api
+++ b/projects/plugins/jetpack/changelog/add-whitelist-jetpack-newsletter-access-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Whitelist the '_jetpack_newsletter_access' post meta

--- a/projects/plugins/jetpack/sal/class.json-api-metadata.php
+++ b/projects/plugins/jetpack/sal/class.json-api-metadata.php
@@ -53,6 +53,11 @@ class WPCOM_JSON_API_Metadata {
 			return false;
 		}
 
+		// We want to always return the `_jetpack_newsletter_access` key to display the correct newsletter access in Calypso.
+		if ( $key === '_jetpack_newsletter_access' ) {
+			return false;
+		}
+
 		if ( 0 === strpos( $key, '_jetpack_' ) ) {
 			return true;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to https://github.com/Automattic/wp-calypso/pull/76382
Relates to https://github.com/Automattic/wp-calypso/issues/75788

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Whitelist  the `_jetpack_newsletter_access` post meta to allow the `_jetpack_newsletter_access` meta to be present in the posts API request.  This meta is needed in Calypso to display the correct newsletter access in the UI

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync changes to WPCOM
* Sandbox `public-api`
* Go to `https://wordpress.com/posts/${WPCOM_URL}`
* Inspect the posts API call and verify that the `_jetpack_newsletter_access` is included in the metadata array for a post.

