### PR TITLE
AI: Introducing translate option

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-translate
+++ b/projects/plugins/jetpack/changelog/add-ai-translate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI: Add translate option

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -223,6 +223,15 @@ const ToolbarControls = ( {
 								{ __( 'Write a summary based on title', 'jetpack' ) }
 							</ToolbarButton>
 						) }
+
+						{ ! showRetry && ! contentIsLoaded && !! wholeContent?.length && (
+							<I18nDropdownControl
+								value="en"
+								label={ __( 'Translate', 'jetpack' ) }
+								onChange={ language => getSuggestionFromOpenAI( 'changeLanguage', { language } ) }
+							/>
+						) }
+
 						{ ! showRetry && ! contentIsLoaded && (
 							<ToolbarDropdownMenu
 								icon={ chevronDown }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/i18n-dropdown-control.tsx
@@ -33,10 +33,13 @@ export type LanguageProp = ( typeof LANGUAGE_LIST )[ number ];
 type LanguageDropdownControlProps = {
 	value: LanguageProp;
 	onChange: ( value: string ) => void;
+	label: string;
 };
 
 const defaultLanguageLocale =
 	window?.Jetpack_Editor_Initial_State?.siteLocale || navigator?.language;
+
+const defaultLabel = __( 'Language', 'jetpack' );
 
 export const defaultLanguage = ( defaultLanguageLocale?.split( '-' )[ 0 ] || 'en' ) as LanguageProp;
 
@@ -110,6 +113,7 @@ export const LANGUAGE_MAP = {
 
 export default function I18nDropdownControl( {
 	value = defaultLanguage,
+	label = defaultLabel,
 	onChange,
 }: LanguageDropdownControlProps ) {
 	// Move the default language to the top of the list.
@@ -121,7 +125,7 @@ export default function I18nDropdownControl( {
 	return (
 		<ToolbarDropdownMenu
 			icon={ globe }
-			label={ __( 'Language', 'jetpack' ) }
+			label={ label }
 			popoverProps={ {
 				variant: 'toolbar',
 			} }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #30592 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `i18n` dropdown menu when has content in the post.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert some content.
* Insert `AI Assistant` block.
* You should see the translate option.
* Select some language to translate the whole content.

