### PR TITLE
 VideoPress: create VideoPress video block when pasting URLs

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-handle-pasting-urls
+++ b/projects/packages/videopress/changelog/update-videopress-handle-pasting-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: create VideoPress video block when pasting URLs

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -8,7 +8,10 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { buildVideoPressURL, pickGUIDFromUrl } from '../../../../lib/url';
+import { buildVideoPressURL, isVideoPressUrl, pickGUIDFromUrl } from '../../../../lib/url';
+/**
+ * Types
+ */
 import { CoreEmbedVideoPressVariationBlockAttributes, VideoBlockAttributes } from '../types';
 
 const transformFromCoreEmbed = {
@@ -82,7 +85,33 @@ const transformToCoreEmbed = {
 	},
 };
 
-const from = [ transformFromCoreEmbed ];
+const transformFromPastingVideoPressURL = {
+	type: 'raw',
+	isMatch: ( node: HTMLDivElement ) => {
+		const { textContent } = node;
+		if ( ! textContent ) {
+			return false;
+		}
+
+		return isVideoPressUrl( textContent.trim() );
+	},
+	transform: ( node: HTMLDivElement ) => {
+		const { textContent } = node;
+		if ( ! textContent ) {
+			return false;
+		}
+
+		const url = textContent.trim();
+		const guid = pickGUIDFromUrl( url );
+		if ( ! guid ) {
+			return false;
+		}
+
+		return createBlock( 'videopress/video', { guid } );
+	},
+};
+
+const from = [ transformFromCoreEmbed, transformFromPastingVideoPressURL ];
 const to = [ transformToCoreEmbed ];
 
 export default { from, to };

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -157,3 +157,15 @@ export function getVideoUrlBasedOnPrivacy( guid: VideoGUID, isPrivate: boolean )
 
 	return `https://videopress.com/v/${ guid }`;
 }
+
+/**
+ * Determines if a given URL is a VideoPress URL.
+ *
+ * @param {string} url - The URL to check.
+ * @returns {boolean}    bool True if the URL is a VideoPress URL, false otherwise.
+ */
+export function isVideoPressUrl( url: string ): boolean {
+	const pattern =
+		/^https?:\/\/(?:(?:v(?:ideo)?\.wordpress\.com|videopress\.com)\/(?:v|embed)|v\.wordpress\.com)\/([a-z\d]{8})(\/|\b)/i;
+	return pattern.test( url );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Part of https://github.com/Automattic/jetpack/issues/30417

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: create VideoPress video block when pasting URLs

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Pick a valid VideoPress video URL (eg: https://videopress.com/v/NGYE1Hqy)
* Paste it into the editor canvas
* Confirm it creates a VideoPress video block
* Paste other content
* Confirm it works as expected
* Additionally, confirm it's still possible to convert to core/embed block, VideoPress variation

https://user-images.githubusercontent.com/77539/236257427-25e77b15-834f-4b46-a39e-9c91ebf3676f.mov