### PR TITLE
Connection: Bring back auto-trigger for connection screen.

### DIFF
--- a/projects/js-packages/connection/changelog/fix-bring-back-connection-auto-trigger
+++ b/projects/js-packages/connection/changelog/fix-bring-back-connection-auto-trigger
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Bring back accidentally removed auto-trigger for connection screen.

--- a/projects/js-packages/connection/components/connect-screen/basic/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/index.jsx
@@ -20,6 +20,7 @@ import ConnectScreenVisual from './visual';
  * @param {string?} props.assetBaseUrl -- The assets base URL.
  * @param {object?} props.footer -- Additional page elements to show after the call to action.
  * @param {boolean?} props.skipUserConnection -- Whether to not require a user connection and just redirect after site connection.
+ * @param {boolean?} props.autoTrigger -- Whether to initiate the connection process automatically upon rendering the component.
  * @returns {React.Component} The `ConnectScreen` component.
  */
 const ConnectScreen = ( {

--- a/projects/js-packages/connection/components/connect-screen/basic/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/index.jsx
@@ -33,6 +33,7 @@ const ConnectScreen = ( {
 	images,
 	children,
 	assetBaseUrl,
+	autoTrigger,
 	footer,
 	skipUserConnection,
 } ) => {
@@ -48,6 +49,7 @@ const ConnectScreen = ( {
 		redirectUri,
 		apiRoot,
 		apiNonce,
+		autoTrigger,
 		from,
 		skipUserConnection,
 	} );
@@ -81,6 +83,7 @@ ConnectScreen.propTypes = {
 	registrationNonce: PropTypes.string.isRequired,
 	from: PropTypes.string,
 	redirectUri: PropTypes.string.isRequired,
+	autoTrigger: PropTypes.bool,
 	images: PropTypes.arrayOf( PropTypes.string ),
 	assetBaseUrl: PropTypes.string,
 	skipUserConnection: PropTypes.bool,
@@ -91,6 +94,7 @@ ConnectScreen.defaultProps = {
 	buttonLabel: __( 'Set up Jetpack', 'jetpack' ),
 	images: [],
 	redirectUri: null,
+	autoTrigger: false,
 	skipUserConnection: false,
 };
 

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.26.5",
+	"version": "0.26.6-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Proposed changes:
Bring back connection auto-trigger for connection screen if `#setup` URL hash is used. Removed in #29443.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pbNhbs-6l1-p2#comment-14837

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Disconnect Jetpack.
2. Load WP-admin Dashboard or Plugins page, you should see the "Set up Jetpack" banner.
3. Click on the banner, you should get redirected to the connection screen with `#setup` URL hash.
4. The connection screen flow should get triggered automatically: the button displays loader, you get redirected to Calypso connection flow shortly after.