### PR TITLE
Image CDN: Fix compatibility on simple sites

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-legacy-photon-calls
+++ b/projects/packages/image-cdn/changelog/fix-legacy-photon-calls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added `is_enabled()` method to check if image CDN is enabled by any plugin'

--- a/projects/packages/image-cdn/package.json
+++ b/projects/packages/image-cdn/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-image-cdn",
-	"version": "0.2.0",
+	"version": "0.2.1-alpha",
 	"description": "Serve images through Jetpack's powerful CDN",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/image-cdn/#readme",
 	"bugs": {

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -46,6 +46,15 @@ final class Image_CDN {
 	private static $image_sizes = null;
 
 	/**
+	 * Weather Image CDN is enabled or not.
+	 *
+	 * This class will be instantiated if any plugin has activated image CDN module. Keeping this variable to check if module is active or not.
+	 *
+	 * @var bool Weather Image CDN is enabled or not.
+	 */
+	private static $is_enabled = false;
+
+	/**
 	 * Singleton implementation
 	 *
 	 * @return object
@@ -54,6 +63,7 @@ final class Image_CDN {
 		if ( ! is_a( self::$instance, self::class ) ) {
 			self::$instance = new self();
 			self::$instance->setup();
+			self::$is_enabled = true;
 		}
 
 		return self::$instance;
@@ -65,6 +75,13 @@ final class Image_CDN {
 	private function __construct() {}
 
 	/**
+	 * Check if image CDN is enabled as a module from Jetpack or any other plugin.
+	 */
+	public static function is_enabled() {
+		return self::$is_enabled;
+	}
+
+	/**
 	 * Register actions and filters, but only if basic Photon functions are available.
 	 * The basic functions are found in ./functions.photon.php.
 	 *
@@ -72,8 +89,12 @@ final class Image_CDN {
 	 * @return void
 	 */
 	private function setup() {
-		// Let other plugins know that we're setting up image CDN module.
-		do_action( 'jetpack_image_cdn_setup' );
+		/*
+		 * Add a filter to easily apply image CDN urls without applying all `the_content` filters to any content.
+		 *
+		 * Since this is only applied if the module is active in Jetpack or any other plugin, it's safe to use without checking if the module is active.
+		 */
+		add_filter( 'jetpack_image_cdn_content', array( __CLASS__, 'filter_the_content' ), 10 );
 
 		// Images in post content and galleries and widgets.
 		add_filter( 'the_content', array( __CLASS__, 'filter_the_content' ), 999999 );

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -46,7 +46,7 @@ final class Image_CDN {
 	private static $image_sizes = null;
 
 	/**
-	 * Weather Image CDN is enabled or not.
+	 * Whether Image CDN is enabled or not.
 	 *
 	 * This class will be instantiated if any plugin has activated image CDN module. Keeping this variable to check if module is active or not.
 	 *

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -72,6 +72,9 @@ final class Image_CDN {
 	 * @return void
 	 */
 	private function setup() {
+		// Let other plugins know that we're setting up image CDN module.
+		do_action( 'jetpack_image_cdn_setup' );
+
 		// Images in post content and galleries and widgets.
 		add_filter( 'the_content', array( __CLASS__, 'filter_the_content' ), 999999 );
 		add_filter( 'get_post_galleries', array( __CLASS__, 'filter_the_galleries' ), 999999 );

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -89,10 +89,10 @@ final class Image_CDN {
 	 * @return void
 	 */
 	private function setup() {
-		/*
+		/**
 		 * Add a filter to easily apply image CDN urls without applying all `the_content` filters to any content.
 		 *
-		 * Since this is only applied if the module is active in Jetpack or any other plugin, it's safe to use without checking if the module is active.
+		 * Since this is only applied if the module is active in Jetpack or any other plugin, it's a safe option to apply photon urls to any content.
 		 */
 		add_filter( 'jetpack_image_cdn_content', array( __CLASS__, 'filter_the_content' ), 10 );
 

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Assets;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.2.0';
+	const PACKAGE_VERSION = '0.2.1-alpha';
 
 	/**
 	 * Singleton.

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -50,7 +50,7 @@ final class Image_CDN {
 	 *
 	 * This class will be instantiated if any plugin has activated image CDN module. Keeping this variable to check if module is active or not.
 	 *
-	 * @var bool Weather Image CDN is enabled or not.
+	 * @var bool Whether Image CDN is enabled or not.
 	 */
 	private static $is_enabled = false;
 

--- a/projects/plugins/jetpack/3rd-party/bbpress.php
+++ b/projects/plugins/jetpack/3rd-party/bbpress.php
@@ -7,6 +7,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Image_CDN\Image_CDN;
+
 // Priority 11 needed to ensure sharing_display is loaded.
 add_action( 'init', 'jetpack_bbpress_compat', 11 );
 
@@ -49,7 +51,7 @@ function jetpack_bbpress_compat() {
 	 *
 	 * @since 4.9.0
 	 */
-	if ( class_exists( 'Automattic\Jetpack\Image_CDN\Image_CDN' ) && Jetpack::is_module_active( 'photon' ) ) {
+	if ( class_exists( 'Automattic\Jetpack\Image_CDN\Image_CDN' ) && Image_CDN::is_enabled() ) {
 		add_filter( 'bbp_get_topic_content', array( Image_CDN::class, 'filter_the_content' ), 999999 );
 		add_filter( 'bbp_get_reply_content', array( Image_CDN::class, 'filter_the_content' ), 999999 );
 	}

--- a/projects/plugins/jetpack/3rd-party/bbpress.php
+++ b/projects/plugins/jetpack/3rd-party/bbpress.php
@@ -51,7 +51,7 @@ function jetpack_bbpress_compat() {
 	 *
 	 * @since 4.9.0
 	 */
-	if ( class_exists( 'Automattic\Jetpack\Image_CDN\Image_CDN' ) && Image_CDN::is_enabled() ) {
+	if ( class_exists( Image_CDN::class ) && Image_CDN::is_enabled() ) {
 		add_filter( 'bbp_get_topic_content', array( Image_CDN::class, 'filter_the_content' ), 999999 );
 		add_filter( 'bbp_get_reply_content', array( Image_CDN::class, 'filter_the_content' ), 999999 );
 	}

--- a/projects/plugins/jetpack/changelog/fix-legacy-photon-calls
+++ b/projects/plugins/jetpack/changelog/fix-legacy-photon-calls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix compatibility issue in simple sites due to image CDN package

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -770,7 +770,7 @@ class Jetpack_PostImages {
 		}
 
 		// Use image cdn magic.
-		if ( class_exists( 'Automattic\Jetpack\Image_CDN\Image_CDN_Core' ) && method_exists( Image_CDN_Core::class, 'cdn_url' ) ) {
+		if ( class_exists( Image_CDN_Core::class ) && method_exists( Image_CDN_Core::class, 'cdn_url' ) ) {
 			return Image_CDN_Core::cdn_url( $src, array( 'resize' => "$width,$height" ) );
 		}
 

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery.php
@@ -218,7 +218,7 @@ class Jetpack_Tiled_Gallery {
 			$gallery       = new $gallery_class( $attachments, $this->atts['link'], $this->atts['grayscale'], (int) $this->atts['columns'] );
 			$gallery_html  = $gallery->HTML();
 
-			if ( $gallery_html && class_exists( 'Jetpack' ) && class_exists( 'Automattic\Jetpack\Image_CDN\Image_CDN' ) ) {
+			if ( $gallery_html && class_exists( 'Jetpack' ) && class_exists( Image_CDN::class ) ) {
 				// Tiled Galleries in Jetpack require that Photon be active.
 				// If it's not active, run it just on the gallery output.
 				if ( ! Image_CDN::is_enabled() && ! ( new Status() )->is_offline_mode() ) {

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery.php
@@ -221,7 +221,7 @@ class Jetpack_Tiled_Gallery {
 			if ( $gallery_html && class_exists( 'Jetpack' ) && class_exists( 'Automattic\Jetpack\Image_CDN\Image_CDN' ) ) {
 				// Tiled Galleries in Jetpack require that Photon be active.
 				// If it's not active, run it just on the gallery output.
-				if ( ! in_array( 'photon', Jetpack::get_active_modules(), true ) && ! ( new Status() )->is_offline_mode() ) {
+				if ( ! Image_CDN::is_enabled() && ! ( new Status() )->is_offline_mode() ) {
 					$gallery_html = Image_CDN::filter_the_content( $gallery_html );
 				}
 			}

--- a/projects/plugins/jetpack/modules/widgets/flickr.php
+++ b/projects/plugins/jetpack/modules/widgets/flickr.php
@@ -3,8 +3,6 @@
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
 
-use Automattic\Jetpack\Image_CDN\Image_CDN;
-
 /**
  * Disable direct access/execution to/of the widget code.
  */
@@ -142,8 +140,8 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 					$photos .= 'title="' . esc_attr( $photo->get_title() ) . '" ';
 					$photos .= ' /></a>';
 				}
-				if ( ! empty( $photos ) && class_exists( 'Automattic\Jetpack\Image_CDN\Image_CDN' ) && Jetpack::is_module_active( 'photon' ) ) {
-					$photos = Image_CDN::filter_the_content( $photos );
+				if ( ! empty( $photos ) ) {
+					$photos = apply_filters( 'jetpack_image_cdn_content', $photos );
 				}
 
 				$flickr_home = $rss->get_link(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Used in flickr/widget.php template file.

--- a/projects/plugins/jetpack/modules/widgets/image-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/image-widget.php
@@ -6,8 +6,6 @@
  * First Introduced: 1.2
  */
 
-use Automattic\Jetpack\Image_CDN\Image_CDN;
-
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
 add_action( 'widgets_init', 'jetpack_image_widget_init', 11 );
@@ -100,9 +98,7 @@ class Jetpack_Image_Widget extends WP_Widget {
 			}
 			$output .= '/>';
 
-			if ( class_exists( 'Automattic\Jetpack\Image_CDN\Image_CDN' ) && Jetpack::is_module_active( 'photon' ) ) {
-				$output = Image_CDN::filter_the_content( $output );
-			}
+			$output = apply_filters( 'jetpack_image_cdn_content', $output );
 
 			if ( $instance['link'] ) {
 				$target = ! empty( $instance['link_target_blank'] )


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added an `Image_CDN::is_enabled()` method to check if the image CDN is activated by any plugin, i.e. Jetpack, Boost
* Added a `jetpack_image_cdn_content` filter that changes images to serve from CDN if the module is active.
* Updated references in Jetpack to use the above two methods.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1683660632289889-slack-C4N88L95W

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Make sure the tiled gallery, flicker widget and image widget still work.