### PR TITLE
Forms fix salesforce variation discoverability

### DIFF
--- a/projects/packages/forms/changelog/forms-fix-salesforce-variation-discoverability
+++ b/projects/packages/forms/changelog/forms-fix-salesforce-variation-discoverability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Add salesforce form variation alongside default variations for better discoverability. Fix private method for action trigger

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -28,9 +28,7 @@ import CRMIntegrationSettings from './components/jetpack-crm-integration/jetpack
 import JetpackEmailConnectionSettings from './components/jetpack-email-connection-settings';
 import JetpackManageResponsesSettings from './components/jetpack-manage-responses-settings';
 import NewsletterIntegrationSettings from './components/jetpack-newsletter-integration-settings';
-import SalesforceLeadFormSettings, {
-	salesforceLeadFormVariation,
-} from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
+import SalesforceLeadFormSettings from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
 import { withStyleVariables } from './util/with-style-variables';
 import defaultVariations from './variations';
 
@@ -105,10 +103,6 @@ export const JetpackContactFormEdit = forwardRef(
 			!! window?.Jetpack_Editor_Initial_State?.available_blocks[
 				'contact-form/salesforce-lead-form'
 			];
-
-		if ( isSalesForceExtensionEnabled ) {
-			variations = [ ...variations, salesforceLeadFormVariation ];
-		}
 
 		const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
 			const blocks = map( innerBlocksTemplate, ( [ name, attr, innerBlocks = [] ] ) =>

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -2,6 +2,7 @@ import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { compact } from 'lodash';
+import { salesforceLeadFormVariation } from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
 import { getIconColor } from './util/block-icons';
 import renderMaterialIcon from './util/render-material-icon';
 
@@ -366,6 +367,7 @@ const variations = compact( [
 			subject: __( 'New feedback received from your website', 'jetpack-forms' ),
 		},
 	},
+	salesforceLeadFormVariation,
 ] );
 
 export default variations;

--- a/projects/packages/forms/src/service/class-post-to-url.php
+++ b/projects/packages/forms/src/service/class-post-to-url.php
@@ -91,7 +91,7 @@ class Post_To_Url {
 	 *
 	 * @return null|void
 	 */
-	private function feedback_post_hook( $post_id, $form, $is_spam, $entry_values ) {
+	public function feedback_post_hook( $post_id, $form, $is_spam, $entry_values ) {
 		if ( ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
 			return;
 		}


### PR DESCRIPTION
This PR moves the salesforce form variation definition alongside the default variations.

## Proposed changes:
The Salesforce variation is not discoverable because of the way it was being included. With this change, the variation becomes discoverable from the inserter:
<img width="325" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/0b9d98e1-aa9f-4f74-b23a-01a3c1e5e682">

The changes also fix a class method by making it public as the action trigger can't execute on private methods.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Checkout and install/build:
```
jetpack install packages/forms && jetpack build packages/forms
```

Create a post and use the block inserter to search for the Salesforce variation (salesforce, lead). Inserter should show the variation. Insert on post and fill the Organization ID setting. Test published post by filling the form and confirm the lead is created on the Salesforce instance.
