### PR TITLE
AI Assistant: Use site-independent completion endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-use-site-independent-completion-endpoint
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-use-site-independent-completion-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Use site-independent completion endpoint to prevent request failures for private WPCOM sites.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -47,11 +47,9 @@ export async function askJetpack( question ) {
  * @param {number} postId - The post where this completion is being requested, if available
  */
 export async function askQuestion( question, postId = null ) {
-	const { blogId, token } = await requestToken();
+	const { token } = await requestToken();
 
-	const url = new URL(
-		'https://public-api.wordpress.com/wpcom/v2/sites/' + blogId + '/jetpack-openai-query'
-	);
+	const url = new URL( 'https://public-api.wordpress.com/wpcom/v2/jetpack-ai-query' );
 	url.searchParams.append( 'question', question );
 	url.searchParams.append( 'token', token );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to #30780.

Depends on D111304-code to work properly.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the request endpoint from `wpcom/v2/sites/BLOG_ID/jetpack-openai-query` to `wpcom/v2/jetpack-ai-query`; this new endpoint is site-independent and will be available soon to help solve the issue of completions on private WPCOM sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this diff to your sandbox to create the new endpoint there: D111304-code
* Go to the block editor on a test site
* Open your browser console and switch to the network activity tab
* Include an AI Assistant block on the editor
* Execute some prompt on the AI Assistant (for example, "write a paragraph about open source code usage")
* Notice the request being executed on the network activity tab: the request will be sent to `wpcom/v2/jetpack-ai-query`
* The request should work properly and you can see the completion being rendered on the block
* Nothing should change on the block behavior