### PR TITLE
[Newsletter] Fix bulk-action checkbox disappearing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-bulk-action
+++ b/projects/plugins/jetpack/changelog/fix-bulk-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Previous implementation would remove buklk-edition checkbox from the posts list. This is now fixed.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -106,8 +106,8 @@ function register_block() {
 	add_filter( 'get_the_excerpt', __NAMESPACE__ . '\jetpack_filter_excerpt_for_newsletter', 10, 2 );
 
 	// Add a 'Newsletter access' column to the Edit posts page
-	add_action( 'manage_posts_columns', __NAMESPACE__ . '\add_newsletter_access_column' );
-	add_action( 'manage_posts_custom_column', __NAMESPACE__ . '\populate_newsletter_access_rows', 10, 2 );
+	add_action( 'manage_posts_columns', __NAMESPACE__ . '\register_newsletter_access_column' );
+	add_action( 'manage_posts_custom_column', __NAMESPACE__ . '\render_newsletter_access_rows', 10, 2 );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
 
@@ -126,7 +126,7 @@ function is_wpcom() {
  * @param array $columns An array of column names.
  * @return array An array of column names.
  */
-function add_newsletter_access_column( $columns ) {
+function register_newsletter_access_column( $columns ) {
 	$position   = array_search( 'title', array_keys( $columns ), true );
 	$new_column = array( NEWSLETTER_COLUMN_ID => '<span>' . __( 'Newsletter', 'jetpack' ) . '</span>' );
 	return array_merge(
@@ -142,7 +142,6 @@ function add_newsletter_access_column( $columns ) {
  * @param string $column_id The ID of the column to display.
  * @param int    $post_id The current post ID.
  */
-function populate_newsletter_access_rows( $column_id, $post_id ) {
 function render_newsletter_access_rows( $column_id, $post_id ) {
 	if ( NEWSLETTER_COLUMN_ID !== $column_id ) {
 		return;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -129,7 +129,11 @@ function is_wpcom() {
 function add_newsletter_access_column( $columns ) {
 	$position   = array_search( 'title', array_keys( $columns ), true );
 	$new_column = array( NEWSLETTER_COLUMN_ID => '<span>' . __( 'Newsletter', 'jetpack' ) . '</span>' );
-	return array_merge( array_slice( $columns, 1, $position ), $new_column, array_slice( $columns, $position ) );
+	return array_merge(
+		array_slice( $columns, 0, $position + 1, true ),
+		$new_column,
+		array_slice( $columns, $position, null, true )
+	);
 }
 
 /**
@@ -139,6 +143,7 @@ function add_newsletter_access_column( $columns ) {
  * @param int    $post_id The current post ID.
  */
 function populate_newsletter_access_rows( $column_id, $post_id ) {
+function render_newsletter_access_rows( $column_id, $post_id ) {
 	if ( NEWSLETTER_COLUMN_ID !== $column_id ) {
 		return;
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/76852

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Modify logic to prevent removing bulk-editing checkbox from posts list

## Testing instructions:
* Go to Post lists page {SITE_URL}/wp-admin/edit.php
* Before (notice the checkboxes are missing)
<img width="810" alt="Screenshot 2023-05-16 at 09 22 12" src="https://github.com/Automattic/jetpack/assets/790558/d33004a1-0ca7-44af-a0e3-ddbae7a9e2eb">


* After
<img width="809" alt="Screenshot 2023-05-16 at 09 20 41" src="https://github.com/Automattic/jetpack/assets/790558/36dd2064-2af2-45a2-aec5-05acd33f3f6c">

