### PR TITLE
Jetpack Visual Refresh: "Activate Stats" banner styling

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -242,24 +242,17 @@ export class DashStats extends Component {
 		return (
 			<div className="jp-at-a-glance__stats-inactive">
 				<div className="jp-at-a-glance__stats-inactive-icon">
-					<img
-						src={ imagePath + 'stats.svg' }
-						width="60"
-						height="60"
-						alt={ __( 'Line chart overlaid on a bar chart', 'jetpack' ) }
-						className="jp-at-a-glance__stats-icon"
-					/>
+					<JetpackLogo height={ 64 } showText={ false } />
 				</div>
 				<div className="jp-at-a-glance__stats-inactive-text">
 					{ this.props.isOfflineMode
 						? __( 'Unavailable in Offline Mode', 'jetpack' )
 						: createInterpolateElement(
 								__(
-									'<Button>Activate Jetpack Stats</Button> to see page views, likes, followers, subscribers, and more! <a1>Learn More</a1>',
+									'Activate Jetpack Stats to see page views, likes, followers, subscribers, and more! <a1>Learn More</a1>',
 									'jetpack'
 								),
 								{
-									Button: <Button className="jp-link-button" onClick={ this.activateStats } />,
 									a1: (
 										<a
 											href={ getRedirectUrl( 'jetpack-support-wordpress-com-stats' ) }

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -1,5 +1,5 @@
 import { getRedirectUrl, JetpackLogo, numberFormat } from '@automattic/jetpack-components';
-import { Spinner } from '@wordpress/components';
+import { ExternalLink, Spinner } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -241,19 +241,20 @@ export class DashStats extends Component {
 		return (
 			<div className="jp-at-a-glance__stats-inactive">
 				<div className="jp-at-a-glance__stats-inactive-icon">
-					<JetpackLogo height={ 64 } showText={ false } />
+					<JetpackLogo height={ 40 } showText={ false } />
 				</div>
 				<div className="jp-at-a-glance__stats-inactive-text">
 					{ this.props.isOfflineMode
 						? __( 'Unavailable in Offline Mode', 'jetpack' )
 						: createInterpolateElement(
 								__(
-									'Activate Jetpack Stats to see page views, likes, followers, subscribers, and more! <a1>Learn More</a1>',
+									'<h3>Activate Jetpack Stats</h3> Get insights on page views, likes, subscribers, and more! <a1>Learn More</a1>',
 									'jetpack'
 								),
 								{
+									h3: <h3 />,
 									a1: (
-										<a
+										<ExternalLink
 											href={ getRedirectUrl( 'jetpack-support-wordpress-com-stats' ) }
 											target="_blank"
 											rel="noopener noreferrer"
@@ -265,7 +266,7 @@ export class DashStats extends Component {
 				{ ! this.props.isOfflineMode && (
 					<div className="jp-at-a-glance__stats-inactive-button">
 						<Button onClick={ this.activateStats } primary>
-							{ __( 'Activate', 'jetpack' ) }
+							{ __( 'Activate Stats', 'jetpack' ) }
 						</Button>
 					</div>
 				) }

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -1,4 +1,3 @@
-import { imagePath } from 'constants/urls';
 import { getRedirectUrl, JetpackLogo, numberFormat } from '@automattic/jetpack-components';
 import { Spinner } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -244,15 +244,17 @@ export class DashStats extends Component {
 					<JetpackLogo height={ 40 } showText={ false } />
 				</div>
 				<div className="jp-at-a-glance__stats-inactive-text">
-					{ this.props.isOfflineMode
-						? __( 'Unavailable in Offline Mode', 'jetpack' )
-						: createInterpolateElement(
+					{ this.props.isOfflineMode ? (
+						__( 'Unavailable in Offline Mode', 'jetpack' )
+					) : (
+						<>
+							<h3> { __( 'Activate Jetpack Stats', 'jetpack' ) }</h3>
+							{ createInterpolateElement(
 								__(
-									'<h3>Activate Jetpack Stats</h3> Get insights on page views, likes, subscribers, and more! <a1>Learn More</a1>',
+									'Get insights on page views, likes, subscribers, and more! <a1>Learn More</a1>',
 									'jetpack'
 								),
 								{
-									h3: <h3 />,
 									a1: (
 										<ExternalLink
 											href={ getRedirectUrl( 'jetpack-support-wordpress-com-stats' ) }
@@ -261,7 +263,9 @@ export class DashStats extends Component {
 										/>
 									),
 								}
-						  ) }
+							) }
+						</>
+					) }
 				</div>
 				{ ! this.props.isOfflineMode && (
 					<div className="jp-at-a-glance__stats-inactive-button">

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -34,7 +34,7 @@
 
 	.dops-banner__description {
 		padding-left: 8px;
-	
+
 		.jp-link-button {
 			padding: 0;
 		}
@@ -92,18 +92,29 @@
 }
 
 .jp-at-a-glance__stats-inactive-icon {
+	padding: 0;
+	display: flex;
+	flex-grow: 0;
+
 	@include breakpoint( '<660px' ) {
 		display: none;
-	}
-
-	@include breakpoint( '>660px' ) {
-		flex-basis: 10%;
 	}
 }
 
 .jp-at-a-glance__stats-inactive-text {
 	font-size: $font-body-small;
 	line-height: 1.5;
+	letter-spacing: -0.3px;
+	color: $gray-80;
+	flex-grow: 1;
+
+	h3 {
+		margin: 0;
+		font-size: 15px;
+		font-weight: 700;
+		line-height: 136%;
+		color: $black;
+	}
 
 	@include breakpoint( '<660px' ) {
 		padding: 0 0 rem( 16px );
@@ -118,9 +129,19 @@
 .jp-at-a-glance__stats-inactive-button {
 	text-align: left;
 
+	button.dops-button.is-primary {
+		padding: 4px 20px;
+		font-size: $font-body-small;
+
+		&:focus {
+			border: 1px solid $white;
+			box-shadow: 0 0 0 1px $black;
+		}
+	}
+
 	@include breakpoint( '>660px' ) {
-		flex-basis: 40%;
-		text-align: right;
+		flex-grow: 0;
+		margin-left: 64px;
 	}
 }
 
@@ -564,7 +585,8 @@ a.jp-dash-item__manage-in-wpcom,
 .dops-banner__title a,
 .jp-connection-settings__actions a,
 .jp-dash-item a:not( .dops-button ),
-.dops-banner__description .jp-link-button {
+.dops-banner__description .jp-link-button,
+.jp-at-a-glance__stats-inactive-text a.components-external-link {
 	&, &:active, &:visited, &:hover, &:focus {
 		cursor: pointer;
 		font-weight: 400;

--- a/projects/plugins/jetpack/changelog/fix-enable-stats-banner
+++ b/projects/plugins/jetpack/changelog/fix-enable-stats-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Minor styling fixes for the At-a-Glance page on WooExpress.


### PR DESCRIPTION
## Proposed changes:
* Fix styling for the "Enable Stats" banner

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1683035226031009-slack-C051H2TQR54

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Install and connect Jetpack.
2. Go to the Modules page (`/wp-admin/admin.php?page=jetpack_modules`) and disable the "Jetpack Stats" module.
3. Go to the "Dashboard -> At-a-Glance" page, you should see the "Activate Jetpack Stats" banner. Confirm that it looks good.

<img width="1060" alt="Screen Shot 2023-05-02 at 13 13 42" src="https://user-images.githubusercontent.com/1341249/235737552-070e6518-0d81-4b7b-9f6c-014f9b340139.png">