### PR TITLE
Update of jetpack-mu-wpcom

### DIFF
--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.3] - 2023-05-12
+
 ## [3.3.2] - 2023-02-20
 ### Changed
 - Minor internal updates.
@@ -147,6 +149,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[3.3.3]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.2...3.3.3
 [3.3.2]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.1...3.3.2
 [3.3.1]: https://github.com/Automattic/jetpack-changelogger/compare/3.3.0...3.3.1
 [3.3.0]: https://github.com/Automattic/jetpack-changelogger/compare/3.2.3...3.3.0

--- a/projects/packages/changelogger/changelog/update-phpcs-rules
+++ b/projects/packages/changelogger/changelog/update-phpcs-rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Standardize on certain PHP function aliases over others, e.g. `implode` rather than `join`.
-
-

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '3.3.3-alpha';
+	const VERSION = '3.3.3';
 
 	/**
 	 * Constructor.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2023-05-12
+### Changed
+- Added plan_completed step for start-writing flow instead of plan_selected [#30686]
+
+### Fixed
+- Ensure calling Launchpad_Task_Lists::list() with an empty ID doesn't result in a PHP warning. [#30509]
+
 ## [2.1.0] - 2023-05-11
 ### Added
 - Add start writing checklist and task definitions to Launchpad Checklist API [#30369]
@@ -138,6 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[2.2.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v1.7.0...v2.0.0
 [1.7.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v1.6.0...v1.7.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-php-warning
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-php-warning
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Ensure calling Launchpad_Task_Lists::list() with an empty ID doesn't result in a PHP warning.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-mu-wpcom-plugin-start-writing-flow
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-mu-wpcom-plugin-start-writing-flow
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Added plan_completed step for start-writing flow instead of plan_selected

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "2.2.0-alpha",
+	"version": "2.2.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '2.2.0-alpha';
+	const PACKAGE_VERSION = '2.2.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.3 - 2023-05-12
+
 ## 1.2.2 - 2023-05-11
 
 ## 1.2.1 - 2023-05-08

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-mu-wpcom-plugin-start-writing-flow
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-mu-wpcom-plugin-start-writing-flow
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_2_3_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_2_3"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.2.3-alpha
+ * Version: 1.2.3
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.2.3-alpha",
+	"version": "1.2.3",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/pull/30686

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We sent the jetpack-mu-wpcom changes of https://github.com/Automattic/jetpack/pull/30686

More context: p1683920653728859/1683823463.684499-slack-CKZHG0QCR

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*