### PR TITLE
[RNMobile] Disable VideoPress player on Android

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-videopress-disable-player-on-android
+++ b/projects/packages/videopress/changelog/rnmobile-videopress-disable-player-on-android
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress block: Disable player on Android

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/player-unavailable.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/player-unavailable.native.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { BottomSheet, Icon } from '@wordpress/components';
+import { usePreferredColorSchemeStyle } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { help } from '@wordpress/icons';
+/**
+ * External dependencies
+ */
+import { Text, View } from 'react-native';
+/**
+ * Internal dependencies
+ */
+import styles from './style.scss';
+
+const PlayerUnavailable = ( { isSheetVisible, onCloseSheet } ) => {
+	const sheetIconStyle = usePreferredColorSchemeStyle(
+		styles[ 'videopress-player-unavailable__sheet-icon' ],
+		styles[ 'videopress-player-unavailable__sheet-icon--dark' ]
+	);
+	const sheetTitleStyle = usePreferredColorSchemeStyle(
+		styles[ 'videopress-player-unavailable__sheet-title' ],
+		styles[ 'videopress-player-unavailable__sheet-title--dark' ]
+	);
+	const sheetDescriptionStyle = usePreferredColorSchemeStyle(
+		styles[ 'videopress-player-unavailable__sheet-description' ],
+		styles[ 'videopress-player-unavailable__sheet-description--dark' ]
+	);
+
+	return (
+		<BottomSheet
+			isVisible={ isSheetVisible }
+			hideHeader
+			onClose={ onCloseSheet }
+			testID="videopress-player-unavailable"
+		>
+			<View style={ styles[ 'videopress-player-unavailable__container' ] }>
+				<View style={ sheetIconStyle }>
+					<Icon icon={ help } fill={ sheetIconStyle.fill } size={ sheetIconStyle.width } />
+				</View>
+				<Text style={ sheetTitleStyle }>
+					{ __( "VideoPress videos can't be played.", 'jetpack-videopress-pkg' ) }
+				</Text>
+				<Text style={ sheetDescriptionStyle }>
+					{ __(
+						'We’re working hard on adding support for playing VideoPress videos.',
+						'jetpack-videopress-pkg'
+					) }
+				</Text>
+			</View>
+		</BottomSheet>
+	);
+};
+
+export default PlayerUnavailable;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/style.native.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/style.native.scss
@@ -31,3 +31,47 @@
 .videopress-player__loading-icon {
 	size: 100;
 }
+
+.videopress-player-unavailable__container {
+	flex-direction: column;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+.videopress-player-unavailable__sheet-icon {
+	width: 36;
+	height: 36;
+	fill: $light-quaternary;
+}
+
+.videopress-player-unavailable__sheet-icon--dark {
+	fill: $gray-20;
+}
+
+.videopress-player-unavailable__sheet-title {
+	font-weight: 600;
+	font-size: 20;
+	line-height: 28px;
+	text-align: center;
+	color: $gray-90;
+
+	padding-top: 8;
+	padding-bottom: 8;
+}
+
+.videopress-player-unavailable__sheet-title--dark {
+	color: $white;
+}
+
+.videopress-player-unavailable__sheet-description {
+	font-size: 16;
+	line-height: 24px;
+	text-align: center;
+	color: $gray-50;
+
+	padding-bottom: 24;
+}
+
+.videopress-player-unavailable__sheet-description--dark {
+	color: $gray-20;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable the player on Android due to issues with the WebView.
* Add the `PlayerUnavailable` component to display a bottom sheet warning the user that the player is disabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1683797536029109-slack-C04LWMHSGLC

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Android - player disabled
* Open the editor in the Android app.
* Add a VideoPress block.
* Add a video.
* Tap on the video to play it.
* Observe the video is not played and that a warning message is displayed.

### iOS - player enabled
* Open the editor in the iOS app.
* Add a VideoPress block.
* Add a video.
* Tap on the video to play it.
* Observe the video can be played.
