### PR TITLE
Publicize: avoid PHP warning

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php
@@ -122,7 +122,11 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connection_Test_Results extends 
 			}
 		}
 
-		if ( 'linkedin' === $item['id'] && 'must_reauth' === $test_result['connectionTestPassed'] ) {
+		if (
+			isset( $item['id'] )
+			&& 'linkedin' === $item['id']
+			&& 'must_reauth' === $test_result['connectionTestPassed']
+		) {
 			$item['test_success'] = 'must_reauth';
 		}
 

--- a/projects/plugins/jetpack/changelog/fix-notice-publicize
+++ b/projects/plugins/jetpack/changelog/fix-notice-publicize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Publicize: avoid PHP warning


### PR DESCRIPTION
## Proposed changes:

This should fix the following warnings:

```
PHP Warning:  Undefined variable $item in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php on line 125
PHP Warning:  Trying to access array offset on value of type null in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connection-test-results.php on line 125
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Start with a site that runs Jetpack, connected to WordPress.com, and where you have activated the Publicize feature under Jetpack > Settings > Social

* Go to Posts > Add New
* Open the Jetpack sidebar
* Check your logs, you should see no warnings.
