### PR TITLE
AI Assistant: add some predef options when generating content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-show-predefs
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-show-predefs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistance: add some predef options when generating content

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -150,6 +150,33 @@ const ToolbarControls = ( {
 						onChange={ tone => getSuggestionFromOpenAI( 'change-tone', { tone } ) }
 						disabled={ contentIsLoaded }
 					/>
+
+					<ToolbarDropdownMenu
+						icon={ pencil }
+						label="More"
+						controls={ [
+							{
+								title: __( 'Summarize', 'jetpack' ),
+								onClick: () => getSuggestionFromOpenAI( 'summarize' ),
+							},
+							{
+								title: __( 'Make longer', 'jetpack' ),
+								onClick: () => getSuggestionFromOpenAI( 'makeLonger' ),
+							},
+							{
+								title: __( 'Make shorter', 'jetpack' ),
+								onClick: () => getSuggestionFromOpenAI( 'makeShorter' ),
+							},
+							{
+								title: __( 'Correct spelling and grammar', 'jetpack' ),
+								onClick: () => getSuggestionFromOpenAI( 'correctSpelling' ),
+							},
+							{
+								title: __( 'Generate a post title', 'jetpack' ),
+								onClick: () => getSuggestionFromOpenAI( 'generateTitle' ),
+							},
+						] }
+					/>
 				</BlockControls>
 			) }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -143,7 +143,7 @@ const ToolbarControls = ( {
 } ) => {
 	return (
 		<>
-			{ ! showRetry && contentIsLoaded && animationDone && (
+			{ contentIsLoaded && animationDone && (
 				<BlockControls group="block">
 					<ToneDropdownControl
 						value="neutral"

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -147,7 +147,7 @@ const ToolbarControls = ( {
 				<BlockControls group="block">
 					<ToneDropdownControl
 						value="neutral"
-						onChange={ tone => getSuggestionFromOpenAI( 'change-tone', { tone } ) }
+						onChange={ tone => getSuggestionFromOpenAI( 'changeTone', { tone } ) }
 						disabled={ contentIsLoaded }
 					/>
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -165,28 +165,28 @@ const useSuggestionsFromOpenAI = ( {
 			switch ( type ) {
 				case 'changeTone':
 					prompt = buildPromptTemplate( {
-						request: `Please, rewrite the given content with a ${ options.tone } tone.`,
+						request: `Please, rewrite with a ${ options.tone } tone.`,
 						content,
 					} );
 					break;
 
 				case 'summarize':
 					prompt = buildPromptTemplate( {
-						request: 'Summarize the given content.',
-						content,
+						request: 'Summarize the content below.',
+						content: content?.length ? content : getContentFromBlocks(),
 					} );
 					break;
 
 				case 'makeLonger':
 					prompt = buildPromptTemplate( {
-						request: 'Make the given content longer.',
+						request: 'Make the content below longer.',
 						content,
 					} );
 					break;
 
 				case 'makeShorter':
 					prompt = buildPromptTemplate( {
-						request: 'Make the given content shoter.',
+						request: 'Make the content below shorter.',
 						content,
 					} );
 					break;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -163,7 +163,7 @@ const useSuggestionsFromOpenAI = ( {
 		if ( ! options.retryRequest ) {
 			// If there is a content already, let's iterate over it.
 			switch ( type ) {
-				case 'titleSummary':
+				case 'changeTone':
 					prompt = buildPromptTemplate( {
 						content,
 						rules: [ `Please, do this with a ${ options.tone } tone` ],

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -191,6 +191,14 @@ const useSuggestionsFromOpenAI = ( {
 					} );
 					break;
 
+				case 'generateTitle':
+					prompt = buildPromptTemplate( {
+						request: 'Generate a title for this blog post',
+						rules: [ 'Only output the raw title, without any prefix or quotes' ],
+						content: content?.length ? content : getContentFromBlocks(),
+					} );
+					break;
+
 				default:
 					if ( content?.length && userPrompt?.length ) {
 						prompt = tellWhatToDoNext( userPrompt, content );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -170,6 +170,13 @@ const useSuggestionsFromOpenAI = ( {
 					} );
 					break;
 
+				case 'summarize':
+					prompt = buildPromptTemplate( {
+						request: 'Summarize the given content',
+						content,
+					} );
+					break;
+
 				default:
 					if ( content?.length && userPrompt?.length ) {
 						prompt = tellWhatToDoNext( userPrompt, content );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -162,23 +162,29 @@ const useSuggestionsFromOpenAI = ( {
 
 		if ( ! options.retryRequest ) {
 			// If there is a content already, let's iterate over it.
-			if ( type === 'changeTone' ) {
-				prompt = buildPromptTemplate( {
-					content,
-					rules: [ `Please, do this with a ${ options.tone } tone` ],
-				} );
-			} else if ( content?.length && userPrompt?.length ) {
-				prompt = tellWhatToDoNext( userPrompt, content );
-			} else {
-				prompt = createPrompt(
-					currentPostTitle,
-					getPartialContentToBlock( clientId ),
-					content?.length ? content : getContentFromBlocks(),
-					userPrompt,
-					type,
-					categoryNames,
-					tagNames
-				);
+			switch ( type ) {
+				case 'titleSummary':
+					prompt = buildPromptTemplate( {
+						content,
+						rules: [ `Please, do this with a ${ options.tone } tone` ],
+					} );
+					break;
+
+				default:
+					if ( content?.length && userPrompt?.length ) {
+						prompt = tellWhatToDoNext( userPrompt, content );
+					} else {
+						prompt = createPrompt(
+							currentPostTitle,
+							getPartialContentToBlock( clientId ),
+							content?.length ? content : getContentFromBlocks(),
+							userPrompt,
+							type,
+							categoryNames,
+							tagNames
+						);
+					}
+					break;
 			}
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -162,7 +162,7 @@ const useSuggestionsFromOpenAI = ( {
 
 		if ( ! options.retryRequest ) {
 			// If there is a content already, let's iterate over it.
-			if ( type === 'change-tone' ) {
+			if ( type === 'changeTone' ) {
 				prompt = buildPromptTemplate( {
 					content,
 					rules: [ `Please, do this with a ${ options.tone } tone` ],

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -165,8 +165,8 @@ const useSuggestionsFromOpenAI = ( {
 			switch ( type ) {
 				case 'changeTone':
 					prompt = buildPromptTemplate( {
+						request: `Please, rewrite the given content with a ${ options.tone } tone`,
 						content,
-						rules: [ `Please, do this with a ${ options.tone } tone` ],
 					} );
 					break;
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -165,14 +165,28 @@ const useSuggestionsFromOpenAI = ( {
 			switch ( type ) {
 				case 'changeTone':
 					prompt = buildPromptTemplate( {
-						request: `Please, rewrite the given content with a ${ options.tone } tone`,
+						request: `Please, rewrite the given content with a ${ options.tone } tone.`,
 						content,
 					} );
 					break;
 
 				case 'summarize':
 					prompt = buildPromptTemplate( {
-						request: 'Summarize the given content',
+						request: 'Summarize the given content.',
+						content,
+					} );
+					break;
+
+				case 'makeLonger':
+					prompt = buildPromptTemplate( {
+						request: 'Make the given content longer.',
+						content,
+					} );
+					break;
+
+				case 'makeShorter':
+					prompt = buildPromptTemplate( {
+						request: 'Make the given content shoter.',
 						content,
 					} );
 					break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

<img width="696" alt="Screenshot 2023-05-11 at 16 27 50" src="https://github.com/Automattic/jetpack/assets/77539/082bd1df-0394-4023-a72d-5966b45d06f0">

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistance: add some predef options when generating content

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

