### PR TITLE
Map block: hook settings to existing block bundle

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-map-loading-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-map-loading-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure Map block settings get hooked to existing block bbubundle.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -39,7 +39,7 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );
 
 		// Load the Map block settings.
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'load_map_block_settings' ) );
+		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_map_block_settings' ) );
 
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.


### PR DESCRIPTION
## Proposed changes:

Follow-up for #30287.

Let's ensure Jetpack_Maps is hooked at the right moment to be added after the rest of the bundle resources.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Test this on WordPress.com:

1. Apply this branch.
2. Go to Posts > Add New
3. In your JavaScript Console, type in `Jetpack_Maps`
    * You should get the map provider back.
