### PR TITLE
AI Assistant: introduce internationalization dropdown when generating content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-introduce-i18n
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-introduce-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: introduce internationalization dropdown when generating content

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -14,6 +14,7 @@ import { arrowRight, chevronDown, image, pencil, update, title } from '@wordpres
 /*
  * Internal dependencies
  */
+import I18nDropdownControl from './i18n-dropdown-control';
 import Loading from './loading';
 import ToneDropdownControl from './tone-dropdown-control';
 
@@ -148,6 +149,12 @@ const ToolbarControls = ( {
 					<ToneDropdownControl
 						value="neutral"
 						onChange={ tone => getSuggestionFromOpenAI( 'changeTone', { tone } ) }
+						disabled={ contentIsLoaded }
+					/>
+
+					<I18nDropdownControl
+						value="en"
+						onChange={ language => getSuggestionFromOpenAI( 'changeLanguage', { language } ) }
 						disabled={ contentIsLoaded }
 					/>
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
@@ -119,7 +119,7 @@ export default function I18nDropdownControl( {
 									onClick={ () => onChange( language ) }
 									isSelected={ value === language }
 								>
-									{ `${ LANGUAGE_MAP[ language ].flag } ${ LANGUAGE_MAP[ language ].label }` }
+									{ LANGUAGE_MAP[ language ].label }
 								</MenuItem>
 							);
 						} ) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
@@ -29,11 +29,18 @@ const LANGUAGE_LIST = [
 	// more languages here...
 ] as const;
 
-const navigatorLanguage = navigator.language.split( '-' )[ 0 ];
-const siteLanguage = window.Jetpack_Editor_Initial_State.siteLocale.split( '-' )[ 0 ];
-const defaultLanguage = siteLanguage || navigatorLanguage;
+export type LanguageProp = ( typeof LANGUAGE_LIST )[ number ];
 
-export const DEFAULT_PROMPT_LANGUAGE = 'en';
+type LanguageDropdownControlProps = {
+	value: LanguageProp;
+	onChange: ( value: string ) => void;
+};
+
+const defaultLanguageLocale =
+	window?.Jetpack_Editor_Initial_State?.siteLocale || navigator?.language;
+
+export const defaultPromptLanguage = ( defaultLanguageLocale?.split( '-' )[ 0 ] ||
+	'en' ) as LanguageProp;
 
 const LANGUAGE_MAP = {
 	en: {
@@ -101,37 +108,30 @@ const LANGUAGE_MAP = {
 	},
 };
 
-export type LanguageProp = ( typeof LANGUAGE_LIST )[ number ];
-
-type LanguageDropdownControlProps = {
-	value: LanguageProp;
-	onChange: ( value: string ) => void;
-};
-
 export default function I18nDropdownControl( {
-	value = DEFAULT_PROMPT_LANGUAGE,
+	value = defaultPromptLanguage,
 	onChange,
 }: LanguageDropdownControlProps ) {
 	// Move the default language to the top of the list.
 	const languageList = [
-		defaultLanguage,
-		...LANGUAGE_LIST.filter( language => language !== defaultLanguage ),
+		defaultPromptLanguage,
+		...LANGUAGE_LIST.filter( language => language !== defaultPromptLanguage ),
 	];
 
 	// Set the `<html lang>` attribute to the selected language.
 	const changeLanguage = useCallback(
-		( language: string ) => {
+		( language: string, label: string ) => {
 			/*
 			 * If the selected language doesn’t match the site language,
 			 * set <html lang=“” />
 			 */
-			if ( language !== defaultLanguage ) {
-				document.documentElement.lang = language;
+			if ( language === defaultPromptLanguage ) {
+				document.documentElement.lang = defaultLanguageLocale;
 			} else {
 				document.documentElement.lang = '';
 			}
 
-			onChange( language );
+			onChange( language + ' (' + label + ')' );
 		},
 		[ onChange ]
 	);
@@ -151,7 +151,7 @@ export default function I18nDropdownControl( {
 							return (
 								<MenuItem
 									key={ `key-${ language }` }
-									onClick={ () => changeLanguage( language ) }
+									onClick={ () => changeLanguage( language, LANGUAGE_MAP[ language ].label ) }
 									isSelected={ value === language }
 								>
 									{ LANGUAGE_MAP[ language ].label }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
@@ -11,7 +11,6 @@ import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components'
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
 import React from 'react';
-import { useCallback } from 'react';
 
 const LANGUAGE_LIST = [
 	'en',
@@ -118,24 +117,6 @@ export default function I18nDropdownControl( {
 		...LANGUAGE_LIST.filter( language => language !== defaultPromptLanguage ),
 	];
 
-	// Set the `<html lang>` attribute to the selected language.
-	const changeLanguage = useCallback(
-		( language: string, label: string ) => {
-			/*
-			 * If the selected language doesn’t match the site language,
-			 * set <html lang=“” />
-			 */
-			if ( language === defaultPromptLanguage ) {
-				document.documentElement.lang = defaultLanguageLocale;
-			} else {
-				document.documentElement.lang = '';
-			}
-
-			onChange( language + ' (' + label + ')' );
-		},
-		[ onChange ]
-	);
-
 	return (
 		<ToolbarDropdownMenu
 			icon={ globe }
@@ -151,7 +132,7 @@ export default function I18nDropdownControl( {
 							return (
 								<MenuItem
 									key={ `key-${ language }` }
-									onClick={ () => changeLanguage( language, LANGUAGE_MAP[ language ].label ) }
+									onClick={ () => onChange( language + ' (' + LANGUAGE_MAP[ language ] + ')' ) }
 									isSelected={ value === language }
 								>
 									{ LANGUAGE_MAP[ language ].label }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
@@ -11,6 +11,7 @@ import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components'
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
 import React from 'react';
+import { useCallback } from 'react';
 
 const LANGUAGE_LIST = [
 	'en',
@@ -117,6 +118,24 @@ export default function I18nDropdownControl( {
 		...LANGUAGE_LIST.filter( language => language !== defaultLanguage ),
 	];
 
+	// Set the `<html lang>` attribute to the selected language.
+	const changeLanguage = useCallback(
+		( language: string ) => {
+			/*
+			 * If the selected language doesn’t match the site language,
+			 * set <html lang=“” />
+			 */
+			if ( language !== defaultLanguage ) {
+				document.documentElement.lang = language;
+			} else {
+				document.documentElement.lang = '';
+			}
+
+			onChange( language );
+		},
+		[ onChange ]
+	);
+
 	return (
 		<ToolbarDropdownMenu
 			icon={ globe }
@@ -132,7 +151,7 @@ export default function I18nDropdownControl( {
 							return (
 								<MenuItem
 									key={ `key-${ language }` }
-									onClick={ () => onChange( language ) }
+									onClick={ () => changeLanguage( language ) }
 									isSelected={ value === language }
 								>
 									{ LANGUAGE_MAP[ language ].label }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
@@ -132,7 +132,9 @@ export default function I18nDropdownControl( {
 							return (
 								<MenuItem
 									key={ `key-${ language }` }
-									onClick={ () => onChange( language + ' (' + LANGUAGE_MAP[ language ] + ')' ) }
+									onClick={ () =>
+										onChange( language + ' (' + LANGUAGE_MAP[ language ].label + ')' )
+									}
 									isSelected={ value === language }
 								>
 									{ LANGUAGE_MAP[ language ].label }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
@@ -1,0 +1,131 @@
+/*
+ * External dependencies
+ */
+import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { globe } from '@wordpress/icons';
+import React from 'react';
+
+const LANGUAGE_LIST = [
+	'en',
+	'es',
+	'fr',
+	'de',
+	'it',
+	'pt',
+	'ru',
+	'zh',
+	'ja',
+	'ar',
+	'hi',
+	'ko',
+	// more languages here...
+] as const;
+
+export const DEFAULT_PROMPT_LANGUAGE = 'en';
+
+const LANGUAGE_MAP = {
+	en: {
+		label: __( 'English', 'jetpack' ),
+		flag: '🇬🇧',
+	},
+	es: {
+		label: __( 'Spanish', 'jetpack' ),
+		flag: '🇪🇸',
+	},
+	fr: {
+		label: __( 'French', 'jetpack' ),
+		flag: '🇫🇷',
+	},
+	de: {
+		label: __( 'German', 'jetpack' ),
+		flag: '🇩🇪',
+	},
+	it: {
+		label: __( 'Italian', 'jetpack' ),
+		flag: '🇮🇹',
+	},
+	pt: {
+		label: __( 'Portuguese', 'jetpack' ),
+		flag: '🇵🇹',
+	},
+	ru: {
+		label: __( 'Russian', 'jetpack' ),
+		flag: '🇷🇺',
+	},
+	zh: {
+		label: __( 'Chinese', 'jetpack' ),
+		flag: '🇨🇳',
+	},
+	ja: {
+		label: __( 'Japanese', 'jetpack' ),
+		flag: '🇯🇵',
+	},
+	ar: {
+		label: __( 'Arabic', 'jetpack' ),
+		flag: '🇸🇦',
+	},
+	hi: {
+		label: __( 'Hindi', 'jetpack' ),
+		flag: '🇮🇳',
+	},
+	ko: {
+		label: __( 'Korean', 'jetpack' ),
+		flag: '🇰🇷',
+	},
+
+	id: {
+		label: __( 'Indonisian', 'jetpack' ),
+		flag: '🇮🇩',
+	},
+
+	tl: {
+		label: __( 'Filipino', 'jetpack' ),
+		flag: '🇵🇭',
+	},
+
+	vi: {
+		label: __( 'Vietnamese', 'jetpack' ),
+		flag: '🇻🇳',
+	},
+};
+
+export type LanguageProp = ( typeof LANGUAGE_LIST )[ number ];
+
+type LanguageDropdownControlProps = {
+	value: LanguageProp;
+	onChange: ( value: string ) => void;
+};
+
+export default function I18nDropdownControl( {
+	value = DEFAULT_PROMPT_LANGUAGE,
+	onChange,
+}: LanguageDropdownControlProps ) {
+	return (
+		<ToolbarDropdownMenu
+			icon={ globe }
+			label={ __( 'Language', 'jetpack' ) }
+			popoverProps={ {
+				variant: 'toolbar',
+			} }
+		>
+			{ () => {
+				return (
+					<MenuGroup label={ __( 'Select language', 'jetpack' ) }>
+						{ LANGUAGE_LIST.map( language => {
+							return (
+								<MenuItem
+									key={ `key-${ language }` }
+									onClick={ () => onChange( language ) }
+									isSelected={ value === language }
+								>
+									{ `${ LANGUAGE_MAP[ language ].flag } ${ LANGUAGE_MAP[ language ].label }` }
+								</MenuItem>
+							);
+						} ) }
+					</MenuGroup>
+				);
+			} }
+		</ToolbarDropdownMenu>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
@@ -1,3 +1,9 @@
+declare global {
+	interface Window {
+		Jetpack_Editor_Initial_State: { siteLocale: string };
+	}
+}
+
 /*
  * External dependencies
  */
@@ -21,6 +27,10 @@ const LANGUAGE_LIST = [
 	'ko',
 	// more languages here...
 ] as const;
+
+const navigatorLanguage = navigator.language.split( '-' )[ 0 ];
+const siteLanguage = window.Jetpack_Editor_Initial_State.siteLocale.split( '-' )[ 0 ];
+const defaultLanguage = siteLanguage || navigatorLanguage;
 
 export const DEFAULT_PROMPT_LANGUAGE = 'en';
 
@@ -101,6 +111,12 @@ export default function I18nDropdownControl( {
 	value = DEFAULT_PROMPT_LANGUAGE,
 	onChange,
 }: LanguageDropdownControlProps ) {
+	// Move the default language to the top of the list.
+	const languageList = [
+		defaultLanguage,
+		...LANGUAGE_LIST.filter( language => language !== defaultLanguage ),
+	];
+
 	return (
 		<ToolbarDropdownMenu
 			icon={ globe }
@@ -112,7 +128,7 @@ export default function I18nDropdownControl( {
 			{ () => {
 				return (
 					<MenuGroup label={ __( 'Select language', 'jetpack' ) }>
-						{ LANGUAGE_LIST.map( language => {
+						{ languageList.map( language => {
 							return (
 								<MenuItem
 									key={ `key-${ language }` }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { buildPromptTemplate } from './create-prompt';
 import { askJetpack } from './get-suggestion-with-stream';
-import { DEFAULT_PROMPT_LANGUAGE } from './i18n-dropdown-control';
+import { defaultPromptLanguage } from './i18n-dropdown-control';
 import { DEFAULT_PROMPT_TONE } from './tone-dropdown-control';
 
 /**
@@ -148,7 +148,8 @@ const useSuggestionsFromOpenAI = ( {
 		options = {
 			retryRequest: false,
 			tone: DEFAULT_PROMPT_TONE,
-			language: DEFAULT_PROMPT_LANGUAGE,
+			language: defaultPromptLanguage,
+			...options,
 		};
 
 		if ( isLoadingCompletion ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -149,7 +149,6 @@ const useSuggestionsFromOpenAI = ( {
 			retryRequest: false,
 			tone: DEFAULT_PROMPT_TONE,
 			language: DEFAULT_PROMPT_LANGUAGE,
-			...options,
 		};
 
 		if ( isLoadingCompletion ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { buildPromptTemplate } from './create-prompt';
 import { askJetpack } from './get-suggestion-with-stream';
+import { DEFAULT_PROMPT_LANGUAGE } from './i18n-dropdown-control';
 import { DEFAULT_PROMPT_TONE } from './tone-dropdown-control';
 
 /**
@@ -147,6 +148,7 @@ const useSuggestionsFromOpenAI = ( {
 		options = {
 			retryRequest: false,
 			tone: DEFAULT_PROMPT_TONE,
+			langiuage: DEFAULT_PROMPT_LANGUAGE,
 			...options,
 		};
 
@@ -257,6 +259,16 @@ const useSuggestionsFromOpenAI = ( {
 				case 'correctSpelling':
 					prompt = buildPromptTemplate( {
 						request: 'Correct any spelling and grammar mistakes from the content below.',
+						content: content?.length ? content : getContentFromBlocks(),
+					} );
+					break;
+
+				/**
+				 * Change the language, based on options.language
+				 */
+				case 'changeLanguage':
+					prompt = buildPromptTemplate( {
+						request: `Please, rewrite in the following language: ${ options.language }`,
 						content: content?.length ? content : getContentFromBlocks(),
 					} );
 					break;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -148,7 +148,7 @@ const useSuggestionsFromOpenAI = ( {
 		options = {
 			retryRequest: false,
 			tone: DEFAULT_PROMPT_TONE,
-			langiuage: DEFAULT_PROMPT_LANGUAGE,
+			language: DEFAULT_PROMPT_LANGUAGE,
 			...options,
 		};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

AI Assistant: introduce internationalization dropdown when generating content

Fixes https://github.com/Automattic/jetpack/issues/30676

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: introduce internationalization dropdown when generating content

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create an AI Assistant
* Generate content
* Confirm you see the i18n option in the toolbar (globe)
* Confirm you can translate the content by selecting the language from there

https://github.com/Automattic/jetpack/assets/77539/721e3433-0654-49e7-8a5e-19ffe8345a16

* Confirm the user language is the default one
<img width="427" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/12f8a389-830c-44bf-9b41-976d289a7814">



