### PR TITLE
AI Assistant: Send post_id on the completion request for logging purposes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-send-post-id-on-completion-request
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-send-post-id-on-completion-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Send the post ID on every text completion so it can be logger and tracked on the backend.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -44,8 +44,9 @@ export async function askJetpack( question ) {
  * Leaving this here to make it easier to debug the streaming API calls for now
  *
  * @param {string} question - The query to send to the API
+ * @param {number} postId - The post where this completion is being requested, if available
  */
-export async function askQuestion( question ) {
+export async function askQuestion( question, postId = null ) {
 	const { blogId, token } = await requestToken();
 
 	const url = new URL(
@@ -53,6 +54,10 @@ export async function askQuestion( question ) {
 	);
 	url.searchParams.append( 'question', question );
 	url.searchParams.append( 'token', token );
+
+	if ( postId ) {
+		url.searchParams.append( 'post_id', postId );
+	}
 
 	const source = new EventSource( url.toString() );
 	return source;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -188,7 +188,7 @@ const useSuggestionsFromOpenAI = ( {
 		let fullMessage = '';
 		try {
 			setIsLoadingCompletion( true );
-			source = await askQuestion( prompt );
+			source = await askQuestion( prompt, postId );
 		} catch ( err ) {
 			if ( err.message ) {
 				setErrorMessage( err.message ); // Message was already translated by the backend


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #30738.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the `post_id` parameter on the GET request that is made to the completion endpoint, so we can get it on backend and add it to the logs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

- p1684267570947559-slack-C054LN8RNVA
- p4vt7e-bh-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add an `AI Assistant` block
* Open your browser console and inspect the network activity
* Ask for some text completion, for example, "list 10 words that are related to WordPress"
* Notice that the request to the `jetpack-openai-query` now includes the `post_id` parameter:

<img width="754" alt="Screen Shot 2023-05-16 at 19 22 22" src="https://github.com/Automattic/jetpack/assets/6760046/a7f42cbb-a1fe-4739-b4d0-0ccf2f239203">

This PR is adding the `post_id` to the request. Following up on this, I am going to change the backend code to accept it and inject it into the logs, the way we did before the change to streaming.