### PR TITLE
 VideoPress: hide core/embed block, VideoPress variation, when video block is available

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-hide-core-embed-videopress-variation
+++ b/projects/packages/videopress/changelog/update-videopress-hide-core-embed-videopress-variation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: hide core/embed core, VideoPress variation, when video block is available

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
@@ -14,6 +14,9 @@ import transforms from './transforms';
 import videoPressBlockExampleImage from './videopress-block-example-image.jpg';
 import './style.scss';
 
+// Extend the core/embed block
+import '../../extend/core-embed';
+
 export const { name, title, description, attributes } = metadata;
 
 registerBlockType( name, {

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
@@ -1,26 +1,33 @@
 /**
  * External dependencies
  */
-import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
-import { unregisterBlockVariation } from '@wordpress/blocks';
-import domReady from '@wordpress/dom-ready';
 import { addFilter } from '@wordpress/hooks';
-import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
 import withCoreEmbedVideoPressBlock from './edit';
 
-const debug = debugFactory( 'videopress:extend:core/embed' );
-
-const extendCoreEmbedVideoPressBlock = ( settings, name ) => {
-	if ( isSimpleSite() ) {
-		return settings;
+const addCoreEmbedOverride = settings => {
+	if ( ! ( 'variations' in settings ) || 'object' !== typeof settings.variations ) {
+		return;
 	}
 
+	settings.variations.some( variation => {
+		if ( 'videopress' === variation.name ) {
+			variation.scope = [];
+			return true;
+		}
+		return false;
+	} );
+};
+
+const extendCoreEmbedVideoPressBlock = ( settings, name ) => {
 	if ( name !== 'core/embed' ) {
 		return settings;
 	}
+
+	// Hide the core/embed block, `videopress` variation.
+	addCoreEmbedOverride( settings );
 
 	return {
 		...settings,
@@ -39,11 +46,3 @@ addFilter(
 	'videopress/core-embed/handle-representation',
 	extendCoreEmbedVideoPressBlock
 );
-
-domReady( function () {
-	// @todo: horrible hack to make the unregister work
-	setTimeout( () => {
-		debug( 'unregister core/embed videopress variation' );
-		unregisterBlockVariation( 'core/embed', 'videopress' );
-	}, 0 );
-} );

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
@@ -3,10 +3,6 @@
  */
 import { getBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
-/**
- * Internal dependencies
- */
-import withCoreEmbedVideoPressBlock from './edit';
 
 const addCoreEmbedOverride = settings => {
 	// Bail if the block doesn't have variations.
@@ -37,16 +33,7 @@ const extendCoreEmbedVideoPressBlock = ( settings, name ) => {
 	// Hide the core/embed block, `videopress` variation.
 	addCoreEmbedOverride( settings );
 
-	return {
-		...settings,
-		attributes: {
-			...settings.attributes,
-			keepUsingOEmbedVariation: {
-				type: 'boolean',
-			},
-		},
-		edit: withCoreEmbedVideoPressBlock( settings.edit ),
-	};
+	return settings;
 };
 
 addFilter(

--- a/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
+++ b/projects/packages/videopress/src/client/block-editor/extend/core-embed/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { getBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
@@ -8,12 +9,19 @@ import { addFilter } from '@wordpress/hooks';
 import withCoreEmbedVideoPressBlock from './edit';
 
 const addCoreEmbedOverride = settings => {
+	// Bail if the block doesn't have variations.
 	if ( ! ( 'variations' in settings ) || 'object' !== typeof settings.variations ) {
+		return;
+	}
+
+	// Bail if the `videopress/video` block doesn't exist.
+	if ( ! getBlockType( 'videopress/video' ) ) {
 		return;
 	}
 
 	settings.variations.some( variation => {
 		if ( 'videopress' === variation.name ) {
+			// Set the scope to an empty array to hide the block.
 			variation.scope = [];
 			return true;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR hides the `core/embed` block, `videopress` variation when the VideoPress video block is registered.
Hiding the variation means it doesn't appear in the blocks list, but it's still supported by the editor, meaning that if there is an instance in the content, it should be renderer anyway.

Fixes https://github.com/Automattic/jetpack/issues/30417

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* VideoPress: hide core/embed block, VideoPress variation, when video block is available

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Go to the block editor
* Try to insert a `core/embed` block, `videopress` variation, instance.
* Confirm it isn't shown in the blocks list
<img width="382" alt="image" src="https://user-images.githubusercontent.com/77539/236306408-70bfc929-d6ee-4090-ae3c-c0fdc3ecc46e.png">
* Anyway, create a `videopress` variation by pasting the following parsed code:

```
<!-- wp:embed {"url":"https://videopress.com/v/NGYE1Hqy","type":"video","providerNameSlug":"videopress","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
<figure class="wp-block-embed is-type-video is-provider-videopress wp-block-embed-videopress wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
https://videopress.com/v/NGYE1Hqy
</div></figure>
<!-- /wp:embed -->
```

* Confirm the block `videopress` variation is properly visualized

<img width="951" alt="Screen Shot 2023-05-04 at 16 18 37" src="https://user-images.githubusercontent.com/77539/236306884-2b468cce-d7e0-4841-bf82-5da74b0ccb7a.png">


* Convert to VideoPress video block

<img width="704" alt="image" src="https://user-images.githubusercontent.com/77539/236306844-b83266c6-8293-4601-b060-8b376f9e3006.png">

* Deactiva the plugin (Jetpack and/or VideoPress)
* Confirm the VideoPress video block is unavailable and the `core/embed` block `videopress` variation is available.

<img width="331" alt="image" src="https://user-images.githubusercontent.com/77539/236307775-db0cf61a-eadc-4283-ab27-4bfe490b6dd5.png">
