### PR TITLE
CRM: Company profile - make sure object prefills include the company name

### DIFF
--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -592,7 +592,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 								<tbody>
 								<?php
 								// prep link to create a new invoice
-								$new_invoice_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_INVOICE ) . '&prefillco=' . $company['id'];
+								$new_invoice_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_INVOICE ) . '&zbsprefillco=' . $company['id'];
 
 								if ( $company_invoice_count_inc_deleted > 0 ) {
 
@@ -708,7 +708,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 									<?php
 
 									// prep link to create a new transaction
-									$new_transaction_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_TRANSACTION ) . '&prefillco=' . $company['id'];
+									$new_transaction_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_TRANSACTION ) . '&zbsprefillco=' . $company['id'];
 
 									if ( count( $company['transactions'] ) > 0 ) {
 
@@ -880,7 +880,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 								<tbody>
 									<?php
 									// prep link to create a new task
-									$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&prefillco=' . $company['id'];
+									$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&zbsprefillco=' . $company['id'];
 
 									if ( isset( $company['tasks'] ) && is_array( $company['tasks'] ) && count( $company['tasks'] ) > 0 ) {
 

--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -880,8 +880,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 								<tbody>
 									<?php
 									// prep link to create a new task
-									$nonce        = wp_create_nonce( 'jpcrm_task_url_nonce' );
-									$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&zbsprefillco=' . $company['id'] . '&jpcrmtaskurlnonce=' . $nonce;
+									$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&zbsprefillco=' . $company['id'];
 
 									if ( isset( $company['tasks'] ) && is_array( $company['tasks'] ) && count( $company['tasks'] ) > 0 ) {
 

--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -880,7 +880,8 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 								<tbody>
 									<?php
 									// prep link to create a new task
-									$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&zbsprefillco=' . $company['id'];
+									$nonce        = wp_create_nonce( 'jpcrm_task_url_nonce' );
+									$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&zbsprefillco=' . $company['id'] . '&jpcrmtaskurlnonce=' . $nonce;
 
 									if ( isset( $company['tasks'] ) && is_array( $company['tasks'] ) && count( $company['tasks'] ) > 0 ) {
 

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -1252,7 +1252,8 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 							<?php
 
 							// prep link to create a new task
-							$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&zbsprefillcust=' . $contact['id'];
+							$nonce        = wp_create_nonce( 'jpcrm_task_url_nonce' );
+							$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&zbsprefillcust=' . $contact['id'] . '&jpcrmtaskurlnonce=' . $nonce;
 
 							if ( isset( $contact['tasks'] ) && is_array( $contact['tasks'] ) && count( $contact['tasks'] ) > 0 ) {
 

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -1252,8 +1252,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 							<?php
 
 							// prep link to create a new task
-							$nonce        = wp_create_nonce( 'jpcrm_task_url_nonce' );
-							$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&zbsprefillcust=' . $contact['id'] . '&jpcrmtaskurlnonce=' . $nonce;
+							$new_task_url = jpcrm_esc_link( 'create', -1, ZBS_TYPE_EVENT ) . '&zbsprefillcust=' . $contact['id'];
 
 							if ( isset( $contact['tasks'] ) && is_array( $contact['tasks'] ) && count( $contact['tasks'] ) > 0 ) {
 

--- a/projects/plugins/crm/changelog/fix-crm-company-profile-prefill-company-name
+++ b/projects/plugins/crm/changelog/fix-crm-company-profile-prefill-company-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Companies: Fix company name prefill so add links - transaction, invoice and tasks - prefill company name

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -645,7 +645,12 @@ function zeroBSCRM_task_ui_for($taskObject = array()){
         if (isset($taskContact['id'])) $custID = $taskContact['id'];
         $custName = $zbs->DAL->contacts->getContactNameWithFallback( $custID );
     }else{
-        if(isset($_GET['zbsprefillcust']) && !empty($_GET['zbsprefillcust'])){
+		if (
+			isset( $_GET['zbsprefillcust'] )
+			&& ! empty( $_GET['zbsprefillcust'] )
+			&& isset( $_GET['jpcrmtaskurlnonce'] )
+			&& wp_verify_nonce( sanitize_key( $_GET['jpcrmtaskurlnonce'] ), 'jpcrm_task_url_nonce' )
+			) {
             $custID = (int)$_GET['zbsprefillcust'];
             $custName = $zbs->DAL->contacts->getContactNameWithFallback( $custID );
         }
@@ -684,8 +689,13 @@ function zeroBSCRM_task_ui_for_co($taskObject = array()){
 
             if (isset($taskCompany['id'])) $coID = $taskCompany['id'];
             if (isset($taskCompany['name'])) $coName = $taskCompany['name'];
-		} elseif ( isset( $_GET['zbsprefillco'] ) && ! empty( $_GET['zbsprefillco'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$co_id   = (int) $_GET['zbsprefillco']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		} elseif (
+			isset( $_GET['zbsprefillco'] )
+			&& ! empty( $_GET['zbsprefillco'] )
+			&& isset( $_GET['jpcrmtaskurlnonce'] )
+			&& wp_verify_nonce( sanitize_key( $_GET['jpcrmtaskurlnonce'] ), 'jpcrm_task_url_nonce' )
+			) {
+				$co_id   = (int) $_GET['zbsprefillco'];
 				$co_name = $zbs->DAL->companies->getCompanyNameEtc( $co_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -661,7 +661,7 @@ function zeroBSCRM_task_ui_for($taskObject = array()){
 }
 
 function zeroBSCRM_task_ui_for_co($taskObject = array()){
-
+	global $zbs;
     $html = "";
 
     if(zeroBSCRM_getSetting('companylevelcustomers') == "1"){
@@ -669,7 +669,8 @@ function zeroBSCRM_task_ui_for_co($taskObject = array()){
         $html .= "<div class='no-contact zbs-task-for-who'><div class='zbs-task-for-help'><i class='ui icon building outline'></i> " . jpcrm_label_company() . "</div>";
 
         //need UI for selecting who the task is for (company, then contact)
-        $coName = ''; $coID = '';
+		$co_name = '';
+		$co_id   = '';
 
         if (isset($taskObject['company']) && is_array($taskObject['company'])){
 
@@ -683,12 +684,15 @@ function zeroBSCRM_task_ui_for_co($taskObject = array()){
 
             if (isset($taskCompany['id'])) $coID = $taskCompany['id'];
             if (isset($taskCompany['name'])) $coName = $taskCompany['name'];
-        }
-        
+		} elseif ( isset( $_GET['zbsprefillco'] ) && ! empty( $_GET['zbsprefillco'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$co_id   = (int) $_GET['zbsprefillco']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$co_name = $zbs->DAL->companies->getCompanyNameEtc( $co_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+
         #} Output
-        $html .= '<div class="zbs-task-for-company">' . zeroBSCRM_CompanyTypeList('zbscrmjs_events_setCompany',$coName,true,'zbscrmjs_events_changeCompany') . "</div>";
-        $html .= '<input type="hidden" name="zbse_company" id="zbse_company" value="' .$coID .'" />';    
-        $html .= "<div class='clear'></div></div>";
+		$html .= '<div class="zbs-task-for-company">' . zeroBSCRM_CompanyTypeList( 'zbscrmjs_events_setCompany', $co_name, true, 'zbscrmjs_events_changeCompany' ) . '</div>';
+		$html .= '<input type="hidden" name="zbse_company" id="zbse_company" value="' . $co_id . '" />';
+		$html .= '<div class="clear"></div></div>';
 
     }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -645,12 +645,7 @@ function zeroBSCRM_task_ui_for($taskObject = array()){
         if (isset($taskContact['id'])) $custID = $taskContact['id'];
         $custName = $zbs->DAL->contacts->getContactNameWithFallback( $custID );
     }else{
-		if (
-			isset( $_GET['zbsprefillcust'] )
-			&& ! empty( $_GET['zbsprefillcust'] )
-			&& isset( $_GET['jpcrmtaskurlnonce'] )
-			&& wp_verify_nonce( sanitize_key( $_GET['jpcrmtaskurlnonce'] ), 'jpcrm_task_url_nonce' )
-			) {
+		if ( isset( $_GET['zbsprefillcust'] ) && ! empty( $_GET['zbsprefillcust'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
             $custID = (int)$_GET['zbsprefillcust'];
             $custName = $zbs->DAL->contacts->getContactNameWithFallback( $custID );
         }
@@ -658,7 +653,7 @@ function zeroBSCRM_task_ui_for($taskObject = array()){
     
     #} Output
     $html .= '<div class="zbs-task-for">' . zeroBSCRM_CustomerTypeList('zbscrmjs_events_setContact',$custName,true,'zbscrmjs_events_changeContact') . "</div>";
-    $html .= '<input type="hidden" name="zbse_customer" id="zbse_customer" value="' . $custID .'" />';
+	$html .= '<input type="hidden" name="zbse_customer" id="zbse_customer" value="' . ( $custName ? $custID : '' ) . '" />'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
     $html .= "<div class='clear'></div></div>";
 
     return $html;
@@ -679,29 +674,27 @@ function zeroBSCRM_task_ui_for_co($taskObject = array()){
 
         if (isset($taskObject['company']) && is_array($taskObject['company'])){
 
-            $taskCompany = $taskObject['company'];
+			$task_company = $taskObject['company']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
             // for now this needs a 0 offset as has potential for multi-contact
-            if (isset($taskCompany[0]) && is_array($taskCompany[0])){
-
-                $taskCompany = $taskCompany[0];
+			if ( isset( $task_company[0] ) && is_array( $task_company[0] ) ) {
+				$task_company = $task_company[0];
             }
 
-            if (isset($taskCompany['id'])) $coID = $taskCompany['id'];
-            if (isset($taskCompany['name'])) $coName = $taskCompany['name'];
-		} elseif (
-			isset( $_GET['zbsprefillco'] )
-			&& ! empty( $_GET['zbsprefillco'] )
-			&& isset( $_GET['jpcrmtaskurlnonce'] )
-			&& wp_verify_nonce( sanitize_key( $_GET['jpcrmtaskurlnonce'] ), 'jpcrm_task_url_nonce' )
-			) {
-				$co_id   = (int) $_GET['zbsprefillco'];
+			if ( isset( $task_company['id'] ) ) {
+				$co_id = $task_company['id'];
+			}
+			if ( isset( $task_company['name'] ) ) {
+				$co_name = $task_company['name'];
+			}
+		} elseif ( isset( $_GET['zbsprefillco'] ) && ! empty( $_GET['zbsprefillco'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$co_id   = (int) $_GET['zbsprefillco']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$co_name = $zbs->DAL->companies->getCompanyNameEtc( $co_id ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 
         #} Output
 		$html .= '<div class="zbs-task-for-company">' . zeroBSCRM_CompanyTypeList( 'zbscrmjs_events_setCompany', $co_name, true, 'zbscrmjs_events_changeCompany' ) . '</div>';
-		$html .= '<input type="hidden" name="zbse_company" id="zbse_company" value="' . $co_id . '" />';
+		$html .= '<input type="hidden" name="zbse_company" id="zbse_company" value="' . ( $co_name ? $co_id : '' ) . '" />';
 		$html .= '<div class="clear"></div></div>';
 
     }


### PR DESCRIPTION

## Proposed changes:

* This PR changes the prefill name on the company 'view.page.php' for invoices, transactions and tasks to match what is expected: `zbsprefillco`. It also fixes the company tasks UI function - `zeroBSCRM_task_ui_for_co` - to add a case that checks for the company prefill (as the previous case isn't working via the company view page 'add tasks' links).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3085

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:
* Using the [Jetpack Beta plugin](https://github.com/Automattic/jetpack-beta) on a test site with this branch applied or testing locally with the branch checked out, view the Company page for any company: `http://localhost/wp-admin/admin.php?page=zbs-add-edit&action=view&zbstype=company&zbsid={companyid}`.
* Underneath the 'Documents' heading, click on any of the tabs and the relevant links to 'add new', for example 'Add Invoice', 'Add Transaction' or 'Add Task' if you already have invoices, transactions or tasks linked to that company, or else click on the 'create one' link that is shown (eg.  'This Company does not have any tasks yet. Do you want to create one?')
* All new invoice, transaction or tasks pages should be prefilled with the company name.
* On trunk or the previous release version if testing on a Jurassic Ninja / test site, those links on the 'View Company' page will not prefill the company name.

