### PR TITLE
AI Assistant: Disable title summary action when there is no title

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-prevent-title-summary-when-there-is-no-title
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-prevent-title-summary-when-there-is-no-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Remove title summary option when there is no title on the post

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -58,7 +58,7 @@ const AIControl = ( {
 					showRetry={ showRetry }
 					toggleAIType={ toggleAIType }
 					contentBefore={ contentBefore }
-					hasPostTitle={ postTitle?.length }
+					hasPostTitle={ !! postTitle?.length }
 				/>
 			) }
 			<div className="jetpack-ai-assistant__input-wrapper">
@@ -116,13 +116,13 @@ const ToolbarControls = ( {
 						</>
 					) }
 
-					{ ! showRetry && ! contentIsLoaded && contentBefore?.length && (
+					{ ! showRetry && ! contentIsLoaded && !! contentBefore?.length && (
 						<ToolbarButton icon={ pencil } onClick={ () => getSuggestionFromOpenAI( 'continue' ) }>
 							{ __( 'Continue writing', 'jetpack' ) }
 						</ToolbarButton>
 					) }
 
-					{ ! showRetry && ! contentIsLoaded && ! contentBefore?.length && (
+					{ ! showRetry && ! contentIsLoaded && ! contentBefore?.length && hasPostTitle && (
 						<ToolbarButton
 							icon={ title }
 							onClick={ () => getSuggestionFromOpenAI( 'titleSummary' ) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -27,6 +27,7 @@ const AIControl = ( {
 	setUserPrompt,
 	showRetry,
 	contentBefore,
+	postTitle,
 } ) => {
 	const handleInputEnter = event => {
 		if ( event.key === 'Enter' && ! event.shiftKey ) {
@@ -57,6 +58,7 @@ const AIControl = ( {
 					showRetry={ showRetry }
 					toggleAIType={ toggleAIType }
 					contentBefore={ contentBefore }
+					hasPostTitle={ postTitle?.length }
 				/>
 			) }
 			<div className="jetpack-ai-assistant__input-wrapper">
@@ -96,6 +98,7 @@ const ToolbarControls = ( {
 	showRetry,
 	toggleAIType,
 	contentBefore,
+	hasPostTitle,
 } ) => {
 	return (
 		<BlockControls>
@@ -139,6 +142,7 @@ const ToolbarControls = ( {
 								{
 									title: __( 'Write a summary based on title', 'jetpack' ),
 									onClick: () => getSuggestionFromOpenAI( 'titleSummary' ),
+									isDisabled: ! hasPostTitle,
 								},
 								{
 									title: __( 'Expand on preceding content', 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -116,7 +116,7 @@ const ToolbarControls = ( {
 						</>
 					) }
 
-					{ ! showRetry && ! contentIsLoaded && !! contentBefore?.length && (
+					{ !! ( ! showRetry && ! contentIsLoaded && contentBefore?.length ) && (
 						<ToolbarButton icon={ pencil } onClick={ () => getSuggestionFromOpenAI( 'continue' ) }>
 							{ __( 'Continue writing', 'jetpack' ) }
 						</ToolbarButton>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -60,6 +60,10 @@ export const createPrompt = (
 	contentBefore = contentBefore.slice( -MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT );
 
 	if ( type === 'titleSummary' ) {
+		if ( ! postTitle?.length ) {
+			return '';
+		}
+
 		const additionalContextPrompt = contentBefore?.length
 			? sprintf(
 					/** translators: This will be the end of a prompt that will be sent to OpenAI with the last MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT characters of content.*/

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -44,6 +44,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		getSuggestionFromOpenAI,
 		showRetry,
 		contentBefore,
+		postTitle,
 	} = useSuggestionsFromOpenAI( {
 		clientId,
 		content: attributes.content,
@@ -165,6 +166,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				setAiType={ setAiType }
 				setUserPrompt={ setUserPrompt }
 				contentBefore={ contentBefore }
+				postTitle={ postTitle }
 			/>
 			{ ! loadingImages && resultImages.length > 0 && (
 				<Flex direction="column" style={ { width: '100%' } }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/test/edit.js
@@ -20,6 +20,9 @@ describe( 'AIParagraphEdit', () => {
 		expect( createPrompt() ).toBeFalsy();
 		expect( createPrompt( '', [], '', '' ) ).toBeFalsy();
 
+		// Test Title summary - with content but no title
+		expect( createPrompt( '', 'some content', '', '', '', 'titleSummary' ) ).toBeFalsy();
+
 		// Test Title summary - no content
 		expect( createPrompt( 'The story of my life', '', '', '', '', 'titleSummary' ) ).toBe(
 			"Please help me write a short piece of a blog post titled 'The story of my life'" +

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -165,6 +165,7 @@ const useSuggestionsFromOpenAI = ( {
 		setIsLoadingCategories,
 		setShowRetry,
 		showRetry,
+		postTitle: currentPostTitle,
 		contentBefore: getPartialContentToBlock( clientId ),
 	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30554

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Prevent prompt generation for `titleSummary` type when there is no title on the post
* Remove `titleSummary` option from toolbar when there is no title
* Disable `titleSummary` option from dropdown menu when there is no title
* Update tests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new blog post or delete the title for an existing one
* Add a `AI Assistant` block
* Notice that, when the post title is empty
   * the "Write a summary based on title" option is not present on the toolbar and it shows only the hamburger icon
   * the "Write a summary based on title" option on the dropdown menu is disabled

<img width="682" alt="Screen Shot 2023-05-09 at 17 37 41" src="https://github.com/Automattic/jetpack/assets/6760046/11e7c2a4-f923-467e-b6df-b26c0f92d950">

* Now change the title of the post so it's not empty anymore
* Notice that the "Write a summary based on title" option is showed on the toolbar
* Notice that the "Write a summary based on title" option is showed as active on the dropdown menu

<img width="685" alt="Screen Shot 2023-05-09 at 17 38 06" src="https://github.com/Automattic/jetpack/assets/6760046/5b01987d-47d1-4e0b-8f7b-ed7bf31b5c76">