### PR TITLE
Bit.ly: avoid errors when using non-official Bit.ly plugins alongside Jetpack.

### DIFF
--- a/projects/plugins/jetpack/3rd-party/bitly.php
+++ b/projects/plugins/jetpack/3rd-party/bitly.php
@@ -22,7 +22,14 @@ function jetpack_bitly_og_tag() {
 		if ( method_exists( $GLOBALS['bitly'], 'og_tags' ) ) {
 			$GLOBALS['bitly']->og_tags();
 		}
-	} elseif ( isset( $GLOBALS['posts'] ) && $GLOBALS['posts'][0]->ID > 0 ) {
-		printf( "<meta property=\"bitly:url\" content=\"%s\" /> \n", esc_attr( $GLOBALS['bitly']->get_bitly_link_for_post_id( $GLOBALS['posts'][0]->ID ) ) );
+	} elseif (
+		isset( $GLOBALS['posts'] )
+		&& $GLOBALS['posts'][0]->ID > 0
+		&& method_exists( $GLOBALS['bitly'], 'get_bitly_link_for_post_id' )
+	) {
+		printf(
+			"<meta property=\"bitly:url\" content=\"%s\" /> \n",
+			esc_attr( $GLOBALS['bitly']->get_bitly_link_for_post_id( $GLOBALS['posts'][0]->ID ) )
+		);
 	}
 }

--- a/projects/plugins/jetpack/changelog/fix-bitly-method-exists-30412
+++ b/projects/plugins/jetpack/changelog/fix-bitly-method-exists-30412
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Bit.ly: avoid errors when using non-official Bit.ly  plugins alongside Jetpack.


### PR DESCRIPTION
Fixes #30412

## Proposed changes:

Follow-up from #30060.

Multiple plugins use the Bitly class, and one of them does not have a `get_bitly_link_for_post_id` method. Let's not assume it exists.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

I do not know the exact plugin one can use to test this. @BrookeDot Any chance you could give it a try on the site where you ran into the issue?
