### PR TITLE
[RNMobile] Disable debug logs when running unit tests

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-videopress-disable-debug-logs-on-tests
+++ b/projects/packages/videopress/changelog/rnmobile-videopress-disable-debug-logs-on-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress block: Disable debug logs when running unit tests

--- a/projects/packages/videopress/src/client/block-editor/editor.native.js
+++ b/projects/packages/videopress/src/client/block-editor/editor.native.js
@@ -2,7 +2,7 @@ import debugFactory from 'debug';
 import registerVideoPressBlock from './blocks/video/index';
 
 // eslint-disable-next-line no-undef
-if ( __DEV__ ) {
+if ( __DEV__ && process.env.JEST_WORKER_ID === undefined ) {
 	debugFactory.enable( 'videopress:*' );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/wordpress-mobile/gutenberg-mobile/issues/5734.

**⚠️ This PR depends on https://github.com/Automattic/jetpack/pull/30486.**

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent enabling debug logs for VideoPress when running unit tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Debug logs are disabled in unit tests
* Checkout changes from https://github.com/wordpress-mobile/gutenberg-mobile/pull/5735.
* Follow the testing instructions to run the unit tests.
* Observe that VideoPress debug logs are not printed.

### Debug logs are enabled in development mode
* Run the app and connect it with the local Metro server (i.e. development mode).
* Add a VideoPress block and add a video.
* Observe that VideoPress debug logs are printed.
