### PR TITLE
Jetpack Social: Add notice to promote Instagram

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-jetpack-social-add-instagram-notice-to-admin-page
+++ b/projects/js-packages/publicize-components/changelog/add-jetpack-social-add-instagram-notice-to-admin-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Social: Add a notice to let users know Instagram is available

--- a/projects/js-packages/publicize-components/index.js
+++ b/projects/js-packages/publicize-components/index.js
@@ -19,5 +19,6 @@ export { default as useSocialMediaConnections } from './src/hooks/use-social-med
 export { default as useSocialMediaMessage } from './src/hooks/use-social-media-message';
 export { default as usePublicizeConfig } from './src/hooks/use-publicize-config';
 export { default as useSharePost } from './src/hooks/use-share-post';
+export { default as useDismissNotice } from './src/hooks/use-dismiss-notice';
 export * from './src/components/share-post';
 export * from './src/hooks/use-saving-post';

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -8,11 +8,12 @@
 
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
-import { PanelRow, Disabled, ExternalLink } from '@wordpress/components';
+import { Button, PanelRow, Disabled, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Fragment, createInterpolateElement, useCallback } from '@wordpress/element';
+import { useState, Fragment, createInterpolateElement, useCallback } from '@wordpress/element';
 import { _n, sprintf, __ } from '@wordpress/i18n';
 import useAttachedMedia from '../../hooks/use-attached-media';
+import useDismissNotice from '../../hooks/use-dismiss-notice';
 import useImageGeneratorConfig from '../../hooks/use-image-generator-config';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
@@ -56,7 +57,17 @@ export default function PublicizeForm( {
 		useSocialMediaConnections();
 	const { message, updateMessage, maxLength } = useSocialMediaMessage();
 	const { isEnabled: isSocialImageGeneratorEnabledForPost } = useImageGeneratorConfig();
+	const { dismissedNotices, dismissNotice } = useDismissNotice();
 
+	const hasInstagramConnection =
+		connections.filter( connection => connection.service_name === 'instagram' ).length > 0;
+	const [ shouldShowInstagramNotice, setShouldShowInstagramNotice ] = useState(
+		! hasInstagramConnection
+	);
+	const onDismissInstagramNotice = useCallback( () => {
+		dismissNotice( 'instagram' );
+		setShouldShowInstagramNotice( false );
+	}, [ dismissNotice, setShouldShowInstagramNotice ] );
 	const shouldDisableMediaPicker =
 		isSocialImageGeneratorEnabled && isSocialImageGeneratorEnabledForPost;
 	const Wrapper = isPublicizeDisabledBySitePlan ? Disabled : Fragment;
@@ -236,9 +247,24 @@ export default function PublicizeForm( {
 						) }
 				</>
 			) }
-
 			{ ! isPublicizeDisabledBySitePlan && (
 				<Fragment>
+					{ ! dismissedNotices.includes( 'instagram' ) && shouldShowInstagramNotice && (
+						<Notice
+							onDismiss={ onDismissInstagramNotice }
+							type={ 'highlight' }
+							actions={ [
+								<Button href={ connectionsAdminUrl } variant="primary">
+									{ __( 'Connect now', 'jetpack' ) }
+								</Button>,
+								<Button href={ getRedirectUrl( 'jetpack-social-connecting-to-social-networks' ) }>
+									{ __( 'Learn more', 'jetpack' ) }
+								</Button>,
+							] }
+						>
+							{ __( 'You can now share directly to your Instagram account!', 'jetpack' ) }
+						</Notice>
+					) }
 					<PublicizeSettingsButton />
 
 					{ isPublicizeEnabled && connections.some( connection => connection.enabled ) && (

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -26,6 +26,7 @@ import PublicizeSettingsButton from '../settings-button';
 import styles from './styles.module.scss';
 
 const CONNECTIONS_NEED_MEDIA = [ 'instagram' ];
+const PUBLICIZE_STORE_ID = 'jetpack/publicize';
 
 const checkConnectionCode = ( connection, code ) =>
 	false === connection.is_healthy && code === ( connection.error_code ?? 'broken' );
@@ -59,11 +60,15 @@ export default function PublicizeForm( {
 	const { isEnabled: isSocialImageGeneratorEnabledForPost } = useImageGeneratorConfig();
 	const { dismissedNotices, dismissNotice } = useDismissNotice();
 
+	const { isInstagramConnectionSupported } = useSelect( select => ( {
+		isInstagramConnectionSupported: select( PUBLICIZE_STORE_ID ).isInstagramConnectionSupported(),
+	} ) );
+
 	const hasInstagramConnection = connections.some(
 		connection => connection.service_name === 'instagram'
 	);
 	const [ shouldShowInstagramNotice, setShouldShowInstagramNotice ] = useState(
-		! hasInstagramConnection
+		! hasInstagramConnection && isInstagramConnectionSupported
 	);
 	const onDismissInstagramNotice = useCallback( () => {
 		dismissNotice( 'instagram' );

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -59,8 +59,9 @@ export default function PublicizeForm( {
 	const { isEnabled: isSocialImageGeneratorEnabledForPost } = useImageGeneratorConfig();
 	const { dismissedNotices, dismissNotice } = useDismissNotice();
 
-	const hasInstagramConnection =
-		connections.filter( connection => connection.service_name === 'instagram' ).length > 0;
+	const hasInstagramConnection = connections.some(
+		connection => connection.service_name === 'instagram'
+	);
 	const [ shouldShowInstagramNotice, setShouldShowInstagramNotice ] = useState(
 		! hasInstagramConnection
 	);

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -254,10 +254,13 @@ export default function PublicizeForm( {
 							onDismiss={ onDismissInstagramNotice }
 							type={ 'highlight' }
 							actions={ [
-								<Button href={ connectionsAdminUrl } variant="primary">
+								<Button key="connect" href={ connectionsAdminUrl } variant="primary">
 									{ __( 'Connect now', 'jetpack' ) }
 								</Button>,
-								<Button href={ getRedirectUrl( 'jetpack-social-connecting-to-social-networks' ) }>
+								<Button
+									key="learn-more"
+									href={ getRedirectUrl( 'jetpack-social-connecting-to-social-networks' ) }
+								>
 									{ __( 'Learn more', 'jetpack' ) }
 								</Button>,
 							] }

--- a/projects/js-packages/publicize-components/src/components/notice/index.js
+++ b/projects/js-packages/publicize-components/src/components/notice/index.js
@@ -1,16 +1,34 @@
+import { VisuallyHidden } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, closeSmall } from '@wordpress/icons';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import styles from './styles.module.scss';
 
-const Notice = ( { children, type = 'default' } ) => {
+const Notice = ( { children, type = 'default', actions = [], onDismiss } ) => {
 	const className = classnames( styles.notice, styles[ `notice--${ type }` ] );
 
-	return <div className={ className }>{ children }</div>;
+	return (
+		<div className={ className }>
+			<div className={ styles.content }> { children } </div>
+			{ onDismiss && (
+				<button className={ styles.dismiss } onClick={ onDismiss }>
+					<VisuallyHidden>{ __( 'Dismiss notice', 'jetpack' ) }</VisuallyHidden>
+					<Icon icon={ closeSmall } />
+				</button>
+			) }
+			{ actions.length && (
+				<div className={ styles.actions }>{ actions.map( action => action ) }</div>
+			) }
+		</div>
+	);
 };
 
 Notice.propTypes = {
 	children: PropTypes.node.isRequired,
-	type: PropTypes.oneOf( [ 'default', 'warning', 'error' ] ),
+	type: PropTypes.oneOf( [ 'default', 'highlight', 'warning', 'error' ] ),
+	actions: PropTypes.arrayOf( PropTypes.element ),
+	onDismiss: PropTypes.func,
 };
 
 export default Notice;

--- a/projects/js-packages/publicize-components/src/components/notice/index.js
+++ b/projects/js-packages/publicize-components/src/components/notice/index.js
@@ -17,7 +17,7 @@ const Notice = ( { children, type = 'default', actions = [], onDismiss } ) => {
 					<Icon icon={ closeSmall } />
 				</button>
 			) }
-			{ actions.length && (
+			{ actions && actions.length > 0 && (
 				<div className={ styles.actions }>{ actions.map( action => action ) }</div>
 			) }
 		</div>

--- a/projects/js-packages/publicize-components/src/components/notice/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/notice/styles.module.scss
@@ -1,13 +1,17 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .notice {
-	margin-bottom: 16px;
+	font-size: 13px;
+	line-height: 24px;
+	margin: 16px 0;
+	position: relative;
 }
 
 .notice--default {
 	color: $gray-700;
 }
 
+.notice--highlight,
 .notice--warning,
 .notice--error {
 	padding: 8px 16px;
@@ -25,4 +29,32 @@
 .notice--error {
 	background-color: lighten( $alert-red, 35% );
 	border-left: 2px solid $alert-red;
+}
+
+.notice--highlight {
+	padding: 12px 16px;
+	border: 1px solid var( --wp-components-color-accent, var( --wp-admin-theme-color, #007cba ) );
+	border-left-width: 4px;
+}
+
+.content {
+	padding-right: 25px;
+}
+
+.dismiss {
+	all: unset;
+	cursor: pointer;
+	position: absolute;
+	top: 12px;
+	right: 16px;
+
+	&:focus:not( :disabled ) {
+		box-shadow: inset 0 0 0 1px var( --wp-components-color-background, #fff ),
+			0 0 0 var( --wp-admin-border-width-focus )
+				var( --wp-components-color-accent, var( --wp-admin-theme-color, #007cba ) );
+	}
+}
+
+.actions {
+	margin-top: 12px;
 }

--- a/projects/js-packages/publicize-components/src/hooks/use-dismiss-notice/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-dismiss-notice/index.js
@@ -1,0 +1,33 @@
+import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * @typedef {object} DismissNoticeHook
+ * @property {Array} dismissedNotices - Array of names of dismissed notices.
+ * @property {Function} dismissNotice - Callback used to dismiss a notice.
+ */
+
+/**
+ * Hook to handle retrieving dismissed notices and dismissing a notice.
+ *
+ * @returns {DismissNoticeHook} - An object with the dismissed notice hook properties set.
+ */
+export default function useDismissNotice() {
+	const dismissedNotices =
+		getJetpackData()?.social?.dismissedNotices ??
+		window?.jetpackSocialInitialState?.jetpackSettings?.dismissedNotices ??
+		[];
+
+	const handleDismiss = notice => {
+		apiFetch( {
+			path: `jetpack/v4/social/dismiss-notice`,
+			method: 'POST',
+			data: { notice },
+		} );
+	};
+
+	return {
+		dismissedNotices,
+		dismissNotice: notice => handleDismiss( notice ),
+	};
+}

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -1,3 +1,4 @@
+import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 import { select } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
@@ -610,4 +611,13 @@ export function shouldUploadAttachedMedia() {
  */
 export function getImageGeneratorPostSettings() {
 	return getJetpackSocialOptions()?.image_generator_settings ?? {};
+}
+
+/**
+ * Checks if the Instagram connection is supported.
+ *
+ * @returns {boolean} Whether the Instagram connection is supported
+ */
+export function isInstagramConnectionSupported() {
+	return !! getJetpackData()?.social?.isInstagramConnectionSupported;
 }

--- a/projects/packages/publicize/changelog/add-jetpack-social-add-instagram-notice-to-admin-page
+++ b/projects/packages/publicize/changelog/add-jetpack-social-add-instagram-notice-to-admin-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Social: Add a notice to let users know Instagram is available

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1757,6 +1757,15 @@ abstract class Publicize_Base {
 	}
 
 	/**
+	 * Check if Instagram connection is enabled.
+	 *
+	 * @return bool
+	 */
+	public function has_instagram_connection_feature() {
+		return Current_Plan::supports( 'social-instagram-connection' );
+	}
+
+	/**
 	 * Call the WPCOM REST API to calculate the scheduled shares.
 	 *
 	 * @param string $blog_id The blog_id.

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1801,21 +1801,6 @@ abstract class Publicize_Base {
 	}
 
 	/**
-	 * Check if we have a Jetpack Social Advanced plan.
-	 *
-	 * @param bool $refresh_from_wpcom Whether to force refresh the plan check.
-	 *
-	 * @return bool True if we have an Advanced plan, false otherwise.
-	 */
-	public function has_advanced_plan( $refresh_from_wpcom = false ) {
-		static $has_advanced_plan = null;
-		if ( $has_advanced_plan === null ) {
-			$has_advanced_plan = Current_Plan::supports( 'social-enhanced-publishing', $refresh_from_wpcom );
-		}
-		return $has_advanced_plan;
-	}
-
-	/**
 	 * Get an array with all dismissed notices.
 	 *
 	 * @return array

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1794,7 +1794,7 @@ abstract class Publicize_Base {
 	 */
 	public function has_paid_plan( $refresh_from_wpcom = false ) {
 		static $has_paid_plan = null;
-		if ( ! $has_paid_plan ) {
+		if ( $has_paid_plan === null ) {
 			$has_paid_plan = Current_Plan::supports( 'social-shares-1000', $refresh_from_wpcom );
 		}
 		return $has_paid_plan;
@@ -1809,8 +1809,8 @@ abstract class Publicize_Base {
 	 */
 	public function has_advanced_plan( $refresh_from_wpcom = false ) {
 		static $has_advanced_plan = null;
-		if ( ! $has_advanced_plan ) {
-			$has_advanced_plan = Current_Plan::supports( 'social-image-generator', $refresh_from_wpcom );
+		if ( $has_advanced_plan === null ) {
+			$has_advanced_plan = Current_Plan::supports( 'social-enhanced-publishing', $refresh_from_wpcom );
 		}
 		return $has_advanced_plan;
 	}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -124,6 +124,13 @@ abstract class Publicize_Base {
 	public $POST_SERVICE_DONE = '_publicize_done_external';
 
 	/**
+	 * Option key for dismissing Jetpack Social notices.
+	 *
+	 * @var string
+	 */
+	const OPTION_JETPACK_SOCIAL_DISMISSED_NOTICES = 'jetpack_social_dismissed_notices';
+
+	/**
 	 * Default pieces of the message used in constructing the
 	 * content pushed out to other social networks.
 	 */
@@ -1782,6 +1789,36 @@ abstract class Publicize_Base {
 			$has_paid_plan = Current_Plan::supports( 'social-shares-1000', $refresh_from_wpcom );
 		}
 		return $has_paid_plan;
+	}
+
+	/**
+	 * Check if we have a Jetpack Social Advanced plan.
+	 *
+	 * @param bool $refresh_from_wpcom Whether to force refresh the plan check.
+	 *
+	 * @return bool True if we have an Advanced plan, false otherwise.
+	 */
+	public function has_advanced_plan( $refresh_from_wpcom = false ) {
+		static $has_advanced_plan = null;
+		if ( ! $has_advanced_plan ) {
+			$has_advanced_plan = Current_Plan::supports( 'social-image-generator', $refresh_from_wpcom );
+		}
+		return $has_advanced_plan;
+	}
+
+	/**
+	 * Get an array with all dismissed notices.
+	 *
+	 * @return array
+	 */
+	public function get_dismissed_notices() {
+		$dismissed_notices = get_option( self::OPTION_JETPACK_SOCIAL_DISMISSED_NOTICES );
+
+		if ( ! is_array( $dismissed_notices ) ) {
+			return array();
+		}
+
+		return $dismissed_notices;
 	}
 }
 

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -89,6 +89,19 @@ class REST_Controller {
 			)
 		);
 
+		// Dismiss a notice.
+		register_rest_route(
+			'jetpack/v4',
+			'/social/dismiss-notice',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'update_dismissed_notices' ),
+				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+				'args'                => rest_get_endpoint_args_for_schema( $this->get_dismiss_notice_endpoint_schema(), WP_REST_Server::CREATABLE ),
+				'schema'              => array( $this, 'get_dismiss_notice_endpoint_schema' ),
+			)
+		);
+
 		register_rest_route(
 			'jetpack/v4',
 			'/publicize/(?P<postId>\d+)',
@@ -138,6 +151,29 @@ class REST_Controller {
 		);
 
 		return new WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
+	}
+
+	/**
+	 * Retrieves the JSON schema for dismissing notices.
+	 *
+	 * @return array Schema data.
+	 */
+	public function get_dismiss_notice_endpoint_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'jetpack-social-dismiss-notice',
+			'type'       => 'object',
+			'properties' => array(
+				'notice' => array(
+					'description' => __( 'Name of the notice to dismiss', 'jetpack-publicize-pkg' ),
+					'type'        => 'string',
+					'enum'        => array( 'instagram' ),
+					'required'    => true,
+				),
+			),
+		);
+
+		return rest_default_additional_properties_to_false( $schema );
 	}
 
 	/**
@@ -202,6 +238,27 @@ class REST_Controller {
 			'advanced' => $products->{self::JETPACK_SOCIAL_ADVANCED_YEARLY},
 			'basic'    => $products->{self::JETPACK_SOCIAL_BASIC_YEARLY},
 		);
+	}
+
+	/**
+	 * Dismisses a notice to prevent it from appearing again.
+	 *
+	 * @param WP_Request $request The request object, which includes the parameters.
+	 * @return WP_REST_Response|WP_Error True if the request was successful, or a WP_Error otherwise.
+	 */
+	public function update_dismissed_notices( $request ) {
+		$notice            = $request->get_param( 'notice' );
+		$dismissed_notices = get_option( Publicize::OPTION_JETPACK_SOCIAL_DISMISSED_NOTICES );
+
+		if ( ! is_array( $dismissed_notices ) ) {
+			$dismissed_notices = array();
+		}
+
+		$dismissed_notices = array_unique( array_merge( $dismissed_notices, array( $notice ) ) );
+
+		update_option( Publicize::OPTION_JETPACK_SOCIAL_DISMISSED_NOTICES, $dismissed_notices );
+
+		return rest_ensure_response( array( 'success' => true ) );
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -254,8 +254,11 @@ class REST_Controller {
 			$dismissed_notices = array();
 		}
 
-		$dismissed_notices = array_unique( array_merge( $dismissed_notices, array( $notice ) ) );
+		if ( in_array( $notice, $dismissed_notices, true ) ) {
+			return rest_ensure_response( array( 'success' => true ) );
+		}
 
+		array_push( $dismissed_notices, $notice );
 		update_option( Publicize::OPTION_JETPACK_SOCIAL_DISMISSED_NOTICES, $dismissed_notices );
 
 		return rest_ensure_response( array( 'success' => true ) );

--- a/projects/plugins/jetpack/changelog/add-jetpack-social-add-instagram-notice-to-admin-page
+++ b/projects/plugins/jetpack/changelog/add-jetpack-social-add-instagram-notice-to-admin-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack Social: Add a notice to let users know Instagram is available

--- a/projects/plugins/jetpack/changelog/add-jetpack-social-add-instagram-notice-to-admin-page#2
+++ b/projects/plugins/jetpack/changelog/add-jetpack-social-add-instagram-notice-to-admin-page#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -728,6 +728,7 @@ class Jetpack_Gutenberg {
 				'isSocialImageGeneratorAvailable' => $sig_settings->is_available(),
 				'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
 				'dismissedNotices'                => $publicize->get_dismissed_notices(),
+				'isInstagramConnectionSupported'  => $publicize->has_instagram_connection_feature(),
 			);
 		}
 

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -723,7 +723,6 @@ class Jetpack_Gutenberg {
 			$initial_state['social'] = array(
 				'sharesData'                      => $publicize->get_publicize_shares_info( $blog_id ),
 				'hasPaidPlan'                     => $publicize->has_paid_plan(),
-				'hasAdvancedPlan'                 => $publicize->has_advanced_plan(),
 				'isEnhancedPublishingEnabled'     => $publicize->has_enhanced_publishing_feature(),
 				'isSocialImageGeneratorAvailable' => $sig_settings->is_available(),
 				'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -723,9 +723,11 @@ class Jetpack_Gutenberg {
 			$initial_state['social'] = array(
 				'sharesData'                      => $publicize->get_publicize_shares_info( $blog_id ),
 				'hasPaidPlan'                     => $publicize->has_paid_plan(),
+				'hasAdvancedPlan'                 => $publicize->has_advanced_plan(),
 				'isEnhancedPublishingEnabled'     => $publicize->has_enhanced_publishing_feature(),
 				'isSocialImageGeneratorAvailable' => $sig_settings->is_available(),
 				'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
+				'dismissedNotices'                => $publicize->get_dismissed_notices(),
 			);
 		}
 

--- a/projects/plugins/social/changelog/add-jetpack-social-add-instagram-notice-to-admin-page
+++ b/projects/plugins/social/changelog/add-jetpack-social-add-instagram-notice-to-admin-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Social: Add a notice to let users know Instagram is available

--- a/projects/plugins/social/changelog/add-jetpack-social-add-instagram-notice-to-admin-page#2
+++ b/projects/plugins/social/changelog/add-jetpack-social-add-instagram-notice-to-admin-page#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -237,6 +237,8 @@ class Jetpack_Social {
 						'publicize_active'  => self::is_publicize_active(),
 						'show_pricing_page' => self::should_show_pricing_page(),
 						'showNudge'         => ! $publicize->has_paid_plan( true ),
+						'hasAdvancedPlan'   => $publicize->has_advanced_plan(),
+						'dismissedNotices'  => $publicize->get_dismissed_notices(),
 					),
 					'connectionData'               => array(
 						'connections' => $publicize->get_all_connections_for_user(), // TODO: Sanitize the array

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -332,6 +332,7 @@ class Jetpack_Social {
 					'isEnhancedPublishingEnabled'     => $publicize->has_enhanced_publishing_feature(),
 					'isSocialImageGeneratorAvailable' => $sig_settings->is_available(),
 					'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
+					'dismissedNotices'                => $publicize->get_dismissed_notices(),
 				),
 			)
 		);

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -334,6 +334,7 @@ class Jetpack_Social {
 					'isSocialImageGeneratorAvailable' => $sig_settings->is_available(),
 					'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
 					'dismissedNotices'                => $publicize->get_dismissed_notices(),
+					'isInstagramConnectionSupported'  => $publicize->has_instagram_connection_feature(),
 				),
 			)
 		);

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -234,11 +234,12 @@ class Jetpack_Social {
 				$state,
 				array(
 					'jetpackSettings'              => array(
-						'publicize_active'  => self::is_publicize_active(),
-						'show_pricing_page' => self::should_show_pricing_page(),
-						'showNudge'         => ! $publicize->has_paid_plan( true ),
-						'hasAdvancedPlan'   => $publicize->has_advanced_plan(),
-						'dismissedNotices'  => $publicize->get_dismissed_notices(),
+						'publicize_active'               => self::is_publicize_active(),
+						'show_pricing_page'              => self::should_show_pricing_page(),
+						'showNudge'                      => ! $publicize->has_paid_plan( true ),
+						'hasAdvancedPlan'                => $publicize->has_advanced_plan(),
+						'dismissedNotices'               => $publicize->get_dismissed_notices(),
+						'isInstagramConnectionSupported' => $publicize->has_instagram_connection_feature(),
 					),
 					'connectionData'               => array(
 						'connections' => $publicize->get_all_connections_for_user(), // TODO: Sanitize the array

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -237,7 +237,7 @@ class Jetpack_Social {
 						'publicize_active'               => self::is_publicize_active(),
 						'show_pricing_page'              => self::should_show_pricing_page(),
 						'showNudge'                      => ! $publicize->has_paid_plan( true ),
-						'hasAdvancedPlan'                => $publicize->has_advanced_plan(),
+						'isEnhancedPublishingEnabled'    => $publicize->has_enhanced_publishing_feature(),
 						'dismissedNotices'               => $publicize->get_dismissed_notices(),
 						'isInstagramConnectionSupported' => $publicize->has_instagram_connection_feature(),
 					),

--- a/projects/plugins/social/src/class-rest-settings-controller.php
+++ b/projects/plugins/social/src/class-rest-settings-controller.php
@@ -135,19 +135,7 @@ class REST_Settings_Controller extends WP_REST_Controller {
 					}
 					break;
 				case 'show_pricing_page':
-					$old_value = get_option( Jetpack_Social::JETPACK_SOCIAL_SHOW_PRICING_PAGE_OPTION );
-
-					if ( $old_value === false || (int) $old_value !== (int) $params[ $name ] ) {
-						$updated = update_option( Jetpack_Social::JETPACK_SOCIAL_SHOW_PRICING_PAGE_OPTION, (int) $params[ $name ] );
-						if ( ! $updated ) {
-							return new WP_Error(
-								'rest_cannot_edit',
-								__( 'Failed to update the show_pricing_page', 'jetpack-social' ),
-								array( 'status' => 500 )
-							);
-						}
-					}
-
+					update_option( Jetpack_Social::JETPACK_SOCIAL_SHOW_PRICING_PAGE_OPTION, (int) $params[ $name ] );
 					break;
 			}
 		}

--- a/projects/plugins/social/src/class-rest-settings-controller.php
+++ b/projects/plugins/social/src/class-rest-settings-controller.php
@@ -137,7 +137,7 @@ class REST_Settings_Controller extends WP_REST_Controller {
 				case 'show_pricing_page':
 					$old_value = get_option( Jetpack_Social::JETPACK_SOCIAL_SHOW_PRICING_PAGE_OPTION );
 
-					if ( (int) $old_value !== (int) $params[ $name ] ) {
+					if ( $old_value === false || (int) $old_value !== (int) $params[ $name ] ) {
 						$updated = update_option( Jetpack_Social::JETPACK_SOCIAL_SHOW_PRICING_PAGE_OPTION, (int) $params[ $name ] );
 						if ( ! $updated ) {
 							return new WP_Error(

--- a/projects/plugins/social/src/class-rest-settings-controller.php
+++ b/projects/plugins/social/src/class-rest-settings-controller.php
@@ -135,13 +135,19 @@ class REST_Settings_Controller extends WP_REST_Controller {
 					}
 					break;
 				case 'show_pricing_page':
-					if ( ! update_option( Jetpack_Social::JETPACK_SOCIAL_SHOW_PRICING_PAGE_OPTION, (int) $params[ $name ] ) ) {
-						return new WP_Error(
-							'rest_cannot_edit',
-							__( 'Failed to update the show_pricing_page', 'jetpack-social' ),
-							array( 'status' => 500 )
-						);
+					$old_value = get_option( Jetpack_Social::JETPACK_SOCIAL_SHOW_PRICING_PAGE_OPTION );
+
+					if ( (int) $old_value !== (int) $params[ $name ] ) {
+						$updated = update_option( Jetpack_Social::JETPACK_SOCIAL_SHOW_PRICING_PAGE_OPTION, (int) $params[ $name ] );
+						if ( ! $updated ) {
+							return new WP_Error(
+								'rest_cannot_edit',
+								__( 'Failed to update the show_pricing_page', 'jetpack-social' ),
+								array( 'status' => 500 )
+							);
+						}
 					}
+
 					break;
 			}
 		}

--- a/projects/plugins/social/src/js/components/admin-page/header/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/header/index.jsx
@@ -17,7 +17,7 @@ const AdminPageHeader = () => {
 
 	return (
 		<div className={ styles.header }>
-			<span class={ styles.logo }>
+			<span className={ styles.logo }>
 				<Logo />
 			</span>
 

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -24,16 +24,10 @@ import './styles.module.scss';
 const Admin = () => {
 	const { isUserConnected, isRegistered } = useConnection();
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
-	const [ manuallyShowPricingPage, setManuallyShowPricingPage ] = useState( false );
+	const [ forceDisplayPricingPage, setForceDisplayPricingPage ] = useState( false );
 
-	const onUpgradeToggle = useCallback(
-		() => setManuallyShowPricingPage( true ),
-		[ setManuallyShowPricingPage ]
-	);
-	const onPricingPageDismiss = useCallback(
-		() => setManuallyShowPricingPage( false ),
-		[ setManuallyShowPricingPage ]
-	);
+	const onUpgradeToggle = useCallback( () => setForceDisplayPricingPage( true ), [] );
+	const onPricingPageDismiss = useCallback( () => setForceDisplayPricingPage( false ), [] );
 
 	const {
 		isModuleEnabled,
@@ -70,7 +64,7 @@ const Admin = () => {
 
 	return (
 		<AdminPage moduleName={ moduleName } header={ <AdminPageHeader /> }>
-			{ ( isShareLimitEnabled && ! hasPaidPlan && showPricingPage ) || manuallyShowPricingPage ? (
+			{ ( isShareLimitEnabled && ! hasPaidPlan && showPricingPage ) || forceDisplayPricingPage ? (
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 						<Col>

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -16,6 +16,7 @@ import SupportSection from '../support-section';
 import ConnectionScreen from './../connection-screen';
 import Header from './../header';
 import InfoSection from './../info-section';
+import InstagramNotice from './../instagram-notice';
 import AdminPageHeader from './header';
 import './styles.module.scss';
 
@@ -30,6 +31,7 @@ const Admin = () => {
 		isShareLimitEnabled,
 		pluginVersion,
 		isSocialImageGeneratorAvailable,
+		dismissedNotices,
 	} = useSelect( select => {
 		const store = select( STORE_ID );
 		return {
@@ -39,6 +41,7 @@ const Admin = () => {
 			isShareLimitEnabled: store.isShareLimitEnabled(),
 			pluginVersion: store.getPluginVersion(),
 			isSocialImageGeneratorAvailable: store.isSocialImageGeneratorAvailable(),
+			dismissedNotices: store.getDismissedNotices(),
 		};
 	} );
 
@@ -72,6 +75,9 @@ const Admin = () => {
 						<Header />
 					</AdminSectionHero>
 					<AdminSection>
+						{ dismissedNotices && ! dismissedNotices.includes( 'instagram' ) && (
+							<InstagramNotice />
+						) }
 						<SocialModuleToggle />
 						{ isModuleEnabled && isSocialImageGeneratorAvailable && <SocialImageGeneratorToggle /> }
 					</AdminSection>

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -7,6 +7,7 @@ import {
 } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { useSelect } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
 import React from 'react';
 import { STORE_ID } from '../../store';
 import PricingPage from '../pricing-page';
@@ -23,6 +24,16 @@ import './styles.module.scss';
 const Admin = () => {
 	const { isUserConnected, isRegistered } = useConnection();
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
+	const [ manuallyShowPricingPage, setManuallyShowPricingPage ] = useState( false );
+
+	const onUpgradeToggle = useCallback(
+		() => setManuallyShowPricingPage( true ),
+		[ setManuallyShowPricingPage ]
+	);
+	const onPricingPageDismiss = useCallback(
+		() => setManuallyShowPricingPage( false ),
+		[ setManuallyShowPricingPage ]
+	);
 
 	const {
 		isModuleEnabled,
@@ -31,7 +42,6 @@ const Admin = () => {
 		isShareLimitEnabled,
 		pluginVersion,
 		isSocialImageGeneratorAvailable,
-		dismissedNotices,
 	} = useSelect( select => {
 		const store = select( STORE_ID );
 		return {
@@ -41,7 +51,6 @@ const Admin = () => {
 			isShareLimitEnabled: store.isShareLimitEnabled(),
 			pluginVersion: store.getPluginVersion(),
 			isSocialImageGeneratorAvailable: store.isSocialImageGeneratorAvailable(),
-			dismissedNotices: store.getDismissedNotices(),
 		};
 	} );
 
@@ -61,11 +70,11 @@ const Admin = () => {
 
 	return (
 		<AdminPage moduleName={ moduleName } header={ <AdminPageHeader /> }>
-			{ isShareLimitEnabled && ! hasPaidPlan && showPricingPage ? (
+			{ ( isShareLimitEnabled && ! hasPaidPlan && showPricingPage ) || manuallyShowPricingPage ? (
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 						<Col>
-							<PricingPage />
+							<PricingPage onDismiss={ onPricingPageDismiss } />
 						</Col>
 					</Container>
 				</AdminSectionHero>
@@ -75,9 +84,7 @@ const Admin = () => {
 						<Header />
 					</AdminSectionHero>
 					<AdminSection>
-						{ dismissedNotices && ! dismissedNotices.includes( 'instagram' ) && (
-							<InstagramNotice />
-						) }
+						<InstagramNotice onUpgrade={ onUpgradeToggle } />
 						<SocialModuleToggle />
 						{ isModuleEnabled && isSocialImageGeneratorAvailable && <SocialImageGeneratorToggle /> }
 					</AdminSection>

--- a/projects/plugins/social/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/social/src/js/components/admin-page/styles.module.scss
@@ -19,9 +19,4 @@
 
 .notice {
 	grid-column: 1 / -1;
-	// display: grid;
-	// grid-template-columns: auto 1fr;
-	// grid-template-rows: repeat( 2, auto );
-	// column-gap: calc( var( --spacing-base ) * 3 );
-	// row-gap: calc( var( --spacing-base ) * 2 );
 }

--- a/projects/plugins/social/src/js/components/admin-page/styles.module.scss
+++ b/projects/plugins/social/src/js/components/admin-page/styles.module.scss
@@ -16,3 +16,12 @@
 * {
 	box-sizing: border-box;
 }
+
+.notice {
+	grid-column: 1 / -1;
+	// display: grid;
+	// grid-template-columns: auto 1fr;
+	// grid-template-rows: repeat( 2, auto );
+	// column-gap: calc( var( --spacing-base ) * 3 );
+	// row-gap: calc( var( --spacing-base ) * 2 );
+}

--- a/projects/plugins/social/src/js/components/instagram-notice/index.jsx
+++ b/projects/plugins/social/src/js/components/instagram-notice/index.jsx
@@ -16,13 +16,13 @@ const freePlanNoticeText = __(
 	'jetpack-social'
 );
 const paidPlanNoticeText = __(
-	'Enjoy automatically sharing unlimited photos and video reels to Instagram Business with your Jetpack Social Advanced plan!',
+	'Enjoy automatically sharing unlimited photos to Instagram Business with your Jetpack Social Advanced plan!',
 	'jetpack-social'
 );
 
 const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
-	const [ showNotice, setShowNotice ] = useState( true );
 	const { dismissedNotices, dismissNotice } = useDismissNotice();
+	const [ showNotice, setShowNotice ] = useState( ! dismissedNotices.includes( 'instagram' ) );
 
 	const { connectionsAdminUrl, hasAdvancedPlan, isInstagramConnectionSupported } = useSelect(
 		select => {
@@ -40,11 +40,7 @@ const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
 		setShowNotice( false );
 	}, [ dismissNotice, setShowNotice ] );
 
-	if (
-		! showNotice ||
-		! isInstagramConnectionSupported ||
-		dismissedNotices.includes( 'instagram' )
-	) {
+	if ( ! showNotice || ! isInstagramConnectionSupported ) {
 		return null;
 	}
 

--- a/projects/plugins/social/src/js/components/instagram-notice/index.jsx
+++ b/projects/plugins/social/src/js/components/instagram-notice/index.jsx
@@ -24,20 +24,27 @@ const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
 	const [ showNotice, setShowNotice ] = useState( true );
 	const { dismissedNotices, dismissNotice } = useDismissNotice();
 
-	const { connectionsAdminUrl, hasAdvancedPlan } = useSelect( select => {
-		const store = select( STORE_ID );
-		return {
-			connectionsAdminUrl: store.getConnectionsAdminUrl(),
-			hasAdvancedPlan: store.hasAdvancedPlan(),
-		};
-	} );
+	const { connectionsAdminUrl, hasAdvancedPlan, isInstagramConnectionSupported } = useSelect(
+		select => {
+			const store = select( STORE_ID );
+			return {
+				connectionsAdminUrl: store.getConnectionsAdminUrl(),
+				hasAdvancedPlan: store.hasAdvancedPlan(),
+				isInstagramConnectionSupported: store.isInstagramConnectionSupported(),
+			};
+		}
+	);
 
 	const handleDismiss = useCallback( () => {
 		dismissNotice( 'instagram' );
 		setShowNotice( false );
 	}, [ dismissNotice, setShowNotice ] );
 
-	if ( ! showNotice || dismissedNotices.includes( 'instagram' ) ) {
+	if (
+		! showNotice ||
+		! isInstagramConnectionSupported ||
+		dismissedNotices.includes( 'instagram' )
+	) {
 		return null;
 	}
 

--- a/projects/plugins/social/src/js/components/instagram-notice/index.jsx
+++ b/projects/plugins/social/src/js/components/instagram-notice/index.jsx
@@ -12,7 +12,7 @@ import { STORE_ID } from '../../store';
 import styles from './styles.module.scss';
 
 const freePlanNoticeText = __(
-	'Share featured images directly to your Instagram Business account for free, or share unlimited photos and video reels with Jetpack Social Advanced.',
+	'Share featured images directly to your Instagram Business account for free, or share unlimited photos with Jetpack Social Advanced.',
 	'jetpack-social'
 );
 const paidPlanNoticeText = __(

--- a/projects/plugins/social/src/js/components/instagram-notice/index.jsx
+++ b/projects/plugins/social/src/js/components/instagram-notice/index.jsx
@@ -37,11 +37,7 @@ const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
 		setShowNotice( false );
 	}, [ dismissNotice, setShowNotice ] );
 
-	if ( dismissedNotices.includes( 'instagram' ) ) {
-		return null;
-	}
-
-	if ( ! showNotice ) {
+	if ( ! showNotice || dismissedNotices.includes( 'instagram' ) ) {
 		return null;
 	}
 

--- a/projects/plugins/social/src/js/components/instagram-notice/index.jsx
+++ b/projects/plugins/social/src/js/components/instagram-notice/index.jsx
@@ -24,16 +24,15 @@ const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
 	const { dismissedNotices, dismissNotice } = useDismissNotice();
 	const [ showNotice, setShowNotice ] = useState( ! dismissedNotices.includes( 'instagram' ) );
 
-	const { connectionsAdminUrl, hasAdvancedPlan, isInstagramConnectionSupported } = useSelect(
-		select => {
+	const { connectionsAdminUrl, isInstagramConnectionSupported, isEnhancedPublishingEnabled } =
+		useSelect( select => {
 			const store = select( STORE_ID );
 			return {
 				connectionsAdminUrl: store.getConnectionsAdminUrl(),
-				hasAdvancedPlan: store.hasAdvancedPlan(),
 				isInstagramConnectionSupported: store.isInstagramConnectionSupported(),
+				isEnhancedPublishingEnabled: store.isEnhancedPublishingEnabled(),
 			};
-		}
-	);
+		} );
 
 	const handleDismiss = useCallback( () => {
 		dismissNotice( 'instagram' );
@@ -45,7 +44,7 @@ const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
 	}
 
 	const Button = () =>
-		hasAdvancedPlan ? (
+		isEnhancedPublishingEnabled ? (
 			<JetpackButton key="connect" variant="primary" href={ connectionsAdminUrl } isExternalLink>
 				{ __( 'Connect Instagram', 'jetpack-social' ) }
 			</JetpackButton>
@@ -73,7 +72,7 @@ const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
 					onClose={ handleDismiss }
 					title={ __( 'Instagram is now available in Jetpack Social', 'jetpack-social' ) }
 				>
-					{ hasAdvancedPlan ? paidPlanNoticeText : freePlanNoticeText }
+					{ isEnhancedPublishingEnabled ? paidPlanNoticeText : freePlanNoticeText }
 				</Notice>
 			</div>
 		</Container>

--- a/projects/plugins/social/src/js/components/instagram-notice/index.jsx
+++ b/projects/plugins/social/src/js/components/instagram-notice/index.jsx
@@ -1,0 +1,61 @@
+import { Button, Container, Notice } from '@automattic/jetpack-components';
+import apiFetch from '@wordpress/api-fetch';
+import { useSelect } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { STORE_ID } from '../../store';
+import styles from './styles.module.scss';
+
+const freePlanNoticeText = __(
+	'Share featured images directly to your Instagram Business account for free, or share unlimited photos and video reels with Jetpack Social Advanced.',
+	'jetpack-social'
+);
+const paidPlanNoticeText = __(
+	'Enjoy automatically sharing unlimited photos and video reels to Instagram Business with your Jetpack Social Advanced plan!',
+	'jetpack-social'
+);
+
+const InstagramNotice = () => {
+	const [ showNotice, setShowNotice ] = useState( true );
+
+	const hasAdvancedPlan = useSelect( select => select( STORE_ID ).hasAdvancedPlan() );
+
+	const handleDismiss = useCallback( () => {
+		apiFetch( {
+			path: `jetpack/v4/social/dismiss-notice`,
+			method: 'POST',
+			data: { notice: 'instagram' },
+		} ).catch( error => {
+			throw error;
+		} );
+
+		setShowNotice( false );
+	}, [] );
+
+	if ( ! showNotice ) {
+		return null;
+	}
+
+	return (
+		<Container horizontalSpacing={ 7 } horizontalGap={ 3 }>
+			<div className={ styles.wrapper }>
+				<Notice
+					actions={ [
+						<Button key="install" variant="primary">
+							Install now
+						</Button>,
+						<Button key="learn-more" variant="link" isExternalLink>
+							Install now
+						</Button>,
+					] }
+					onClose={ handleDismiss }
+					title={ __( 'Instagram is now available in Jetpack Social', 'jetpack-social' ) }
+				>
+					{ hasAdvancedPlan ? paidPlanNoticeText : freePlanNoticeText }
+				</Notice>
+			</div>
+		</Container>
+	);
+};
+
+export default InstagramNotice;

--- a/projects/plugins/social/src/js/components/instagram-notice/styles.module.scss
+++ b/projects/plugins/social/src/js/components/instagram-notice/styles.module.scss
@@ -1,0 +1,3 @@
+.wrapper {
+	grid-column: 1 / -1;
+}

--- a/projects/plugins/social/src/js/components/pricing-page/index.js
+++ b/projects/plugins/social/src/js/components/pricing-page/index.js
@@ -21,7 +21,7 @@ const UNLIMITED_SHARES = __( 'Unlimited shares', 'jetpack-social' );
 const UP_TO_30 = __( 'Up to 30', 'jetpack-social' );
 const UP_TO_30_SHARES = __( 'Up to 30 shares in 30 days', 'jetpack-social' );
 
-const PricingPage = () => {
+const PricingPage = ( { onDismiss = () => {} } = {} ) => {
 	const [ productInfo ] = useProductInfo();
 
 	const siteSuffix = useSelect( select => select( STORE_ID ).getSiteSuffix() );
@@ -34,7 +34,8 @@ const PricingPage = () => {
 			show_pricing_page: false,
 		};
 		updateOptions( newOption );
-	}, [ updateOptions ] );
+		onDismiss();
+	}, [ updateOptions, onDismiss ] );
 
 	const UNLIMITED_SHARES_TABLE_ITEM = (
 		<PricingTableItem

--- a/projects/plugins/social/src/js/components/publicize-panel/index.jsx
+++ b/projects/plugins/social/src/js/components/publicize-panel/index.jsx
@@ -70,7 +70,6 @@ const PublicizePanel = ( { prePublish } ) => {
 						/>
 					</PanelRow>
 				) }
-
 				<PublicizeConnectionVerify />
 				<PublicizeForm
 					isPublicizeEnabled={ isPublicizeEnabled }

--- a/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
+++ b/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
@@ -4,6 +4,8 @@ const jetpackSettingSelectors = {
 	showPricingPage: state => state.jetpackSettings.show_pricing_page,
 	isUpdatingJetpackSettings: state => state.jetpackSettings.is_updating,
 	hasPaidPlan: state => ! ( state.jetpackSettings?.showNudge ?? true ),
+	hasAdvancedPlan: state => state.jetpackSettings?.hasAdvancedPlan,
+	getDismissedNotices: state => state.jetpackSettings?.dismissedNotices,
 };
 
 export default jetpackSettingSelectors;

--- a/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
+++ b/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
@@ -6,6 +6,7 @@ const jetpackSettingSelectors = {
 	hasPaidPlan: state => ! ( state.jetpackSettings?.showNudge ?? true ),
 	hasAdvancedPlan: state => state.jetpackSettings?.hasAdvancedPlan,
 	getDismissedNotices: state => state.jetpackSettings?.dismissedNotices,
+	isInstagramConnectionSupported: state => state.jetpackSettings?.isInstagramConnectionSupported,
 };
 
 export default jetpackSettingSelectors;

--- a/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
+++ b/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
@@ -4,7 +4,8 @@ const jetpackSettingSelectors = {
 	showPricingPage: state => state.jetpackSettings.show_pricing_page,
 	isUpdatingJetpackSettings: state => state.jetpackSettings.is_updating,
 	hasPaidPlan: state => ! ( state.jetpackSettings?.showNudge ?? true ),
-	hasAdvancedPlan: state => state.jetpackSettings?.hasAdvancedPlan,
+	isEnhancedPublishingEnabled: state =>
+		! ( state.jetpackSettings?.isEnhancedPublishingEnabled ?? false ),
 	getDismissedNotices: state => state.jetpackSettings?.dismissedNotices,
 	isInstagramConnectionSupported: state => state.jetpackSettings?.isInstagramConnectionSupported,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds a notice to the Jetpack Social admin page, as well as the Jetpack Social sidebar, to promote that Instagram is now available.

- On the admin page, the text as well as primary button change depending on whether or not the user has a paid plan.
- Dismissing one notice should prevent the other one from showing.

**Note:** We cannot merge this until we have implemented a proper feature check for Instagram.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdrWKz-XH-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Create a new site with Jetpack Social.
* Open the Social admin page and verify that you don't see a notice.
* Add support for Instagram connections to your site: D111381-code
* Refresh and make sure there notice is there.

* Dismiss the notice, refresh the page and confirm that the notice is missing.
* Reset the notice: `jetpack docker wp option delete jetpack_social_dismissed_notices`
* Refresh and make sure it appears again.
* Buy the Advanced plan and make sure the notice has different text and CTA.



* Create a new post, go to the Jetpack Social sidebar.
* Check that the notice is there and dismissable.
* Make sure the notices match the designs.

![Screenshot 2023-05-17 at 16 49 25@2x](https://github.com/Automattic/jetpack/assets/1713699/ec586fc3-e57b-4dc7-92b2-c2ddd24227af)

<img width="662" alt="Screenshot 2023-05-17 at 16 48 36@2x" src="https://github.com/Automattic/jetpack/assets/1713699/3ef120dc-e954-462c-a9f8-5b2270d0d96b">