### PR TITLE
VideoPress: fix playing state of poster mini-player

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-fix-mini-player-playing-status
+++ b/projects/packages/videopress/changelog/update-videopress-fix-mini-player-playing-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: fix playing state of poster mini-player

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -252,9 +252,16 @@ function VideoFramePicker( {
 	const { preview = { html: null }, isRequestingEmbedPreview } = usePreview( url );
 	const { html } = preview;
 
-	const { playerIsReady } = useVideoPlayer( playerWrapperRef, isRequestingEmbedPreview, {
+	const { playerIsReady, pause } = useVideoPlayer( playerWrapperRef, isRequestingEmbedPreview, {
 		initialTimePosition: atTime,
 	} );
+
+	useEffect( () => {
+		if ( ! playerIsReady ) {
+			return;
+		}
+		pause();
+	}, [ playerIsReady, pause ] );
 
 	const onTimestampDebounceChange = useCallback(
 		iframeTimePosition => {

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-player/index.ts
@@ -119,7 +119,8 @@ const useVideoPlayer = (
 
 	// Listen player events.
 	useEffect( () => {
-		if ( ! sandboxIFrameWindow ) {
+		const win = getIframeWindowFromRef( iFrameRef );
+		if ( ! win ) {
 			return;
 		}
 
@@ -128,13 +129,13 @@ const useVideoPlayer = (
 		}
 
 		debug( 'player is ready to listen events' );
-		sandboxIFrameWindow.addEventListener( 'message', listenEventsHandler );
+		win.addEventListener( 'message', listenEventsHandler );
 
 		return () => {
 			// Remove the listener when the component is unmounted.
-			sandboxIFrameWindow.removeEventListener( 'message', listenEventsHandler );
+			win.removeEventListener( 'message', listenEventsHandler );
 		};
-	}, [ sandboxIFrameWindow, isRequestingPreview, wasPreviewOnHoverJustEnabled, previewOnHover ] );
+	}, [ iFrameRef, isRequestingPreview, wasPreviewOnHoverJustEnabled, previewOnHover ] );
 
 	const play = useCallback( () => {
 		if ( ! sandboxIFrameWindow || ! playerIsReady ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

There is an issue when the app visualizes the poster mini-player. In short, it automatically plays once it's rendered. 
This PR fixes the issue of picking the WIndow object (iFrame contentWindow) and pauses the video every time the player renders.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: fix playing state of poster mini-player

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Enable `beta` extensions
* Create a VideoPress video instance
* Show the block sidebwar
* Switch the video frame poster by toggling the proper controlsd
* **Before**, confirm that the mini-player plays automatically
* **After**, confirm the player is rendered and paused.

#### Before
https://user-images.githubusercontent.com/77539/235495271-dca1d2e5-b5cb-4a24-a42d-82acf374b37c.mov

#### After
https://user-images.githubusercontent.com/77539/235495316-9c995ba1-18a6-4658-8766-30209aaf8aea.mov





