### PR TITLE
VideoPress: introduce helper function to get VideoPress video block attributes from URL

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-pick-video-customization-from-url
+++ b/projects/packages/videopress/changelog/update-videopress-pick-video-customization-from-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: introduce helper function to get VideoPress video block attributes from URL

--- a/projects/packages/videopress/src/client/lib/url/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/index.ts
@@ -1,20 +1,23 @@
 import { addQueryArgs } from '@wordpress/url';
 import { VideoBlockAttributes, VideoGUID } from '../../block-editor/blocks/video/types';
 
-type VideoPressUrlOptions = Pick<
-	VideoBlockAttributes,
-	| 'autoplay'
-	| 'controls'
-	| 'loop'
-	| 'muted'
-	| 'playsinline'
-	| 'poster'
-	| 'preload'
-	| 'seekbarColor'
-	| 'seekbarPlayedColor'
-	| 'seekbarLoadingColor'
-	| 'useAverageColor'
->;
+const VIDEOPRESS_URL_ARGS = [
+	'autoplay',
+	'controls',
+	'loop',
+	'muted',
+	'playsinline',
+	'poster',
+	'preload',
+	'seekbarColor',
+	'seekbarPlayedColor',
+	'seekbarLoadingColor',
+	'useAverageColor',
+] as const;
+
+type VideoPressUrlArgsProps = typeof VIDEOPRESS_URL_ARGS;
+type VideoPressUrlArgProp = VideoPressUrlArgsProps[ number ];
+type VideoPressUrlOptions = Pick< VideoBlockAttributes, VideoPressUrlArgProp >;
 
 export const getVideoPressUrl = (
 	guid: string,

--- a/projects/packages/videopress/src/client/lib/url/test/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/test/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { buildVideoPressURL } from '..';
+import { buildVideoPressURL, pickVideoBlockAttributesFromUrl } from '..';
 
 describe( 'buildVideoPressURL', () => {
 	it( 'should return empty object when invalid URL', () => {
@@ -59,5 +59,68 @@ describe( 'buildVideoPressURL', () => {
 			url: 'https://videos.files.wordpress.com/xyrdcYF4/screen-recording-2023-01-13-at-08.21.53-1.mov',
 			guid: 'xyrdcYF4',
 		} );
+	} );
+} );
+
+describe( 'pickVideoBlockAttributesFromUrl', () => {
+	it( 'should return empty object when no URL', () => {
+		const attributes = pickVideoBlockAttributesFromUrl( '' );
+		expect( attributes ).toStrictEqual( {} );
+	} );
+
+	it( 'should return empty object when not valid URL', () => {
+		const attributes = pickVideoBlockAttributesFromUrl( 'not-valid-url' );
+		expect( attributes ).toStrictEqual( {} );
+	} );
+
+	it( 'should return controls attribute False from controls=0', () => {
+		const attributes = pickVideoBlockAttributesFromUrl(
+			'https://videopress.com/embed/7GMaYckU?cover=1&autoPlay=1&controls=0&loop=1&muted=1&persistVolume=0&playsinline=1&posterUrl=http%3A%2F%2Flocalhost%2Fwp-content%2Fuploads%2F2023%2F04%2Fpexels-photo-2693212.jpg&preloadContent=metadata&sbc=%23cf2e2e&sbpc=%23fcb900&sblc=%239b51e0&hd=1'
+		);
+		expect( attributes.controls ).toBe( false );
+	} );
+
+	it( 'should return controls attribute False from controls=1', () => {
+		const attributes = pickVideoBlockAttributesFromUrl(
+			'https://videopress.com/embed/7GMaYckU?cover=1&autoPlay=1&controls=1&loop=1&muted=1&persistVolume=0&playsinline=1&posterUrl=http%3A%2F%2Flocalhost%2Fwp-content%2Fuploads%2F2023%2F04%2Fpexels-photo-2693212.jpg&preloadContent=metadata&sbc=%23cf2e2e&sbpc=%23fcb900&sblc=%239b51e0&hd=1'
+		);
+		expect( attributes.controls ).toBe( true );
+	} );
+
+	it( 'should return controls attribute False from controls=false', () => {
+		const attributes = pickVideoBlockAttributesFromUrl(
+			'https://videopress.com/embed/7GMaYckU?cover=1&autoPlay=1&controls=false&loop=1&muted=1&persistVolume=0&playsinline=1&posterUrl=http%3A%2F%2Flocalhost%2Fwp-content%2Fuploads%2F2023%2F04%2Fpexels-photo-2693212.jpg&preloadContent=metadata&sbc=%23cf2e2e&sbpc=%23fcb900&sblc=%239b51e0&hd=1'
+		);
+		expect( attributes.controls ).toBe( false );
+	} );
+
+	it( 'should return controls attribute False from controls=true', () => {
+		const attributes = pickVideoBlockAttributesFromUrl(
+			'https://videopress.com/embed/7GMaYckU?cover=1&autoPlay=1&controls=true&loop=1&muted=1&persistVolume=0&playsinline=1&posterUrl=http%3A%2F%2Flocalhost%2Fwp-content%2Fuploads%2F2023%2F04%2Fpexels-photo-2693212.jpg&preloadContent=metadata&sbc=%23cf2e2e&sbpc=%23fcb900&sblc=%239b51e0&hd=1'
+		);
+		expect( attributes.controls ).toBe( true );
+	} );
+
+	it( 'should return attributes without controls key', () => {
+		const attributes = pickVideoBlockAttributesFromUrl(
+			'https://videopress.com/embed/7GMaYckU?cover=1&autoPlay=1&loop=1&muted=1&persistVolume=0&playsinline=1&posterUrl=http%3A%2F%2Flocalhost%2Fwp-content%2Fuploads%2F2023%2F04%2Fpexels-photo-2693212.jpg&preloadContent=metadata&sbc=%23cf2e2e&sbpc=%23fcb900&sblc=%239b51e0&hd=1'
+		);
+		expect( attributes.controls ).toBeUndefined();
+	} );
+
+	it( 'should not return a not expected attribute', () => {
+		const attributes = pickVideoBlockAttributesFromUrl(
+			'https://videopress.com/embed/7GMaYckU?not-expected=1'
+		);
+		expect( attributes ).toStrictEqual( {} );
+	} );
+
+	it( 'should return the poster imahge URL', () => {
+		const attributes = pickVideoBlockAttributesFromUrl(
+			'https://videopress.com/embed/7GMaYckU?cover=1&autoPlay=1&loop=1&muted=1&persistVolume=0&playsinline=1&posterUrl=http%3A%2F%2Flocalhost%2Fwp-content%2Fuploads%2F2023%2F04%2Fpexels-photo-2693212.jpg&preloadContent=metadata&sbc=%23cf2e2e&sbpc=%23fcb900&sblc=%239b51e0&hd=1'
+		);
+		expect( attributes.poster ).toBe(
+			'http://localhost/wp-content/uploads/2023/04/pexels-photo-2693212.jpg'
+		);
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR introduces a function that picks and maps the VideoPress attributes from an URL. It's going to be used in a follow-up.

Fixes #
Part of https://github.com/Automattic/jetpack/issues/30417

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: introduce helper function to get VideoPress video block attributes from URL

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* For now, run the tests

```cli
jetpack test packages/videopress js
```

<img width="727" alt="image" src="https://user-images.githubusercontent.com/77539/236498646-86f001f2-47f8-46b2-b164-9ce71c1c237c.png">


```
cd projects/packages/videopress
pnpm test
```

* Confirm that the app works as expected (paste a URL, create a block, etc.)

