### PR TITLE
My Jetpack: Add check for product status before requesting stats

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -15,9 +15,9 @@ import ProductCard, { PRODUCT_STATUSES } from '../product-card';
 const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuItems = [] } ) => {
 	const { isRegistered, isUserConnected } = useConnection();
 
-	const { detail, status, activate, deactivate, isFetching, installStandalonePlugin } =
-		useProduct( slug );
-	const { name, description, manageUrl, requiresUserConnection, standalonePluginInfo } = detail;
+	const { detail, activate, deactivate, isFetching, installStandalonePlugin } = useProduct( slug );
+	const { name, description, manageUrl, requiresUserConnection, standalonePluginInfo, status } =
+		detail;
 	const [ installingStandalone, setInstallingStandalone ] = useState( false );
 
 	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -2,19 +2,18 @@
  * External dependencies
  */
 import { numberFormat } from '@automattic/jetpack-components';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 /**
  * Internal dependencies
  */
-import { STORE_ID } from '../../state/store';
+import { useProduct } from '../../hooks/use-product';
 import ProductCard from '../connected-product-card';
 import { SingleContextualInfo, ChangePercentageContext } from './contextual-card-info';
 
 const useVideoPressStats = () => {
-	const stats = useSelect( select => select( STORE_ID ).getProductStats( 'videopress' ) );
+	const { stats } = useProduct( 'videopress' );
 
 	const loading = stats === undefined;
 	const hasError = stats === null;

--- a/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
@@ -27,5 +27,6 @@ export function useProduct( productId ) {
 		detail,
 		isActive: detail.status === 'active',
 		isFetching: useSelect( select => select( STORE_ID ).isFetching( productId ) ),
+		stats: useSelect( select => select( STORE_ID ).getProductStats( productId ) ),
 	};
 }

--- a/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
@@ -1,4 +1,10 @@
+/**
+ * External dependencies
+ */
 import { useSelect, useDispatch } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
 import { STORE_ID } from '../../state/store';
 
 /**
@@ -21,6 +27,5 @@ export function useProduct( productId ) {
 		detail,
 		isActive: detail.status === 'active',
 		isFetching: useSelect( select => select( STORE_ID ).isFetching( productId ) ),
-		status: detail.status, // shorthand. Consider to remove.
 	};
 }

--- a/projects/packages/my-jetpack/_inc/state/resolvers.js
+++ b/projects/packages/my-jetpack/_inc/state/resolvers.js
@@ -1,6 +1,12 @@
+/**
+ * External dependencies
+ */
 import restApi from '@automattic/jetpack-api';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
 import {
 	REST_API_SITE_PURCHASES_ENDPOINT,
 	REST_API_SITE_PRODUCTS_ENDPOINT,

--- a/projects/packages/my-jetpack/_inc/state/resolvers.js
+++ b/projects/packages/my-jetpack/_inc/state/resolvers.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { PRODUCT_STATUSES } from '../components/product-card';
 import {
 	REST_API_SITE_PURCHASES_ENDPOINT,
 	REST_API_SITE_PRODUCTS_ENDPOINT,
@@ -118,7 +119,16 @@ const getProductStats = {
 	},
 	fulfill:
 		productId =>
-		async ( { dispatch } ) => {
+		async ( { dispatch, select } ) => {
+			const { status } = select.getProduct( productId );
+
+			// If the product is not active, we don't need to fetch the stats.
+			if ( status !== PRODUCT_STATUSES.ACTIVE ) {
+				// Set it to null so the requester knows the stats are not available
+				dispatch.setProductStats( productId, null );
+				return Promise.resolve();
+			}
+
 			try {
 				dispatch.setIsFetchingProductStats( productId, true );
 
@@ -132,7 +142,7 @@ const getProductStats = {
 
 				return Promise.resolve();
 			} catch ( error ) {
-				// Set it to null so the requester can know the stats are not available
+				// Set it to null so the requester knows the stats are not available
 				dispatch.setProductStats( productId, null );
 				dispatch.setIsFetchingProductStats( productId, false );
 

--- a/projects/packages/my-jetpack/_inc/state/stats-resolvers/index.js
+++ b/projects/packages/my-jetpack/_inc/state/stats-resolvers/index.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { PRODUCT_ID_VIDEOPRESS } from '../constants';
 import videoPressStatsResolver from './videopress';
 

--- a/projects/packages/my-jetpack/_inc/state/stats-resolvers/videopress.js
+++ b/projects/packages/my-jetpack/_inc/state/stats-resolvers/videopress.js
@@ -1,4 +1,10 @@
+/**
+ * External dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
 import { REST_API_VIDEOPRESS_FEATURED_STATS } from '../constants';
 
 /**

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-videopress-request-not-active
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-videopress-request-not-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Add check for product status before requesting stats


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30387

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks for the product status and, if not active, does not send a request for stats

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on a site with Jetpack, without the VideoPress plugin and VideoPress stats enabled
* Make sure VideoPress is disabled (Jetpack > Settings > Media > `Enable Videopress` is off)
* With the `network` dev tools tab opnen, go to My Jetpack
* Check that there is no request to `videopress/v1/stats/featured`
* Enable VideoPress via the Media settings page (if the plugin is installed and disabled, enabling via the card will enable the plugin as well, which we don't want now)
* Go back to My Jetpack
* Check that there is a request to `videopress/v1/stats/featured` and the card shows the stats as intended
* Now install/activate the VideoPress plugin (if on JN, use Jetpack Beta to install this PR's branch version of the plugin, as installing via the car will install the production version)
* Check that there is a request to `videopress/v1/stats/featured` and the card shows the stats as intended

https://user-images.githubusercontent.com/8486249/235983710-7a497c09-10b6-4265-a16d-e71074bbf69f.mp4