### PR TITLE
Add WAF tests for unsupported environments

### DIFF
--- a/projects/packages/waf/changelog/add-waf-tests-for-unsupported-envs
+++ b/projects/packages/waf/changelog/add-waf-tests-for-unsupported-envs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Integration tests for unsupported environments

--- a/projects/packages/waf/changelog/add-waf-tests-for-unsupported-envs
+++ b/projects/packages/waf/changelog/add-waf-tests-for-unsupported-envs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Integration tests for unsupported environments
+Add integration tests for unsupported environments

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -30,6 +30,7 @@ class Waf_Initializer {
 	public static function init() {
 		// Do not run in unsupported environments
 		add_action( 'jetpack_get_available_modules', __CLASS__ . '::remove_module_on_unsupported_environments' );
+		add_action( 'jetpack_get_available_standalone_modules', __CLASS__ . '::remove_module_on_unsupported_environments' );
 
 		// Ensure backwards compatibility
 		Waf_Compatibility::add_compatibility_hooks();
@@ -205,7 +206,13 @@ class Waf_Initializer {
 	public static function remove_module_on_unsupported_environments( $modules ) {
 		if ( ! Waf_Runner::is_supported_environment() ) {
 			// WAF should never be available on unsupported platforms.
-			unset( $modules['waf'] );
+			$modules = array_filter(
+				$modules,
+				function ( $module ) {
+					return $module !== 'waf';
+				}
+			);
+
 		}
 
 		return $modules;

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -197,7 +197,7 @@ class Waf_Initializer {
 	}
 
 	/**
-	 * Disables the WAF module when on an supported platform.
+	 * Disables the WAF module when on an supported platform in Jetpack.
 	 *
 	 * @param array $modules Filterable value for `jetpack_get_available_modules`.
 	 *
@@ -212,6 +212,13 @@ class Waf_Initializer {
 		return $modules;
 	}
 
+	/**
+	 * Disables the WAF module when on an supported platform in a standalone plugin.
+	 *
+	 * @param array $modules Filterable value for `jetpack_get_available_standalone_modules`.
+	 *
+	 * @return array Array of module slugs.
+	 */
 	public static function remove_standalone_module_on_unsupported_environments( $modules ) {
 		if ( ! Waf_Runner::is_supported_environment() ) {
 			// WAF should never be available on unsupported platforms.

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -197,7 +197,7 @@ class Waf_Initializer {
 	}
 
 	/**
-	 * Disables the WAF module when on an supported platform in Jetpack.
+	 * Disables the WAF module when on an unsupported platform in Jetpack.
 	 *
 	 * @param array $modules Filterable value for `jetpack_get_available_modules`.
 	 *
@@ -213,7 +213,7 @@ class Waf_Initializer {
 	}
 
 	/**
-	 * Disables the WAF module when on an supported platform in a standalone plugin.
+	 * Disables the WAF module when on an unsupported platform in a standalone plugin.
 	 *
 	 * @param array $modules Filterable value for `jetpack_get_available_standalone_modules`.
 	 *

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -30,7 +30,7 @@ class Waf_Initializer {
 	public static function init() {
 		// Do not run in unsupported environments
 		add_action( 'jetpack_get_available_modules', __CLASS__ . '::remove_module_on_unsupported_environments' );
-		add_action( 'jetpack_get_available_standalone_modules', __CLASS__ . '::remove_module_on_unsupported_environments' );
+		add_action( 'jetpack_get_available_standalone_modules', __CLASS__ . '::remove_standalone_module_on_unsupported_environments' );
 
 		// Ensure backwards compatibility
 		Waf_Compatibility::add_compatibility_hooks();
@@ -204,6 +204,15 @@ class Waf_Initializer {
 	 * @return array Array of module slugs.
 	 */
 	public static function remove_module_on_unsupported_environments( $modules ) {
+		if ( ! Waf_Runner::is_supported_environment() ) {
+			// WAF should never be available on unsupported platforms.
+			unset( $modules['waf'] );
+		}
+
+		return $modules;
+	}
+
+	public static function remove_standalone_module_on_unsupported_environments( $modules ) {
 		if ( ! Waf_Runner::is_supported_environment() ) {
 			// WAF should never be available on unsupported platforms.
 			$modules = array_filter(

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -97,7 +97,7 @@ class Waf_Runner {
 		}
 
 		// Do not run in the WPCOM context
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		if ( ( new Host() )->is_wpcom_simple() ) {
 			return false;
 		}
 

--- a/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
@@ -67,15 +67,10 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	 * Test WAF init in a supported environment.
 	 */
 	public function testInitSupportedEnvironment() {
-		// Waf_Runner::enable();
-		// Brute_Force_Protection::enable();
-
 		$available_modules = ( new Modules() )->get_available();
 
 		$this->assertContains( 'waf', $available_modules );
 		$this->assertContains( 'protect', $available_modules );
-		// $this->assertTrue( Waf_Runner::is_enabled() );
-		// $this->assertTrue( Brute_Force_Protection::is_enabled() );
 	}
 
 	/**
@@ -84,15 +79,10 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	public function testInitWpcomEnvironment() {
 		Constants::set_constant( 'IS_WPCOM', true );
 
-		// Waf_Runner::enable();
-		// Brute_Force_Protection::enable();
-
 		$available_modules = ( new Modules() )->get_available();
 
 		$this->assertNotContains( 'waf', $available_modules );
 		$this->assertContains( 'protect', $available_modules );
-		// $this->assertFalse( Waf_Runner::is_enabled() );
-		// $this->assertTrue( Brute_Force_Protection::is_enabled() );
 	}
 
 	/**
@@ -102,15 +92,10 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 		Constants::set_constant( 'ATOMIC_CLIENT_ID', 999 );
 		Constants::set_constant( 'ATOMIC_SITE_ID', 999 );
 
-		// Waf_Runner::enable();
-		// Brute_Force_Protection::enable();
-
 		$available_modules = ( new Modules() )->get_available();
 
 		$this->assertNotContains( 'waf', $available_modules );
 		$this->assertContains( 'protect', $available_modules );
-		// $this->assertFalse( Waf_Runner::is_enabled() );
-		// $this->assertTrue( Brute_Force_Protection::is_enabled() );
 	}
 
 	/**
@@ -119,14 +104,9 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	public function testInitVipEnvironment() {
 		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
 
-		// Waf_Runner::enable();
-		// Brute_Force_Protection::enable();
-
 		$available_modules = ( new Modules() )->get_available();
 
 		$this->assertNotContains( 'waf', $available_modules );
 		$this->assertContains( 'protect', $available_modules );
-		// $this->assertFalse( Waf_Runner::is_enabled() );
-		// $this->assertTrue( Brute_Force_Protection::is_enabled() );
 	}
 }

--- a/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Unsupported environment tests.
+ *
+ * @package automattic/jetpack-waf
+ */
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status\Cache;
+use Automattic\Jetpack\Waf\Waf_Initializer;
+
+/**
+ * Integration tests for unsupported environments.
+ */
+final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestCase {
+	/**
+	 * Mock data for the 'available_modules' option.
+	 */
+	private static $test_available_modules;
+
+	/**
+	 * Test setup.
+	 */
+	protected function set_up() {
+		Cache::clear();
+
+		self::$test_available_modules = array(
+			0 => 'waf',
+			1 => 'protect',
+		);
+
+		// Set a blog token and id so the site is connected.
+		Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		Jetpack_Options::update_option( 'id', 1234 );
+
+		// Add the WAF and Brute force protection module to the available modules.
+		add_filter( 'jetpack_get_available_modules', array( $this, 'add_modules_to_available_modules' ), 10, 1 );
+		add_filter( 'jetpack_get_available_standalone_modules', array( $this, 'add_modules_to_available_modules' ), 10, 1 );
+
+		// Initialize the firewall.
+		Waf_Initializer::init();
+	}
+
+	/**
+	 * Test teardown.
+	 */
+	protected function tear_down() {
+		Constants::clear_constants();
+		Cache::clear();
+	}
+
+	/**
+	 * Add "waf" and "protect" to the available Jetpack modules.
+	 *
+	 * @param array $modules The available modules.
+	 * @return array The available modules, including "waf" and "protect".
+	 */
+	public function add_modules_to_available_modules( $modules ) {
+		return self::$test_available_modules;
+	}
+
+	/**
+	 * Test WAF init in a supported environment.
+	 */
+	public function testInitSupportedEnvironment() {
+		// Waf_Runner::enable();
+		// Brute_Force_Protection::enable();
+
+		$available_modules = ( new Modules() )->get_available();
+
+		$this->assertContains( 'waf', $available_modules );
+		$this->assertContains( 'protect', $available_modules );
+		// $this->assertTrue( Waf_Runner::is_enabled() );
+		// $this->assertTrue( Brute_Force_Protection::is_enabled() );
+	}
+
+	/**
+	 * Test WAF init in a WPcom environment.
+	 */
+	public function testInitWpcomEnvironment() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		// Waf_Runner::enable();
+		// Brute_Force_Protection::enable();
+
+		$available_modules = ( new Modules() )->get_available();
+
+		$this->assertNotContains( 'waf', $available_modules );
+		$this->assertContains( 'protect', $available_modules );
+		// $this->assertFalse( Waf_Runner::is_enabled() );
+		// $this->assertTrue( Brute_Force_Protection::is_enabled() );
+	}
+
+	/**
+	 * Test WAF init in an Atomic environment.
+	 */
+	public function testInitAtomicEnvironment() {
+		Constants::set_constant( 'ATOMIC_CLIENT_ID', 999 );
+		Constants::set_constant( 'ATOMIC_SITE_ID', 999 );
+
+		// Waf_Runner::enable();
+		// Brute_Force_Protection::enable();
+
+		$available_modules = ( new Modules() )->get_available();
+
+		$this->assertNotContains( 'waf', $available_modules );
+		$this->assertContains( 'protect', $available_modules );
+		// $this->assertFalse( Waf_Runner::is_enabled() );
+		// $this->assertTrue( Brute_Force_Protection::is_enabled() );
+	}
+
+	/**
+	 * Test WAF init in a VIP environment.
+	 */
+	public function testInitVipEnvironment() {
+		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
+
+		// Waf_Runner::enable();
+		// Brute_Force_Protection::enable();
+
+		$available_modules = ( new Modules() )->get_available();
+
+		$this->assertNotContains( 'waf', $available_modules );
+		$this->assertContains( 'protect', $available_modules );
+		// $this->assertFalse( Waf_Runner::is_enabled() );
+		// $this->assertTrue( Brute_Force_Protection::is_enabled() );
+	}
+}

--- a/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
@@ -37,7 +37,6 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 		Jetpack_Options::update_option( 'id', 1234 );
 
 		// Add the WAF and Brute force protection module to the available modules.
-		add_filter( 'jetpack_get_available_modules', array( $this, 'add_modules_to_available_modules' ), 10, 1 );
 		add_filter( 'jetpack_get_available_standalone_modules', array( $this, 'add_modules_to_available_modules' ), 10, 1 );
 
 		// Initialize the firewall.

--- a/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
@@ -66,7 +66,7 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	/**
 	 * Test WAF init in a supported environment.
 	 */
-	public function testInitSupportedEnvironment() {
+	public function testWafInitSupportedEnvironment() {
 		$available_modules = ( new Modules() )->get_available();
 
 		$this->assertContains( 'waf', $available_modules );
@@ -76,7 +76,7 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	/**
 	 * Test WAF init in a WPcom environment.
 	 */
-	public function testInitWpcomEnvironment() {
+	public function testWafInitWpcomEnvironment() {
 		Constants::set_constant( 'IS_WPCOM', true );
 
 		$available_modules = ( new Modules() )->get_available();
@@ -88,7 +88,7 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	/**
 	 * Test WAF init in an Atomic environment.
 	 */
-	public function testInitAtomicEnvironment() {
+	public function testWafInitAtomicEnvironment() {
 		Constants::set_constant( 'ATOMIC_CLIENT_ID', 999 );
 		Constants::set_constant( 'ATOMIC_SITE_ID', 999 );
 
@@ -101,7 +101,7 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	/**
 	 * Test WAF init in a VIP environment.
 	 */
-	public function testInitVipEnvironment() {
+	public function testWafInitVipEnvironment() {
 		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
 
 		$available_modules = ( new Modules() )->get_available();

--- a/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
@@ -15,7 +15,9 @@ use Automattic\Jetpack\Waf\Waf_Initializer;
  */
 final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestCase {
 	/**
-	 * Mock data for the 'available_modules' option.
+	 * Mock data for the 'available_modules' option
+	 *
+	 * @var array
 	 */
 	private static $test_available_modules;
 
@@ -57,7 +59,9 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	 * @return array The available modules, including "waf" and "protect".
 	 */
 	public function add_modules_to_available_modules( $modules ) {
-		return self::$test_available_modules;
+		$modules = array_merge( $modules, self::$test_available_modules );
+
+		return $modules;
 	}
 
 	/**

--- a/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-unsupported-environment.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Waf\Waf_Initializer;
  */
 final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestCase {
 	/**
-	 * Mock data for the 'available_modules' option
+	 * Mock data for the available modules
 	 *
 	 * @var array
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

### Description
This PR introduces some fixes/improvements to code related to unsupported environments and adds tests to validate things are working as expected when certain platform constants are set.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replaces the `IS_WPCOM` constant check with the `Host` class `is_wpcom_simple` method in `Waf_Runner::is_supported_environment`
* Adds an action for the `jetpack_get_available_standalone_modules` filter to ensure the callback to remove the `waf` module from the available modules list also applies to the standalone plugin
* Adds a `Waf_Initializer::remove_standalone_module_on_unsupported_environments` method to ensure that when an unsupported environment is detected an array with the `waf` module removed is returned when it is used as the callback for the above
   * Note that the available/active modules array provided by Jetpack is an associated array with module slugs as the keys and versions as the values. The array provided by standalone Protect is a simple array of module slugs. Therefore a separate callback method was required to handle entry removal in each situation.
* Tests were added for the various unsupported environments. 
   * The tests establish a base set of available modules that would be generated by the plugin that employs the WAF package. It then initializes the WAF, verifies that the package properly recognizes and handles the environment, and removes the WAF module from the list of available modules when applicable. The resulting available modules list is what is used for eventual module activation - if the module is not in the list when `Waf_Runner::enable` (or `Brute_Force_Protect::enable`) is called within the package or plugin, the module will not be moved to the active modules list, `Waf_Runner:: is_enabled` (or `Brute_Force_Protection::is_enabled`) methods will return `false`, and no package code reliant on these checks should be run, effectively disabling it.
   * Testing covers the following:
      * Supported environment 
      * WPcom environment
      * Atomic environment
      * VIP environment

### Other information:
- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1204565761279419
- p1683666778750069/1683665504.220709-slack-C04E0KTGW9Z

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* Run `jetpack test packages/waf php` and verify that all testing succeeds
* Install the Jetpack Beta Tester plugin on a Pressable or Atomic site (using this branch for Jetpack only first, Protect only next, and then Jetpack and Protect) and ensure that the WAF settings are inaccessible and functionality disabled and that Brute force protection settings continue to be accessible and functionality available
   * Ensure no regression in functionality
* Install the Jetpack Beta Tester plugin on a Jurassic Ninja site (using this branch for Jetpack only first, Protect only next, and then Jetpack and Protect) and ensure that the WAF settings are inaccessible and functionality available and that Brute force protection settings are accessible and functionality available
   * Ensure no regression in functionality
