### PR TITLE
Launchpad: migrate business logic to Task definitions

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-migrate-launchpad-business-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-migrate-launchpad-business-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Migrates Launchpad business logic from the mu-plugin to being defined by tasks

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -33,7 +33,7 @@ class Jetpack_Mu_Wpcom {
 		// Coming Soon feature.
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_coming_soon' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_launchpad' ) );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_launchpad' ), 0 );
 
 		// Unified navigation fix for changes in WordPress 6.2.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -327,7 +327,7 @@ class Launchpad_Task_Lists {
 		if ( ! $this->is_launchpad_enabled() ) {
 			return;
 		}
-		lor( 'do that shit' );
+
 		$task_list_id = $task_list_id ? $task_list_id : get_option( 'site_intent' );
 		if ( ! $task_list_id ) {
 			return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -298,6 +298,7 @@ class Launchpad_Task_Lists {
 		if ( ! $this->is_launchpad_enabled() ) {
 			return;
 		}
+		lor( 'do that shit' );
 		$task_list_id = $task_list_id ? $task_list_id : get_option( 'site_intent' );
 		if ( ! $task_list_id ) {
 			return;
@@ -315,6 +316,25 @@ class Launchpad_Task_Lists {
 				call_user_func_array( $task_definition['add_listener_callback'], array( $task, $task_definition ) );
 			}
 		}
+	}
+
+	/**
+	 * Marks a task as complete.
+	 *
+	 * @param string $task_id The task ID.
+	 * @return bool True if successful, false if not.
+	 */
+	public function mark_task_complete( $task_id ) {
+		$task = $this->get_task( $task_id );
+		if ( empty( $task ) ) {
+			return false;
+		}
+		$key              = isset( $task['id_map'] ) ? $task['id_map'] : $task['id'];
+		$statuses         = get_option( 'launchpad_checklist_tasks_statuses', array() );
+		$statuses[ $key ] = true;
+
+		// todo This is where we can disable launchpad if all tasks are complete.
+		return update_option( 'launchpad_checklist_tasks_statuses', $statuses );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -129,6 +129,15 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
+	 * Get all registered Launchpad Task Lists.
+	 *
+	 * @return array All registered Launchpad Task Lists.
+	 */
+	public function get_all_task_lists() {
+		return $this->task_list_registry;
+	}
+
+	/**
 	 * Get a Launchpad Task definition
 	 *
 	 * @param string $id Task id.
@@ -141,6 +150,15 @@ class Launchpad_Task_Lists {
 		}
 
 		return $this->task_registry[ $id ];
+	}
+
+	/**
+	 * Get all registered Launchpad Tasks.
+	 *
+	 * @return array All registered Launchpad Tasks.
+	 */
+	public function get_all_tasks() {
+		return $this->task_registry;
 	}
 
 	/**
@@ -242,10 +260,21 @@ class Launchpad_Task_Lists {
 		// Othewise there is the temptation for the callback to fall back to the option, which would cause infinite recursion
 		// as it continues to calculate the callback which falls back to the option: ∞.
 		$statuses    = get_option( 'launchpad_checklist_tasks_statuses', array() );
-		$key         = isset( $task['id_map'] ) ? $task['id_map'] : $task['id'];
+		$key         = $this->get_task_key( $task );
 		$is_complete = isset( $statuses[ $key ] ) ? $statuses[ $key ] : false;
 
 		return (bool) $this->load_value_from_callback( $task, 'is_complete_callback', $is_complete );
+	}
+
+	/**
+	 * Gets the task key, which is used to store and retrieve the task's status.
+	 * Either the task's id_map or id is used.
+	 *
+	 * @param Task $task Task definition.
+	 * @return string The task key to use.
+	 */
+	public function get_task_key( $task ) {
+		return isset( $task['id_map'] ) ? $task['id_map'] : $task['id'];
 	}
 
 	/**
@@ -329,7 +358,7 @@ class Launchpad_Task_Lists {
 		if ( empty( $task ) ) {
 			return false;
 		}
-		$key              = isset( $task['id_map'] ) ? $task['id_map'] : $task['id'];
+		$key              = $this->get_task_key( $task );
 		$statuses         = get_option( 'launchpad_checklist_tasks_statuses', array() );
 		$statuses[ $key ] = true;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -178,12 +178,27 @@ class Launchpad_Task_Lists {
 			$task_definition = $this->get_task( $task_id );
 
 			// if task can't be found don't add anything
-			if ( ! empty( $task_definition ) ) {
+			if ( $this->is_visible( $task_definition ) ) {
 				$tasks_for_task_list[] = $this->build_task( $task_definition );
 			}
 		}
 
 		return $tasks_for_task_list;
+	}
+
+	/**
+	 * Allows a function to be called to determine if a task should be visible.
+	 * For instance: we don't even want to show the verify_email task if it's already done.
+	 *
+	 * @param Task $task_definition A task definition.
+	 * @return boolean True if task is visible, false if not.
+	 */
+	protected function is_visible( $task_definition ) {
+		if ( empty( $task_definition ) ) {
+			return false;
+		}
+
+		return $this->load_value_from_callback( $task_definition, 'is_visible_callback', true );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -382,7 +382,6 @@ class Launchpad_Task_Lists {
 		// Ensure that the task is an active one
 		$active_tasks_by_task_id = wp_list_filter( $this->get_active_tasks(), array( 'id' => $task_id ) );
 		if ( empty( $active_tasks_by_task_id ) ) {
-			l( 'didnnot find task: ' . $task_id . ' in active tasks' );
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -82,30 +82,6 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
-	 * Register a new Launchpad Task
-	 *
-	 * @param Task[] $tasks Collection of task definitions.
-	 *
-	 * @return bool True if successful, false if not.
-	 */
-	public function register_tasks( $tasks = array() ) {
-		$tasks_to_register = array();
-
-		foreach ( $tasks as $task ) {
-			// Register none of the tasks if any are invalid.
-			if ( ! $this->validate_task( $task ) ) {
-				return false;
-			}
-
-			$tasks_to_register[ $task['id'] ] = $task;
-		}
-
-		// TODO: Handle duplicate tasks
-		$this->task_registry = array_merge( $this->task_registry, $tasks_to_register );
-		return true;
-	}
-
-	/**
 	 * Unregister a Launchpad Task List
 	 *
 	 * @param string $id Task List id.
@@ -159,7 +135,7 @@ class Launchpad_Task_Lists {
 	 *
 	 * @return Task Task.
 	 */
-	protected function get_task( $id ) {
+	public function get_task( $id ) {
 		if ( ! array_key_exists( $id, $this->task_registry ) ) {
 			return array();
 		}
@@ -181,11 +157,11 @@ class Launchpad_Task_Lists {
 		// Takes a registered task list, looks at its associated task ids,
 		// and returns a collection of associated tasks.
 		foreach ( $task_list['task_ids'] as $task_id ) {
-			$task = $this->get_task( $task_id );
+			$task_definition = $this->get_task( $task_id );
 
 			// if task can't be found don't add anything
-			if ( ! empty( $task ) ) {
-				$tasks_for_task_list[] = $this->build_task( $task );
+			if ( ! empty( $task_definition ) ) {
+				$tasks_for_task_list[] = $this->build_task( $task_definition );
 			}
 		}
 
@@ -206,9 +182,25 @@ class Launchpad_Task_Lists {
 		$built_task['completed']    = $this->is_task_complete( $task );
 		$built_task['disabled']     = $this->is_task_disabled( $task );
 		$built_task['subtitle']     = $this->load_subtitle( $task );
+		$built_task['badge_text']   = $this->load_value_from_callback( $task, 'badge_text_callback' );
 		$built_task['isLaunchTask'] = isset( $task['isLaunchTask'] ) ? $task['isLaunchTask'] : false;
-		$built_task['badge_text']   = isset( $task['badge_text'] ) ? $task['badge_text'] : '';
+
 		return $built_task;
+	}
+
+	/**
+	 * Given a task definition and a possible callback, call it and return the value.
+	 *
+	 * @param Task   $task A task definition.
+	 * @param string $callback The callback to attempt to call.
+	 * @param mixed  $default The default value, passed to the callback if it exists.
+	 * @return mixed The value returned by the callback, or the default value.
+	 */
+	private function load_value_from_callback( $task, $callback, $default = '' ) {
+		if ( isset( $task[ $callback ] ) && is_callable( $task[ $callback ] ) ) {
+			return call_user_func_array( $task[ $callback ], array( $task, $default ) );
+		}
+		return $default;
 	}
 
 	/**
@@ -218,11 +210,13 @@ class Launchpad_Task_Lists {
 	 * @return string The subtitle for the task.
 	 */
 	private function load_subtitle( $task ) {
+		$subtitle = $this->load_value_from_callback( $task, 'subtitle' );
+		if ( ! empty( $subtitle ) ) {
+			return $subtitle;
+		}
+		// if it wasn't a callback, but still a string, return it.
 		if ( isset( $task['subtitle'] ) ) {
-			if ( is_callable( $task['subtitle'] ) ) {
-				return call_user_func( $task['subtitle'] );
-			}
-			return $task['subtitle'];
+			$task['subtitle'];
 		}
 		return '';
 	}
@@ -234,10 +228,7 @@ class Launchpad_Task_Lists {
 	 * @return boolean
 	 */
 	public function is_task_disabled( $task ) {
-		if ( isset( $task['is_disabled_callback'] ) && is_callable( $task['is_disabled_callback'] ) ) {
-			return call_user_func( $task['is_disabled_callback'] );
-		}
-		return false;
+		return $this->load_value_from_callback( $task, 'is_disabled_callback', false );
 	}
 
 	/**
@@ -247,12 +238,28 @@ class Launchpad_Task_Lists {
 	 * @return boolean
 	 */
 	public function is_task_complete( $task ) {
-		if ( isset( $task['is_complete_callback'] ) && is_callable( $task['is_complete_callback'] ) ) {
-			return call_user_func( $task['is_complete_callback'] );
+		// First we calculate the value from our statuses option. This will get passed to the callback, if it exists.
+		// Othewise there is the temptation for the callback to fall back to the option, which would cause infinite recursion
+		// as it continues to calculate the callback which falls back to the option: ∞.
+		$statuses    = get_option( 'launchpad_checklist_tasks_statuses', array() );
+		$key         = isset( $task['id_map'] ) ? $task['id_map'] : $task['id'];
+		$is_complete = isset( $statuses[ $key ] ) ? $statuses[ $key ] : false;
+
+		return (bool) $this->load_value_from_callback( $task, 'is_complete_callback', $is_complete );
+	}
+
+	/**
+	 * Checks if a task wight given ID is complete.
+	 *
+	 * @param string $task_id The task ID.
+	 * @return boolean
+	 */
+	public function is_task_id_complete( $task_id ) {
+		$task = $this->get_task( $task_id );
+		if ( empty( $task ) ) {
+			return false;
 		}
-		$statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
-		$key      = isset( $task['id_map'] ) ? $task['id_map'] : $task['id'];
-		return isset( $statuses[ $key ] ) ? $statuses[ $key ] : false;
+		return $this->is_task_complete( $task );
 	}
 
 	/**
@@ -281,6 +288,36 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
+	 * Adds task-defined `add_listener_callback` hooks for incomplete tasks.
+	 *
+	 * @param string $task_list_id Optional. Will default to `site_intent` option.
+	 * @return void
+	 */
+	public function add_hooks_for_active_tasks( $task_list_id = null ) {
+		// leave things alone if Launchpad is not enabled.
+		if ( ! $this->is_launchpad_enabled() ) {
+			return;
+		}
+		$task_list_id = $task_list_id ? $task_list_id : get_option( 'site_intent' );
+		if ( ! $task_list_id ) {
+			return;
+		}
+		$task_list = $this->get_task_list( $task_list_id );
+		if ( empty( $task_list ) ) {
+			return;
+		}
+		$built_tasks = $this->build( $task_list_id );
+		// filter for incomplete tasks that have a callback
+		$tasks_to_hook = wp_list_filter( $built_tasks, array( 'completed' => false ) );
+		foreach ( $tasks_to_hook as $task ) {
+			$task_definition = $this->get_task( $task['id'] );
+			if ( isset( $task_definition['add_listener_callback'] ) && is_callable( $task_definition['add_listener_callback'] ) ) {
+				call_user_func_array( $task_definition['add_listener_callback'], array( $task, $task_definition ) );
+			}
+		}
+	}
+
+	/**
 	 * Validate a Launchpad Task
 	 *
 	 * @param Task $task Task.
@@ -303,6 +340,17 @@ class Launchpad_Task_Lists {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks if Launchpad is enabled.
+	 *
+	 * @return boolean
+	 */
+	private function is_launchpad_enabled() {
+		$launchpad_screen = get_option( 'launchpad_screen' );
+		// todo also check for incomplete tasks
+		return 'full' === $launchpad_screen;
 	}
 
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -502,7 +502,9 @@ function wpcom_launchpad_checklists() {
  * @return void
  */
 function wpcom_track_publish_first_post_task() {
-	wpcom_mark_launchpad_task_complete( 'publish_first_post' );
+	// Since we share the same callback for generic first post and newsletter-specific, we mark both.
+	wpcom_mark_launchpad_task_complete( 'first_post_published' );
+	wpcom_mark_launchpad_task_complete( 'first_post_published_newsletter' );
 }
 
 /**
@@ -548,7 +550,11 @@ function wpcom_launch_task_listener_atomic( $old_value, $new_value ) {
  * @return void
  */
 function wpcom_track_site_launch_task() {
+	// it would be ideal if the registry was smart enough to map based on id_map but it isn't.
+	// So we mark them all. We'd avoid this if we had dedicated callbacks for each task.
 	wpcom_mark_launchpad_task_complete( 'site_launched' );
+	wpcom_mark_launchpad_task_complete( 'link_in_bio_launched' );
+	wpcom_mark_launchpad_task_complete( 'videopress_launched' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -502,6 +502,10 @@ function wpcom_launchpad_checklists() {
  * @return void
  */
 function wpcom_track_publish_first_post_task() {
+	// Ensure that Headstart posts don't mark this as complete
+	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+		return;
+	}
 	// Since we share the same callback for generic first post and newsletter-specific, we mark both.
 	wpcom_mark_launchpad_task_complete( 'first_post_published' );
 	wpcom_mark_launchpad_task_complete( 'first_post_published_newsletter' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -327,18 +327,6 @@ function wpcom_launchpad_add_active_task_listeners() {
 	wpcom_launchpad_checklists()->add_hooks_for_active_tasks();
 }
 
-// unhook our old mu-plugin
-add_action(
-	'plugins_loaded',
-	function () {
-		if ( class_exists( 'WPCOM_Launchpad' ) ) {
-			l( 'Found old mu-plugin, removing it' );
-			remove_action( 'plugins_loaded', array( WPCOM_Launchpad::get_instance(), 'init' ) );
-		}
-	},
-	9
-);
-
 /**
  * Determines whether or not the videopress upload task is enabled
  *
@@ -663,4 +651,9 @@ function wpcom_log_launchpad_being_enabled_for_test_sites( $option, $value ) {
 			'extra'   => wp_json_encode( $extra ),
 		)
 	);
+}
+
+// Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.
+if ( class_exists( 'WPCOM_Launchpad' ) ) {
+	remove_action( 'plugins_loaded', array( WPCOM_Launchpad::get_instance(), 'init' ) );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -85,9 +85,12 @@ function wpcom_register_default_launchpad_checklists() {
 
 	wpcom_register_launchpad_task(
 		array(
-			'id'     => 'links_added',
-			'title'  => __( 'Add links', 'jetpack-mu-wpcom' ),
-			'id_map' => 'links_edited',
+			'id'                    => 'links_added',
+			'title'                 => __( 'Add links', 'jetpack-mu-wpcom' ),
+			'id_map'                => 'links_edited',
+			'add_listener_callback' => function () {
+				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
+			},
 		)
 	);
 
@@ -517,6 +520,7 @@ function wpcom_track_publish_first_post_task() {
  * @return void
  */
 function wpcom_track_edit_site_task() {
+	wpcom_mark_launchpad_task_complete( 'links_added' );
 	wpcom_mark_launchpad_task_complete( 'design_edited' );
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -583,6 +583,29 @@ function wpcom_track_video_uploaded_task( $post_id ) {
 }
 
 /**
+ * The `/rest/v1.1/video-uploads` endpoint operates without calling the `rest_api_switched_to_blog` hook.
+ * Which prevents our listeners from being added.
+ * This mimics the legacy mu-plugin logic of always adding the listener.
+ *
+ * @param int $post_id The attachment ID.
+ * @return void
+ */
+function wpcom_hacky_track_video_uploaded_task( $post_id ) {
+	if ( get_option( 'site_intent' ) !== 'videopress' ) {
+		return;
+	}
+	if ( get_option( 'launchpad_screen' ) !== 'full' ) {
+		return;
+	}
+	if ( has_action( 'add_attachment', 'wpcom_track_video_uploaded_task' ) ) {
+		return;
+	}
+
+	wpcom_track_video_uploaded_task( $post_id );
+}
+add_action( 'add_attachment', 'wpcom_hacky_track_video_uploaded_task' );
+
+/**
  * Callback for email verification visibility.
  *
  * @return bool True if email is unverified, false otherwise.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -192,9 +192,9 @@ function wpcom_register_default_launchpad_checklists() {
 
 	wpcom_register_launchpad_task(
 		array(
-			'id'                   => 'verify_email',
-			'title'                => __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' ),
-			'is_disabled_callback' => '__return_true',
+			'id'                  => 'verify_email',
+			'title'               => __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' ),
+			'is_visible_callback' => 'wpcom_launchpad_is_email_unverified',
 		)
 	);
 
@@ -580,6 +580,20 @@ function wpcom_track_video_uploaded_task( $post_id ) {
 		return;
 	}
 	wpcom_mark_launchpad_task_complete( 'video_uploaded' );
+}
+
+/**
+ * Callback for email verification visibility.
+ *
+ * @return bool True if email is unverified, false otherwise.
+ */
+function wpcom_launchpad_is_email_unverified() {
+	// TODO: handle the edge case where an Atomic user can be unverified.
+	if ( ! class_exists( 'Email_Verification' ) ) {
+		return false;
+	}
+
+	return Email_Verification::is_email_unverified();
 }
 
 //

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -354,7 +354,7 @@ function wpcom_is_videopress_launch_disabled() {
  * @return boolean True if link-in-bio launch task is enabled
  */
 function wpcom_is_link_in_bio_launch_disabled() {
-	return ! wpcom_is_checklist_task_complete( 'links_edited' );
+	return ! wpcom_is_checklist_task_complete( 'links_added' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -123,6 +123,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
 			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
+			'is_enabled'         => wpcom_launchpad_checklists()->is_launchpad_enabled(),
 		);
 	}
 
@@ -145,6 +146,8 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					if ( update_option( 'launchpad_checklist_tasks_statuses', $launchpad_checklist_tasks_statuses_option ) ) {
 						$updated[ $key ] = $value;
 					}
+					// This will check if we have completed all the tasks and disable Launchpad if so.
+					wpcom_launchpad_checklists()->maybe_disable_launchpad();
 					break;
 
 				default:

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -85,7 +85,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 		$tasks            = wpcom_launchpad_checklists()->get_all_tasks();
 		$allowed_task_ids = array();
 		foreach ( $tasks as $task ) {
-			$allowed_task_ids[] = $task->get_slug();
+			$allowed_task_ids[] = wpcom_launchpad_checklists()->get_task_key( $task );
 		}
 		$allowed_task_ids = array_unique( $allowed_task_ids );
 		$properties       = array();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -40,16 +40,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 						'checklist_slug' => array(
 							'description' => 'Checklist slug',
 							'type'        => 'string',
-							'enum'        => array(
-								// todo source from registry
-								'build',
-								'free',
-								'link-in-bio',
-								'link-in-bio-tld',
-								'newsletter',
-								'videopress',
-								'write',
-							),
+							'enum'        => $this->get_checklist_slug_enums(),
 						),
 					),
 				),
@@ -61,33 +52,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 						'checklist_statuses' => array(
 							'description'          => 'Launchpad statuses',
 							'type'                 => 'object',
-							'properties'           => array(
-								// todo: source this from the registry
-								'domain_upsell_deferred' => array(
-									'type' => 'boolean',
-								),
-								'links_edited'           => array(
-									'type' => 'boolean',
-								),
-								'site_edited'            => array(
-									'type' => 'boolean',
-								),
-								'site_launched'          => array(
-									'type' => 'boolean',
-								),
-								'first_post_published'   => array(
-									'type' => 'boolean',
-								),
-								'video_uploaded'         => array(
-									'type' => 'boolean',
-								),
-								'publish_first_course'   => array(
-									'type' => 'boolean',
-								),
-								'plan_completed'         => array(
-									'type' => 'boolean',
-								),
-							),
+							'properties'           => $this->get_checklist_statuses_properties(),
 							'additionalProperties' => false,
 						),
 						'launchpad_screen'   => array(
@@ -99,6 +64,37 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Returns all available checklist slugs.
+	 *
+	 * @return array Array of checklist slugs.
+	 */
+	public function get_checklist_slug_enums() {
+		$checklists = wpcom_launchpad_checklists()->get_all_task_lists();
+		return array_keys( $checklists );
+	}
+
+	/**
+	 * Returns all registered checklist statuses.
+	 *
+	 * @return array Associative array of checklist status properties for the REST API.
+	 */
+	public function get_checklist_statuses_properties() {
+		$tasks            = wpcom_launchpad_checklists()->get_all_tasks();
+		$allowed_task_ids = array();
+		foreach ( $tasks as $task ) {
+			$allowed_task_ids[] = $task->get_slug();
+		}
+		$allowed_task_ids = array_unique( $allowed_task_ids );
+		$properties       = array();
+		foreach ( $allowed_task_ids as $task_id ) {
+			$properties[ $task_id ] = array(
+				'type' => 'boolean',
+			);
+		}
+		return $properties;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -41,6 +41,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 							'description' => 'Checklist slug',
 							'type'        => 'string',
 							'enum'        => array(
+								// todo source from registry
 								'build',
 								'free',
 								'link-in-bio',
@@ -121,20 +122,11 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	public function get_data( $request ) {
 		$checklist_slug = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
 
-		// deploy-time compat, remove me later.
-		if ( function_exists( 'get_launchpad_checklist_by_checklist_slug' ) ) {
-			$checklist = get_launchpad_checklist_by_checklist_slug( $checklist_slug );
-		} elseif ( function_exists( 'wpcom_get_launchpad_checklist_by_checklist_slug' ) ) {
-			$checklist = wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug );
-		} else {
-			$checklist = array();
-		}
-
 		return array(
 			'site_intent'        => get_option( 'site_intent' ),
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
-			'checklist'          => $checklist,
+			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
@@ -7,6 +7,8 @@
 
 //phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php';
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/launchpad/launchpad.php';
 
 /**
  * Test class for WPCOM_REST_API_V2_Endpoint_Launchpad.
@@ -35,7 +37,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 			)
 		);
 		wp_set_current_user( 0 );
-
+		wpcom_register_default_launchpad_checklists();
 		do_action( 'rest_api_init' );
 	}
 
@@ -86,8 +88,8 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 		wp_set_current_user( $this->admin_id );
 
 		$values = array(
-			'publish_first_course' => false,
-			'site_launched'        => true,
+			'domain_upsell_deferred' => true,
+			'site_launched'          => true,
 		);
 		$data   = array( 'checklist_statuses' => $values );
 


### PR DESCRIPTION
See Automattic/wp-calypso#75504

## Proposed changes:
This finishes work begun in #30397 to consolidate all task-completing logic from the old mu-plugin to the Task registry, using `add_listener_callback`.

### Other information:

- [x] Have you written new tests for your changes, if applicable? **Fixed tests **
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

1. apply this to your wpcom sandbox
2. sandbox `public-api.wordpress.com`
3. sandbox the URL of the site **you create before you create it** (eg `wiebelaunchpadwrite.wordpress.com`)

With each type of Launchpad-supporting site, go through the full flow and ensure that:

1. All tasks are marked off when they should be
2. Launching works

## Known issues
The VideoPress upload detector does not work properly. I've added a workaround in 284c921e4726976fec70ddd12281e69d5376652e that mimics the old mu-plugin logic that worked. Unfortunately this can't be tested until this lands in production because it needs to be on job servers.

