### PR TITLE
VideoPress: enqueue iframe api file in the player Sandbox

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-enqueue-iframe-api-when-registering-block
+++ b/projects/packages/videopress/changelog/update-videopress-enqueue-iframe-api-when-registering-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: enqueue iframe api file in the player Sandbox.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -37,6 +37,9 @@ if ( window.videopressAjax ) {
 
 if ( window?.videoPressEditorState?.playerBridgeUrl ) {
 	sandboxScripts.push( window.videoPressEditorState.playerBridgeUrl );
+	sandboxScripts.push(
+		'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress-iframe-api.js'
+	);
 }
 
 /**

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -16,13 +16,13 @@ const debug = debugFactory( 'videopress:use-video-player' );
  * Return the (content) Window object of the iframe,
  * given the iframe's ref.
  *
- * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - iframe ref
+ * @param {React.MutableRefObject< HTMLDivElement >} iFrameWrapperRef - iframe ref
  * @returns {Window | null}	                                     Window object of the iframe
  */
 export const getIframeWindowFromRef = (
-	iFrameRef: React.MutableRefObject< HTMLDivElement >
+	iFrameWrapperRef: React.MutableRefObject< HTMLDivElement >
 ): Window | null => {
-	const iFrame: HTMLIFrameElement = iFrameRef?.current?.querySelector(
+	const iFrame: HTMLIFrameElement = iFrameWrapperRef?.current?.querySelector(
 		'iframe.components-sandbox'
 	);
 	return iFrame?.contentWindow;
@@ -31,13 +31,13 @@ export const getIframeWindowFromRef = (
 /**
  * Custom hook to set the player ready to use:
  *
- * @param {React.MutableRefObject< HTMLDivElement >} iFrameRef - useRef of the sandbox wrapper.
- * @param {boolean} isRequestingPreview                        - Whether the preview is being requested.
- * @param {UseVideoPlayerOptions} options                      - Options object.
- * @returns {UseVideoPlayer}                                     playerIsReady and playerState
+ * @param {React.MutableRefObject< HTMLDivElement >} iFrameWrapperRef - useRef of the sandbox wrapper.
+ * @param {boolean} isRequestingPreview                               - Whether the preview is being requested.
+ * @param {UseVideoPlayerOptions} options                             - Options object.
+ * @returns {UseVideoPlayer}                                            playerIsReady and playerState
  */
 const useVideoPlayer = (
-	iFrameRef: React.MutableRefObject< HTMLDivElement >,
+	iFrameWrapperRef: React.MutableRefObject< HTMLDivElement >,
 	isRequestingPreview: boolean,
 	{ initialTimePosition, wrapperElement, previewOnHover }: UseVideoPlayerOptions
 ): UseVideoPlayer => {
@@ -115,7 +115,7 @@ const useVideoPlayer = (
 	const wasPreviewOnHoverEnabled = usePrevious( isPreviewOnHoverEnabled );
 	const wasPreviewOnHoverJustEnabled = isPreviewOnHoverEnabled && ! wasPreviewOnHoverEnabled;
 
-	const sandboxIFrameWindow = getIframeWindowFromRef( iFrameRef );
+	const sandboxIFrameWindow = getIframeWindowFromRef( iFrameWrapperRef );
 
 	// Listen player events.
 	useEffect( () => {
@@ -143,7 +143,7 @@ const useVideoPlayer = (
 		}
 
 		sandboxIFrameWindow.postMessage( { event: 'videopress_action_play' }, '*' );
-	}, [ iFrameRef, playerIsReady, sandboxIFrameWindow ] );
+	}, [ iFrameWrapperRef, playerIsReady, sandboxIFrameWindow ] );
 
 	const pause = useCallback( () => {
 		if ( ! sandboxIFrameWindow || ! playerIsReady ) {
@@ -151,7 +151,7 @@ const useVideoPlayer = (
 		}
 
 		sandboxIFrameWindow.postMessage( { event: 'videopress_action_pause' }, '*' );
-	}, [ iFrameRef, playerIsReady, sandboxIFrameWindow ] );
+	}, [ iFrameWrapperRef, playerIsReady, sandboxIFrameWindow ] );
 
 	useEffect( () => {
 		if ( ! wrapperElement || ! isPreviewOnHoverEnabled ) {

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -119,7 +119,7 @@ const useVideoPlayer = (
 
 	// Listen player events.
 	useEffect( () => {
-		const win = getIframeWindowFromRef( iFrameRef );
+		const win = getIframeWindowFromRef( iFrameWrapperRef );
 		if ( ! win ) {
 			return;
 		}
@@ -135,7 +135,7 @@ const useVideoPlayer = (
 			// Remove the listener when the component is unmounted.
 			win.removeEventListener( 'message', listenEventsHandler );
 		};
-	}, [ iFrameRef, isRequestingPreview, wasPreviewOnHoverJustEnabled, previewOnHover ] );
+	}, [ iFrameWrapperRef, isRequestingPreview, wasPreviewOnHoverJustEnabled, previewOnHover ] );
 
 	const play = useCallback( () => {
 		if ( ! sandboxIFrameWindow || ! playerIsReady ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR enqueued the IFrame API file in the player sandbox instance of the VideoPress video block.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: enqueue iframe api file in the player Sandbox

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD...
*

