### PR TITLE
Update forms dashboard card border radius

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-corners
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-corners
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated border radius on forms dashboard cards

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -196,7 +196,7 @@ $action-bar-height: 88px;
 .jp-forms__inbox-list,
 .jp-forms__inbox-response {
 	border: 1px solid #dcdcde;
-	border-radius: 5px;
+	border-radius: 8px;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;

--- a/projects/packages/forms/src/dashboard/style.wpcom.scss
+++ b/projects/packages/forms/src/dashboard/style.wpcom.scss
@@ -171,6 +171,7 @@ body.toplevel_page_jetpack-forms.toplevel_page_jetpack-forms {
 
 	.jp-forms__inbox-list.jp-forms__table {
 		background-color: #fdfdfd;
+		border-radius: 5px;
 
 		@media (min-width: 1025px) {
 			min-height: calc(100vh - calc(var(--wp-admin--admin-bar--height) + #{$tabs-height} + #{$action-bar-height} + 48px));
@@ -194,6 +195,7 @@ body.toplevel_page_jetpack-forms.toplevel_page_jetpack-forms {
 
 	.jp-forms__inbox-response {
 		background-color: #fff;
+		border-radius: 5px;
 
 		@media (min-width: 1025px) {
 			height: calc(100vh - calc(var(--wp-admin--admin-bar--height) + #{$tabs-height} + #{$action-bar-height} + 48px));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30402.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Wee change to update the border radius setting on the response and the list for the Jetpack version to `8px` to conform to the emerald design system. WP.com's version should remain unaffected.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

puPv3-eGZ-p2#comment-25419

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to `admin.php?page=jetpack-forms`.
- Border radius of the list and response 'cards' should be `8px` for Jetpack and `5px` for WP.com.
