### PR TITLE
Forms: Improve Multiple/Single choice fields sidebar style settings

### DIFF
--- a/projects/packages/forms/changelog/update-forms-mc-sc-sidebar
+++ b/projects/packages/forms/changelog/update-forms-mc-sc-sidebar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update Multiple Choice and Single Choice fields Sidebar style settings

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -50,15 +50,15 @@ const JetpackFieldControls = ( {
 
 	const inputColorLabel = isChoicesBlock
 		? __( 'Option Text', 'jetpack-forms' )
-		: __( 'Field Text', 'jetpack-forms' );
+		: __( 'Field Text', 'jetpack-forms', 0 );
 
 	const backgroundColorLabel = isChoicesBlock
 		? __( 'Background', 'jetpack-forms' )
-		: __( 'Field Background', 'jetpack-forms' );
+		: __( 'Field Background', 'jetpack-forms', 0 );
 
 	const stylesPanelTitle = isChoicesBlock
 		? __( 'Options Styles', 'jetpack-forms' )
-		: __( 'Input Field Styles', 'jetpack-forms' );
+		: __( 'Input Field Styles', 'jetpack-forms', 0 );
 
 	const colorSettings = [
 		{

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -17,6 +17,7 @@ import {
 	RangeControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useFormStyle, FORM_STYLE } from '../util/form';
 import renderMaterialIcon from '../util/render-material-icon';
 import JetpackFieldCss from './jetpack-field-css';
 import JetpackFieldWidth from './jetpack-field-width';
@@ -24,6 +25,7 @@ import JetpackManageResponsesSettings from './jetpack-manage-responses-settings'
 
 const JetpackFieldControls = ( {
 	attributes,
+	clientId,
 	id,
 	placeholder,
 	placeholderField = 'placeholder',
@@ -33,6 +35,9 @@ const JetpackFieldControls = ( {
 	type,
 	width,
 } ) => {
+	const formStyle = useFormStyle( clientId );
+	const isChoicesBlock = [ 'radio', 'checkbox' ].includes( type );
+
 	const setNumberAttribute =
 		( key, parse = parseInt ) =>
 		value => {
@@ -43,12 +48,17 @@ const JetpackFieldControls = ( {
 			} );
 		};
 
-	const inputColorLabel = [ 'radio', 'checkbox' ].includes( type )
+	const inputColorLabel = isChoicesBlock
 		? __( 'Option Text', 'jetpack-forms' )
 		: __( 'Field Text', 'jetpack-forms' );
-	const backgroundColorLabel = [ 'radio', 'checkbox' ].includes( type )
+
+	const backgroundColorLabel = isChoicesBlock
 		? __( 'Background', 'jetpack-forms' )
 		: __( 'Field Background', 'jetpack-forms' );
+
+	const stylesPanelTitle = isChoicesBlock
+		? __( 'Options Styles', 'jetpack-forms' )
+		: __( 'Input Field Styles', 'jetpack-forms' );
 
 	const colorSettings = [
 		{
@@ -61,17 +71,21 @@ const JetpackFieldControls = ( {
 			onChange: value => setAttributes( { inputColor: value } ),
 			label: inputColorLabel,
 		},
-		{
+	];
+
+	if ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) {
+		colorSettings.push( {
 			value: attributes.fieldBackgroundColor,
 			onChange: value => setAttributes( { fieldBackgroundColor: value } ),
 			label: backgroundColorLabel,
-		},
-		{
+		} );
+
+		colorSettings.push( {
 			value: attributes.borderColor,
 			onChange: value => setAttributes( { borderColor: value } ),
 			label: __( 'Border', 'jetpack-forms' ),
-		},
-	];
+		} );
+	}
 
 	return (
 		<>
@@ -129,7 +143,7 @@ const JetpackFieldControls = ( {
 					initialOpen={ false }
 					colorSettings={ colorSettings }
 				/>
-				<PanelBody title={ __( 'Input Field Styles', 'jetpack-forms' ) } initialOpen={ false }>
+				<PanelBody title={ stylesPanelTitle } initialOpen={ false }>
 					<BaseControl>
 						<FontSizePicker
 							withReset={ true }
@@ -148,22 +162,26 @@ const JetpackFieldControls = ( {
 							size="__unstable-large"
 						/>
 					</BaseControl>
-					<RangeControl
-						label={ __( 'Border Width', 'jetpack-forms' ) }
-						value={ attributes.borderWidth }
-						initialPosition={ 1 }
-						onChange={ setNumberAttribute( 'borderWidth' ) }
-						min={ 0 }
-						max={ 100 }
-					/>
-					<RangeControl
-						label={ __( 'Border Radius', 'jetpack-forms' ) }
-						value={ attributes.borderRadius }
-						initialPosition={ 0 }
-						onChange={ setNumberAttribute( 'borderRadius' ) }
-						min={ 0 }
-						max={ 100 }
-					/>
+					{ ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) && (
+						<>
+							<RangeControl
+								label={ __( 'Border Width', 'jetpack-forms' ) }
+								value={ attributes.borderWidth }
+								initialPosition={ 1 }
+								onChange={ setNumberAttribute( 'borderWidth' ) }
+								min={ 0 }
+								max={ 100 }
+							/>
+							<RangeControl
+								label={ __( 'Border Radius', 'jetpack-forms' ) }
+								value={ attributes.borderRadius }
+								initialPosition={ 0 }
+								onChange={ setNumberAttribute( 'borderRadius' ) }
+								min={ 0 }
+								max={ 100 }
+							/>
+						</>
+					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Label Styles', 'jetpack-forms' ) } initialOpen={ false }>
 					<BaseControl>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
@@ -68,6 +68,7 @@ function JetpackFieldMultiple( props ) {
 			</div>
 
 			<JetpackFieldControls
+				clientId={ clientId }
 				id={ id }
 				required={ required }
 				attributes={ attributes }


### PR DESCRIPTION
## Proposed changes:
Update Multiple Choice and Single Choice fields Sidebar style settings: 
- Rename some labels to match the elements on the MC/SC fields
- Hide some style options when the Form style is Default or Animated

Form style: Default or Animated
![image](https://user-images.githubusercontent.com/7811225/236017615-259fccd4-738e-4a50-b780-6e686090d495.png)

Form style: Outlined
![image](https://user-images.githubusercontent.com/7811225/236017812-be8461fd-b388-415b-b3fd-9a3a9f9d4d0b.png)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Make sure you have the Forms package enabled

* Create a post, add a Form block and a MC/SC field
* Check if the Sidebar works as describe above

