### PR TITLE
My Jetpack: Fix title responsiveness

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -95,7 +95,7 @@ export default function MyJetpackScreen() {
 					</Col>
 				</Container>
 				<Container horizontalSpacing={ 5 } horizontalGap={ message ? 3 : 6 }>
-					<Col sm={ 4 } md={ 7 } lg={ 6 }>
+					<Col sm={ 4 } md={ 8 } lg={ 12 }>
 						<Text variant="headline-small">
 							{ __( 'Manage your Jetpack products', 'jetpack-my-jetpack' ) }
 						</Text>

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-title-responsiveness
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-title-responsiveness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Use a single column for the page title section


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30388.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use a full width column for the page title, so it uses all the available space before spliting lines

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Jetpack > My Jetpack`
* Change the width of the window and observe how the page title wrap on the available space
* It should not break the line while there is available space, only wrapping the words when the available width is small enought

| **Before** | **After** |
| -----------|----------|
| <img width="1081" alt="Screen Shot 2023-05-02 at 14 40 37" src="https://user-images.githubusercontent.com/6760046/235743395-e5292297-70b7-47c2-94ea-75c2d585d5f2.png"> | <img width="867" alt="Screen Shot 2023-05-02 at 14 43 18" src="https://user-images.githubusercontent.com/6760046/235743551-592ddb34-7179-411f-9bf2-58805bf73a4e.png"> |


