### PR TITLE
Boost: Update Minify to include latest page optimize updates

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -235,7 +235,7 @@ function jetpack_boost_page_optimize_build_output() {
 			if ( 0 === strpos( $buf, '@charset' ) ) {
 				preg_replace_callback(
 					'/(?P<charset_rule>@charset\s+[\'"][^\'"]+[\'"];)/i',
-					function ( $match ) use ( $pre_output ) {
+					function ( $match ) use ( &$pre_output ) {
 						if ( 0 === strpos( $pre_output, '@charset' ) ) {
 							return '';
 						}
@@ -253,7 +253,7 @@ function jetpack_boost_page_optimize_build_output() {
 			if ( false !== strpos( $buf, '@import' ) ) {
 				$buf = preg_replace_callback(
 					'/(?P<pre_path>@import\s+(?:url\s*\()?[\'"\s]*)(?P<path>[^\'"\s](?:https?:\/\/.+\/?)?.+?)(?P<post_path>[\'"\s\)]*;)/i',
-					function ( $match ) use ( $dirpath, $pre_output ) {
+					function ( $match ) use ( $dirpath, &$pre_output ) {
 						if ( 0 !== strpos( $match['path'], 'http' ) && '/' !== $match['path'][0] ) {
 							$pre_output .= $match['pre_path'] . ( $dirpath === '/' ? '/' : $dirpath . '/' ) .
 											$match['path'] . $match['post_path'] . "\n";

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -235,10 +235,8 @@ function jetpack_boost_page_optimize_build_output() {
 			if ( 0 === strpos( $buf, '@charset' ) ) {
 				preg_replace_callback(
 					'/(?P<charset_rule>@charset\s+[\'"][^\'"]+[\'"];)/i',
-					function ( $match ) {
-						global $pre_output;
-
-						if ( 0 === strpos( (string) $pre_output, '@charset' ) ) {
+					function ( $match ) use ( $pre_output ) {
+						if ( 0 === strpos( $pre_output, '@charset' ) ) {
 							return '';
 						}
 
@@ -255,9 +253,7 @@ function jetpack_boost_page_optimize_build_output() {
 			if ( false !== strpos( $buf, '@import' ) ) {
 				$buf = preg_replace_callback(
 					'/(?P<pre_path>@import\s+(?:url\s*\()?[\'"\s]*)(?P<path>[^\'"\s](?:https?:\/\/.+\/?)?.+?)(?P<post_path>[\'"\s\)]*;)/i',
-					function ( $match ) use ( $dirpath ) {
-						global $pre_output;
-
+					function ( $match ) use ( $dirpath, $pre_output ) {
 						if ( 0 !== strpos( $match['path'], 'http' ) && '/' !== $match['path'][0] ) {
 							$pre_output .= $match['pre_path'] . ( $dirpath === '/' ? '/' : $dirpath . '/' ) .
 											$match['path'] . $match['post_path'] . "\n";

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -238,7 +238,7 @@ function jetpack_boost_page_optimize_build_output() {
 					function ( $match ) {
 						global $pre_output;
 
-						if ( 0 === strpos( $pre_output, '@charset' ) ) {
+						if ( 0 === strpos( (string) $pre_output, '@charset' ) ) {
 							return '';
 						}
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -7,7 +7,7 @@ use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_CSS;
 
 class Minify_CSS implements Pluggable {
 
-	public static $default_excludes = array( 'admin-bar', 'dashicons' );
+	public static $default_excludes = array( 'admin-bar', 'dashicons', 'elementor-app' );
 
 	public function setup() {
 		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';

--- a/projects/plugins/boost/changelog/update-boost-add-latest-page-optimize-updates
+++ b/projects/plugins/boost/changelog/update-boost-add-latest-page-optimize-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Update Minify codebase to include latest updates from Page Optimize.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* During the migration of Page Optimize into Boost, there were some updates made to [Page Optimize's codebase](https://github.com/Automattic/page-optimize/commits/master). This PR adds those changes to Minify.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1683185893703879-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

n/a

## Testing instructions:

* Install the plugin;
* Turn on debugging;
* Turn on CSS/JS concatenate;
* View a few pages to generate cache;
* Check logs to make sure there are no Minify related warnings/notices.