### PR TITLE
Launchpad: update task completion logic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-task-completion-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-task-completion-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow Launchpad tasks to be marked complete even if the registry doesn't think they're active

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -386,18 +386,21 @@ class Launchpad_Task_Lists {
 	 * Marks a task as complete.
 	 *
 	 * @param string $task_id The task ID.
+	 * @param bool   $force     Optional. Force task completion, even if it's not active.
+	 *                          (This will will be the case in most non-REST API switch_to_blog operations).
 	 * @return bool True if successful, false if not.
 	 */
-	public function mark_task_complete( $task_id ) {
+	public function mark_task_complete( $task_id, $force = false ) {
 		$task = $this->get_task( $task_id );
 		if ( empty( $task ) ) {
 			return false;
 		}
-
-		// Ensure that the task is an active one
-		$active_tasks_by_task_id = wp_list_filter( $this->get_active_tasks(), array( 'id' => $task_id ) );
-		if ( empty( $active_tasks_by_task_id ) ) {
-			return false;
+		if ( ! $force ) {
+			// Ensure that the task is an active one
+			$active_tasks_by_task_id = wp_list_filter( $this->get_active_tasks(), array( 'id' => $task_id ) );
+			if ( empty( $active_tasks_by_task_id ) ) {
+				return false;
+			}
 		}
 
 		$key              = $this->get_task_key( $task );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -482,10 +482,12 @@ function wpcom_register_launchpad_task( $task ) {
  * Marks a task as complete.
  *
  * @param string $task_id The task ID.
+ * @param bool   $force     Optional. Force task completion, even if it's not active.
+ *                          (This will will be the case in most non-REST API switch_to_blog operations).
  * @return bool True if successful, false if not.
  */
-function wpcom_mark_launchpad_task_complete( $task_id ) {
-	return wpcom_launchpad_checklists()->mark_task_complete( $task_id );
+function wpcom_mark_launchpad_task_complete( $task_id, $force = false ) {
+	return wpcom_launchpad_checklists()->mark_task_complete( $task_id, $force );
 }
 
 /**


### PR DESCRIPTION
The current task completion logic depends on the task being active, due to the limitations of sharing a callback between multiple tasks.

This allows marking a task complete, no matter the system's assumptions about whether it's active or not. Particularly useful in Multisite situations, as tasks are not set up properly outside of the `rest_api_switched_to_blog` call.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* allow forcing a task to be marked complete

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
try it on your sandbox: `wpcom_mark_launchpad_task_complete( 'id', true )` for an inactive task

* Go to '..'
*

