### PR TITLE
AI Assistance: switch the default `Continue writing` option when no previous content from the assistant block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-check-continue-writing
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-check-continue-writing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistance: swtich default option depending on previous-block content

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -119,6 +119,15 @@ const ToolbarControls = ( {
 						</ToolbarButton>
 					) }
 
+					{ ! showRetry && ! contentIsLoaded && ! contentBefore?.length && (
+						<ToolbarButton
+							icon={ title }
+							onClick={ () => getSuggestionFromOpenAI( 'titleSummary' ) }
+						>
+							{ __( 'Write a summary based on title', 'jetpack' ) }
+						</ToolbarButton>
+					) }
+
 					{ ! showRetry && ! contentIsLoaded && (
 						<ToolbarDropdownMenu
 							label="More"

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -8,7 +8,7 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { arrowRight, check, image, pencil, update, undo } from '@wordpress/icons';
+import { arrowRight, check, image, pencil, update, title, undo } from '@wordpress/icons';
 import Loading from './loading';
 
 const AIControl = ( {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -26,6 +26,7 @@ const AIControl = ( {
 	setAiType,
 	setUserPrompt,
 	showRetry,
+	contentBefore,
 } ) => {
 	const handleInputEnter = event => {
 		if ( event.key === 'Enter' && ! event.shiftKey ) {
@@ -55,6 +56,7 @@ const AIControl = ( {
 					handleTryAgain={ handleTryAgain }
 					showRetry={ showRetry }
 					toggleAIType={ toggleAIType }
+					contentBefore={ contentBefore }
 				/>
 			) }
 			<div className="jetpack-ai-assistant__input-wrapper">
@@ -93,6 +95,7 @@ const ToolbarControls = ( {
 	handleGetSuggestion,
 	showRetry,
 	toggleAIType,
+	contentBefore,
 } ) => {
 	return (
 		<BlockControls>
@@ -109,11 +112,13 @@ const ToolbarControls = ( {
 							</ToolbarButton>
 						</>
 					) }
-					{ ! showRetry && ! contentIsLoaded && (
+
+					{ ! showRetry && ! contentIsLoaded && contentBefore?.length && (
 						<ToolbarButton icon={ pencil } onClick={ () => getSuggestionFromOpenAI( 'continue' ) }>
 							{ __( 'Continue writing', 'jetpack' ) }
 						</ToolbarButton>
 					) }
+
 					{ ! showRetry && ! contentIsLoaded && (
 						<ToolbarDropdownMenu
 							label="More"

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -38,15 +38,20 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		};
 	}, [] );
 
-	const { isLoadingCategories, isLoadingCompletion, getSuggestionFromOpenAI, showRetry } =
-		useSuggestionsFromOpenAI( {
-			clientId,
-			content: attributes.content,
-			setAttributes,
-			setErrorMessage,
-			tracks,
-			userPrompt,
-		} );
+	const {
+		isLoadingCategories,
+		isLoadingCompletion,
+		getSuggestionFromOpenAI,
+		showRetry,
+		contentBefore,
+	} = useSuggestionsFromOpenAI( {
+		clientId,
+		content: attributes.content,
+		setAttributes,
+		setErrorMessage,
+		tracks,
+		userPrompt,
+	} );
 
 	const saveImage = async image => {
 		if ( loadingImages ) {
@@ -159,6 +164,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				showRetry={ showRetry }
 				setAiType={ setAiType }
 				setUserPrompt={ setUserPrompt }
+				contentBefore={ contentBefore }
 			/>
 			{ ! loadingImages && resultImages.length > 0 && (
 				<Flex direction="column" style={ { width: '100%' } }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -165,6 +165,7 @@ const useSuggestionsFromOpenAI = ( {
 		setIsLoadingCategories,
 		setShowRetry,
 		showRetry,
+		contentBefore: getPartialContentToBlock( clientId ),
 	};
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When there is no previous content to the Assistant block, maybe the `Continue writing` option doesn't make sense. This PR switches to the `Write a summary based on title` option when no content before.

https://github.com/Automattic/jetpack/assets/77539/fdb55164-2a13-42d4-b60a-14501f9347c4

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack AI: switch the default `Continue writing` option when no previous content from the assistant block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create an AI Assistance block
* Without any content before, the block should show the `Write a summary based on title` option
* With content before, the block should show the `Continue writing` option

