### PR TITLE
WAF: avoid multisite errors when used by the Protect plugin

### DIFF
--- a/projects/packages/waf/changelog/fix-error-constant-protect
+++ b/projects/packages/waf/changelog/fix-error-constant-protect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Multisite: avoid errors when the package is used in the Protect plugin instead of the Jetpack plugin.

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -276,7 +276,16 @@ class Brute_Force_Protection {
 				require_once ABSPATH . '/wp-admin/includes/plugin.php';
 			}
 
-			if ( ! is_plugin_active_for_network( plugin_basename( JETPACK__PLUGIN_FILE ) ) ) {
+			// This warning is only relevant if either Jetpack or Jetpack Protect is active.
+			if ( defined( 'JETPACK__PLUGIN_FILE' ) ) {
+				$plugin_root_file = JETPACK__PLUGIN_FILE;
+			} elseif ( defined( 'JETPACK_PROTECT_ROOT_FILE' ) ) {
+				$plugin_root_file = JETPACK_PROTECT_ROOT_FILE;
+			} else {
+				return;
+			}
+
+			if ( ! is_plugin_active_for_network( plugin_basename( $plugin_root_file ) ) ) {
 				add_action( 'load-index.php', array( $this, 'prepare_jetpack_protect_multisite_notice' ) );
 				add_action( 'wp_ajax_jetpack-protect-dismiss-multisite-banner', array( $this, 'ajax_dismiss_handler' ) );
 			}
@@ -319,7 +328,15 @@ class Brute_Force_Protection {
 		<div class="jetpack-protect-warning notice notice-warning is-dismissible" data-dismiss-nonce="<?php echo esc_attr( wp_create_nonce( 'jetpack_protect_multisite_banner_opt_out' ) ); ?>">
 			<h2><?php esc_html_e( 'Brute Force Protection cannot keep your site secure', 'jetpack-waf' ); ?></h2>
 
-			<p><?php esc_html_e( 'Thanks for activating the Brute Force Protection feature! To start protecting your whole WordPress Multisite Network, please network activate the Jetpack plugin. Due to the way logins are handled on WordPress Multisite Networks, Jetpack must be network activated in order for the Brute Force Protection feature to work properly.', 'jetpack-waf' ); ?></p>
+			<p>
+			<?php
+			printf(
+				/* Translators: placeholder is a plugin name (Jetpack Protect or Jetpack). */
+				esc_html__( 'Thanks for activating the Brute Force Protection feature! To start protecting your whole WordPress Multisite Network, please network activate the %1$s plugin. Due to the way logins are handled on WordPress Multisite Networks, %1$s must be network activated in order for the Brute Force Protection feature to work properly.', 'jetpack-waf' ),
+				defined( 'JETPACK_PROTECT_NAME' ) ? esc_html( JETPACK_PROTECT_NAME ) : 'Jetpack'
+			);
+			?>
+			</p>
 
 			<p>
 				<a class="button-primary" href="<?php echo esc_url( network_admin_url( 'plugins.php' ) ); ?>">


### PR DESCRIPTION
Fixes #30766

## Proposed changes:

The WAF package can be used by both the Jetpack plugin and the Jetpack Protect plugin; we should handle both in the package.

> **Note**
> Ideally we should handle just about any plugin using the package, but I'm not sure looking for the plugin by going several directories up would be a good approach. I would be happy to have a second opinion on this.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a fresh multisite installation.
* Install the Jetpack Protect plugin.
* **do not** network activate the plugin.
* In a subsite of the network, go to the Plugins menu and activate the Protect plugin.
* Notice the error in your logs.
* Apply patch.
* The error should be gone, and the dashboard notice should mention Jetpack Protect instead of Jetpack.
