### PR TITLE
My Jetpack: Allow purchase of Jetpack AI Monthly

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -164,17 +164,9 @@ const ProductDetailCard = ( {
 			price
 		);
 	} else if ( productTerm === 'year' ) {
-		priceDescription = __(
-			'/month, paid yearly',
-			'jetpack-my-jetpack',
-			/* dummy arg to avoid bad minification */ 0
-		);
+		priceDescription = __( '/month, paid yearly', 'jetpack-my-jetpack' );
 	} else {
-		priceDescription = __(
-			'/month',
-			'jetpack-my-jetpack',
-			/* dummy arg to avoid bad minification */ 0
-		);
+		priceDescription = __( '/month', 'jetpack-my-jetpack' );
 	}
 	const clickHandler = useCallback( () => {
 		trackButtonClick();

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -166,7 +166,11 @@ const ProductDetailCard = ( {
 	} else if ( productTerm === 'year' ) {
 		priceDescription = __( '/month, paid yearly', 'jetpack-my-jetpack' );
 	} else {
-		priceDescription = __( '/month', 'jetpack-my-jetpack' );
+		priceDescription = __(
+			'/month',
+			'jetpack-my-jetpack',
+			/* dummy arg to avoid bad minification */ 0
+		);
 	}
 	const clickHandler = useCallback( () => {
 		trackButtonClick();

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -104,6 +104,7 @@ const ProductDetailCard = ( {
 		wpcomProductSlug,
 		wpcomFreeProductSlug,
 		introductoryOffer,
+		productTerm,
 	} = pricingForUi;
 
 	const { recordEvent } = useAnalytics();
@@ -155,19 +156,26 @@ const ProductDetailCard = ( {
 				} )
 		: null;
 
-	const priceDescription =
-		introductoryOffer?.intervalUnit === 'month' && introductoryOffer?.intervalCount === 1
-			? sprintf(
-					// translators: %s is the monthly price for a product
-					__( 'trial for the first month, then $%s /month, billed yearly', 'jetpack-my-jetpack' ),
-					price
-			  )
-			: __(
-					'/month, paid yearly',
-					'jetpack-my-jetpack',
-					/* dummy arg to avoid bad minification */ 0
-			  );
-
+	let priceDescription;
+	if ( introductoryOffer?.intervalUnit === 'month' && introductoryOffer?.intervalCount === 1 ) {
+		priceDescription = sprintf(
+			// translators: %s is the monthly price for a product
+			__( 'trial for the first month, then $%s /month, billed yearly', 'jetpack-my-jetpack' ),
+			price
+		);
+	} else if ( productTerm === 'year' ) {
+		priceDescription = __(
+			'/month, paid yearly',
+			'jetpack-my-jetpack',
+			/* dummy arg to avoid bad minification */ 0
+		);
+	} else {
+		priceDescription = __(
+			'/month',
+			'jetpack-my-jetpack',
+			/* dummy arg to avoid bad minification */ 0
+		);
+	}
 	const clickHandler = useCallback( () => {
 		trackButtonClick();
 		onClick?.( mainCheckoutRedirect, detail );

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -261,7 +261,7 @@ export function ExtrasInterstitial() {
  */
 export function JetpackAIInterstitial() {
 	return (
-		<ProductInterstitial slug="jetpack-ai" installsPlugin={ false }>
+		<ProductInterstitial slug="jetpack-ai" installsPlugin={ true }>
 			<img src={ jetpackAiImage } alt="Jetpack AI" />
 		</ProductInterstitial>
 	);

--- a/projects/packages/my-jetpack/_inc/state/selectors.js
+++ b/projects/packages/my-jetpack/_inc/state/selectors.js
@@ -37,10 +37,14 @@ export const getProduct = ( state, productId ) => {
 	product.supportedProducts = product.supportedProducts || [];
 
 	product.pricingForUi.fullPricePerMonth =
-		Math.ceil( ( product.pricingForUi.fullPrice / 12 ) * 100 ) / 100;
+		product.pricingForUi.productTerm === 'year'
+			? Math.ceil( ( product.pricingForUi.fullPrice / 12 ) * 100 ) / 100
+			: product.pricingForUi.fullPrice;
 
 	product.pricingForUi.discountPricePerMonth =
-		Math.ceil( ( product.pricingForUi.discountPrice / 12 ) * 100 ) / 100;
+		product.pricingForUi.productTerm === 'year'
+			? Math.ceil( ( product.pricingForUi.discountPrice / 12 ) * 100 ) / 100
+			: product.pricingForUi.discountPrice;
 
 	return product;
 };

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-for-jetpack-ai-monthly
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-for-jetpack-ai-monthly
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added ability to purchase Jetpack AI monthly product

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -189,6 +189,7 @@ class Wpcom_Products {
 			'discount_price'        => $discount_price,
 			'is_introductory_offer' => $is_introductory_offer,
 			'introductory_offer'    => $introductory_offer,
+			'product_term'          => $product->product_term,
 		);
 
 		return self::populate_with_discount( $product, $pricing, $discount_price );

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -7,8 +7,10 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+use Jetpack_Options;
 
 /**
  * Class responsible for handling the Jetpack AI product
@@ -104,6 +106,71 @@ class Jetpack_Ai extends Module_Product {
 	}
 
 	/**
+	 * Gets the site purchases from WPCOM.
+	 *
+	 * @todo Maybe add caching.
+	 *
+	 * @return Object|WP_Error
+	 */
+	private static function get_site_current_purchases() {
+		static $purchases = null;
+
+		if ( $purchases !== null ) {
+			return $purchases;
+		}
+
+		$site_id = Jetpack_Options::get_option( 'id' );
+
+		$response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d/purchases', $site_id ),
+			'1.1',
+			array(
+				'method' => 'GET',
+			)
+		);
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return new WP_Error( 'purchases_state_fetch_failed' );
+		}
+
+		$body      = wp_remote_retrieve_body( $response );
+		$purchases = json_decode( $body );
+		return $purchases;
+	}
+
+	/**
+	 * Checks whether the current plan (or purchases) of the site already supports the product
+	 *
+	 * @return boolean
+	 */
+	public static function has_required_plan() {
+		$purchases_data = static::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
+			return false;
+		}
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				if (
+					0 === strpos( $purchase->product_slug, static::get_wpcom_product_slug() )
+				) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Checks whether the Product is active
+	 *
+	 * Jetpack AI is not actually a module.
+	 *
+	 * @return boolean
+	 */
+	public static function is_active() {
+		return static::is_jetpack_plugin_active() && static::has_required_plan();
+	}
+
+	/**
 	 * Checks whether the Jetpack module is active
 	 *
 	 * This is a bundle and not a product. We should not use this information for anything
@@ -111,7 +178,7 @@ class Jetpack_Ai extends Module_Product {
 	 * @return bool
 	 */
 	public static function is_module_active() {
-		return false;
+		return true;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Jetpack_Options;
+use WP_Error;
 
 /**
  * Class responsible for handling the Jetpack AI product

--- a/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
+++ b/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
@@ -99,6 +99,7 @@ class Test_Wpcom_Products extends TestCase {
 				'cost_display'           => 'R$4.90',
 				'cost'                   => 4.9,
 				'currency_code'          => 'BRL',
+				'product_term'           => 'one time',
 			),
 			'jetpack_videopress_monthly' => (object) array(
 				'product_id'             => 2222,
@@ -111,6 +112,7 @@ class Test_Wpcom_Products extends TestCase {
 				'cost_display'           => 'R$4.90',
 				'cost'                   => 4.9,
 				'currency_code'          => 'BRL',
+				'product_term'           => 'month',
 				'sale_coupon'            => (object) array(
 					'start_date' => gmdate( 'Y' ) . '-01-01',
 					'expires'    => gmdate( 'Y' ) . '-12-31',
@@ -211,6 +213,7 @@ class Test_Wpcom_Products extends TestCase {
 			'discount_price'        => 2.45,
 			'is_introductory_offer' => false,
 			'introductory_offer'    => null,
+			'product_term'          => 'month',
 			'coupon_discount'       => 50,
 		);
 


### PR DESCRIPTION
Updates My Jetpack to allow for purchase of Jetpack AI product

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the Jetpack AI product class (My Jetpack PHP) to account for the existence of the plan
  * Updates lass-wpcom-products.php and the product detail card to receive the product term property of the product
* Fixes prices calculation to account for "Only monthly plans" while maintaining functionality for yearly plans and offers

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* On a site without the plan 
* Go to `wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai`
* Confirm you see pricing in the interstitial and a button to Get Jetpack AI
  
  ![image](https://github.com/Automattic/jetpack/assets/746152/06732477-e3ce-4d0b-8ef1-02bc820b6756)

* Click **Get Jetpack AI**
* Expect to be taken to the purchase flow
* Pay for the product and continue with the flow
* Expect to be thrown back into My Jetpack
* Confirm you see the plan under the *My Plans* section
* Got back to `wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai`
* Expect to see something like this. Ignore the "Install Jetpack AI". This needs to be addressed in a follow-up as Scan also shows the same bug
  <img width="886" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/ee51b123-3327-4ac3-a12a-47f23ee6c5fd">

