### PR TITLE
Jetpack > My Plan: Show plans without expire date as active

### DIFF
--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -67,7 +67,9 @@ class MyPlanHeader extends React.Component {
 				/>
 			);
 			if ( purchase.active === '1' ) {
-				if ( ! isInTheFuture( purchase.expiry_date ) ) {
+				// Purchases might not have an expiration date, so we need to check
+				// for their existence (e.g.: lifetime plan like Golden Token).
+				if ( ! isInTheFuture( purchase.expiry_date ) && purchase.expiry_date !== null ) {
 					activation = <ProductActivated key="product-expired" type="product-expired" />;
 				} else {
 					activation = <ProductActivated key="product-activated" />;

--- a/projects/plugins/jetpack/changelog/fix-show-lifetime-plans-as-active
+++ b/projects/plugins/jetpack/changelog/fix-show-lifetime-plans-as-active
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Lifetime plans was shown as expired under "My Plan"
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We do not take purchases into account that doesn't have an expire date which makes for a confusing experience for (AFAIK) primarily Golden Token recipients.

Fixes #30505 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a condition to `Jetpack > My Plan` to ensure that we have an expire date before we rely on it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up site locally using `trunk`
  * You can reproduce the same steps using the Beta plugin in JN or spin up two different sites where one of them uses trunk and the other uses this branch.
* Go to Golden Token MC tool and assign a Golden Token to your site (302fe-pb)
* Go to `WP Admin > Jetpack > My Plan`
* Verify that the plan is shown as `Expired`
* Switch to this branch
* Verify that the plan is shown as `Subscription Active` 

### Screenshots

**Before**

![Screenshot 2023-05-08 at 16 06 42](https://user-images.githubusercontent.com/3846700/236851388-b88726ef-90e5-46a2-8a08-56579dc8fd8b.png)

**After**
![Screenshot 2023-05-08 at 16 05 58](https://user-images.githubusercontent.com/3846700/236851369-7d06abab-5c69-41df-991b-f0150457514b.png)