### PR TITLE
CRM: Removing HTML from all invoice date HTML functions, renaming functions

### DIFF
--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -591,57 +591,33 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 									foreach ( $company['invoices'] as $invoice ) {
 										// debugecho '<pre>'; print_r($invoice); echo '</pre><hr>';
 
-										$idRefStr = '';
-										// DAL3 change of field name
-										if ( $zbs->isDAL3() ) {
+										$id_ref_str = '';
 
-											// 3.0
-											if ( isset( $invoice['id'] ) ) {
-												$idRefStr = '#' . $invoice['id'];
+										if ( isset( $invoice['id'] ) ) {
+											$id_ref_str = '#' . $invoice['id'];
+										}
+										if ( isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ) {
+											if ( ! empty( $id_ref_str ) ) {
+												$id_ref_str .= ' -';
 											}
-											if ( isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ) {
-												if ( ! empty( $idRefStr ) ) {
-													$idRefStr .= ' -';
-												}
-												$idRefStr .= ' ' . $invoice['id_override'];
-											}
-											$invoice_date = '';
-											if ( isset( $invoice['date_date'] ) ) {
-												$invoice_date = $invoice['date_date'];
-											}
-
-											$invoiceURL = jpcrm_esc_link( 'edit', $invoice['id'], ZBS_TYPE_INVOICE );
-
-											$invoiceVal = $invoice['total'];
-
-											$invoiceStatus = $invoice['status'];
-
-										} else {
-
-											// <3.0
-											if ( isset( $invoice['zbsid'] ) ) {
-												$idRefStr = '#' . $invoice['zbsid'];
-											}
-											if ( isset( $invoice['meta'] ) && isset( $invoice['meta']['ref'] ) ) {
-												if ( ! empty( $idRefStr ) ) {
-													$idRefStr .= ' -';
-												}
-												$idRefStr .= ' ' . $invoice['meta']['ref'];
-											}
-
-											$invoiceURL = jpcrm_esc_link( 'edit', $invoice['id'], ZBS_TYPE_INVOICE );// admin_url('post.php?action=edit&post='.$invoice['id']);
-
-											$invoiceVal = $invoice['meta']['val'];
-
-											$invoiceStatus = $invoice['meta']['status'];
-
+											$id_ref_str .= ' ' . $invoice['id_override'];
+										}
+										$invoice_date = '';
+										if ( isset( $invoice['date_date'] ) ) {
+											$invoice_date = $invoice['date_date'];
 										}
 
+										$invoice_url = jpcrm_esc_link( 'edit', $invoice['id'], ZBS_TYPE_INVOICE );
+
+										$invoice_val = $invoice['total'];
+
+										$invoice_status = $invoice['status'];
+
 										echo '<tr>';
-										echo '<td><a href="' . esc_url( $invoiceURL ) . '">' . esc_html( $idRefStr ) . '</a></td>';
+										echo '<td><a href="' . esc_url( $invoice_url ) . '">' . esc_html( $id_ref_str ) . '</a></td>';
 										echo '<td>' . esc_html( $invoice_date ) . '</td>';
-										echo '<td>' . esc_html( zeroBSCRM_formatCurrency( $invoiceVal ) ) . '</td>';
-										echo "<td><span class='" . esc_attr( zeroBSCRM_html_invoiceStatusLabel( $invoice ) ) . "'>" . esc_html( ucfirst( $invoiceStatus ) ) . '</span></td>';
+										echo '<td>' . esc_html( zeroBSCRM_formatCurrency( $invoice_val ) ) . '</td>';
+										echo "<td><span class='" . esc_attr( zeroBSCRM_html_invoiceStatusLabel( $invoice ) ) . "'>" . esc_html( ucfirst( $invoice_status ) ) . '</span></td>';
 										echo '</tr>';
 									}
 								} else {

--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -635,7 +635,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 										echo '<tr>';
 										echo '<td><a href="' . esc_url( $invoiceURL ) . '">' . esc_html( $idRefStr ) . '</a></td>';
-										echo '<td>' . esc_html( zeroBSCRM_html_InvoiceDate( $invoice ) ) . '</td>';
+										echo '<td>' . esc_html( zeroBSCRM_InvoiceDate( $invoice ) ) . '</td>';
 										echo '<td>' . esc_html( zeroBSCRM_formatCurrency( $invoiceVal ) ) . '</td>';
 										echo "<td><span class='" . esc_attr( zeroBSCRM_html_invoiceStatusLabel( $invoice ) ) . "'>" . esc_html( ucfirst( $invoiceStatus ) ) . '</span></td>';
 										echo '</tr>';

--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -599,11 +599,15 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 											if ( isset( $invoice['id'] ) ) {
 												$idRefStr = '#' . $invoice['id'];
 											}
-											if ( isset( $invoice['id_override'] ) ) {
+											if ( isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ) {
 												if ( ! empty( $idRefStr ) ) {
 													$idRefStr .= ' -';
 												}
 												$idRefStr .= ' ' . $invoice['id_override'];
+											}
+											$invoice_date = '';
+											if ( isset( $invoice['date_date'] ) ) {
+												$invoice_date = $invoice['date_date'];
 											}
 
 											$invoiceURL = jpcrm_esc_link( 'edit', $invoice['id'], ZBS_TYPE_INVOICE );
@@ -635,7 +639,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 										echo '<tr>';
 										echo '<td><a href="' . esc_url( $invoiceURL ) . '">' . esc_html( $idRefStr ) . '</a></td>';
-										echo '<td>' . esc_html( zeroBSCRM_InvoiceDate( $invoice ) ) . '</td>';
+										echo '<td>' . esc_html( $invoice_date ) . '</td>';
 										echo '<td>' . esc_html( zeroBSCRM_formatCurrency( $invoiceVal ) ) . '</td>';
 										echo "<td><span class='" . esc_attr( zeroBSCRM_html_invoiceStatusLabel( $invoice ) ) . "'>" . esc_html( ucfirst( $invoiceStatus ) ) . '</span></td>';
 										echo '</tr>';

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -741,62 +741,39 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 									$quoteValue = '-';
 
-									$idRefStr = '';
-									// DAL3 change of field name
-									if ( $zbs->isDAL3() ) {
+									$id_ref_str = '';
 
-										// 3.0
-										if ( isset( $quote['id'] ) ) {
-											$idRefStr = '#' . $quote['id'];
+									if ( isset( $quote['id'] ) ) {
+										$id_ref_str = '#' . $quote['id'];
+									}
+									if ( isset( $quote['id_override'] ) && ! empty( $quote['id_override'] ) ) {
+										if ( ! empty( $id_ref_str ) ) {
+											$id_ref_str .= ' -';
 										}
-										if ( isset( $quote['id_override'] ) && ! empty( $quote['id_override'] ) ) {
-											if ( ! empty( $idRefStr ) ) {
-												$idRefStr .= ' -';
-											}
-											$idRefStr .= ' ' . $quote['id_override'];
+										$id_ref_str .= ' ' . $quote['id_override'];
+									}
+									if ( isset( $quote['title'] ) && ! empty( $quote['title'] ) ) {
+										if ( ! empty( $id_ref_str ) ) {
+											$id_ref_str .= ' -';
 										}
-										if ( isset( $quote['title'] ) && ! empty( $quote['title'] ) ) {
-											if ( ! empty( $idRefStr ) ) {
-												$idRefStr .= ' -';
-											}
-											$idRefStr .= ' ' . $quote['title'];
-										}
-										$quote_date = '';
-										if ( isset( $quote['date_date'] ) ) {
-											$quote_date = $quote['date_date'];
-										}
-
-										$quoteURL    = jpcrm_esc_link( 'edit', $quote['id'], ZBS_TYPE_QUOTE );
-										$quoteValue  = $quote['value'];
-										$quoteStatus = $quote['status'];
-
-									} else {
-
-										if ( isset( $quote['zbsid'] ) ) {
-											$idRefStr = '#' . $quote['zbsid'];
-										}
-										if ( isset( $quote['meta'] ) && isset( $quote['meta']['ref'] ) ) {
-											if ( ! empty( $idRefStr ) ) {
-												$idRefStr .= ' -';
-											}
-											$idRefStr .= ' ' . $quote['meta']['ref'];
-										}
-
-										$quoteURL = jpcrm_esc_link( 'edit', $quote['id'], ZBS_TYPE_QUOTE );// admin_url('post.php?action=edit&post='.$quote['id']);
-
-										if ( isset( $quote['meta']['val'] ) ) {
-											$quoteValue = $quote['meta']['val'];
-										}
+										$id_ref_str .= ' ' . $quote['title'];
+									}
+									$quote_date = '';
+									if ( isset( $quote['date_date'] ) ) {
+										$quote_date = $quote['date_date'];
 									}
 
-									if ( $quoteValue != '-' && ! empty( $quoteValue ) ) {
-										$quoteValue = zeroBSCRM_formatCurrency( $quoteValue );
+									$quote_url   = jpcrm_esc_link( 'edit', $quote['id'], ZBS_TYPE_QUOTE );
+									$quote_value = $quote['value'];
+
+									if ( $quote_value !== '-' && ! empty( $quote_value ) ) {
+										$quote_value = zeroBSCRM_formatCurrency( $quote_value );
 									}
 
 									echo '<tr>';
-									echo '<td><a href="' . esc_url( $quoteURL ) . '">' . esc_html( $idRefStr ) . '</a></td>';
+									echo '<td><a href="' . esc_url( $quote_url ) . '">' . esc_html( $id_ref_str ) . '</a></td>';
 									echo '<td>' . esc_html( $quote_date ) . '</td>';
-									echo '<td>' . esc_html( $quoteValue ) . '</td>';
+									echo '<td>' . esc_html( $quote_value ) . '</td>';
 									echo "<td><span class='" . esc_attr( zeroBSCRM_html_quoteStatusLabel( $quote ) ) . "'>" . wp_kses( zeroBS_getQuoteStatus( $quote, false ), $zbs->acceptable_restricted_html ) . '</span></td>';
 									echo '</tr>';
 								}
@@ -875,57 +852,33 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 								foreach ( $contact['invoices'] as $invoice ) {
 
-									$idRefStr = '';
-									// DAL3 change of field name
-									if ( $zbs->isDAL3() ) {
+									$id_ref_str = '';
 
-										// 3.0
-										if ( isset( $invoice['id'] ) ) {
-											$idRefStr = '#' . $invoice['id'];
+									if ( isset( $invoice['id'] ) ) {
+										$id_ref_str = '#' . $invoice['id'];
+									}
+									if ( isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ) {
+										if ( ! empty( $id_ref_str ) ) {
+											$id_ref_str .= ' -';
 										}
-										if ( isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ) {
-											if ( ! empty( $idRefStr ) ) {
-												$idRefStr .= ' -';
-											}
-											$idRefStr .= ' ' . $invoice['id_override'];
-										}
-										$invoice_date = '';
-										if ( isset( $invoice['date_date'] ) ) {
-											$invoice_date = $invoice['date_date'];
-										}
-
-										$invoiceURL = jpcrm_esc_link( 'edit', $invoice['id'], ZBS_TYPE_INVOICE );
-
-										$invoiceVal = $invoice['total'];
-
-										$invoiceStatus = $invoice['status'];
-
-									} else {
-
-										// <3.0
-										if ( isset( $invoice['zbsid'] ) ) {
-											$idRefStr = '#' . $invoice['zbsid'];
-										}
-										if ( isset( $invoice['meta'] ) && isset( $invoice['meta']['ref'] ) ) {
-											if ( ! empty( $idRefStr ) ) {
-												$idRefStr .= ' -';
-											}
-											$idRefStr .= ' ' . $invoice['meta']['ref'];
-										}
-
-										$invoiceURL = jpcrm_esc_link( 'edit', $invoice['id'], ZBS_TYPE_INVOICE );
-
-										$invoiceVal = $invoice['meta']['val'];
-
-										$invoiceStatus = $invoice['meta']['status'];
-
+										$id_ref_str .= ' ' . $invoice['id_override'];
+									}
+									$invoice_date = '';
+									if ( isset( $invoice['date_date'] ) ) {
+										$invoice_date = $invoice['date_date'];
 									}
 
+									$invoice_url = jpcrm_esc_link( 'edit', $invoice['id'], ZBS_TYPE_INVOICE );
+
+									$invoice_val = $invoice['total'];
+
+									$invoice_status = $invoice['status'];
+
 									echo '<tr>';
-									echo '<td><a href="' . esc_url( $invoiceURL ) . '">' . esc_html( $idRefStr ) . '</a></td>';
+									echo '<td><a href="' . esc_url( $invoice_url ) . '">' . esc_html( $id_ref_str ) . '</a></td>';
 									echo '<td>' . esc_html( $invoice_date ) . '</td>';
-									echo '<td>' . esc_html( zeroBSCRM_formatCurrency( $invoiceVal ) ) . '</td>';
-									echo "<td><span class='" . esc_attr( zeroBSCRM_html_invoiceStatusLabel( $invoice ) ) . "'>" . esc_html( ucfirst( $invoiceStatus ) ) . '</span></td>';
+									echo '<td>' . esc_html( zeroBSCRM_formatCurrency( $invoice_val ) ) . '</td>';
+									echo "<td><span class='" . esc_attr( zeroBSCRM_html_invoiceStatusLabel( $invoice ) ) . "'>" . esc_html( ucfirst( $invoice_status ) ) . '</span></td>';
 									echo '</tr>';
 								}
 

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -761,6 +761,10 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 											}
 											$idRefStr .= ' ' . $quote['title'];
 										}
+										$quote_date = '';
+										if ( isset( $quote['date_date'] ) ) {
+											$quote_date = $quote['date_date'];
+										}
 
 										$quoteURL    = jpcrm_esc_link( 'edit', $quote['id'], ZBS_TYPE_QUOTE );
 										$quoteValue  = $quote['value'];
@@ -791,7 +795,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 									echo '<tr>';
 									echo '<td><a href="' . esc_url( $quoteURL ) . '">' . esc_html( $idRefStr ) . '</a></td>';
-									echo '<td>' . esc_html( zeroBSCRM_QuoteDate( $quote ) ) . '</td>';
+									echo '<td>' . esc_html( $quote_date ) . '</td>';
 									echo '<td>' . esc_html( $quoteValue ) . '</td>';
 									echo "<td><span class='" . esc_attr( zeroBSCRM_html_quoteStatusLabel( $quote ) ) . "'>" . wp_kses( zeroBS_getQuoteStatus( $quote, false ), $zbs->acceptable_restricted_html ) . '</span></td>';
 									echo '</tr>';
@@ -885,6 +889,10 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 											}
 											$idRefStr .= ' ' . $invoice['id_override'];
 										}
+										$invoice_date = '';
+										if ( isset( $invoice['date_date'] ) ) {
+											$invoice_date = $invoice['date_date'];
+										}
 
 										$invoiceURL = jpcrm_esc_link( 'edit', $invoice['id'], ZBS_TYPE_INVOICE );
 
@@ -915,7 +923,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 									echo '<tr>';
 									echo '<td><a href="' . esc_url( $invoiceURL ) . '">' . esc_html( $idRefStr ) . '</a></td>';
-									echo '<td>' . esc_html( zeroBSCRM_InvoiceDate( $invoice ) ) . '</td>';
+									echo '<td>' . esc_html( $invoice_date ) . '</td>';
 									echo '<td>' . esc_html( zeroBSCRM_formatCurrency( $invoiceVal ) ) . '</td>';
 									echo "<td><span class='" . esc_attr( zeroBSCRM_html_invoiceStatusLabel( $invoice ) ) . "'>" . esc_html( ucfirst( $invoiceStatus ) ) . '</span></td>';
 									echo '</tr>';

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -791,7 +791,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 									echo '<tr>';
 									echo '<td><a href="' . esc_url( $quoteURL ) . '">' . esc_html( $idRefStr ) . '</a></td>';
-									echo '<td>' . zeroBSCRM_html_QuoteDate( $quote ) . '</td>';
+									echo '<td>' . esc_html( zeroBSCRM_QuoteDate( $quote ) ) . '</td>';
 									echo '<td>' . esc_html( $quoteValue ) . '</td>';
 									echo "<td><span class='" . esc_attr( zeroBSCRM_html_quoteStatusLabel( $quote ) ) . "'>" . wp_kses( zeroBS_getQuoteStatus( $quote, false ), $zbs->acceptable_restricted_html ) . '</span></td>';
 									echo '</tr>';
@@ -915,7 +915,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 									echo '<tr>';
 									echo '<td><a href="' . esc_url( $invoiceURL ) . '">' . esc_html( $idRefStr ) . '</a></td>';
-									echo '<td>' . zeroBSCRM_html_InvoiceDate( $invoice ) . '</td>';
+									echo '<td>' . esc_html( zeroBSCRM_InvoiceDate( $invoice ) ) . '</td>';
 									echo '<td>' . esc_html( zeroBSCRM_formatCurrency( $invoiceVal ) ) . '</td>';
 									echo "<td><span class='" . esc_attr( zeroBSCRM_html_invoiceStatusLabel( $invoice ) ) . "'>" . esc_html( ucfirst( $invoiceStatus ) ) . '</span></td>';
 									echo '</tr>';

--- a/projects/plugins/crm/changelog/fix-crm-company-view-all-invoices-list-style
+++ b/projects/plugins/crm/changelog/fix-crm-company-view-all-invoices-list-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact / Company: Fix date styling for transactions, invoices and quotes.

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -850,36 +850,6 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
 
 	}
 
-/**
- * Given a quote, fetches the creation date and returns that.
- *
- * @param array $quote The quote details aas an array.
- *
- * @returns string
- */
-function zeroBSCRM_QuoteDate( $quote = array() ) {
-
-	// v3.0:
-	if ( isset( $quote['date_date'] ) ) {
-		return $quote['date_date'];
-	}
-
-	// <3.0
-	if ( isset( $quote['meta'] ) && isset( $quote['meta']['date'] ) ) {
-
-		// wh fix, we're now saving this in format, no need to get it then resave it
-		// also, with 22/06/18 it's in a format DateTime can't get.
-		// use DateTime::createFromFormat('!'.zeroBSCRM_date_defaultFormat(), $dateInFormat)->getTimestamp();
-		//$d = new DateTime($quote['meta']['date']);
-		//$formatted_date = $d->format(zeroBSCRM_getDateFormat());
-
-		return $quote['meta']['date'];
-
-	}
-
-	return '-';
-}
-
 /* ======================================================
   /	Quotes
    ====================================================== */
@@ -919,38 +889,6 @@ function zeroBSCRM_QuoteDate( $quote = array() ) {
 
 	}
 
-/**
- * Given an invoice, fetches the creation date and returns that.
- *
- * @param array $inv The invoice details as an array.
- *
- * @returns string
- */
-function zeroBSCRM_invoiceDate( $inv = array() ) {
-
-	if ( isset( $inv['date_date'] ) ) {
-
-		return $inv['date_date'];
-
-	}
-
-	// else <3.0
-
-	if ( isset( $inv['meta'] ) && isset( $inv['meta']['date'] ) ) {
-
-		// wh fix, MS, you're saving this in format, no need to get it then resave it
-		// also, with 22/06/18 it's in a format DateTime can't get.
-		// use DateTime::createFromFormat('!'.zeroBSCRM_date_defaultFormat(), $dateInFormat)->getTimestamp();
-		//$d = new DateTime($inv['meta']['date']);
-		//$formatted_date = $d->format(zeroBSCRM_getDateFormat());
-
-		return $inv['meta']['date'];
-
-	}
-
-	return '-';
-}
-
 /* ======================================================
   /	Invoices
    ====================================================== */
@@ -988,35 +926,6 @@ function zeroBSCRM_invoiceDate( $inv = array() ) {
 		
 		return 'ui grey label';
 	}
-
-/**
- * Given a transaction, fetches the creation date and returns that.
- *
- * @param array $transaction The transaction details as an array.
- *
- * @returns string
- */
-function zeroBSCRM_transactionDate( $transaction ) {
-
-	// v3 no need for any of the below
-	if (isset($transaction['date_date'])){
-
-		return $transaction['date_date'];
-
-	}
-
-	// <3.0
-
-	// saved in format, no need
-		//$d = new DateTime($transaction['created']);
-		//$formatted_date = $d->format(zeroBSCRM_getDateFormat());  
-	// zeroBSCRM_date_i18n('H:i', $log['createduts'], true, false);
-
-	//transaction created in $post->post_date_gmt so will be the correct UTS for the below
-	$transaction_uts = strtotime($transaction['created']);
-	$formatted_date = zeroBSCRM_date_i18n(zeroBSCRM_getDateFormat() . " " . zeroBSCRM_getTimeFormat(), $transaction_uts, true, false);
-	return $formatted_date;
-}
 
 /* ======================================================
   /	Transactions
@@ -1922,7 +1831,9 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 						$ret = '<a href="'.$linkOpen.'" class="ui button basic small">'. __('Edit','zero-bs-crm') . "</a>";
 						break;
 					case 'date':
-						$ret = zeroBSCRM_transactionDate( $obj );
+				if ( isset( $obj['date_date'] ) ) {
+					$ret = $obj['date_date'];
+				}
 						break;
 					case 'item':
 						$itemStr = ''; 

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -872,9 +872,8 @@ function zeroBSCRM_QuoteDate( $quote = array() ) {
 		// use DateTime::createFromFormat('!'.zeroBSCRM_date_defaultFormat(), $dateInFormat)->getTimestamp();
 		//$d = new DateTime($quote['meta']['date']);
 		//$formatted_date = $d->format(zeroBSCRM_getDateFormat());
-		$formatted_date = $quote['meta']['date'];
 
-		return $formatted_date;
+		return $quote['meta']['date'];
 
 	}
 
@@ -944,9 +943,8 @@ function zeroBSCRM_invoiceDate( $inv = array() ) {
 		// use DateTime::createFromFormat('!'.zeroBSCRM_date_defaultFormat(), $dateInFormat)->getTimestamp();
 		//$d = new DateTime($inv['meta']['date']);
 		//$formatted_date = $d->format(zeroBSCRM_getDateFormat());
-		$formatted_date = $inv['meta']['date'];
 
-		return $formatted_date;
+		return $inv['meta']['date'];
 
 	}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -850,27 +850,36 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
 
 	}
 
-	function zeroBSCRM_html_QuoteDate($quote=array()){
+/**
+ * Given a quote, fetches the creation date and returns that.
+ *
+ * @param array $quote The quote details aas an array.
+ *
+ * @returns string
+ */
+function zeroBSCRM_QuoteDate( $quote = array() ) {
 
-		// v3.0:
-		if (isset($quote['date_date'])) return "<span class='zbs-action'><strong>" . $quote['date_date'] . "</strong></span>";
-
-		// <3.0
-		if (isset($quote['meta']) && isset($quote['meta']['date'])){
-
-			// wh fix, we're now saving this in format, no need to get it then resave it
-			// also, with 22/06/18 it's in a format DateTime can't get.
-			// use DateTime::createFromFormat('!'.zeroBSCRM_date_defaultFormat(), $dateInFormat)->getTimestamp();
-			//$d = new DateTime($quote['meta']['date']);
-			//$formatted_date = $d->format(zeroBSCRM_getDateFormat());  
-			$formatted_date = $quote['meta']['date'];
-
-			return "<span class='zbs-action'><strong>" . $formatted_date . "</strong></span>";
-
-		}
-
-		return '-';
+	// v3.0:
+	if ( isset( $quote['date_date'] ) ) {
+		return $quote['date_date'];
 	}
+
+	// <3.0
+	if ( isset( $quote['meta'] ) && isset( $quote['meta']['date'] ) ) {
+
+		// wh fix, we're now saving this in format, no need to get it then resave it
+		// also, with 22/06/18 it's in a format DateTime can't get.
+		// use DateTime::createFromFormat('!'.zeroBSCRM_date_defaultFormat(), $dateInFormat)->getTimestamp();
+		//$d = new DateTime($quote['meta']['date']);
+		//$formatted_date = $d->format(zeroBSCRM_getDateFormat());
+		$formatted_date = $quote['meta']['date'];
+
+		return $formatted_date;
+
+	}
+
+	return '-';
+}
 
 /* ======================================================
   /	Quotes
@@ -911,31 +920,38 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
 
 	}
 
-	function zeroBSCRM_html_invoiceDate($inv=array()){
+/**
+ * Given an invoice, fetches the creation date and returns that.
+ *
+ * @param array $inv The invoice details as an array.
+ *
+ * @returns string
+ */
+function zeroBSCRM_invoiceDate( $inv = array() ) {
 
-		if (isset($inv['date_date'])){
+	if ( isset( $inv['date_date'] ) ) {
 
-			return "<span class='zbs-action'><strong>" . $inv['date_date'] . "</strong></span>";
+		return $inv['date_date'];
 
-		}
-
-		// else <3.0
-
-		if (isset($inv['meta']) && isset($inv['meta']['date'])){
-
-			// wh fix, MS, you're saving this in format, no need to get it then resave it
-			// also, with 22/06/18 it's in a format DateTime can't get.
-			// use DateTime::createFromFormat('!'.zeroBSCRM_date_defaultFormat(), $dateInFormat)->getTimestamp();
-			//$d = new DateTime($inv['meta']['date']);
-			//$formatted_date = $d->format(zeroBSCRM_getDateFormat());  
-			$formatted_date = $inv['meta']['date'];
-
-			return "<span class='zbs-action'><strong>" . $formatted_date . "</strong></span>";
-
-		}
-
-		return '-';
 	}
+
+	// else <3.0
+
+	if ( isset( $inv['meta'] ) && isset( $inv['meta']['date'] ) ) {
+
+		// wh fix, MS, you're saving this in format, no need to get it then resave it
+		// also, with 22/06/18 it's in a format DateTime can't get.
+		// use DateTime::createFromFormat('!'.zeroBSCRM_date_defaultFormat(), $dateInFormat)->getTimestamp();
+		//$d = new DateTime($inv['meta']['date']);
+		//$formatted_date = $d->format(zeroBSCRM_getDateFormat());
+		$formatted_date = $inv['meta']['date'];
+
+		return $formatted_date;
+
+	}
+
+	return '-';
+}
 
 /* ======================================================
   /	Invoices
@@ -975,26 +991,33 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
 		return 'ui grey label';
 	}
 
-function zeroBSCRM_html_transactionDate($transaction){
+/**
+ * Given a transaction, fetches the creation date and returns that.
+ *
+ * @param array $transaction The transaction details as an array.
+ *
+ * @returns string
+ */
+function zeroBSCRM_transactionDate( $transaction ) {
 
 	// v3 no need for any of the below
 	if (isset($transaction['date_date'])){
 
-		return "<span class='zbs-action'><strong>" . $transaction['date_date']  . "</strong></span>";
+		return $transaction['date_date'];
 
 	}
 
 	// <3.0
 
 	// saved in format, no need
-	  //$d = new DateTime($transaction['created']);
+		//$d = new DateTime($transaction['created']);
 		//$formatted_date = $d->format(zeroBSCRM_getDateFormat());  
 	// zeroBSCRM_date_i18n('H:i', $log['createduts'], true, false);
 
 	//transaction created in $post->post_date_gmt so will be the correct UTS for the below
 	$transaction_uts = strtotime($transaction['created']);
 	$formatted_date = zeroBSCRM_date_i18n(zeroBSCRM_getDateFormat() . " " . zeroBSCRM_getTimeFormat(), $transaction_uts, true, false);
-  return "<span class='zbs-action'><strong>" . $formatted_date  . "</strong></span>";
+	return $formatted_date;
 }
 
 /* ======================================================
@@ -1901,7 +1924,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 						$ret = '<a href="'.$linkOpen.'" class="ui button basic small">'. __('Edit','zero-bs-crm') . "</a>";
 						break;
 					case 'date':
-						$ret = zeroBSCRM_html_transactionDate($obj);
+						$ret = zeroBSCRM_transactionDate( $obj );
 						break;
 					case 'item':
 						$itemStr = ''; 


### PR DESCRIPTION
## Proposed changes:

* This PR removes HTML from the `zeroBSCRM_html_invoiceDate`, `zeroBSCRM_html_transactionDate` and `zeroBSCRM_html_QuoteDate` functions (and renames those functions accordingly).
* The reason for the change was due to an observable issue with incorrect output for invoice dates showing on Company pages due to over-escaping (HTML was showing).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3076

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Using the [Jetpack Beta plugin](https://github.com/Automattic/jetpack-beta) on a test site with this branch applied or testing locally with the branch checked out, open up the 'View Contact' page for a contact (`/wp-admin/admin.php?page=zbs-add-edit&action=view&zbstype=contact&zbsid={contactid}`), and 'View Company page for a company (`/wp-admin/admin.php?page=zbs-add-edit&action=view&zbstype=company&zbsid={companyid}`).
* Click on the 'Quotes', 'Invoices' and 'Transactions' tabs for Contacts and the 'Invoices' and 'Transactions' tabs for Companies.
* View the Date column for each - the date of the relevant Quote/Invoice/Transaction should show, with no HTML visible. The date formats are all different but that is a [separate issue](https://github.com/Automattic/zero-bs-crm/issues/3084).
* To test the original issue with Invoice dates showing HTML for companies, check out trunk or open a test site with CRM 5.7.0 running, and on the View Company page open up the Invoices tab. The date field should show HTML.

The View Company page Invoice date styling before this PR is applied:

<img width="1067" alt="235151987-b5242bd8-4210-449d-b77a-63d8cbab9d4d" src="https://user-images.githubusercontent.com/16754605/236447502-c1f38ec4-51f6-4aba-ba68-2f64e79c46c8.png">

After:

<img width="1098" alt="Screenshot 2023-05-05 at 12 54 29" src="https://user-images.githubusercontent.com/16754605/236451190-f713e8e0-24b4-42a7-9b39-de6f6cb954cd.png">


