### PR TITLE
AI Assistant: Factor out getSuggestionsFromOpenAI into a hook and createPrompt into own file

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-factor-out-suggestions-from-ai-and-create-prompt
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-factor-out-suggestions-from-ai-and-create-prompt
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Just a refactor on an unpublished block
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -1,0 +1,114 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+// Maximum number of characters we send from the content
+export const MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT = 1024;
+export const PROMPT_SUFFIX = __(
+	'. Please always output the generated content in markdown format. Do not include a top level heading by default. Please only output generated content ready for publishing.',
+	'jetpack'
+);
+
+/*
+ * Creates the prompt that will eventually be sent to OpenAI.
+ * It uses the current post title, content (before the actual AI block)
+ * - or a slice of it if too long, and tags + categories names
+ * to create a prompt.
+ *
+ * @param {string} postTitle                - The current post title.
+ * @param {Array} contentBeforeCurrentBlock - The content before the current block.
+ * @param {string} categoriesNames          - The categories names.
+ * @param {string} tagsNames                - The tags names.
+ * @param {string} userPrompt               - The user prompt.
+ * @param {string} type                     - The type of prompt to create.
+ *
+ * @return {string} The prompt.
+ */
+export const createPrompt = (
+	postTitle = '',
+	contentBeforeCurrentBlock = [],
+	// eslint-disable-next-line no-unused-vars
+	categoriesNames = '',
+	// eslint-disable-next-line no-unused-vars
+	tagsNames = '',
+	userPrompt = '',
+	type = 'userPrompt'
+) => {
+	if ( ! postTitle?.length ) {
+		return '';
+	}
+
+	if ( type === 'userPrompt' ) {
+		return userPrompt + PROMPT_SUFFIX;
+	}
+
+	if ( type === 'titleSummary' ) {
+		const titlePrompt = sprintf(
+			/** translators: This will be the beginning of a prompt that will be sent to OpenAI based on the post title. */
+			__( "Please help me write a short piece of a blog post titled '%1$s'", 'jetpack' ),
+			postTitle
+		);
+
+		return titlePrompt + PROMPT_SUFFIX;
+	}
+
+	if ( type === 'summarize' ) {
+		const content = contentBeforeCurrentBlock
+			.filter( function ( block ) {
+				return block && block.attributes && block.attributes.content;
+			} )
+			.map( function ( block ) {
+				return block.attributes.content.replaceAll( '<br/>', '\n' );
+			} )
+			.join( '\n' );
+		const shorter_content = content.slice( -1 * MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT );
+
+		const expandPrompt = sprintf(
+			/** translators: This will be the end of a prompt that will be sent to OpenAI with the last MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT characters of content.*/
+			__( 'Summarize this:\n\n … %s', 'jetpack' ), // eslint-disable-line @wordpress/i18n-no-collapsible-whitespace
+			shorter_content
+		);
+
+		return expandPrompt + PROMPT_SUFFIX;
+	}
+
+	if ( type === 'continue' ) {
+		const content = contentBeforeCurrentBlock
+			.filter( function ( block ) {
+				return block && block.attributes && block.attributes.content;
+			} )
+			.map( function ( block ) {
+				return block.attributes.content.replaceAll( '<br/>', '\n' );
+			} )
+			.join( '\n' );
+		const shorter_content = content.slice( -1 * MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT );
+
+		const expandPrompt = sprintf(
+			/** translators: This will be the end of a prompt that will be sent to OpenAI with the last MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT characters of content.*/
+			__( ' Please continue from here:\n\n … %s', 'jetpack' ), // eslint-disable-line @wordpress/i18n-no-collapsible-whitespace
+			shorter_content
+		);
+
+		return expandPrompt + PROMPT_SUFFIX;
+	}
+
+	// TODO: add some error handling if user supplied prompts or existing content is too short.
+
+	// We prevent a prompt if everything is empty.
+	// if ( ! postTitle && ! shorter_content && ! categoriesNames && ! tagsNames && ! userPrompt ) {
+	// 	return false;
+	// }
+
+	// TODO: decide if we want to use categories and tags in the prompt now that user is supplying their own prompt default.
+	// The following was copied over from the AI Paragraph block.
+
+	// if ( categoriesNames ) {
+	// 	/** translators: This will be the follow up of a prompt that will be sent to OpenAI based on comma-seperated category names. */
+	// 	prompt += sprintf( __( ", published in categories '%1$s'", 'jetpack' ), categoriesNames );
+	// }
+
+	// if ( tagsNames ) {
+	// 	/** translators: This will be the follow up of a prompt that will be sent to OpenAI based on comma-seperated category names. */
+	// 	prompt += sprintf( __( " and tagged '%1$s'", 'jetpack' ), tagsNames );
+	// }
+
+	// return prompt.trim();
+};

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -7,7 +7,7 @@ import { rawHandler, createBlock } from '@wordpress/blocks';
 import { Flex, FlexBlock, Modal } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -17,119 +17,6 @@ import { getImagesFromOpenAI } from './lib';
 import ShowLittleByLittle from './show-little-by-little';
 import useSuggestionsFromOpenAI from './use-suggestions-from-openai';
 import './editor.scss';
-
-// Maximum number of characters we send from the content
-export const MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT = 1024;
-export const PROMPT_SUFFIX = __(
-	'. Please always output the generated content in markdown format. Do not include a top level heading by default. Please only output generated content ready for publishing.',
-	'jetpack'
-);
-
-/*
- * Creates the prompt that will eventually be sent to OpenAI.
- * It uses the current post title, content (before the actual AI block)
- * - or a slice of it if too long, and tags + categories names
- * to create a prompt.
- *
- * @param {string} postTitle                - The current post title.
- * @param {Array} contentBeforeCurrentBlock - The content before the current block.
- * @param {string} categoriesNames          - The categories names.
- * @param {string} tagsNames                - The tags names.
- * @param {string} userPrompt               - The user prompt.
- * @param {string} type                     - The type of prompt to create.
- *
- * @return {string} The prompt.
- */
-export const createPrompt = (
-	postTitle = '',
-	contentBeforeCurrentBlock = [],
-	// eslint-disable-next-line no-unused-vars
-	categoriesNames = '',
-	// eslint-disable-next-line no-unused-vars
-	tagsNames = '',
-	userPrompt = '',
-	type = 'userPrompt'
-) => {
-	if ( ! postTitle?.length ) {
-		return '';
-	}
-
-	if ( type === 'userPrompt' ) {
-		return userPrompt + PROMPT_SUFFIX;
-	}
-
-	if ( type === 'titleSummary' ) {
-		const titlePrompt = sprintf(
-			/** translators: This will be the beginning of a prompt that will be sent to OpenAI based on the post title. */
-			__( "Please help me write a short piece of a blog post titled '%1$s'", 'jetpack' ),
-			postTitle
-		);
-
-		return titlePrompt + PROMPT_SUFFIX;
-	}
-
-	if ( type === 'summarize' ) {
-		const content = contentBeforeCurrentBlock
-			.filter( function ( block ) {
-				return block && block.attributes && block.attributes.content;
-			} )
-			.map( function ( block ) {
-				return block.attributes.content.replaceAll( '<br/>', '\n' );
-			} )
-			.join( '\n' );
-		const shorter_content = content.slice( -1 * MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT );
-
-		const expandPrompt = sprintf(
-			/** translators: This will be the end of a prompt that will be sent to OpenAI with the last MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT characters of content.*/
-			__( 'Summarize this:\n\n … %s', 'jetpack' ), // eslint-disable-line @wordpress/i18n-no-collapsible-whitespace
-			shorter_content
-		);
-
-		return expandPrompt + PROMPT_SUFFIX;
-	}
-
-	if ( type === 'continue' ) {
-		const content = contentBeforeCurrentBlock
-			.filter( function ( block ) {
-				return block && block.attributes && block.attributes.content;
-			} )
-			.map( function ( block ) {
-				return block.attributes.content.replaceAll( '<br/>', '\n' );
-			} )
-			.join( '\n' );
-		const shorter_content = content.slice( -1 * MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT );
-
-		const expandPrompt = sprintf(
-			/** translators: This will be the end of a prompt that will be sent to OpenAI with the last MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT characters of content.*/
-			__( ' Please continue from here:\n\n … %s', 'jetpack' ), // eslint-disable-line @wordpress/i18n-no-collapsible-whitespace
-			shorter_content
-		);
-
-		return expandPrompt + PROMPT_SUFFIX;
-	}
-
-	// TODO: add some error handling if user supplied prompts or existing content is too short.
-
-	// We prevent a prompt if everything is empty.
-	// if ( ! postTitle && ! shorter_content && ! categoriesNames && ! tagsNames && ! userPrompt ) {
-	// 	return false;
-	// }
-
-	// TODO: decide if we want to use categories and tags in the prompt now that user is supplying their own prompt default.
-	// The following was copied over from the AI Paragraph block.
-
-	// if ( categoriesNames ) {
-	// 	/** translators: This will be the follow up of a prompt that will be sent to OpenAI based on comma-seperated category names. */
-	// 	prompt += sprintf( __( ", published in categories '%1$s'", 'jetpack' ), categoriesNames );
-	// }
-
-	// if ( tagsNames ) {
-	// 	/** translators: This will be the follow up of a prompt that will be sent to OpenAI based on comma-seperated category names. */
-	// 	prompt += sprintf( __( " and tagged '%1$s'", 'jetpack' ), tagsNames );
-	// }
-
-	// return prompt.trim();
-};
 
 export default function Edit( { attributes, setAttributes, clientId } ) {
 	const [ userPrompt, setUserPrompt ] = useState();
@@ -155,7 +42,6 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		useSuggestionsFromOpenAI( {
 			clientId,
 			content: attributes.content,
-			createPrompt,
 			setAttributes,
 			setErrorMessage,
 			tracks,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/test/edit.js
@@ -2,7 +2,7 @@ import {
 	createPrompt,
 	// MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT,
 	PROMPT_SUFFIX,
-} from '../edit';
+} from '../create-prompt';
 
 describe( 'AIParagraphEdit', () => {
 	test( 'createPrompt', () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -1,0 +1,148 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import MarkdownIt from 'markdown-it';
+
+const useSuggestionsFromOpenAI = ( {
+	clientId,
+	content,
+	createPrompt,
+	setAttributes,
+	setErrorMessage,
+	tracks,
+	userPrompt,
+} ) => {
+	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
+	const [ isLoadingCompletion, setIsLoadingCompletion ] = useState( false );
+	const [ showRetry, setShowRetry ] = useState( false );
+	// Let's grab post data so that we can do something smart.
+
+	const currentPostTitle = useSelect( select =>
+		select( 'core/editor' ).getEditedPostAttribute( 'title' )
+	);
+
+	//TODO: decide if we still want to load categories and tags now user is providing the prompt by default.
+	// If not the following can be removed.
+	let loading = false;
+	const categories =
+		useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'categories' ) ) || [];
+
+	const categoryObjects = useSelect(
+		select => {
+			return categories
+				.map( categoryId => {
+					const category = select( 'core' ).getEntityRecord( 'taxonomy', 'category', categoryId );
+
+					if ( ! category ) {
+						// Data is not yet loaded
+						loading = true;
+						return;
+					}
+
+					return category;
+				} )
+				.filter( Boolean ); // Remove undefined values
+		},
+		[ categories ]
+	);
+
+	const tags =
+		useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'tags' ), [] ) || [];
+	const tagObjects = useSelect(
+		select => {
+			return tags
+				.map( tagId => {
+					const tag = select( 'core' ).getEntityRecord( 'taxonomy', 'post_tag', tagId );
+
+					if ( ! tag ) {
+						// Data is not yet loaded
+						loading = true;
+						return;
+					}
+
+					return tag;
+				} )
+				.filter( Boolean ); // Remove undefined values
+		},
+		[ tags ]
+	);
+
+	useEffect( () => {
+		setIsLoadingCategories( loading );
+	}, [ loading ] );
+
+	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId() );
+	const categoryNames = categoryObjects
+		.filter( cat => cat.id !== 1 )
+		.map( ( { name } ) => name )
+		.join( ', ' );
+	const tagNames = tagObjects.map( ( { name } ) => name ).join( ', ' );
+
+	const contentBefore = useSelect( select => {
+		const editor = select( 'core/block-editor' );
+		const index = editor.getBlockIndex( clientId );
+		return editor.getBlocks().slice( 0, index ) ?? [];
+	} );
+
+	const getSuggestionFromOpenAI = type => {
+		if ( !! content || isLoadingCompletion ) {
+			return;
+		}
+
+		setShowRetry( false );
+		setErrorMessage( false );
+		setIsLoadingCompletion( true );
+
+		const data = {
+			content: createPrompt(
+				currentPostTitle,
+				contentBefore,
+				categoryNames,
+				tagNames,
+				userPrompt,
+				type
+			),
+		};
+
+		tracks.recordEvent( 'jetpack_ai_gpt3_completion', {
+			post_id: postId,
+		} );
+
+		apiFetch( {
+			path: '/wpcom/v2/jetpack-ai/completions',
+			method: 'POST',
+			data: data,
+		} )
+			.then( res => {
+				const result = res.trim();
+				const markdownConverter = new MarkdownIt();
+				setAttributes( { content: result.length ? markdownConverter.render( result ) : '' } );
+				setIsLoadingCompletion( false );
+			} )
+			.catch( e => {
+				if ( e.message ) {
+					setErrorMessage( e.message ); // Message was already translated by the backend
+				} else {
+					setErrorMessage(
+						__(
+							'Whoops, we have encountered an error. AI is like really, really hard and this is an experimental feature. Please try again later.',
+							'jetpack'
+						)
+					);
+				}
+				setShowRetry( true );
+				setIsLoadingCompletion( false );
+			} );
+	};
+	return {
+		getSuggestionFromOpenAI,
+		isLoadingCategories,
+		isLoadingCompletion,
+		setIsLoadingCategories,
+		setShowRetry,
+		showRetry,
+	};
+};
+
+export default useSuggestionsFromOpenAI;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -3,11 +3,11 @@ import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import MarkdownIt from 'markdown-it';
+import { createPrompt } from './create-prompt';
 
 const useSuggestionsFromOpenAI = ( {
 	clientId,
 	content,
-	createPrompt,
 	setAttributes,
 	setErrorMessage,
 	tracks,


### PR DESCRIPTION
Just a janitorial PR cleaning the edit file a bit

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves getSuggestionsFromOpenAI into hook `useGetSuggestionsFromOpenAI`
* Moves createPrompt, `MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT`, and `PROMPT_SUFFIX` into own file `create-prompt`.js

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

**For Jetpack sites**
* Follow instructions in pe4Cmx-1cK-p2 under **How to develop AI blocks for Jetpack and review ongoing Pull Requests**

* Checkout this branch
* Confirm you can still get suggestions from the block

**For WordPress.com**

- Sync PR to Sandbox with beta blocks setting enabled and add the AI Assistant block to a post and try various prompts for text and images

