### PR TITLE
Blog onboarding: Add new callback for scheduled posts

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -60,6 +60,7 @@ function wpcom_register_default_launchpad_checklists() {
 			'title'                 => __( 'Write your first post', 'jetpack-mu-wpcom' ),
 			'add_listener_callback' => function () {
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
+				add_action( 'future_to_publish', 'wpcom_track_schedule_first_post_task' );
 			},
 		)
 	);
@@ -595,6 +596,23 @@ function wpcom_track_publish_first_post_task() {
 	// Since we share the same callback for generic first post and newsletter-specific, we mark both.
 	wpcom_mark_launchpad_task_complete_if_active( 'first_post_published' );
 	wpcom_mark_launchpad_task_complete_if_active( 'first_post_published_newsletter' );
+}
+
+/**
+ * Callback for completing first post published task if post is scheduled.
+ *
+ * @return void
+ */
+function wpcom_track_schedule_first_post_task() {
+	// Ensure that Headstart posts don't mark this as complete.
+	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+		return;
+	}
+
+	// Only mark scheduled posts complete for the 'start-writing' flow.
+	if ( get_option( 'site_intent' ) === 'start-writing' ) {
+		wpcom_mark_launchpad_task_complete_if_active( 'first_post_published' );
+	}
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -59,7 +59,6 @@ function wpcom_register_default_launchpad_checklists() {
 			'id'                    => 'first_post_published',
 			'title'                 => __( 'Write your first post', 'jetpack-mu-wpcom' ),
 			'add_listener_callback' => function () {
-				error_log(print_r('callbacks added', true));
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
 				add_action( 'transition_post_status', 'wpcom_track_schedule_first_post_task' );
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -59,8 +59,9 @@ function wpcom_register_default_launchpad_checklists() {
 			'id'                    => 'first_post_published',
 			'title'                 => __( 'Write your first post', 'jetpack-mu-wpcom' ),
 			'add_listener_callback' => function () {
+				error_log(print_r('callbacks added', true));
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
-				add_action( 'future_to_publish', 'wpcom_track_schedule_first_post_task' );
+				add_action( 'transition_post_status', 'wpcom_track_schedule_first_post_task' );
 			},
 		)
 	);
@@ -601,16 +602,17 @@ function wpcom_track_publish_first_post_task() {
 /**
  * Callback for completing first post published task if post is scheduled.
  *
+ * @param string $new_status the new status of the post.
  * @return void
  */
-function wpcom_track_schedule_first_post_task() {
+function wpcom_track_schedule_first_post_task( $new_status ) {
 	// Ensure that Headstart posts don't mark this as complete.
 	if ( defined( 'HEADSTART' ) && HEADSTART ) {
 		return;
 	}
 
-	// Only mark scheduled posts complete for the 'start-writing' flow.
-	if ( get_option( 'site_intent' ) === 'start-writing' ) {
+	// Mark scheduled posts complete for the 'start-writing' flow.
+	if ( get_option( 'site_intent' ) === 'start-writing' && 'future' === $new_status ) {
 		wpcom_mark_launchpad_task_complete_if_active( 'first_post_published' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

