### PR TITLE
AI Assistant: Update tracks event name for chat completion

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-tracks-event-name
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-tracks-event-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Updates tracks event name for AI Assistant block

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -175,7 +175,7 @@ const useSuggestionsFromOpenAI = ( {
 			} );
 		}
 
-		tracks.recordEvent( 'jetpack_ai_gpt3_completion', {
+		tracks.recordEvent( 'jetpack_ai_chat_completion', {
 			post_id: postId,
 		} );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-paragraph/edit.js
@@ -199,7 +199,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			content: createPrompt( currentPostTitle, contentBefore, categoryNames, tagNames ),
 		};
 
-		tracks.recordEvent( 'jetpack_ai_gpt3_completion', {
+		tracks.recordEvent( 'jetpack_ai_chat_completion', {
 			post_id: postId,
 		} );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

To match this naming to the actual backend usage we better use the term `chat` instead of a model name.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the event name from `jetpack_ai_gpt3_completion` to `jetpack_ai_chat_completion`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1684505019279379/1684503998.509919-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Confirm the change makes sense