### PR TITLE
AI Assistant: make the block content persistent

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-store-content-persistently
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-store-content-persistently
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: make the block content persistent

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
@@ -1,6 +1,5 @@
 export default {
 	content: {
 		type: 'string',
-		source: 'html',
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -113,7 +113,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 
 	const placeholder =
 		aiType === 'text'
-			? __( 'Write a paragraph about …', 'jetpack' )
+			? __( 'Ask AI to write anything…', 'jetpack' )
 			: __( 'What would you like to see?', 'jetpack', /* dummy arg to avoid bad minification */ 0 );
 
 	const handleGetSuggestion = type => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/30594

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: make the block content persistent

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create an AI Assistant block instance
* Do not accept the content (Do not click on DONE button)
* Save the post
* Hard refresh
* **Before**: block doesn't contain content
* **After**: the b;ock shows the previeos generated content


https://github.com/Automattic/jetpack/assets/77539/6e2be6d4-76fe-42cf-a861-08895d0a2894



