### PR TITLE
My Jetpack: Remove icon from plugin activation action in product card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -1,7 +1,7 @@
 import { Button, Text } from '@automattic/jetpack-components';
 import { Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { moreVertical, download, check } from '@wordpress/icons';
+import { moreVertical, download } from '@wordpress/icons';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
@@ -73,7 +73,6 @@ const Menu = ( {
 							weight="regular"
 							fullWidth
 							variant="tertiary"
-							icon={ check }
 							onClick={ () => {
 								onClose();
 								onActivate?.();

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-action-icons
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-action-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Remove icon from plugin activation action in product card


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30395

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Just removes the icon for now. There is no state where there are more than one action, including the `Activate` action, so the center text alignment does not contrast with other options.
* The `Manage` action was removed entirely in a previous PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack with Search, VideoPress or Social plugin installed, but not activated
* Check that the Activation action in the actions menu does not have an icon

![2023-05-04_10-30-45](https://user-images.githubusercontent.com/8486249/236219951-a0ad00ac-e812-4030-8edb-f0d5bf4f72ed.png)

