### PR TITLE
Stats Admin: Add rest endpoints to mark / unmark referrers as spam

### DIFF
--- a/projects/packages/stats-admin/changelog/add-stats-admin-new-spam-referrer-api
+++ b/projects/packages/stats-admin/changelog/add-stats-admin-new-spam-referrer-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats Admin: adds rest api for marking and unmarking referrers as spam

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -195,7 +195,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'mark_referrer_spam' ),
-				'permission_callback' => array( $this, 'can_user_view_wordads_stats_callback' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 				'args'                => array(
 					'domain' => array(
 						'required'    => true,
@@ -213,7 +213,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'unmark_referrer_spam' ),
-				'permission_callback' => array( $this, 'can_user_view_wordads_stats_callback' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 				'args'                => array(
 					'domain' => array(
 						'required'    => true,

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -187,11 +187,13 @@ class REST_Controller {
 				),
 			)
 		);
+		// https://public-api.wordpress.com/rest/v1.1/sites/189825737/stats/referrers/spam/delete?http_envelope=1&domain=sogou.com%2Fweb%3Fquery%3Dsite%253Ablog.kangzj.net
+		// https://public-api.wordpress.com/rest/v1.1/sites/189825737/stats/referrers/spam/new?http_envelope=1&domain=sogou.com%2Fweb%3Fquery%3Dsite%253Ablog.kangzj.net
 
 		// Mark referrer spam.
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/sites/%d/referrers/spam/new', Jetpack_Options::get_option( 'id' ) ),
+			sprintf( '/sites/%d/stats/referrers/spam/new', Jetpack_Options::get_option( 'id' ) ),
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'mark_referrer_spam' ),
@@ -209,7 +211,7 @@ class REST_Controller {
 		// Unmark referrer spam.
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/sites/%d/referrers/spam/delete', Jetpack_Options::get_option( 'id' ) ),
+			sprintf( '/sites/%d/stats/referrers/spam/delete', Jetpack_Options::get_option( 'id' ) ),
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'unmark_referrer_spam' ),
@@ -526,7 +528,7 @@ class REST_Controller {
 	public function mark_referrer_spam( $req ) {
 		return $this->request_as_blog_cached(
 			sprintf(
-				'/sites/%d/referrers/spam/new?%s',
+				'/sites/%d/stats/referrers/spam/new?%s',
 				Jetpack_Options::get_option( 'id' ),
 				$this->filter_and_build_query_string(
 					$req->get_params()
@@ -537,6 +539,7 @@ class REST_Controller {
 				'timeout' => 5,
 				'method'  => 'POST',
 			),
+			null,
 			'rest',
 			false
 		);
@@ -551,7 +554,7 @@ class REST_Controller {
 	public function unmark_referrer_spam( $req ) {
 		return $this->request_as_blog_cached(
 			sprintf(
-				'/sites/%d/referrers/spam/delete?%s',
+				'/sites/%d/stats/referrers/spam/delete?%s',
 				Jetpack_Options::get_option( 'id' ),
 				$this->filter_and_build_query_string(
 					$req->get_params()
@@ -562,6 +565,7 @@ class REST_Controller {
 				'timeout' => 5,
 				'method'  => 'POST',
 			),
+			null,
 			'rest',
 			false
 		);

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -538,10 +538,7 @@ class REST_Controller {
 			array(
 				'timeout' => 5,
 				'method'  => 'POST',
-			),
-			null,
-			'rest',
-			false
+			)
 		);
 	}
 
@@ -564,10 +561,7 @@ class REST_Controller {
 			array(
 				'timeout' => 5,
 				'method'  => 'POST',
-			),
-			null,
-			'rest',
-			false
+			)
 		);
 	}
 
@@ -583,6 +577,9 @@ class REST_Controller {
 	 * @return array|WP_Error $response Data.
 	 */
 	protected function request_as_blog_cached( $path, $version = '1.1', $args = array(), $body = null, $base_api_path = 'rest', $use_cache = true ) {
+		// Only allow caching GET requests.
+		$use_cache = $use_cache && ! ( isset( $args['method'] ) && strtoupper( $args['method'] ) !== 'GET' );
+
 		// Arrays are serialized without considering the order of objects, but it's okay atm.
 		$cache_key = 'STATS_REST_RESP_' . md5( implode( '|', array( $path, $version, wp_json_encode( $args ), wp_json_encode( $body ), $base_api_path ) ) );
 

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -187,8 +187,6 @@ class REST_Controller {
 				),
 			)
 		);
-		// https://public-api.wordpress.com/rest/v1.1/sites/189825737/stats/referrers/spam/delete?http_envelope=1&domain=sogou.com%2Fweb%3Fquery%3Dsite%253Ablog.kangzj.net
-		// https://public-api.wordpress.com/rest/v1.1/sites/189825737/stats/referrers/spam/new?http_envelope=1&domain=sogou.com%2Fweb%3Fquery%3Dsite%253Ablog.kangzj.net
 
 		// Mark referrer spam.
 		register_rest_route(

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -12,7 +12,7 @@ use WP_REST_Server;
  * @package automattic/jetpack-stats-admin
  */
 class Test_REST_Controller extends Stats_Test_Case {
-	const SUPPORTED_ROUTES = array(
+	const SUPPORTED_GET_ROUTES = array(
 		'/jetpack/v4/stats-app/sites/999/stats/visits',
 		'/jetpack/v4/stats-app/sites/999/stats/highlights',
 		'/jetpack/v4/stats-app/sites/999/stats',
@@ -37,6 +37,11 @@ class Test_REST_Controller extends Stats_Test_Case {
 		'/jetpack/v4/stats-app/sites/999/stats/post/1',
 		'/jetpack/v4/stats-app/sites/999/stats/video/1',
 		'/jetpack/v4/stats-app/sites/999/site-has-never-published-post',
+	);
+
+	const SUPPORTED_POST_ROUTES = array(
+		'/jetpack/v4/stats-app/sites/999/stats/referrers/spam/new',
+		'/jetpack/v4/stats-app/sites/999/stats/referrers/spam/delete',
 	);
 
 	const UNSUPPORTED_ROUTES = array(
@@ -91,12 +96,22 @@ class Test_REST_Controller extends Stats_Test_Case {
 	}
 
 	/**
-	 * Test /stats exists.
+	 * Test GET routes exists.
 	 */
-	public function test_blog_stats_endpoints_exists() {
+	public function test_blog_stats_get_endpoints_exists() {
 		wp_set_current_user( $this->admin_id );
-		foreach ( self::SUPPORTED_ROUTES as $route ) {
-			$this->assert_route_exists( $route );
+		foreach ( self::SUPPORTED_GET_ROUTES as $route ) {
+			$this->assert_get_route_exists( $route );
+		}
+	}
+
+	/**
+	 * Test POST routes exists.
+	 */
+	public function test_blog_stats_post_endpoints_exists() {
+		wp_set_current_user( $this->admin_id );
+		foreach ( self::SUPPORTED_POST_ROUTES as $route ) {
+			$this->assert_post_route_exists( $route );
 		}
 	}
 
@@ -115,12 +130,25 @@ class Test_REST_Controller extends Stats_Test_Case {
 	 *
 	 * @param string $route The route to check.
 	 */
-	public function assert_route_exists( $route ) {
+	public function assert_get_route_exists( $route ) {
 		$request = new WP_REST_Request( 'GET', $route );
 		$request->set_header( 'content-type', 'application/json' );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertNotEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Ensure required routes exists
+	 *
+	 * @param string $route The route to check.
+	 */
+	public function assert_post_route_exists( $route ) {
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotEquals( 404, $response->get_status() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76569

## Proposed changes:

Adds two endpoints to forward mark and unmark referrers as spam to WPCOM. 

- `/sites/%d/stats/referrers/spam/new`
- `/sites/%d/stats/referrers/spam/delete`

The PR also takes the chance to improve the error handling.

- Only set transient when $use_cache is true
- Only cache when method is GET or empty (default is GET)
- Check errors even when status code is 200 because sometimes there is still error

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Apply `D110498-code` to your sandbox and sandbox Jetpack
* Open `/wp-admin/admin.php?page=stats#!/stats/day/referrers/siteId?startDate=2023-05-11&summarize=1&num=-1`
* Ensure marking a referrer as spam works (please inspect network requests)
* Ensure marking it as not spam works (please inspect network requests)

Known issue: the style of the button is not particularly good and we are about to fix it.

![image](https://github.com/Automattic/jetpack/assets/1425433/0d7e01ba-3bf5-45e3-a771-7f35f21fc025)

