### PR TITLE
Image CDN: Fixes and improvements

### DIFF
--- a/projects/packages/image-cdn/changelog/update-image-cdn
+++ b/projects/packages/image-cdn/changelog/update-image-cdn
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Small fixes to a recently merged PR.
+
+

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -1215,7 +1215,7 @@ final class Image_CDN {
 		}
 
 		Assets::register_script(
-			'jetpack-image-cdn',
+			'jetpack-photon',
 			'../dist/image-cdn.js',
 			__FILE__,
 			array(

--- a/projects/plugins/jetpack/changelog/update-image-cdn
+++ b/projects/plugins/jetpack/changelog/update-image-cdn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixes to integration with image-cdn

--- a/projects/plugins/jetpack/functions.photon.php
+++ b/projects/plugins/jetpack/functions.photon.php
@@ -22,7 +22,6 @@ use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
  * @return string The raw final URL. You should run this through esc_url() before displaying it.
  */
 function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Image_CDN\Image_CDN_Core::cdn_url' );
 	return Image_CDN_Core::cdn_url( $image_url, $args, $scheme );
 }
 
@@ -35,7 +34,6 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
  * @return array|string Args for Photon to use for the URL.
  */
 function jetpack_photon_parse_wpcom_query_args( $args, $image_url ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Image_CDN\Image_CDN_Core::parse_wpcom_query_args' );
 	return Image_CDN_Core::parse_wpcom_query_args( $args, $image_url );
 }
 

--- a/projects/plugins/jetpack/functions.photon.php
+++ b/projects/plugins/jetpack/functions.photon.php
@@ -8,6 +8,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Image_CDN\Image_CDN;
 use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
 
 /**
@@ -68,12 +69,12 @@ function jetpack_photon_banned_domains( $skip, $image_url ) {
 /**
  * Jetpack Photon - Support Text Widgets.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Image_CDN\Image_CDN_Core::support_text_widgets instead.
+ * @deprecated $$next-version$$
  * @access public
  * @param string $content Content from text widget.
  * @return string
  */
 function jetpack_photon_support_text_widgets( $content ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\Jetpack\Image_CDN\Image_CDN_Core::support_text_widgets' );
-	return Image_CDN_Core::support_text_widgets( $content );
+	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+	return Image_CDN::filter_the_content( $content );
 }


### PR DESCRIPTION
Follow up on #30050

## Proposed changes:
* Removed deprecation notice for `jetpack_photon_url` as it is widely used
* Removed deprecation notice from `jetpack_photon_parse_wpcom_query_args`
* Change photon script handle back to `jetpack-photon`
* Fixed a broken function reference.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/30050#pullrequestreview-1411062078

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
None

