### PR TITLE
Blocks: avoid cache issues due to multiple content types

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-h1-1906271
+++ b/projects/plugins/jetpack/changelog/fix-h1-1906271
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Security: ensure blocks are always fully displayed on your site, even when using a caching plugin.

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -428,25 +428,83 @@ function jetpack_is_file_supported_for_sideloading( $file ) {
 }
 
 /**
+ * Go through headers and get a list of Vary headers to add,
+ * including a Vary Accept header if necessary.
+ *
+ * @since $$next-version$$
+ *
+ * @param array $headers The headers to be sent.
+ *
+ * @return array $vary_header_parts Vary Headers to be sent.
+ */
+function jetpack_get_vary_headers( $headers = array() ) {
+	$vary_header_parts = array( 'accept', 'content-type' );
+
+	foreach ( $headers as $header ) {
+		// Check for a Vary header.
+		if ( 'vary:' !== substr( strtolower( $header ), 0, 5 ) ) {
+			continue;
+		}
+
+		// If the header is a wildcard, we'll return that.
+		if ( false !== strpos( $header, '*' ) ) {
+			$vary_header_parts = array( '*' );
+			break;
+		}
+
+		// Remove the Vary: part of the header.
+		$header = preg_replace( '/^vary\:\s?/i', '', $header );
+
+		// Remove spaces from the header.
+		$header = str_replace( ' ', '', $header );
+
+		// Break the header into parts.
+		$header_parts = explode( ',', strtolower( $header ) );
+
+		// Build an array with the Accept header and what was already there.
+		$vary_header_parts = array_values( array_unique( array_merge( $vary_header_parts, $header_parts ) ) );
+	}
+
+	return $vary_header_parts;
+}
+
+/**
  * Determine whether the current request is for accessing the frontend.
+ * Also update Vary headers to indicate that the response may vary by Accept header.
  *
  * @return bool True if it's a frontend request, false otherwise.
  */
 function jetpack_is_frontend() {
-	$is_frontend = true;
+	$is_frontend        = true;
+	$is_varying_request = true;
 
 	if (
-		is_admin() ||
-		wp_doing_ajax() ||
-		wp_is_json_request() ||
-		wp_is_jsonp_request() ||
-		wp_is_xml_request() ||
-		is_feed() ||
-		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
-		( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST ) ||
-		( defined( 'WP_CLI' ) && WP_CLI )
+		is_admin()
+		|| wp_doing_ajax()
+		|| wp_is_jsonp_request()
+		|| is_feed()
+		|| ( defined( 'REST_REQUEST' ) && REST_REQUEST )
+		|| ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST )
+		|| ( defined( 'WP_CLI' ) && WP_CLI )
+	) {
+		$is_frontend        = false;
+		$is_varying_request = false;
+	} elseif (
+		wp_is_json_request()
+		|| wp_is_xml_request()
 	) {
 		$is_frontend = false;
+	}
+
+	/*
+	 * Check existing headers for the request.
+	 * If there is no existing Vary Accept header, add one.
+	 */
+	if ( $is_varying_request && ! headers_sent() ) {
+		$headers           = headers_list();
+		$vary_header_parts = jetpack_get_vary_headers( $headers );
+
+		header( 'Vary: ' . implode( ', ', $vary_header_parts ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/test_class.functions.global.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.functions.global.php
@@ -57,4 +57,79 @@ class WP_Test_Functions_Global extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test jetpack_get_vary_headers.
+	 *
+	 * @dataProvider get_test_headers
+	 * @covers ::jetpack_get_vary_headers
+	 *
+	 * @param array $headers  Array of headers.
+	 * @param array $expected Expected array of headers, to be used as Vary header.
+	 */
+	public function test_jetpack_get_vary_headers( $headers, $expected ) {
+		$vary_header_parts = jetpack_get_vary_headers( $headers );
+
+		$this->assertEquals( $expected, $vary_header_parts );
+	}
+
+	/**
+	 * Data provider for the test_jetpack_get_vary_headers() test.
+	 *
+	 * @return array
+	 */
+	public function get_test_headers() {
+		return array(
+			'no headers'                             => array(
+				array(),
+				array( 'accept', 'content-type' ),
+			),
+			'Single Vary Encoding header'            => array(
+				array(
+					'Vary: Accept-Encoding',
+				),
+				array( 'accept', 'content-type', 'accept-encoding' ),
+			),
+			'Double Vary: Accept-Encoding & Accept'  => array(
+				array(
+					'Vary: Accept, Accept-Encoding',
+				),
+				array( 'accept', 'content-type', 'accept-encoding' ),
+			),
+			'vary header'                            => array(
+				array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: Accept',
+				),
+				array( 'accept', 'content-type' ),
+			),
+			'Wildcard Vary header'                   => array(
+				array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: *',
+				),
+				array( '*' ),
+			),
+			'Multiple Vary headers'                  => array(
+				array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: Accept',
+					'Vary: Accept-Encoding',
+				),
+				array( 'accept', 'content-type', 'accept-encoding' ),
+			),
+			'Multiple Vary headers, with a wildcard' => array(
+				array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: *',
+					'Vary: Accept-Encoding',
+				),
+				array( '*' ),
+			),
+		);
+	}
 }


### PR DESCRIPTION
> **Note**
> This is a port of a fix already deployed in Jetpack 12.1
> e34bf033f72cc775f4fffe5713de43e532f870e4

## Proposed changes:

Jetpack uses the `jetpack_is_frontend()` function to output different content for some of our blocks, depending on the type of request. For example, we want to avoid outputting full block markup that needs JS and CSS to be actionable, in environments when you do not get those extra resources.

As a result, loading a post with a Form block in your browser vs. requesting it with a JSON request will output different content (the full block vs. a link to visit the post in the browser to submit a form).

We want to avoid any type of cache pollution when this happens, so folks get the full blocks in their browsers, and not a simple version of it that may have been cached by a past JSON request. To do that, we set the Vary Header to instruct caching services to treat that content differently.
Internal references:

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* D104957-code
* 1906271-h1
* p1678816029904169-slack-CRA4UEQQ3

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* See internal references
