### PR TITLE
External Media: Define request method directly

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -1626,8 +1626,6 @@ class Jetpack_Tweetstorm_Helper {
 	 * @return array The Twitter card data.
 	 */
 	public static function generate_cards( $urls ) {
-		global $wp_version;
-
 		$validator = new Twitter_Validator();
 
 		$requests = array_map(
@@ -1649,7 +1647,7 @@ class Jetpack_Tweetstorm_Helper {
 		$requests = array_filter( $requests );
 
 		// Remove this check once WordPress 6.2 is the minimum supported version.
-		if ( version_compare( $wp_version, '6.2-alpha', '<' ) ) {
+		if ( ! class_exists( '\WpOrg\Requests\Hooks' ) ) {
 			$hooks = new Requests_Hooks();
 		} else {
 			$hooks = new \WpOrg\Requests\Hooks();
@@ -1661,9 +1659,9 @@ class Jetpack_Tweetstorm_Helper {
 		);
 
 		// Remove this check once WordPress 6.2 is the minimum supported version.
-		$results = version_compare( $wp_version, '6.2-alpha', '<' )
-			? Requests::request_multiple( $requests, array( 'hooks' => $hooks ) )
-			: \WpOrg\Requests\Requests::request_multiple( $requests, array( 'hooks' => $hooks ) );
+		$results = class_exists( '\WpOrg\Requests\Requests' )
+			? \WpOrg\Requests\Requests::request_multiple( $requests, array( 'hooks' => $hooks ) )
+			: Requests::request_multiple( $requests, array( 'hooks' => $hooks ) );
 
 		foreach ( $results as $result ) {
 			if ( $result instanceof Requests_Exception || $result instanceof \WpOrg\Requests\Exception ) {
@@ -1740,11 +1738,9 @@ class Jetpack_Tweetstorm_Helper {
 	 * @return void
 	 */
 	public static function validate_redirect_url( $redirect_url ) {
-		global $wp_version;
-
 		if ( ! wp_http_validate_url( $redirect_url ) ) {
 			// Remove this check once WordPress 6.2 is the minimum supported version.
-			if ( version_compare( $wp_version, '6.2-alpha', '<' ) ) {
+			if ( ! class_exists( '\WpOrg\Requests\Exception' ) ) {
 				throw new Requests_Exception( __( 'A valid URL was not provided.', 'jetpack' ), 'wp_http.redirect_failed_validation' );
 			}
 			throw new \WpOrg\Requests\Exception( __( 'A valid URL was not provided.', 'jetpack' ), 'wp_http.redirect_failed_validation' );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -390,18 +390,11 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 	 * @return array|WP_Error|WP_REST_Response
 	 */
 	public function delete_connection( WP_REST_Request $request ) {
-		global $wp_version;
-
 		$service    = rawurlencode( $request->get_param( 'service' ) );
 		$wpcom_path = sprintf( '/meta/external-media/connection/%s', $service );
 
-		// Remove this check once WordPress 6.2 is the minimum supported version.
-		$delete_request = version_compare( $wp_version, '6.2-alpha', '<' )
-			? Requests::DELETE
-			: \WpOrg\Requests\Requests::DELETE;
-
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$internal_request = new WP_REST_Request( $delete_request, '/' . $this->namespace . $wpcom_path );
+			$internal_request = new WP_REST_Request( 'DELETE', '/' . $this->namespace . $wpcom_path );
 			$internal_request->set_query_params( $request->get_params() );
 
 			return rest_do_request( $internal_request );
@@ -411,7 +404,7 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 			$wpcom_path,
 			'2',
 			array(
-				'method' => $delete_request,
+				'method' => 'DELETE',
 			)
 		);
 

--- a/projects/plugins/jetpack/changelog/fix-google-photos-disconnect
+++ b/projects/plugins/jetpack/changelog/fix-google-photos-disconnect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixes a bug on WP installations that are not fully updated to 6.2.0 yet.

--- a/projects/plugins/jetpack/changelog/fix-google-photos-disconnect
+++ b/projects/plugins/jetpack/changelog/fix-google-photos-disconnect
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Fixes a bug on WP installations that are not fully updated to 6.2.0 yet.
+Fixes a bug on WP.com Simple, which is not fully updated to 6.2 yet.


### PR DESCRIPTION
Fixes a bug on WP installations that are not fully updated to 6.2.0 yet and are missing `\WpOrg\Requests\Requests`.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Introduced in #29542.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the use of the Requests library entirely, in favor of defining the request method directly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1683302169075199-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Posts > Add New, and add some content
* Add a Twitter block and paste a Twitter URL for a thread, e.g. https://twitter.com/kelseyhightower/status/1654098279116992513
* Click on Unroll
* Watch the tweet unroll
* Open the Jetpack sidebar
* Change Publicize options to publish a thread instead of a single tweet.
* Watch the separators added to the post content.
* Click on the "Social Previews" section at the bottom of the sidebar.
* You should see previews under some of the tweets, and you should not see any notices in your logs.
* Now add an image block, and select "Select Image > Google Photos".
* If you have not connected your Google account yet, you should be able to do so now.
* Once you've connected, hit the disconnect button in the top right corner of the modal.
* It should disconnect and not show a never ending spinner.