### PR TITLE
Map block: only hook map settings in the right place.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-map-loading-settings-duplicate
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-map-loading-settings-duplicate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid hooking Map settings multiple times.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -106,6 +106,18 @@ class Jetpack_Mu_Wpcom {
 	 * @return void
 	 */
 	public static function load_map_block_settings() {
+		if (
+			! function_exists( 'get_current_screen' )
+			|| \get_current_screen() === null
+		) {
+			return;
+		}
+
+		// Return early if we are not in the block editor.
+		if ( ! wp_should_load_block_editor_scripts_and_styles() ) {
+			return;
+		}
+
 		$map_provider = apply_filters( 'wpcom_map_block_map_provider', 'mapbox' );
 		wp_localize_script( 'jetpack-blocks-editor', 'Jetpack_Maps', array( 'provider' => $map_provider ) );
 	}


### PR DESCRIPTION
## Proposed changes:

Follow-up to #30287

This should ensure that `Jetpack_Maps` is only hooked in the right place.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1683189449858459/1683182684.802489-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Test this on WordPress.com Simple:

1. Apply this branch.
2. Go to Posts > Add New
3. In your browser dev tools, look for `Jetpack_Maps` in the page's source code.
    * You should find it, only once.
