### PR TITLE
Odyssey Stats: add several configs for Odyssey

### DIFF
--- a/projects/packages/stats-admin/changelog/update-add-several-configs-odyssey
+++ b/projects/packages/stats-admin/changelog/update-add-several-configs-odyssey
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats Admin: adds versions and platform info to Odyssey config data

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -50,7 +50,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.7.x-dev"
+			"dev-trunk": "0.8.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.7.3",
+	"version": "0.8.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.7.3';
+	const VERSION = '0.8.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
 
 /**
@@ -33,8 +34,12 @@ class Odyssey_Config_Data {
 	 * Return the config for the app.
 	 */
 	public function get_data() {
+		global $wp_version;
+
 		$blog_id      = Jetpack_Options::get_option( 'id' );
 		$empty_object = json_decode( '{}' );
+		$host         = new Host();
+
 		return array(
 			'admin_page_base'                => $this->get_admin_path(),
 			'api_root'                       => esc_url_raw( rest_url() ),
@@ -55,8 +60,9 @@ class Odyssey_Config_Data {
 			'features'                       => array(),
 			// Intended for apps that do not use redux.
 			'gmt_offset'                     => $this->get_gmt_offset(),
-			// TODO: check whether this works with Pressable.
 			'odyssey_stats_base_url'         => admin_url( 'admin.php?page=stats' ),
+			'stats_admin_version'            => Main::VERSION,
+			'wp_version'                     => $wp_version,
 			'intial_state'                   => array(
 				'currentUser' => array(
 					'id'           => 1000,
@@ -71,19 +77,21 @@ class Odyssey_Config_Data {
 				'sites'       => array(
 					'items'    => array(
 						"$blog_id" => array(
-							'ID'            => $blog_id,
-							'URL'           => site_url(),
-							'jetpack'       => true,
-							'visible'       => true,
-							'capabilities'  => $empty_object,
-							'products'      => array(),
-							'plan'          => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
-							'options'       => array(
+							'ID'              => $blog_id,
+							'URL'             => site_url(),
+							'is_wpcom_atomic' => $host->is_woa_site(),
+							'is_vip'          => $host->is_vip_site(),
+							'jetpack'         => true,
+							'visible'         => true,
+							'capabilities'    => $empty_object,
+							'products'        => array(),
+							'plan'            => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
+							'options'         => array(
 								'wordads'    => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url'  => admin_url(),
 								'gmt_offset' => $this->get_gmt_offset(),
 							),
-							'stats_notices' => ( new Notices() )->get_notices_to_show(),
+							'stats_notices'   => ( new Notices() )->get_notices_to_show(),
 						),
 					),
 					'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -77,21 +77,23 @@ class Odyssey_Config_Data {
 				'sites'       => array(
 					'items'    => array(
 						"$blog_id" => array(
-							'ID'              => $blog_id,
-							'URL'             => site_url(),
-							'is_wpcom_atomic' => $host->is_woa_site(),
-							'is_vip'          => $host->is_vip_site(),
-							'jetpack'         => true,
-							'visible'         => true,
-							'capabilities'    => $empty_object,
-							'products'        => array(),
-							'plan'            => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
-							'options'         => array(
-								'wordads'    => ( new Modules() )->is_active( 'wordads' ),
-								'admin_url'  => admin_url(),
-								'gmt_offset' => $this->get_gmt_offset(),
+							'ID'            => $blog_id,
+							'URL'           => site_url(),
+							'jetpack'       => true,
+							'visible'       => true,
+							'capabilities'  => $empty_object,
+							'products'      => array(),
+							'plan'          => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
+							'options'       => array(
+								'wordads'               => ( new Modules() )->is_active( 'wordads' ),
+								'admin_url'             => admin_url(),
+								'gmt_offset'            => $this->get_gmt_offset(),
+								'is_automated_transfer' => $host->is_woa_site(),
+								'is_wpcom_atomic'       => $host->is_woa_site(),
+								'is_vip'                => $host->is_vip_site(),
+								'jetpack_version'       => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
 							),
-							'stats_notices'   => ( new Notices() )->get_notices_to_show(),
+							'stats_notices' => ( new Notices() )->get_notices_to_show(),
 						),
 					),
 					'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -61,8 +61,6 @@ class Odyssey_Config_Data {
 			// Intended for apps that do not use redux.
 			'gmt_offset'                     => $this->get_gmt_offset(),
 			'odyssey_stats_base_url'         => admin_url( 'admin.php?page=stats' ),
-			'stats_admin_version'            => Main::VERSION,
-			'wp_version'                     => $wp_version,
 			'intial_state'                   => array(
 				'currentUser' => array(
 					'id'           => 1000,
@@ -92,6 +90,8 @@ class Odyssey_Config_Data {
 								'is_wpcom_atomic'       => $host->is_woa_site(),
 								'is_vip'                => $host->is_vip_site(),
 								'jetpack_version'       => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
+								'stats_admin_version'   => Main::VERSION,
+								'software_version'      => $wp_version,
 							),
 							'stats_notices' => ( new Notices() )->get_notices_to_show(),
 						),

--- a/projects/plugins/jetpack/changelog/update-add-several-configs-odyssey
+++ b/projects/plugins/jetpack/changelog/update-add-several-configs-odyssey
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2281,7 +2281,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "1e07ddecf105bbe32e3f69e6654449594aa53e00"
+                "reference": "cc191277c2f3d7980556703070eb3e5e7d6c0ad3"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2303,7 +2303,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.7.x-dev"
+                    "dev-trunk": "0.8.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
## Proposed changes:

The PR proposes to add several configs for Odyssey, including

- `is_wpcom_atomic`
- `is_automated_transfer`
- `is_vip`
- `stats_admin_version`
- `software_version` <- wp version
- `jetpack_version`

So that the front end could decide which platform it's on and also the version of the API and WP (providing reactjs etc).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

- Spin up a JN site
- Navigate to `/wp-admin/`
- Open console
- Ensure `window.jetpackStatsOdysseyWidgetConfigData` has the key/value pairs added in the PR
