### PR TITLE
CRM: Resolves 2891 - clean up logic surrounding Woo status mapping

### DIFF
--- a/projects/plugins/crm/admin/settings/transactions.page.php
+++ b/projects/plugins/crm/admin/settings/transactions.page.php
@@ -278,7 +278,7 @@ if ( isset( $sbupdated ) ) {
 
 								?>
 								<input type="text" name="jpcrm-status-transactions" id="jpcrm-status-transactions" value="<?php echo esc_attr( $jpcrmTranStatusStr ); ?>" class="form-control" />
-								<p style="margin-top:4px"><?php esc_html_e( 'Default is', 'zero-bs-crm' ); ?>:<br /><span style="background:#ceeaea;padding:0 4px">Succeeded,Completed,Failed,Refunded,Processing,Pending,Hold,Cancelled,Deleted</span></p>
+								<p style="margin-top:4px"><?php esc_html_e( 'Default is', 'zero-bs-crm' ); ?>:<br /><span style="background:#ceeaea;padding:0 4px">Succeeded,Completed,Failed,Refunded,Processing,Pending,Hold,Cancelled,Deleted,Draft</span></p>
 							</td>
 						</tr>
 

--- a/projects/plugins/crm/changelog/fix-crm-2891-remove_ambiguous_default_woo_status_mapping
+++ b/projects/plugins/crm/changelog/fix-crm-2891-remove_ambiguous_default_woo_status_mapping
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+WooSync: improved status mapping logic

--- a/projects/plugins/crm/includes/ZeroBSCRM.Config.Init.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Config.Init.php
@@ -252,7 +252,7 @@ $zeroBSCRM_Conf_Def = array(
 	// 'customisedfields' contains additional settings spread across multiple tabs
 	'shippingfortransactions'            => -1,
 	'paiddatestransaction'               => -1,
-	'transinclude_status'                => array( 'Succeeded', 'Completed', 'Failed', 'Refunded', 'Processing', 'Pending', 'Hold' ),
+	'transinclude_status'                => array( 'Succeeded', 'Completed', 'Failed', 'Refunded', 'Processing', 'Pending', 'Hold', 'Draft' ),
 	'transaction_fee'                    => -1,
 	'transaction_tax'                    => -1,
 	'transaction_discount'               => -1,
@@ -324,7 +324,7 @@ $zeroBSCRM_Conf_Def = array(
 			// Note: Changes here should be reflected in `transinclude_status` as well
 			'status' => array(
 				1,
-				'Succeeded,Completed,Failed,Refunded,Processing,Pending,Hold,Cancelled,Deleted',
+				'Succeeded,Completed,Failed,Refunded,Processing,Pending,Hold,Cancelled,Deleted,Draft',
 			),
 		),
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -428,6 +428,34 @@ class zbsDAL {
 
     }
 
+	/**
+	 * Check if a given status is valid for the given object
+	 *
+	 * @param int $obj_type_id Object type ID.
+	 * @param str $obj_status  Object status string.
+	 */
+	public function is_valid_obj_status( $obj_type_id, $obj_status ) {
+		switch ( $obj_type_id ) {
+			case ZBS_TYPE_CONTACT:
+				$valid_statuses = zeroBSCRM_getCustomerStatuses( true );
+				break;
+			case ZBS_TYPE_COMPANY:
+				$valid_statuses = zeroBSCRM_getCompanyStatuses();
+				break;
+			case ZBS_TYPE_INVOICE:
+				$valid_statuses = zeroBSCRM_getInvoicesStatuses();
+				break;
+			case ZBS_TYPE_TRANSACTION:
+				$valid_statuses = zeroBSCRM_getTransactionsStatuses( true );
+				break;
+			default:
+				return false;
+		}
+
+		// if required, check if default status is a valid one
+		return in_array( $obj_status, $valid_statuses, true );
+	}
+
     // takes in an obj type str (e.g. 'contact') and returns DEFINED KEY ID = 1
     public function objTypeID($objTypeStr=''){
 

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -326,28 +326,28 @@ function jpcrm_settings_page_html_woosync_main() {
 									?>
 									<tr class="jpcrm_woosync_order_status_map">
 										<td><?php echo esc_html( $woo_order_value ); ?></td>
-										<?php 
-											foreach ( $woo_order_mapping_types as $map_type_value ) :
-												$selected    = '';
-												$mapping_key = $map_type_value['prefix'] . $woo_order_key;
+										<?php
+										foreach ( $woo_order_mapping_types as $map_type_value ) :
+											$selected    = '';
+											$mapping_key = $map_type_value['prefix'] . $woo_order_key;
 
-												if ( is_array( $settings ) && isset( $settings[ $mapping_key ] ) ) {
-													$selected = $settings[ $mapping_key ];
-												}
+											if ( is_array( $settings ) && isset( $settings[ $mapping_key ] ) ) {
+												$selected = $settings[ $mapping_key ];
+											}
 
-										?>
+											?>
 											<td>
 												<select class="winput" style="width: 90%;" name="<?php echo esc_attr( $mapping_key ); ?>" id="<?php echo esc_attr( $mapping_key ); ?>">
 													<option value="-1"><?php esc_html_e( 'Default', 'zero-bs-crm' ); ?></option>
 													<?php
-														foreach ( $map_type_value['statuses'] as $status ) {
-															printf( '<option value="%s" %s>%s</option>', esc_attr( $status ), ( $selected === $status ? 'selected' : '' ), esc_html( $status ) );
-														}
+													foreach ( $map_type_value['statuses'] as $status ) {
+														printf( '<option value="%s" %s>%s</option>', esc_attr( $status ), ( $selected === $status ? 'selected' : '' ), esc_html( $status ) );
+													}
 													?>
 												</select>
 											</td>
-										<?php
-											endforeach;
+											<?php
+										endforeach;
 										?>
 									</tr>
 									<?php

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -335,7 +335,7 @@ function jpcrm_settings_page_html_woosync_main() {
 
 											if ( ! isset( $settings[ $mapping_key ] ) || $settings[ $mapping_key ] === '-1' ) {
 												// use default mapping as fallback
-												$selected = $zbs->modules->woosync->get_default_woo_order_status_mapping_for_obj_type( $obj_type_id, $woo_order_status );
+												$selected = $zbs->modules->woosync->get_default_status_for_order_obj( $obj_type_id, $woo_order_status );
 											} else {
 												// select mapping from settings
 												$selected = $settings[ $mapping_key ];

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -38,8 +38,8 @@ function jpcrm_settings_page_html_woosync_main() {
 		$updatedSettings['enable_woo_status_mapping'] = empty( $_POST['jpcrm_enable_woo_status_mapping'] ) ? 0 : 1;
 
 		foreach ( $woo_order_mapping_types as $map_type_value ) {
-			foreach ( $woo_order_statuses as $woo_order_status_key => $woo_order_status_value ) {
-				$mapping_key                     = $map_type_value['prefix'] . $woo_order_status_key;
+			foreach ( $woo_order_statuses as $woo_order_status => $woo_order_status_value ) {
+				$mapping_key                     = $map_type_value['prefix'] . 'wc' . str_replace( '-', '', $woo_order_status );
 				$updatedSettings[ $mapping_key ] = ! empty( $_POST[ $mapping_key ] ) ? sanitize_text_field( $_POST[ $mapping_key ] ) : '';
 			}
 		}
@@ -322,20 +322,20 @@ function jpcrm_settings_page_html_woosync_main() {
 								</tr>
 								<?php
 
-								foreach ( $woo_order_statuses as $woo_order_key => $woo_order_value ) {
+								foreach ( $woo_order_statuses as $woo_order_status => $woo_order_value ) {
 									?>
 									<tr class="jpcrm_woosync_order_status_map">
 										<td><?php echo esc_html( $woo_order_value ); ?></td>
 										<?php
 										foreach ( $woo_order_mapping_types as $obj_type => $map_type_value ) :
 											$selected    = '';
-											$mapping_key = $map_type_value['prefix'] . $woo_order_key;
+											$mapping_key = $map_type_value['prefix'] . 'wc' . str_replace( '-', '', $woo_order_status );
 
 											$obj_type_id = $zbs->DAL->objTypeID( $obj_type ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 											if ( ! isset( $settings[ $mapping_key ] ) || $settings[ $mapping_key ] === '-1' ) {
 												// use default mapping as fallback
-												$selected = $zbs->modules->woosync->get_default_woo_order_status_mapping_for_obj_type( $obj_type_id, $woo_order_value );
+												$selected = $zbs->modules->woosync->get_default_woo_order_status_mapping_for_obj_type( $obj_type_id, $woo_order_status );
 											} else {
 												// select mapping from settings
 												$selected = $settings[ $mapping_key ];

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1170,10 +1170,6 @@ class Woo_Sync_Background_Sync_Job {
 
 	    }
 
-	    $order_status_to_invoice_settings     = $this->woosync()->woo_order_status_mapping( 'invoice' );
-	    $order_status_to_transaction_settings = $this->woosync()->woo_order_status_mapping( 'transaction' );
-	    $valid_transaction_statuses           = zeroBSCRM_getTransactionsStatuses( true );
-	    $valid_invoice_statuses               = zeroBSCRM_getInvoicesStatuses();
 	    // pre-processing from the $order_data
 	    $order_status   = $order_data['status'];
 	    $order_currency = $order_data['currency'];

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1594,14 +1594,12 @@ class Woo_Sync_Background_Sync_Job {
 			$transaction_paid_date_uts = $order_data['date_paid']->date( 'U' );
 		}
 
-		$invoice_status = __( 'Unpaid', 'zero-bs-crm' );
-
-		// Look for a custom user-defined status mapping value, otherwise we keep using the default value.
 		if ( $is_status_mapping_enabled ) {
-			$candidate_invoice_status = ! empty( $settings[ $order_status_to_invoice_settings[ $order_status ] ] ) ? $settings[ $order_status_to_invoice_settings[ $order_status ] ] : -1;
-
-			// Make sure that the user-defined invoice status mapping is still in the list of allowed Contact statuses.
-			$invoice_status = in_array( $candidate_invoice_status, $valid_invoice_statuses ) ? $candidate_invoice_status : $invoice_status;
+			// use status mapping logic
+			$invoice_status = $this->woosync()->translate_order_status_to_obj_status( ZBS_TYPE_INVOICE, $order_status );
+		} else {
+			// use default mapping
+			$invoice_status = $this->woosync()->get_default_woo_order_status_mapping_for_obj_type( ZBS_TYPE_INVOICE, $order_status );
 		}
 
 		// retrieve completed date, where available

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1728,14 +1728,12 @@ class Woo_Sync_Background_Sync_Job {
 
 		}
 
-		// Transactions have a "Hold" status by default, not "On-hold"
-		$transaction_status = ( $order_status == "on-hold" ? "Hold" : ucfirst( $order_status ) );
-		
 		if ( $is_status_mapping_enabled ) {
-			$candidate_transaction_status = ! empty( $settings[ $order_status_to_transaction_settings[ $order_status ] ] ) ? $settings[ $order_status_to_transaction_settings[ $order_status ] ] : -1;
-
-			// Make sure that the user-defined transaction status mapping is still in the list of allowed transaction statuses.
-			$transaction_status = in_array( $candidate_transaction_status, $valid_transaction_statuses ) ? $candidate_transaction_status : $transaction_status;
+			// use status mapping logic
+			$transaction_status = $this->woosync()->translate_order_status_to_obj_status( ZBS_TYPE_TRANSACTION, $order_status );
+		} else {
+			// use default mapping, which is essentially order status
+			$transaction_status = $this->woosync()->get_default_woo_order_status_mapping_for_obj_type( ZBS_TYPE_TRANSACTION, $order_status );
 		}
 
 		// fill out transaction header (object)

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1324,7 +1324,7 @@ class Woo_Sync_Background_Sync_Job {
 				$contact_id = zeroBS_getCustomerIDWithEmail( $contact_email );
 				// If this is a new contact or the current status equals the first status (CRM's default value is 'Lead'), we are allowed to change it.
 				if ( empty( $contact_id ) || $zbs->DAL->contacts->getContactStatus( $contact_id ) === $contact_statuses[0] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$data['contact']['status'] = $this->woosync()->woocommerce_order_status_to_contact_status( $order_status );
+					$data['contact']['status'] = $this->woosync()->translate_order_status_to_obj_status( ZBS_TYPE_CONTACT, $order_status );
 				}
 			}
 			$data['contact']['created']         = $contact_creation_date_uts;

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1594,13 +1594,7 @@ class Woo_Sync_Background_Sync_Job {
 			$transaction_paid_date_uts = $order_data['date_paid']->date( 'U' );
 		}
 
-		if ( $is_status_mapping_enabled ) {
-			// use status mapping logic
-			$invoice_status = $this->woosync()->translate_order_status_to_obj_status( ZBS_TYPE_INVOICE, $order_status );
-		} else {
-			// use default mapping
-			$invoice_status = $this->woosync()->get_default_woo_order_status_mapping_for_obj_type( ZBS_TYPE_INVOICE, $order_status );
-		}
+		$invoice_status = $this->woosync()->translate_order_status_to_obj_status( ZBS_TYPE_INVOICE, $order_status );
 
 		// retrieve completed date, where available
 		if ( array_key_exists( 'date_completed', $order_data ) && !empty( $order_data['date_completed'] ) ) {
@@ -1726,13 +1720,7 @@ class Woo_Sync_Background_Sync_Job {
 
 		}
 
-		if ( $is_status_mapping_enabled ) {
-			// use status mapping logic
-			$transaction_status = $this->woosync()->translate_order_status_to_obj_status( ZBS_TYPE_TRANSACTION, $order_status );
-		} else {
-			// use default mapping, which is essentially order status
-			$transaction_status = $this->woosync()->get_default_woo_order_status_mapping_for_obj_type( ZBS_TYPE_TRANSACTION, $order_status );
-		}
+		$transaction_status = $this->woosync()->translate_order_status_to_obj_status( ZBS_TYPE_TRANSACTION, $order_status );
 
 		// fill out transaction header (object)
 		$data['transaction'] = array(

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -274,7 +274,11 @@ class Woo_Sync {
 		} elseif ( $obj_type_id === ZBS_TYPE_TRANSACTION ) {
 			// weird legacy mapping fix
 			if ( $order_status === 'on-hold' ) {
-				$status = __( 'Hold', 'zero-bs-crm' );
+				// transaction statuses aren't translated, as they're user-configurable
+				$status = 'Hold';
+			} elseif ( $order_status === 'checkout-draft' ) {
+				// for lack of a better status
+				$status = 'Hold';
 			} else {
 				// default transaction status is the same as the Woo order status
 				$status = ucfirst( $order_status );

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -248,7 +248,7 @@ class Woo_Sync {
 	 *
 	 * @return str|bool Status string to use for object
 	 */
-	public function get_default_woo_order_status_mapping_for_obj_type( $obj_type_id, $order_status ) {
+	public function get_default_status_for_order_obj( $obj_type_id, $order_status ) {
 		global $zbs;
 
 		$status = false;
@@ -1606,7 +1606,7 @@ class Woo_Sync {
 		$settings = $this->get_settings();
 
 		// get default object status for given Woo order status
-		$default_status = $this->get_default_woo_order_status_mapping_for_obj_type( $obj_type_id, $order_status );
+		$default_status = $this->get_default_status_for_order_obj( $obj_type_id, $order_status );
 
 		// if status mapping is disabled, return default status
 		$is_status_mapping_enabled = ( isset( $settings['enable_woo_status_mapping'] ) ? ( (int) $settings['enable_woo_status_mapping'] === 1 ) : true );

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -272,13 +272,13 @@ class Woo_Sync {
 				$status = __( 'Unpaid', 'zero-bs-crm' );
 			}
 		} elseif ( $obj_type_id === ZBS_TYPE_TRANSACTION ) {
-			// weird legacy mapping fix
+			// note that transaction statuses aren't translated, as they're user-configurable
 			if ( $order_status === 'on-hold' ) {
-				// transaction statuses aren't translated, as they're user-configurable
+				// weird legacy mapping fix
 				$status = 'Hold';
 			} elseif ( $order_status === 'checkout-draft' ) {
 				// for lack of a better status
-				$status = 'Hold';
+				$status = 'Draft';
 			} else {
 				// default transaction status is the same as the Woo order status
 				$status = ucfirst( $order_status );

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1608,6 +1608,12 @@ class Woo_Sync {
 		// get default object status for given Woo order status
 		$default_status = $this->get_default_woo_order_status_mapping_for_obj_type( $obj_type_id, $order_status );
 
+		// if status mapping is disabled, return default status
+		$is_status_mapping_enabled = ( isset( $settings['enable_woo_status_mapping'] ) ? ( (int) $settings['enable_woo_status_mapping'] === 1 ) : true );
+		if ( ! $is_status_mapping_enabled ) {
+			return $default_status;
+		}
+
 		// mappings
 		$woo_order_status_mapping = $this->woo_order_status_mapping( 'contact' );
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1572,12 +1572,17 @@ class Woo_Sync {
 	/**
 	 * Translates a WooCommerce order status to the equivalent settings key
 	 *
-	 * @param string $crm_type The type of CRM object: [ 'contact', 'invoice', 'transaction' ]
+	 * @param string $obj_type_id Object type ID.
 	 *
 	 * @return array The associated settings key array [ $order_status => $settings_key ]
 	 */
-	public function woo_order_status_mapping( $crm_type ) {
-		$setting_prefix = $this->get_woo_order_mapping_types()[ $crm_type ]['prefix'];
+	public function woo_order_status_mapping( $obj_type_id ) {
+		global $zbs;
+
+		// convert to key for use in legacy setting name
+		$obj_type_key = $zbs->DAL->objTypeKey( $obj_type_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+		$setting_prefix = $this->get_woo_order_mapping_types()[ $obj_type_key ]['prefix'];
 
 		return array(
 			'completed'      => $setting_prefix . 'wccompleted',
@@ -1615,7 +1620,7 @@ class Woo_Sync {
 		}
 
 		// mappings
-		$woo_order_status_mapping = $this->woo_order_status_mapping( 'contact' );
+		$woo_order_status_mapping = $this->woo_order_status_mapping( $obj_type_id );
 
 		if (
 			! empty( $settings[ $woo_order_status_mapping[ $order_status ] ] )
@@ -1628,7 +1633,7 @@ class Woo_Sync {
 			return $default_status;
 		}
 
-		// use provided order status as fallback contact status (though this should never occur)
+		// use provided order status as fallback status
 		return $order_status;
 	}
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1599,45 +1599,36 @@ class Woo_Sync {
 	 *
 	 * @return string contact status
 	 */
-	public function woocommerce_order_status_to_contact_status( $order_status ){
+	public function woocommerce_order_status_to_contact_status( $order_status ) {
 
-	    // $order_status is the WooCommerce order status
+		// $order_status is the WooCommerce order status
 		$settings = $this->get_settings();
 
-	    // retrieve default status
-	    $default_status = zeroBSCRM_getSetting( 'defaultstatus' );
+		// retrieve default status
+		$default_status = zeroBSCRM_getSetting( 'defaultstatus' );
 
-	    // retrieve contact_statuses to ensure we are getting a valid one
-	    $contact_statuses = zeroBSCRM_getCustomerStatuses( true );
+		// retrieve contact_statuses to ensure we are getting a valid one
+		$contact_statuses = zeroBSCRM_getCustomerStatuses( true );
 
-	    // mappings
-	    $woo_order_status_mapping = $this->woo_order_status_mapping( 'contact' );
+		// mappings
+		$woo_order_status_mapping = $this->woo_order_status_mapping( 'contact' );
 
-	    // get the mapping setting from woocommerce
-	    if ( 
-	        array_key_exists( $order_status, $woo_order_status_mapping ) 
-	        && isset( $settings[ $woo_order_status_mapping[ $order_status ] ] )
-	        && in_array( $settings[ $woo_order_status_mapping[ $order_status ] ], $contact_statuses )
-	    ) {
+		// get the mapping setting from woocommerce
+		if (
+			array_key_exists( $order_status, $woo_order_status_mapping )
+			&& isset( $settings[ $woo_order_status_mapping[ $order_status ] ] )
+			&& in_array( $settings[ $woo_order_status_mapping[ $order_status ] ], $contact_statuses, true )
+		) {
+			$order_status = $settings[ $woo_order_status_mapping[ $order_status ] ];
+		} else {
+			$order_status = $default_status;
+		}
 
-	        $order_status = $settings[ $woo_order_status_mapping[ $order_status ] ];
-
-	    } else {
-
-	        $order_status = $default_status;
-
-	    }
-
-	    if ( ! isset( $order_status ) || $order_status == -1 ) {
-
-	        return $default_status;
-
-	    } else {
-
-	        return $order_status;
-
-	    }
-
+		if ( ! isset( $order_status ) || $order_status === -1 ) {
+			return $default_status;
+		} else {
+			return $order_status;
+		}
 	}
 
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -228,14 +228,14 @@ class Woo_Sync {
 	 */
 	public function get_woo_order_statuses() {
 		$woo_order_statuses = array(
-			'wcpending'       => __( 'Pending', 'zero-bs-crm' ),
-			'wcprocessing'    => __( 'Processing', 'zero-bs-crm' ),
-			'wconhold'        => __( 'On hold', 'zero-bs-crm' ),
-			'wccompleted'     => __( 'Completed', 'zero-bs-crm' ),
-			'wccancelled'     => __( 'Cancelled', 'zero-bs-crm' ),
-			'wcrefunded'      => __( 'Refunded', 'zero-bs-crm' ),
-			'wcfailed'        => __( 'Failed', 'zero-bs-crm' ),
-			'wccheckoutdraft' => __( 'Draft', 'zero-bs-crm' ),
+			'pending'        => __( 'Pending', 'zero-bs-crm' ),
+			'processing'     => __( 'Processing', 'zero-bs-crm' ),
+			'on-hold'        => __( 'On hold', 'zero-bs-crm' ),
+			'completed'      => __( 'Completed', 'zero-bs-crm' ),
+			'cancelled'      => __( 'Cancelled', 'zero-bs-crm' ),
+			'refunded'       => __( 'Refunded', 'zero-bs-crm' ),
+			'failed'         => __( 'Failed', 'zero-bs-crm' ),
+			'checkout-draft' => __( 'Draft', 'zero-bs-crm' ),
 		);
 		return apply_filters( 'zbs-woo-additional-status', $woo_order_statuses );
 	}
@@ -260,22 +260,24 @@ class Woo_Sync {
 			// reasonable default paid mapping based on Woo status descriptions:
 			// https://woocommerce.com/document/managing-orders/#order-statuses
 			$paid_statuses = array(
-				__( 'Pending', 'zero-bs-crm' ),
-				__( 'Processing', 'zero-bs-crm' ),
+				'pending',
+				'processing',
 			);
 
 			if ( in_array( $order_status, $paid_statuses, true ) ) {
 				$status = __( 'Paid', 'zero-bs-crm' );
+			} elseif ( $order_status === 'checkout-draft' ) {
+				$status = __( 'Draft', 'zero-bs-crm' );
 			} else {
 				$status = __( 'Unpaid', 'zero-bs-crm' );
 			}
 		} elseif ( $obj_type_id === ZBS_TYPE_TRANSACTION ) {
-			// default transaction status is the same as the Woo order status
-			$status = $order_status;
-
 			// weird legacy mapping fix
-			if ( $status === __( 'On hold', 'zero-bs-crm' ) ) {
+			if ( $order_status === 'on-hold' ) {
 				$status = __( 'Hold', 'zero-bs-crm' );
+			} else {
+				// default transaction status is the same as the Woo order status
+				$status = ucfirst( $order_status );
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#2891 - clean up logic surrounding Woo status mapping

## Proposed changes:
This PR cleans up and centralises the Woo order status mapping logic. There is some legacy code (e.g. settings keys) that made it a bit difficult, but we're now in a better place.

It introduces three new functions, which should be roughly understandable by name:
* `is_valid_obj_status()`
* `get_default_status_for_order_obj()`
* `translate_order_status_to_obj_status()`

It refines the "default" order -> object status mapping:
* contacts: use default set in settings (same as before)
* invoices: processing and completed are considered paid (instead of unpaid), draft is draft (instead of unpaid), and others are unpaid (as before)
* transactions: uses order statuses (same as before, but now maps "Draft" order transactions to "Draft" status)

In settings, one will no longer see "Default" if there is no setting saved, but instead will see an accurate representation of the status to which it will map. If the default status isn't a valid one, the dropdown will show a message to select a status.

When syncing from WooCommerce, it will use the following mapping precedence:

1. The status mapping selected in settings (if a valid status)
2. The default mapping
3. The order status (only really applies to transactions)

If the status mapping setting is disabled:
* new contacts use the default mapping status (none passed, but DAL uses default)
* existing contacts maintain their current status
* transactions and invoices use the default mapping status

Note that the changes to `includes/ZeroBSCRM.DAL3.Helpers.php` are irrelevant to this PR; I just chopped some commented code when I was planning to add a function to this file (but ultimately didn't).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There's a lot of behind-the-scenes stuff, but in most cases things should work as before. Read through the changes listed in this PR's description, and make sure they work as expected.

Likewise, make sure that the actual sync process works as expected, both with new and existing objects. 

Before:
![image](https://github.com/Automattic/jetpack/assets/32492176/49f58c27-061f-4919-910d-64f01f1eea5e)

After:
![image](https://github.com/Automattic/jetpack/assets/32492176/2e6773a7-e089-45fb-9e5c-575cb94bead9)
