### PR TITLE
Odyssey: bust the cache buster

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-cache-bust-the-cache-buster
+++ b/projects/packages/stats-admin/changelog/fix-cache-bust-the-cache-buster
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats Admin: Cache bust the cache buster

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.7.2",
+	"version": "0.7.3-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.7.2';
+	const VERSION = '0.7.3-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -75,16 +75,20 @@ class Odyssey_Assets {
 	/**
 	 * Returns cache buster string for assets.
 	 * Development mode doesn't need this, as it's handled by `Assets` class.
+	 *
+	 * @param bool $force_refresh Whether to force refresh the cache buster.
 	 */
-	protected function get_cdn_asset_cache_buster() {
+	protected function get_cdn_asset_cache_buster( $force_refresh = false ) {
 		// Use cached cache buster in production.
 		$remote_asset_version = get_transient( self::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY );
-		if ( ! empty( $remote_asset_version ) ) {
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $remote_asset_version ) && ! $force_refresh && ! isset( $_GET['force_refresh'] ) ) {
 			return $remote_asset_version;
 		}
 
 		// If no cached cache buster, we fetch it from CDN and set to transient.
-		$response = wp_remote_get( sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, 'build_meta.json' ), array( 'timeout' => 5 ) );
+		$response = wp_remote_get( sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, 'build_meta.json?t=' . time() ), array( 'timeout' => 5 ) );
 
 		if ( is_wp_error( $response ) ) {
 			// fallback to the package version.

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -75,15 +75,13 @@ class Odyssey_Assets {
 	/**
 	 * Returns cache buster string for assets.
 	 * Development mode doesn't need this, as it's handled by `Assets` class.
-	 *
-	 * @param bool $force_refresh Whether to force refresh the cache buster.
 	 */
-	protected function get_cdn_asset_cache_buster( $force_refresh = false ) {
+	protected function get_cdn_asset_cache_buster() {
 		// Use cached cache buster in production.
 		$remote_asset_version = get_transient( self::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! empty( $remote_asset_version ) && ! $force_refresh && ! isset( $_GET['force_refresh'] ) ) {
+		if ( ! empty( $remote_asset_version ) && ! isset( $_GET['force_refresh'] ) ) {
 			return $remote_asset_version;
 		}
 


### PR DESCRIPTION
## Proposed changes:

* When `force_refresh` is set, ignore cache to do a force refresh
* Added `t=time()` to avoid WP request cache ( by third parties? )

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
CBG1CP4EN/p1682835579193019-slack


## Does this pull request change what data or activity we track or use?
n/a

## Testing instructions:

* Spin up a JN site
* Ensure Odyssey Stats Widget works on `/wp-admin/index.php`
* Enusre Odyssey Stats works on `/wp-admin/admin.php?page=stats`
