### PR TITLE
Boost: Update `list-site-urls` endpoint groups

### DIFF
--- a/projects/plugins/boost/app/lib/class-site-urls.php
+++ b/projects/plugins/boost/app/lib/class-site-urls.php
@@ -86,7 +86,7 @@ class Site_Urls {
 			$urls[ 'post_id_' . $result->ID ] = array(
 				'url'      => get_permalink( $result->ID ),
 				'modified' => get_post_modified_time( 'Y-m-d H:i:s', false, $result ),
-				'group'    => get_post_type( $result->ID ),
+				'group'    => self::get_post_group( $result ),
 			);
 		}
 
@@ -130,5 +130,21 @@ class Site_Urls {
 				'is_post_type_viewable'
 			)
 		);
+	}
+
+	/**
+	 * Returns the group for the post.
+	 *
+	 * @param $p Post object.
+	 *
+	 * @return string
+	 */
+	private static function get_post_group( $p ) {
+		$post_type = get_post_type( $p->ID );
+		if ( 'post' === $post_type || 'page' === $post_type ) {
+			return $post_type;
+		}
+
+		return 'other';
 	}
 }

--- a/projects/plugins/boost/changelog/update-boost-site-urls-other-group
+++ b/projects/plugins/boost/changelog/update-boost-site-urls-other-group
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update site urls rest api endpoint, to return 'other' for custom post type posts.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update group for posts from custom post types to other when fetching site URLs via the `list-site-urls` endpoint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup branch;
* Register custom post type (if your website doesn't have one already);
* Add a post to the custom post type;
* Open `/wp-json/jetpack-boost/v1/list-site-urls` to and make sure the post is there and its group says `other`.