### PR TITLE
[RNMobile] refactor webview pressable

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-refactor-webview-pressable
+++ b/projects/packages/videopress/changelog/rnmobile-refactor-webview-pressable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Refactor Pressable component for the Android embed overlay

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
@@ -148,17 +148,28 @@ export default function Player( { isSelected, attributes } ) {
 
 	let overlay = ! isSelected && <View style={ style[ 'videopress-player__overlay' ] } />;
 
-	// On Android render an overlay to send the embed markup to a native WebView.
-	if ( isSelected && IS_ANDROID ) {
-		overlay = (
-			<View style={ style[ 'videopress-player__overlay' ] }>
-				<Pressable
-					style={ style[ 'videopress-player__open-embed-button' ] }
-					onPress={ () => {
-						requestEmbedFullscreenPreview( html, title );
-					} }
-				/>
-			</View>
+	let sandbox = (
+		<SandBox
+			html={ html }
+			onWindowEvents={ { message: onSandboxMessage } }
+			viewportProps="user-scalable=0"
+			testID="videopress-player"
+			onLoadEnd={ onLoadEnd }
+		/>
+	);
+
+	// On Android, we need to open the embed preview in a Native WebView
+	if ( IS_ANDROID ) {
+		sandbox = (
+			<Pressable
+				style={ style[ 'videopress-player__open-embed-button' ] }
+				onPress={ () => {
+					requestEmbedFullscreenPreview( html, title );
+				} }
+			>
+				<View style={ style[ 'videopress-player__overlay' ] } />
+				{ sandbox }
+			</Pressable>
 		);
 	}
 
@@ -171,15 +182,7 @@ export default function Player( { isSelected, attributes } ) {
 		<View style={ [ style[ 'videopress-player' ], { aspectRatio } ] }>
 			{ overlay }
 			{ showLoadingOverlay && loadingOverlay }
-			{ html && (
-				<SandBox
-					html={ html }
-					onWindowEvents={ { message: onSandboxMessage } }
-					viewportProps="user-scalable=0"
-					testID="videopress-player"
-					onLoadEnd={ onLoadEnd }
-				/>
-			) }
+			{ html && sandbox }
 		</View>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.native.js
@@ -146,8 +146,6 @@ export default function Player( { isSelected, attributes } ) {
 		</View>
 	);
 
-	let overlay = ! isSelected && <View style={ style[ 'videopress-player__overlay' ] } />;
-
 	let sandbox = (
 		<SandBox
 			html={ html }
@@ -179,8 +177,10 @@ export default function Player( { isSelected, attributes } ) {
 	const showLoadingOverlay = ! isPlayerReady || ( isPlayerLoaded && ! isPreviewReady );
 
 	return (
-		<View style={ [ style[ 'videopress-player' ], { aspectRatio } ] }>
-			{ overlay }
+		<View
+			style={ [ style[ 'videopress-player' ], { aspectRatio } ] }
+			pointerEvents={ isSelected ? 'auto' : 'none' }
+		>
 			{ showLoadingOverlay && loadingOverlay }
 			{ html && sandbox }
 		</View>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Refactor the VideoPress embed overlay on Android

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Nest the `Sandbox` component inside the embed `Pressable` component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On Android
* Visit a post with a VideoPress block
* Verify that the WebView does not open when selecting the block
* Tap on the video player
* The video should load in a Native WebView

On iOS
- Verify that the video does not play when selecting a VideoPress block.

