### PR TITLE
CRM: Adding Automation contact triggers

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-automation-triggers-contacts
+++ b/projects/plugins/crm/changelog/add-crm-automation-triggers-contacts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Automation: Added contact triggers

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -2712,6 +2712,8 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 						// Check if obj exists (here) - for now just brutal update (will error when doesn't exist)
 						$originalStatus = $this->getContactStatus( $id );
 
+						$previous_contact_obj = $this->getContact( $id );
+
 						// get any segments (whom counts may be affected by changes)
 						// $contactsPreUpdateSegments = $this->DAL()->segments->getSegmentsContainingContact($id,true);
 
@@ -3006,10 +3008,9 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
                                     'id'=>$id,
                                     'againstid' => $id,
                                     'userMeta'=> $dataArr,
-                                    'prevSegments' => $contactsPreUpdateSegments
+									'prevSegments' => $contactsPreUpdateSegments,
+									'prev_contact' => $previous_contact_obj,
                                     ));
-
-                                
 
                             }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
@@ -55,6 +55,7 @@
 	#} WP Hook tie-ins (for Mike [and 3rd party developers!], mostly)
 	zeroBSCRM_AddInternalAutomatorRecipe('contact.new','zeroBSCRM_IA_NewCustomerWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('contact.update','zeroBSCRM_IA_EditCustomerWPHook',array());
+	zeroBSCRM_AddInternalAutomatorRecipe( 'contact.status.update', 'zeroBSCRM_IA_EditCustomerWPHook', array() );
 	zeroBSCRM_AddInternalAutomatorRecipe('contact.vitals.update','zeroBSCRM_IA_EditCustomerVitalsWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('contact.email.update','zeroBSCRM_IA_EditCustomerEmailWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('contact.delete','zeroBSCRM_IA_DeleteCustomerWPHook',array());
@@ -1288,6 +1289,8 @@
 	function zeroBSCRM_IA_NewCustomerWPHook($obj=array()){
 
 		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) {
+
+			do_action( 'jpcrm_automation_contact_new', $obj );
 		
 			do_action( 'jpcrm_after_contact_insert', $obj['id'] );
 
@@ -1297,42 +1300,78 @@
 		}
 
 	}
-   	#} Fires on 'customer.edit' IA 
-	function zeroBSCRM_IA_EditCustomerWPHook($obj=array()){
 
-		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) {
-		
-			do_action( 'jpcrm_after_contact_update', $obj['id'] );
+/**
+ * Fires on 'contact.update', 'contact.email.update', and 'contact.status.update IA.
+ *
+ * @param array $obj An array holding contact object data.
+ */
+function zeroBSCRM_IA_EditCustomerWPHook( $obj = array() ) {
 
-			// legacy, use `jpcrm_after_contact_update` from 5.3+
-			do_action( 'zbs_edit_customer', $obj['id'] );
+	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
 
+		do_action( 'jpcrm_after_contact_update', $obj['id'] );
+
+		// legacy, use `jpcrm_after_contact_update` from 5.3+
+		do_action( 'zbs_edit_customer', $obj['id'] );
+
+		// If the contact status has changed.
+		if ( isset( $obj['from'] ) && ! empty( $obj['from'] ) ) {
+			do_action( 'jpcrm_automation_contact_status_update', $obj );
+		} elseif ( isset( $obj['userMeta']['zbsc_email'] ) && $obj['prev_contact']['email'] !== $obj['userMeta']['zbsc_email'] ) {  // If the contact email has changed.
+			do_action( 'jpcrm_automation_contact_email_update', $obj );
+		} else { // Fallback if any other contact field has changed.
+			do_action( 'jpcrm_automation_contact_update', $obj );
 		}
 
 	}
-   	#} Fires on 'customer.vitals.edit' IA 
+}
+
+	#} Fires on 'customer.vitals.edit' IA.
 	function zeroBSCRM_IA_EditCustomerVitalsWPHook($obj=array()){
 
 		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) do_action('zbs_edit_customer_vitals', $obj['id']);
 
 	}
-   	#} Fires on 'customer.email.edit' IA 
+
+	/**
+	 * Fires on 'contact.email.update' IA. Now legacy, redirecting to zeroBSCRM_IA_EditCustomerWPHook
+	 *
+	 * @param array $obj An array holding contact object data.
+	 */
 	function zeroBSCRM_IA_EditCustomerEmailWPHook($obj=array()){
+
+		zeroBSCRM_IA_EditCustomerWPHook( $obj );
 
 		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) do_action('zbs_edit_customer_email', $obj['id']);
 
 	}
-   	#} Fires on 'customer.delete' IA 
-	function zeroBSCRM_IA_DeleteCustomerWPHook($obj=array()){
 
-		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) do_action('zbs_delete_customer', $obj['id']);
+/**
+ * Fires on 'contact.delete' IA.
+ *
+ * @param array $obj An array holding contact object data.
+ */
+function zeroBSCRM_IA_DeleteCustomerWPHook( $obj = array() ) {
 
+	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
+		do_action( 'jpcrm_automation_contact_delete', $obj );
+		// Legacy:
+		do_action( 'zbs_delete_customer', $obj['id'] );
 	}
+}
 
-	#} Fires on 'contact.before.delete' IA
+	/**
+	 * Fires on 'contact.before.delete' IA.
+	 *
+	 * @param array $obj An array holding contact object data.
+	 */
 	function zeroBSCRM_IA_BeforeDeleteCustomerWPHook($obj=array()){
 
-		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) do_action('jpcrm_before_delete_contact', $obj);
+	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
+		do_action( 'jpcrm_automation_contact_before_delete', $obj );
+		do_action( 'jpcrm_before_delete_contact', $obj );
+	}
 
 	}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
@@ -1310,6 +1310,7 @@ function zeroBSCRM_IA_EditCustomerWPHook( $obj = array() ) {
 
 	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
 
+		do_action( 'jpcrm_automation_contact_update', $obj );
 		do_action( 'jpcrm_after_contact_update', $obj['id'] );
 
 		// legacy, use `jpcrm_after_contact_update` from 5.3+
@@ -1318,12 +1319,13 @@ function zeroBSCRM_IA_EditCustomerWPHook( $obj = array() ) {
 		// If the contact status has changed.
 		if ( isset( $obj['from'] ) && ! empty( $obj['from'] ) ) {
 			do_action( 'jpcrm_automation_contact_status_update', $obj );
-		} elseif ( isset( $obj['userMeta']['zbsc_email'] ) && $obj['prev_contact']['email'] !== $obj['userMeta']['zbsc_email'] ) {  // If the contact email has changed.
-			do_action( 'jpcrm_automation_contact_email_update', $obj );
-		} else { // Fallback if any other contact field has changed.
-			do_action( 'jpcrm_automation_contact_update', $obj );
 		}
-
+		// If the contact email has changed.
+		if ( isset( $obj['userMeta']['zbsc_email'] ) && isset( $obj['prev_contact'] ) ) {
+			if ( $obj['prev_contact']['email'] !== $obj['userMeta']['zbsc_email'] ) {
+				do_action( 'jpcrm_automation_contact_email_update', $obj );
+			}
+		}
 	}
 }
 

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
@@ -19,41 +19,66 @@ class Contact_Before_Deleted extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Contact_Before_Deleted instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'contact_before_delete';
-		self::$title       = __( 'Contact Before Deleted', 'zero-bs-crm' );
-		self::$description = __( 'Triggered just before a contact is deleted', 'zero-bs-crm' );
-		self::$category    = 'contact';
+	public static function get_slug(): string {
+		return 'jpcrm/contact_before_delete';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Contact Before Deleted', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered just before a CRM contact is deleted', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'contact', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_contact_before_delete',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $contact_data The contact data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $contact_data ) {
+	public function execute_workflow( $contact_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $contact_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_contact_before_delete',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
@@ -17,21 +17,22 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 class Contact_Before_Deleted extends Base_Trigger {
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Contact_Before_Deleted instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'contact_before_delete',
-			'title'       => 'Contact Before Deleted',
-			'description' => 'Triggered just before a contact is deleted.',
-			'category'    => 'contact',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'contact_before_delete';
+		self::$title       = __( 'Contact Before Deleted', 'zero-bs-crm' );
+		self::$description = __( 'Triggered just before a contact is deleted', 'zero-bs-crm' );
+		self::$category    = 'contact';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -39,11 +40,19 @@ class Contact_Before_Deleted extends Base_Trigger {
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
 			'jpcrm_automation_contact_before_delete',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $contact_data The contact data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $contact_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $contact_data );
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Contact_Before_Deleted extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'contact', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $contact_data The contact data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $contact_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $contact_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
@@ -38,6 +38,7 @@ class Contact_Before_Deleted extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_contact_before_delete',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-before-deleted.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack CRM Automation Contact_Before_Deleted trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Contact_Before_Deleted class.
+ */
+class Contact_Before_Deleted extends Base_Trigger {
+
+	/**
+	 * Contructs the Contact_Before_Deleted instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'contact_before_delete',
+			'title'       => 'Contact Before Deleted',
+			'description' => 'Triggered just before a contact is deleted.',
+			'category'    => 'contact',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_contact_before_delete',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Contact_Deleted extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'contact', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $contact_data The contact data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $contact_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $contact_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
@@ -17,21 +17,22 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 class Contact_Deleted extends Base_Trigger {
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Contact_Deleted instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'contact_delete',
-			'title'       => 'Contact Deleted',
-			'description' => 'Triggered when a contact is deleted.',
-			'category'    => 'contact',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'contact_delete';
+		self::$title       = __( 'Contact Deleted', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a contact is deleted', 'zero-bs-crm' );
+		self::$category    = 'contact';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -39,11 +40,19 @@ class Contact_Deleted extends Base_Trigger {
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
 			'jpcrm_automation_contact_delete',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $contact_data The contact data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $contact_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $contact_data );
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack CRM Automation Contact_Deleted trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Contact_Deleted class.
+ */
+class Contact_Deleted extends Base_Trigger {
+
+	/**
+	 * Contructs the Contact_Deleted instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'contact_delete',
+			'title'       => 'Contact Deleted',
+			'description' => 'Triggered when a contact is deleted.',
+			'category'    => 'contact',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_contact_delete',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
@@ -19,41 +19,66 @@ class Contact_Deleted extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Contact_Deleted instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'contact_delete';
-		self::$title       = __( 'Contact Deleted', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a contact is deleted', 'zero-bs-crm' );
-		self::$category    = 'contact';
+	public static function get_slug(): string {
+		return 'jpcrm/contact_delete';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Contact Deleted', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a CRM contact is deleted', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'contact', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_contact_delete',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $contact_data The contact data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $contact_data ) {
+	public function execute_workflow( $contact_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $contact_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_contact_delete',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-deleted.php
@@ -38,6 +38,7 @@ class Contact_Deleted extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_contact_delete',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
@@ -17,21 +17,22 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 class Contact_Email_Updated extends Base_Trigger {
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Contact_Email_Updated instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'contact_email_updated',
-			'title'       => 'Contact Email Updated',
-			'description' => 'Triggered when a CRM contact email is updated',
-			'category'    => 'contact',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'contact_email_updated';
+		self::$title       = __( 'Contact Email Updated', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a CRM contact email is updated', 'zero-bs-crm' );
+		self::$category    = 'contact';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -39,11 +40,19 @@ class Contact_Email_Updated extends Base_Trigger {
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
 			'jpcrm_automation_contact_email_update',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $contact_data The contact data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $contact_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $contact_data );
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Contact_Email_Updated extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'contact', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $contact_data The contact data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $contact_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $contact_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
@@ -19,41 +19,66 @@ class Contact_Email_Updated extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Contact_Email_Updated instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'contact_email_updated';
-		self::$title       = __( 'Contact Email Updated', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a CRM contact email is updated', 'zero-bs-crm' );
-		self::$category    = 'contact';
+	public static function get_slug(): string {
+		return 'jpcrm/contact_email_updated';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Contact Email Updated', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a CRM contact email is updated', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'contact', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_contact_email_update',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $contact_data The contact data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $contact_data ) {
+	public function execute_workflow( $contact_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $contact_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_contact_email_update',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
@@ -38,6 +38,7 @@ class Contact_Email_Updated extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_contact_email_update',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-email-updated.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack CRM Automation Contact_Email_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Contact_Email_Updated class.
+ */
+class Contact_Email_Updated extends Base_Trigger {
+
+	/**
+	 * Contructs the Contact_Email_Updated instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'contact_email_updated',
+			'title'       => 'Contact Email Updated',
+			'description' => 'Triggered when a CRM contact email is updated',
+			'category'    => 'contact',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_contact_email_update',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Contact_New extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'contact', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $contact_data The contact data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $contact_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $contact_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack CRM Automation Contact_New trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Contact_New class.
+ */
+class Contact_New extends Base_Trigger {
+
+	/**
+	 * Contructs the Contact_New instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'contact_new',
+			'title'       => 'New Contact',
+			'description' => 'Triggered when a new CRM contact is added',
+			'category'    => 'contact',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_contact_update',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
@@ -17,33 +17,42 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 class Contact_New extends Base_Trigger {
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Contact_New instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'contact_new',
-			'title'       => 'New Contact',
-			'description' => 'Triggered when a new CRM contact is added',
-			'category'    => 'contact',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'contact_new';
+		self::$title       = __( 'New Contact', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a new CRM contact is added', 'zero-bs-crm' );
+		self::$category    = 'contact';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
-			'jpcrm_automation_contact_update',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			'jpcrm_automation_contact_new',
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $contact_data The contact data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $contact_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $contact_data );
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
@@ -38,6 +38,7 @@ class Contact_New extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_contact_new',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-new.php
@@ -19,41 +19,66 @@ class Contact_New extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Contact_New instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'contact_new';
-		self::$title       = __( 'New Contact', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a new CRM contact is added', 'zero-bs-crm' );
-		self::$category    = 'contact';
+	public static function get_slug(): string {
+		return 'jpcrm/contact_new';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'New Contact', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a CRM contact is added', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'contact', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_contact_new',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $contact_data The contact data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $contact_data ) {
+	public function execute_workflow( $contact_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $contact_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_contact_new',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Contact_Status_Updated extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'contact', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $contact_data The contact data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $contact_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $contact_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
@@ -38,6 +38,7 @@ class Contact_Status_Updated extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_contact_status_update',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
@@ -17,21 +17,22 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 class Contact_Status_Updated extends Base_Trigger {
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Contact_Status_Updated instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'contact_status_updated',
-			'title'       => 'Contact Status Updated',
-			'description' => 'Triggered when a CRM contact status is updated',
-			'category'    => 'contact',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'contact_status_updated';
+		self::$title       = __( 'Contact Status Updated', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a CRM contact status is updated', 'zero-bs-crm' );
+		self::$category    = 'contact';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -39,11 +40,19 @@ class Contact_Status_Updated extends Base_Trigger {
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
 			'jpcrm_automation_contact_status_update',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $contact_data The contact data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $contact_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $contact_data );
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
@@ -19,41 +19,66 @@ class Contact_Status_Updated extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Contact_Status_Updated instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'contact_status_updated';
-		self::$title       = __( 'Contact Status Updated', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a CRM contact status is updated', 'zero-bs-crm' );
-		self::$category    = 'contact';
+	public static function get_slug(): string {
+		return 'jpcrm/contact_status_updated';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Contact Status Updated', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a CRM contact status is updated', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'contact', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_contact_status_update',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $contact_data The contact data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $contact_data ) {
+	public function execute_workflow( $contact_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $contact_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_contact_status_update',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack CRM Automation Contact_Status_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Contact_Status_Updated class.
+ */
+class Contact_Status_Updated extends Base_Trigger {
+
+	/**
+	 * Contructs the Contact_Status_Updated instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'contact_status_updated',
+			'title'       => 'Contact Status Updated',
+			'description' => 'Triggered when a CRM contact status is updated',
+			'category'    => 'contact',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_contact_status_update',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Jetpack CRM Automation Contact_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Contact_Updated class.
+ */
+class Contact_Updated extends Base_Trigger {
+	/**
+	 * @var array The contact object before update.
+	 */
+	private $contact_before_update = array();
+
+	/**
+	 * Contructs the Contact_Updated instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'contact_updated',
+			'title'       => 'Contact Updated',
+			'description' => 'Triggered when a CRM contact is updated',
+			'category'    => 'contact',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_contact_update',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
@@ -42,6 +42,7 @@ class Contact_Updated extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_contact_update',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Contact_Updated extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'contact', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $contact_data The contact data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $contact_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $contact_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
@@ -15,49 +15,71 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  * Adds the Contact_Updated class.
  */
 class Contact_Updated extends Base_Trigger {
-	/**
-	 * @var array The contact object before update.
-	 */
-	private $contact_before_update = array();
 
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Contact_Updated instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'contact_updated';
-		self::$title       = __( 'Contact Updated', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a contact is updated', 'zero-bs-crm' );
-		self::$category    = 'contact';
+	public static function get_slug(): string {
+		return 'jpcrm/contact_updated';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Contact Updated', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a CRM contact is updated', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'contact', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
+		$this->listen_to_event();
+	}
+
+	/**
+	 * Execute the workflow.
+	 *
+	 * @param array $contact_data The contact data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $contact_data = null ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $contact_data );
+		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
 		add_action(
 			'jpcrm_automation_contact_update',
 			array( $this, 'execute_workflow' )
 		);
 	}
 
-	/**
-	 * Execute the workflow. Listen to the desired event
-	 *
-	 * @param array $contact_data The contact data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $contact_data ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $contact_data );
-		}
-	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-updated.php
@@ -21,21 +21,22 @@ class Contact_Updated extends Base_Trigger {
 	private $contact_before_update = array();
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Contact_Updated instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'contact_updated',
-			'title'       => 'Contact Updated',
-			'description' => 'Triggered when a CRM contact is updated',
-			'category'    => 'contact',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'contact_updated';
+		self::$title       = __( 'Contact Updated', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a contact is updated', 'zero-bs-crm' );
+		self::$category    = 'contact';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -43,11 +44,19 @@ class Contact_Updated extends Base_Trigger {
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
 			'jpcrm_automation_contact_update',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $contact_data The contact data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $contact_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $contact_data );
+		}
 	}
 }

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
@@ -35,21 +35,25 @@ class Contact_Trigger_Test extends BaseTestCase {
 
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_updated' );
 
-		// Build a PHPUnit mock Contact_Updated trigger.
-		$trigger = $this->getMockBuilder( Contact_Updated::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Contact_Updated();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Contact_Updated trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$contact_data = $this->automation_faker->contact_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the contact data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on contact_update event with the contact data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $contact_data )
 		);
 
@@ -64,21 +68,25 @@ class Contact_Trigger_Test extends BaseTestCase {
 
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_status_updated' );
 
-		// Build a PHPUnit mock Contact_Status_Updated trigger.
-		$trigger = $this->getMockBuilder( Contact_Status_Updated::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Contact_Status_Updated();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Contact_Status_Updated trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$contact_data = $this->automation_faker->contact_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the contact data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on contact_status_update event with the contact data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $contact_data )
 		);
 
@@ -93,21 +101,25 @@ class Contact_Trigger_Test extends BaseTestCase {
 
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_new' );
 
-		// Build a PHPUnit mock Contact_New trigger.
-		$trigger = $this->getMockBuilder( Contact_New::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Contact_New();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Contact_New trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$contact_data = $this->automation_faker->contact_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the contact data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on contact_new event with the contact data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $contact_data )
 		);
 
@@ -122,25 +134,29 @@ class Contact_Trigger_Test extends BaseTestCase {
 
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_email_updated' );
 
-		// Build a PHPUnit mock Contact_New trigger.
-		$trigger = $this->getMockBuilder( Contact_Email_Updated::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Contact_Email_Updated();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Contact_Email_Updated trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$contact_data = $this->automation_faker->contact_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the contact data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on contact_email_update event with the contact data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $contact_data )
 		);
 
-		// Run the contact_email_updated action.
+		// Run the contact_email_update action.
 		do_action( 'jpcrm_automation_contact_email_update', $contact_data );
 	}
 
@@ -151,21 +167,25 @@ class Contact_Trigger_Test extends BaseTestCase {
 
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_deleted' );
 
-		// Build a PHPUnit mock Contact_Deleted trigger.
-		$trigger = $this->getMockBuilder( Contact_Deleted::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Contact_Deleted();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Contact_Deleted trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$contact_data = $this->automation_faker->contact_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the contact data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on contact_deleted event with the contact data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $contact_data )
 		);
 
@@ -178,23 +198,27 @@ class Contact_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_contact_before_deleted_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_before_delete' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_before_deleted' );
 
-		// Build a PHPUnit mock Contact_Before_Deleted trigger.
-		$trigger = $this->getMockBuilder( Contact_Before_Deleted::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Contact_Before_Deleted();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Contact_Before_Deleted trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$contact_data = $this->automation_faker->contact_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the contact data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on contact_before_deleted event with the contact data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $contact_data )
 		);
 

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
@@ -1,0 +1,205 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\CRM\Automation\Tests;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Engine;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Before_Deleted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Deleted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Email_Updated;
+use Automattic\Jetpack\CRM\Automation\Triggers\Contact_New;
+use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Status_Updated;
+use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Updated;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '../../tools/class-automation-faker.php';
+
+/**
+ * Test Automation Workflow functionalities
+ *
+ * @covers Automattic\Jetpack\CRM\Automation
+ */
+class Contact_Trigger_Test extends BaseTestCase {
+
+	private $automation_faker;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->automation_faker = Automation_Faker::instance();
+	}
+
+	/**
+	 * @testdox Test the contact updated trigger executes the workflow with an action
+	 */
+	public function test_contact_updated_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_updated' );
+
+		// Build a PHPUnit mock Contact_Updated trigger.
+		$trigger = $this->getMockBuilder( Contact_Updated::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$contact_data = $this->automation_faker->contact_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the contact data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $contact_data )
+		);
+
+		// Run the contact_update action.
+		do_action( 'jpcrm_automation_contact_update', $contact_data );
+	}
+
+	/**
+	 * @testdox Test the contact status updated trigger executes the workflow with an action
+	 */
+	public function test_contact_status_updated_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_status_updated' );
+
+		// Build a PHPUnit mock Contact_Status_Updated trigger.
+		$trigger = $this->getMockBuilder( Contact_Status_Updated::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$contact_data = $this->automation_faker->contact_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the contact data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $contact_data )
+		);
+
+		// Run the contact_status_update action.
+		do_action( 'jpcrm_automation_contact_status_update', $contact_data );
+	}
+
+	/**
+	 * @testdox Test the contact new trigger executes the workflow with an action
+	 */
+	public function test_contact_new_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_new' );
+
+		// Build a PHPUnit mock Contact_New trigger.
+		$trigger = $this->getMockBuilder( Contact_New::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$contact_data = $this->automation_faker->contact_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the contact data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $contact_data )
+		);
+
+		// Run the contact_new action.
+		do_action( 'jpcrm_automation_contact_new', $contact_data );
+	}
+
+	/**
+	 * @testdox Test the contact email updated trigger executes the workflow with an action
+	 */
+	public function test_contact_email_updated_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_email_updated' );
+
+		// Build a PHPUnit mock Contact_New trigger.
+		$trigger = $this->getMockBuilder( Contact_Email_Updated::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$contact_data = $this->automation_faker->contact_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the contact data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $contact_data )
+		);
+
+		// Run the contact_email_updated action.
+		do_action( 'jpcrm_automation_contact_email_update', $contact_data );
+	}
+
+	/**
+	 * @testdox Test the contact email updated trigger executes the workflow with an action
+	 */
+	public function test_contact_deleted_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_deleted' );
+
+		// Build a PHPUnit mock Contact_Deleted trigger.
+		$trigger = $this->getMockBuilder( Contact_Deleted::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$contact_data = $this->automation_faker->contact_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the contact data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $contact_data )
+		);
+
+		// Run the contact_deleted action.
+		do_action( 'jpcrm_automation_contact_delete', $contact_data );
+	}
+
+	/**
+	 * @testdox Test the contact email updated trigger executes the workflow with an action
+	 */
+	public function test_contact_before_deleted_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_before_deleted' );
+
+		// Build a PHPUnit mock Contact_Deleted trigger.
+		$trigger = $this->getMockBuilder( Contact_Before_Deleted::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$contact_data = $this->automation_faker->contact_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the contact data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $contact_data )
+		);
+
+		// Run the contact_before_deleted action.
+		do_action( 'jpcrm_automation_contact_before_delete', $contact_data );
+	}
+
+}

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
@@ -145,7 +145,7 @@ class Contact_Trigger_Test extends BaseTestCase {
 	}
 
 	/**
-	 * @testdox Test the contact email updated trigger executes the workflow with an action
+	 * @testdox Test the contact deleted trigger executes the workflow with an action
 	 */
 	public function test_contact_deleted_trigger() {
 
@@ -174,13 +174,13 @@ class Contact_Trigger_Test extends BaseTestCase {
 	}
 
 	/**
-	 * @testdox Test the contact email updated trigger executes the workflow with an action
+	 * @testdox Test the contact before deleted trigger executes the workflow with an action
 	 */
 	public function test_contact_before_deleted_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_before_deleted' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_before_delete' );
 
-		// Build a PHPUnit mock Contact_Deleted trigger.
+		// Build a PHPUnit mock Contact_Before_Deleted trigger.
 		$trigger = $this->getMockBuilder( Contact_Before_Deleted::class )
 		->onlyMethods( array( 'execute_workflow' ) )
 		->getMock();

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
@@ -33,7 +33,7 @@ class Contact_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_contact_updated_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_updated' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/contact_updated' );
 
 		$trigger = new Contact_Updated();
 
@@ -66,7 +66,7 @@ class Contact_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_contact_status_updated_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_status_updated' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/contact_status_updated' );
 
 		$trigger = new Contact_Status_Updated();
 
@@ -99,7 +99,7 @@ class Contact_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_contact_new_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_new' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/contact_new' );
 
 		$trigger = new Contact_New();
 
@@ -132,7 +132,7 @@ class Contact_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_contact_email_updated_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_email_updated' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/contact_email_updated' );
 
 		$trigger = new Contact_Email_Updated();
 
@@ -165,7 +165,7 @@ class Contact_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_contact_deleted_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_deleted' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/contact_deleted' );
 
 		$trigger = new Contact_Deleted();
 
@@ -198,7 +198,7 @@ class Contact_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_contact_before_deleted_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'contact_before_deleted' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/contact_before_deleted' );
 
 		$trigger = new Contact_Before_Deleted();
 

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -60,25 +60,6 @@ class Automation_Faker {
 	}
 
 	/**
-	 * Return a basic workflow with a customizable trigger and without initial step
-	 *
-	 * @param string $trigger_name The name of the trigger to be included in the workflow.
-	 *
-	 * @return array
-	 */
-	public function workflow_without_initial_step_customize_trigger( $trigger_name ): array {
-		return array(
-			'name'        => 'Workflow Test',
-			'description' => 'Test: the description of the workflow',
-			'category'    => 'Test',
-			'is_active'   => true,
-			'triggers'    => array(
-				$trigger_name,
-			),
-		);
-	}
-
-	/**
 	 * Return dummy contact triggers name list
 	 * @return array
 	 */

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -60,6 +60,25 @@ class Automation_Faker {
 	}
 
 	/**
+	 * Return a basic workflow with a customizable trigger and without initial step
+	 *
+	 * @param string $trigger_name The name of the trigger to be included in the workflow.
+	 *
+	 * @return array
+	 */
+	public function workflow_without_initial_step_customize_trigger( $trigger_name ): array {
+		return array(
+			'name'        => 'Workflow Test',
+			'description' => 'Test: the description of the workflow',
+			'category'    => 'Test',
+			'is_active'   => true,
+			'triggers'    => array(
+				$trigger_name,
+			),
+		);
+	}
+
+	/**
 	 * Return dummy contact triggers name list
 	 * @return array
 	 */

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -33,12 +33,12 @@ class Automation_Faker {
 				'jpcrm/contact_created',
 			),
 			'initial_step' => array(
-				'slug'        => 'send_email_action',
-				'attributes'  => array(
+				'slug'       => 'send_email_action',
+				'attributes' => array(
 					'to'       => 'admin@example.com',
 					'template' => 'send_welcome_email',
 				),
-				'next_step'   => null,
+				'next_step'  => null,
 			),
 		);
 	}
@@ -116,9 +116,9 @@ class Automation_Faker {
 				'jpcrm/contact_created',
 			),
 			'initial_step' => array(
-				'slug'         => 'contact_status_condition',
-				'class_name'   => Contact_Condition::class,
-				'attributes'   => array(
+				'slug'            => 'contact_status_condition',
+				'class_name'      => Contact_Condition::class,
+				'attributes'      => array(
 					'field'    => 'status',
 					'operator' => 'is',
 					'value'    => 'lead',


### PR DESCRIPTION
## Proposed changes:

* This PR adds Automation Contact triggers. The files with triggers will likely need changes as we better understand what data is being passed in and out, but currently all triggers take contact objects (with modified data depending on what was passed into the object, such as in this example: https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php#L3007)
* This PR also includes tests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3097


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).
* To test the objects that would be passed to the actions within each trigger, you can add an `error_log` within the relevant hook such as `zeroBSCRM_IA_EditCustomerWPHook` (within each case), such as `error_log('Firing the contact update: ' . json_encode( $obj ) );`. 
* You can then test updating (status / email / any contact field) / deleting / adding a new contact, and then make sure the $obj from the error log you are expecting is fired.