### PR TITLE
My Jetpack: Add deactivate plugin menu action on product card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -12,13 +12,20 @@ import { useProduct } from '../../hooks/use-product';
 import ProductCard, { PRODUCT_STATUSES } from '../product-card';
 
 const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuItems = [] } ) => {
-	const { pluginsUrl } = window?.myJetpackInitialState ?? {};
 	const { isRegistered, isUserConnected } = useConnection();
 
-	const { detail, activate, deactivate, isFetching, installStandalonePlugin } = useProduct( slug );
+	const {
+		detail,
+		activate,
+		deactivate,
+		isFetching,
+		installStandalonePlugin,
+		deactivateStandalonePlugin,
+	} = useProduct( slug );
 	const { name, description, manageUrl, requiresUserConnection, standalonePluginInfo, status } =
 		detail;
 	const [ installingStandalone, setInstallingStandalone ] = useState( false );
+	const [ deactivatingStandalone, setDeactivatingStandalone ] = useState( false );
 
 	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
 	const navigateToAddProductPage = useMyJetpackNavigate( `add-${ slug }` );
@@ -83,8 +90,16 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 	}, [ installStandalonePlugin ] );
 
 	const handleDeactivateStandalone = useCallback( () => {
-		window.location = pluginsUrl;
-	}, [ pluginsUrl ] );
+		setDeactivatingStandalone( true );
+
+		deactivateStandalonePlugin()
+			.then( () => {
+				window?.location?.reload();
+			} )
+			.catch( () => {
+				setDeactivatingStandalone( false );
+			} );
+	}, [ deactivateStandalonePlugin ] );
 
 	return (
 		<ProductCard
@@ -94,6 +109,7 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 			admin={ admin }
 			isFetching={ isFetching }
 			isInstallingStandalone={ installingStandalone }
+			isDeactivatingStandalone={ deactivatingStandalone }
 			onDeactivate={ deactivate }
 			slug={ slug }
 			onActivate={ handleActivate }

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -12,6 +12,7 @@ import { useProduct } from '../../hooks/use-product';
 import ProductCard, { PRODUCT_STATUSES } from '../product-card';
 
 const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuItems = [] } ) => {
+	const { pluginsUrl } = window?.myJetpackInitialState ?? {};
 	const { isRegistered, isUserConnected } = useConnection();
 
 	const { detail, activate, deactivate, isFetching, installStandalonePlugin } = useProduct( slug );
@@ -27,6 +28,7 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 	const isStandaloneInstalled = standalonePluginInfo?.isStandaloneInstalled;
 	const isStandaloneActive = standalonePluginInfo?.isStandaloneActive;
 	const showActivateOption = hasStandalonePlugin && isStandaloneInstalled && ! isStandaloneActive;
+	const showDeactivateOption = hasStandalonePlugin && isStandaloneInstalled && isStandaloneActive;
 	const showInstallOption = hasStandalonePlugin && ! isStandaloneInstalled;
 	const isConnected = isRegistered && isUserConnected;
 	const isAbsent =
@@ -39,6 +41,7 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 		isConnected && // the site is connected AND
 		( menuItems?.length > 0 || // Show custom menus, if present
 			showActivateOption || // Show install | activate options for standalone plugin
+			showDeactivateOption || // Show deactivate option for standalone plugin
 			showInstallOption );
 	/* End Menu Handling */
 
@@ -79,6 +82,10 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 			} );
 	}, [ installStandalonePlugin ] );
 
+	const handleDeactivateStandalone = useCallback( () => {
+		window.location = pluginsUrl;
+	}, [ pluginsUrl ] );
+
 	return (
 		<ProductCard
 			name={ name }
@@ -96,9 +103,11 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 			showMenu={ menuIsActive }
 			menuItems={ menuItems }
 			showActivateOption={ showActivateOption }
+			showDeactivateOption={ showDeactivateOption }
 			showInstallOption={ showInstallOption }
 			onInstallStandalone={ handleInstallStandalone }
 			onActivateStandalone={ handleInstallStandalone }
+			onDeactivateStandalone={ handleDeactivateStandalone }
 		>
 			{ children }
 		</ProductCard>

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
@@ -21,6 +21,7 @@ const ActionButton = ( {
 	onFixConnection,
 	isFetching,
 	isInstallingStandalone,
+	isDeactivatingStandalone,
 	className,
 	onAdd,
 } ) => {
@@ -35,7 +36,7 @@ const ActionButton = ( {
 		);
 	}
 
-	const isBusy = isFetching || isInstallingStandalone;
+	const isBusy = isFetching || isInstallingStandalone || isDeactivatingStandalone;
 
 	const buttonState = {
 		variant: ! isBusy ? 'primary' : undefined,

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -137,6 +137,7 @@ const ProductCard = props => {
 		onManage,
 		isFetching,
 		isInstallingStandalone,
+		isDeactivatingStandalone,
 		slug,
 		children,
 		// Menu Related
@@ -172,7 +173,7 @@ const ProductCard = props => {
 		[ styles.active ]: isActive,
 		[ styles.inactive ]: isInactive || isPurchaseRequired,
 		[ styles.error ]: isError,
-		[ styles[ 'is-fetching' ] ]: isFetching || isInstallingStandalone,
+		[ styles[ 'is-fetching' ] ]: isFetching || isInstallingStandalone || isDeactivatingStandalone,
 	} );
 
 	const { recordEvent } = useAnalytics();
@@ -318,6 +319,7 @@ ProductCard.propTypes = {
 	admin: PropTypes.bool.isRequired,
 	isFetching: PropTypes.bool,
 	isInstallingStandalone: PropTypes.bool,
+	isDeactivatingStandalone: PropTypes.bool,
 	onManage: PropTypes.func,
 	onFixConnection: PropTypes.func,
 	onActivate: PropTypes.func,
@@ -351,6 +353,7 @@ ProductCard.propTypes = {
 ProductCard.defaultProps = {
 	isFetching: false,
 	isInstallingStandalone: false,
+	isDeactivatingStandalone: false,
 	onManage: () => {},
 	onFixConnection: () => {},
 	onActivate: () => {},

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -23,7 +23,9 @@ const Menu = ( {
 	showInstall = false,
 	onInstall,
 	showActivate = false,
+	showDeactivate = false,
 	onActivate,
+	onDeactivate,
 } ) => {
 	return (
 		<Dropdown
@@ -81,12 +83,48 @@ const Menu = ( {
 							{ __( 'Activate Plugin', 'jetpack-my-jetpack' ) }
 						</Button>
 					) }
+					{ showDeactivate && (
+						<Button
+							weight="regular"
+							fullWidth
+							variant="tertiary"
+							onClick={ () => {
+								onClose();
+								onDeactivate?.();
+							} }
+						>
+							{ __( 'Deactivate Plugin', 'jetpack-my-jetpack' ) }
+						</Button>
+					) }
 				</>
 			) }
 		/>
 	);
 };
 /* eslint-enable react/jsx-no-bind */
+
+Menu.propTypes = {
+	onActivate: PropTypes.func,
+	onDeactivate: PropTypes.func,
+	showActivate: PropTypes.bool,
+	showDeactivate: PropTypes.bool,
+	showInstall: PropTypes.bool,
+	items: PropTypes.arrayOf(
+		PropTypes.shape( {
+			label: PropTypes.string,
+			icon: PropTypes.node,
+			onClick: PropTypes.func,
+		} )
+	),
+	onInstall: PropTypes.func,
+};
+
+Menu.defaultProps = {
+	onActivate: () => {},
+	onDeactivate: () => {},
+	showActivate: false,
+	showDeactivate: false,
+};
 
 const ProductCard = props => {
 	const {
@@ -104,10 +142,12 @@ const ProductCard = props => {
 		// Menu Related
 		showMenu = false,
 		showActivateOption = false,
+		showDeactivateOption = false,
 		showInstallOption = false,
 		menuItems = [],
 		onInstallStandalone,
 		onActivateStandalone,
+		onDeactivateStandalone,
 	} = props;
 
 	const isActive = status === PRODUCT_STATUSES.ACTIVE;
@@ -204,6 +244,16 @@ const ProductCard = props => {
 		onActivateStandalone();
 	}, [ slug, onActivateStandalone, recordEvent ] );
 
+	/**
+	 * Use a Tracks event to count a standalone plugin deactivation menu click
+	 */
+	const deactivateStandaloneHandler = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_product_card_deactivate_standalone_plugin_click', {
+			product: slug,
+		} );
+		onDeactivateStandalone();
+	}, [ slug, onDeactivateStandalone, recordEvent ] );
+
 	const CardWrapper = isAbsent
 		? ( { children: wrapperChildren, ...cardProps } ) => (
 				<a { ...cardProps } href="#" onClick={ addHandler }>
@@ -224,7 +274,9 @@ const ProductCard = props => {
 					<Menu
 						items={ menuItems }
 						showActivate={ showActivateOption }
+						showDeactivate={ showDeactivateOption }
 						onActivate={ activateStandaloneHandler }
+						onDeactivate={ deactivateStandaloneHandler }
 						showInstall={ showInstallOption }
 						onInstall={ installStandaloneHandler }
 					/>
@@ -271,6 +323,20 @@ ProductCard.propTypes = {
 	onActivate: PropTypes.func,
 	onAdd: PropTypes.func,
 	slug: PropTypes.string.isRequired,
+	showMenu: PropTypes.bool,
+	showActivateOption: PropTypes.bool,
+	showDeactivateOption: PropTypes.bool,
+	showInstallOption: PropTypes.bool,
+	menuItems: PropTypes.arrayOf(
+		PropTypes.shape( {
+			label: PropTypes.string,
+			icon: PropTypes.node,
+			onClick: PropTypes.func,
+		} )
+	),
+	onInstallStandalone: PropTypes.func,
+	onActivateStandalone: PropTypes.func,
+	onDeactivateStandalone: PropTypes.func,
 	status: PropTypes.oneOf( [
 		PRODUCT_STATUSES.ACTIVE,
 		PRODUCT_STATUSES.INACTIVE,
@@ -289,6 +355,11 @@ ProductCard.defaultProps = {
 	onFixConnection: () => {},
 	onActivate: () => {},
 	onAdd: () => {},
+	showMenu: false,
+	showActivateOption: false,
+	showDeactivateOption: false,
+	showInstallOption: false,
+	menuItems: [],
 };
 
 export { PRODUCT_STATUSES };

--- a/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product/index.js
@@ -15,13 +15,18 @@ import { STORE_ID } from '../../state/store';
  * @returns {object}         - Site product data.
  */
 export function useProduct( productId ) {
-	const { activateProduct, deactivateProduct, installStandalonePluginForProduct } =
-		useDispatch( STORE_ID );
+	const {
+		activateProduct,
+		deactivateProduct,
+		installStandalonePluginForProduct,
+		deactivateStandalonePluginForProduct,
+	} = useDispatch( STORE_ID );
 	const detail = useSelect( select => select( STORE_ID ).getProduct( productId ) );
 
 	return {
 		activate: () => activateProduct( productId ),
 		deactivate: () => deactivateProduct( productId ),
+		deactivateStandalonePlugin: () => deactivateStandalonePluginForProduct( productId ),
 		installStandalonePlugin: () => installStandalonePluginForProduct( productId ),
 		productsList: useSelect( select => select( STORE_ID ).getProducts() ),
 		detail,

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -164,6 +164,17 @@ const activateProduct = productId => async store => {
 
 /**
  * Side effect action that will trigger
+ * the standalone plugin activation state on the server.
+ *
+ * @param {string} productId - My Jetpack product ID.
+ * @returns {Promise}        - Promise which resolves when the product plugin is deactivated.
+ */
+const deactivateStandalonePluginForProduct = productId => async store => {
+	return await requestProductStatus( productId, { activate: false }, store );
+};
+
+/**
+ * Side effect action that will trigger
  * the standalone plugin installation on the server.
  *
  * @param {string} productId - My Jetpack product ID.
@@ -230,6 +241,7 @@ const setIsFetchingProductStats = ( productId, isFetching ) => {
 const productActions = {
 	setProduct,
 	activateProduct,
+	deactivateStandalonePluginForProduct,
 	installStandalonePluginForProduct,
 	setIsFetchingProduct,
 	setRequestProductError,

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-deactivate-plugin-menu-action
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-deactivate-plugin-menu-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add deactivate plugin menu action on product card

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -163,7 +163,6 @@ class Initializer {
 				),
 				'plugins'               => Plugins_Installer::get_plugins(),
 				'myJetpackUrl'          => admin_url( 'admin.php?page=my-jetpack' ),
-				'pluginsUrl'            => admin_url( 'plugins.php' ),
 				'topJetpackMenuItemUrl' => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'            => ( new Status() )->get_site_suffix(),
 				'myJetpackVersion'      => self::PACKAGE_VERSION,

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -163,6 +163,7 @@ class Initializer {
 				),
 				'plugins'               => Plugins_Installer::get_plugins(),
 				'myJetpackUrl'          => admin_url( 'admin.php?page=my-jetpack' ),
+				'pluginsUrl'            => admin_url( 'plugins.php' ),
 				'topJetpackMenuItemUrl' => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'            => ( new Status() )->get_site_suffix(),
 				'myJetpackVersion'      => self::PACKAGE_VERSION,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30394

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `Deactivate plugin` action in the card's menu for products that have activated plugins, deactivating the plugin and refreshing the page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes. It adds a `jetpack_myjetpack_product_card_deactivate_standalone_plugin_click` track event when clicking on the `Deactivate plugin` menu action, in line with the activation event.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate a standalone plugin
* Go to My Jetpack
* In the activated standalone plugin's card, check that there is a `Deactivate plugin` action
* Click it
* Check that the plugin is deactivated
* Check that the deactivation action is not there anymore
* Activate the plugin
* Check that it still works as expected

https://user-images.githubusercontent.com/8486249/236556650-84b342d1-38ec-4cd1-9eb6-c133bbe9322a.mp4
