### PR TITLE
Social previews | Remove duplicate "Auto-shared" preview for Twitter and LinkedIn

### DIFF
--- a/projects/js-packages/publicize-components/changelog/social-previews-remove-duplicate-preview-for-twitter
+++ b/projects/js-packages/publicize-components/changelog/social-previews-remove-duplicate-preview-for-twitter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Removed duplicate twitter preview

--- a/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
@@ -39,7 +39,7 @@ export function LinkedIn( props ) {
 					name={ name }
 					profileImage={ profileImage }
 					title={ title }
-					text={ `${ autoSharedText } ${ url }` }
+					description={ `${ autoSharedText } ${ url }` }
 				/>
 			</section>
 			<section>

--- a/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
@@ -1,5 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { LinkedInPreview, FEED_TEXT_MAX_LENGTH } from '@automattic/social-previews';
+import { LinkedInPreview } from '@automattic/social-previews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
@@ -19,29 +19,8 @@ export function LinkedIn( props ) {
 
 	const { message: text } = useSocialMediaMessage();
 
-	const autoSharedText = text
-		.substring( 0, FEED_TEXT_MAX_LENGTH )
-		// Subtract the length of the URL and the space before it.
-		.slice( 0, -( url.length + 1 ) );
-
 	return (
 		<div className="linked-preview-tab">
-			<section>
-				<header>
-					<h2>{ __( 'Auto-shared', 'jetpack' ) }</h2>
-					<p className="description">
-						{ __( 'This is how it will look like when auto-shared', 'jetpack' ) }
-					</p>
-				</header>
-				<LinkedInPreview
-					jobTitle="Job Title (Company Name)"
-					image={ image }
-					name={ name }
-					profileImage={ profileImage }
-					title={ title }
-					description={ `${ autoSharedText } ${ url }` }
-				/>
-			</section>
 			<section>
 				<header>
 					<h2>{ __( 'Your post', 'jetpack' ) }</h2>

--- a/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
@@ -4,7 +4,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { getTweetTemplate } from '../../store/selectors';
-import { getAutoSharedTweetText } from './utils';
 
 /**
  * The twitter tab component.
@@ -20,27 +19,8 @@ export function Twitter( { isTweetStorm, tweets, media } ) {
 
 	const linkTweet = { ...tweets[ 0 ], ...template, text: '' };
 
-	const autoSharedTweet = {
-		...tweets[ 0 ],
-		media,
-		card: undefined,
-		text: getAutoSharedTweetText( { ...tweets[ 0 ], ...tweets[ 0 ]?.card } ),
-	};
-
 	return (
 		<div className="twitter-preview-tab">
-			<section>
-				<header>
-					<h2>{ __( 'Auto-shared', 'jetpack' ) }</h2>
-					<p className="description">
-						{ __( 'This is how it will look like when auto-shared', 'jetpack' ) }
-					</p>
-				</header>
-				<TwitterPreview
-					isTweetStorm={ isTweetStorm }
-					tweets={ isTweetStorm ? tweets : [ autoSharedTweet ] }
-				/>
-			</section>
 			<section>
 				<header>
 					<h2>{ __( 'Your post', 'jetpack' ) }</h2>
@@ -48,7 +28,7 @@ export function Twitter( { isTweetStorm, tweets, media } ) {
 						{ __( 'This is what your social post will look like on Twitter', 'jetpack' ) }
 					</p>
 				</header>
-				<TwitterPreview tweets={ [ tweets[ 0 ] ] } />
+				<TwitterPreview isTweetStorm={ isTweetStorm } tweets={ tweets } media={ media } />
 			</section>
 			<section>
 				<header>

--- a/projects/js-packages/publicize-components/src/components/social-previews/utils.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/utils.js
@@ -12,29 +12,3 @@ export function getMediaSourceUrl( media ) {
 	// Try getting the large size (1024px width) and fallback to the full size.
 	return media.media_details?.sizes?.large?.source_url || media.source_url;
 }
-
-/**
- * Get the text for the auto-shared tweet.
- *
- * @param {object} params - The params.
- * @param {string} params.title - The title.
- * @param {string} params.url 	- The url.
- * @param {string} params.text 	- The text.
- * @returns {string} The text for the auto-shared tweet.
- */
-export function getAutoSharedTweetText( { title, url, text } ) {
-	let content = ( text || title || '' ).trim();
-
-	// 24 is the length of the URL and 2 is for the space and the ellipsis.
-	const maxTweetLength = 280 - ( 24 + 2 );
-
-	if ( content.length > maxTweetLength ) {
-		// Get the limited number of characters without breaking words.
-		content =
-			content.match( new RegExp( '.{1,' + maxTweetLength + '}(?:\\s|$)', 'u' ) )?.[ 0 ]?.trim() ||
-			'';
-		content += '…';
-	}
-
-	return `${ content } ${ url }`;
-}


### PR DESCRIPTION
There is a duplicate preview for Twitter section as discussed here - p1683191097521009-slack-C04UC7YGPNY

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR removes the duplicate preview and keeps only the two previews needed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdrWKz-Ka-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

* Checkout this PR branch and run `pnpn install` in the root directory
* Checkout the latest `trunk` in calypso
* In `wp-calypso/packages/social-previews/` directory, run `pnpm link --global` to expose the package to global `node_modules` for `pnpm`
* In `jetpack/projects/js-packages/publicize-components/` directory, run `pnpm link --global @automattic/social-previews`
* In `wp-calypso` root, run `yarn` and then `yarn workspace @automattic/social-previews run build`
* In Jetpack, run `jetpack build plugins/jetpack --no-pnpm-install`
* Start writing a new post with JT site via Jetpack
* Click Jetpack icon on the top of the sidebar
* Under "Social Previews", click on "Preview"
* Confirm that the Twitter preview has only two types of previews instead of 3.


BEFORE


https://user-images.githubusercontent.com/18226415/236818416-6fd66aa4-f191-4a3b-8a3b-5e3986532712.mov

AFTER

https://user-images.githubusercontent.com/18226415/236818521-333ca361-3eb2-4266-a354-e2e042fcf7a8.mov

