### PR TITLE
Forms: denormalize comment column

### DIFF
--- a/projects/packages/forms/changelog/forms-denormalize-comment-column
+++ b/projects/packages/forms/changelog/forms-denormalize-comment-column
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Do not normalize feedback posts main comment when possible, allowing fexports to not guess which is the Comment and simply adding a column with the input's label

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1291,7 +1291,16 @@ class Contact_Form_Plugin {
 			}
 		}
 
-		return $md;
+		// flatten all values.
+		$result = array();
+		foreach ( $md as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$value = implode( ', ', $value );
+			}
+			$result[ $key ] = $value;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1321,12 +1321,15 @@ class Contact_Form_Plugin {
 	 * to names, that are similar to those of the post meta.
 	 *
 	 * @param array $parsed_post_content Parsed post content.
+	 * @param bool  $use_main_comment Whether to use the main comment from the post_content or not.
+	 *                                Defaults to true for backwards compatibility. New JSON format
+	 *                                does not have a main comment and instead has all fields in the parsed content.
 	 *
 	 * @see parse_fields_from_content for how the input data is generated.
 	 *
 	 * @return array Mapped fields.
 	 */
-	public function map_parsed_field_contents_of_post_to_field_names( $parsed_post_content ) {
+	public function map_parsed_field_contents_of_post_to_field_names( $parsed_post_content, $use_main_comment = true ) {
 
 		$mapped_fields = array();
 
@@ -1336,9 +1339,12 @@ class Contact_Form_Plugin {
 			'_feedback_author'       => '1_Name',
 			'_feedback_author_email' => '2_Email',
 			'_feedback_author_url'   => '3_Website',
-			'_feedback_main_comment' => '4_Comment',
 			'_feedback_ip'           => '93_ip_address',
 		);
+
+		if ( $use_main_comment ) {
+			$field_mapping['_feedback_main_comment'] = '4_Comment';
+		}
 
 		foreach ( $field_mapping as $parsed_field_name => $field_name ) {
 			if (
@@ -1682,7 +1688,7 @@ class Contact_Form_Plugin {
 			/**
 			 * Map parsed fields to proper field names
 			 */
-			$mapped_fields = $this->map_parsed_field_contents_of_post_to_field_names( $post_real_data );
+			$mapped_fields = $this->map_parsed_field_contents_of_post_to_field_names( $post_real_data, ! $post_has_json_data );
 
 			/**
 			 * Fetch post meta data.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1666,7 +1666,7 @@ class Contact_Form_Plugin {
 			 * Whether the feedback post has JSON data or not.
 			 * This is used as optional parameter on legacy functions.
 			 */
-			$post_has_json_data = self::has_json_data( $post_id );
+			$post_has_json_data = $this->has_json_data( $post_id );
 
 			/**
 			 * If `$post_real_data` is not an array or there is no `_feedback_subject` set,
@@ -2103,7 +2103,7 @@ class Contact_Form_Plugin {
 	 * @param int $post_id The feedback post ID to check.
 	 * @return bool
 	 */
-	public static function has_json_data( $post_id ) {
+	public function has_json_data( $post_id ) {
 		$post_content = get_post_field( 'post_content', $post_id );
 		$content      = explode( "\nJSON_DATA", $post_content );
 		if ( empty( $content[1] ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1291,13 +1291,13 @@ class Contact_Form_Plugin {
 			}
 		}
 
-		// flatten all values.
+		// flatten and decode all values.
 		$result = array();
 		foreach ( $md as $key => $value ) {
 			if ( is_array( $value ) ) {
 				$value = implode( ', ', $value );
 			}
-			$result[ $key ] = $value;
+			$result[ $key ] = html_entity_decode( $value );
 		}
 
 		return $result;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1297,7 +1297,7 @@ class Contact_Form_Plugin {
 			if ( is_array( $value ) ) {
 				$value = implode( ', ', $value );
 			}
-			$result[ $key ] = html_entity_decode( $value );
+			$result[ $key ] = html_entity_decode( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 		}
 
 		return $result;

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -1167,6 +1167,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					'get_parsed_field_contents_of_post',
 					'get_post_content_for_csv_export',
 					'map_parsed_field_contents_of_post_to_field_names',
+					'has_json_data',
 				)
 			)
 			->disableOriginalConstructor()
@@ -1242,6 +1243,10 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$mock->expects( $this->exactly( 2 ) )
 			->method( 'map_parsed_field_contents_of_post_to_field_names' )
 			->will( $this->returnValueMap( $mapped_fields_contents_map ) );
+
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'has_json_data' )
+			->will( $this->returnValue( false ) );
 
 		$result = $mock->get_export_data_for_posts( array( 15, 16 ) );
 

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -1176,6 +1176,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$get_post_meta_for_csv_export_map = array(
 			array(
 				15,
+				false,
 				array(
 					'key1' => 'value1',
 					'key2' => 'value2',
@@ -1186,6 +1187,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 			),
 			array(
 				16,
+				false,
 				array(
 					'key3' => 'value3',
 					'key4' => 'value4',
@@ -1211,6 +1213,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					'_feedback_subject'      => 'subj1',
 					'_feedback_main_comment' => 'This is my test 15',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj1',
 					'4_Comment'    => 'This is my test 15',
@@ -1221,6 +1224,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					'_feedback_subject'      => 'subj2',
 					'_feedback_main_comment' => 'This is my test 16',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj2',
 					'4_Comment'    => 'This is my test 16',
@@ -1289,9 +1293,10 @@ class WP_Test_Contact_Form extends BaseTestCase {
 			->getMock();
 
 		$get_post_meta_for_csv_export_map = array(
-			array( 15, null ),
+			array( 15, false, null ),
 			array(
 				16,
+				false,
 				array(
 					'key3' => 'value3',
 					'key4' => 'value4',
@@ -1317,6 +1322,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					'_feedback_subject'      => 'subj1',
 					'_feedback_main_comment' => 'This is my test 15',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj1',
 					'Comment'      => 'This is my test 15',
@@ -1327,6 +1333,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					'_feedback_subject'      => 'subj2',
 					'_feedback_main_comment' => 'This is my test 16',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj2',
 					'Comment'      => 'This is my test 16',
@@ -1391,8 +1398,8 @@ class WP_Test_Contact_Form extends BaseTestCase {
 			->getMock();
 
 		$get_post_meta_for_csv_export_map = array(
-			array( 15, null ),
-			array( 16, null ),
+			array( 15, false, null ),
+			array( 16, false, null ),
 		);
 
 		$get_parsed_field_contents_of_post_map = array(
@@ -1411,6 +1418,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					'_feedback_subject'      => 'subj1',
 					'_feedback_main_comment' => 'This is my test 15',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj1',
 					'Comment'      => 'This is my test 15',
@@ -1421,6 +1429,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					'_feedback_subject'      => 'subj2',
 					'_feedback_main_comment' => 'This is my test 16',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj2',
 					'Comment'      => 'This is my test 16',
@@ -1481,6 +1490,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$get_post_meta_for_csv_export_map = array(
 			array(
 				15,
+				false,
 				array(
 					'key1' => 'value1',
 					'key2' => 'value2',
@@ -1491,6 +1501,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 			),
 			array(
 				16,
+				false,
 				array(
 					'key3' => 'value3',
 					'key4' => 'value4',
@@ -1516,6 +1527,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					'_feedback_subject'      => 'subj1',
 					'_feedback_main_comment' => 'This is my test 15',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj1',
 					'Comment'      => 'This is my test 15',
@@ -1526,6 +1538,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 					'_feedback_subject'      => 'subj2',
 					'_feedback_main_comment' => 'This is my test 16',
 				),
+				true,
 				array(
 					'Contact Form' => 'subj2',
 					'Comment'      => 'This is my test 16',


### PR DESCRIPTION
This PR is the second attempt to make export process to be a more faithful representation of the form's response.

## Proposed changes:
The export process now checks if the feedback post has new response format and uses it instead of relying on the post's meta for fields label/value pairs. 

This way, new responses won't have a "normalized" main _comment_ or _feedback_, but instead will export any `textarea` field as a column named after the input's label.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1683220500744339-slack-C01CSBEN0QZ

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply and try exporting single a multi (add as much as you can) responses, both to CSV and GSheets. Compare to same exports checking out `trunk`.
