### PR TITLE
[RNMobile] Turn off autoplay if hover effect's active

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-videopress-conditionally-disable-autoplay
+++ b/projects/packages/videopress/changelog/rnmobile-videopress-conditionally-disable-autoplay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RNMobile: Turn off autoplay if poster hover effect's active

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/playback-panel/index.native.js
@@ -30,7 +30,10 @@ export default function PlaybackPanel( { attributes, setAttributes } ) {
 		setShowSubSheet( true );
 	}, [] );
 
-	const { autoplay, loop, muted, controls, playsinline, preload } = attributes;
+	const { autoplay, loop, muted, controls, playsinline, preload, posterData } = attributes;
+
+	// Is Preview On Hover effect enabled?
+	const isPreviewOnHoverEnabled = posterData?.previewOnHover;
 
 	const handleAttributeChange = useCallback(
 		( attributeName, attributeValue ) => {
@@ -40,6 +43,41 @@ export default function PlaybackPanel( { attributes, setAttributes } ) {
 		},
 		[ setAttributes ]
 	);
+
+	const AutoplayHelp = () => {
+		/*
+		 * If the preview on hover effect is enabled,
+		 * we want to let the user know that the autoplay
+		 * option is not available.
+		 */
+		if ( isPreviewOnHoverEnabled ) {
+			return (
+				<Text>
+					{ __(
+						'Autoplay is turned off as the preview on hover is active.',
+						'jetpack-videopress-pkg'
+					) }
+				</Text>
+			);
+		}
+
+		return (
+			<>
+				<Text>
+					{ __( 'Start playing the video as soon as the page loads.', 'jetpack-videopress-pkg' ) }
+				</Text>
+				{ autoplay && (
+					<Text>
+						{ '\n\n' +
+							__(
+								'Note: Autoplaying videos may cause usability issues for some visitors.',
+								'jetpack-videopress-pkg'
+							) }
+					</Text>
+				) }
+			</>
+		);
+	};
 
 	return (
 		<BottomSheet.SubSheet
@@ -66,26 +104,9 @@ export default function PlaybackPanel( { attributes, setAttributes } ) {
 					<ToggleControl
 						label={ __( 'Autoplay', 'jetpack-videopress-pkg' ) }
 						onChange={ handleAttributeChange( 'autoplay' ) }
-						checked={ autoplay }
-						help={
-							<>
-								<Text>
-									{ __(
-										'Start playing the video as soon as the page loads.',
-										'jetpack-videopress-pkg'
-									) }
-								</Text>
-								{ autoplay && (
-									<Text>
-										{ '\n\n' +
-											__(
-												'Note: Autoplaying videos may cause usability issues for some visitors.',
-												'jetpack-videopress-pkg'
-											) }
-									</Text>
-								) }
-							</>
-						}
+						checked={ autoplay && ! isPreviewOnHoverEnabled }
+						disabled={ isPreviewOnHoverEnabled }
+						help={ <AutoplayHelp /> }
 					/>
 
 					<ToggleControl


### PR DESCRIPTION
**Note, the change in this PR is dependant on the changes in https://github.com/WordPress/gutenberg/pull/50560.**

## Proposed changes:

* With these changes, the autoplay toggle is disabled when preview on hover is enabled on a video.
* The PR applies the changes introduced to the web in https://github.com/Automattic/jetpack/pull/30214 to native.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1683840917884969-slack-C03TA48NSUX 

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

* _**On the web:**_ Navigate to the editor for a post with an existing VideoPress block or go through the steps to add a new one. 
* In the **Post and preview** section of the block's settings, toggle the **Video preview on hover** option on.
* Verify that the autoplay setting is no longer usable under the **Playback** section and save the post.
* _**In the app:**_ Navigate to the editor for the post you just saved.
* Tap on the VideoPress block to then open its settings.
* Select **Playback Settings** and verify that the autoplay setting is no longer usable. It should display the same note as the web.

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/Automattic/jetpack/assets/2998162/88fa48e6-8187-4d6d-b9f1-71877756275a" width="100%"> | <img src="https://github.com/Automattic/jetpack/assets/2998162/b9b021bf-2a61-4e5b-b99c-a58f3c708383" width="100%"> |