### PR TITLE
Launchpad: Set launchpad_screen site option when "Don't show this again" box is checked.

### DIFF
--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -52,13 +52,13 @@ export const settings = {
 		} );
 		const { tracks } = useAnalytics();
 
-		const [ launchpadModalOff, setLaunchpadModalOff ] = useEntityProp( 'root', 'site', 'launchpad_modal_status' );
+		const [ launchpadModalStatus, setLaunchpadModalStatus ] = useEntityProp( 'root', 'site', 'launchpad_save_modal_status' );
 
 		function updateLaunchpadModalStatus( checked ) {
 			if ( ! checked ) {
 				return;
 			}
-			return setLaunchpadModalOff( true );
+			return setLaunchpadModalStatus( 'off' );
 		}
 
 		const recordTracksEvent = eventName =>
@@ -148,7 +148,7 @@ export const settings = {
 		const showModal =
 			( ( isInsidePostEditor && isCurrentPostPublished ) || isInsideSiteEditor ) &&
 			launchpadScreenOption === 'full' &&
-			! launchpadModalOff &&
+			! launchpadModalStatus === 'off' &&
 			isModalOpen;
 
 		return (

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -2,6 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { getSiteFragment, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Modal, Button, CheckboxControl } from '@wordpress/components';
 import { usePrevious } from '@wordpress/compose';
+import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useRef, useState } from '@wordpress/element';
@@ -142,6 +143,15 @@ export const settings = {
 			! dontShowAgain &&
 			isModalOpen;
 
+		const [ launchpadScreen, setLaunchpadScreen ] = useEntityProp( 'root', 'site', 'launchpad_screen' );
+
+		function updateLaunchpadScreen( checked ) {
+			if ( ! checked ) {
+				return;
+			}
+			setLaunchpadScreen( 'off' );
+		}
+
 		return (
 			showModal && (
 				<Modal
@@ -174,6 +184,7 @@ export const settings = {
 									variant="secondary"
 									onClick={ () => {
 										setDontShowAgain( isChecked );
+										updateLaunchpadScreen( isChecked );
 										setIsModalOpen( false );
 										recordTracksEvent( 'jetpack_launchpad_save_modal_back_to_edit' );
 									} }
@@ -183,7 +194,11 @@ export const settings = {
 								<Button
 									variant="primary"
 									href={ actionButtonHref }
-									onClick={ () => recordTracksEvent( actionButtonTracksEvent ) }
+									onClick={ () => {
+											updateLaunchpadScreen( isChecked );
+											recordTracksEvent( actionButtonTracksEvent );
+										}
+									}
 									target="_top"
 								>
 									{ actionButtonText }

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -2,8 +2,8 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { getSiteFragment, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Modal, Button, CheckboxControl } from '@wordpress/components';
 import { usePrevious } from '@wordpress/compose';
-import { useEntityProp } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useEntityProp, store } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -52,6 +52,7 @@ export const settings = {
 		} );
 		const { tracks } = useAnalytics();
 
+		const { saveEntityRecord } = useDispatch( store );
 		const [ launchpadModalStatus, setLaunchpadModalStatus ] =
 			useEntityProp(
 				'root',
@@ -63,8 +64,9 @@ export const settings = {
 			if ( ! checked ) {
 				return;
 			}
-			
-			return setLaunchpadModalStatus( 'off' );
+
+			setLaunchpadModalStatus( 'off' );
+			return saveEntityRecord( 'root', 'site', { launchpad_save_modal_status: 'off' } );
 		}
 
 		const recordTracksEvent = eventName =>

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -52,15 +52,18 @@ export const settings = {
 		} );
 		const { tracks } = useAnalytics();
 
-		const [ launchpadModalStatus, setLaunchpadModalStatus ] = useEntityProp( 'root', 'site', 'launchpad_save_modal_status' );
-		console.log(launchpadModalStatus);
+		const [ launchpadModalStatus, setLaunchpadModalStatus ] =
+			useEntityProp(
+				'root',
+				'site',
+				'launchpad_save_modal_status'
+			);
 
-		function updateLaunchpadModalStatus( checked ) {
-			console.log( "I clicked the modal!" );
-			console.log( launchpadModalStatus );
+		const updateLaunchpadModalStatus = ( checked ) => {
 			if ( ! checked ) {
 				return;
 			}
+			
 			return setLaunchpadModalStatus( 'off' );
 		}
 
@@ -151,7 +154,7 @@ export const settings = {
 		const showModal =
 			( ( isInsidePostEditor && isCurrentPostPublished ) || isInsideSiteEditor ) &&
 			launchpadScreenOption === 'full' &&
-			! launchpadModalStatus === 'off' &&
+			launchpadModalStatus !== 'off' &&
 			isModalOpen;
 
 		return (

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -37,7 +37,6 @@ export const settings = {
 		const [ isInitialPostPublish, setIsInitialPostPublish ] = useState( false );
 
 		const [ isModalOpen, setIsModalOpen ] = useState( false );
-		const [ dontShowAgain, setDontShowAgain ] = useState( false );
 		const [ isChecked, setIsChecked ] = useState( false );
 
 		const { launchpadScreenOption, hasNeverPublishedPostOption, siteIntentOption } =
@@ -52,6 +51,15 @@ export const settings = {
 			query: `siteSlug=${ siteFragment }`,
 		} );
 		const { tracks } = useAnalytics();
+
+		const [ launchpadModalOff, setLaunchpadModalOff ] = useEntityProp( 'root', 'site', 'launchpad_modal_status' );
+
+		function updateLaunchpadModalStatus( checked ) {
+			if ( ! checked ) {
+				return;
+			}
+			return setLaunchpadModalOff( true );
+		}
 
 		const recordTracksEvent = eventName =>
 			tracks.recordEvent( eventName, {
@@ -140,17 +148,8 @@ export const settings = {
 		const showModal =
 			( ( isInsidePostEditor && isCurrentPostPublished ) || isInsideSiteEditor ) &&
 			launchpadScreenOption === 'full' &&
-			! dontShowAgain &&
+			! launchpadModalOff &&
 			isModalOpen;
-
-		const [ launchpadScreen, setLaunchpadScreen ] = useEntityProp( 'root', 'site', 'launchpad_screen' );
-
-		function updateLaunchpadScreen( checked ) {
-			if ( ! checked ) {
-				return;
-			}
-			setLaunchpadScreen( 'off' );
-		}
 
 		return (
 			showModal && (
@@ -164,7 +163,7 @@ export const settings = {
 							return;
 						}
 						setIsModalOpen( false );
-						setDontShowAgain( isChecked );
+						updateLaunchpadModalStatus( isChecked );
 						recordTracksEvent( 'jetpack_launchpad_save_modal_close' );
 					} }
 				>
@@ -183,8 +182,7 @@ export const settings = {
 								<Button
 									variant="secondary"
 									onClick={ () => {
-										setDontShowAgain( isChecked );
-										updateLaunchpadScreen( isChecked );
+										updateLaunchpadModalStatus( isChecked );
 										setIsModalOpen( false );
 										recordTracksEvent( 'jetpack_launchpad_save_modal_back_to_edit' );
 									} }
@@ -195,7 +193,7 @@ export const settings = {
 									variant="primary"
 									href={ actionButtonHref }
 									onClick={ () => {
-											updateLaunchpadScreen( isChecked );
+											updateLaunchpadModalStatus( isChecked );
 											recordTracksEvent( actionButtonTracksEvent );
 										}
 									}

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -53,8 +53,11 @@ export const settings = {
 		const { tracks } = useAnalytics();
 
 		const [ launchpadModalStatus, setLaunchpadModalStatus ] = useEntityProp( 'root', 'site', 'launchpad_save_modal_status' );
+		console.log(launchpadModalStatus);
 
 		function updateLaunchpadModalStatus( checked ) {
+			console.log( "I clicked the modal!" );
+			console.log( launchpadModalStatus );
 			if ( ! checked ) {
 				return;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/76880

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set a new site option for the Launchpad save modal so its state persists across page loads. This should fix the "Don't show this again." checkbox and make it do what it says it does. :) 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

