### PR TITLE
Add package for Boost Score API

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,40 @@ importers:
         specifier: 4.23.0
         version: 4.23.0
 
+  projects/js-packages/boost-score-api:
+    dependencies:
+      '@wordpress/i18n':
+        specifier: 4.32.0
+        version: 4.32.0
+      zod:
+        specifier: 3.20.2
+        version: 3.20.2
+    devDependencies:
+      '@automattic/jetpack-webpack-config':
+        specifier: workspace:*
+        version: link:../webpack-config
+      '@typescript-eslint/parser':
+        specifier: 5.59.0
+        version: 5.59.0(eslint@8.39.0)(typescript@5.0.4)
+      eslint:
+        specifier: 8.39.0
+        version: 8.39.0
+      jest:
+        specifier: 29.5.0
+        version: 29.5.0
+      ts-loader:
+        specifier: 9.4.2
+        version: 9.4.2(typescript@5.0.4)(webpack@5.76.0)
+      typescript:
+        specifier: 5.0.4
+        version: 5.0.4
+      webpack:
+        specifier: 5.76.0
+        version: 5.76.0(webpack-cli@4.9.1)
+      webpack-cli:
+        specifier: 4.9.1
+        version: 4.9.1(webpack@5.76.0)
+
   projects/js-packages/components:
     dependencies:
       '@automattic/format-currency':
@@ -10482,7 +10516,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.2.3
+      picomatch: 2.3.1
 
   /app-root-dir@1.0.2:
     resolution: {integrity: sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==}
@@ -15403,7 +15437,7 @@ packages:
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
-      picomatch: 2.2.3
+      picomatch: 2.3.1
 
   /jest-validate@29.5.0:
     resolution: {integrity: sha512-pC26etNIi+y3HV8A+tUGr/lph9B18GnzSRAkPaaZJIE1eFdiYm6/CewuiJQ8/RlfHd1u/8Ioi8/sJ+CmbA+zAQ==}
@@ -15470,6 +15504,26 @@ packages:
 
   /jest@29.4.3:
     resolution: {integrity: sha512-XvK65feuEFGZT8OO0fB/QAQS+LGHvQpaadkH5p47/j3Ocqq3xf2pK9R+G0GzgfuhXVxEv76qCOOcMb5efLk6PA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.5.0
+      '@jest/types': 29.5.0
+      import-local: 3.1.0
+      jest-cli: 29.5.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest@29.5.0:
+    resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
@@ -20504,7 +20558,7 @@ packages:
       chalk: 4.1.2
       enhanced-resolve: 5.13.0
       micromatch: 4.0.5
-      semver: 7.3.5
+      semver: 7.5.0
       typescript: 5.0.4
       webpack: 5.76.0(webpack-cli@4.9.1)
     dev: true
@@ -21143,7 +21197,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.1
       acorn: 8.8.2
       acorn-import-assertions: 1.8.0(acorn@8.8.2)
-      browserslist: 4.20.4
+      browserslist: 4.21.5
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.13.0
       es-module-lexer: 0.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2461,9 +2461,6 @@ importers:
         specifier: 3.20.2
         version: 3.20.2
     devDependencies:
-      '@automattic/jetpack-boost-score-api':
-        specifier: workspace:*
-        version: link:../../js-packages/boost-score-api
       '@automattic/jetpack-components':
         specifier: workspace:*
         version: link:../../js-packages/components

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2461,6 +2461,9 @@ importers:
         specifier: 3.20.2
         version: 3.20.2
     devDependencies:
+      '@automattic/jetpack-boost-score-api':
+        specifier: workspace:*
+        version: link:../../js-packages/boost-score-api
       '@automattic/jetpack-components':
         specifier: workspace:*
         version: link:../../js-packages/components

--- a/projects/js-packages/boost-score-api/.eslintrc.cjs
+++ b/projects/js-packages/boost-score-api/.eslintrc.cjs
@@ -1,0 +1,31 @@
+const loadIgnorePatterns = require( '../../../tools/js-tools/load-eslint-ignore.js' );
+
+module.exports = {
+	root: true,
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/base' ) ],
+	ignorePatterns: loadIgnorePatterns( __dirname ),
+	parserOptions: {
+		babelOptions: {
+			configFile: require.resolve( './babel.config.cjs' ),
+		},
+		sourceType: 'module',
+		tsconfigRootDir: __dirname,
+		project: [ './tsconfig.json' ],
+	},
+	overrides: [
+		{
+			files: [ '*.js', '*.cjs' ],
+			parserOptions: {
+				project: null,
+			},
+		},
+	],
+	rules: {
+		'@wordpress/i18n-text-domain': [
+			'error',
+			{
+				allowedTextDomain: 'boost-score-api',
+			},
+		],
+	},
+};

--- a/projects/js-packages/boost-score-api/.gitattributes
+++ b/projects/js-packages/boost-score-api/.gitattributes
@@ -1,0 +1,16 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+node_modules      export-ignore
+package.json      export-ignore
+
+/build/**         production-exclude
+
+# Files to exclude from the mirror repo
+/changelog/**     production-exclude
+/.eslintrc.cjs    production-exclude
+.gitignore        production-exclude
+tests/**          production-exclude
+babel.config.js   production-exclude
+webpack.config.js production-exclude
+tsconfig.json     production-exclude
+

--- a/projects/js-packages/boost-score-api/.gitignore
+++ b/projects/js-packages/boost-score-api/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+node_modules/
+build/

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/js-packages/boost-score-api/README.md
+++ b/projects/js-packages/boost-score-api/README.md
@@ -4,11 +4,7 @@ A package to get the Jetpack Boost score of a site
 
 ## How to install boost-score-api
 
-### Installation From Git Repo
-
-## Contribute
-
-## Get Help
+Add `"@automattic/jetpack-boost-score-api": "workspace:*",` to your project's `package.json` and run `pnpm install` (or `yarn` if your project uses yarn)
 
 ## Using this package in your WordPress plugin
 

--- a/projects/js-packages/boost-score-api/README.md
+++ b/projects/js-packages/boost-score-api/README.md
@@ -1,0 +1,24 @@
+# boost-score-api
+
+A package to get the Jetpack Boost score of a site
+
+## How to install boost-score-api
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use[Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+boost-score-api is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/js-packages/boost-score-api/babel.config.cjs
+++ b/projects/js-packages/boost-score-api/babel.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+	presets: [
+		[
+			'@automattic/jetpack-webpack-config/babel/preset',
+			{
+				/* options */
+			},
+		],
+	],
+};

--- a/projects/js-packages/boost-score-api/changelog/add-boost-score-api-package
+++ b/projects/js-packages/boost-score-api/changelog/add-boost-score-api-package
@@ -1,0 +1,4 @@
+Significance: major
+Type: added
+
+Create package for the boost score bar API

--- a/projects/js-packages/boost-score-api/composer.json
+++ b/projects/js-packages/boost-score-api/composer.json
@@ -1,0 +1,49 @@
+{
+	"name": "automattic/jetpack-boost-score-api",
+	"description": "A package to get the Jetpack Boost score of a site",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "1.0.4",
+		"automattic/jetpack-changelogger": "@dev"
+	},
+	"scripts": {
+		"build-development": [
+			"pnpm run build"
+		],
+		"build-production": [
+			"NODE_ENV=production pnpm run build"
+		],
+		"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run watch"
+		],
+		"test-js": [
+			"pnpm run test"
+		]
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"npmjs-autopublish": true,
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-boost-score-api/compare/v${old}...v${new}"
+		},
+		"autotagger": true
+	}
+}

--- a/projects/js-packages/boost-score-api/composer.json
+++ b/projects/js-packages/boost-score-api/composer.json
@@ -41,6 +41,7 @@
 	"prefer-stable": true,
 	"extra": {
 		"npmjs-autopublish": true,
+		"mirror-repo": "Automattic/jetpack-boost-score-api",
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-boost-score-api/compare/v${old}...v${new}"
 		},

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,5 +1,4 @@
 {
-	"private": true,
 	"name": "@automattic/jetpack-boost-score-api",
 	"version": "0.1.0-alpha",
 	"description": "A package to get the Jetpack Boost score of a site",

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -17,7 +17,7 @@
 		"build": "pnpm run clean && webpack",
 		"clean": "rm -rf build/",
 		"watch": "pnpm run build && pnpm webpack watch",
-		"test": "jest tests"
+		"test": "jest"
 	},
 	"dependencies": {
 		"@wordpress/i18n": "4.32.0",

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,0 +1,50 @@
+{
+	"private": true,
+	"name": "@automattic/jetpack-boost-score-api",
+	"version": "0.1.0-alpha",
+	"description": "A package to get the Jetpack Boost score of a site",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[JS Package] Boost Score Api"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/js-packages/boost-score-api"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "pnpm run clean && webpack",
+		"clean": "rm -rf build/",
+		"watch": "pnpm run build && pnpm webpack watch",
+		"test": "jest tests"
+	},
+	"dependencies": {
+		"@wordpress/i18n": "4.32.0",
+		"zod": "3.20.2"
+	},
+	"devDependencies": {
+		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@typescript-eslint/parser": "5.59.0",
+		"eslint": "8.39.0",
+		"jest": "29.5.0",
+		"ts-loader": "9.4.2",
+		"typescript": "5.0.4",
+		"webpack": "5.76.0",
+		"webpack-cli": "4.9.1"
+	},
+	"engines": {
+		"node": "^18.13.0",
+		"yarn": "use pnpm instead - see docs/yarn-upgrade.md"
+	},
+	"exports": {
+		".": {
+			"jetpack:src": "./src/index.ts",
+			"types": "./build/index.d.ts",
+			"default": "./build/index.js"
+		}
+	},
+	"main": "./build/index.js",
+	"types": "./build/index.d.ts"
+}

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -17,7 +17,7 @@
 		"build": "pnpm run clean && webpack",
 		"clean": "rm -rf build/",
 		"watch": "pnpm run build && pnpm webpack watch",
-		"test": "jest"
+		"test": "jest tests"
 	},
 	"dependencies": {
 		"@wordpress/i18n": "4.32.0",

--- a/projects/js-packages/boost-score-api/src/api-error.ts
+++ b/projects/js-packages/boost-score-api/src/api-error.ts
@@ -1,0 +1,65 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { castToString } from './utils/cast-to-string';
+import { isJsonObject } from './utils/json-types';
+import type { JSONObject } from './utils/json-object-type';
+
+/**
+ * Special error subclass returned by API Calls with extra
+ * information.
+ */
+export class ApiError extends Error {
+	public constructor(
+		public readonly httpCode: number,
+		public readonly body: JSONObject | string | null,
+		public readonly parseError: Error | null
+	) {
+		super();
+	}
+
+	// Override Error.message to generate a message based on http code and json body.
+	get message(): string {
+		switch ( this.httpCode ) {
+			case 403: {
+				return this.getRestApiErrorMessage();
+			}
+
+			// For HTTP 200 responses, look for JSON parsing issues.
+			case 200: {
+				if ( this.parseError ) {
+					return sprintf(
+						/* Translators: %s refers to a browser-supplied error message (hopefully already in the right language) */
+						__(
+							'Received invalid response while communicating with your WordPress site: %s',
+							'boost-score-api'
+						),
+						this.parseError.message
+					);
+				}
+
+				break;
+			}
+		}
+
+		return sprintf(
+			/* Translators: %d refers to numeric HTTP error code */
+			__( 'HTTP %d error received while communicating with the server.', 'boost-score-api' ),
+			this.httpCode
+		);
+	}
+
+	// Returns the body of this in a string format for display. Pretty printed JSON if valid, raw dump if not.
+	public getDisplayBody(): string {
+		if ( isJsonObject( this.body ) ) {
+			return JSON.stringify( this.body, null, '  ' );
+		}
+		return castToString( this.body, '' ).substring( 0, 1000 );
+	}
+
+	// Returns an error message appropriate for a site whose API doesn't seem to be available.
+	getRestApiErrorMessage(): string {
+		return __(
+			"Your site's REST API does not seem to be accessible. Jetpack Boost requires access to your REST API in order to receive site performance scores. Please make sure that your site's REST API is active and accessible, and try again.",
+			'boost-score-api'
+		);
+	}
+}

--- a/projects/js-packages/boost-score-api/src/api.ts
+++ b/projects/js-packages/boost-score-api/src/api.ts
@@ -1,0 +1,156 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { ApiError } from './api-error';
+import { JETPACK_BOOST_REST_NAMESPACE, JETPACK_BOOST_REST_PREFIX } from './config';
+import type { JSONObject } from './utils/json-object-type';
+
+/**
+ * Get the full URL to an endpoint.
+ *
+ * @param {string} path - The path to the endpoint.
+ * @param {string} root - The root URL to use.
+ * @returns {string} - The full URL.
+ */
+function getEndpointUrl( path: string, root: string ): string {
+	return root + JETPACK_BOOST_REST_NAMESPACE + JETPACK_BOOST_REST_PREFIX + path;
+}
+
+/**
+ * Send a request to the Boost REST API.
+ *
+ * @param {string} method - The HTTP method to use.
+ * @param {string} root - The root URL to use.
+ * @param {string} path - The path to the endpoint.
+ * @param {null | JSONObject} body - The body of the request.
+ * @param {string} nonce - The nonce to use.
+ * @returns {Promise} - The response.
+ */
+async function sendRequest(
+	method: string,
+	root: string,
+	path: string,
+	body: null | JSONObject = null,
+	nonce: string
+): Promise< Response > {
+	const args: JSONObject = {
+		method,
+		mode: 'cors',
+		headers: {
+			'X-WP-Nonce': nonce,
+		},
+	};
+
+	if ( ( 'post' === method || 'delete' === method ) && body ) {
+		args.body = JSON.stringify( body );
+		args.headers[ 'Content-Type' ] = 'application/json';
+	}
+
+	const endpointFullUrl = getEndpointUrl( path, root );
+	let apiCall: Response;
+
+	try {
+		apiCall = await fetch( endpointFullUrl, args );
+	} catch ( error ) {
+		const cleanupArgs = args;
+		delete cleanupArgs.body;
+		delete cleanupArgs.headers[ 'X-WP-Nonce' ];
+		const errorInfo = {
+			requestInitiator: window.location.href,
+			requestUrl: endpointFullUrl,
+			requestArgs: cleanupArgs,
+			originalErrorMessage: error.toString(),
+		};
+
+		// Throwing again an error so it can be caught higher up and displayed in the UI.
+		throw new Error(
+			sprintf(
+				/* Translators: %s refers to a string representation of an error object containing useful debug information  */
+				__(
+					'An error occurred while trying to communicate with the site REST API. Extra debug info: %s',
+					'boost-score-api'
+				),
+				JSON.stringify( errorInfo )
+			)
+		);
+	}
+
+	return apiCall;
+}
+
+/**
+ * Make a request to the Boost REST API.
+ *
+ * @param {string} method - The HTTP method to use.
+ * @param {string} root - The root URL to use.
+ * @param {string} path - The path to the endpoint.
+ * @param {null | JSONObject} body - The body of the request.
+ * @param {string} nonce - The nonce to use.
+ * @returns {Promise} - The response.
+ */
+async function makeRequest< T = JSONObject >(
+	method: string,
+	root: string,
+	path: string,
+	body: null | JSONObject = null,
+	nonce: string
+): Promise< T > {
+	const response = await sendRequest( method, root, path, body, nonce );
+
+	// Fetch response as text.
+	let responseBody: string;
+	try {
+		responseBody = await response.text();
+	} catch ( err ) {
+		throw new ApiError( response.status, null, err );
+	}
+
+	// Try to parse it as JSON, catch errors explicitly.
+	let jsonBody: JSONObject;
+	try {
+		jsonBody = JSON.parse( responseBody );
+	} catch ( err ) {
+		throw new ApiError( response.status, responseBody, err );
+	}
+
+	// Throw an error if not HTTP 200.
+	if ( ! response.ok ) {
+		throw new ApiError( response.status, jsonBody, null );
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return jsonBody as any;
+}
+
+/**
+ * Make a GET request to the Boost REST API.
+ *
+ * @param {string} root - The root URL to use.
+ * @param {string} path - The path to the endpoint.
+ * @param {string} nonce - The nonce to use.
+ * @returns {Promise} - The response.
+ */
+function get< T = JSONObject >( root: string, path: string, nonce: string ): Promise< T > {
+	return makeRequest< T >( 'get', root, path, null, nonce );
+}
+
+/**
+ * Make a POST request to the Boost REST API.
+ *
+ * @param {string} root - The root URL to use.
+ * @param {string} path - The path to the endpoint.
+ * @param {null | JSONObject} body - The body of the request.
+ * @param {string} nonce - The nonce to use.
+ * @returns {Promise} - The response.
+ */
+function post< T = JSONObject >(
+	root: string,
+	path: string,
+	body: JSONObject | null = null,
+	nonce: string
+): Promise< T > {
+	return makeRequest< T >( 'post', root, path, body, nonce );
+}
+
+export default {
+	get,
+	post,
+};

--- a/projects/js-packages/boost-score-api/src/config.ts
+++ b/projects/js-packages/boost-score-api/src/config.ts
@@ -1,0 +1,2 @@
+export const JETPACK_BOOST_REST_NAMESPACE = 'jetpack-boost/v1';
+export const JETPACK_BOOST_REST_PREFIX = '';

--- a/projects/js-packages/boost-score-api/src/index.ts
+++ b/projects/js-packages/boost-score-api/src/index.ts
@@ -44,8 +44,8 @@ export async function requestSpeedScores(
 	// Request metrics
 	const response = parseResponse(
 		await api.post(
-			force ? '/speed-scores/refresh' : '/speed-scores',
 			rootUrl,
+			force ? '/speed-scores/refresh' : '/speed-scores',
 			{ url: siteUrl },
 			nonce
 		)
@@ -132,7 +132,7 @@ async function pollRequest(
 		timeoutError: __( 'Timed out while waiting for speed-score.', 'boost-score-api' ),
 		callback: async resolve => {
 			const response = parseResponse(
-				await api.post( '/speed-scores', rootUrl, { url: siteUrl }, nonce )
+				await api.post( rootUrl, '/speed-scores', { url: siteUrl }, nonce )
 			);
 
 			if ( response.scores ) {

--- a/projects/js-packages/boost-score-api/src/index.ts
+++ b/projects/js-packages/boost-score-api/src/index.ts
@@ -1,0 +1,220 @@
+import { __ } from '@wordpress/i18n';
+import api from './api';
+import { castToNumber } from './utils/cast-to-number';
+import { castToString } from './utils/cast-to-string';
+import { isJsonObject, JSONObject } from './utils/json-types';
+import pollPromise from './utils/poll-promise';
+import { standardizeError } from './utils/standardize-error';
+
+const pollTimeout = 2 * 60 * 1000;
+const pollInterval = 5 * 1000;
+
+type SpeedScores = {
+	mobile: number;
+	desktop: number;
+};
+
+type SpeedScoresSet = {
+	current: SpeedScores;
+	noBoost: SpeedScores;
+	isStale: boolean;
+};
+
+type ParsedApiResponse = {
+	status: string;
+	scores?: SpeedScoresSet;
+};
+
+/**
+ * Kick off a request to generate speed scores for this site. Will automatically
+ * poll for a response until the task is done, returning a SpeedScores object.
+ *
+ * @param {boolean} force - Force regenerate speed scores.
+ * @param {string} rootUrl - Root URL for the HTTP request.
+ * @param {string} siteUrl - URL of the site.
+ * @param {string} nonce - Nonce to use for authentication.
+ * @returns {SpeedScoresSet} Speed scores returned by the server.
+ */
+export async function requestSpeedScores(
+	force = false,
+	rootUrl: string,
+	siteUrl: string,
+	nonce: string
+): Promise< SpeedScoresSet > {
+	// Request metrics
+	const response = parseResponse(
+		await api.post(
+			force ? '/speed-scores/refresh' : '/speed-scores',
+			rootUrl,
+			{ url: siteUrl },
+			nonce
+		)
+	);
+
+	// If the response contains ready-to-use metrics, we're done here.
+	if ( response.scores ) {
+		return response.scores;
+	}
+
+	// Poll for metrics.
+	return await pollRequest( rootUrl, siteUrl, nonce );
+}
+
+/**
+ * Helper method for parsing a response from a speed score API request. Returns
+ * scores (if ready), and a status (success|pending|error).
+ *
+ * @param {JSONObject} response - API response to parse
+ * @returns {ParsedApiResponse} API response, processed.
+ */
+function parseResponse( response: JSONObject ): ParsedApiResponse {
+	// Handle an explicit error
+	if ( response.error ) {
+		const defaultErrorMessage = __(
+			'An unknown error occurred while requesting metrics',
+			'boost-score-api'
+		);
+
+		throw standardizeError( response.error, defaultErrorMessage );
+	}
+
+	// Check if ready.
+	if ( isJsonObject( response.scores ) ) {
+		return {
+			status: 'success',
+			scores: {
+				current: isJsonObject( response.scores.current )
+					? {
+							mobile: castToNumber( response.scores.current.mobile, 0 ),
+							desktop: castToNumber( response.scores.current.desktop, 0 ),
+					  }
+					: {
+							mobile: 0,
+							desktop: 0,
+					  },
+				noBoost: isJsonObject( response.scores.noBoost )
+					? {
+							mobile: castToNumber( response.scores.noBoost.mobile, 0 ),
+							desktop: castToNumber( response.scores.noBoost.desktop, 0 ),
+					  }
+					: null,
+				isStale: !! response.scores.isStale,
+			},
+		};
+	}
+
+	const requestStatus = castToString( response.status );
+	if ( ! requestStatus ) {
+		throw new Error( __( 'Invalid response while requesting metrics', 'boost-score-api' ) );
+	}
+
+	return {
+		status: requestStatus,
+	};
+}
+
+/**
+ * Poll a speed score request for results, timing out if it takes too long.
+ *
+ * @param {string} rootUrl - Root URL of the site to request metrics for
+ * @param {string} siteUrl - Site URL to request metrics for
+ * @param {string} nonce - Nonce to use for authentication
+ * @returns {SpeedScoresSet} Speed scores returned by the server.
+ */
+async function pollRequest(
+	rootUrl: string,
+	siteUrl: string,
+	nonce: string
+): Promise< SpeedScoresSet > {
+	return pollPromise< SpeedScoresSet >( {
+		timeout: pollTimeout,
+		interval: pollInterval,
+		timeoutError: __( 'Timed out while waiting for speed-score.', 'boost-score-api' ),
+		callback: async resolve => {
+			const response = parseResponse(
+				await api.post( '/speed-scores', rootUrl, { url: siteUrl }, nonce )
+			);
+
+			if ( response.scores ) {
+				resolve( response.scores );
+			}
+		},
+	} );
+}
+
+/**
+ * Given a mobile and desktop score, return a letter summarizing the overall
+ * score.
+ *
+ * @param {number} mobile  - Mobile speed score
+ * @param {number} desktop - Desktop speed score
+ * @returns {string} letter score
+ */
+export function getScoreLetter( mobile: number, desktop: number ): string {
+	const sum = mobile + desktop;
+	const averageScore = sum / 2;
+
+	if ( averageScore > 90 ) {
+		return 'A';
+	}
+	if ( averageScore > 75 ) {
+		return 'B';
+	}
+	if ( averageScore > 50 ) {
+		return 'C';
+	}
+	if ( averageScore > 35 ) {
+		return 'D';
+	}
+	if ( averageScore > 25 ) {
+		return 'E';
+	}
+	return 'F';
+}
+
+/**
+ * Find out if site scores changed. We fire a popout modal if they improve or worsen.
+ * The message varies depending on the results of the speed scores so lets modify this
+ *
+ * @param {SpeedScoresSet} scores - Speed scores returned by the server.
+ * @returns {boolean} true if scores changed.
+ */
+export function didScoresChange( scores: SpeedScoresSet ): boolean {
+	const current = scores.current;
+	const noBoost = scores.noBoost;
+
+	// lets make this a little bit more readable. If one of the scores is null.
+	// then the scores haven't changed. So return false.
+	if ( null == current || null == noBoost ) {
+		return false;
+	}
+
+	// if either the mobile or the desktop scores have changed. Return true.
+	if ( current.mobile !== noBoost.mobile || current.desktop !== noBoost.desktop ) {
+		return true;
+	}
+
+	//else if reach here then the scores are the same.
+	return false;
+}
+
+/**
+ * Determine the change in scores to pass through to other functions.
+ *
+ * @param {SpeedScoresSet} scores - Speed scores returned by the server.
+ * @returns {number} - The change in scores in percentage.
+ */
+export function getScoreMovementPercentage( scores: SpeedScoresSet ): number {
+	const current = scores.current;
+	const noBoost = scores.noBoost;
+	let currentScore = 0;
+	let noBoostScore = 0;
+
+	if ( current !== null && noBoost !== null ) {
+		currentScore = scores.current.mobile + scores.current.desktop;
+		noBoostScore = scores.noBoost.mobile + scores.noBoost.desktop;
+		const change = currentScore / noBoostScore - 1;
+		return Math.round( change * 100 );
+	}
+	return 0;
+}

--- a/projects/js-packages/boost-score-api/src/utils/cast-to-number.ts
+++ b/projects/js-packages/boost-score-api/src/utils/cast-to-number.ts
@@ -1,0 +1,27 @@
+/**
+ * Given an unknown value from an external source (e.g.: API response), parse
+ * it as a number. Returns defaultValue if the value does not seem to be a valid
+ * number.
+ *
+ * @template DefaultType
+ * @param {*}           value        - External value to process as a number
+ * @param {DefaultType} defaultValue - Default value to return if not a number.
+ * @returns {number | DefaultType} value as a number, of defaultValue.
+ */
+export function castToNumber< DefaultType = number >(
+	value: unknown,
+	defaultValue: DefaultType = undefined
+): number | DefaultType {
+	if ( typeof value === 'number' ) {
+		return value;
+	}
+
+	if ( typeof value === 'string' ) {
+		const float = parseFloat( value );
+		if ( ! isNaN( float ) ) {
+			return float;
+		}
+	}
+
+	return defaultValue;
+}

--- a/projects/js-packages/boost-score-api/src/utils/cast-to-string.ts
+++ b/projects/js-packages/boost-score-api/src/utils/cast-to-string.ts
@@ -1,0 +1,28 @@
+/**
+ * Given an unknown value from an external source (e.g.: API response), parse
+ * it as a string. Returns defaultValue if the value does not seem to be a valid
+ * string.
+ *
+ * @template DefaultType
+ * @param {*}           value        - External value to process as a string
+ * @param {DefaultType} defaultValue - Default value to return if not a string
+ * @returns {string | DefaultType} value as a string, of defaultValue.
+ */
+export function castToString< DefaultType = undefined >(
+	value: unknown,
+	defaultValue: DefaultType | undefined = undefined
+): string | DefaultType | undefined {
+	if ( typeof value === 'string' ) {
+		return value;
+	}
+
+	if ( ! value ) {
+		return defaultValue;
+	}
+
+	if ( value.toString instanceof Function ) {
+		return value.toString();
+	}
+
+	return defaultValue;
+}

--- a/projects/js-packages/boost-score-api/src/utils/json-object-type.ts
+++ b/projects/js-packages/boost-score-api/src/utils/json-object-type.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+/**
+ * Definition for JSON types:
+ * - JSONValue can be any value compatible with JSON; an object (containing JSONValues), array, string, number, boolean, or null
+ * - JSONObject is an object containing JSONValues
+ * - JSONSchema is a zod schema that can be used to validate JSONValues
+ */
+const literalSchema = z.union( [ z.string(), z.number(), z.boolean(), z.null() ] );
+type Literal = z.infer< typeof literalSchema >;
+export type JSONValue = Literal | JSONObject | JSONValue[];
+export type JSONObject = { [ key: string ]: JSONValue };

--- a/projects/js-packages/boost-score-api/src/utils/json-types.ts
+++ b/projects/js-packages/boost-score-api/src/utils/json-types.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-use-before-define */
+/**
+ * Generic type for handling JSON-like objects.
+ *
+ * Use this as a last resort if you can't reasonably describe the possible shapes an object can take.
+ */
+export type JSONObject = {
+	[ key: string ]: JSONValue;
+};
+export type JSONArray = JSONValue[];
+export type JSONValue = string | number | boolean | JSONObject | JSONArray | null | undefined;
+
+/**
+ * Returns true if the given JSONValue is a JSONObject.
+ *
+ * @param {JSONValue} value - Value to check.
+ * @returns {boolean} True if the given value is a JSONObject.
+ */
+export function isJsonObject( value: JSONValue ): value is JSONObject {
+	return !! value && value instanceof Object && ! ( value instanceof Array );
+}
+
+/**
+ * Returns true if the given JSONValue is a JSONArray.
+ * Sure, you could use x instanceof Array but this is shorter and more consistent.
+ *
+ * @param {JSONValue} value - Value to check.
+ * @returns {boolean} True if the given value is a JSONArray.
+ */
+export function isJsonArray( value: JSONValue ): value is JSONArray {
+	return value instanceof Array;
+}

--- a/projects/js-packages/boost-score-api/src/utils/poll-promise.ts
+++ b/projects/js-packages/boost-score-api/src/utils/poll-promise.ts
@@ -1,0 +1,51 @@
+import { __ } from '@wordpress/i18n';
+
+type Resolve< ReturnType = void > = ( value: ReturnType | PromiseLike< ReturnType > ) => void;
+
+type PollPromiseArgs< ReturnType = void > = {
+	interval: number;
+	timeout: number;
+	timeoutError?: string;
+	callback: ( resolve: Resolve< ReturnType > ) => Promise< void > | void;
+};
+
+/**
+ * Repeatedly poll callback every <interval> milliseconds until it calls the
+ * resolve() callback. If the callback throws an error, the whole polling
+ * promise will reject.
+ *
+ * Rejects with a timeout after <timeout> milliseconds.
+ *
+ * @template ReturnType
+ * @param {object}   obj              - Arguments object.
+ * @param {number}   obj.interval     - Milliseconds between calling callback
+ * @param {number}   obj.timeout      - Milliseconds before rejecting w/ a timeout
+ * @param {Function} obj.callback     - Callback to call every <interval> ms.
+ * @param {string}   obj.timeoutError - Message to throw on timeout.
+ * @returns {Promise< ReturnType >} - A promise which resolves to the value resolved() inside callback.
+ */
+export default async function pollPromise< ReturnType = void >( {
+	interval,
+	callback,
+	timeout,
+	timeoutError,
+}: PollPromiseArgs< ReturnType > ): Promise< ReturnType > {
+	let timeoutHandle: number, intervalHandle: number;
+
+	return new Promise< ReturnType >( ( resolve, reject ) => {
+		timeoutHandle = setTimeout( () => {
+			reject( new Error( timeoutError || __( 'Timed out', 'boost-score-api' ) ) );
+		}, timeout || 2 * 60 * 1000 );
+
+		intervalHandle = setInterval( async () => {
+			try {
+				await Promise.resolve( callback( resolve ) );
+			} catch ( err ) {
+				reject( err );
+			}
+		}, interval );
+	} ).finally( () => {
+		clearTimeout( timeoutHandle );
+		clearInterval( intervalHandle );
+	} );
+}

--- a/projects/js-packages/boost-score-api/src/utils/standardize-error.ts
+++ b/projects/js-packages/boost-score-api/src/utils/standardize-error.ts
@@ -1,0 +1,33 @@
+import type { JSONValue } from './json-types';
+
+/**
+ * JavaScript offers no guarantee that caught objects in catch blocks are actually
+ * Error objects. This method fixes that, for type safety. :)
+ *
+ * @param {*}               data           - Any thrown error data to interpret as an Error (or subclass)
+ * @param {JSONValue|Error} defaultMessage - A default message to throw if no sensible error can be found.
+ * @returns {Error} the data guaranteed to be an Error or subclass thereof.
+ */
+export function standardizeError( data: JSONValue | Error, defaultMessage?: string ): Error {
+	if ( data instanceof Error ) {
+		return data;
+	}
+
+	if ( typeof data === 'string' || data instanceof String ) {
+		return new Error( data.toString() );
+	}
+
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	if ( data.message ) {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		return new Error( data.message );
+	}
+
+	if ( defaultMessage ) {
+		return new Error( defaultMessage );
+	}
+
+	return new Error( JSON.stringify( data ) );
+}

--- a/projects/js-packages/boost-score-api/tests/index.test.js
+++ b/projects/js-packages/boost-score-api/tests/index.test.js
@@ -1,0 +1,7 @@
+// We recommend using `jest` for testing. If you're testing React code, we recommend `@testing-library/react` and related packages.
+// Please match the versions used elsewhere in the monorepo.
+//
+// Please don't add new uses of `mocha`, `chai`, `sinon`, `enzyme`, and so on. We're trying to standardize on one testing framework.
+//
+// The default setup is to have files named like "name.test.js" (or .jsx, .ts, or .tsx) in this `tests/` directory.
+// But you could instead put them in `src/`, or put files like "name.js" (or .jsx, .ts, or .tsx) in `test` or `__tests__` directories somewhere.

--- a/projects/js-packages/boost-score-api/tests/index.test.js
+++ b/projects/js-packages/boost-score-api/tests/index.test.js
@@ -1,7 +1,1 @@
-// We recommend using `jest` for testing. If you're testing React code, we recommend `@testing-library/react` and related packages.
-// Please match the versions used elsewhere in the monorepo.
-//
-// Please don't add new uses of `mocha`, `chai`, `sinon`, `enzyme`, and so on. We're trying to standardize on one testing framework.
-//
-// The default setup is to have files named like "name.test.js" (or .jsx, .ts, or .tsx) in this `tests/` directory.
-// But you could instead put them in `src/`, or put files like "name.js" (or .jsx, .ts, or .tsx) in `test` or `__tests__` directories somewhere.
+// Todo: Add tests

--- a/projects/js-packages/boost-score-api/tests/index.test.js
+++ b/projects/js-packages/boost-score-api/tests/index.test.js
@@ -1,1 +1,0 @@
-// Todo: Add tests

--- a/projects/js-packages/boost-score-api/tests/index.test.js
+++ b/projects/js-packages/boost-score-api/tests/index.test.js
@@ -1,0 +1,8 @@
+import { requestSpeedScores } from '../src/index';
+
+// This is a placeholder test, new tests will be added soon
+describe( 'requestSpeedScores', () => {
+	it( 'should be a function', () => {
+		expect( typeof requestSpeedScores ).toBe( 'function' );
+	} );
+} );

--- a/projects/js-packages/boost-score-api/tsconfig.json
+++ b/projects/js-packages/boost-score-api/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "jetpack-js-tools/tsconfig.base.json",
 	"include": [ "./src/*", "./src/utils/*" ],
 	"compilerOptions": {
-		"typeRoots": [ "./node_modules/@types/", "./src/*" ],
+		"typeRoots": [ "./node_modules/@types/", "src/*" ],
 		"sourceMap": true,
 		"forceConsistentCasingInFileNames": true,
 		"outDir": "./build/",

--- a/projects/js-packages/boost-score-api/tsconfig.json
+++ b/projects/js-packages/boost-score-api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "jetpack-js-tools/tsconfig.base.json",
+	"include": [ "./src/*", "./src/utils/*" ],
+	"compilerOptions": {
+		"typeRoots": [ "./node_modules/@types/", "./src/*" ],
+		"sourceMap": true,
+		"forceConsistentCasingInFileNames": true,
+		"outDir": "./build/",
+		"noEmit": false,
+		"declaration": true,
+		"module": "es6",
+		"target": "es5",
+		"moduleResolution": "nodenext"
+	}
+}

--- a/projects/js-packages/boost-score-api/webpack.config.cjs
+++ b/projects/js-packages/boost-score-api/webpack.config.cjs
@@ -1,0 +1,34 @@
+const path = require( 'path' );
+const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
+
+module.exports = {
+	entry: './src/index.ts',
+	mode: jetpackWebpackConfig.mode,
+	devtool: jetpackWebpackConfig.isProduction ? false : 'source-map',
+	module: {
+		strictExportPresence: true,
+		rules: [
+			{
+				test: /\.ts?$/,
+				use: 'ts-loader',
+				exclude: /node_modules/,
+			},
+		],
+	},
+	optimization: {
+		...jetpackWebpackConfig.optimization,
+	},
+	resolve: {
+		...jetpackWebpackConfig.resolve,
+	},
+	output: {
+		...jetpackWebpackConfig.output,
+		path: path.resolve( __dirname, 'build' ),
+		filename: 'index.js',
+		library: {
+			name: 'BoostScoreApiLibrary',
+			type: 'umd',
+		},
+	},
+	plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+};


### PR DESCRIPTION
Adds `js-package` for the boost score bar API so it can be used outside of the boost plugin

## Proposed changes:
 * Create new boost-score-api package
 * Use TypeScript and handle build and export of JS files
 * Edit the logic of the API a bit to become independent of the Jetpack Boost backend PHP code
 * Remove Score Change modal from the API as it will not be needed outside the plugin

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
P2: p1HpG7-k9o-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

When reviewing this, take note that most of this written code came from the Boost plugin codebase, and this is just extracting it to a package so it can be used in other plugins. The following directories are where I got most of this code

 * `projects/plugins/boost/app/assets/src/js/api`
 * `projects/plugins/boost/app/assets/src/js/utils`

1. Checkout this branch
2. Get your local environment running
3. Install and activate the Jetpack Boost plugin
4. Go to `/wp-admin/admin.php?page=jetpack-boost#/` and make sure the scores are loading correctly
5. Make the following edits to the following files to use the new package instead of the built in functionality

`projects/plugins/boost/package.json`

Add the following package to the dependencies object
```json
"@automattic/jetpack-boost-score-api": "workspace:*",
```
After doing this, run `pnpm install` in the `projects/plugins/boost` directory to install the new package

`projects/plugins/boost/rollup-tsconfig.json`

Add the following line to the `include` array
```json
"../../js-packages/boost-score-api/**/*",
```

`projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte`

Change lines 3-9 to this
```svelte
import { getScoreLetter, requestSpeedScores, didScoresChange } from '@automattic/jetpack-boost-score-api';
import { scoreChangeModal, ScoreChangeMessage } from '../../../api/speed-scores';
```

Update line 63 to this
```svelte
scores = await requestSpeedScores( force, wpApiSettings.root, Jetpack_Boost.site.url, wpApiSettings.nonce );
```

6. Install Boost via `jetpack install plugins/boost`
7. Build the boost plugin via `jetpack build` and choose `plugins` and then `boost`. When it asks if you'd like to build the dependencies as well, say yes
8. Refresh the page and make sure the scores still load correctly

![image](https://github.com/Automattic/jetpack/assets/65001528/15a2c5fd-64b9-4800-a375-a36daae0c598)

NOTE: Because seeing changes made in the boost plugin have been iffy lately, I'd recommend logging something to the console when editing the files so you can make sure the changes are actually made. Or break something on purpose and see if it breaks in your environment