### PR TITLE
VideoPress: update UI/UX when the video block doesn't belong to site

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-add-not-edition-allowed-notice
+++ b/projects/packages/videopress/changelog/update-videopress-add-not-edition-allowed-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: add a Notice when trying to edit a video that doesn't belong to the site

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/index.tsx
@@ -62,6 +62,15 @@ export default function DetailsPanel( {
 
 	return (
 		<PanelBody title={ __( 'Details', 'jetpack-videopress-pkg' ) }>
+			{ ! videoBelongToSite && (
+				<Notice status="warning" isDismissible={ false } className="not-belong-to-site-notice">
+					{ __(
+						'Video not owned by this site: editing not possible, yet embedding and customization are still supported.',
+						'jetpack-videopress-pkg'
+					) }
+				</Notice>
+			) }
+
 			<TextControl
 				label={ __( 'Title', 'jetpack-videopress-pkg' ) }
 				value={ title }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/index.tsx
@@ -16,11 +16,11 @@ import { __ } from '@wordpress/i18n';
 import ChaptersLearnMoreHelper from '../../../../../components/chapters-learn-more-helper';
 import IncompleteChaptersNotice from '../../../../../components/incomplete-chapters-notice';
 import useChaptersLiveParsing from '../../../../../hooks/use-chapters-live-parsing';
-import { DetailsPanelProps } from '../../types';
 import './styles.scss';
 /**
  * Types
  */
+import type { DetailsPanelProps } from '../../types';
 import type React from 'react';
 
 const CHARACTERS_PER_LINE = 31;
@@ -65,7 +65,7 @@ export default function DetailsPanel( {
 			{ ! videoBelongToSite && (
 				<Notice status="warning" isDismissible={ false } className="not-belong-to-site-notice">
 					{ __(
-						'Video not owned by this site: editing not possible, yet embedding and customization are still supported.',
+						'This video is not owned by this site. You can still embed it and customize the player, but you won’t be able to edit the video.',
 						'jetpack-videopress-pkg'
 					) }
 				</Notice>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/styles.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/styles.scss
@@ -1,4 +1,5 @@
 .details-panel__error,
+.not-belong-to-site-notice,
 .learn-how-notice {
 	margin: 0;
 
@@ -20,4 +21,9 @@
 	--spacing-base: 8px;
 	// Match helper text margin
 	margin-top: calc( -1 * calc( var( --spacing-base ) * 2 ) ); // -16px
+}
+
+.not-belong-to-site-notice {
+	--spacing-base: 8px;
+	margin-bottom: calc( var( --spacing-base ) * 2 );
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -548,7 +548,7 @@ export default function PosterPanel( {
 		<PanelBody title={ panelTitle } className="poster-panel" initialOpen={ false }>
 			<ToggleControl
 				label={ __( 'Pick from video frame', 'jetpack-videopress-pkg' ) }
-				checked={ pickPosterFromFrame }
+				checked={ pickPosterFromFrame && videoBelongToSite }
 				onChange={ switchPosterSource }
 				disabled={ ! videoBelongToSite }
 			/>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -438,6 +438,7 @@ export default function PosterPanel( {
 	attributes,
 	setAttributes,
 	isGeneratingPoster,
+	videoBelongToSite,
 }: PosterPanelProps ): React.ReactElement {
 	const { poster, posterData } = attributes;
 
@@ -549,6 +550,7 @@ export default function PosterPanel( {
 				label={ __( 'Pick from video frame', 'jetpack-videopress-pkg' ) }
 				checked={ pickPosterFromFrame }
 				onChange={ switchPosterSource }
+				disabled={ ! videoBelongToSite }
 			/>
 
 			<div

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/index.tsx
@@ -5,19 +5,19 @@ import PrivacyAndRatingSettings from './privacy-and-rating-settings';
 /**
  * Types
  */
-import type { VideoControlProps } from '../../types';
+import type { PrivacyAndRatingPanelProps } from '../../types';
 import type React from 'react';
 
 /**
  * React component that renders the main privacy and ratings panel.
  *
- * @param {VideoControlProps} props - Component props.
- * @returns {React.ReactElement}    - Panel to contain privacy and ratings settings.
+ * @param {PrivacyAndRatingPanelProps} props - Component props.
+ * @returns {React.ReactElement}               Panel to contain privacy and ratings settings.
  */
 export default function PrivacyAndRatingPanel( {
 	attributes,
 	setAttributes,
 	privateEnabledForSite,
-}: VideoControlProps ): React.ReactElement {
+}: PrivacyAndRatingPanelProps ): React.ReactElement {
 	return <PrivacyAndRatingSettings { ...{ attributes, setAttributes, privateEnabledForSite } } />;
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/privacy-and-rating-settings.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/privacy-and-rating-settings.tsx
@@ -18,21 +18,21 @@ import {
 /**
  * Types
  */
-import type { VideoControlProps } from '../../types';
+import type { PrivacyAndRatingPanelProps } from '../../types';
 import type React from 'react';
 
 /**
  * React component that renders the settings within the privacy and ratings panel.
  *
- * @param {VideoControlProps} props - Component props.
- * @returns {React.ReactElement}    - Settings to change video's privacy and ratings.
+ * @param {PrivacyAndRatingPanelProps} props - Component props.
+ * @returns {React.ReactElement}               Settings to change video's privacy and ratings.
  */
 export default function PrivacyAndRatingSettings( {
 	attributes,
 	setAttributes,
 	privateEnabledForSite,
 	videoBelongToSite,
-}: VideoControlProps & { videoBelongToSite: boolean } ): React.ReactElement {
+}: PrivacyAndRatingPanelProps ): React.ReactElement {
 	const { privacySetting, rating, allowDownload, displayEmbed } = attributes;
 
 	const privacyLabels = {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/privacy-and-rating-settings.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/privacy-and-rating-panel/privacy-and-rating-settings.tsx
@@ -31,7 +31,8 @@ export default function PrivacyAndRatingSettings( {
 	attributes,
 	setAttributes,
 	privateEnabledForSite,
-}: VideoControlProps ): React.ReactElement {
+	videoBelongToSite,
+}: VideoControlProps & { videoBelongToSite: boolean } ): React.ReactElement {
 	const { privacySetting, rating, allowDownload, displayEmbed } = attributes;
 
 	const privacyLabels = {
@@ -82,6 +83,7 @@ export default function PrivacyAndRatingSettings( {
 				onChange={ value => {
 					setAttributes( { rating: value } );
 				} }
+				disabled={ ! videoBelongToSite }
 			/>
 
 			<SelectControl
@@ -104,6 +106,7 @@ export default function PrivacyAndRatingSettings( {
 				} }
 				value={ String( privacySetting ) }
 				options={ [ privacyOptionSiteDefault, privacyOptionPublic, privacyOptionPrivate ] }
+				disabled={ ! videoBelongToSite }
 			/>
 
 			<ToggleControl
@@ -112,6 +115,7 @@ export default function PrivacyAndRatingSettings( {
 				onChange={ value => {
 					setAttributes( { allowDownload: value } );
 				} }
+				disabled={ ! videoBelongToSite }
 			/>
 
 			<ToggleControl
@@ -124,6 +128,7 @@ export default function PrivacyAndRatingSettings( {
 					'Gives viewers the option to share the video link and HTML embed code',
 					'jetpack-videopress-pkg'
 				) }
+				disabled={ ! videoBelongToSite }
 			/>
 		</PanelBody>
 	);

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -535,6 +535,7 @@ export default function VideoPressEdit( {
 					attributes={ attributes }
 					setAttributes={ setAttributes }
 					isGeneratingPoster={ isGeneratingPoster }
+					videoBelongToSite={ videoBelongToSite }
 				/>
 
 				<PrivacyAndRatingPanel

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -539,7 +539,13 @@ export default function VideoPressEdit( {
 				/>
 
 				<PrivacyAndRatingPanel
-					{ ...{ attributes, setAttributes, isRequestingVideoData, privateEnabledForSite } }
+					{ ...{
+						attributes,
+						setAttributes,
+						isRequestingVideoData,
+						privateEnabledForSite,
+						videoBelongToSite,
+					} }
 				/>
 			</InspectorControls>
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -152,6 +152,7 @@ export type VideoControlProps = {
 
 export type PosterPanelProps = VideoControlProps & {
 	isGeneratingPoster?: boolean;
+	videoBelongToSite?: boolean;
 };
 
 export type VideoEditProps = VideoControlProps;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/types.ts
@@ -155,6 +155,10 @@ export type PosterPanelProps = VideoControlProps & {
 	videoBelongToSite?: boolean;
 };
 
+export type PrivacyAndRatingPanelProps = VideoControlProps & {
+	videoBelongToSite?: boolean;
+};
+
 export type VideoEditProps = VideoControlProps;
 
 export type DetailsPanelProps = VideoControlProps & {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: update UI/UX when the video block doesn't belong to site

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit a VideoPress video block instance that belongs to the site
* Confirm everything works as expected
* Create a new instance but using an external video (https://videopress.com/v/NGYE1Hqy)
* Confirm the side shows a Notice about it in the Details panel
* Confirm `title` and `description` are disabled
* Confirm Video frame poster is disabled
* Confirm all controls of Privacy are disabled
* Confirm the rest work as expected 


Details panel | Poster | Privacy
-------|-------|----------
<img width="282" alt="image" src="https://user-images.githubusercontent.com/77539/236046248-4748c514-4e51-48cc-a69b-343c995d8333.png"> | <img width="284" alt="image" src="https://user-images.githubusercontent.com/77539/236046207-37f78b43-2a17-4c46-a0d4-855a910a6a34.png"> | <img width="290" alt="image" src="https://user-images.githubusercontent.com/77539/236046123-de2aac99-5407-4c42-997d-7f3da97acced.png">

https://user-images.githubusercontent.com/77539/236045131-a119be62-a44f-4134-aa16-fcbdb47120b0.mov


