### PR TITLE
[Newsletter] misconfiguration notice and various design fixes

### DIFF
--- a/projects/plugins/jetpack/changelog/add-misconfiguration-panels
+++ b/projects/plugins/jetpack/changelog/add-misconfiguration-panels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add misconfiguration warning functionnality. Also added various design fixes.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -16,7 +16,7 @@ import './panel.scss';
 import { getSubscriberCounts } from './api';
 import { META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, accessOptions } from './constants';
 import { NewsletterAccessDocumentSettings, NewsletterAccessPrePublishSettings } from './settings';
-import { isNewsletterFeatureEnabled, MisconfigurationWarning } from './utils';
+import { isNewsletterFeatureEnabled } from './utils';
 import { name } from './';
 
 const SubscriptionsPanelPlaceholder = ( { children } ) => {
@@ -56,7 +56,6 @@ function NewsletterEditorSettingsPanel( {
 			title={ __( 'Newsletter access', 'jetpack' ) }
 			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
 		>
-			{ showMisconfigurationWarning && <MisconfigurationWarning /> }
 			<NewsletterAccessDocumentSettings
 				accessLevel={ accessLevel }
 				setPostMeta={ setPostMeta }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -247,7 +247,7 @@ function NewsletterAccessRadioButtons( {
 
 					{ /* Only show the notice below each access radio buttons in the PrePublish panel  */ }
 					{ isPrePublishPanel && key === accessLevel && (
-						<p>
+						<p className="pre-public-panel-notice-reach">
 							<NewsletterNotice
 								accessLevel={ accessLevel }
 								socialFollowers={ socialFollowers }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -112,11 +112,16 @@ function NewsletterNotice( { accessLevel, socialFollowers, emailSubscribers, pai
 	return (
 		<FlexBlock>
 			<Notice status="info" isDismissible={ false } className="edit-post-post-visibility__notice">
-				{ sprintf(
-					/* translators: %s is the number of subscribers in numerical format */
-					__( 'This will be sent to <strong>%s subscribers</strong>.', 'jetpack' ),
-					reachCount
-				) }
+				{
+					createInterpolateElement(
+						sprintf(
+							/* translators: %s is the number of subscribers in numerical format */
+							__( 'This will be sent to <strong>%s subscribers</strong>.', 'jetpack' ),
+							reachCount
+						),
+						{ strong: <strong /> }
+					)
+				}
 			</Notice>
 		</FlexBlock>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -213,7 +213,10 @@ function NewsletterAccessRadioButtons( {
 						id={ `editor-post-${ key }-${ instanceId }` }
 						name={ `editor-newsletter-access__setting-${ instanceId }` }
 						aria-describedby={ `editor-post-${ key }-${ instanceId }-description` }
-						disabled={ key === accessOptions.paid_subscribers.key && ! isStripeConnected }
+						disabled={
+							key === accessOptions.paid_subscribers.key &&
+							( ! isStripeConnected || ! hasNewsletterPlans )
+						}
 						onChange={ event => {
 							const obj = {};
 							obj[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ] = event?.target?.value;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -305,6 +305,7 @@ export function NewsletterAccessDocumentSettings( {
 			render={ ( { canEdit } ) => (
 				<PanelRow className="edit-post-post-visibility">
 					<Flex direction="column">
+						{ showMisconfigurationWarning && <MisconfigurationWarning /> }
 						<Flex direction="row" justify="flex-start">
 							<span>{ __( 'Access', 'jetpack' ) }</span>
 							{ canEdit && (

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -228,7 +228,7 @@ function NewsletterAccessRadioButtons( {
 
 						{ /* Do not show subscriber numbers in the PrePublish panel */ }
 						{ ! isPrePublishPanel &&
-							'(' +
+							' (' +
 								getReachForAccessLevelKey(
 									key,
 									emailSubscribers,

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -211,7 +211,7 @@ function NewsletterAccessRadioButtons( {
 						checked={ key === accessLevel }
 						className="editor-post-visibility__radio"
 						id={ `editor-post-${ key }-${ instanceId }` }
-						name={ `editor-post-visibility__setting-${ instanceId }` }
+						name={ `editor-newsletter-access__setting-${ instanceId }` }
 						aria-describedby={ `editor-post-${ key }-${ instanceId }-description` }
 						disabled={ key === accessOptions.paid_subscribers.key && ! isStripeConnected }
 						onChange={ event => {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -17,7 +17,7 @@ import { PostVisibilityCheck } from '@wordpress/editor';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, accessOptions } from './constants';
-import { getPaidPlanLink } from './utils';
+import { getPaidPlanLink, MisconfigurationWarning } from './utils';
 
 import './settings.scss';
 
@@ -73,7 +73,13 @@ function NewsletterLearnMore() {
 	);
 }
 
-function NewsletterNotice( { accessLevel, socialFollowers, emailSubscribers, paidSubscribers } ) {
+function NewsletterNotice( {
+	accessLevel,
+	socialFollowers,
+	emailSubscribers,
+	paidSubscribers,
+	showMisconfigurationWarning,
+} ) {
 	// Get the reach count for the access level
 	let reachCount = getReachForAccessLevelKey(
 		accessLevel,
@@ -81,6 +87,11 @@ function NewsletterNotice( { accessLevel, socialFollowers, emailSubscribers, pai
 		paidSubscribers,
 		socialFollowers
 	);
+
+	// If there is a misconfiguration, we do not show the NewsletterNotice
+	if ( showMisconfigurationWarning ) {
+		return;
+	}
 
 	if ( 0 === reachCount ) {
 		return (
@@ -112,16 +123,14 @@ function NewsletterNotice( { accessLevel, socialFollowers, emailSubscribers, pai
 	return (
 		<FlexBlock>
 			<Notice status="info" isDismissible={ false } className="edit-post-post-visibility__notice">
-				{
-					createInterpolateElement(
-						sprintf(
-							/* translators: %s is the number of subscribers in numerical format */
-							__( 'This will be sent to <strong>%s subscribers</strong>.', 'jetpack' ),
-							reachCount
-						),
-						{ strong: <strong /> }
-					)
-				}
+				{ createInterpolateElement(
+					sprintf(
+						/* translators: %s is the number of subscribers in numerical format */
+						__( 'This will be sent to <strong>%s subscribers</strong>.', 'jetpack' ),
+						reachCount
+					),
+					{ strong: <strong /> }
+				) }
 			</Notice>
 		</FlexBlock>
 	);
@@ -186,6 +195,7 @@ function NewsletterAccessRadioButtons( {
 	hasNewsletterPlans,
 	stripeConnectUrl,
 	isPrePublishPanel = false,
+	showMisconfigurationWarning,
 } ) {
 	const isStripeConnected = stripeConnectUrl === null;
 	const instanceId = useInstanceId( NewsletterAccessRadioButtons );
@@ -243,6 +253,7 @@ function NewsletterAccessRadioButtons( {
 								socialFollowers={ socialFollowers }
 								emailSubscribers={ emailSubscribers }
 								paidSubscribers={ paidSubscribers }
+								showMisconfigurationWarning={ showMisconfigurationWarning }
 							/>
 						</p>
 					) }
@@ -263,6 +274,7 @@ export function NewsletterAccessDocumentSettings( {
 	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
+	showMisconfigurationWarning,
 } ) {
 	const { hasNewsletterPlans, stripeConnectUrl, isLoading } = useSelect( select => {
 		const { getProducts, getConnectUrl, isApiStateLoading } = select(
@@ -329,6 +341,7 @@ export function NewsletterAccessDocumentSettings( {
 												paidSubscribers={ paidSubscribers }
 												stripeConnectUrl={ stripeConnectUrl }
 												hasNewsletterPlans={ hasNewsletterPlans }
+												showMisconfigurationWarning={ showMisconfigurationWarning }
 											/>
 										</div>
 									) }
@@ -344,6 +357,7 @@ export function NewsletterAccessDocumentSettings( {
 							socialFollowers={ socialFollowers }
 							emailSubscribers={ emailSubscribers }
 							paidSubscribers={ paidSubscribers }
+							showMisconfigurationWarning={ showMisconfigurationWarning }
 						/>
 
 						<FlexBlock>
@@ -362,6 +376,7 @@ export function NewsletterAccessPrePublishSettings( {
 	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
+	showMisconfigurationWarning,
 } ) {
 	const { hasNewsletterPlans, stripeConnectUrl, isLoading } = useSelect( select => {
 		const { getProducts, getConnectUrl, isApiStateLoading } = select(
@@ -392,6 +407,7 @@ export function NewsletterAccessPrePublishSettings( {
 			render={ ( { canEdit } ) => (
 				<PanelRow className="edit-post-post-visibility">
 					<Flex direction="column">
+						{ showMisconfigurationWarning && MisconfigurationWarning() }
 						{ canEdit && (
 							<>
 								<FlexBlock>
@@ -404,6 +420,7 @@ export function NewsletterAccessPrePublishSettings( {
 										stripeConnectUrl={ stripeConnectUrl }
 										hasNewsletterPlans={ hasNewsletterPlans }
 										isPrePublishPanel={ true }
+										showMisconfigurationWarning={ showMisconfigurationWarning }
 									/>
 								</FlexBlock>
 							</>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -144,7 +144,7 @@ function NewsletterAccessSetupNudge( { stripeConnectUrl, isStripeConnected, hasN
 			<div className="editor-post-visibility__info">
 				{ createInterpolateElement(
 					__(
-						"You'll need a <paidPlanLink>paid plan</paidPlanLink> and a <stripeAccountLink>Stripe account</stripeAccountLink> to collect payments.",
+						"You'll need to connect <stripeAccountLink>Stripe</stripeAccountLink> and add a <paidPlanLink>paid plan</paidPlanLink> to collect payments.",
 						'jetpack'
 					),
 					{

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.scss
@@ -42,3 +42,7 @@
 .editor-post-visibility__choice input[disabled] {
 	background-color: $gray-400;
 }
+
+.pre-public-panel-notice-reach{
+		margin-bottom:20px;
+}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.scss
@@ -8,25 +8,31 @@
 	}
 }
 
-.jetpack-subscribe-notice-misconfiguration.warning {
-	color: $alert-red;
-	border: solid 1px $alert-red;
-	padding: 1em;
-	text-align: justify;
-}
+.edit-post-post-misconfiguration {
+	&__warning {
+		margin: 0;
+		font-size: 12px;
 
+		.components-notice__content {
+			margin-right: 0;
+		}
+	}
+}
 .edit-post-post-visibility {
 	&__notice {
 		margin: 0;
-		// General notice
+
+		// General notice background color
 		&.is-info {
 			background: var(--color-primary-0, #e9f0f5);
 		}
 	}
 
-	.components-notice__content {
-		margin-right: 0;
+		.components-notice__content {
+			margin-right: 0;
+		}
 	}
+
 }
 
 .jetpack-newsletter-link {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/utils.js
@@ -1,5 +1,6 @@
 import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
-import { Button, ToolbarButton } from '@wordpress/components';
+import { Button, ToolbarButton, Notice } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { _x, __ } from '@wordpress/i18n';
 
 /**
@@ -29,6 +30,24 @@ export const getPaidPlanLink = forNewsletterPlans => {
 export const isNewsletterFeatureEnabled = () => {
 	return getJetpackData()?.jetpack?.is_newsletter_feature_enabled ?? false;
 };
+
+export const MisconfigurationWarning = () => (
+	<Notice
+		status="warning"
+		isDismissible={ false }
+		className="edit-post-post-misconfiguration__warning"
+	>
+		{ createInterpolateElement(
+			__(
+				'You’ll need to change the post’s access to Everybody or visibility to Public.<br/>' +
+					'<br/>' +
+					'Subscribers aren’t able to view private or password-protected posts.',
+				'jetpack'
+			),
+			{ br: <br /> }
+		) }
+	</Notice>
+);
 
 export default function GetAddPaidPlanButton( { context = 'other', hasNewsletterPlans } ) {
 	const addPaidPlanButtonText = hasNewsletterPlans


### PR DESCRIPTION
Add Misconfiguration notice (fixes https://github.com/Automattic/gold/issues/31)
Add margins to Notice in pre-publish panel (fixes https://github.com/Automattic/jetpack/issues/30447)
Modify no Strip/plan text (Fixes https://github.com/Automattic/jetpack/issues/30449)
Fix some spacing (fixes https://github.com/Automattic/jetpack/issues/30452)


## Proposed changes:
* Shows a warning when Newsletter are misconfigured

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

See main branch for the setup

#### Videos of the warning on the editor and post-publish:

https://github.com/Automattic/jetpack/assets/790558/bc0b99df-ba49-49ee-a014-63cdf9466946
https://github.com/Automattic/jetpack/assets/790558/8666956d-dd62-4148-b427-c3d7f3696c61

#### Fix margins (it will show better with https://github.com/Automattic/jetpack/pull/30473):

| result |
|---|
| <img width="230" alt="Screenshot 2023-05-09 at 16 30 20" src="https://github.com/Automattic/jetpack/assets/790558/bd2328d1-e6ca-48f4-8047-b589616fc9e2"> |


#### Fix no Stripe/plan text (disconnect Stripe or switch to prod/sandbox store):
| result |
|---|
| <img width="230" alt="Screenshot 2023-05-09 at 16 39 33" src="https://github.com/Automattic/jetpack/assets/790558/9204a690-3812-489b-9e4b-4004a35297ee"> |


#### Spaces are fixed
| result |
|---|
| <img width="230" alt="Screenshot 2023-05-09 at 16 43 28" src="https://github.com/Automattic/jetpack/assets/790558/0a3a6402-97c2-457f-aed5-68a014bde138"> |
