### PR TITLE
Blog onboarding: Added plan_completed step for start-writing flow instead of plan_selected

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-mu-wpcom-plugin-start-writing-flow
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-mu-wpcom-plugin-start-writing-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added plan_completed step for start-writing flow instead of plan_selected

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "2.1.x-dev"
+			"dev-trunk": "2.2.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "2.1.1-alpha",
+	"version": "2.2.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '2.1.1-alpha';
+	const PACKAGE_VERSION = '2.2.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -647,6 +647,7 @@ function wpcom_track_site_launch_task() {
 	wpcom_mark_launchpad_task_complete_if_active( 'site_launched' );
 	wpcom_mark_launchpad_task_complete_if_active( 'link_in_bio_launched' );
 	wpcom_mark_launchpad_task_complete_if_active( 'videopress_launched' );
+	wpcom_mark_launchpad_task_complete_if_active( 'blog_launched' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -39,6 +39,15 @@ function wpcom_register_default_launchpad_checklists() {
 
 	wpcom_register_launchpad_task(
 		array(
+			'id'                   => 'plan_completed',
+			'title'                => __( 'Choose a plan', 'jetpack-mu-wpcom' ),
+			'subtitle'             => 'wpcom_get_plan_completed_subtitle',
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
+		)
+	);
+
+	wpcom_register_launchpad_task(
+		array(
 			'id'                   => 'subscribers_added',
 			'title'                => __( 'Add subscribers', 'jetpack-mu-wpcom' ),
 			'is_complete_callback' => '__return_true',
@@ -146,8 +155,8 @@ function wpcom_register_default_launchpad_checklists() {
 		array(
 			'id'                   => 'setup_blog',
 			'title'                => __( 'Name your blog', 'jetpack-mu-wpcom' ),
-			'is_complete_callback' => '__return_false',
-			'is_disabled_callback' => '__return_false',
+			'is_complete_callback' => 'wpcom_is_setup_blog_completed',
+			'is_disabled_callback' => 'wpcom_is_task_option_completed',
 		)
 	);
 
@@ -340,7 +349,7 @@ function wpcom_register_default_launchpad_checklists() {
 				'first_post_published',
 				'setup_blog',
 				'domain_upsell',
-				'plan_selected',
+				'plan_completed',
 				'blog_launched',
 			),
 		)
@@ -438,6 +447,20 @@ function wpcom_is_domain_upsell_completed( $task, $default ) {
 		return true;
 	}
 	return $default;
+}
+
+/**
+ * Returns the option value for a task and false if no option exists.
+ *
+ * @param array $task The Task object.
+ * @return bool True if the blog was named.
+ */
+function wpcom_is_task_option_completed( $task ) {
+	$checklist = get_option( 'launchpad_checklist_tasks_statuses', array() );
+	if ( ! empty( $checklist[ $task['id'] ] ) ) {
+		return true;
+	}
+	return false;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -155,8 +155,7 @@ function wpcom_register_default_launchpad_checklists() {
 		array(
 			'id'                   => 'setup_blog',
 			'title'                => __( 'Name your blog', 'jetpack-mu-wpcom' ),
-			'is_complete_callback' => 'wpcom_is_setup_blog_completed',
-			'is_disabled_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
 		)
 	);
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-mu-wpcom-plugin-start-writing-flow
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-mu-wpcom-plugin-start-writing-flow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_2_2"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_2_3_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "ee0e379d588819c05e51c7f987fe95fbbc263cab"
+                "reference": "6975b84f818f889d1a596fb508a273738f6039d5"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.2.2
+ * Version: 1.2.3-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.2.2",
+	"version": "1.2.3-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Task-related: 2275-gh-Automattic/dotcom-forge


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added `plan_completed` step for `start-writing` flow instead of `plan_selected`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch on your sandbox
* Start a new site in the http://calypso.localhost:3000/setup/start-writing (from a new user or a user without sites)
* Ensure the flow works as expected