### PR TITLE
VideoPress: move video frame poster to production

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-move-video-frame-poster-to-prod
+++ b/projects/packages/videopress/changelog/update-videopress-move-video-frame-poster-to-prod
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: move video frame poster to production

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -533,21 +533,6 @@ export default function PosterPanel( {
 		} );
 	};
 
-	if ( ! isVideoFramePosterEnabled() ) {
-		return (
-			<PanelBody title={ __( 'Poster', 'jetpack-videopress-pkg' ) } className="poster-panel">
-				<PosterDropdown attributes={ attributes } setAttributes={ setAttributes } />
-				<VideoPosterCard poster={ poster } className="poster-panel-card" />
-
-				{ poster && (
-					<MenuItem onClick={ onRemovePoster } icon={ linkOff } isDestructive variant="tertiary">
-						{ __( 'Remove and use default', 'jetpack-videopress-pkg' ) }
-					</MenuItem>
-				) }
-			</PanelBody>
-		);
-	}
-
 	const panelTitle = isVideoFramePosterEnabled()
 		? __( 'Poster and preview', 'jetpack-videopress-pkg' )
 		: __( 'Poster', 'jetpack-videopress-pkg' );
@@ -590,15 +575,17 @@ export default function PosterPanel( {
 				) }
 			</div>
 
-			<VideoHoverPreviewControl
-				previewOnHover={ previewOnHover }
-				previewAtTime={ previewAtTime }
-				loopDuration={ previewLoopDuration }
-				videoDuration={ videoDuration }
-				onPreviewOnHoverChange={ onPreviewOnHoverChange }
-				onPreviewAtTimeChange={ onPreviewAtTimeChange }
-				onLoopDurationChange={ onLoopDurationChange }
-			/>
+			{ isVideoFramePosterEnabled() && (
+				<VideoHoverPreviewControl
+					previewOnHover={ previewOnHover }
+					previewAtTime={ previewAtTime }
+					loopDuration={ previewLoopDuration }
+					videoDuration={ videoDuration }
+					onPreviewOnHoverChange={ onPreviewOnHoverChange }
+					onPreviewAtTimeChange={ onPreviewAtTimeChange }
+					onLoopDurationChange={ onLoopDurationChange }
+				/>
+			) }
 		</PanelBody>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -297,8 +297,7 @@ function VideoFramePicker( {
 				max={ duration }
 				value={ timestamp }
 				wait={ 250 }
-				fineAdjustment={ 1 }
-				decimalPlaces={ 2 }
+				fineAdjustment={ 50 }
 				onChange={ setTimestamp }
 				onDebounceChange={ onTimestampDebounceChange }
 			/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR reorganizes the poster panel component's code not to hide the video frame poster behind the `beta` extensions.
Thus, with these changes, the feature will be in production in the next cycle release.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: move video frame poster to production

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a connected site
* Disable `beta` extensions
* Go to the block editor
* Create/edit a VideoPress video instance
* Confirm that the Video frame poster is available in the block sidebar

<img width="967" alt="Screen Shot 2023-05-01 at 14 49 09" src="https://user-images.githubusercontent.com/77539/235500363-3f2d7852-9225-4c40-958b-86ee17371480.png">

* Confirm you can pick an iframe by using the Timestamp controls

https://user-images.githubusercontent.com/77539/235499998-4c785f01-8fc7-450c-8145-bf1a1f011b32.mov

There is an issue with the mini-player that doesn't pause it, and sometimes it shows the `loading` state constantly. [This PR tackles it](https://github.com/Automattic/jetpack/pull/30383).
