### PR TITLE
AI Assistant: Remove icons from single actions in dropdown

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-control-labels
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-control-labels
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: just an update on an unpublished block
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -8,16 +8,7 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	arrowRight,
-	check,
-	image,
-	pencil,
-	postContent,
-	postExcerpt,
-	title,
-	update,
-} from '@wordpress/icons';
+import { arrowRight, check, image, pencil, update } from '@wordpress/icons';
 import Loading from './loading';
 
 const AIControl = ( {
@@ -119,21 +110,18 @@ const ToolbarControls = ( {
 					) }
 					{ ! showRetry && ! contentIsLoaded && (
 						<ToolbarDropdownMenu
-							label="Generate from content"
+							label="More"
 							controls={ [
 								{
 									title: __( 'Summarize', 'jetpack' ),
-									icon: postExcerpt,
 									onClick: () => getSuggestionFromOpenAI( 'summarize' ),
 								},
 								{
 									title: __( 'Write a summary based on title', 'jetpack' ),
-									icon: title,
 									onClick: () => getSuggestionFromOpenAI( 'titleSummary' ),
 								},
 								{
 									title: __( 'Expand on preceding content', 'jetpack' ),
-									icon: postContent,
 									onClick: () => getSuggestionFromOpenAI( 'continue' ),
 								},
 							] }


### PR DESCRIPTION
Actions in a dropdown should not carry an icon and label. Only groups (the dropdown toggle)

#### After

<img width="769" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/1f67604b-cbca-4469-b37b-e2ee1b52c6b5">


#### Before

<img width="761" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/d4ce4c6f-0bed-40a6-adac-b51aad8fee0d">


Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes icon from menu actions

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
## Testing instructions:

**For Jetpack sites**
* Follow instructions in pe4Cmx-1cK-p2 under **How to develop AI blocks for Jetpack and review ongoing Pull Requests**

* Checkout this branch
* Add the block
* Select it and click the dropdown
* Confirm the actions do not have an icon

**For WordPress.com**

- Sync PR to Sandbox with beta blocks setting enabled and add the AI Assistant block to a post and try various prompts for text and images


