### PR TITLE
Publicize components: add Tumblr preview

### DIFF
--- a/projects/js-packages/publicize-components/src/components/social-previews/constants.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/constants.js
@@ -2,6 +2,7 @@ import { SocialServiceIcon } from '@automattic/jetpack-components';
 import { SearchPreview } from '@automattic/social-previews';
 import { __ } from '@wordpress/i18n';
 import FacebookPreview from '../facebook-preview';
+import TumblrPreview from '../tumblr-preview';
 import { LinkedIn } from './linkedin';
 import { Twitter } from './twitter';
 
@@ -40,7 +41,7 @@ export const AVAILABLE_SERVICES = [
 		title: __( 'Tumblr', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="tumblr" { ...props } />,
 		name: 'tumblr',
-		preview: () => null,
+		preview: TumblrPreview,
 	},
 	{
 		title: __( 'Mastodon', 'jetpack' ),

--- a/projects/js-packages/publicize-components/src/components/tumblr-preview/index.js
+++ b/projects/js-packages/publicize-components/src/components/tumblr-preview/index.js
@@ -1,9 +1,16 @@
 import { TumblrFullPreview } from '@automattic/social-previews';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 
 const TumblrPreview = props => {
+	const { content } = useSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+
+		return {
+			content: getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
+		};
+	} );
 	const { connections } = useSocialMediaConnections();
 	const { message } = useSocialMediaMessage();
 
@@ -19,18 +26,8 @@ const TumblrPreview = props => {
 	}
 
 	return (
-		<TumblrFullPreview
-			{ ...props }
-			user={ user }
-			description={ props.content }
-			customText={ message }
-		/>
+		<TumblrFullPreview { ...props } user={ user } description={ content } customText={ message } />
 	);
 };
-export default withSelect( select => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
 
-	return {
-		content: getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
-	};
-} )( TumblrPreview );
+export default TumblrPreview;

--- a/projects/js-packages/publicize-components/src/components/tumblr-preview/index.js
+++ b/projects/js-packages/publicize-components/src/components/tumblr-preview/index.js
@@ -1,0 +1,36 @@
+import { TumblrFullPreview } from '@automattic/social-previews';
+import { withSelect } from '@wordpress/data';
+import useSocialMediaConnections from '../../hooks/use-social-media-connections';
+import useSocialMediaMessage from '../../hooks/use-social-media-message';
+
+const TumblrPreview = props => {
+	const { connections } = useSocialMediaConnections();
+	const { message } = useSocialMediaMessage();
+
+	const connection = connections?.find( conn => conn.service_name === 'tumblr' );
+
+	let user;
+
+	if ( connection ) {
+		user = {
+			displayName: props.author,
+			avatarUrl: connection.profile_picture,
+		};
+	}
+
+	return (
+		<TumblrFullPreview
+			{ ...props }
+			user={ user }
+			description={ props.content }
+			customText={ message }
+		/>
+	);
+};
+export default withSelect( select => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+
+	return {
+		content: getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
+	};
+} )( TumblrPreview );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes (1204250791794927-as-1204281808721020)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR implements the Tumblr share preview of a post.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
[Project thread](https://github.com/Automattic/jetpack/pull/pdrWKz-Ka-p2)

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this PR branch
* Checkout the latest `trunk` in calypso
* In `wp-calypso/packages/social-previews/` directory, run `pnpm link --global` to expose the package to global `node_modules` for `pnpm`
* In `jetpack/projects/js-packages/publicize-components/` directory, run `pnpm link --global @automattic/social-previews`
* In `wp-calypso` root, run `yarn` and then `yarn workspace @automattic/social-previews run build`
* In Jetpack, run `jetpack build plugins/jetpack --no-pnpm-install`
* Start writing a new post with JT site via Jetpack
* Click Jetpack icon on the top of the sidebar
* Under "Social Previews", click on "Preview"
* Check that you see the new Tumblr preview and that there's no error in the console
* Once you are done, run `pnpm unlink` in Jetpack

<img width="400" alt="Screenshot 2023-05-01 at 2 06 48 PM" src="https://user-images.githubusercontent.com/1620183/235503948-c3b9cf78-c3e9-4d96-b1a7-400dca4550e5.png">
<img width="400" alt="Screenshot 2023-05-01 at 2 06 48 PM" src="https://user-images.githubusercontent.com/1620183/235503950-418087e3-c1ef-49cb-88f2-1b688e9b156d.png">
