### PR TITLE
Stats Admin: align is_automated_transfer option with Jetpack plugin

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-odyssey-is-automated-transfer
+++ b/projects/packages/stats-admin/changelog/fix-odyssey-is-automated-transfer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats Admin: align is_automated_transfer with other places

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -86,7 +86,7 @@ class Odyssey_Config_Data {
 								'wordads'               => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url'             => admin_url(),
 								'gmt_offset'            => $this->get_gmt_offset(),
-								'is_automated_transfer' => $host->is_woa_site(),
+								'is_automated_transfer' => $this->is_automated_transfer( $blog_id ),
 								'is_wpcom_atomic'       => $host->is_woa_site(),
 								'is_vip'                => $host->is_vip_site(),
 								'jetpack_version'       => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
@@ -99,6 +99,33 @@ class Odyssey_Config_Data {
 					'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),
 				),
 			),
+		);
+	}
+
+	/**
+	 * Defines a filter to set whether a site is an automated_transfer site or not.
+	 *
+	 * Default is false. On Atomic, this is set to true by `wpcomsh`.
+	 *
+	 * @param int $blog_id Blog ID.
+	 *
+	 * @return bool
+	 */
+	public function is_automated_transfer( $blog_id ) {
+		/**
+		 * Filter if a site is an automated-transfer site.
+		 *
+		 * @module json-api
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param bool is_automated_transfer( $this->blog_id )
+		 * @param int  $blog_id Blog identifier.
+		 */
+		return apply_filters(
+			'jetpack_site_automated_transfer',
+			false,
+			$blog_id
 		);
 	}
 


### PR DESCRIPTION
## Proposed changes:

The PR is a follow up for  #30573, which aligns option `is_automated_transfer` with Jetpack and WPCOM.

https://github.com/Automattic/jetpack/blob/69035e35fa009318a92a8d3cbec8b41ca1bfdba3/projects/plugins/jetpack/sal/class.json-api-site-base.php#L419


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Open `/wp-admin` on a self hosted Jetpack site
* Open console and enter `jetpackStatsOdysseyWidgetConfigData`
* Ensure `jetpackStatsOdysseyWidgetConfigData.intial_state.sites?.items?.[ siteId ]?.options?.is_automated_transfer` is false

