### PR TITLE
AI Assistant: add upgrade notice to AI Assistant

### DIFF
--- a/projects/plugins/jetpack/changelog/add-upgrade-notice-to-ai-assistant
+++ b/projects/plugins/jetpack/changelog/add-upgrade-notice-to-ai-assistant
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Upgrade banner for Jetpack AI Assistant (not in use yet)
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -79,7 +79,7 @@ const AIControl = ( {
 
 	return (
 		<>
-			<UpgradePrompt />
+			{ false && <UpgradePrompt /> }
 			{ ! isWaitingState && (
 				<ToolbarControls
 					aiType={ aiType }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -17,6 +17,7 @@ import { arrowRight, chevronDown, image, pencil, update, title } from '@wordpres
 import I18nDropdownControl from './i18n-dropdown-control';
 import Loading from './loading';
 import ToneDropdownControl from './tone-dropdown-control';
+import UpgradePrompt from './upgrade-prompt';
 
 const AIControl = ( {
 	aiType,
@@ -78,6 +79,7 @@ const AIControl = ( {
 
 	return (
 		<>
+			<UpgradePrompt />
 			{ ! isWaitingState && (
 				<ToolbarControls
 					aiType={ aiType }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/upgrade-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/upgrade-prompt.js
@@ -1,6 +1,7 @@
 /*
  * External dependencies
  */
+import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 /*
@@ -9,11 +10,15 @@ import React from 'react';
 import { Nudge } from '../../shared/components/upgrade-nudge';
 
 const UpgradePrompt = () => {
+	if ( isAtomicSite() || isSimpleSite() ) {
+		return null;
+	}
+
 	return (
 		<Nudge
 			buttonText={ 'Upgrade' }
-			checkoutUrl={ 'admin.php?page=my-jetpack#/add-jetpack-ai' }
-			className={ 'jetpack-ai' }
+			checkoutUrl={ `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/add-jetpack-ai` }
+			className={ 'jetpack-ai-upgrade-banner' }
 			description={ __( 'Free requests used. Upgrade now to keep using Jetpack AI.', 'jetpack' ) }
 			goToCheckoutPage={ () => {} }
 			isRedirecting={ false }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/upgrade-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/upgrade-prompt.js
@@ -1,0 +1,25 @@
+/*
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+/*
+ * Internal dependencies
+ */
+import { Nudge } from '../../shared/components/upgrade-nudge';
+
+const UpgradePrompt = () => {
+	return (
+		<Nudge
+			buttonText={ 'Upgrade' }
+			checkoutUrl={ 'admin.php?page=my-jetpack#/add-jetpack-ai' }
+			className={ 'jetpack-ai' }
+			description={ __( 'Free requests used. Upgrade now to keep using Jetpack AI.', 'jetpack' ) }
+			goToCheckoutPage={ () => {} }
+			isRedirecting={ false }
+			visible={ true }
+		/>
+	);
+};
+
+export default UpgradePrompt;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30736

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add upgrade notice to the AI Assistant block. It won't be used yet.
It will be enabled once we have the monetization logic. 


![Screenshot 2023-05-18 at 13 23 37](https://github.com/Automattic/jetpack/assets/16329583/b79ccaae-501d-486f-999c-4f4f2c36502d)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply to your local JP
* Enable it by removing the `false && `
* confirm that it is visible on your editor
* Confirm that it redirects to the Jetpack AI interstitial

