### PR TITLE
VideoPress: Add a wpcom/v2/videopress `check-ownership` endpoint

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-endpoint-to-check-if-video-belong-to-site
+++ b/projects/packages/videopress/changelog/update-videopress-add-endpoint-to-check-if-video-belong-to-site
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-VideoPress: Add a wpcom/v2/videopress `belong-to-site` endpoint
+VideoPress: Add a wpcom/v2/videopress `check-ownership` endpoint

--- a/projects/packages/videopress/changelog/update-videopress-add-endpoint-to-check-if-video-belong-to-site
+++ b/projects/packages/videopress/changelog/update-videopress-add-endpoint-to-check-if-video-belong-to-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: Add a wpcom/v2/videopress `belong-to-site` endpoint

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.14.0",
+	"version": "0.14.1-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.14.0';
+	const PACKAGE_VERSION = '0.14.1-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -150,7 +150,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		// Endpoint to know if the video metadata is editable.
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<video_guid>\w+)/belong-to/(?P<post_id>\d+)/',
+			$this->rest_base . '/(?P<video_guid>\w+)/check-ownership/(?P<post_id>\d+)/',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -190,7 +190,8 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 	}
 
 	/**
-	 * Check whether the video belongs to the current site.
+	 * Check whether the video belongs to the current site,
+	 * considering the given post_id and the video_guid.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response True if the video belongs to the current site, false otherwise.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -150,7 +150,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		// Endpoint to know if the video metadata is editable.
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<guid>\w+)/belong-to-site',
+			$this->rest_base . '/(?P<video_guid>\w+)/belong-to/(?P<post_id>\d+)/',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -196,17 +196,22 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 	 * @return WP_REST_Response True if the video belongs to the current site, false otherwise.
 	 */
 	public function videopress_video_belong_to_site( $request ) {
-		$guid = $request->get_param( 'guid' );
+		$post_id    = $request->get_param( 'post_id' );
+		$video_guid = $request->get_param( 'video_guid' );
 
 		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-			$found_guid = get_post_meta( $guid, 'videopress_guid', true );
+			$found_guid = get_post_meta( $post_id, 'videopress_guid', true );
 		} else {
 			$blog_id    = get_current_blog_id();
-			$info       = video_get_info_by_blogpostid( $blog_id, $guid );
+			$info       = video_get_info_by_blogpostid( $blog_id, $post_id );
 			$found_guid = $info->guid;
 		}
 
-		return rest_ensure_response( (bool) $found_guid );
+		if ( ! $found_guid ) {
+			return rest_ensure_response( false );
+		}
+
+		return rest_ensure_response( $found_guid === $video_guid );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the `check-ownership` endpoint:

```
wpcom/v2/videopress/<guid>/check-ownership/<post-id>
```

Fixes #
Part of https://github.com/Automattic/jetpack/issues/30417

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: Add a wpcom/v2/videopress `check-ownership` endpoint

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Jetpack / Atomic sites

* Pick the video post ID and GUID from a video that belongs to the site. You can use the video details page:

<img width="799" alt="Screen Shot 2023-05-03 at 14 34 10" src="https://user-images.githubusercontent.com/77539/235998575-4e56ce53-35b3-47e2-8d6b-9cf9e31fd67f.png">
* On the same page, you can open the dev-console tool and hit the endpoint:

```es6
await wp.apiFetch( {
    path: '/wpcom/v2/videopress/xpNECfX6/check-ownership/7',
} )
```

* Confirm it returns `true`

<img width="397" alt="image" src="https://user-images.githubusercontent.com/77539/235999094-0b4010a9-89e2-421f-95c0-249102781a6f.png">


Test with a valid VideoPress video, knowing the post ID and the GUID. Feel free to use `NGYE1Hqy`, `115580`

* Confirm it returns `false
