### PR TITLE
CRM: Resolves 98 - export company data with segments

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-98-export_company_data_with_segments
+++ b/projects/plugins/crm/changelog/fix-crm-98-export_company_data_with_segments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Export: contact segments now export company info

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Segments.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Segments.php
@@ -713,7 +713,6 @@ class zbsDAL_segments extends zbsDAL_ObjectLayer {
 
 			// count ver
 			if ( $only_count ) {
-				$contact_get_args            = $contact_get_args;
 				$contact_get_args['page']    = -1;
 				$contact_get_args['perPage'] = -1;
 				$contact_get_args['count']   = true;

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Segments.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Segments.php
@@ -635,106 +635,123 @@ class zbsDAL_segments extends zbsDAL_ObjectLayer {
                 return $this->getSegmentAudience( $segmentID, $page, $perPage, $sortByField, $sortOrder, $onlyCount, $withDND );
             }
 
-           /**
-             * Runs a filtered search on customers based on a segment's condition
-             * returns array or count ($onlyCount)
-             */
-            public function getSegmentAudience(
-                $segmentID = -1,
-                $page = 0,
-                $perPage = 20,
-                $sortByField = 'ID',
-                $sortOrder = 'DESC',
-                $onlyCount = false,
-                $withDND = false,
-                $limited_fields = false
-            ){
+	/**
+	 * Runs a filtered search on customers based on a segment's condition
+	 *
+	 * @param int $segment_id ID of segment.
+	 * @param int $page Page number.
+	 * @param int $per_page Number of objects per page.
+	 * @param int $sort_by_field Field to sort by.
+	 * @param int $sort_order Sort order.
+	 * @param int $only_count Only return counts.
+	 * @param int $with_dnd Return DND info.
+	 * @param int $limited_fields Only return specific fields.
+	 *
+	 * @return array or count ($onlyCount)
+	 */
+	public function getSegmentAudience(
+		$segment_id = -1,
+		$page = 0,
+		$per_page = 20,
+		$sort_by_field = 'ID',
+		$sort_order = 'DESC',
+		$only_count = false,
+		$with_dnd = false,
+		$limited_fields = false
+	) {
 
+		// assumes sensible paging + sort vars... no checking of them
 
-                // assumes sensible paging + sort vars... no checking of them
+		if ( $segment_id > 0 ) {
 
-                if ($segmentID > 0){
+			#} Retrieve segment + conditions
+			$segment = $this->getSegment( $segment_id, true );
 
-                    #} Retrieve segment + conditions
-                    $segment = $this->getSegment($segmentID,true);
-                    $conditions = array(); if (isset($segment['conditions'])) $conditions = $segment['conditions'];
-                    $matchType = 'all'; if (isset($segment['matchtype'])) $matchType = $segment['matchtype'];
+			$conditions = array();
+			if ( isset( $segment['conditions'] ) ) {
+				$conditions = $segment['conditions'];
+			}
 
-                    try {
+			$match_type = 'all';
+			if ( isset( $segment['matchtype'] ) ) {
+				$match_type = $segment['matchtype'];
+			}
 
-                        // retrieve getContacts arguments from a list of segment conditions
-                        $contactGetArgs = $this->segmentConditionsToArgs($conditions,$matchType);
+			try {
 
-                        // Remove any segment area error notice
-                        $this->remove_segment_error( $segmentID );
+				// retrieve getContacts arguments from a list of segment conditions
+				$contact_get_args = $this->segmentConditionsToArgs( $conditions, $match_type );
 
-                    } catch ( Segment_Condition_Exception $exception ){
+				// Remove any segment area error notice
+				$this->remove_segment_error( $segment_id );
 
-                        // We're missing the condition class for one or more of this segment's conditions.
-                        $this->segment_error_condition_missing( $segmentID, $exception );
+			} catch ( Segment_Condition_Exception $exception ) {
 
-                        // return fail
-                        return false;
-                        
-                    }
+				// We're missing the condition class for one or more of this segment's conditions.
+				$this->segment_error_condition_missing( $segment_id, $exception );
 
-                        // needs to be ownerless for now
-                        $contactGetArgs['ignoreowner'] = zeroBSCRM_DAL2_ignoreOwnership(ZBS_TYPE_CONTACT);
+				// return fail
+				return false;
 
-                        // add paging params
-                        $contactGetArgs['sortByField'] = $sortByField;
-                        $contactGetArgs['sortOrder'] = $sortOrder;
-                        $contactGetArgs['page'] = $page;
-                        if ($perPage !== -1)
-                            $contactGetArgs['perPage'] = $perPage; // over 100k? :o
-                        else { 
-                            // no limits
-                            $contactGetArgs['page'] = -1;
-                            $contactGetArgs['perPage'] = -1;
-                        }
+			}
 
-                        // count ver
-                        if ($onlyCount){
-                            $contactGetArgs = $contactGetArgs;
-                            $contactGetArgs['page'] = -1;
-                            $contactGetArgs['perPage'] = -1;
-                            $contactGetArgs['count'] = true;
+			// needs to be ownerless for now
+			$contact_get_args['ignoreowner'] = zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_CONTACT );
 
-                            $count = $this->DAL()->contacts->getContacts($contactGetArgs);
+			// add paging params
+			$contact_get_args['sortByField'] = $sort_by_field;
+			$contact_get_args['sortOrder']   = $sort_order;
+			$contact_get_args['page']        = $page;
 
-                                // effectively a compile, so update compiled no on record
-                                $this->updateSegmentCompiled($segmentID,$count,time());
+			if ( $per_page !== -1 ) {
+				$contact_get_args['perPage'] = $per_page; // over 100k? :o
+			} else {
+				// no limits
+				$contact_get_args['page']    = -1;
+				$contact_get_args['perPage'] = -1;
+			}
 
-                            return $count;
-                        }
+			// count ver
+			if ( $only_count ) {
+				$contact_get_args            = $contact_get_args;
+				$contact_get_args['page']    = -1;
+				$contact_get_args['perPage'] = -1;
+				$contact_get_args['count']   = true;
 
-                        // got dnd?
-                        if ( $withDND ){
-                            $contactGetArgs['withDND'] = true;
-                        }
+				$count = $this->DAL()->contacts->getContacts( $contact_get_args );
 
-                        // limited fields?
-                        if ( is_array( $limited_fields ) ){
-                            $contactGetArgs['onlyColumns'] = $limited_fields;
-                        }
+					// effectively a compile, so update compiled no on record
+					$this->updateSegmentCompiled( $segment_id, $count, time() );
 
-                        $contacts = $this->DAL()->contacts->getContacts( $contactGetArgs );
+				return $count;
+			}
 
-                        // if no limits, update compile record (effectively a compile)
-                        if ($contactGetArgs['page'] == -1 && $contactGetArgs['perPage'] == -1){
+			// got dnd?
+			if ( $with_dnd ) {
+				$contact_get_args['withDND'] = true;
+			}
 
-                            $this->updateSegmentCompiled($segmentID,count($contacts),time());
+			// limited fields?
+			if ( is_array( $limited_fields ) ) {
+				$contact_get_args['onlyColumns'] = $limited_fields;
+			}
 
-                        }
-           
-                        // Retrieve
-                        return $contacts;
+			$contacts = $this->DAL()->contacts->getContacts( $contact_get_args );
 
-                }
+			// if no limits, update compile record (effectively a compile)
+			if ( $contact_get_args['page'] === -1 && $contact_get_args['perPage'] === -1 ) {
 
-                return false;
+				$this->updateSegmentCompiled( $segment_id, count( $contacts ), time() );
 
-           }
+			}
+
+			// Retrieve
+			return $contacts;
+
+		}
+
+		return false;
+	}
 
            /**
              * checks all segments against a contact

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Segments.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Segments.php
@@ -719,8 +719,8 @@ class zbsDAL_segments extends zbsDAL_ObjectLayer {
 
 				$count = $this->DAL()->contacts->getContacts( $contact_get_args );
 
-					// effectively a compile, so update compiled no on record
-					$this->updateSegmentCompiled( $segment_id, $count, time() );
+				// effectively a compile, so update compiled no on record
+				$this->updateSegmentCompiled( $segment_id, $count, time() );
 
 				return $count;
 			}

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Segments.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Segments.php
@@ -736,6 +736,8 @@ class zbsDAL_segments extends zbsDAL_ObjectLayer {
 				$contact_get_args['onlyColumns'] = $limited_fields;
 			}
 
+			$contact_get_args['withAssigned'] = true;
+
 			$contacts = $this->DAL()->contacts->getContacts( $contact_get_args );
 
 			// if no limits, update compile record (effectively a compile)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#98 - export company data with segments

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The original issue was to export company data with contacts. When testing, I confirmed that company data was properly exported, but not when exporting a segment, which gave this error:

`PHP Notice:  Undefined index: company in /includes/ZeroBSCRM.DAL3.Export.php on line 462`

Finding the root cause was a bit of a rabbit hole, but ultimately the fix seems to be that `getSegmentAudience()` didn't use the `withAssigned` param when running `getContacts()`, so it never got company data.

This PR adds that param, thereby fixing the issue. I also code-standardised the function and removed this silly line:
https://github.com/Automattic/jetpack/blob/db8ae2cb6530941e400139f28ff2e6d946c37551/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Segments.php#L698

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure some contacts have company data in them.
2. Go to segments: `/wp-admin/admin.php?page=manage-segments`
3. Click "Export .CSV" next to one of the segments that has contacts with company data.
4. Ensure company fields are ticked.
5. Export the segment.

In `trunk`, one gets a PHP notice and the company data is blank.

In `fix/crm/98-export_company_data_with_segments`, the PHP notice is no more, and the company data is present.
