### PR TITLE
Social: Featured image check classic editor

### DIFF
--- a/projects/packages/publicize/changelog/add-featured-image-check-classic-editor
+++ b/projects/packages/publicize/changelog/add-featured-image-check-classic-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Check for featured image in the classic editor

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -39,6 +39,10 @@
 		"build-development": [
 			"pnpm run build"
 		],
+		"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run watch"
+		],
 		"build-production": [
 			"pnpm run build-production-concurrently"
 		]

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -342,14 +342,9 @@ jQuery( function($) {
 	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
 }
 .publicize__notice-media-warning {
-	display: block;
-	padding: 1px 12px;
-	margin: 5px 0;
-	border: 1px solid #c3c4c7;
-	border-left-width: 4px;
-	border-left-color: #dba617;
-	border-left-style: solid;
-	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+	border-right: 1px solid #c3c4c7;
+	border-bottom: 1px solid #c3c4c7;
+	border-top: 1px solid #c3c4c7;
 }
 .publicize-external-link {
 	display: block;

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -341,6 +341,16 @@ jQuery( function($) {
 	font-size: 12px;
 	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
 }
+.publicize__notice-media-warning {
+	display: block;
+	padding: 1px 12px;
+	margin: 5px 0;
+	border: 1px solid #c3c4c7;
+	border-left-width: 4px;
+	border-left-color: #dba617;
+	border-left-style: solid;
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+}
 .publicize-external-link {
 	display: block;
 	text-decoration: none;
@@ -623,6 +633,8 @@ jQuery( function($) {
 			<a href="#" class="hide-if-no-js button" id="publicize-form-hide"><?php esc_html_e( 'OK', 'jetpack-publicize-pkg' ); ?></a>
 			<input type="hidden" name="wpas[0]" value="1" />
 		</div>
+
+		<div id="pub-connection-needs-media" class="publicize__notice-media-warning"></div>
 
 		<?php if ( ! $all_done ) : ?>
 			<?php if ( $broken_connections ) : ?>

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -634,7 +634,7 @@ jQuery( function($) {
 			<input type="hidden" name="wpas[0]" value="1" />
 		</div>
 
-		<div id="pub-connection-needs-media" class="publicize__notice-media-warning"></div>
+		<div id="pub-connection-needs-media"></div>
 
 		<?php if ( ! $all_done ) : ?>
 			<?php if ( $broken_connections ) : ?>

--- a/projects/packages/publicize/src/js/classic-editor-connections.js
+++ b/projects/packages/publicize/src/js/classic-editor-connections.js
@@ -2,8 +2,63 @@ import { _n, __ } from '@wordpress/i18n';
 import jQuery from 'jquery';
 
 const { ajaxUrl, connectionsUrl } = window.jetpackSocialClassicEditorConnections;
+const CONNECTIONS_NEED_MEDIA = [ 'facebook' ];
+
+const validateFeaturedMedia = ( $, connectionsNeedValidation ) => {
+	const featuredImage = window.wp.media.featuredImage.get();
+	// TODO: Find a way to get size for validation.
+	const isFeaturedImageValid = featuredImage && featuredImage !== -1;
+	const warningDiv = $( '#pub-connection-needs-media' );
+	const warningDivHasContent = !! warningDiv.html();
+
+	// If the state is already correct, don't do anything.
+	if ( isFeaturedImageValid !== warningDivHasContent ) {
+		return;
+	}
+
+	connectionsNeedValidation.forEach( connectionName => {
+		$( '.wpas-submit-' + connectionName )
+			.prop( 'checked', isFeaturedImageValid )
+			.prop( 'disabled', ! isFeaturedImageValid );
+	} );
+
+	if ( isFeaturedImageValid ) {
+		warningDiv.removeClass( 'publicize__notice-media-warning' ).html( '' );
+		return;
+	}
+
+	/* translators: %s is the link to the media upload best practices. */
+	const connectionNeedsMediaString = __(
+		'You need a valid image in your post to share to Instagram. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more</a>.',
+		'jetpack-publicize-pkg'
+	);
+
+	warningDiv
+		.addClass( 'publicize__notice-media-warning' )
+		.append(
+			connectionNeedsMediaString.replace(
+				'%s',
+				'https://jetpack.com/redirect/?source=jetpack-social-media-support-information'
+			)
+		);
+};
 
 jQuery( function ( $ ) {
+	const connectionsNeedValidation = CONNECTIONS_NEED_MEDIA.filter(
+		connectionName => $( '.wpas-submit-' + connectionName ).length
+	);
+
+	if ( connectionsNeedValidation.length > 0 ) {
+		validateFeaturedMedia( $, connectionsNeedValidation );
+
+		const oldSet = window.wp.media.featuredImage.set;
+		// We need to override the set method to validate the featured image when it changes.
+		window.wp.media.featuredImage.set = function ( id ) {
+			oldSet( id );
+			validateFeaturedMedia( $, connectionsNeedValidation );
+		};
+	}
+
 	let fetchingConnTest = false;
 	const publicizeConnTestStart = function () {
 		if ( ! fetchingConnTest ) {
@@ -69,7 +124,7 @@ jQuery( function ( $ ) {
 		if ( unsupportedConnections ) {
 			/* translators: %s is the link to the connections page in Calypso */
 			const msg = __(
-				'Twitter is not supported anymore. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more here</a>.',
+				'Twitter is not supported anymore. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more</a>.',
 				'jetpack-publicize-pkg'
 			);
 

--- a/projects/packages/publicize/src/js/classic-editor-connections.js
+++ b/projects/packages/publicize/src/js/classic-editor-connections.js
@@ -30,7 +30,7 @@ const validateFeaturedMedia = ( $, connectionsNeedValidation ) => {
 	} );
 
 	if ( isFeaturedImageValid ) {
-		warningDiv.removeClass( 'publicize__notice-media-warning' ).html( '' );
+		warningDiv.removeClass().html( '' );
 		return;
 	}
 
@@ -41,7 +41,7 @@ const validateFeaturedMedia = ( $, connectionsNeedValidation ) => {
 	);
 
 	warningDiv
-		.addClass( 'publicize__notice-media-warning' )
+		.addClass( 'notice-warning publicize__notice-media-warning publicize__notice-warning' )
 		.append(
 			connectionNeedsMediaString.replace(
 				'%s',

--- a/projects/packages/publicize/src/js/classic-editor-connections.js
+++ b/projects/packages/publicize/src/js/classic-editor-connections.js
@@ -2,7 +2,7 @@ import { _n, __ } from '@wordpress/i18n';
 import jQuery from 'jquery';
 
 const { ajaxUrl, connectionsUrl } = window.jetpackSocialClassicEditorConnections;
-const CONNECTIONS_NEED_MEDIA = [ 'instagram' ];
+const CONNECTIONS_NEED_MEDIA = [ 'instagram-business' ];
 
 const validateFeaturedMedia = ( $, connectionsNeedValidation ) => {
 	const featuredImage = window.wp.media.featuredImage.get();
@@ -17,9 +17,16 @@ const validateFeaturedMedia = ( $, connectionsNeedValidation ) => {
 	}
 
 	connectionsNeedValidation.forEach( connectionName => {
-		$( '.wpas-submit-' + connectionName )
-			.prop( 'checked', isFeaturedImageValid )
-			.prop( 'disabled', ! isFeaturedImageValid );
+		$( '.wpas-submit-' + connectionName ).each( ( _, element ) => {
+			const el = $( element );
+			const disabled = el.prop( 'disabled' );
+
+			if ( ! disabled && ! isFeaturedImageValid ) {
+				el.data( 'checkedVal', el.prop( 'checked' ) );
+			}
+			el.prop( 'checked', isFeaturedImageValid && el.data( 'checkedVal' ) );
+			el.prop( 'disabled', ! isFeaturedImageValid );
+		} );
 	} );
 
 	if ( isFeaturedImageValid ) {

--- a/projects/packages/publicize/src/js/classic-editor-connections.js
+++ b/projects/packages/publicize/src/js/classic-editor-connections.js
@@ -2,7 +2,7 @@ import { _n, __ } from '@wordpress/i18n';
 import jQuery from 'jquery';
 
 const { ajaxUrl, connectionsUrl } = window.jetpackSocialClassicEditorConnections;
-const CONNECTIONS_NEED_MEDIA = [ 'facebook' ];
+const CONNECTIONS_NEED_MEDIA = [ 'instagram' ];
 
 const validateFeaturedMedia = ( $, connectionsNeedValidation ) => {
 	const featuredImage = window.wp.media.featuredImage.get();

--- a/projects/plugins/crm/changelog/add-featured-image-check-classic-editor
+++ b/projects/plugins/crm/changelog/add-featured-image-check-classic-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated composer.lock refs

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -2273,12 +2273,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fe940fbf782b7dd437db2e96a7590bff0b999b6f"
+                "reference": "685f488dd73e7d2c089027e15ae3c60ec568f01c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fe940fbf782b7dd437db2e96a7590bff0b999b6f",
-                "reference": "fe940fbf782b7dd437db2e96a7590bff0b999b6f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/685f488dd73e7d2c089027e15ae3c60ec568f01c",
+                "reference": "685f488dd73e7d2c089027e15ae3c60ec568f01c",
                 "shasum": ""
             },
             "require": {
@@ -2363,7 +2363,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-25T06:21:43+00:00"
+            "time": "2023-05-26T13:01:53+00:00"
         },
         {
             "name": "psr/http-message",

--- a/projects/plugins/jetpack/changelog/add-featured-image-check-classic-editor
+++ b/projects/plugins/jetpack/changelog/add-featured-image-check-classic-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1980,7 +1980,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "77faf21d49887cda1819f5f38b01d492239bd2fa"
+                "reference": "1ae0c5ef9dbf511c3f1575f49d476a43d76c98c2"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -2033,6 +2033,10 @@
                 ],
                 "build-development": [
                     "pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ],
                 "build-production": [
                     "pnpm run build-production-concurrently"

--- a/projects/plugins/social/changelog/add-featured-image-check-classic-editor
+++ b/projects/plugins/social/changelog/add-featured-image-check-classic-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1127,7 +1127,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/publicize",
-                "reference": "77faf21d49887cda1819f5f38b01d492239bd2fa"
+                "reference": "1ae0c5ef9dbf511c3f1575f49d476a43d76c98c2"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1180,6 +1180,10 @@
                 ],
                 "build-development": [
                     "pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ],
                 "build-production": [
                     "pnpm run build-production-concurrently"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the featured image check for the Classic editor to finish up #30724 which added it for Gutenberg. This version has the limitation to only check for the availability, not the size. We can find a way for that in a follow-up

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added new div and styling for the warning message
* Added logic that validates the featured image if needed on start and on image change.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1204479765121257-as-1204618693786023
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build the package with `jetpack build packages/publicize`.
* Activate the Classic editor, then open up the editor with a Facebook connection. You should see the message, and clicking edit should show the checkbox as unchecked an disabled.
* Add a featured image. Clicking edit should show the checkbox as enabled and checked.
* Clear the image. It should get disabled again.
* Change back the action in the first step. Build. Now the validation should not run.

<img width="301" alt="CleanShot 2023-05-17 at 11 14 25 png" src="https://github.com/Automattic/jetpack/assets/36671565/075db3a2-b999-496a-b080-1e10f8698878">
