### PR TITLE
Staging Sites: Delete implementation of is_wpcom_staging_site() method

### DIFF
--- a/projects/plugins/jetpack/changelog/delete-implementation-of-is-staging-method
+++ b/projects/plugins/jetpack/changelog/delete-implementation-of-is-staging-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Delete implementation of is_wpcom_staging_site() as we are moving it to trait

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -478,18 +478,6 @@ abstract class SAL_Site {
 	}
 
 	/**
-	 * Detect whether a site is WordPress.com Staging Site.
-	 *
-	 * @return bool
-	 */
-	public function is_wpcom_staging_site() {
-		if ( function_exists( 'is_blog_wpcom_staging' ) ) {
-			return is_blog_wpcom_staging( $this->blog_id );
-		}
-		return false;
-	}
-
-	/**
 	 * Detect whether a site is an automated transfer site and WooCommerce is active.
 	 *
 	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php.
@@ -1483,6 +1471,13 @@ abstract class SAL_Site {
 
 		return array();
 	}
+
+	/**
+	 * Detect whether a site is WordPress.com Staging Site.
+	 *
+	 * @see class.json-api-site-jetpack.php for implementation.
+	 */
+	abstract public function is_wpcom_staging_site();
 
 	/**
 	 * Get site option for the production blog id (if is a WP.com Staging Site).

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -643,6 +643,17 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	/**
+	 * Detect whether a site is WordPress.com Staging Site. Not used in Jetpack.
+	 *
+	 * @see /wpcom/public.api/rest/sal/trait.json-api-site-wpcom.php.
+	 *
+	 * @return false
+	 */
+	public function is_wpcom_staging_site() {
+		return false;
+	}
+
+	/**
 	 * Get site option for the production blog id (if is a WP.com Staging Site). Not used in Jetpack.
 	 *
 	 * @see /wpcom/public.api/rest/sal/trait.json-api-site-wpcom.php.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to: https://github.com/Automattic/dotcom-forge/issues/2168

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

In this PR, I propose to delete the implementation of the `is_wpcom_staging_site()` method and keep it abstract in the base class, and implement it for Jetpack purposes to always return false.

Then, on the WPCOM side, we implement the method inside trait.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See D109668-code