### PR TITLE
Social: Add a test Instagram connection

### DIFF
--- a/projects/packages/publicize/changelog/test-social-instagram-connection
+++ b/projects/packages/publicize/changelog/test-social-instagram-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fake instagram connection

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -201,7 +201,19 @@ class Connections_Post_Field {
 			return $is_valid;
 		}
 
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$context              = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$output_connections[] = array(
+			'id'              => '12345',
+			'unique_id'       => '12346',
+			'service_name'    => 'instagram',
+			'service_label'   => 'Instagram',
+			'display_name'    => '@testinstahipster',
+			'profile_picture' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png',
+			'enabled'         => true,
+			'done'            => false,
+			'toggleable'      => true,
+			'global'          => false,
+		);
 		return $this->filter_response_by_context( $output_connections, $full_schema, $context );
 	}
 

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -738,6 +738,18 @@ abstract class Publicize_Base {
 			}
 		}
 
+		$test_results[] = array(
+			'connectionID'            => '12345',
+			'serviceName'             => 'instagram',
+			'connectionTestPassed'    => true,
+			'connectionTestErrorCode' => '',
+			'connectionTestMessage'   => 'This connection is working correctly.',
+			'userCanRefresh'          => false,
+			'refreshText'             => '',
+			'refreshURL'              => '',
+			'unique_id'               => '12346',
+		);
+
 		return $test_results;
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -139,6 +139,15 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 			}
 		}
 
+		$items[] = array(
+			'id'              => '12346',
+			'connection_id'   => '12345',
+			'service_name'    => 'instagram',
+			'display_name'    => '@testinstahipster',
+			'profile_picture' => 'https://abs.twimg.com/sticky/default_profile_images/default_profile.png',
+			'global'          => false,
+		);
+
 		return $items;
 	}
 

--- a/projects/plugins/jetpack/changelog/test-social-instagram-connection
+++ b/projects/plugins/jetpack/changelog/test-social-instagram-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fake changelog connection


### PR DESCRIPTION
In order to develop the front end changes separately from WPCOM, this hardcodes a fake Instagram connection.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

