### PR TITLE
[Boost] Tidy up around the minify functionality

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -7,6 +7,9 @@ use WP_Styles;
 // Disable complaints about enqueuing stylesheets, as this class alters the way enqueuing them works.
 // phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 
+/**
+ * Replacement for, and subclass of WP_Styles - used to control the way that styles are enqueued and output.
+ */
 class Concatenate_CSS extends WP_Styles {
 	private $dependency_path_mapping;
 	private $old_styles;

--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -7,6 +7,9 @@ use WP_Scripts;
 // Disable complaints about enqueuing scripts, as this class alters the way enqueuing them works.
 // phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
+/**
+ * Replacement for, and subclass of WP_Scripts - used to control the way that scripts are enqueued and output.
+ */
 class Concatenate_JS extends WP_Scripts {
 	private $dependency_path_mapping;
 	private $old_scripts;
@@ -55,6 +58,9 @@ class Concatenate_JS extends WP_Scripts {
 		return false;
 	}
 
+	/**
+	 * Override for WP_Scripts::do_item() - this is the method that actually outputs the scripts.
+	 */
 	public function do_items( $handles = false, $group = false ) {
 		global $wp_filesystem;
 

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -3,8 +3,12 @@
 use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\Dependency_Path_Mapping;
 
-// @todo - refactor this. Dump of functions from page optimize.
-
+/**
+ * Cleanup the given cache folder, removing all files older than $file_age seconds.
+ *
+ * @param string $cache_folder The path to the cache folder to cleanup.
+ * @param int $file_age The age of files to purge, in seconds.
+ */
 function jetpack_boost_page_optimize_cache_cleanup( $cache_folder = false, $file_age = DAY_IN_SECONDS ) {
 	if ( ! is_dir( $cache_folder ) ) {
 		return;
@@ -17,6 +21,7 @@ function jetpack_boost_page_optimize_cache_cleanup( $cache_folder = false, $file
 	if ( ! $using_cache ) {
 		$file_age = 0;
 	}
+
 	// If the cache folder changed since queueing, purge it
 	if ( $using_cache && $cache_folder !== $defined_cache_dir ) {
 		$file_age = 0;
@@ -37,7 +42,9 @@ function jetpack_boost_page_optimize_cache_cleanup( $cache_folder = false, $file
 	}
 }
 
-// Unschedule cache cleanup, and purge cache directory
+/**
+ * Plugin deactivation hook - unschedule cronjobs and purge cache.
+ */
 function jetpack_boost_page_optimize_deactivate() {
 	$cache_folder = Config::get_cache_dir_path();
 
@@ -46,6 +53,9 @@ function jetpack_boost_page_optimize_deactivate() {
 	wp_clear_scheduled_hook( 'jetpack_boost_minify_cron_cache_cleanup', array( $cache_folder ) );
 }
 
+/**
+ * Plugin uninstall hook - cleanup options.
+ */
 function jetpack_boost_page_optimize_uninstall() {
 	// Run cleanup on uninstall. You can uninstall an active plugin w/o deactivation.
 	jetpack_boost_page_optimize_deactivate();
@@ -71,28 +81,18 @@ function jetpack_boost_init_filesystem() {
 	}
 }
 
+/**
+ * Get the list of JS slugs to exclude from minification.
+ */
 function jetpack_boost_page_optimize_js_exclude_list() {
 	return jetpack_boost_ds_get( 'minify_js_excludes' );
 }
 
+/**
+ * Get the list of CSS slugs to exclude from minification.
+ */
 function jetpack_boost_page_optimize_css_exclude_list() {
 	return jetpack_boost_ds_get( 'minify_css_excludes' );
-}
-
-function jetpack_boost_page_optimize_sanitize_exclude_field( $value ) {
-	if ( empty( $value ) ) {
-		return '';
-	}
-
-	$excluded_strings = explode( ',', sanitize_text_field( $value ) );
-	$sanitized_values = array();
-	foreach ( $excluded_strings as $excluded_string ) {
-		if ( ! empty( $excluded_string ) ) {
-			$sanitized_values[] = trim( $excluded_string );
-		}
-	}
-
-	return implode( ',', $sanitized_values );
 }
 
 /**
@@ -147,6 +147,9 @@ function jetpack_boost_page_optimize_remove_concat_base_prefix( $original_fs_pat
 	return '/page-optimize-resource-outside-base-path/' . basename( $original_fs_path );
 }
 
+/**
+ * Schedule a cronjob for cache cleanup, if one isn't already scheduled.
+ */
 function jetpack_boost_page_optimize_schedule_cache_cleanup() {
 	$cache_folder = Config::get_cache_dir_path();
 	$args         = array( $cache_folder );
@@ -201,7 +204,9 @@ function jetpack_boost_page_optimize_bail() {
 	return $should_bail;
 }
 
-// Taken from utils.php/Jetpack_Boost_Page_Optimize_Utils
+/**
+ * Return a URL with a cache-busting query string based on the file's mtime.
+ */
 function jetpack_boost_page_optimize_cache_bust_mtime( $path, $siteurl ) {
 	static $dependency_path_mapping;
 

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -244,12 +244,12 @@ function jetpack_boost_page_optimize_cache_bust_mtime( $path, $siteurl ) {
 }
 
 /**
- * Initializes the cache service for minification in Jetpack Boost.
+ * Detects requests within the `/_static/` directory, and serves minified content.
  *
  * @return void
  */
-function jetpack_boost_minify_init_cache_service() {
-	// TODO: Make concat URL dir configurable
+function jetpack_boost_minify_serve_concatenated() {
+	// Potential improvement: Make concat URL dir configurable
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	if ( isset( $_SERVER['REQUEST_URI'] ) && '/_static/' === substr( wp_unslash( $_SERVER['REQUEST_URI'] ), 0, 9 ) ) {
 		require_once __DIR__ . '/functions-service.php';
@@ -272,8 +272,8 @@ function jetpack_boost_minify_setup() {
 	}
 	$setup_done = true;
 
-	// Handle cache service requests.
-	jetpack_boost_minify_init_cache_service();
+	// Handle requests for minified / concatenated content.
+	jetpack_boost_minify_serve_concatenated();
 
 	// Hook up deactivation and uninstall cleanup paths.
 	register_deactivation_hook( JETPACK_BOOST_PATH, 'jetpack_boost_page_optimize_deactivate' );

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -283,8 +283,11 @@ function jetpack_boost_minify_setup() {
 	add_action( 'jetpack_boost_minify_cron_cache_cleanup', 'jetpack_boost_page_optimize_cache_cleanup' );
 	jetpack_boost_page_optimize_schedule_cache_cleanup();
 
-	// Disable Jetpack Site Accelerator CDN for static JS/CSS, if we're minifying this page.
 	if ( ! jetpack_boost_page_optimize_bail() ) {
+		// Disable Jetpack Site Accelerator CDN for static JS/CSS, if we're minifying this page.
 		add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );
+
+		// Setup wp_filesystem for use.
+		jetpack_boost_init_filesystem();
 	}
 }

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -11,6 +11,9 @@ function jetpack_boost_page_optimize_types() {
 	);
 }
 
+/**
+ * Handle serving a minified / concatenated file from the virtual _static dir.
+ */
 function jetpack_boost_page_optimize_service_request() {
 	global $wp_filesystem;
 
@@ -18,6 +21,8 @@ function jetpack_boost_page_optimize_service_request() {
 
 	$cache_dir = Config::get_cache_dir_path();
 	$use_cache = ! empty( $cache_dir );
+
+	// Ensure the cache directory exists.
 	if ( $use_cache && ! is_dir( $cache_dir ) && ! $wp_filesystem->mkdir( $cache_dir, 0775, true ) ) {
 		$use_cache = false;
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -32,6 +37,7 @@ function jetpack_boost_page_optimize_service_request() {
 		}
 	}
 
+	// Ensure the cache directory is writable.
 	if ( $use_cache && ( ! is_dir( $cache_dir ) || ! $wp_filesystem->is_writable( $cache_dir ) || ! is_executable( $cache_dir ) ) ) {
 		$use_cache = false;
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -53,6 +59,7 @@ function jetpack_boost_page_optimize_service_request() {
 		$cache_file       = $cache_dir . "/page-optimize-cache-$request_uri_hash";
 		$cache_file_meta  = $cache_dir . "/page-optimize-cache-meta-$request_uri_hash";
 
+		// Serve an existing file.
 		if ( file_exists( $cache_file ) ) {
 			if ( isset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) ) {
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -82,6 +89,7 @@ function jetpack_boost_page_optimize_service_request() {
 		}
 	}
 
+	// Existing file not available; generate new content.
 	$output  = jetpack_boost_page_optimize_build_output();
 	$content = $output['content'];
 	$headers = $output['headers'];
@@ -95,6 +103,7 @@ function jetpack_boost_page_optimize_service_request() {
 
 	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to trust this unfortunately.
 
+	// Cache the generated data, if available.
 	if ( $use_cache ) {
 		$wp_filesystem->put_contents( $cache_file, $content );
 		$wp_filesystem->put_contents( $cache_file_meta, wp_json_encode( array( 'headers' => $headers ) ) );
@@ -103,6 +112,9 @@ function jetpack_boost_page_optimize_service_request() {
 	die();
 }
 
+/**
+ * Generate a combined and minified output for the current request.
+ */
 function jetpack_boost_page_optimize_build_output() {
 	global $wp_filesystem;
 
@@ -119,8 +131,9 @@ function jetpack_boost_page_optimize_build_output() {
 		jetpack_boost_page_optimize_status_exit( 400 );
 	}
 
+	// Ensure the path follows one of these forms:
 	// /_static/??/foo/bar.css,/foo1/bar/baz.css?m=293847g
-	// or
+	// -- or --
 	// /_static/??-eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
@@ -131,9 +144,8 @@ function jetpack_boost_page_optimize_build_output() {
 
 	$args = substr( $args, strpos( $args, '?' ) + 1 );
 
-	// /foo/bar.css,/foo1/bar/baz.css?m=293847g
-	// or
-	// -eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
+	// Detect paths with - in their filename - this implies a base64 encoded gzipped string for the file list.
+	// e.g.: /_static/??-eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
 	if ( '-' === $args[0] ) {
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$args = @gzuncompress( base64_decode( substr( $args, 1 ) ) );
@@ -144,6 +156,7 @@ function jetpack_boost_page_optimize_build_output() {
 		}
 	}
 
+	// Handle comma separated list of files. e.g.:
 	// /foo/bar.css,/foo1/bar/baz.css?m=293847g
 	$version_string_pos = strpos( $args, '?' );
 	if ( false !== $version_string_pos ) {

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -12,12 +12,9 @@ class Minify_CSS implements Pluggable {
 	public function setup() {
 		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
 
-		$should_minify = jetpack_boost_minify_setup();
-		if ( false === $should_minify ) {
-			return;
-		}
+		jetpack_boost_minify_setup();
 
-		if ( is_admin() ) {
+		if ( jetpack_boost_page_optimize_bail() ) {
 			return;
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -18,8 +18,6 @@ class Minify_CSS implements Pluggable {
 			return;
 		}
 
-		jetpack_boost_init_filesystem();
-
 		add_action( 'init', array( $this, 'init_minify' ) );
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
@@ -18,8 +18,6 @@ class Minify_JS implements Pluggable {
 			return;
 		}
 
-		jetpack_boost_init_filesystem();
-
 		add_action( 'init', array( $this, 'init_minify' ) );
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
@@ -12,12 +12,9 @@ class Minify_JS implements Pluggable {
 	public function setup() {
 		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
 
-		$should_minify = jetpack_boost_minify_setup();
-		if ( false === $should_minify ) {
-			return;
-		}
+		jetpack_boost_minify_setup();
 
-		if ( is_admin() ) {
+		if ( jetpack_boost_page_optimize_bail() ) {
 			return;
 		}
 

--- a/projects/plugins/boost/changelog/boost-minify-cleanup
+++ b/projects/plugins/boost/changelog/boost-minify-cleanup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Various internal cleanups for minify feature
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a bunch of comments, and simplifies some function calls around initialization and setup of the minify features in Boost.

## Proposed changes:
* Moves calls to init filesystem objects into the minify setup function
* Renames jetpack_boost_minify_init_cache_service to describe its purpose / functionality a bit more clearly
* Simplifies the minify_setup API (no longer returns a boolean), and moves checks for is_admin into the _bail function
* Adds a bunch of comments

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Make sure the minify functionality hasn't been broken by these changes :) 

