### PR TITLE
AI Assistant: store last prompt to be able to retry the request

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistance-fix-retrying-request
+++ b/projects/plugins/jetpack/changelog/update-ai-assistance-fix-retrying-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: store last prompt to be able to retry the request

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -16,6 +16,7 @@ const AIControl = ( {
 	content,
 	contentIsLoaded,
 	getSuggestionFromOpenAI,
+	retryRequest,
 	handleAcceptContent,
 	handleTryAgain,
 	handleGetSuggestion,
@@ -32,7 +33,7 @@ const AIControl = ( {
 	const handleInputEnter = event => {
 		if ( event.key === 'Enter' && ! event.shiftKey ) {
 			event.preventDefault();
-			handleGetSuggestion();
+			handleGetSuggestion( 'userPrompt' );
 		}
 	};
 
@@ -52,6 +53,7 @@ const AIControl = ( {
 					animationDone={ animationDone }
 					contentIsLoaded={ contentIsLoaded }
 					getSuggestionFromOpenAI={ getSuggestionFromOpenAI }
+					retryRequest={ retryRequest }
 					handleAcceptContent={ handleAcceptContent }
 					handleGetSuggestion={ handleGetSuggestion }
 					handleTryAgain={ handleTryAgain }
@@ -71,7 +73,7 @@ const AIControl = ( {
 				/>
 				<div className="jetpack-ai-assistant__controls">
 					<Button
-						onClick={ () => handleGetSuggestion() }
+						onClick={ () => handleGetSuggestion( 'userPrompt' ) }
 						isSmall={ true }
 						disabled={ isWaitingState || ! userPrompt?.length }
 						label={ __( 'Do some magic!', 'jetpack' ) }
@@ -91,9 +93,9 @@ const ToolbarControls = ( {
 	animationDone,
 	contentIsLoaded,
 	getSuggestionFromOpenAI,
+	retryRequest,
 	handleAcceptContent,
 	handleTryAgain,
-	handleGetSuggestion,
 	showRetry,
 	toggleAIType,
 	contentBefore,
@@ -151,7 +153,7 @@ const ToolbarControls = ( {
 						/>
 					) }
 					{ showRetry && (
-						<ToolbarButton icon={ update } onClick={ handleGetSuggestion }>
+						<ToolbarButton icon={ update } onClick={ retryRequest }>
 							{ __( 'Retry', 'jetpack' ) }
 						</ToolbarButton>
 					) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -157,6 +157,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				content={ attributes.content }
 				contentIsLoaded={ contentIsLoaded }
 				getSuggestionFromOpenAI={ getSuggestionFromOpenAI }
+				retryRequest={ retryRequest }
 				handleAcceptContent={ handleAcceptContent }
 				handleGetSuggestion={ handleGetSuggestion }
 				handleTryAgain={ handleTryAgain }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -45,6 +45,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		showRetry,
 		contentBefore,
 		postTitle,
+		retryRequest,
 	} = useSuggestionsFromOpenAI( {
 		clientId,
 		content: attributes.content,
@@ -116,7 +117,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 
 	const handleGetSuggestion = () => {
 		if ( aiType === 'text' ) {
-			getSuggestionFromOpenAI();
+			retryRequest();
 			return;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -115,9 +115,9 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			? __( 'Write a paragraph about …', 'jetpack' )
 			: __( 'What would you like to see?', 'jetpack', /* dummy arg to avoid bad minification */ 0 );
 
-	const handleGetSuggestion = () => {
+	const handleGetSuggestion = type => {
 		if ( aiType === 'text' ) {
-			retryRequest();
+			getSuggestionFromOpenAI( type );
 			return;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -18,7 +18,7 @@ import ShowLittleByLittle from './show-little-by-little';
 import useSuggestionsFromOpenAI from './use-suggestions-from-openai';
 import './editor.scss';
 
-export default function Edit( { attributes, setAttributes, clientId } ) {
+export default function AIAssistantEdit( { attributes, setAttributes, clientId } ) {
 	const [ userPrompt, setUserPrompt ] = useState();
 	const [ , setErrorMessage ] = useState( false );
 	const [ aiType, setAiType ] = useState( 'text' );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -45,7 +45,7 @@ const useSuggestionsFromOpenAI = ( {
 	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
 	const [ isLoadingCompletion, setIsLoadingCompletion ] = useState( false );
 	const [ showRetry, setShowRetry ] = useState( false );
-	const [ , setLastPrompt ] = useState( '' );
+	const [ lastPrompt, setLastPrompt ] = useState( '' );
 
 	// Let's grab post data so that we can do something smart.
 
@@ -110,7 +110,7 @@ const useSuggestionsFromOpenAI = ( {
 		.join( ', ' );
 	const tagNames = tagObjects.map( ( { name } ) => name ).join( ', ' );
 
-	const getSuggestionFromOpenAI = type => {
+	const getSuggestionFromOpenAI = ( type, retryRequest = false ) => {
 		if ( !! content || isLoadingCompletion ) {
 			return;
 		}
@@ -119,14 +119,16 @@ const useSuggestionsFromOpenAI = ( {
 		setErrorMessage( false );
 		setIsLoadingCompletion( true );
 
-		const prompt = createPrompt(
-			currentPostTitle,
-			getPartialContentToBlock( clientId ),
-			categoryNames,
-			tagNames,
-			userPrompt,
-			type
-		);
+		const prompt = retryRequest
+			? lastPrompt
+			: createPrompt(
+					currentPostTitle,
+					getPartialContentToBlock( clientId ),
+					categoryNames,
+					tagNames,
+					userPrompt,
+					type
+			  );
 
 		const data = { content: prompt };
 
@@ -171,6 +173,7 @@ const useSuggestionsFromOpenAI = ( {
 		showRetry,
 		postTitle: currentPostTitle,
 		contentBefore: getPartialContentToBlock( clientId ),
+		retryRequest: () => getSuggestionFromOpenAI( '', true ),
 	};
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -136,7 +136,9 @@ const useSuggestionsFromOpenAI = ( {
 			post_id: postId,
 		} );
 
-		setLastPrompt( prompt );
+		if ( ! retryRequest ) {
+			setLastPrompt( prompt );
+		}
 
 		apiFetch( {
 			path: '/wpcom/v2/jetpack-ai/completions',

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -45,6 +45,8 @@ const useSuggestionsFromOpenAI = ( {
 	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
 	const [ isLoadingCompletion, setIsLoadingCompletion ] = useState( false );
 	const [ showRetry, setShowRetry ] = useState( false );
+	const [ , setLastPrompt ] = useState( '' );
+
 	// Let's grab post data so that we can do something smart.
 
 	const currentPostTitle = useSelect( select =>
@@ -117,20 +119,22 @@ const useSuggestionsFromOpenAI = ( {
 		setErrorMessage( false );
 		setIsLoadingCompletion( true );
 
-		const data = {
-			content: createPrompt(
-				currentPostTitle,
-				getPartialContentToBlock( clientId ),
-				categoryNames,
-				tagNames,
-				userPrompt,
-				type
-			),
-		};
+		const prompt = createPrompt(
+			currentPostTitle,
+			getPartialContentToBlock( clientId ),
+			categoryNames,
+			tagNames,
+			userPrompt,
+			type
+		);
+
+		const data = { content: prompt };
 
 		tracks.recordEvent( 'jetpack_ai_gpt3_completion', {
 			post_id: postId,
 		} );
+
+		setLastPrompt( prompt );
 
 		apiFetch( {
 			path: '/wpcom/v2/jetpack-ai/completions',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR exposes a new `retryRequest` helper function from the `useSuggestionsFromOpenAI()` custom hook.
Under the hood, the app stores the last prompt and uses it when it requires to retry the request.

Fixes https://github.com/Automattic/jetpack/issues/30558

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: store last prompt to be able to retry the request

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Block editor
* Create an AI Assistant block instance
* Generate content
* Expect the request fails by timeout
* Retry button should appear
* Click on the button
* Confirm the app retries the same request as before

https://github.com/Automattic/jetpack/assets/77539/52c305d1-1025-418d-a4cd-35c25569b8ab

