### PR TITLE
[RNMobile] Ensure "play inline" setting is saved in Video block for WP.com/Jetpack sites

### DIFF
--- a/projects/plugins/jetpack/changelog/rnmobile-support-playinline-video-setting
+++ b/projects/plugins/jetpack/changelog/rnmobile-support-playinline-video-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+RNMobile: Enable playsInline setting to be saved in video block.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.native.js
@@ -50,7 +50,7 @@ const addVideoPressSupport = ( settings, name ) => {
 			source: 'attribute',
 			selector: 'video',
 			attribute: 'playsinline',
-		},		
+		},
 		poster: {
 			type: 'string',
 		},

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.native.js
@@ -45,9 +45,12 @@ const addVideoPressSupport = ( settings, name ) => {
 		original: {
 			type: 'string',
 		},
-		playsinline: {
+		playsInline: {
 			type: 'boolean',
-		},
+			source: 'attribute',
+			selector: 'video',
+			attribute: 'playsinline',
+		},		
 		poster: {
 			type: 'string',
 		},


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1721

- Related issue: https://github.com/Automattic/jetpack/issues/29075

## Proposed changes:

* In the apps, the "play inline" setting is not currently being saved in the core Video block for WordPress.com or Jetpack sites. The difference with this site type is that the Video block is edited via [this `editor.native.js` file](https://github.com/Automattic/jetpack/blob/0a236dbe7c65ccb240a97c1273bf3bcd30c0cb07/projects/plugins/jetpack/extensions/blocks/videopress/editor.native.js) when saved.
* To fix this, the `playsInline` definition has been updated to include its source, selector, and attribute. The capitalisation has also been corrected to align with the core Video block:

https://github.com/Automattic/jetpack/blob/0a236dbe7c65ccb240a97c1273bf3bcd30c0cb07/projects/plugins/jetpack/extensions/blocks/videopress/editor.native.js#L48-L53  

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/wordpress-mobile/gutenberg-mobile/issues/1721

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

* Go to '..'
*

