### PR TITLE
Plugin config: update reference links to releases in changelogs

### DIFF
--- a/projects/plugins/backup/changelog/fix-changelog-compare-references
+++ b/projects/plugins/backup/changelog/fix-changelog-compare-references
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update link references to releases in changelog.

--- a/projects/plugins/backup/changelog/fix-changelog-compare-references#2
+++ b/projects/plugins/backup/changelog/fix-changelog-compare-references#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -47,6 +47,7 @@
 			"v": false
 		},
 		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-backup-plugin/compare/${old}...${new}",
 			"versioning": "wordpress"
 		},
 		"release-branch-prefix": [

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "956dd9a315da14ff0d60eec621051af4",
+    "content-hash": "1642ed8c7788de3567148d6259b348d7",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/changelog/fix-changelog-compare-references
+++ b/projects/plugins/boost/changelog/fix-changelog-compare-references
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update link references to releases in changelog.

--- a/projects/plugins/boost/changelog/fix-changelog-compare-references#2
+++ b/projects/plugins/boost/changelog/fix-changelog-compare-references#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -100,7 +100,7 @@
 		"wp-plugin-slug": "jetpack-boost",
 		"wp-svn-autopublish": true,
 		"changelogger": {
-			"link-template": "https://github.com/Automattic/jetpack-boost-production/compare/v${old}...v${new}"
+			"link-template": "https://github.com/Automattic/jetpack-boost-production/compare/${old}...${new}"
 		}
 	}
 }

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b5c5f00fdeeb83dece060d4032d9ad7",
+    "content-hash": "d2417a26f00a41f8dfc059a07a0b6974",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/crm/changelog/fix-changelog-compare-references
+++ b/projects/plugins/crm/changelog/fix-changelog-compare-references
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update link references to releases in changelog.

--- a/projects/plugins/crm/changelog/fix-changelog-compare-references#2
+++ b/projects/plugins/crm/changelog/fix-changelog-compare-references#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -84,7 +84,7 @@
 		"autorelease": true,
 		"mirror-repo": "Automattic/jetpack-crm",
 		"changelogger": {
-			"link-template": "https://github.com/Automattic/jetpack-crm/compare/v${old}...v${new}"
+			"link-template": "https://github.com/Automattic/jetpack-crm/compare/${old}...${new}"
 		},
 		"release-branch-prefix": "crm",
 		"wp-plugin-slug": "zero-bs-crm",

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3199bd9b8c873d74218e5c71b8df7ca6",
+    "content-hash": "bf0ad82e4ed3e91867deda3f51ad9855",
     "packages": [
         {
             "name": "automattic/jetpack-assets",

--- a/projects/plugins/search/changelog/fix-changelog-compare-references
+++ b/projects/plugins/search/changelog/fix-changelog-compare-references
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update link references to releases in changelog.

--- a/projects/plugins/search/changelog/fix-changelog-compare-references#2
+++ b/projects/plugins/search/changelog/fix-changelog-compare-references#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -56,7 +56,7 @@
 		"wp-plugin-slug": "jetpack-search",
 		"wp-svn-autopublish": true,
 		"changelogger": {
-			"link-template": "https://github.com/Automattic/jetpack-search-plugin/compare/v${old}...v${new}"
+			"link-template": "https://github.com/Automattic/jetpack-search-plugin/compare/${old}...${new}"
 		},
 		"version-constants": {
 			"JETPACK_SEARCH_PLUGIN__VERSION": "jetpack-search.php"

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ba7e8f2e6393f54e185dc3050da388c",
+    "content-hash": "6f5d02b21439677019428f6f0f7539e6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",


### PR DESCRIPTION
Fixes #30631

## Proposed changes:

Let's update changelogger link formats when a plugin is set to use a different format for its tags.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here, check if the format matches the version expected by the plugin (check the `autotagger` key).

