### PR TITLE
My Jetpack: Remove manage option from menu

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -25,22 +25,22 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 
 	/* Menu Handling */
 	const hasStandalonePlugin = standalonePluginInfo?.hasStandalonePlugin;
-	const isConnected = isRegistered && isUserConnected;
 	const isStandaloneInstalled = standalonePluginInfo?.isStandaloneInstalled;
 	const isStandaloneActive = standalonePluginInfo?.isStandaloneActive;
+	const showActivateOption = hasStandalonePlugin && isStandaloneInstalled && ! isStandaloneActive;
+	const showInstallOption = hasStandalonePlugin && ! isStandaloneInstalled;
+	const isConnected = isRegistered && isUserConnected;
 	const isAbsent =
 		status === PRODUCT_STATUSES.ABSENT || status === PRODUCT_STATUSES.ABSENT_WITH_PLAN;
-	const installOrActivateStandalone =
-		hasStandalonePlugin && ( ! isStandaloneInstalled || ! isStandaloneActive );
 
 	const menuIsActive =
 		showMenu && // The menu is enabled for the product AND
 		! isAbsent && // product status is not absent AND
 		status !== PRODUCT_STATUSES.ERROR && // product status is not error AND
 		isConnected && // the site is connected AND
-		( status === PRODUCT_STATUSES.ACTIVE || // product is active, show at least the Manage option
-			menuItems?.length > 0 || // Show custom menus, if present
-			installOrActivateStandalone ); // Show install | activate options for standalone plugin
+		( menuItems?.length > 0 || // Show custom menus, if present
+			showActivateOption || // Show install | activate options for standalone plugin
+			showInstallOption );
 	/* End Menu Handling */
 
 	/*
@@ -99,9 +99,8 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 			onFixConnection={ navigateToConnectionPage }
 			showMenu={ menuIsActive }
 			menuItems={ menuItems }
-			showManageOption={ status === PRODUCT_STATUSES.ACTIVE }
-			showActivateOption={ hasStandalonePlugin && isStandaloneInstalled && ! isStandaloneActive }
-			showInstallOption={ hasStandalonePlugin && ! isStandaloneInstalled }
+			showActivateOption={ showActivateOption }
+			showInstallOption={ showInstallOption }
 			onInstallStandalone={ handleInstallStandalone }
 			onActivateStandalone={ handleInstallStandalone }
 		>

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -1,7 +1,7 @@
 import { Button, Text } from '@automattic/jetpack-components';
 import { Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { external, moreVertical, download, check } from '@wordpress/icons';
+import { moreVertical, download, check } from '@wordpress/icons';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
@@ -20,8 +20,6 @@ const PRODUCT_STATUSES_LABELS = {
 /* eslint-disable react/jsx-no-bind */
 const Menu = ( {
 	items = [],
-	showManage = false,
-	onManage,
 	showInstall = false,
 	onInstall,
 	showActivate = false,
@@ -56,20 +54,6 @@ const Menu = ( {
 							{ item?.label }
 						</Button>
 					) ) }
-					{ showManage && (
-						<Button
-							weight="regular"
-							fullWidth
-							variant="tertiary"
-							icon={ external }
-							onClick={ () => {
-								onClose();
-								onManage?.();
-							} }
-						>
-							{ __( 'Manage', 'jetpack-my-jetpack' ) }
-						</Button>
-					) }
 					{ showInstall && (
 						<Button
 							weight="regular"
@@ -121,7 +105,6 @@ const ProductCard = props => {
 		children,
 		// Menu Related
 		showMenu = false,
-		showManageOption = false,
 		showActivateOption = false,
 		showInstallOption = false,
 		menuItems = [],
@@ -243,8 +226,6 @@ const ProductCard = props => {
 				{ showMenu ? (
 					<Menu
 						items={ menuItems }
-						showManage={ showManageOption }
-						onManage={ onManage }
 						showActivate={ showActivateOption }
 						onActivate={ activateStandaloneHandler }
 						showInstall={ showInstallOption }

--- a/projects/packages/my-jetpack/changelog/update-mj-remove-manage-from-menu
+++ b/projects/packages/my-jetpack/changelog/update-mj-remove-manage-from-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Remove manage option from menu


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #30396 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the default `Manage` option from the menu.
* Update logic to make the menu visible.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start `My Jetpack`
* Make sure that you have only `Jetpack` plugin installed.
* Check if the `Install or Activate plugin` is the only action in the cards (`VideoPress`, `Backup`, `Search` and `Social`).

## Demo

<img width="288" alt="CleanShot 2023-05-03 at 16 40 34@2x" src="https://user-images.githubusercontent.com/1663717/236027910-973e4dc9-80a4-4f4a-a43e-a407885bde37.png">

