### PR TITLE
Fix Map provider typo

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-map-provider-fix
+++ b/projects/plugins/jetpack/changelog/fix-map-provider-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Hotfix for a typo in the map provider code

--- a/projects/plugins/jetpack/extensions/blocks/map/utils/get-map-provider.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/utils/get-map-provider.js
@@ -19,7 +19,7 @@ const getMapProvider = props => {
 
 	if ( window && typeof window.Jetpack_Maps?.provider === 'string' ) {
 		if ( [ 'mapbox', 'mapkit' ].includes( window.Jetpack_Maps?.provider ) ) {
-			return window.map_block_settings?.provider;
+			return window.Jetpack_Maps?.provider;
 		}
 	}
 	return 'mapbox';


### PR DESCRIPTION
## Proposed changes:
This PR fixes a typo in the map provider code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1683188078371099/1683182684.802489-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply this PR
- Map provider selection should now be working