### PR TITLE
Jetpack REST Endpoint: Fix plugin modify endpoint race condition bug.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-plugin-modify-endpoint-race-condition
+++ b/projects/plugins/jetpack/changelog/fix-plugin-modify-endpoint-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix race condition bug in the Plugin update endpoint.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -386,7 +386,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		if ( isset( $query_args['autoupdate'] ) && $query_args['autoupdate'] ) {
 			Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 		}
-		wp_clean_plugins_cache();
+		wp_clean_plugins_cache( false );
 		ob_start();
 		wp_update_plugins(); // Check for Plugin updates
 		ob_end_clean();
@@ -487,7 +487,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 		// Clear the cache.
-		wp_clean_plugins_cache();
+		wp_clean_plugins_cache( false );
 		ob_start();
 		wp_update_plugins(); // Check for Plugin updates
 		ob_end_clean();


### PR DESCRIPTION
We recently found an issue in the Plugin management UI with the bulk update plugins that caused it not to function as expected. Initially discovered from a user interview for the Agency Pro dashboard.  

We found out that the cause of the issue was due to a race condition bug with the Plugin update REST endpoint, I posted [my investigation](pedEI5-Fb-p2/) on p2, which explains the issue further.

In Summary, the current Update plugin endpoint relies on the WP plugin cache to keep track of plugins that needs updating. The operation always starts with clearing the cache, pulling the information of outdated plugins, and caching the data (**update_plugins**).

While clearing the plugin cache before the update operation seems reasonable for ensuring we start from new data, this becomes problematic when dealing with simultaneous update requests that depend on the same cache. In this case, it was the **update_plugins** cache data that was getting cleared in the middle of the operation that caused the bug.


## Proposed changes:

This PR aims to slightly tweak the endpoint not to clear the **update_plugins** cache data and prevent the logic from a race condition. Luckily, this requires a one-line change as the WP function (**wp_clean_plugins_cache**) we use to clear the cache already has a parameter to skip removing this data specifically.

```
/**
 * Clears the plugins cache used by get_plugins() and by default, the plugin updates cache.
 *
 * @since 3.7.0
 *
 * @param bool $clear_update_cache Whether to clear the plugin updates cache. Default true.
 */
function wp_clean_plugins_cache( $clear_update_cache = true ) {
	if ( $clear_update_cache ) {
		delete_site_transient( 'update_plugins' );
	}
	wp_cache_delete( 'plugins,' 'plugins' );
}
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
1202619025189113-as-1204373712028503
pedEI5-Fb-p2

## Does this pull request to change what data or activity we track or use?
No

## Testing instructions:
To make this easier to test with actual user scenarios. We will test the changes in the Plugin Management UI in the Pro Dashboard. Make sure you have an agency account so you can access the UI. 2c49b-pb

1. Spin up a JN site and use Jetpack beta pointing to this branch.
2. Connect your JN site to Jetpack.
3. Once connected, please install at least two old versions of any plugins you can download. Or you can install MainWP and MainWP - Child's previous plugin version by going to this link https://wordpress.org/plugins/mainwp/advanced/ and this https://wordpress.org/plugins/mainwp-child/advanced/.
4. Scroll down below and look for the version selector. You should be able to download the zip file and upload/install it to your JN site.
<img width="860" alt="Screen Shot 2023-05-17 at 8 40 39 PM" src="https://github.com/Automattic/jetpack/assets/56598660/fd13ca53-81ab-432a-b676-b3cbf0d9409d">
5. Once you have installed the old plugins. You can go to the plugin management UI by going to this link.

```
https://cloud.jetpack.com/plugins/manage/<REPLACE WITH YOUR JN SITE>
```
6. From there should be able to click the bulk update button. Clicking this should update all the outdated plugins on your site simultaneously.
<img width="1145" alt="Screen Shot 2023-05-17 at 8 49 25 PM" src="https://github.com/Automattic/jetpack/assets/56598660/669d2c3c-1755-4e1a-8c63-66a4df9372c0">

7. Once it says successfully updated. Try to refresh the page and ensure it is indeed updated. The initially reported issue was that some of the plugins would not be updated will appear so. The fix should prevent this issue.
