### PR TITLE
Fix/plugins modify endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-plugins-modify-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-plugins-modify-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes the Plugins_Modify endpoint to correct declare $args

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -153,6 +153,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	 * @return bool|WP_Error
 	 */
 	public function callback( $path = '', $blog_id = 0, $object = null ) {
+		$args = $this->input();
+
 		Jetpack_JSON_API_Endpoint::validate_input( $object );
 		switch ( $this->action ) {
 			case 'delete':

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -153,7 +153,6 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	 * @return bool|WP_Error
 	 */
 	public function callback( $path = '', $blog_id = 0, $object = null ) {
-		$args = $this->input();
 
 		Jetpack_JSON_API_Endpoint::validate_input( $object );
 		switch ( $this->action ) {
@@ -169,7 +168,9 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				break;
 		}
 
-		if ( isset( $args['autoupdate'] ) || isset( $args['autoupdate_translations'] ) ) {
+		$args = $this->input();
+
+		if ( is_array( $args ) && ( isset( $args['autoupdate'] ) || isset( $args['autoupdate_translations'] ) ) ) {
 			$this->needed_capabilities = 'update_plugins';
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The `Plugins_Modify` endpoint references `$args` for a check on [line 170](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php#L170) but `$args` is never defined.

This adds a declaration for `$args` in the same fashion we do elsewhere in the endpoint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Visual inspection.

