### PR TITLE
Fix action backwards compatibility

### DIFF
--- a/projects/packages/forms/changelog/fix-action-backwards-compat
+++ b/projects/packages/forms/changelog/fix-action-backwards-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Change hook parameter to what it was before (fields collection). Modify Post_To_Url hook to handle such collection instead of a form instance

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.17.0",
+	"version": "0.17.1-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.17.0';
+	const PACKAGE_VERSION = '0.17.1-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1357,7 +1357,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param boolean $is_spam Whether the form submission has been identified as spam.
 		 * @param array   $entry_values The feedback entry values.
 		 */
-		do_action( 'grunion_after_feedback_post_inserted', $post_id, $this, $is_spam, $entry_values );
+		do_action( 'grunion_after_feedback_post_inserted', $post_id, $this->fields, $is_spam, $entry_values );
 
 		$message = self::get_compiled_form_for_email( $post_id, $this );
 

--- a/projects/packages/forms/src/service/class-post-to-url.php
+++ b/projects/packages/forms/src/service/class-post-to-url.php
@@ -85,14 +85,22 @@ class Post_To_Url {
 	 * Hook on `grunion_after_feedback_post_inserted` action to send form data to specified URL.
 	 *
 	 * @param int   $post_id - the post_id for the CPT that is created.
-	 * @param array $form - Automattic\Jetpack\Forms\ContactForm\Contact_Form instance.
+	 * @param array $fields - a collection of Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field instances.
 	 * @param bool  $is_spam - marked as spam by Akismet(?).
 	 * @param array $entry_values - extra fields added to from the contact form.
 	 *
 	 * @return null|void
 	 */
-	public function feedback_post_hook( $post_id, $form, $is_spam, $entry_values ) {
-		if ( ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
+	public function feedback_post_hook( $post_id, $fields, $is_spam, $entry_values ) {
+		// Try and get the form from any of the fields
+		$form = null;
+		foreach ( $fields as $field ) {
+			if ( ! empty( $field->form ) ) {
+				$form = $field->form;
+				break;
+			}
+		}
+		if ( ! $form || ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR is a fix for a breaking change introduced in #30191 

## Proposed changes:
- Rollback the hook parameter change, make it the fields collection instead of the form instance.
- Change the hook handler introduced on #30191 so it will try to get the form instance from the first field that can return it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1684177869512529-slack-C02ER2E0Z

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
JPCRM should continue to work as before.

Repeat the tests on #30191 to verify the new feature is still working as expected