### PR TITLE
e2e tests: add new step to form block test

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -34,7 +34,7 @@ const projects = [
 		project: 'Jetpack blocks',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/blocks', '--retries=1' ],
-		targets: [ 'plugins/jetpack', 'monorepo' ],
+		targets: [ 'plugins/jetpack' ],
 		suite: '',
 	},
 	{

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -34,7 +34,7 @@ const projects = [
 		project: 'Jetpack blocks',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/blocks', '--retries=1' ],
-		targets: [ 'plugins/jetpack' ],
+		targets: [ 'plugins/jetpack', 'monorepo' ],
 		suite: '',
 	},
 	{

--- a/tools/e2e-commons/pages/wp-admin/blocks/form.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/form.js
@@ -17,6 +17,7 @@ export default class FormBlock extends EditorCanvas {
 	async selectFormVariation() {
 		logger.step( `Selecting form variation` );
 		await this.canvas().click( `button:has-text('Explore Form Patterns')` );
+		await this.click( `button[aria-label='Carousel view']` );
 		await this.click( `button:has-text('Choose')` );
 	}
 


### PR DESCRIPTION
## Proposed changes:

Following #28906, you now need one additional step to pick a form in the block editor: the default view mode is now the grid mode, so we need to switch to the carousel mode so the choose button can appear, and so we can select the default form pattern.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Is CI happy? Block tests are failing, but not the form ones:
https://github.com/Automattic/jetpack/actions/runs/4870781951/jobs/8687816981

I think the failures with the tiled gallery block aren't related and can be ignored here.
