### PR TITLE
VideoPress: set Preview On Hover player initial state only when it's enabled

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-set-pho-state-only-when-enabled
+++ b/projects/packages/videopress/changelog/update-videopress-set-pho-state-only-when-enabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: set Preview On Hover player initial state only when it's enabled

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -71,16 +71,22 @@ const useVideoPlayer = (
 			playerState.current = 'first-play';
 			debug( 'state: first-play detected' );
 
-			debug( 'pause video' );
-			source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
+			/*
+			 * Pause and set the position at time
+			 * if the previewOnHover feature is enabled.
+			 */
+			if ( previewOnHover ) {
+				debug( 'pause video' );
+				source.postMessage( { event: 'videopress_action_pause' }, { targetOrigin: '*' } );
 
-			// Set position at time if it was provided.
-			if ( typeof initialTimePosition !== 'undefined' ) {
-				debug( 'set position at time %o ', initialTimePosition );
-				source.postMessage(
-					{ event: 'videopress_action_set_currenttime', currentTime: initialTimePosition / 1000 },
-					{ targetOrigin: '*' }
-				);
+				// Set position at time if it was provided.
+				if ( typeof initialTimePosition !== 'undefined' ) {
+					debug( 'set position at time %o ', initialTimePosition );
+					source.postMessage(
+						{ event: 'videopress_action_set_currenttime', currentTime: initialTimePosition / 1000 },
+						{ targetOrigin: '*' }
+					);
+				}
 			}
 
 			// Here we consider the video as ready to be controlled.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an issue that happens in the VideoPress video block. The `useVideoPlayer()` hook pauses and sets the player's initial position without checking if the Preview On Hover effect is defined.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: set Preview On Hover player initial state only when it's enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a VideoPress video block instance
* Set the block video
* Select the block
* Play the video by clicking on it
* **Before**: confirm the first time the video pauses right after it starts to play
You can check the logs() in the debug console:

<img width="492" alt="Screen Shot 2023-05-01 at 11 09 07" src="https://user-images.githubusercontent.com/77539/235464243-486ac0d9-ec38-4807-88f9-68ad37df4db4.png">

* **After**: confirm the video plays correctly after clicking on it.



