### PR TITLE
Fix: Allow any module to update jetpack_waf_ip_allow_list option

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-endpoint-for-brute
+++ b/projects/packages/waf/changelog/fix-waf-endpoint-for-brute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix unavailable endpoint when WAF module is disabled

--- a/projects/packages/waf/src/class-rest-controller.php
+++ b/projects/packages/waf/src/class-rest-controller.php
@@ -22,6 +22,12 @@ class REST_Controller {
 	 * @return void
 	 */
 	public static function register_rest_routes() {
+		// Ensure routes are only initialized once.
+		static $routes_registered = false;
+		if ( $routes_registered ) {
+			return;
+		}
+
 		register_rest_route(
 			'jetpack/v4',
 			'/waf',
@@ -51,6 +57,8 @@ class REST_Controller {
 				'permission_callback' => __CLASS__ . '::waf_permissions_callback',
 			)
 		);
+
+		$routes_registered = true;
 	}
 
 	/**

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -34,6 +34,9 @@ class Waf_Initializer {
 		// Ensure backwards compatibility
 		Waf_Compatibility::add_compatibility_hooks();
 
+		// Register REST routes.
+		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
+
 		// Run the WAF on supported environments
 		if ( Waf_Runner::is_supported_environment() ) {
 			// Update the WAF after installing or upgrading a relevant Jetpack plugin

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -86,7 +86,7 @@ const ProtectComponent = class extends Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				module="any"
+				module="protect"
 				header={ _x( 'Brute force protection', 'Settings header', 'jetpack' ) }
 				saveDisabled={ this.props.isSavingAnyOption( 'jetpack_waf_ip_allow_list' ) }
 			>
@@ -175,7 +175,7 @@ export const Protect = connect(
 			allowListInputState:
 				null !== allowListInputState
 					? allowListInputState
-					: getSetting( state, 'jetpack_waf_ip_allow_list', 'waf' ),
+					: getSetting( state, 'jetpack_waf_ip_allow_list' ),
 		};
 	},
 	dispatch => {

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -12,6 +12,7 @@ import analytics from 'lib/analytics';
 import { includes } from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import QueryWafSettings from '../components/data/query-waf-bootstrap-path';
 import { getSetting } from '../state/settings';
 import { getWafIpAllowListInputState, updateWafIpAllowList } from '../state/waf';
 
@@ -85,10 +86,11 @@ const ProtectComponent = class extends Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				module="protect"
+				module="any"
 				header={ _x( 'Brute force protection', 'Settings header', 'jetpack' ) }
 				saveDisabled={ this.props.isSavingAnyOption( 'jetpack_waf_ip_allow_list' ) }
 			>
+				{ isProtectActive && <QueryWafSettings /> }
 				<SettingsGroup
 					hasChild
 					disableInOfflineMode
@@ -173,7 +175,7 @@ export const Protect = connect(
 			allowListInputState:
 				null !== allowListInputState
 					? allowListInputState
-					: getSetting( state, 'jetpack_waf_ip_allow_list' ),
+					: getSetting( state, 'jetpack_waf_ip_allow_list', 'waf' ),
 		};
 	},
 	dispatch => {

--- a/projects/plugins/jetpack/_inc/client/state/waf/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/waf/reducer.js
@@ -20,6 +20,10 @@ export const data = ( state = {}, action ) => {
 				automaticRulesEnabled: Boolean( action.settings?.jetpack_waf_automatic_rules ),
 				manualRulesEnabled: Boolean( action.settings?.jetpack_waf_ip_list ),
 				ipAllowList: action.settings?.jetpack_waf_ip_allow_list || '',
+				allowListInputState:
+					state.allowListInputState === undefined
+						? action.settings?.jetpack_waf_ip_allow_list
+						: state.allowListInputState,
 				ipBlockList: action.settings?.jetpack_waf_ip_block_list || '',
 				shareData: Boolean( action.settings?.jetpack_waf_share_data ),
 			} );

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2352,7 +2352,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_string',
 				'sanitize_callback' => 'esc_textarea',
-				'jp_group'          => 'waf',
+				'jp_group'          => 'settings',
 			),
 			'jetpack_waf_share_data'               => array(
 				'description'       => esc_html__( 'Share data with Jetpack.', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2352,7 +2352,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_string',
 				'sanitize_callback' => 'esc_textarea',
-				'jp_group'          => 'waf',
+				'jp_group'          => 'any',
 			),
 			'jetpack_waf_share_data'               => array(
 				'description'       => esc_html__( 'Share data with Jetpack.', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2352,7 +2352,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'default'           => '',
 				'validate_callback' => __CLASS__ . '::validate_string',
 				'sanitize_callback' => 'esc_textarea',
-				'jp_group'          => 'any',
+				'jp_group'          => 'waf',
 			),
 			'jetpack_waf_share_data'               => array(
 				'description'       => esc_html__( 'Share data with Jetpack.', 'jetpack' ),

--- a/projects/plugins/jetpack/changelog/fix-allow-list-option-group
+++ b/projects/plugins/jetpack/changelog/fix-allow-list-option-group
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix IP allow list updates on Atomic sites.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jpop-issues/issues/8222

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fetch WAF settings in the Brute Force Protection settings card. When the Firewall settings card is unavailable, this data is still needed to fetch the IP allow list.
* Updates the `jetpack_waf_ip_allow_list` option to the broader `'jp_group' => 'settings'` so that it is accessible to both the `waf` and the `protect` modules if either or is unset.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1204541796176019

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On Jurassic Ninja/Tube with a mocked unsupported environment:
* Checkout this branch and start your Jurassic Tube on a clean docker instance or start a fresh Jurassic Ninja instance
* Define the WAF killswitch `DISABLE_JETPACK_WAF` in your `wp-config.php`
* Enable Jetpack and connect your user
* Proceed to `/wp-admin/admin.php?page=jetpack#/settings`
* Verify that the WAF module is missing and Brute force module settings are available and enabled
* Return the Brute force mode settings and add an IP address/range to the allow list input field and save
* Ensure the settings are saved without error
* Verify that the list is found within the `jetpack_waf_ip_allow_list` option


Alternatively, on a new Pressable or Atomic site:
- Install Jetpack and verify that you are unable to successfully update your Brute force allow list from the Jetpack settings page
- Deactivate Jetpack
- Install the Jetpack Beta Tester plugin and apply this branch of the Jetpack plugin and connect your user
- Return to the Brute force settings and ensure you are now able to add and save IPs to the allow list
- Verify that the list is found within the `jetpack_waf_ip_allow_list` option

Ensure no regression in WAF or Brute force functionality in Jetpack or Protect
