### PR TITLE
Fix feedback post status untrash filter

### DIFF
--- a/projects/packages/forms/changelog/fix-feedback-post-status-untrash
+++ b/projects/packages/forms/changelog/fix-feedback-post-status-untrash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Change post_type comparison on untrash filter to only affect feedback posts

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2289,7 +2289,7 @@ class Contact_Form_Plugin {
 	 */
 	public function untrash_feedback_status_handler( $current_status, $post_id, $previous_status ) {
 		$post = get_post( $post_id );
-		if ( 'feedback' !== $post->post_type ) {
+		if ( 'feedback' === $post->post_type ) {
 			if ( in_array( $previous_status, array( 'spam', 'publish' ), true ) ) {
 				return $previous_status;
 			}


### PR DESCRIPTION
This PR fixes a wrong comparison on the untrash filter for the responses inbox


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1683215554200659-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the responses inbox, move some response to Spam and then, from there, to Trash. Untrashing the post should get it back to its original status (Spam/Inbox) as opposed to always land it on Inbox.

Props to @anomiex for spotting it!