### PR TITLE
AI Assistant: Make token request endpoint be a POST request

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -79,7 +79,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'jetpack/v4',
 			'jetpack-ai-jwt',
 			array(
-				'methods'             => WP_REST_Server::READABLE,
+				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => __CLASS__ . '::get_openai_jwt',
 				'permission_callback' => function () {
 					return ( new Connection_Manager( 'jetpack' ) )->is_user_connected() && current_user_can( 'edit_posts' );

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-token-post
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-token-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: not needed. change on unpublished block
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -63,9 +63,7 @@ export async function requestToken() {
 	const siteSuffix = window.JP_CONNECTION_INITIAL_STATE.siteSuffix;
 	const isJetpackSite = ! window.wpcomFetch;
 	let data;
-	/**
-	 * TODO: Make both endpoints be POST requests
-	 */
+
 	if ( isJetpackSite ) {
 		data = await apiFetch( {
 			path: '/jetpack/v4/jetpack-ai-jwt?_cacheBuster=' + Date.now(),
@@ -73,6 +71,7 @@ export async function requestToken() {
 			headers: {
 				'X-WP-Nonce': apiNonce,
 			},
+			method: 'POST',
 		} );
 	} else {
 		data = await apiFetch( {


### PR DESCRIPTION
For consistency with the endpoint in .com we make this one be POST instead of GET

Fixes https://github.com/orgs/Automattic/projects/667/views/1?pane=issue&itemId=28218855

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates endpoint and client to satisfy a POST request for the token

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1683915227589159/1683840462.276189-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

For a Jetpack site

* On a Jetpack site able to use AI
* Visit the editor
* Add an AI Assistant block. 
* Write a query.
* Expect the block to work properly

For .com sites

* Start with a sandboxed wpcom site 
* Do One of the following:
  * Wait for the build here to run and in your sandbox, run `bin/jetpack-downloader test jetpack add/ai-assistant-streaming-alternative` 
  * Use `jetpack rsync` standing on your monorepo root while running `jetpack watch plugins/jetpack`
* Visit the editor
* Add an AI Assistant block. 
* Write a query.
* Expect the block to work properly