### PR TITLE
CRM: Resolves 2874 - handle missing transaction status

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-2874-handle_missing_transaction_status
+++ b/projects/plugins/crm/changelog/fix-crm-2874-handle_missing_transaction_status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Transactions: always show current status in editor

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
@@ -222,7 +222,9 @@
 				$available_statuses = zeroBSCRM_getTransactionsStatuses( true );
 
 				// if current status is not a valid one, add it to statuses array
-				if ( ! $zbs->DAL->is_valid_obj_status( ZBS_TYPE_TRANSACTION, $transaction['status'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				if ( empty( $transaction['status'] ) ) {
+					$transaction['status'] = $available_statuses[0];
+				} elseif ( ! $zbs->DAL->is_valid_obj_status( ZBS_TYPE_TRANSACTION, $transaction['status'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					$available_statuses[] = $transaction['status'];
 				}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
@@ -216,14 +216,16 @@
 						<td colspan="2"><hr /></td>
 					</tr>
 
-					<?php
+				<?php
 
-					// Transaction Status
-					$potential_statuses = zeroBSCRM_getTransactionsStatuses( true );
-					$current_status     = '';
-				if ( is_array( $transaction ) && isset( $transaction['status'] ) ) {
-						$current_status = $transaction['status'];
+				// get transaction statuses
+				$available_statuses = zeroBSCRM_getTransactionsStatuses( true );
+
+				// if current status is not a valid one, add it to statuses array
+				if ( ! $zbs->DAL->is_valid_obj_status( ZBS_TYPE_TRANSACTION, $transaction['status'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					$available_statuses[] = $transaction['status'];
 				}
+
 				?>
 					<tr class="wh-large">
 						<th><label for="zbst_status"><?php echo esc_html( __( 'Transaction Status:', 'zero-bs-crm' ) ); ?></label>
@@ -231,8 +233,8 @@
 						<td>
 						<select id="zbst_status" name="zbst_status">
 							<?php
-						foreach ( $potential_statuses as $status ) {
-							$sel = $status === $current_status ? ' selected' : '';
+						foreach ( $available_statuses as $status ) {
+							$sel = $status === $transaction['status'] ? ' selected' : '';
 							echo '<option value="' .
 							esc_attr( $status ) .
 							'"' .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#2874 - handle missing transaction status

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If a transaction was synced with an unofficial status, the transaction status dropdown when editing will show as if the initial status is selected (generally "Succeeded").

This PR adds the unofficial status to the dropdown so that it accurately reflects the current transaction status.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a transaction with an unofficial status (e.g. use DevTools to edit the select options).
2. View the transaction editor.

In `trunk` the status will appear to be "Succeeded".

In `fix/crm/2874-handle_missing_transaction_status` the status will be the unofficial status you used.