### PR TITLE
AI Assistant: Parse markdown inside ShowLittleByLittle

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-markdown-rendering-html-storing-ai-assistant
+++ b/projects/plugins/jetpack/changelog/fix-markdown-rendering-html-storing-ai-assistant
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: not needed
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
@@ -5,7 +5,4 @@ export default {
 	promptType: {
 		type: 'string',
 	},
-	rawContent: {
-		type: 'string',
-	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -109,7 +109,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	};
 
 	const handleAcceptTitle = () => {
-		editPost( { title: attributes.rawContent.trim() } );
+		editPost( { title: attributes.content.trim() } );
 		removeBlock( clientId );
 	};
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -149,7 +149,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 							setAnimationDone( true );
 						} }
 						clientId={ clientId }
-						html={ attributes.content }
+						markdown={ attributes.content }
 					/>
 				</>
 			) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/show-little-by-little.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/show-little-by-little.js
@@ -1,4 +1,9 @@
 import { RawHTML, useState, useEffect } from '@wordpress/element';
+import MarkdownIt from 'markdown-it';
+
+const markdownConverter = new MarkdownIt( {
+	breaks: true,
+} );
 
 // TODO: Switch the API to use streaming in which case this won't be needed.
 // This component displays the text word by word if show animation is true
@@ -15,14 +20,14 @@ const ShowLittleByLittle = ( { html, showAnimation, onAnimationDone } ) => {
 				const tokens = html.split( ' ' );
 				for ( let i = 1; i < tokens.length; i++ ) {
 					const output = tokens.slice( 0, i ).join( ' ' );
-					setTimeout( () => setDisplayedRawHTML( output ), 50 * i );
+					setTimeout( () => setDisplayedRawHTML( markdownConverter.render( output ), 50 * i ) );
 				}
 				setTimeout( () => {
-					setDisplayedRawHTML( html );
+					setDisplayedRawHTML( markdownConverter.render( html ) );
 					onAnimationDone();
 				}, 50 * tokens.length );
 			} else {
-				setDisplayedRawHTML( html );
+				setDisplayedRawHTML( markdownConverter.render( html ) );
 			}
 		},
 		// eslint-disable-next-line

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/show-little-by-little.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/show-little-by-little.js
@@ -7,7 +7,7 @@ const markdownConverter = new MarkdownIt( {
 
 // TODO: Switch the API to use streaming in which case this won't be needed.
 // This component displays the text word by word if show animation is true
-const ShowLittleByLittle = ( { html, showAnimation, onAnimationDone } ) => {
+const ShowLittleByLittle = ( { markdown, showAnimation, onAnimationDone } ) => {
 	// This is the HTML to be displayed.
 	const [ displayedRawHTML, setDisplayedRawHTML ] = useState( '' );
 
@@ -17,17 +17,17 @@ const ShowLittleByLittle = ( { html, showAnimation, onAnimationDone } ) => {
 			if ( showAnimation ) {
 				// This is to animate text input. I think this will give an idea of a "better" AI.
 				// At this point this is an established pattern.
-				const tokens = html.split( ' ' );
+				const tokens = markdown.split( ' ' );
 				for ( let i = 1; i < tokens.length; i++ ) {
 					const output = tokens.slice( 0, i ).join( ' ' );
 					setTimeout( () => setDisplayedRawHTML( markdownConverter.render( output ), 50 * i ) );
 				}
 				setTimeout( () => {
-					setDisplayedRawHTML( markdownConverter.render( html ) );
+					setDisplayedRawHTML( markdownConverter.render( markdown ) );
 					onAnimationDone();
 				}, 50 * tokens.length );
 			} else {
-				setDisplayedRawHTML( markdownConverter.render( html ) );
+				setDisplayedRawHTML( markdownConverter.render( markdown ) );
 			}
 		},
 		// eslint-disable-next-line

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -5,7 +5,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { useSelect, select as selectData } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import MarkdownIt from 'markdown-it';
 /**
  * Internal dependencies
  */
@@ -210,7 +209,7 @@ const useSuggestionsFromOpenAI = ( {
 					const markdownConverter = new MarkdownIt();
 					setAttributes( {
 						rawContent: result.length ? result : '',
-						content: result.length ? markdownConverter.render( result ) : '',
+						content: result.length ?  result : '',
 					} );
 				}, 10 );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -203,13 +203,11 @@ const useSuggestionsFromOpenAI = ( {
 				 * Hack to udpate the content.
 				 * @todo: maybe we should not pass the setAttributes function
 				 */
-				setAttributes( { content: '', rawContent: '' } );
+				setAttributes( { content: '' } );
 
 				setTimeout( () => {
-					const markdownConverter = new MarkdownIt();
 					setAttributes( {
-						rawContent: result.length ? result : '',
-						content: result.length ?  result : '',
+						content: result.length ? result : '',
 					} );
 				}, 10 );
 


### PR DESCRIPTION
Moves markdown parsing to the ShowLittleByLittle intead of doing it in the hook

This was making retry queries be rendered with escaped html as the second query would send html (stored in `attributes.content` to the API

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves call to `markdownConverter.render()` into the ShowLittleByLittle component
* Fixes lack of new lines transformation to `<br/>`. Evident when requesting poems of haikus

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Add an AI Assitant block
2. Run a query
3. Run a second query after the first one comes back
4. Expect to see no HTML markup in the second result
