### PR TITLE
Update Twitter/LinkedIn previews to use the "Your post" and "Link preview" sections from Calypso

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,8 +652,8 @@ importers:
         specifier: workspace:*
         version: link:../shared-extension-utils
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.3
-        version: 2.0.0-beta.3(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.4
+        version: 2.0.0-beta.4(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@wordpress/annotations':
         specifier: 2.32.0
         version: 2.32.0(react@18.2.0)
@@ -2693,8 +2693,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.3
-        version: 2.0.0-beta.3(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.4
+        version: 2.0.0-beta.4(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@automattic/viewport':
         specifier: 1.0.0
         version: 1.0.0
@@ -3911,8 +3911,8 @@ packages:
       '@automattic/popup-monitor': 1.0.2
     dev: false
 
-  /@automattic/social-previews@2.0.0-beta.3(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-lG67rwPQH16jN8xFx88wdRtKBv3CZXnRqvb32lkVNA2dQ/QzDrsy/vva2q3lZ6Nt0CLhQMmZUw/f1HqhA3+Q3Q==}
+  /@automattic/social-previews@2.0.0-beta.4(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-h2yVudhw5x0DlMSZ+NKMldyibmXFZcMjOT9Sp682ESkkiEMlapSEFc9GJuYq2MfKkL2tvb9GcC+/d8kqEFUHaw==}
     peerDependencies:
       '@babel/runtime': ^7
       react: ^17.0.2 || ^18

--- a/projects/js-packages/publicize-components/changelog/update-social-previews-twitter-linkedin
+++ b/projects/js-packages/publicize-components/changelog/update-social-previews-twitter-linkedin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated the social previews to use the updated calypso components

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -22,7 +22,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
-		"@automattic/social-previews": "2.0.0-beta.3",
+		"@automattic/social-previews": "2.0.0-beta.4",
 		"@wordpress/annotations": "2.32.0",
 		"@wordpress/api-fetch": "6.29.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.24.0",
+	"version": "0.25.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/social-previews/constants.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/constants.js
@@ -1,23 +1,23 @@
 import { SocialServiceIcon } from '@automattic/jetpack-components';
-import { GoogleSearchPreview } from '@automattic/social-previews';
 import { __ } from '@wordpress/i18n';
-import FacebookPreview from '../facebook-preview';
-import TumblrPreview from '../tumblr-preview';
+import FacebookPreview from './facebook';
+import GoogleSearch from './google-search';
 import { LinkedIn } from './linkedin';
-import { Twitter } from './twitter';
+import TumblrPreview from './tumblr';
+import Twitter from './twitter';
 
 export const AVAILABLE_SERVICES = [
 	{
 		title: __( 'Google Search', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="google" { ...props } />,
 		name: 'google',
-		preview: GoogleSearchPreview,
+		preview: GoogleSearch,
 	},
 	{
 		title: __( 'Twitter', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="twitter" { ...props } />,
 		name: 'twitter',
-		preview: props => <Twitter { ...props } />,
+		preview: Twitter,
 	},
 	{
 		title: __( 'Facebook', 'jetpack' ),
@@ -25,17 +25,17 @@ export const AVAILABLE_SERVICES = [
 		name: 'facebook',
 		preview: FacebookPreview,
 	},
-	{
+	/* {
 		title: __( 'Instagram', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="instagram" { ...props } />,
 		name: 'instagram',
 		preview: () => null,
-	},
+	}, */
 	{
 		title: __( 'LinkedIn', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="linkedin" { ...props } />,
 		name: 'linkedin',
-		preview: props => <LinkedIn { ...props } />,
+		preview: LinkedIn,
 	},
 	{
 		title: __( 'Tumblr', 'jetpack' ),
@@ -43,10 +43,10 @@ export const AVAILABLE_SERVICES = [
 		name: 'tumblr',
 		preview: TumblrPreview,
 	},
-	{
+	/* {
 		title: __( 'Mastodon', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="mastodon" { ...props } />,
 		name: 'mastadon',
 		preview: () => null,
-	},
+	}, */
 ];

--- a/projects/js-packages/publicize-components/src/components/social-previews/facebook.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/facebook.js
@@ -1,4 +1,4 @@
-import { FacebookPreview as Preview } from '@automattic/social-previews';
+import { FacebookPreviews as Previews } from '@automattic/social-previews';
 import { withSelect } from '@wordpress/data';
 import useAttachedMedia from '../../hooks/use-attached-media';
 import useMediaDetails from '../../hooks/use-media-details';
@@ -31,7 +31,7 @@ const FacebookPreview = props => {
 	}
 
 	return (
-		<Preview
+		<Previews
 			{ ...props }
 			type="article"
 			user={ user }

--- a/projects/js-packages/publicize-components/src/components/social-previews/google-search.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/google-search.js
@@ -1,0 +1,24 @@
+import { GoogleSearchPreview } from '@automattic/social-previews';
+import { useSelect } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+import React from 'react';
+
+/**
+ * The Google Search tab component.
+ *
+ * @param {object} props - The props.
+ * @param {object[]} props.tweets - The tweets.
+ * @param {object} props.media - The media.
+ * @returns {React.ReactNode} The Google Search tab component.
+ */
+export function GoogleSearch( props ) {
+	const siteTitle = useSelect( select => {
+		const { getEntityRecord } = select( 'core' );
+
+		return decodeEntities( getEntityRecord( 'root', 'site' ).title );
+	} );
+
+	return <GoogleSearchPreview { ...props } siteTitle={ siteTitle } />;
+}
+
+export default GoogleSearch;

--- a/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
@@ -1,7 +1,4 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
-import { LinkedInPreview } from '@automattic/social-previews';
-import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { LinkedInPreviews } from '@automattic/social-previews';
 import React from 'react';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { getLinkedInDetails } from '../../store/selectors';
@@ -20,53 +17,14 @@ export function LinkedIn( props ) {
 	const { message: text } = useSocialMediaMessage();
 
 	return (
-		<div className="linked-preview-tab">
-			<section>
-				<header>
-					<h2>{ __( 'Your post', 'jetpack' ) }</h2>
-					<p className="description">
-						{ __( 'This is what your social post will look like on LinkedIn', 'jetpack' ) }
-					</p>
-				</header>
-				<LinkedInPreview
-					jobTitle="Job Title (Company Name)"
-					image={ image }
-					name={ name }
-					profileImage={ profileImage }
-					title={ title }
-					text={ text }
-					url={ url }
-				/>
-			</section>
-			<section>
-				<header>
-					<h2>{ __( 'Link preview', 'jetpack' ) }</h2>
-					<p className="description">
-						{ createInterpolateElement(
-							__(
-								'This is what it will look like when someone shares the link to your WordPress post on LinkedIn. <LearnMoreLink>Learn more about links</LearnMoreLink>',
-								'jetpack'
-							),
-							{
-								LearnMoreLink: (
-									<a
-										href={ getRedirectUrl( 'jetpack-social-image-generator' ) }
-										rel="noopener noreferrer"
-										target="_blank"
-									/>
-								),
-							}
-						) }
-					</p>
-				</header>
-				<LinkedInPreview
-					jobTitle="Job Title (Company Name)"
-					image={ image }
-					title={ title }
-					url={ url }
-					{ ...getLinkedInDetails( { forceDefaults: true } ) }
-				/>
-			</section>
-		</div>
+		<LinkedInPreviews
+			jobTitle="Job Title (Company Name)"
+			image={ image }
+			name={ name }
+			profileImage={ profileImage }
+			title={ title }
+			text={ text }
+			url={ url }
+		/>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
@@ -81,10 +81,6 @@ $highlight-color: #3858e9;
 		}
 	}
 
-	.twitter-preview__summary {
-		max-width: 100%;
-	}
-
 	@media ( min-width: $break-small ) {
 		width: calc( 100vw - 40px );
 	}
@@ -189,25 +185,3 @@ $highlight-color: #3858e9;
 	}
 }
 
-.twitter-preview-tab {
-	header{
-		padding-inline-start: 37px;
-		padding-inline-end: 20px;
-		width: 635px;
-	}
-	p.description {
-		font-size: 1rem;
-	}
-}
-
-.linked-preview-tab {
-	header {
-		width: 555px;
-	}
-	p.description {
-		font-size: 1rem;
-	}
-	.linkedin-preview {
-		margin: 1.25rem 0 3rem;
-	}
-}

--- a/projects/js-packages/publicize-components/src/components/social-previews/tumblr.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/tumblr.js
@@ -1,14 +1,18 @@
-import { TumblrFullPreview } from '@automattic/social-previews';
+import { TumblrPreviews } from '@automattic/social-previews';
 import { useSelect } from '@wordpress/data';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 
 const TumblrPreview = props => {
-	const { content } = useSelect( select => {
+	const { content, author } = useSelect( select => {
+		const { getUser } = select( 'core' );
 		const { getEditedPostAttribute } = select( 'core/editor' );
+		const authorId = getEditedPostAttribute( 'author' );
+		const user = authorId && getUser( authorId );
 
 		return {
 			content: getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
+			author: user?.name,
 		};
 	} );
 	const { connections } = useSocialMediaConnections();
@@ -20,13 +24,13 @@ const TumblrPreview = props => {
 
 	if ( connection ) {
 		user = {
-			displayName: props.author,
+			displayName: author,
 			avatarUrl: connection.profile_picture,
 		};
 	}
 
 	return (
-		<TumblrFullPreview { ...props } user={ user } description={ content } customText={ message } />
+		<TumblrPreviews { ...props } user={ user } description={ content } customText={ message } />
 	);
 };
 

--- a/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
@@ -1,58 +1,53 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
-import { TwitterPreview } from '@automattic/social-previews';
-import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { TwitterPreviews } from '@automattic/social-previews';
+import { withSelect } from '@wordpress/data';
 import React from 'react';
-import { getTweetTemplate } from '../../store/selectors';
+import { getMediaSourceUrl } from './utils';
 
 /**
  * The twitter tab component.
  *
  * @param {object} props - The props.
- * @param {boolean} props.isTweetStorm  - Whether it's a tweetstorm.
  * @param {object[]} props.tweets - The tweets.
  * @param {object} props.media - The media.
  * @returns {React.ReactNode} The twitter tab component.
  */
-export function Twitter( { isTweetStorm, tweets, media } ) {
-	const template = getTweetTemplate( { connections: [] } );
-
-	const linkTweet = { ...tweets[ 0 ], ...template, text: '' };
-
-	return (
-		<div className="twitter-preview-tab">
-			<section>
-				<header>
-					<h2>{ __( 'Your post', 'jetpack' ) }</h2>
-					<p className="description">
-						{ __( 'This is what your social post will look like on Twitter', 'jetpack' ) }
-					</p>
-				</header>
-				<TwitterPreview isTweetStorm={ isTweetStorm } tweets={ tweets } media={ media } />
-			</section>
-			<section>
-				<header>
-					<h2>{ __( 'Link preview', 'jetpack' ) }</h2>
-					<p className="description">
-						{ createInterpolateElement(
-							__(
-								'This is what it will look like when someone shares the link to your WordPress post on Twitter. <LearnMoreLink>Learn more about links</LearnMoreLink>',
-								'jetpack'
-							),
-							{
-								LearnMoreLink: (
-									<a
-										href={ getRedirectUrl( 'jetpack-social-image-generator' ) }
-										rel="noopener noreferrer"
-										target="_blank"
-									/>
-								),
-							}
-						) }
-					</p>
-				</header>
-				<TwitterPreview tweets={ [ linkTweet ] } />
-			</section>
-		</div>
-	);
+export function Twitter( { tweets, media } ) {
+	return <TwitterPreviews tweets={ tweets } media={ media } />;
 }
+
+export default withSelect( ( select, { title, description, image, url } ) => {
+	const { getMedia } = select( 'core' );
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getTweetTemplate, getTweetStorm, getShareMessage, isTweetStorm } =
+		select( 'jetpack/publicize' );
+
+	const media = getMedia( getEditedPostAttribute( 'featured_media' ) );
+
+	let tweets = [];
+	if ( isTweetStorm() ) {
+		tweets = getTweetStorm();
+	} else {
+		tweets.push( {
+			...getTweetTemplate(),
+			text: getShareMessage(),
+			cardType: image ? 'summary_large_image' : 'summary',
+			title,
+			description,
+			image,
+			url,
+		} );
+	}
+
+	return {
+		tweets,
+		media: media
+			? [
+					{
+						type: media.mime_type,
+						url: getMediaSourceUrl( media ),
+						alt: media.alt_text,
+					},
+			  ]
+			: null,
+	};
+} )( Twitter );

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -107,7 +107,7 @@ export function getTweetStorm( state ) {
 			media: tweet.media,
 			tweet: tweet.tweet,
 			urls: tweet.urls,
-			card: getTwitterCardForURLs( state, tweet.urls ),
+			...getTwitterCardForURLs( state, tweet.urls ),
 		} ) ),
 	];
 
@@ -146,17 +146,15 @@ export function getFirstTweet( state ) {
 		...tweetTemplate,
 		text: getShareMessage() + ` ${ url }`,
 		urls: [ url ],
-		card: {
-			title: getEditedPostAttribute( 'title' ),
-			description:
-				getEditedPostAttribute( 'meta' )?.advanced_seo_description ||
-				getEditedPostAttribute( 'excerpt' ) ||
-				getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ] ||
-				__( 'Visit the post for more.', 'jetpack' ),
-			url,
-			image,
-			type: image ? 'summary_large_image' : 'summary',
-		},
+		title: getEditedPostAttribute( 'title' ),
+		description:
+			getEditedPostAttribute( 'meta' )?.advanced_seo_description ||
+			getEditedPostAttribute( 'excerpt' ) ||
+			getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ] ||
+			__( 'Visit the post for more.', 'jetpack' ),
+		url,
+		image,
+		cardType: image ? 'summary_large_image' : 'summary',
 	};
 }
 

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -1,5 +1,9 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { FacebookPreview, TwitterPreview, GoogleSearchPreview } from '@automattic/social-previews';
+import {
+	FacebookPreviews,
+	TwitterPreviews,
+	GoogleSearchPreview,
+} from '@automattic/social-previews';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import Button from 'components/button';
@@ -73,7 +77,7 @@ export const SEO = withModuleSettingsFormHelpers(
 		);
 
 		SocialPreviewFacebook = siteData => (
-			<FacebookPreview
+			<FacebookPreviews
 				title={ siteData.title }
 				url={ siteData.url }
 				type="website"
@@ -83,7 +87,7 @@ export const SEO = withModuleSettingsFormHelpers(
 		);
 
 		SocialPreviewTwitter = siteData => (
-			<TwitterPreview
+			<TwitterPreviews
 				title={ siteData.title }
 				url={ siteData.url }
 				type="summary"

--- a/projects/plugins/jetpack/changelog/update-social-previews-twitter-linkedin
+++ b/projects/plugins/jetpack/changelog/update-social-previews-twitter-linkedin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated the social previews to use the updated calypso components

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -57,7 +57,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/request-external-access": "1.0.0",
-		"@automattic/social-previews": "2.0.0-beta.3",
+		"@automattic/social-previews": "2.0.0-beta.4",
 		"@automattic/viewport": "1.0.0",
 		"@wordpress/base-styles": "4.23.0",
 		"@wordpress/block-editor": "12.0.0",


### PR DESCRIPTION
Related https://github.com/Automattic/wp-calypso/pull/76808

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR moves the "Your post" and "Link preview" logic from Publicize components to the `social-previews` package in calypso via https://github.com/Automattic/wp-calypso/pull/76808
* It also hides the Instagram and Mastodon previews for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdrWKz-Ka-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

* In Jetpack, run `jetpack build plugins/jetpack`
* Start writing a new post with JT site via Jetpack
* Click Jetpack icon on the top of the sidebar
* Under "Social Previews", click on "Preview"
* Confirm that the Twitter and LinkedIn preview have "Your post" and "Link preview" sections.

