### PR TITLE
WP Super Cache: use constants in the email dropdown

### DIFF
--- a/projects/plugins/super-cache/changelog/update-wp_super_cache_email_dropdown
+++ b/projects/plugins/super-cache/changelog/update-wp_super_cache_email_dropdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+WP Super Cache: use a constant instead of hard coding email numbers in preload dropdown

--- a/projects/plugins/super-cache/partials/preload.php
+++ b/projects/plugins/super-cache/partials/preload.php
@@ -59,10 +59,12 @@ echo __( 'Send me status emails when files are refreshed.', 'wp-super-cache' ) .
 if ( !isset( $wp_cache_preload_email_volume ) )
 	$wp_cache_preload_email_volume = 'none';
 echo '<select type="select" name="wp_cache_preload_email_volume">';
-echo '<option value="none" '. selected( 'none', $wp_cache_preload_email_volume ) . '>'.  __( 'No Emails', 'wp-super-cache' ) . '</option>';
-echo '<option value="many" '. selected( 'many', $wp_cache_preload_email_volume ) . '>'.  __( 'Many emails, 2 emails per 100 posts.', 'wp-super-cache' ) . '</option>';
-echo '<option value="medium" '. selected( 'medium', $wp_cache_preload_email_volume ) . '>'.  __( 'Medium, 1 email per 100 posts.', 'wp-super-cache' ) . '</option>';
-echo '<option value="less" '. selected( 'less', $wp_cache_preload_email_volume ) . '>'.  __( 'Less emails, 1 at the start and 1 at the end of preloading all posts.', 'wp-super-cache' ) . '</option>';
+echo '<option value="none" ' . selected( 'none', $wp_cache_preload_email_volume ) . '>' . esc_html__( 'No Emails', 'wp-super-cache' ) . '</option>';
+// translators: %d is the number of posts
+echo '<option value="many" ' . selected( 'many', $wp_cache_preload_email_volume ) . '>' . esc_html( sprintf( __( 'Many emails, 2 emails per %d posts.', 'wp-super-cache' ), WPSC_PRELOAD_POST_COUNT ) ) . '</option>';
+// translators: %d is the number of posts
+echo '<option value="medium" ' . selected( 'medium', $wp_cache_preload_email_volume ) . '>' . esc_html( sprintf( __( 'Medium, 1 email per %d posts.', 'wp-super-cache' ), WPSC_PRELOAD_POST_COUNT ) ) . '</option>';
+echo '<option value="less" ' . selected( 'less', $wp_cache_preload_email_volume ) . '>' . esc_html__( 'Less emails, 1 at the start and 1 at the end of preloading all posts.', 'wp-super-cache' ) . '</option>';
 echo "</select>";
 
 if ( wp_next_scheduled( 'wp_cache_preload_hook' ) || wp_next_scheduled( 'wp_cache_full_preload_hook' ) ) {


### PR DESCRIPTION
This is a tiny PR to change the preload email dropdown so it uses a newly defined constant rather than hard coding the number of emails.

## Proposed changes:
The dropdown used to display 100 as the number of emails but we just introduced the constant WPSC_PRELOAD_POST_COUNT so this PR changes that number to that constant. There won't be any visible changes except 100 will be 10 in the dropdown that appears on the Preload page now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply PR
Go to the Preload page of the WP Super Cache settings.
Note the email dropdown says 10 emails rather than 100.
