### PR TITLE
Actions: add new action to update test sites

### DIFF
--- a/.github/files/update-jetpack-staging-sites.sh
+++ b/.github/files/update-jetpack-staging-sites.sh
@@ -9,7 +9,6 @@
 TMP_DIR=$(mktemp -d) # Temp dir where the plugin .zip files are downloaded and unpacked.
 REMOTE_DIR='/srv/htdocs/jetpack-staging' # Remote dir where the unpacked plugin files are synced to.
 PLUGINS=( "jetpack" "jetpack-mu-wpcom-plugin" ); # Plugins to update.
-declare -A PLUGIN_VERSIONS # Array used to hold fetched plugin versions.
 declare -A PLUGIN_DOWNLOAD_URLS # Array used to hold fetched plugin download URLs.
 
 SITES='{
@@ -77,7 +76,6 @@ for PLUGIN in "${PLUGINS[@]}"; do
     exit 1
   else
     echo "Returned version number for $PLUGIN: $PLUGIN_VERSION"
-    PLUGIN_VERSIONS[$PLUGIN]="$PLUGIN_VERSION"
     PLUGIN_DOWNLOAD_URLS[$PLUGIN]="$DOWNLOAD_URL"
   fi
 done
@@ -101,8 +99,6 @@ for PLUGIN in "${PLUGINS[@]}"; do
     exit 1
   else
     echo "Unpacking of $PLUGIN completed successfully."
-    # Add a version.txt file for easy curl retrieval on the MC staging-updater page.
-    echo "${PLUGIN_VERSIONS[$PLUGIN]}" > "$TMP_DIR/$PLUGIN-dev/version.txt"
   fi
 done
 

--- a/.github/files/update-jetpack-staging-sites.sh
+++ b/.github/files/update-jetpack-staging-sites.sh
@@ -106,10 +106,6 @@ done
 ## Sync the new Jetpack files.
 ####################################################
 
-# Write the SSH key to temp file for use in the rsync command.
-echo "$UPDATEJETPACKSTAGING_SSH_KEY" > "$TMP_DIR/ssh_key"
-chmod 0600 "$TMP_DIR/ssh_key"
-
 # Sync new plugin files to the Atomic test sites.
 EXIT_CODE=0
 for key in $(jq -r 'keys[]' <<<"$SITES"); do
@@ -120,7 +116,7 @@ for key in $(jq -r 'keys[]' <<<"$SITES"); do
   # Attempt to rsync each plugin directory files over SSH.
   for PLUGIN in "${PLUGINS[@]}"; do
     echo "Attempting to sync $PLUGIN files to $key | blog_id: $blog_id"
-    if ! rsync -az --quiet --delete -e "ssh -i $TMP_DIR/ssh_key" "$TMP_DIR/$PLUGIN-dev/" "$ssh_string:$REMOTE_DIR/$PLUGIN/"; then
+    if ! rsync -az --quiet --delete "$TMP_DIR/$PLUGIN-dev/" "$ssh_string:$REMOTE_DIR/$PLUGIN/"; then
       echo "Failed to sync $PLUGIN files to $key | blog_id: $blog_id"
       EXIT_CODE=1
     else

--- a/.github/files/update-jetpack-staging-sites.sh
+++ b/.github/files/update-jetpack-staging-sites.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# This script is ran as part of the `UpdateJetpackStaging` TeamCity build.
+# It updates pre-defined Atomic test sites with the latest plugin versions.
+
+####################################################
+## Script variables.
+####################################################
+
+TMP_DIR=$(mktemp -d) # Temp dir where the plugin .zip files are downloaded and unpacked.
+REMOTE_DIR='/srv/htdocs/jetpack-staging' # Remote dir where the unpacked plugin files are synced to.
+PLUGINS=( "jetpack" "jetpack-mu-wpcom-plugin" ); # Plugins to update.
+declare -A PLUGIN_VERSIONS # Array used to hold fetched plugin versions.
+declare -A PLUGIN_DOWNLOAD_URLS # Array used to hold fetched plugin download URLs.
+
+SITES='{
+  "jetpackedge.wpcomstaging.com": {
+    "url": "https://jetpackedge.wpcomstaging.com/",
+    "note": "normal site",
+    "ssh_string": "jetpackedge.wordpress.com@sftp.wp.com",
+    "blog_id": "215379549"
+  },
+  "jetpackedgephp74.wpcomstaging.com": {
+    "url": "https://jetpackedgephp74.wpcomstaging.com/",
+    "note": "php 7.4",
+    "ssh_string": "jetpackedgephp74.wordpress.com@sftp.wp.com",
+    "blog_id": "215379848"
+  },
+  "jetpackedgephp82.wpcomstaging.com": {
+    "url": "https://jetpackedgephp82.wpcomstaging.com/",
+    "note": "php 8.2",
+    "ssh_string": "jetpackedgephp82.wordpress.com@sftp.wp.com",
+    "blog_id": "215380000"
+  },
+  "jetpackedgeecomm.wpcomstaging.com": {
+    "url": "https://jetpackedgeecomm.wpcomstaging.com/",
+    "note": "ecommerce plan",
+    "ssh_string": "jetpackedgeecomm.wordpress.com@sftp.wp.com",
+    "blog_id": "215380391"
+  },
+  "jetpackedgeprivate.wpcomstaging.com": {
+    "url": "https://jetpackedgeprivate.wpcomstaging.com/",
+    "note": "private site",
+    "ssh_string": "jetpackedgeprivate.wordpress.com@sftp.wp.com",
+    "blog_id": "215380534"
+  },
+  "jetpackedgewpbeta.wpcomstaging.com": {
+    "url": "https://jetpackedgewpbeta.wpcomstaging.com/",
+    "note": "latest wp beta",
+    "ssh_string": "jetpackedgewpbeta.wordpress.com@sftp.wp.com",
+    "blog_id": "215380197"
+  },
+  "jetpackedgewpprevious.wpcomstaging.com": {
+    "url": "https://jetpackedgewpprevious.wpcomstaging.com/",
+    "note": "previous wp version",
+    "ssh_string": "jetpackedgewpprevious.wordpress.com@sftp.wp.com",
+    "blog_id": "215380213"
+  }
+}'
+
+####################################################
+## Fetch plugin data from the Jetpack Beta Builder.
+####################################################
+
+# Fetch the latest data from the Jetpack Beta Builder for each plugin.
+for PLUGIN in "${PLUGINS[@]}"; do
+  echo "Fetching latest $PLUGIN data from the Jetpack Beta Builder..."
+  if ! RESPONSE=$(curl -s https://betadownload.jetpack.me/$PLUGIN-branches.json); then
+    echo "Error: unable to fetch data from Jetpack Beta Builder for $PLUGIN."
+    exit 1
+  fi
+
+  DOWNLOAD_URL=$(echo "$RESPONSE" | jq -r ".master.download_url")
+  PLUGIN_VERSION=$(echo "$RESPONSE" | jq -r ".master.version")
+
+  if [[ -z "$DOWNLOAD_URL" || -z "$PLUGIN_VERSION" ]]; then
+    echo "Error: unable to extract data from Jetpack Beta Builder response for $PLUGIN."
+    exit 1
+  else
+    echo "Returned version number for $PLUGIN: $PLUGIN_VERSION"
+    PLUGIN_VERSIONS[$PLUGIN]="$PLUGIN_VERSION"
+    PLUGIN_DOWNLOAD_URLS[$PLUGIN]="$DOWNLOAD_URL"
+  fi
+done
+
+####################################################
+## Download and unpack the plugin .zip files.
+####################################################
+
+for PLUGIN in "${PLUGINS[@]}"; do
+  echo "Attempting to download $PLUGIN .zip file..."
+  if ! curl -f -o "$TMP_DIR/$PLUGIN-dev.zip" "${PLUGIN_DOWNLOAD_URLS[$PLUGIN]}"; then
+    echo "Download of $PLUGIN .zip failed, exiting."
+    exit 1
+  else
+    echo "Download of $PLUGIN .zip completed."
+  fi
+
+  echo "Unpacking .zip file to: $TMP_DIR/$PLUGIN"
+  if ! unzip -q "$TMP_DIR/$PLUGIN-dev.zip" -d "$TMP_DIR"; then
+    echo "Unpacking of the .zip failed, exiting."
+    exit 1
+  else
+    echo "Unpacking of $PLUGIN completed successfully."
+    # Add a version.txt file for easy curl retrieval on the MC staging-updater page.
+    echo "${PLUGIN_VERSIONS[$PLUGIN]}" > "$TMP_DIR/$PLUGIN-dev/version.txt"
+  fi
+done
+
+####################################################
+## Sync the new Jetpack files.
+####################################################
+
+# Write the SSH key to temp file for use in the rsync command.
+echo "$UPDATEJETPACKSTAGING_SSH_KEY" > "$TMP_DIR/ssh_key"
+chmod 0600 "$TMP_DIR/ssh_key"
+
+# Sync new plugin files to the Atomic test sites.
+EXIT_CODE=0
+for key in $(echo "${SITES}" | jq -r 'keys[]'); do
+  # Extract values for each site.
+  ssh_string=$(echo "${SITES}" | jq -r --arg key "$key" '.[$key].ssh_string')
+  blog_id=$(echo "${SITES}" | jq -r --arg key "$key" '.[$key].blog_id')
+
+  # Attempt to rsync each plugin directory files over SSH.
+  for PLUGIN in "${PLUGINS[@]}"; do
+    echo "Attempting to sync $PLUGIN files to $key | blog_id: $blog_id"
+    if ! rsync -az --quiet --delete -e "ssh -i $TMP_DIR/ssh_key" "$TMP_DIR/$PLUGIN-dev/" "$ssh_string:$REMOTE_DIR/$PLUGIN/"; then
+      echo "Failed to sync $PLUGIN files to $key | blog_id: $blog_id"
+      EXIT_CODE=1
+    else
+      echo "Successfully synced $PLUGIN files to $key | blog_id: $blog_id"
+    fi
+  done
+done
+
+####################################################
+## Cleanup.
+####################################################
+
+echo 'Cleaning up...'
+rm -rf "$TMP_DIR"
+echo "$(basename $0) script finished."
+exit $EXIT_CODE

--- a/.github/files/update-jetpack-staging-sites.sh
+++ b/.github/files/update-jetpack-staging-sites.sh
@@ -68,8 +68,8 @@ for PLUGIN in "${PLUGINS[@]}"; do
     exit 1
   fi
 
-  DOWNLOAD_URL=$(echo "$RESPONSE" | jq -r ".master.download_url")
-  PLUGIN_VERSION=$(echo "$RESPONSE" | jq -r ".master.version")
+  DOWNLOAD_URL=$(jq -r ".master.download_url" <<<"$RESPONSE")
+  PLUGIN_VERSION=$(jq -r ".master.version" <<<"$RESPONSE")
 
   if [[ -z "$DOWNLOAD_URL" || -z "$PLUGIN_VERSION" ]]; then
     echo "Error: unable to extract data from Jetpack Beta Builder response for $PLUGIN."
@@ -112,10 +112,10 @@ chmod 0600 "$TMP_DIR/ssh_key"
 
 # Sync new plugin files to the Atomic test sites.
 EXIT_CODE=0
-for key in $(echo "${SITES}" | jq -r 'keys[]'); do
+for key in $(jq -r 'keys[]' <<<"$SITES"); do
   # Extract values for each site.
-  ssh_string=$(echo "${SITES}" | jq -r --arg key "$key" '.[$key].ssh_string')
-  blog_id=$(echo "${SITES}" | jq -r --arg key "$key" '.[$key].blog_id')
+  ssh_string=$(jq -r --arg key "$key" '.[$key].ssh_string' <<<"$SITES")
+  blog_id=$(jq -r --arg key "$key" '.[$key].blog_id' <<<"$SITES")
 
   # Attempt to rsync each plugin directory files over SSH.
   for PLUGIN in "${PLUGINS[@]}"; do

--- a/.github/workflows/update-jetpack-staging-sites.yml
+++ b/.github/workflows/update-jetpack-staging-sites.yml
@@ -19,6 +19,7 @@ jobs:
           mkdir -p ~/.ssh/
           echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
           echo "$SSH_KEY" > ~/.ssh/id_rsa
+          chmod 0600 ~/.ssh/id_rsa
 
       - name: Execute shell script
         shell: bash

--- a/.github/workflows/update-jetpack-staging-sites.yml
+++ b/.github/workflows/update-jetpack-staging-sites.yml
@@ -1,0 +1,25 @@
+name: Update Jetpack Staging Test Sites
+# Ran as part of the `UpdateJetpackStaging` TeamCity build.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run_shell_script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Env config
+        env:
+          SSH_KNOWN_HOSTS: ${{ secrets.UPDATEJETPACKSTAGING_SSH_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+
+      - name: Execute shell script
+        shell: bash
+        env:
+          UPDATEJETPACKSTAGING_SSH_KEY: ${{ secrets.UPDATEJETPACKSTAGING_SSH_KEY }}
+        run: .github/files/update-jetpack-staging-sites.sh

--- a/.github/workflows/update-jetpack-staging-sites.yml
+++ b/.github/workflows/update-jetpack-staging-sites.yml
@@ -13,13 +13,13 @@ jobs:
 
       - name: Env config
         env:
+          SSH_KEY: ${{ secrets.UPDATEJETPACKSTAGING_SSH_KEY }}
           SSH_KNOWN_HOSTS: ${{ secrets.UPDATEJETPACKSTAGING_SSH_KNOWN_HOSTS }}
         run: |
           mkdir -p ~/.ssh/
           echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          echo "$SSH_KEY" > ~/.ssh/id_rsa
 
       - name: Execute shell script
         shell: bash
-        env:
-          UPDATEJETPACKSTAGING_SSH_KEY: ${{ secrets.UPDATEJETPACKSTAGING_SSH_KEY }}
         run: .github/files/update-jetpack-staging-sites.sh


### PR DESCRIPTION
## Proposed changes:

Add a new GH workflow to update plugin files on predefined WoA test sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal: p3topS-1zT-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
With access to the proper secrets, can test this in a personal repo. Though when this gets merged, dispatch can be manually tested and any adjustments made as needed.

## Todo:

- [x] Land related wpcom diff: D109727-code
- [x] Add `UPDATEJETPACKSTAGING_SSH_KNOWN_HOSTS` secret
- [x] Add `UPDATEJETPACKSTAGING_SSH_KEY` secret
- [x] Document new secrets: PCYsg-xsv-p2