### PR TITLE
Removed unset variable

### DIFF
--- a/projects/plugins/jetpack/changelog/rm-unset-variable
+++ b/projects/plugins/jetpack/changelog/rm-unset-variable
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Removed unused/unset variable
+
+

--- a/projects/plugins/jetpack/modules/widgets/gallery.php
+++ b/projects/plugins/jetpack/modules/widgets/gallery.php
@@ -299,9 +299,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 			$max_width = min( (int) $content_width, $max_width );
 		}
 
-		$color     = Jetpack_Options::get_option( 'slideshow_background_color', 'black' );
-		$autostart = isset( $attr['autostart'] ) ? $attr['autostart'] : true; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- Todo: should read off the $instance? Also not sure if slideshow_widget() is used still.
-
+		$color   = Jetpack_Options::get_option( 'slideshow_background_color', 'black' );
 		$js_attr = array(
 			'gallery'   => $gallery,
 			'selector'  => $gallery_instance,
@@ -309,7 +307,7 @@ class Jetpack_Gallery_Widget extends WP_Widget {
 			'height'    => $max_height,
 			'trans'     => 'fade',
 			'color'     => $color,
-			'autostart' => $autostart,
+			'autostart' => true,
 		);
 
 		$html = $slideshow->slideshow_js( $js_attr );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR removes the `$autostart` variable because it's always `true`, since `$attr` is never set.
* This change does not change the behavior of the code.
* More context here p1684153352762479-slack-CDLH4C1UZ

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Visual inspection should be fine since it's such a small change.