### PR TITLE
Jetpack: set default plan-icon image path

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
@@ -145,11 +145,12 @@ const DEFAULT_SIZE = 32;
 export default class PlanIcon extends Component {
 	render() {
 		const { className, alt, plan } = this.props;
+		const icon = PRODUCT_ICON_MAP[ plan ] || PRODUCT_ICON_MAP[ PLAN_FREE ];
 
 		return (
 			<img
 				className={ className }
-				src={ imagePath + PRODUCT_ICON_MAP[ plan ] }
+				src={ imagePath + icon }
 				width={ DEFAULT_SIZE }
 				height={ DEFAULT_SIZE }
 				alt={ alt || '' }

--- a/projects/plugins/jetpack/changelog/update-use-default-plan-icon
+++ b/projects/plugins/jetpack/changelog/update-use-default-plan-icon
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack: set default plan-icon image path
+
+


### PR DESCRIPTION
## Proposed changes:

Sets a default image plan icon to use, follow-up to #30612

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Follow-up to #30612

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

TBD
