### PR TITLE
AI Assistant: Implement streaming client

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-streaming-alternative
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-streaming-alternative
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: not needed. changes on unpublished block
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -20,7 +20,6 @@ import ToneDropdownControl from './tone-dropdown-control';
 
 const AIControl = ( {
 	aiType,
-	animationDone,
 	contentIsLoaded,
 	getSuggestionFromOpenAI,
 	retryRequest,
@@ -82,7 +81,7 @@ const AIControl = ( {
 			{ ! isWaitingState && (
 				<ToolbarControls
 					aiType={ aiType }
-					animationDone={ animationDone }
+					isWaitingState={ isWaitingState }
 					contentIsLoaded={ contentIsLoaded }
 					getSuggestionFromOpenAI={ getSuggestionFromOpenAI }
 					retryRequest={ retryRequest }
@@ -128,7 +127,6 @@ export default AIControl;
 
 const ToolbarControls = ( {
 	aiType,
-	animationDone,
 	contentIsLoaded,
 	getSuggestionFromOpenAI,
 	retryRequest,
@@ -144,7 +142,7 @@ const ToolbarControls = ( {
 } ) => {
 	return (
 		<>
-			{ contentIsLoaded && animationDone && (
+			{ contentIsLoaded && (
 				<BlockControls group="block">
 					<ToneDropdownControl
 						value="neutral"
@@ -191,7 +189,7 @@ const ToolbarControls = ( {
 				{ aiType === 'text' && (
 					// Text controls
 					<ToolbarGroup>
-						{ ! showRetry && contentIsLoaded && animationDone && (
+						{ ! showRetry && contentIsLoaded && (
 							<>
 								{ promptType === 'generateTitle' ? (
 									<ToolbarButton onClick={ handleAcceptTitle }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -6,7 +6,7 @@ import { useBlockProps, store as blockEditorStore } from '@wordpress/block-edito
 import { rawHandler, createBlock } from '@wordpress/blocks';
 import { Flex, FlexBlock, Modal } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { RawHTML, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import MarkdownIt from 'markdown-it';
 /**
@@ -15,7 +15,6 @@ import MarkdownIt from 'markdown-it';
 import AIControl from './ai-control';
 import ImageWithSelect from './image-with-select';
 import { getImagesFromOpenAI } from './lib';
-import ShowLittleByLittle from './show-little-by-little';
 import useSuggestionsFromOpenAI from './use-suggestions-from-openai';
 import './editor.scss';
 
@@ -27,7 +26,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	const [ userPrompt, setUserPrompt ] = useState();
 	const [ , setErrorMessage ] = useState( false );
 	const [ aiType, setAiType ] = useState( 'text' );
-	const [ animationDone, setAnimationDone ] = useState( false );
 	const [ loadingImages, setLoadingImages ] = useState( false );
 	const [ resultImages, setResultImages ] = useState( [] );
 	const [ imageModal, setImageModal ] = useState( null );
@@ -151,19 +149,13 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		<div { ...useBlockProps() }>
 			{ contentIsLoaded && (
 				<>
-					<ShowLittleByLittle
-						showAnimation={ ! animationDone }
-						onAnimationDone={ () => {
-							setAnimationDone( true );
-						} }
-						clientId={ clientId }
-						markdown={ attributes.content }
-					/>
+					<div className="jetpack-ai-assistant__content">
+						<RawHTML>{ attributes.content }</RawHTML>
+					</div>
 				</>
 			) }
 			<AIControl
 				aiType={ aiType }
-				animationDone={ animationDone }
 				content={ attributes.content }
 				contentIsLoaded={ contentIsLoaded }
 				getSuggestionFromOpenAI={ getSuggestionFromOpenAI }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -150,7 +150,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			{ contentIsLoaded && (
 				<>
 					<div className="jetpack-ai-assistant__content">
-						<RawHTML>{ attributes.content }</RawHTML>
+						<RawHTML>{ markdownConverter.render( attributes.content ) }</RawHTML>
 					</div>
 				</>
 			) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -246,122 +246,16 @@ const useSuggestionsFromOpenAI = ( {
 
 		if ( ! options.retryRequest ) {
 			// If there is a content already, let's iterate over it.
-			switch ( type ) {
-				/*
-				 * Generate content from title.
-				 */
-				case 'titleSummary':
-					prompt = buildPromptTemplate( {
-						request:
-							'Please help me write a short piece for a blog post based on the content below',
-						content: currentPostTitle,
-					} );
-					break;
-
-				/*
-				 * Continue generating from the content below.
-				 */
-				case 'continue':
-					prompt = buildPromptTemplate( {
-						request: 'Please continue writing from the content below.',
-						rules: [ 'Only output the continuation of the content, without repeating it' ],
-						content: getPartialContentToBlock( clientId ),
-					} );
-					break;
-
-				/*
-				 * Change the tone of the content.
-				 */
-				case 'changeTone':
-					prompt = buildPromptTemplate( {
-						request: `Please, rewrite with a ${ options.tone } tone.`,
-						content,
-					} );
-					break;
-
-				/*
-				 * Summarize the content.
-				 */
-				case 'summarize':
-					prompt = buildPromptTemplate( {
-						request: 'Summarize the content below.',
-						content: content?.length ? content : getContentFromBlocks(),
-					} );
-					break;
-
-				/*
-				 * Make the content longer.
-				 */
-				case 'makeLonger':
-					prompt = buildPromptTemplate( {
-						request: 'Make the content below longer.',
-						content,
-					} );
-					break;
-
-				/*
-				 * Make the content shorter.
-				 */
-				case 'makeShorter':
-					prompt = buildPromptTemplate( {
-						request: 'Make the content below shorter.',
-						content,
-					} );
-					break;
-
-				/*
-				 * Generate a title for this blog post, based on the content.
-				 */
-				case 'generateTitle':
-					prompt = buildPromptTemplate( {
-						request: 'Generate a title for this blog post',
-						rules: [ 'Only output the raw title, without any prefix or quotes' ],
-						content: content?.length ? content : getContentFromBlocks(),
-					} );
-					break;
-
-				/*
-				 * Simplify the content.
-				 */
-				case 'simplify':
-					prompt = buildPromptTemplate( {
-						request: 'Simplify the content below.',
-						rules: [
-							'Use words and phrases that are easier to understand for non-technical people',
-							'Output in the same language of the content',
-							'Use as much of the original language as possible',
-						],
-						content: content?.length ? content : getContentFromBlocks(),
-					} );
-					break;
-
-				/**
-				 * Correct grammar and spelling
-				 */
-				case 'correctSpelling':
-					prompt = buildPromptTemplate( {
-						request: 'Correct any spelling and grammar mistakes from the content below.',
-						content: content?.length ? content : getContentFromBlocks(),
-					} );
-					break;
-
-				/**
-				 * Change the language, based on options.language
-				 */
-				case 'changeLanguage':
-					prompt = buildPromptTemplate( {
-						request: `Please, rewrite in the following language: ${ options.language }`,
-						content: content?.length ? content : getContentFromBlocks(),
-					} );
-					break;
-
-				default:
-					prompt = buildPromptTemplate( {
-						request: userPrompt,
-						content,
-					} );
-					break;
-			}
+			prompt = buildPrompt( {
+				content,
+				currentPostTitle,
+				contentFromBlocks: getContentFromBlocks(),
+				partialContentAsBlock: getPartialContentToBlock( clientId ),
+				options,
+				prompt,
+				userPrompt,
+				type,
+			} );
 		}
 
 		tracks.recordEvent( 'jetpack_ai_gpt3_completion', {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -5,13 +5,16 @@ import apiFetch from '@wordpress/api-fetch';
 import { useSelect, select as selectData } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
 import { buildPrompt } from './create-prompt';
-import { askJetpack } from './get-suggestion-with-stream';
+import { askJetpack, askQuestion } from './get-suggestion-with-stream';
 import { defaultPromptLanguage } from './i18n-dropdown-control';
 import { DEFAULT_PROMPT_TONE } from './tone-dropdown-control';
+
+const debug = debugFactory( 'jetpack:ai-assistant' );
 
 /**
  * Returns partial content from the beginning of the post
@@ -223,6 +226,196 @@ const useSuggestionsFromOpenAI = ( {
 				setIsLoadingCompletion( false );
 			} );
 	};
+
+	const getStreamedSuggestionFromOpenAI = async ( type, options = {} ) => {
+		options = {
+			retryRequest: false,
+			tone: DEFAULT_PROMPT_TONE,
+			language: defaultPromptLanguage,
+			...options,
+		};
+
+		if ( isLoadingCompletion ) {
+			return;
+		}
+
+		setShowRetry( false );
+		setErrorMessage( false );
+
+		let prompt = lastPrompt;
+
+		if ( ! options.retryRequest ) {
+			// If there is a content already, let's iterate over it.
+			switch ( type ) {
+				/*
+				 * Generate content from title.
+				 */
+				case 'titleSummary':
+					prompt = buildPromptTemplate( {
+						request:
+							'Please help me write a short piece for a blog post based on the content below',
+						content: currentPostTitle,
+					} );
+					break;
+
+				/*
+				 * Continue generating from the content below.
+				 */
+				case 'continue':
+					prompt = buildPromptTemplate( {
+						request: 'Please continue writing from the content below.',
+						rules: [ 'Only output the continuation of the content, without repeating it' ],
+						content: getPartialContentToBlock( clientId ),
+					} );
+					break;
+
+				/*
+				 * Change the tone of the content.
+				 */
+				case 'changeTone':
+					prompt = buildPromptTemplate( {
+						request: `Please, rewrite with a ${ options.tone } tone.`,
+						content,
+					} );
+					break;
+
+				/*
+				 * Summarize the content.
+				 */
+				case 'summarize':
+					prompt = buildPromptTemplate( {
+						request: 'Summarize the content below.',
+						content: content?.length ? content : getContentFromBlocks(),
+					} );
+					break;
+
+				/*
+				 * Make the content longer.
+				 */
+				case 'makeLonger':
+					prompt = buildPromptTemplate( {
+						request: 'Make the content below longer.',
+						content,
+					} );
+					break;
+
+				/*
+				 * Make the content shorter.
+				 */
+				case 'makeShorter':
+					prompt = buildPromptTemplate( {
+						request: 'Make the content below shorter.',
+						content,
+					} );
+					break;
+
+				/*
+				 * Generate a title for this blog post, based on the content.
+				 */
+				case 'generateTitle':
+					prompt = buildPromptTemplate( {
+						request: 'Generate a title for this blog post',
+						rules: [ 'Only output the raw title, without any prefix or quotes' ],
+						content: content?.length ? content : getContentFromBlocks(),
+					} );
+					break;
+
+				/*
+				 * Simplify the content.
+				 */
+				case 'simplify':
+					prompt = buildPromptTemplate( {
+						request: 'Simplify the content below.',
+						rules: [
+							'Use words and phrases that are easier to understand for non-technical people',
+							'Output in the same language of the content',
+							'Use as much of the original language as possible',
+						],
+						content: content?.length ? content : getContentFromBlocks(),
+					} );
+					break;
+
+				/**
+				 * Correct grammar and spelling
+				 */
+				case 'correctSpelling':
+					prompt = buildPromptTemplate( {
+						request: 'Correct any spelling and grammar mistakes from the content below.',
+						content: content?.length ? content : getContentFromBlocks(),
+					} );
+					break;
+
+				/**
+				 * Change the language, based on options.language
+				 */
+				case 'changeLanguage':
+					prompt = buildPromptTemplate( {
+						request: `Please, rewrite in the following language: ${ options.language }`,
+						content: content?.length ? content : getContentFromBlocks(),
+					} );
+					break;
+
+				default:
+					prompt = buildPromptTemplate( {
+						request: userPrompt,
+						content,
+					} );
+					break;
+			}
+		}
+
+		tracks.recordEvent( 'jetpack_ai_gpt3_completion', {
+			post_id: postId,
+		} );
+
+		if ( ! options.retryRequest ) {
+			setLastPrompt( prompt );
+			setAttributes( { promptType: type } );
+		}
+
+		let source;
+		let fullMessage = '';
+		try {
+			setIsLoadingCompletion( true );
+			source = await askQuestion( prompt );
+		} catch ( err ) {
+			if ( err.message ) {
+				setErrorMessage( err.message ); // Message was already translated by the backend
+			} else {
+				setErrorMessage(
+					__(
+						'Whoops, we have encountered an error. AI is like really, really hard and this is an experimental feature. Please try again later.',
+						'jetpack'
+					)
+				);
+			}
+			setShowRetry( true );
+			setIsLoadingCompletion( false );
+		}
+
+		source.addEventListener( 'message', e => {
+			if ( e.data === '[DONE]' ) {
+				source.close();
+				setIsLoadingCompletion( false );
+				setAttributes( {
+					content: fullMessage,
+				} );
+				debug( 'Done. Full message: ' + fullMessage );
+				return;
+			}
+
+			const data = JSON.parse( e.data );
+			const chunk = data.choices[ 0 ].delta.content;
+			if ( chunk ) {
+				fullMessage += chunk;
+				setAttributes( {
+					content: fullMessage,
+				} );
+				debug( fullMessage );
+				// debug( chunk );
+			}
+		} );
+	};
 	return {
 		isLoadingCategories,
 		isLoadingCompletion,
@@ -233,11 +426,16 @@ const useSuggestionsFromOpenAI = ( {
 		contentBefore: getPartialContentToBlock( clientId ),
 		wholeContent: getContentFromBlocks( clientId ),
 
-		getSuggestionFromOpenAI,
-		retryRequest: () => getSuggestionFromOpenAI( '', { retryRequest: true } ),
+		getSuggestionFromOpenAI: getStreamedSuggestionFromOpenAI,
+		oldgetSuggestionFromOpenAI: getSuggestionFromOpenAI,
+		getStreamedSuggestionFromOpenAI,
+		retryRequest: () => getStreamedSuggestionFromOpenAI( '', { retryRequest: true } ),
 	};
 };
 
 export default useSuggestionsFromOpenAI;
 
+/**
+ * askJetpack is exposed just for debugging purposes
+ */
 window.askJetpack = askJetpack;


### PR DESCRIPTION
Updates the `useSuggestionsFromOpenAI` hook to use a streamed events version of the suggestions API.

What's most noticeable is the latency difference

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Updates the suggestions request to be event based.

https://github.com/Automattic/jetpack/assets/746152/c0c5ce7f-d980-4255-aeb4-7480b0c9b3a2



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

For a Jetpack site

* On a Jetpack site able to use AI
* Visit the editor
* Add an AI Assistant block. Expect the content to start loading faster than before and fail less frequently


For .com sites

* Start with a sandboxed wpcom site 
* Do One of the following:
  * Wait for the build here to run and in your sandbox, run `bin/jetpack-downloader test jetpack add/ai-assistant-streaming-alternative` 
  * Use `jetpack rsync` standing on your monorepo root while running `jetpack watch plugins/jetpack`
* Visit the editor
* Add an AI Assistant block. Expect the content to start loading faster than before and fail less frequently