### PR TITLE
Social previews | Fix multiple issues

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,8 +686,8 @@ importers:
         specifier: workspace:*
         version: link:../shared-extension-utils
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.6
-        version: 2.0.0-beta.6(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@wordpress/annotations':
         specifier: 2.32.0
         version: 2.32.0(react@18.2.0)
@@ -2727,8 +2727,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.6
-        version: 2.0.0-beta.6(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@automattic/viewport':
         specifier: 1.0.0
         version: 1.0.0
@@ -3945,8 +3945,8 @@ packages:
       '@automattic/popup-monitor': 1.0.2
     dev: false
 
-  /@automattic/social-previews@2.0.0-beta.6(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-M45iQQ2NmCcej0xSB1eonySY8hA5e2DALDQXPFt3tPoVN+KmWEBKgDEyl5dtO8lx8i1oRhVfADSSXv5DbmlDgA==}
+  /@automattic/social-previews@2.0.0-beta.7(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-WZQL9RRwW8xY0fiHs1rLN/D8/1v9J6uRTq1DF1IibJQUOl62XZCGRfWCouDs500ytKioeC3oZQintT/K+khA1w==}
     peerDependencies:
       '@babel/runtime': ^7
       react: ^17.0.2 || ^18

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,8 +686,8 @@ importers:
         specifier: workspace:*
         version: link:../shared-extension-utils
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.5
-        version: 2.0.0-beta.5(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.6
+        version: 2.0.0-beta.6(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@wordpress/annotations':
         specifier: 2.32.0
         version: 2.32.0(react@18.2.0)
@@ -2727,8 +2727,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@automattic/social-previews':
-        specifier: 2.0.0-beta.5
-        version: 2.0.0-beta.5(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.0-beta.6
+        version: 2.0.0-beta.6(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@automattic/viewport':
         specifier: 1.0.0
         version: 1.0.0
@@ -3945,8 +3945,8 @@ packages:
       '@automattic/popup-monitor': 1.0.2
     dev: false
 
-  /@automattic/social-previews@2.0.0-beta.5(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-3n8Zu+2eytPGDTnuKRCWCOtM5Mpg1XHKDRyfV8a5OLCwwX2hSLs6SXNqfS8v++kUypthtpNnDeE+4poBOJSdwQ==}
+  /@automattic/social-previews@2.0.0-beta.6(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-M45iQQ2NmCcej0xSB1eonySY8hA5e2DALDQXPFt3tPoVN+KmWEBKgDEyl5dtO8lx8i1oRhVfADSSXv5DbmlDgA==}
     peerDependencies:
       '@babel/runtime': ^7
       react: ^17.0.2 || ^18

--- a/projects/js-packages/publicize-components/changelog/fix-social-previews-styling
+++ b/projects/js-packages/publicize-components/changelog/fix-social-previews-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Social Preview modal styling

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -22,7 +22,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
-		"@automattic/social-previews": "2.0.0-beta.5",
+		"@automattic/social-previews": "2.0.0-beta.6",
 		"@wordpress/annotations": "2.32.0",
 		"@wordpress/api-fetch": "6.29.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -22,7 +22,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
-		"@automattic/social-previews": "2.0.0-beta.6",
+		"@automattic/social-previews": "2.0.0-beta.7",
 		"@wordpress/annotations": "2.32.0",
 		"@wordpress/api-fetch": "6.29.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/js-packages/publicize-components/src/components/social-previews/constants.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/constants.js
@@ -4,6 +4,7 @@ import FacebookPreview from './facebook';
 import GoogleSearch from './google-search';
 import { LinkedIn } from './linkedin';
 import TumblrPreview from './tumblr';
+import Twitter from './twitter';
 
 export const AVAILABLE_SERVICES = [
 	{
@@ -12,12 +13,12 @@ export const AVAILABLE_SERVICES = [
 		name: 'google',
 		preview: GoogleSearch,
 	},
-	/* {
+	{
 		title: __( 'Twitter', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="twitter" { ...props } />,
 		name: 'twitter',
 		preview: Twitter,
-	}, */
+	},
 	{
 		title: __( 'Facebook', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="facebook" { ...props } />,

--- a/projects/js-packages/publicize-components/src/components/social-previews/constants.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/constants.js
@@ -4,7 +4,6 @@ import FacebookPreview from './facebook';
 import GoogleSearch from './google-search';
 import { LinkedIn } from './linkedin';
 import TumblrPreview from './tumblr';
-import Twitter from './twitter';
 
 export const AVAILABLE_SERVICES = [
 	{
@@ -13,12 +12,12 @@ export const AVAILABLE_SERVICES = [
 		name: 'google',
 		preview: GoogleSearch,
 	},
-	{
+	/* {
 		title: __( 'Twitter', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="twitter" { ...props } />,
 		name: 'twitter',
 		preview: Twitter,
-	},
+	}, */
 	{
 		title: __( 'Facebook', 'jetpack' ),
 		icon: props => <SocialServiceIcon serviceName="facebook" { ...props } />,

--- a/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
@@ -10,11 +10,14 @@ import { getLinkedInDetails } from '../../store/selectors';
  * @returns {React.ReactNode} The linkedin tab component.
  */
 export function LinkedIn( props ) {
-	const { title, url, image, description, media } = props;
+	const { title, url, image, media } = props;
 
 	const { name, profileImage } = getLinkedInDetails();
 
 	const { message: text } = useSocialMediaMessage();
+
+	// Add the URL to the description if there is media
+	const description = `${ text || title } ${ media.length ? url : '' }`.trim();
 
 	return (
 		<LinkedInPreviews
@@ -24,7 +27,6 @@ export function LinkedIn( props ) {
 			profileImage={ profileImage }
 			title={ title }
 			description={ description }
-			text={ text }
 			url={ url }
 			media={ media }
 		/>

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -103,16 +103,26 @@ export default withSelect( select => {
 				alt: '',
 			} );
 		} else {
-			for ( const { id } of attachedMedia ) {
+			const getMediaDetails = id => {
 				const mediaItem = getMedia( id );
-
-				if ( mediaItem ) {
-					media.push( {
-						type: mediaItem.mime_type,
-						url: getMediaSourceUrl( mediaItem ),
-						alt: mediaItem.alt_text,
-					} );
+				if ( ! mediaItem ) {
+					return null;
 				}
+				return {
+					type: mediaItem.mime_type,
+					url: getMediaSourceUrl( mediaItem ),
+					alt: mediaItem.alt_text,
+				};
+			};
+
+			for ( const { id } of attachedMedia ) {
+				const mediaDetails = getMediaDetails( id );
+				if ( mediaDetails ) {
+					media.push( mediaDetails );
+				}
+			}
+			if ( 0 === media.length && featuredImageId ) {
+				media.push( getMediaDetails( featuredImageId ) );
 			}
 		}
 	}

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
@@ -15,6 +15,7 @@ $highlight-color: #3858e9;
 
 	.components-modal__content {
 		padding: 0;
+		overflow: hidden;
 	}
 }
 
@@ -87,7 +88,6 @@ $highlight-color: #3858e9;
 
 	@media ( min-width: $break-large ) {
 		width: calc( #{$break-large} - 40px );
-		min-height: 500px;
 
 		.components-tab-panel__tabs {
 

--- a/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/twitter.js
@@ -9,8 +9,8 @@ import React from 'react';
  * @param {object[]} props.tweets - The tweets.
  * @returns {React.ReactNode} The twitter tab component.
  */
-export function Twitter( { tweets } ) {
-	return <TwitterPreviews tweets={ tweets } />;
+function Twitter( { tweets } ) {
+	return <TwitterPreviews tweets={ tweets } hidePostPreview />;
 }
 
 export default withSelect( ( select, { title, description, image, url, media } ) => {

--- a/projects/plugins/jetpack/changelog/fix-social-previews-styling
+++ b/projects/plugins/jetpack/changelog/fix-social-previews-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed Social Previews modal styling

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -57,7 +57,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/request-external-access": "1.0.0",
-		"@automattic/social-previews": "2.0.0-beta.5",
+		"@automattic/social-previews": "2.0.0-beta.6",
 		"@automattic/viewport": "1.0.0",
 		"@wordpress/base-styles": "4.23.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -57,7 +57,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/request-external-access": "1.0.0",
-		"@automattic/social-previews": "2.0.0-beta.6",
+		"@automattic/social-previews": "2.0.0-beta.7",
 		"@automattic/viewport": "1.0.0",
 		"@wordpress/base-styles": "4.23.0",
 		"@wordpress/block-editor": "12.0.0",


### PR DESCRIPTION
Fixes 1203820933396971-as-1204619418011134/f

## Proposed changes:

* Hides "Your post" section for Twitter preview
* Fix custom message not used for LinkedIn preview
* Fix modal header scrolling issue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdrWKz-Ka-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In Jetpack, run `jetpack build plugins/jetpack`
* Start writing a new post with a JT site with Social Advanced plan/features enabled
* Add a Featured Image to the post
* Click Jetpack icon on the top of the sidebar
* Under "Social Previews", click on "Preview"
* Resize the browser window to a smaller height (< 500px)
* Confirm that the modal header is not scrollable
* Confirm that Twitter preview is no longer available
* Confirm that LinkedIn preview reflects the custom message

| BEFORE | AFTER |
|--------|--------|
| <img width="962" alt="Screenshot 2023-05-19 at 1 51 56 PM" src="https://github.com/Automattic/jetpack/assets/18226415/79669b25-6480-4cbf-971e-9b6b1d55c405"> | <img width="948" alt="Screenshot 2023-05-19 at 1 52 06 PM" src="https://github.com/Automattic/jetpack/assets/18226415/6b684c4b-3dc1-4c08-bcb6-16158b725bd8">  | 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - 0-as-1204619418011134