### PR TITLE
Load wpcom block editor styles in atomic sites

### DIFF
--- a/projects/plugins/jetpack/changelog/add-wpcom-block-editor-wpcom-editor-styles
+++ b/projects/plugins/jetpack/changelog/add-wpcom-block-editor-wpcom-editor-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Load wpcom block editor styles

--- a/projects/plugins/jetpack/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/projects/plugins/jetpack/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -363,6 +363,14 @@ class Jetpack_WPCOM_Block_Editor {
 				$version,
 				true
 			);
+			wp_enqueue_style(
+				'wpcom-block-editor-wpcom-editor-styles',
+				$debug
+					? '//widgets.wp.com/wpcom-block-editor/wpcom.editor.css?minify=false'
+					: '//widgets.wp.com/wpcom-block-editor/wpcom.editor.min.css',
+				array(),
+				$version
+			);
 		}
 
 		if ( $this->is_iframed_block_editor() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/76321
Fixes https://github.com/Automattic/wp-calypso/issues/73445
Related to https://github.com/Automattic/wp-calypso/pull/72944

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Load wpcom block editor styles in atomic sites

### Other information:

- [ ] ~Have you written new tests for your changes, if applicable?~
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/post-new.php` on an atomic site (for simple sites, it should already be loaded)
* Check in Network tab if `wpcom.editor.min.css` is loaded
![css loaded](https://github.com/Automattic/jetpack/assets/6586048/481413c7-aed4-42d2-b52f-073e3851c20b)


