### PR TITLE
Users: Add is_super_admin flag to single user response

### DIFF
--- a/projects/plugins/jetpack/changelog/add-is-super-admin-flag-to-single-user-response
+++ b/projects/plugins/jetpack/changelog/add-is-super-admin-flag-to-single-user-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes issue with missing "Super Admin" in edit user form

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
@@ -184,6 +184,9 @@ class WPCOM_JSON_API_Site_User_Endpoint extends WPCOM_JSON_API_Endpoint {
 		if ( $the_user && ! is_wp_error( $the_user ) ) {
 			$userdata        = get_userdata( $user_id );
 			$the_user->roles = ! is_wp_error( $userdata ) ? array_values( $userdata->roles ) : array();
+			if ( is_multisite() ) {
+				$the_user->is_super_admin = user_can( $the_user->ID, 'manage_network' );
+			}
 		}
 
 		return $the_user;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/76632

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

In this PR, I propose to add the `is_super_admin` flag to a single user response to make it consistent with the users list response.

It will fix the frontend issue where we display the "Super Admin" badge on the site's users list but not in the individual user form.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See D109946-code