### PR TITLE
Fix link area glith on forms dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-link-area
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-link-area
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the hitbox for the source link on the forms dashboard response list.

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -273,10 +273,10 @@ $action-bar-height: 88px;
 		.is-link {
 			cursor: pointer;
 			display: inline-block;
+			max-width: 100%;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
-			width: 100%;
 			text-decoration: none;
 
 			 &:hover {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30330.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This fixes an issue where the hitbox for source links on the forms dashboard response list takes up the entire column width, even if the text is shorter. After the change, it should only cover the actual text.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pcsBup-1aJ-p2#comment-417

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to `/wp-admin/admin.php?page=jetpack-forms`
- The links in the source column should only trigger when clicking on the text.
- When clicking outside of the text but swill within the source column, it should only select that response.
- Overflow ellipsis should still work as expected on narrower screens.
