### PR TITLE
Jetpack AI: Introduce new module

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -8,6 +8,8 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status;
 
 /**
@@ -67,22 +69,14 @@ class Jetpack_AI_Helper {
 	 * Currently, it's limited to WPCOM Simple and Atomic.
 	 */
 	public static function is_enabled() {
-		$default = false;
-
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$default = true;
-		} elseif ( ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
-			$default = true;
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) { // Active on Simple.
+			return true;
+		} elseif ( ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) { // Active on Atomic.
+			return true;
+		} else { // Active on Jetpack sites with AI module and flag.
+			// TODO: Remove this flag once we release.
+			return ( new Modules() )->is_active( 'ai' ) && Constants::is_true( 'JETPACK__AI__ENABLED' );
 		}
-
-		/**
-		 * Filter whether the AI features are enabled in the Jetpack plugin.
-		 *
-		 * @since 11.8
-		 *
-		 * @param bool $default Are AI features enabled? Defaults to false.
-		 */
-		return apply_filters( 'jetpack_ai_enabled', $default );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-module
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: Add AI module

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Constants;
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
@@ -230,6 +231,12 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			if ( ! in_array( $module_tag, array_map( 'jetpack_get_module_i18n_tag', $module['module_tags'] ), true ) ) {
 				return false;
 			}
+		}
+
+		// Check module visibility based on flag.
+		if ( $module['module'] === 'ai' ) {
+			$jetpack_ai_enabled = Constants::is_true( 'JETPACK_AI_ENABLED' );
+			return $jetpack_ai_enabled;
 		}
 
 		// If nothing rejected it, include it!

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -84,11 +84,11 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			'jetpack-modules-list-table',
 			'jetpackModulesData',
 			array(
-				'modules'   => Jetpack::get_translated_modules( $this->all_items ),
+				'modules'   => Jetpack::get_translated_modules( $this->items ),
 				'i18n'      => array(
 					'search_placeholder' => __( 'Search modules…', 'jetpack' ),
 				),
-				'modalinfo' => $this->module_info_check( $modal_info, $this->all_items ),
+				'modalinfo' => $this->module_info_check( $modal_info, $this->items ),
 				'nonces'    => array(
 					'bulk' => wp_create_nonce( 'bulk-jetpack_page_jetpack_modules' ),
 				),

--- a/projects/plugins/jetpack/modules/ai.php
+++ b/projects/plugins/jetpack/modules/ai.php
@@ -5,6 +5,7 @@
  * First Introduced: 12.2
  * Sort Order: 20
  * Requires Connection: Yes
+ * Requires User Connection: Yes
  * Auto Activate: No
  * Module Tags: AI, Recommended
  * Feature: Writing

--- a/projects/plugins/jetpack/modules/ai.php
+++ b/projects/plugins/jetpack/modules/ai.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Module Name: Jetpack AI
+ * Module Description: Allow AI assistant to help you write your posts for you or selecting images.
+ * First Introduced: 12.2
+ * Sort Order: 20
+ * Requires Connection: Yes
+ * Auto Activate: No
+ * Module Tags: AI, Recommended
+ * Feature: Writing
+ * Additional Search Queries: ai, openai
+ *
+ * @package automattic/jetpack
+ */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related with #30728 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add new `ai.php` module.
* Make it available or not in module list through `JETPACK_AI_ENABLED` flag.
* Check for module and flag in `Jetpack_AI_Helper`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spawn a new JN site.
* Goes to Jetpack Dashboard and navigate to modules list (link at the page footer).
* You should not see `Jetpack AI` module.
* Now, goes into `Jetpack Constants` settings and enabled `JETPACK_AI` and set `JETPACK_BLOCKS` to experimental.
* Goes back to modules list and you should see it listed.
* Make sure the module is deactivate.
* Open a new post. You should not be able to see `AI Assistant` block.
* Return to module list and activate it.
* Now return to post and you should be able to see the block.

### Demo

<img width="571" alt="image" src="https://github.com/Automattic/jetpack/assets/1663717/c5441a2c-3284-45a5-abf3-f5bbc612dd52">


