### PR TITLE
AI Assistant: Disable content expansion when there is no previous content

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-expand-disable
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-expand-disable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Disable content expansion when there is no previous content

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -148,6 +148,7 @@ const ToolbarControls = ( {
 								{
 									title: __( 'Expand on preceding content', 'jetpack' ),
 									onClick: () => getSuggestionFromOpenAI( 'continue' ),
+									isDisabled: ! contentBefore?.length,
 								},
 							] }
 						/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30569

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disables the `Expand on preceding content` button when there is no content above the block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add an AI Assistant block
* Check that if there is content before the block, the option is enabled
* Check that if there is no content before, the option is disabled

https://github.com/Automattic/jetpack/assets/8486249/b8b4c614-205c-401b-ac9c-e03b1320c29e
