### PR TITLE
Add/publicize mastodon integration

### DIFF
--- a/projects/packages/publicize/changelog/add-publicize-mastodon-integration
+++ b/projects/packages/publicize/changelog/add-publicize-mastodon-integration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added Mastodon to list of supported services

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -513,6 +513,7 @@ class Publicize extends Publicize_Base {
 			'twitter'  => array(),
 			'linkedin' => array(),
 			'tumblr'   => array(),
+			'mastodon' => array(),
 		);
 
 		if ( 'all' === $filter ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30659

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR enables post sharing with Mastodon in the Publicize package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- pdrWKz-Tm-p2
- Primary issue: #7790

## Does this pull request change what data or activity we track or use?
No.
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
- Make sure you have a Mastodon account
- Make sure your test site has a Social Advanced or Complete subscription, and activate Social (from the _My Jetpack_ section, for instance)

### Testing
- Check out this branch and spin up a test site
- Create a new post
- Click on the Jetpack menu in the top bar
- In the _Share this post_ section, click _Connect an account_
- You should be redirected to wordpress.com. Enable the `mastodon` feature flag by adding the query parameter `flags=mastodon` and reloading the page.
- You should now have the option to connect your Mastodon account. Connect it.
- Go back to edit your post
- You should now see Mastodon in the list of available services. Reload the page if you don't.

![Screenshot 2023-05-11 at 4 20 28 PM](https://github.com/Automattic/jetpack/assets/1620183/465445fb-b832-40ec-9c22-77de122e3c03)

- Enable sharing on Mastodon
- Publish your post
- Notice it was published on your Mastodon account