### PR TITLE
Forms: Remove Forms landing page redirection logic

### DIFF
--- a/projects/packages/forms/changelog/update-landing-page-redirection
+++ b/projects/packages/forms/changelog/update-landing-page-redirection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Remove Forms landing page redirection logic

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -160,6 +160,9 @@ class Dashboard {
 	 * @return boolean
 	 */
 	private function has_feedback() {
+		// We want to hold the redirection logic a bit for now
+		return true;
+
 		$posts = new \WP_Query(
 			array(
 				'post_type'   => 'feedback',

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -163,6 +163,7 @@ class Dashboard {
 		// We want to hold the redirection logic a bit for now
 		return true;
 
+		// phpcs:disable Squiz.PHP.NonExecutableCode.Unreachable
 		$posts = new \WP_Query(
 			array(
 				'post_type'   => 'feedback',
@@ -171,5 +172,6 @@ class Dashboard {
 		);
 
 		return $posts->found_posts > 0;
+		// phpcs:enable
 	}
 }


### PR DESCRIPTION


## Proposed changes:
* Remove Forms landing page redirection logic

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* When you open your Feedback dashboard you shouldn't be redirected to the landing page, even when you have no feedback

