### PR TITLE
e2e tests: increase time waiting for Openverse response

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -34,7 +34,7 @@ const projects = [
 		project: 'Jetpack blocks',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/blocks', '--retries=1' ],
-		targets: [ 'plugins/jetpack', 'monorepo' ],
+		targets: [ 'plugins/jetpack' ],
 		suite: '',
 	},
 	{

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -34,7 +34,7 @@ const projects = [
 		project: 'Jetpack blocks',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/blocks', '--retries=1' ],
-		targets: [ 'plugins/jetpack' ],
+		targets: [ 'plugins/jetpack', 'monorepo' ],
 		suite: '',
 	},
 	{

--- a/tools/e2e-commons/pages/wp-admin/blocks/tilled-gallery.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/tilled-gallery.js
@@ -20,7 +20,10 @@ export default class TiledGallery extends EditorCanvas {
 		await this.click( 'text=Openverse' );
 
 		const modal = this.page.getByRole( 'dialog' );
-		await this.waitForElementToBeHidden( 'jetpack-external-media-browser__media__placeholder' );
+		await this.waitForElementToBeHidden(
+			'jetpack-external-media-browser__media__placeholder',
+			6000
+		);
 
 		for ( let i = 0; i < numImages; i++ ) {
 			await modal.getByRole( 'checkbox' ).nth( i ).click();


### PR DESCRIPTION
## Proposed changes:

Try to wait a little longer for a response from Openverse, to see if that helps us fix those flaky Tiled Gallery tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1683120094065059-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Is CI happy? https://github.com/Automattic/jetpack/actions/runs/4872651945/jobs/8691878995?pr=30426
