### PR TITLE
Debug Helper: Add WPCOM API Request Tracker Module

### DIFF
--- a/projects/plugins/debug-helper/changelog/add-debug-helper-wpcom-api-request-tracker
+++ b/projects/plugins/debug-helper/changelog/add-debug-helper-wpcom-api-request-tracker
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a new WPCOM API Request Tracker module.

--- a/projects/plugins/debug-helper/modules/class-wpcom-api-request-tracker-module.php
+++ b/projects/plugins/debug-helper/modules/class-wpcom-api-request-tracker-module.php
@@ -42,7 +42,7 @@ class WPCOM_API_Request_Tracker_Module {
 	 */
 	public function enqueue_scripts() {
 		wp_enqueue_style( 'broken_token_style', plugin_dir_url( __FILE__ ) . 'inc/css/wpcom-api-request-tracker.css', array(), JETPACK_DEBUG_HELPER_VERSION );
-		wp_enqueue_script( 'broken_token_script', plugin_dir_url( __FILE__ ) . 'inc/js/wpcom-api-request-tracker.js', array( 'jquery' ), JETPACK_DEBUG_HELPER_VERSION );
+		wp_enqueue_script( 'broken_token_script', plugin_dir_url( __FILE__ ) . 'inc/js/wpcom-api-request-tracker.js', array( 'jquery' ), JETPACK_DEBUG_HELPER_VERSION, true );
 	}
 
 	/**

--- a/projects/plugins/debug-helper/modules/class-wpcom-api-request-tracker-module.php
+++ b/projects/plugins/debug-helper/modules/class-wpcom-api-request-tracker-module.php
@@ -1,0 +1,95 @@
+<?php // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r
+/**
+ * Plugin Name: WPCOM API Request Tracker
+ * Description: Displays the number of requests to WPCOM API endpoints for the current page request.
+ * Author: Bestpack
+ * Version: 1.0
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack-debug-helper
+ */
+
+/**
+ * Require the core WPCOM API request tracker functionality.
+ */
+require __DIR__ . '/inc/class-wpcom-api-request-tracker.php';
+WPCOM_API_Request_Tracker::init();
+
+/**
+ * Class WPCOM_API_Request_Tracker_Module
+ */
+class WPCOM_API_Request_Tracker_Module {
+	/**
+	 * WPCOM API request count.
+	 *
+	 * @var int
+	 */
+	public $request_count = 0;
+
+	/**
+	 * WPCOM_Request_Tracker constructor.
+	 */
+	public function __construct() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'wp_before_admin_bar_render', array( $this, 'register_admin_bar_menu' ), 1000000 );
+		add_action( 'admin_footer', array( $this, 'render' ), 1000 );
+		add_action( 'wp_footer', array( $this, 'render' ), 1000 );
+	}
+
+	/**
+	 * Enqueue scripts.
+	 */
+	public function enqueue_scripts() {
+		wp_enqueue_style( 'broken_token_style', plugin_dir_url( __FILE__ ) . 'inc/css/wpcom-api-request-tracker.css', array(), JETPACK_DEBUG_HELPER_VERSION );
+		wp_enqueue_script( 'broken_token_script', plugin_dir_url( __FILE__ ) . 'inc/js/wpcom-api-request-tracker.js', array( 'jquery' ), JETPACK_DEBUG_HELPER_VERSION );
+	}
+
+	/**
+	 * Register the admin bar menu.
+	 */
+	public function register_admin_bar_menu() {
+		global $wp_admin_bar;
+
+		$wp_admin_bar->add_menu(
+			array(
+				'id'     => 'wpcom-api-request-tracker',
+				'parent' => 'top-secondary',
+				'title'  => 'WPCOM API Requests',
+			)
+		);
+	}
+
+	/**
+	 * Render the details panel.
+	 */
+	public function render() {
+		$requests = WPCOM_API_Request_Tracker::init()->get_requests();
+
+		?>
+		<script>var wpcom_api_request_tracker_count = <?php echo esc_js( array_sum( $requests ) ); ?>;</script>
+		<div id='wpcom-api-request-tracker'>
+
+			<div id="wpcom-api-request-tracker-actions">
+				<span class="maximize">+</span>
+				<span class="restore">&ndash;</span>
+				<span class="close">&times;</span>
+			</div>
+
+			<div id='wpcom-api-request-tracker-info'>
+				<p>Request Count: <?php echo esc_html( array_sum( $requests ) ); ?></p>
+				<p>Request URLs:</p>
+				<ul>
+					<?php foreach ( $requests as $request => $count ) : ?>
+						<li><?php echo esc_html( "$count - $request" ); ?></li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+		</div>
+		<?php
+	}
+}
+
+new WPCOM_API_Request_Tracker_Module();
+
+// phpcs:enable

--- a/projects/plugins/debug-helper/modules/inc/class-wpcom-api-request-tracker.php
+++ b/projects/plugins/debug-helper/modules/inc/class-wpcom-api-request-tracker.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * The WPCOM_API_Request_Tracker class
+ *
+ * @package automattic/jetpack-debug-helper.
+ */
+
+/**
+ * WPCOM_API_Request_Tracker.
+ *
+ * Tracks requests to WPCOM public API.
+ */
+class WPCOM_API_Request_Tracker {
+
+	/**
+	 * Singleton WPCOM_API_Request_Tracker instance.
+	 *
+	 * @var WPCOM_API_Request_Tracker
+	 **/
+	private static $instance = null;
+
+	/**
+	 * Holds requests to WPCOM public API.
+	 *
+	 * @var array
+	 */
+	protected $requests = array();
+
+	/**
+	 * Private WPCOM_API_Request_Tracker constructor.
+	 *
+	 * Use the WPCOM_API_Request_Tracker::init() method to get an instance.
+	 */
+	private function __construct() {
+		add_action( 'requests-requests.before_request', array( $this, 'store_requests' ), 1, 1 );
+	}
+
+	/**
+	 * Initialize class and get back a singleton instance.
+	 *
+	 * @return WPCOM_API_Request_Tracker
+	 */
+	public static function init() {
+		if ( null === self::$instance ) {
+			self::$instance = new WPCOM_API_Request_Tracker();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Tracks request count to WPCOM public API.
+	 *
+	 * Attached to the `requests-requests.before_request` filter.
+	 *
+	 * @param string $url URL of request about to be made.
+	 * @return void
+	 */
+	public function store_requests( $url ) {
+		$url_host = wp_parse_url( $url, PHP_URL_HOST );
+
+		if ( 'public-api.wordpress.com' === $url_host ) {
+			$this->requests[ $url ] = array_key_exists( $url, $this->requests ) ? $this->requests[ $url ]++ : 1;
+		}
+	}
+
+	/**
+	 * Returns the stored requests.
+	 *
+	 * @return array Stored URLs array as URL => request count.
+	 */
+	public function get_requests() {
+		return $this->requests;
+	}
+}

--- a/projects/plugins/debug-helper/modules/inc/css/wpcom-api-request-tracker.css
+++ b/projects/plugins/debug-helper/modules/inc/css/wpcom-api-request-tracker.css
@@ -14,6 +14,14 @@
 	line-height: 150% !important;
 	text-align: left;
 	font-size: 12px;
+	border-top: 1px solid #cccccc;
+	padding: 15px;
+	overflow: auto;
+}
+
+#wpcom-api-request-tracker li {
+	list-style: disc;
+	margin-left: 15px;
 }
 
 #wpcom-api-request-tracker a {

--- a/projects/plugins/debug-helper/modules/inc/css/wpcom-api-request-tracker.css
+++ b/projects/plugins/debug-helper/modules/inc/css/wpcom-api-request-tracker.css
@@ -1,0 +1,35 @@
+#wpcom-api-request-tracker {
+	direction: ltr;
+	display: none;
+	position: fixed;
+	height: 33%;
+	min-height: 350px;
+	font-family: "Helvetica Neue", sans-serif;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: #f1f1f1;
+	z-index: 99000;
+	color: #000;
+	line-height: 150% !important;
+	text-align: left;
+	font-size: 12px;
+}
+
+#wpcom-api-request-tracker a {
+	border: 0;
+}
+
+.wpcom-api-request-tracker-visible #wpcom-api-request-tracker {
+	display: block;
+}
+
+.wpcom-api-request-tracker-maximized #wpcom-api-request-tracker {
+	position: fixed;
+	top: 28px;
+	height: auto;
+}
+
+body.wpcom-api-request-tracker-maximized.wpcom-api-request-tracker-visible {
+	overflow: hidden;
+}

--- a/projects/plugins/debug-helper/modules/inc/js/wpcom-api-request-tracker.js
+++ b/projects/plugins/debug-helper/modules/inc/js/wpcom-api-request-tracker.js
@@ -1,0 +1,140 @@
+let wpcomApiRequestTracker;
+
+( function ( $ ) {
+	let api;
+
+	wpcomApiRequestTracker = api = {
+		// The element that we will pad to prevent the debug bar
+		// from overlapping the bottom of the page.
+		body: undefined,
+
+		init: function init() {
+			// If we're not in the admin, pad the body.
+			api.body = $( document.body );
+
+			api.toggle.init();
+			api.tabs();
+			api.actions.init();
+			api.updateAdminBarTitle();
+		},
+
+		updateAdminBarTitle: function () {
+			/* eslint-disable no-undef */
+			if ( typeof wpcom_api_request_tracker_count === 'undefined' ) {
+				setTimeout( api.updateAdminBarTitle, 100 );
+			} else {
+				const newTitle =
+					$( '#wp-admin-bar-wpcom-api-request-tracker .ab-item' ).html() +
+					' (<strong>' +
+					wpcom_api_request_tracker_count +
+					'</strong>)';
+				$( '#wp-admin-bar-wpcom-api-request-tracker .ab-item' ).html( newTitle );
+			}
+			/* eslint-enable no-undef */
+		},
+
+		isVisible: function isVisible() {
+			return api.body.hasClass( 'wpcom-api-request-tracker-visible' );
+		},
+
+		toggle: {
+			init: function init() {
+				$( '#wp-admin-bar-wpcom-api-request-tracker' ).on( 'click', function ( event ) {
+					event.preventDefault();
+
+					// Click on submenu item.
+					if ( event.target.hash ) {
+						const $menuLink = $( event.target.rel );
+
+						// Open/close debug bar.
+						if ( ! api.isVisible() ) {
+							api.toggle.visibility();
+						} else if ( $menuLink.hasClass( 'current' ) ) {
+							$menuLink.removeClass( 'current' );
+							api.toggle.visibility();
+
+							return;
+						}
+
+						// Deselect other tabs and hide other panels.
+						$( '.debug-menu-target' ).hide().trigger( 'wpcom-api-request-tracker-hide' );
+						$( '.debug-menu-link' ).removeClass( 'current' );
+
+						$menuLink.addClass( 'current' );
+						$( event.target.hash ).show().trigger( 'wpcom-api-request-tracker-show' );
+					} else {
+						api.toggle.visibility();
+					}
+				} );
+			},
+			visibility: function visibility( show ) {
+				show = typeof show === 'undefined' ? ! api.isVisible() : show;
+
+				// Show/hide the debug bar.
+				api.body.toggleClass( 'wpcom-api-request-tracker-visible', show );
+
+				// Press/unpress the button.
+				$( this ).toggleClass( 'active', show );
+			},
+		},
+
+		tabs: function tabs() {
+			const debugMenuLinks = $( '.debug-menu-link' ),
+				debugMenuTargets = $( '.debug-menu-target' );
+
+			debugMenuLinks.on( 'click', function ( event ) {
+				const $this = $( this );
+
+				event.preventDefault();
+
+				if ( $this.hasClass( 'current' ) ) {
+					return;
+				}
+
+				// Deselect other tabs and hide other panels.
+				debugMenuTargets.hide().trigger( 'wpcom-api-request-tracker-hide' );
+				debugMenuLinks.removeClass( 'current' );
+
+				// Select the current tab and show the current panel.
+				$this.addClass( 'current' );
+				// The hashed component of the href is the id that we want to display.
+				$( '#' + this.href.substr( this.href.indexOf( '#' ) + 1 ) )
+					.show()
+					.trigger( 'wpcom-api-request-tracker-show' );
+			} );
+		},
+
+		actions: {
+			init: function init() {
+				const actions = $( '#wpcom-api-request-tracker-actions' );
+
+				// Close the panel with the esc key if it's open.
+				$( document ).on( 'keydown', function ( event ) {
+					const key = event.key || event.which || event.keyCode;
+
+					if ( 27 /* esc */ === key && api.isVisible() ) {
+						event.preventDefault();
+						api.actions.close();
+					}
+				} );
+
+				$( '.maximize', actions ).on( 'click', api.actions.maximize );
+				$( '.restore', actions ).on( 'click', api.actions.restore );
+				$( '.close', actions ).on( 'click', api.actions.close );
+			},
+			maximize: function maximize() {
+				api.body.removeClass( 'wpcom-api-request-tracker-partial' );
+				api.body.addClass( 'wpcom-api-request-tracker-maximized' );
+			},
+			restore: function restore() {
+				api.body.removeClass( 'wpcom-api-request-tracker-maximized' );
+				api.body.addClass( 'wpcom-api-request-tracker-partial' );
+			},
+			close: function close() {
+				api.toggle.visibility( false );
+			},
+		},
+	};
+
+	$( wpcomApiRequestTracker.init );
+} )( jQuery );

--- a/projects/plugins/debug-helper/plugin.php
+++ b/projects/plugins/debug-helper/plugin.php
@@ -39,65 +39,70 @@ define( 'JETPACK_DEBUG_HELPER_VERSION', '1.6.0-alpha' );
  * Include file names from the modules directory here.
  */
 $jetpack_dev_debug_modules = array(
-	'autoloader'         => array(
+	'autoloader'                => array(
 		'file'        => 'class-autoloader-debug-helper.php',
 		'name'        => 'Autoloader Debug Helper',
 		'description' => '',
 	),
-	'broken-token'       => array(
+	'broken-token'              => array(
 		'file'        => 'class-broken-token.php',
 		'name'        => 'Broken token Utilities',
 		'description' => '',
 	),
-	'idc-simulator'      => array(
+	'idc-simulator'             => array(
 		'file'        => 'class-idc-simulator.php',
 		'name'        => 'Identity Crisis Simulation Utility',
 		'description' => '',
 	),
-	'sync-debug'         => array(
+	'sync-debug'                => array(
 		'file'        => 'class-jetpack-sync-debug-helper.php',
 		'name'        => 'Sync Debug Utilities',
 		'description' => '',
 	),
-	'rest-api-tester'    => array(
+	'rest-api-tester'           => array(
 		'file'        => 'class-rest-api-tester.php',
 		'name'        => 'REST API Tester',
 		'description' => '',
 	),
-	'mocker'             => array(
+	'mocker'                    => array(
 		'file'        => 'class-mocker.php',
 		'name'        => 'Mocker',
 		'description' => '',
 	),
-	'sync-data-settings' => array(
+	'sync-data-settings'        => array(
 		'file'        => 'class-sync-data-settings-tester.php',
 		'name'        => 'Sync Data Settings Utility',
 		'description' => '',
 	),
-	'modules-helper'     => array(
+	'modules-helper'            => array(
 		'file'        => 'class-modules-helper.php',
 		'name'        => 'Jetpack Modules Debug Helper',
 		'description' => '',
 	),
-	'protect-helper'     => array(
+	'protect-helper'            => array(
 		'file'        => 'class-protect-helper.php',
 		'name'        => 'Jetpack Protect Helper',
 		'description' => 'Allows you to force different results for the Jetpack Protect plugin to make it easier to develop it.',
 	),
-	'scan-helper'        => array(
+	'scan-helper'               => array(
 		'file'        => 'class-scan-helper.php',
 		'name'        => 'Jetpack Scan Helper',
 		'description' => '',
 	),
-	'waf-helper'         => array(
+	'waf-helper'                => array(
 		'file'        => 'class-waf-helper.php',
 		'name'        => 'Jetpack Firewall Helper',
 		'description' => '',
 	),
-	'cookie-state'       => array(
+	'cookie-state'              => array(
 		'file'        => 'class-cookie-state.php',
 		'name'        => 'Cookie State Faker',
 		'description' => '',
+	),
+	'wpcom-api-request-tracker' => array(
+		'file'        => 'class-wpcom-api-request-tracker-module.php',
+		'name'        => 'WPCOM API Request Tracker',
+		'description' => 'Displays the number of requests to WPCOM API endpoints for the current page request.',
 	),
 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Some recent Atomic reverts were due to unnecessary-large numbers of WPCOM API requests. This change aims to add visibility to these requests to make it easier to catch problems related to the number of requests before shipping the code and experiencing problems in production.
    
With this new WPCOM API Request Tracker module activated in the Debug Tools, an admin bar menu entry "WPCOM API Requests" appears. After a page loads, the entry title updates to indicate the total number of requests. Clicking on the entry toggles the display of a panel with further details.

The changes will affect the following:
* Debug Helper

#### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?

#### Jetpack product discussion:
p9dueE-7dr-p2

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
* Apply the PR.
* On the Jetpack Debug Jetpack Debug page, enable the "WPCOM API Request Tracker" module.
* Visit pages that make requests to the WPCOM API and confirm that the number of requests is accurately counted and displayed in both the "WPCOM API Requests" admin bar entry title and in the panel displayed when clicking that admin bar entry.
* You can also use the Debug Bar plugin to confirm the number of reported requests