### PR TITLE
Change "premium content" block to "paid content"

### DIFF
--- a/projects/plugins/jetpack/changelog/update-premium-content-name
+++ b/projects/plugins/jetpack/changelog/update-premium-content-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Change "Premium Content" block to "Paid Content" block

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -106,7 +106,7 @@ function Edit( props ) {
 					{ isApiLoading && (
 						<Placeholder
 							icon="lock"
-							label={ __( 'Premium Content', 'jetpack' ) }
+							label={ __( 'Paid Content', 'jetpack' ) }
 							instructions={ __( 'Loading data…', 'jetpack' ) }
 						>
 							<Spinner />

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/index.js
@@ -53,7 +53,7 @@ const blocksCanBeTransformed = blocks => {
 
 export const name = 'premium-content/container';
 export const settings = {
-	title: __( 'Premium Content', 'jetpack' ),
+	title: __( 'Paid Content', 'jetpack' ),
 	description: __( 'Restrict access to your content for paying subscribers.', 'jetpack' ),
 	icon,
 	category: 'grow',
@@ -73,6 +73,7 @@ export const settings = {
 		_x( 'pay', 'block search term', 'jetpack' ),
 		_x( 'payments', 'block search term', 'jetpack' ),
 		_x( 'paywall', 'block search term', 'jetpack' ),
+		_x( 'premium content', 'block search term', 'jetpack' ),
 		_x( 'purchase', 'block search term', 'jetpack' ),
 		_x( 'recurring', 'block search term', 'jetpack' ),
 		_x( 'repeat', 'block search term', 'jetpack' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Discussion came up in slack to rename "premium content" block to "paid content". p1684319777723229-slack-C052XEUUBL4

“Premium” was yet another use of “premium” term, conflating with premium plan, premium themes, etc. If felt confusing, especially as we are going to open this block for the free plan as well.

Now is good time to rename, as we've only released the block in WP.com and not yet in Jetpack.

We will need some simple documentation changes as well, cc @donalirl (**update**: see 1963-GH-en.support-docs-content)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the name from "Premium Content" to "Paid Content"
* Add "premium content" to keywords to ensure folks who know the previous name can find the block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In the editor, see that the block picker has new block name, as well as the block sidebar.

Screenshots with old name:

<img width="317" alt="Screenshot 2023-05-17 at 16 48 38" src="https://github.com/Automattic/jetpack/assets/87168/2631e6d2-3d3f-426c-8183-b2b8b3d1a408">

<img width="1338" alt="Screenshot 2023-05-17 at 16 53 23" src="https://github.com/Automattic/jetpack/assets/87168/fdcb82cd-e621-498b-9cf0-43489ffee77b">
