### PR TITLE
Contact Form: add necessary context to the word "Trash"

### DIFF
--- a/projects/packages/forms/changelog/fix-reference-contact-form-trash
+++ b/projects/packages/forms/changelog/fix-reference-contact-form-trash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add necessary context to the word "Trash".

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -888,9 +888,9 @@ class Admin {
 			);
 			$actions['trash'] = sprintf(
 				'<a class="submitdelete" title="%s" href="%s">%s</a>',
-				esc_attr__( 'Trash', 'jetpack-forms' ),
+				esc_attr_x( 'Trash', 'verb', 'jetpack-forms' ),
 				get_delete_post_link( $post->ID ),
-				esc_html__( 'Trash', 'jetpack-forms' )
+				esc_html_x( 'Trash', 'verb', 'jetpack-forms' )
 			);
 		} elseif ( $post->post_status === 'spam' ) {
 			$actions['unspam unapprove'] = sprintf(
@@ -1193,7 +1193,7 @@ class Admin {
 				$status_html .= ' class="current"';
 			}
 
-			$status_html .= '>' . __( 'Trash', 'jetpack-forms' ) . ' <span class="count">';
+			$status_html .= '>' . _x( 'Trash', 'noun', 'jetpack-forms' ) . ' <span class="count">';
 			$status_html .= '(' . number_format( $status['trash'] ) . ')';
 			$status_html .= '</span></a>';
 			if ( isset( $status['spam'] ) ) {

--- a/projects/packages/forms/src/dashboard/inbox/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/index.js
@@ -12,7 +12,7 @@ import {
 	useState,
 	useRef,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { arrowLeft } from '@wordpress/icons';
 import classnames from 'classnames';
 import { find, findIndex, includes, isEqual, join, keys, map, pick } from 'lodash';
@@ -48,7 +48,7 @@ const TABS = [
 	},
 	{
 		name: 'trash',
-		title: __( 'Trash', 'jetpack-forms' ),
+		title: _x( 'Trash', 'noun', 'jetpack-forms' ),
 		className: 'jp-forms__inbox-tab-item',
 	},
 ];

--- a/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
+++ b/projects/packages/forms/src/dashboard/inbox/single-actions-menu.js
@@ -3,7 +3,7 @@
  */
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { trash, inbox, moreHorizontal } from '@wordpress/icons';
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ const SingleActionsMenu = ( { id } ) => {
 
 	const deleteLabel =
 		currentTab !== TABS.trash
-			? __( 'Trash', 'jetpack-forms' )
+			? _x( 'Trash', 'verb', 'jetpack-forms' )
 			: __( 'Delete permanently', 'jetpack-forms' );
 	const deleteAction = currentTab !== TABS.trash ? ACTIONS.moveToTrash : ACTIONS.delete;
 

--- a/projects/plugins/jetpack/changelog/fix-reference-contact-form-trash
+++ b/projects/plugins/jetpack/changelog/fix-reference-contact-form-trash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Internationalization: add necessary context to the word "Trash" in the Contact Form interface.

--- a/projects/plugins/jetpack/modules/contact-form/admin.php
+++ b/projects/plugins/jetpack/modules/contact-form/admin.php
@@ -510,9 +510,9 @@ function grunion_manage_post_row_actions( $actions ) {
 		);
 		$actions['trash'] = sprintf(
 			'<a class="submitdelete" title="%s" href="%s">%s</a>',
-			esc_attr__( 'Trash', 'jetpack' ),
+			esc_attr_x( 'Trash', 'verb', 'jetpack' ),
 			get_delete_post_link( $post->ID ),
-			esc_html__( 'Trash', 'jetpack' )
+			esc_html_x( 'Trash', 'verb', 'jetpack' )
 		);
 	} elseif ( $post->post_status === 'spam' ) {
 		$actions['unspam unapprove'] = sprintf(
@@ -819,7 +819,7 @@ function grunion_ajax_spam() {
 			$status_html .= ' class="current"';
 		}
 
-		$status_html .= '>' . __( 'Trash', 'jetpack' ) . ' <span class="count">';
+		$status_html .= '>' . _x( 'Trash', 'noun', 'jetpack' ) . ' <span class="count">';
 		$status_html .= '(' . number_format( $status['trash'] ) . ')';
 		$status_html .= '</span></a>';
 		if ( isset( $status['spam'] ) ) {


### PR DESCRIPTION
## Proposed changes:

This should help with translations, so the word can be translated differently depending on context (verb or noun).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

The interface should not change, in wp-admin > Feedback. The different "trash" links should remain.
