### PR TITLE
Fix inbox dropdown menu overflow

### DIFF
--- a/projects/packages/forms/changelog/fix-inbox-dropdown-menu-overflow
+++ b/projects/packages/forms/changelog/fix-inbox-dropdown-menu-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix dropdown menu not working due to some CSS issues

--- a/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
@@ -30,11 +30,14 @@ const SingleActionsMenu = ( { id } ) => {
 			} );
 			await doBulkAction( [ id ], action );
 
-			await fetchResponses( {
-				...query,
-				limit: RESPONSES_FETCH_LIMIT,
-				offset: ( currentPage - 1 ) * RESPONSES_FETCH_LIMIT,
-			} );
+			await fetchResponses(
+				{
+					...query,
+					limit: RESPONSES_FETCH_LIMIT,
+					offset: ( currentPage - 1 ) * RESPONSES_FETCH_LIMIT,
+				},
+				{ append: true }
+			);
 			setLoading( false );
 		} catch ( error ) {
 			setLoading( false );

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -211,8 +211,11 @@ $action-bar-height: 88px;
 
 	.jp-forms__table-item {
 		max-height: 52px;
-		overflow: hidden;
 		transition: max-height .2s;
+
+		&.exit-active {
+			overflow: hidden;
+		}
 
 		&.exit-active,
 		&.exit-done {


### PR DESCRIPTION
Fix an issue with responses inbox dropdown menu

## Proposed changes:
The dropdown menu was not showing due to some recent CSS changes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1683039477761239-slack-C01CSBEN0QZ

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the responses inbox. Verify the kebab dropdown menu on the rows works. Verify rows animation still works correctly (move to trash/spam and back)