### PR TITLE
VideoPress: pick video block attrs from URL when pasting/inserting

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-pick-block-attrs-before-to-paste
+++ b/projects/packages/videopress/changelog/update-videopress-pick-block-attrs-before-to-paste
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: pick video block attrs from URL when pasting/inserting

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import useResumableUploader from '../../../../../hooks/use-resumable-uploader';
 import { uploadFromLibrary } from '../../../../../hooks/use-uploader';
-import { buildVideoPressURL } from '../../../../../lib/url';
+import { buildVideoPressURL, pickVideoBlockAttributesFromUrl } from '../../../../../lib/url';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../../constants';
 import { PlaceholderWrapper } from '../../edit';
 import { description, title } from '../../index';
@@ -113,7 +113,8 @@ const VideoPressUploader = ( {
 			return;
 		}
 
-		handleDoneUpload( { guid: guidFromSource, src: srcFromSource, id } );
+		const attrs = pickVideoBlockAttributesFromUrl( srcFromSource );
+		handleDoneUpload( { ...attrs, guid: guidFromSource, id } );
 	}
 
 	const startUpload = file => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -338,7 +338,7 @@ export default function VideoPressEdit( {
 
 	// Render uploading block view
 	if ( isUploadingFile ) {
-		const handleDoneUpload = newVideoData => {
+		const handleDoneUpload = ( newVideoData: VideoBlockAttributes ) => {
 			setIsUploadingFile( false );
 			if ( isReplacingFile.isReplacing ) {
 				const newBlockAttributes = {
@@ -354,7 +354,7 @@ export default function VideoPressEdit( {
 				return;
 			}
 
-			setAttributes( { id: newVideoData.id, guid: newVideoData.guid, title: newVideoData.title } );
+			setAttributes( newVideoData );
 		};
 
 		return (

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -8,7 +8,12 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { buildVideoPressURL, isVideoPressUrl, pickGUIDFromUrl } from '../../../../lib/url';
+import {
+	buildVideoPressURL,
+	isVideoPressUrl,
+	pickGUIDFromUrl,
+	pickVideoBlockAttributesFromUrl,
+} from '../../../../lib/url';
 /**
  * Types
  */
@@ -103,11 +108,12 @@ const transformFromPastingVideoPressURL = {
 
 		const url = textContent.trim();
 		const guid = pickGUIDFromUrl( url );
+		const attrs = pickVideoBlockAttributesFromUrl( url );
 		if ( ! guid ) {
 			return false;
 		}
 
-		return createBlock( 'videopress/video', { guid } );
+		return createBlock( 'videopress/video', { guid, ...attrs } );
 	},
 };
 

--- a/projects/packages/videopress/src/client/lib/url/test/index.ts
+++ b/projects/packages/videopress/src/client/lib/url/test/index.ts
@@ -115,7 +115,7 @@ describe( 'pickVideoBlockAttributesFromUrl', () => {
 		expect( attributes ).toStrictEqual( {} );
 	} );
 
-	it( 'should return the poster imahge URL', () => {
+	it( 'should return the poster image URL', () => {
 		const attributes = pickVideoBlockAttributesFromUrl(
 			'https://videopress.com/embed/7GMaYckU?cover=1&autoPlay=1&loop=1&muted=1&persistVolume=0&playsinline=1&posterUrl=http%3A%2F%2Flocalhost%2Fwp-content%2Fuploads%2F2023%2F04%2Fpexels-photo-2693212.jpg&preloadContent=metadata&sbc=%23cf2e2e&sbpc=%23fcb900&sblc=%239b51e0&hd=1'
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR picks and propagates the block attributes when users paste VideoPress URLs in the editor canvas or when inserting the video via URL (MediaPlaceholder)

Fixes #
Part of https://github.com/Automattic/jetpack/issues/30417

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: pick video block attrs from URL when pasting/inserting

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Take a valid URL that customizes the player, for instance:

```
https://videopress.com/v/7GMaYckU?cover=true&autoPlay=false&controls=0&loop=1&muted=1&persistVolume=0&playsinline=1&posterUrl=http%3A%2F%2Flocalhost%2Fwp-content%2Fuploads%2F2023%2F04%2Fpexels-photo-2693212.jpg&preloadContent=metadata&sbc=%23cf2e2e&sbpc=%23fcb900&sblc=%239b51e0&hd=10
```

* Paste the URL in the editor canvas
* Confirm a VideoPress block instance is created
* Confirm the blocks contains the customizations defined by the URL, for instance: `autoplay`, `loop`, `controls`, `poster`, etc
* Same, but setting the URL via the MediaPlaceholder

https://user-images.githubusercontent.com/77539/236537050-f84fd6ab-baba-425a-a76b-164648e1d721.mov

