### PR TITLE
[Boost] Fix broken e2e test

### DIFF
--- a/projects/plugins/boost/changelog/boost-fix-e2e-tests
+++ b/projects/plugins/boost/changelog/boost-fix-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix broken e2e test
+
+

--- a/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
@@ -164,7 +164,7 @@ export default class JetpackBoostPage extends WpPage {
 		return (
 			( await this.getSpeedScore( 'mobile' ) ) > 0 &&
 			( await this.getSpeedScore( 'desktop' ) ) > 0 &&
-			( await this.currentPageTitleIs( /Overall score: [A-Z]/ ) )
+			( await this.currentPageTitleIs( /Overall Score: [A-Z]/i ) )
 		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes e2e test failure when showing speed scores.

## Proposed changes:
* #30751 introduced a minor change to the text displayed in the speed score area, which were not reflected in e2e tests.
* This fixes that.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* make sure e2e tests pass.

