### PR TITLE
CRM: fix undefined variable `$order_id` in `get_transaction_from_order_num()`

### DIFF
--- a/projects/plugins/crm/changelog/fix-order-id-crm-warning
+++ b/projects/plugins/crm/changelog/fix-order-id-crm-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Woo Sync module: fix PHP Warning.

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1212,7 +1212,7 @@ class Woo_Sync {
 
 		$source_args = array(
 			'externalSource'    => 'woo',
-			'externalSourceUID' => $order_id,
+			'externalSourceUID' => $order_num,
 			'origin'            => $origin,
 		);
 


### PR DESCRIPTION
This resolves a PHP Warning in the CRM's Woo Sync module: `Undefined variable $order_id in zero-bs-crm/modules/woo-sync/includes/class-woo-sync.php on line 1215`

## Proposed changes:
* Use the available `$order_num` instead of `$order_id`

(GitHub's UI added the newline change at the end of the file, hopefully that's okay)

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

TBD