### PR TITLE
[RNMobile] Play VideoPress videos using the native player on Android

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-videopress-android-play-original-video
+++ b/projects/packages/videopress/changelog/rnmobile-videopress-android-play-original-video
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress block: Use native player to play videos on Android

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
@@ -32,7 +32,7 @@ const IS_ANDROID = Platform.isAndroid;
  * @param {boolean} props.isSelected - Whether the block is selected.
  * @returns {import('react').ReactElement} - React component.
  */
-export default function Player( { isSelected, attributes } ) {
+export default function Player( { isSelected, attributes, source } ) {
 	const {
 		controls,
 		guid,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.native.js
@@ -90,7 +90,7 @@ export default function VideoPressEdit( {
 	);
 
 	const { videoData } = useSyncMedia( attributes, setAttributes );
-	const { private_enabled_for_site: privateEnabledForSite } = videoData;
+	const { private_enabled_for_site: privateEnabledForSite, original: originalVideo } = videoData;
 
 	const handleDoneUpload = useCallback(
 		newVideoData => {
@@ -222,7 +222,7 @@ export default function VideoPressEdit( {
 				</InspectorControls>
 			) }
 
-			<Player { ...{ attributes, isSelected } } />
+			<Player source={ originalVideo } { ...{ attributes, isSelected } } />
 
 			<BlockCaption
 				clientId={ clientId }

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-video-data/index.ts
@@ -95,6 +95,7 @@ export default function useVideoData( {
 					tracks: response.tracks,
 					is_private: response.is_private,
 					private_enabled_for_site: response.private_enabled_for_site,
+					original: response.original,
 				} );
 
 				// Check if the video belongs to the current site.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

⚠️ Depends on https://github.com/wordpress-mobile/WordPress-Android/pull/18408 to play private videos.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* [TBD]

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1683801599417669/1683797536.029109-slack-C04LWMHSGLC

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [TBD]