### PR TITLE
CRM: Initialize new CRM cycle - 5.8.1

### DIFF
--- a/projects/plugins/crm/changelog/init-release-cycle
+++ b/projects/plugins/crm/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 5.8.1-alpha
+
+

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, woodyhayday, mikemayhem3030
 Tags: CRM, Invoice, Woocommerce CRM, Clients, Lead Generation, contacts, customers, billing, email marketing, Marketing Automation, contact form, automations
 Tested up to: 6.2
-Stable tag: 5.7.0
+Stable tag: 5.8.0
 Requires at least: 5.0
 Requires PHP: 7.2
 License: GPLv2


### PR DESCRIPTION

## Proposed changes:

* This PR initializes the new CRM plugin version (5.8.1-alpha for a 5.8.1 release), and updates the stable tag in readme.txt to match the current stable version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read, check versions are as expected.

