### PR TITLE
AI Assistant: Disable request button when no user prompt provided

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assitant-disable-request-when-no-user-prompt
+++ b/projects/plugins/jetpack/changelog/update-ai-assitant-disable-request-when-no-user-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Disable request button when not user prompt provided

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -113,7 +113,7 @@ const ToolbarControls = ( {
 						</>
 					) }
 
-					{ ! showRetry && ! contentIsLoaded && contentBefore?.length && (
+					{ !! ( ! showRetry && ! contentIsLoaded && contentBefore?.length ) && (
 						<ToolbarButton icon={ pencil } onClick={ () => getSuggestionFromOpenAI( 'continue' ) }>
 							{ __( 'Continue writing', 'jetpack' ) }
 						</ToolbarButton>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -24,6 +24,7 @@ const AIControl = ( {
 	loadingImages,
 	placeholder,
 	setAiType,
+	userPrompt,
 	setUserPrompt,
 	showRetry,
 	contentBefore,
@@ -72,7 +73,7 @@ const AIControl = ( {
 					<Button
 						onClick={ () => handleGetSuggestion() }
 						isSmall={ true }
-						disabled={ isWaitingState }
+						disabled={ isWaitingState || ! userPrompt?.length }
 						label={ __( 'Do some magic!', 'jetpack' ) }
 					>
 						<Icon icon={ arrowRight } />

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -165,6 +165,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 				setAiType={ setAiType }
 				setUserPrompt={ setUserPrompt }
 				contentBefore={ contentBefore }
+				userPrompt={ userPrompt }
 			/>
 			{ ! loadingImages && resultImages.length > 0 && (
 				<Flex direction="column" style={ { width: '100%' } }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes two visdual issues:

* Remove an undesired `0` from the toolbar
* Disables the request button when there isn't user user prompt

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: Disable request button when not user prompt provided

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit an AI Assitant block instance
* Confirm the `0` is not there
<img width="478" alt="Screenshot 2023-05-09 at 17 34 57" src="https://github.com/Automattic/jetpack/assets/77539/6627d5f2-fe6d-418a-ad54-73755705c91c">


* Confirm the request button gets disabled when there isn't user prompt content provided by the user

before | after
-----|----
<img width="452" alt="Screenshot 2023-05-09 at 17 34 04" src="https://github.com/Automattic/jetpack/assets/77539/7b83ab9f-39ff-40dd-924f-e3aa3abf7990"> | <img width="458" alt="Screenshot 2023-05-09 at 17 28 37" src="https://github.com/Automattic/jetpack/assets/77539/cac796a8-5d93-4255-9935-1f9b8d24f8c6">
