### PR TITLE
AI Assistant: Add option to simplify preceding text

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-simplify-text-option
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-simplify-text-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add option to simplify preceding content.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -164,6 +164,11 @@ const ToolbarControls = ( {
 									onClick: () => getSuggestionFromOpenAI( 'continue' ),
 									isDisabled: ! contentBefore?.length,
 								},
+								{
+									title: __( 'Simplify preceding content', 'jetpack' ),
+									onClick: () => getSuggestionFromOpenAI( 'simplify' ),
+									isDisabled: ! contentBefore?.length,
+								},
 							] }
 						/>
 					) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -111,6 +111,20 @@ export const createPrompt = (
 		return expandPrompt + PROMPT_SUFFIX;
 	}
 
+	if ( type === 'simplify' ) {
+		if ( ! contentBefore?.length ) {
+			return '';
+		}
+
+		const simplifyPrompt = sprintf(
+			'The selected text should be simplified to use words and phrases that are easier to understand. Output in the same language as the user%1$s. Selected text:\n\n%2$s',
+			PROMPT_SUFFIX,
+			contentBefore
+		);
+
+		return simplifyPrompt;
+	}
+
 	// TODO: add some error handling if user supplied prompts or existing content is too short.
 
 	// We prevent a prompt if everything is empty.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -117,7 +117,7 @@ export const createPrompt = (
 		}
 
 		const simplifyPrompt = sprintf(
-			'The selected text should be simplified to use words and phrases that are easier to understand. Output in the same language as the user%1$s. Selected text:\n\n%2$s',
+			'The selected text should be simplified to use words and phrases that are easier to understand for non-technical people. Output in the same language as the user%1$s. Selected text:\n\n%2$s',
 			PROMPT_SUFFIX,
 			contentBefore
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30595 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add "Simplify preceding content" option to the menu to trigger the `simplify` action
* Add prompt generation for the `simplify` action

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add some content to be simplified (tip: use AI Assistant itself to generate a couple of paragraphs on some complex topic)
* Add the AI Assistant block, click the options menu and click "Simplify preceding content":

<img width="400" alt="Screen Shot 2023-05-10 at 15 01 57" src="https://github.com/Automattic/jetpack/assets/6760046/062055cc-0d43-4dd3-9792-e1a863b812d3">

* Notice that the options is only active when there is preceding content to process:

<img width="400" alt="Screen Shot 2023-05-10 at 15 02 45" src="https://github.com/Automattic/jetpack/assets/6760046/e049a179-7837-44da-bb57-8e4e214bc754">

* Notice that it takes into account just the content preceding the AI Assistant block, ignoring what is after it
* Notice that it returns the response on the same language as the content:

<img width="400" alt="Screen Shot 2023-05-10 at 15 03 11" src="https://github.com/Automattic/jetpack/assets/6760046/69e296d0-e406-4433-b8b0-4d98e7082b94">

* English example:

<img width="400" alt="Screen Shot 2023-05-10 at 15 10 26" src="https://github.com/Automattic/jetpack/assets/6760046/e27a1e23-4afb-4579-9726-38a98984c7e6">
