### PR TITLE
AI Assistant: disable `Summarize` when no content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistance-iterate-over-summarize
+++ b/projects/plugins/jetpack/changelog/update-ai-assistance-iterate-over-summarize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: disable `Summarize` when no content

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -28,7 +28,11 @@ const AIControl = ( {
 	setUserPrompt,
 	showRetry,
 	contentBefore,
+<<<<<<< HEAD
 	postTitle,
+=======
+	wholeContent,
+>>>>>>> 5eef1a0095 ([not verified] disable summarize when no content)
 } ) => {
 	const handleInputEnter = event => {
 		if ( event.key === 'Enter' && ! event.shiftKey ) {
@@ -61,6 +65,7 @@ const AIControl = ( {
 					toggleAIType={ toggleAIType }
 					contentBefore={ contentBefore }
 					hasPostTitle={ !! postTitle?.length }
+					wholeContent={ wholeContent }
 				/>
 			) }
 			<div className="jetpack-ai-assistant__input-wrapper">
@@ -99,7 +104,11 @@ const ToolbarControls = ( {
 	showRetry,
 	toggleAIType,
 	contentBefore,
+<<<<<<< HEAD
 	hasPostTitle,
+=======
+	wholeContent,
+>>>>>>> 5eef1a0095 ([not verified] disable summarize when no content)
 } ) => {
 	return (
 		<BlockControls>
@@ -139,6 +148,7 @@ const ToolbarControls = ( {
 								{
 									title: __( 'Summarize', 'jetpack' ),
 									onClick: () => getSuggestionFromOpenAI( 'summarize' ),
+									isDisabled: ! wholeContent?.length,
 								},
 								{
 									title: __( 'Write a summary based on title', 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -28,11 +28,8 @@ const AIControl = ( {
 	setUserPrompt,
 	showRetry,
 	contentBefore,
-<<<<<<< HEAD
 	postTitle,
-=======
 	wholeContent,
->>>>>>> 5eef1a0095 ([not verified] disable summarize when no content)
 } ) => {
 	const handleInputEnter = event => {
 		if ( event.key === 'Enter' && ! event.shiftKey ) {
@@ -104,11 +101,8 @@ const ToolbarControls = ( {
 	showRetry,
 	toggleAIType,
 	contentBefore,
-<<<<<<< HEAD
 	hasPostTitle,
-=======
 	wholeContent,
->>>>>>> 5eef1a0095 ([not verified] disable summarize when no content)
 } ) => {
 	return (
 		<BlockControls>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -39,7 +39,12 @@ export const createPrompt = (
 	// eslint-disable-next-line no-unused-vars
 	tagsNames = ''
 ) => {
-	if ( ! postTitle?.length && ! contentBefore?.length && ! userPrompt?.length ) {
+	if (
+		! postTitle?.length &&
+		! contentBefore?.length &&
+		! userPrompt?.length &&
+		! content?.length
+	) {
 		return '';
 	}
 
@@ -84,6 +89,9 @@ export const createPrompt = (
 	}
 
 	if ( type === 'summarize' ) {
+		content = content?.length ? content.replace( /<br\s*\/?>/gi, '\n' ) : '';
+		content = content.slice( -MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT );
+
 		const expandPrompt = sprintf(
 			/** translators: This will be the end of a prompt that will be sent to OpenAI with the last MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT characters of content.*/
 			__( 'Summarize this:\n\n … %s', 'jetpack' ), // eslint-disable-line @wordpress/i18n-no-collapsible-whitespace

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -20,22 +20,24 @@ export const PROMPT_SUFFIX = __(
  *
  * @param {string} postTitle       - The current post title.
  * @param {string} contentBefore   - The content before the current block.
- * @param {string} categoriesNames - The categories names.
- * @param {string} tagsNames       - The tags names.
+ * @param {string} content         - The whole content.
  * @param {string} userPrompt      - The user prompt.
  * @param {string} type            - The type of prompt to create.
+ * @param {string} categoriesNames - The categories names.
+ * @param {string} tagsNames       - The tags names.
  *
  * @return {string} The prompt.
  */
 export const createPrompt = (
 	postTitle = '',
 	contentBefore = '',
+	content = '',
+	userPrompt = '',
+	type = '',
 	// eslint-disable-next-line no-unused-vars
 	categoriesNames = '',
 	// eslint-disable-next-line no-unused-vars
-	tagsNames = '',
-	userPrompt = '',
-	type = ''
+	tagsNames = ''
 ) => {
 	if ( ! postTitle?.length && ! contentBefore?.length && ! userPrompt?.length ) {
 		return '';
@@ -64,7 +66,7 @@ export const createPrompt = (
 			return '';
 		}
 
-		const additionalContextPrompt = contentBefore?.length
+		const continueFromHere = contentBefore?.length
 			? sprintf(
 					/** translators: This will be the end of a prompt that will be sent to OpenAI with the last MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT characters of content.*/
 					__( '. Additional context:\n\n … %s', 'jetpack' ), // eslint-disable-line @wordpress/i18n-no-collapsible-whitespace
@@ -76,7 +78,7 @@ export const createPrompt = (
 			/** translators: This will be the beginning of a prompt that will be sent to OpenAI based on the post title. */
 			__( "Please help me write a short piece of a blog post titled '%1$s'%2$s", 'jetpack' ),
 			postTitle,
-			additionalContextPrompt
+			continueFromHere
 		);
 		return titlePrompt + PROMPT_SUFFIX;
 	}
@@ -85,7 +87,7 @@ export const createPrompt = (
 		const expandPrompt = sprintf(
 			/** translators: This will be the end of a prompt that will be sent to OpenAI with the last MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT characters of content.*/
 			__( 'Summarize this:\n\n … %s', 'jetpack' ), // eslint-disable-line @wordpress/i18n-no-collapsible-whitespace
-			contentBefore
+			content
 		);
 
 		return expandPrompt + PROMPT_SUFFIX;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -45,7 +45,11 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		showRetry,
 		contentBefore,
 		postTitle,
+<<<<<<< HEAD
 		retryRequest,
+=======
+		wholeContent,
+>>>>>>> e5b867e863 ([not verified] disable summarize when no content)
 	} = useSuggestionsFromOpenAI( {
 		clientId,
 		content: attributes.content,
@@ -170,6 +174,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				contentBefore={ contentBefore }
 				postTitle={ postTitle }
 				userPrompt={ userPrompt }
+				wholeContent={ wholeContent }
 			/>
 			{ ! loadingImages && resultImages.length > 0 && (
 				<Flex direction="column" style={ { width: '100%' } }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -45,11 +45,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		showRetry,
 		contentBefore,
 		postTitle,
-<<<<<<< HEAD
 		retryRequest,
-=======
 		wholeContent,
->>>>>>> e5b867e863 ([not verified] disable summarize when no content)
 	} = useSuggestionsFromOpenAI( {
 		clientId,
 		content: attributes.content,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/test/edit.js
@@ -54,7 +54,7 @@ describe( 'AIAssistanceEdit', () => {
 		);
 
 		// Summarize
-		expect( createPrompt( '', longContent, '', '', 'summarize' ) ).toBe(
+		expect( createPrompt( '', '', longContent, '', 'summarize' ) ).toBe(
 			'Summarize this:\n\n … ' +
 				longContent.slice( -MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT ) +
 				PROMPT_SUFFIX

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/test/edit.js
@@ -7,7 +7,7 @@ import {
 	createPrompt,
 } from '../create-prompt';
 
-describe( 'AIParagraphEdit', () => {
+describe( 'AIAssistanceEdit', () => {
 	test( 'createPrompt', () => {
 		const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 		const charactersLength = characters.length;
@@ -18,7 +18,7 @@ describe( 'AIParagraphEdit', () => {
 
 		// Test empty posts get falsy
 		expect( createPrompt() ).toBeFalsy();
-		expect( createPrompt( '', [], '', '' ) ).toBeFalsy();
+		expect( createPrompt( '', '', '' ) ).toBeFalsy();
 
 		// Test Title summary - with content but no title
 		expect( createPrompt( '', 'some content', '', '', '', 'titleSummary' ) ).toBeFalsy();
@@ -31,12 +31,12 @@ describe( 'AIParagraphEdit', () => {
 
 		// Test `continue` preceding - with content
 		expect(
-			createPrompt( 'The story of my life', 'whatver the post content is', '', '', '', 'continue' )
+			createPrompt( 'The story of my life', 'whatver the post content is', '', '', 'continue' )
 		).toBe( ' Please continue from here:\n\n … whatver the post content is' + PROMPT_SUFFIX );
 
 		// Test that <BR/> are being translated. And content trimmed
 		expect(
-			createPrompt( 'The story of my life', 'content<br/>content2', '', '', '', 'continue' )
+			createPrompt( 'The story of my life', 'content<br/>content2', '', '', 'continue' )
 		).toBe( ' Please continue from here:\n\n … content\ncontent2' + PROMPT_SUFFIX );
 
 		// Generated based on `title` and `content`.
@@ -54,7 +54,7 @@ describe( 'AIParagraphEdit', () => {
 		);
 
 		// Summarize
-		expect( createPrompt( '', longContent, '', '', '', 'summarize' ) ).toBe(
+		expect( createPrompt( '', longContent, '', '', 'summarize' ) ).toBe(
 			'Summarize this:\n\n … ' +
 				longContent.slice( -MAXIMUM_NUMBER_OF_CHARACTERS_SENT_FROM_CONTENT ) +
 				PROMPT_SUFFIX

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -34,6 +34,30 @@ export function getPartialContentToBlock( clientId ) {
 		.join( '\n' );
 }
 
+/**
+ * Returns content from all blocks,
+ * by inspecting the blocks `content` attributes
+ *
+ * @returns {string} The content.
+ */
+export function getContentFromBlocks() {
+	const editor = selectData( 'core/block-editor' );
+	const blocks = editor.getBlocks();
+
+	if ( ! blocks?.length ) {
+		return '';
+	}
+
+	return blocks
+		.filter( function ( block ) {
+			return block && block.attributes && block.attributes.content;
+		} )
+		.map( function ( block ) {
+			return block.attributes.content.replaceAll( '<br/>', '\n' );
+		} )
+		.join( '\n' );
+}
+
 const useSuggestionsFromOpenAI = ( {
 	clientId,
 	content,
@@ -124,6 +148,7 @@ const useSuggestionsFromOpenAI = ( {
 			: createPrompt(
 					currentPostTitle,
 					getPartialContentToBlock( clientId ),
+					getContentFromBlocks(),
 					categoryNames,
 					tagNames,
 					userPrompt,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -192,7 +192,6 @@ const useSuggestionsFromOpenAI = ( {
 			} );
 	};
 	return {
-		getSuggestionFromOpenAI,
 		isLoadingCategories,
 		isLoadingCompletion,
 		setIsLoadingCategories,
@@ -200,6 +199,9 @@ const useSuggestionsFromOpenAI = ( {
 		showRetry,
 		postTitle: currentPostTitle,
 		contentBefore: getPartialContentToBlock( clientId ),
+		wholeContent: getContentFromBlocks( clientId ),
+
+		getSuggestionFromOpenAI,
 		retryRequest: () => getSuggestionFromOpenAI( '', true ),
 	};
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -149,14 +149,13 @@ const useSuggestionsFromOpenAI = ( {
 					currentPostTitle,
 					getPartialContentToBlock( clientId ),
 					getContentFromBlocks(),
-					categoryNames,
-					tagNames,
 					userPrompt,
-					type
+					type,
+					categoryNames,
+					tagNames
 			  );
 
 		const data = { content: prompt };
-
 		tracks.recordEvent( 'jetpack_ai_gpt3_completion', {
 			post_id: postId,
 		} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR disables/enables the `Summarize` option when there isn't content in the post. Just in case, the content is retrieved from the content attribute of the blocks.

Fixes https://github.com/Automattic/jetpack/issues/30550

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: disable `Summarize` when no content

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create an AI Assistant instance 
* Confirm when it isn't content, the `Summarize` option is disabled
* When content, `Summarize` is enabled
* Confirm the proper prompt when requesting


https://github.com/Automattic/jetpack/assets/77539/1dcb5ba7-4480-4d29-995e-e5c28fcc4fdb

