### PR TITLE
CRM: Client Portal PHP fatal error when loading endpoints/shortcodes

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3003-client-portal-fatal-error-loading-endpoints
+++ b/projects/plugins/crm/changelog/fix-crm-3003-client-portal-fatal-error-loading-endpoints
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix a Client Portal faltal error initializationg the endpoints
+Client Portal: Fix a fatal error initializing endpoints and shortcodes.

--- a/projects/plugins/crm/changelog/fix-crm-3003-client-portal-fatal-error-loading-endpoints
+++ b/projects/plugins/crm/changelog/fix-crm-3003-client-portal-fatal-error-loading-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a Client Portal faltal error initializationg the endpoints

--- a/projects/plugins/crm/modules/portal/class-client-portal.php
+++ b/projects/plugins/crm/modules/portal/class-client-portal.php
@@ -34,7 +34,8 @@ class Client_Portal {
 		$this->router = new Client_Portal_Router();
 		$this->render = new Client_Portal_Render_Helper( $this );
 
-		$this->init();
+		// Initializes it later. Priority 10
+		add_action( 'init', array( $this, 'init' ) );
 	}
 
 	/**

--- a/projects/plugins/crm/modules/portal/class-client-portal.php
+++ b/projects/plugins/crm/modules/portal/class-client-portal.php
@@ -57,7 +57,7 @@ class Client_Portal {
 		// Custom login redirect hook (this one is in our $router).
 		add_action( 'login_redirect', array( $this->router, 'redirect_contacts_upon_login' ), 10, 3 );
 		// Initializes all endpoints (including the ones from external plugins).
-		add_action( 'init', array( $this, 'init_endpoints' ) );
+		$this->init_endpoints();
 		// this catches failed logins, checks if from our page, then redirs
 		// From mr pippin https://pippinsplugins.com/redirect-to-custom-login-page-on-failed-login/
 		add_action( 'wp_login_failed', array( $this, 'portal_login_fail_redirect' ) );  // hook failed login


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3003

## Proposed changes:
This PR fixes a PHP fatal error during the Client Portal module initialization. The module was initializing the endpoints too late, via action hook. In some cases, there are third parties (plugins/themes) that could process page content during the WP init process, which implies a call to the `do_shortcode` function, which will initialize the Client Portal module, but the endpoints initialization is enqueued in the WP init process and is not ready to be used, causing that fatal error.

To replicate it, add this code, for example, in the theme `functions.php` file:

```
add_action( 'init', function() {
	do_shortcode( '[jetpackcrm_clientportal]' );	
}, 5);
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Add the `do_shortcode` code described above to your `functions.php` file.
- Add the `[jetpackcrm_clientportal]` shortcode in a page
- Save the page and try to visit it (I did it in the incognito tab)
- In trunk, you will get the fatal error
- With this branch, everything will work

