### PR TITLE
AI Assistant: Fix markup rendering on Done click

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-markup-render-on-done
+++ b/projects/plugins/jetpack/changelog/fix-markup-render-on-done
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: not needed
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -8,6 +8,7 @@ import { Flex, FlexBlock, Modal } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import MarkdownIt from 'markdown-it';
 /**
  * Internal dependencies
  */
@@ -17,6 +18,10 @@ import { getImagesFromOpenAI } from './lib';
 import ShowLittleByLittle from './show-little-by-little';
 import useSuggestionsFromOpenAI from './use-suggestions-from-openai';
 import './editor.scss';
+
+const markdownConverter = new MarkdownIt( {
+	breaks: true,
+} );
 
 export default function AIAssistantEdit( { attributes, setAttributes, clientId } ) {
 	const [ userPrompt, setUserPrompt ] = useState();
@@ -105,7 +110,10 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	const contentIsLoaded = !! attributes.content;
 
 	const handleAcceptContent = () => {
-		replaceBlocks( clientId, rawHandler( { HTML: attributes.content } ) );
+		replaceBlocks(
+			clientId,
+			rawHandler( { HTML: markdownConverter.render( attributes.content ) } )
+		);
 	};
 
 	const handleAcceptTitle = () => {


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/30656

A small bug was left. When clicking done, we just render `attributes.content` without going through the markup renderer



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates edit.js to take care of rendering markup on submission

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* Add an Assitant block
* Request `a haiku` (cause it include evident new lines
* Click done
Confirm new lines are respected

