### PR TITLE
CRM: Adding Automation company triggers

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-automation-triggers-companies
+++ b/projects/plugins/crm/changelog/add-crm-automation-triggers-companies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Automations: Added company triggers

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
@@ -2167,6 +2167,8 @@ class zbsDAL_companies extends zbsDAL_ObjectLayer {
                 #} Check if obj exists (here) - for now just brutal update (will error when doesn't exist)
                 $originalStatus = $this->getCompanyStatus($id);
 
+				$previous_company_obj = $this->getCompany( $id );
+
                 // log any change of status
                 if (isset($dataArr['zbsco_status']) && !empty($dataArr['zbsco_status']) && !empty($originalStatus) && $dataArr['zbsco_status'] != $originalStatus){
 
@@ -2394,7 +2396,8 @@ class zbsDAL_companies extends zbsDAL_ObjectLayer {
                                 zeroBSCRM_FireInternalAutomator('company.update',array(
                                     'id'=>$id,
                                     'againstid' => $id,
-                                    'data'=> $dataArr
+									'data'         => $dataArr, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+									'prev_company' => $previous_company_obj,
                                     ));
 
                                 

--- a/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
@@ -61,6 +61,8 @@
 	zeroBSCRM_AddInternalAutomatorRecipe('contact.delete','zeroBSCRM_IA_DeleteCustomerWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('company.new','zeroBSCRM_IA_NewCompanyWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('company.delete','zeroBSCRM_IA_DeleteCompanyWPHook',array());
+	zeroBSCRM_AddInternalAutomatorRecipe( 'company.update', 'zeroBSCRM_IA_EditCompanyWPHook', array() );
+	zeroBSCRM_AddInternalAutomatorRecipe( 'company.status.update', 'zeroBSCRM_IA_EditCompanyWPHook', array() );
 	zeroBSCRM_AddInternalAutomatorRecipe('quote.new','zeroBSCRM_IA_NewQuoteWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('quote.accepted','zeroBSCRM_IA_AcceptedQuoteWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('quote.delete','zeroBSCRM_IA_DeleteQuoteWPHook',array());
@@ -1377,18 +1379,53 @@ function zeroBSCRM_IA_DeleteCustomerWPHook( $obj = array() ) {
 
 	}
 
-   	#} Fires on 'company.new' IA 
-	function zeroBSCRM_IA_NewCompanyWPHook($obj=array()){
+/**
+ * Fires on 'company.update' and 'company.status.update IA.
+ *
+ * @param array $obj An array holding company object data.
+ */
+function zeroBSCRM_IA_EditCompanyWPHook( $obj = array() ) {
 
-		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) do_action('zbs_new_company', $obj['id']);
+	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
+
+		do_action( 'jpcrm_automation_company_update', $obj );
+
+		// If the company status has changed.
+		if ( isset( $obj['from'] ) && ! empty( $obj['from'] ) ) {
+			do_action( 'jpcrm_automation_company_status_update', $obj );
+		}
+	}
+}
+
+/**
+ * Fires on 'company.new' IA.
+ *
+ * @param array $obj An array holding company object data.
+ */
+function zeroBSCRM_IA_NewCompanyWPHook( $obj = array() ) {
+
+	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
+
+		do_action( 'jpcrm_automation_company_new', $obj );
+		// Legacy:
+		do_action( 'zbs_new_company', $obj['id'] );
 
 	}
-   	#} Fires on 'company.delete' IA 
-	function zeroBSCRM_IA_DeleteCompanyWPHook($obj=array()){
+}
 
-		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) do_action('zbs_delete_company', $obj['id']);
+/**
+ * Fires on 'company.delete' IA.
+ *
+ * @param array $obj An array holding company object data.
+ */
+function zeroBSCRM_IA_DeleteCompanyWPHook( $obj = array() ) {
 
+	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
+		do_action( 'jpcrm_automation_company_delete', $obj );
+		// Legacy:
+		do_action( 'zbs_delete_company', $obj['id'] );
 	}
+}
    	#} Fires on 'quote.new' IA 
 	function zeroBSCRM_IA_NewQuoteWPHook($obj=array()){
 

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
@@ -17,21 +17,22 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 class Company_Deleted extends Base_Trigger {
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Company_Delete instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'company_delete',
-			'title'       => 'Company Deleted',
-			'description' => 'Triggered when a CRM company is deleted',
-			'category'    => 'company',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'company_delete';
+		self::$title       = __( 'Company Deleted', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a CRM company is deleted', 'zero-bs-crm' );
+		self::$category    = 'company';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -39,11 +40,19 @@ class Company_Deleted extends Base_Trigger {
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
 			'jpcrm_automation_company_delete',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $company_data The company data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $company_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $company_data );
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack CRM Automation Company_Deleted trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Company_Deleted class.
+ */
+class Company_Deleted extends Base_Trigger {
+
+	/**
+	 * Contructs the Company_Delete instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'company_delete',
+			'title'       => 'Company Deleted',
+			'description' => 'Triggered when a CRM company is deleted',
+			'category'    => 'company',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_company_delete',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
@@ -50,7 +50,7 @@ class Company_Deleted extends Base_Trigger {
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -61,7 +61,7 @@ class Company_Deleted extends Base_Trigger {
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $company_data The company data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
@@ -38,6 +38,7 @@ class Company_Deleted extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_company_delete',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Company_Deleted extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'company', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $company_data The company data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $company_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $company_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
@@ -19,16 +19,34 @@ class Company_Deleted extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Company_Delete instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'company_delete';
-		self::$title       = __( 'Company Deleted', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a CRM company is deleted', 'zero-bs-crm' );
-		self::$category    = 'company';
+	public static function get_slug(): string {
+		return 'jpcrm/company_delete';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Company Deleted', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a CRM company is deleted', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'company', 'zero-bs-crm' );
 	}
 
 	/**
@@ -39,10 +57,7 @@ class Company_Deleted extends Base_Trigger {
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_company_delete',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
@@ -51,9 +66,19 @@ class Company_Deleted extends Base_Trigger {
 	 * @param array $company_data The company data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $company_data ) {
+	public function execute_workflow( $company_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $company_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_company_delete',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-deleted.php
@@ -15,11 +15,6 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  */
 class Company_Deleted extends Base_Trigger {
 
-	/**
-	 * @var Automation_Workflow The Automation workflow object.
-	 */
-	protected $workflow;
-
 	/** Get the slug name of the trigger
 	 * @return string
 	 */

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
@@ -38,6 +38,7 @@ class Company_New extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_company_new',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack CRM Automation Company_New trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Company_New class.
+ */
+class Company_New extends Base_Trigger {
+
+	/**
+	 * Contructs the Company_New instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'company_new',
+			'title'       => 'New Company',
+			'description' => 'Triggered when a new CRM company is added',
+			'category'    => 'company',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_company_new',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
@@ -50,7 +50,7 @@ class Company_New extends Base_Trigger {
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -61,7 +61,7 @@ class Company_New extends Base_Trigger {
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $company_data The company data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
@@ -19,16 +19,34 @@ class Company_New extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Company_New instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'company_new';
-		self::$title       = __( 'New Company', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a CRM company is added', 'zero-bs-crm' );
-		self::$category    = 'company';
+	public static function get_slug(): string {
+		return 'jpcrm/company_new';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'New Company', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a CRM company is added', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'company', 'zero-bs-crm' );
 	}
 
 	/**
@@ -39,10 +57,7 @@ class Company_New extends Base_Trigger {
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_company_new',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
@@ -51,9 +66,19 @@ class Company_New extends Base_Trigger {
 	 * @param array $company_data The company data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $company_data ) {
+	public function execute_workflow( $company_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $company_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_company_new',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Company_New extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'company', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $company_data The company data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $company_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $company_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
@@ -17,21 +17,22 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 class Company_New extends Base_Trigger {
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Company_New instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'company_new',
-			'title'       => 'New Company',
-			'description' => 'Triggered when a new CRM company is added',
-			'category'    => 'company',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'company_new';
+		self::$title       = __( 'New Company', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a CRM company is added', 'zero-bs-crm' );
+		self::$category    = 'company';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -39,11 +40,19 @@ class Company_New extends Base_Trigger {
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
 			'jpcrm_automation_company_new',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $company_data The company data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $company_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $company_data );
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-new.php
@@ -15,11 +15,6 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  */
 class Company_New extends Base_Trigger {
 
-	/**
-	 * @var Automation_Workflow The Automation workflow object.
-	 */
-	protected $workflow;
-
 	/** Get the slug name of the trigger
 	 * @return string
 	 */

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
@@ -19,16 +19,34 @@ class Company_Status_Updated extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Company_Status_Updated instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'company_status_update';
-		self::$title       = __( 'Company Status Updated', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a new company status is updated', 'zero-bs-crm' );
-		self::$category    = 'company';
+	public static function get_slug(): string {
+		return 'jpcrm/company_status_update';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Company Status Updated', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a new company status is updated', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'company', 'zero-bs-crm' );
 	}
 
 	/**
@@ -39,10 +57,7 @@ class Company_Status_Updated extends Base_Trigger {
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_company_status_update',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
@@ -51,9 +66,19 @@ class Company_Status_Updated extends Base_Trigger {
 	 * @param array $company_data The company data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $company_data ) {
+	public function execute_workflow( $company_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $company_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_company_status_update',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
@@ -50,7 +50,7 @@ class Company_Status_Updated extends Base_Trigger {
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -61,7 +61,7 @@ class Company_Status_Updated extends Base_Trigger {
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $company_data The company data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Company_Status_Updated extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'company', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $company_data The company data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $company_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $company_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
@@ -17,21 +17,22 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 class Company_Status_Updated extends Base_Trigger {
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Company_Status_Updated instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'company_status_update',
-			'title'       => 'Company Status Updated',
-			'description' => 'Triggered when a new company status is updated',
-			'category'    => 'company',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'company_status_update';
+		self::$title       = __( 'Company Status Updated', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a new company status is updated', 'zero-bs-crm' );
+		self::$category    = 'company';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -39,11 +40,19 @@ class Company_Status_Updated extends Base_Trigger {
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
 			'jpcrm_automation_company_status_update',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $company_data The company data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $company_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $company_data );
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
@@ -38,6 +38,7 @@ class Company_Status_Updated extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_company_status_update',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack CRM Automation Company_Status_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Company_Status_Updated class.
+ */
+class Company_Status_Updated extends Base_Trigger {
+
+	/**
+	 * Contructs the Company_Status_Updated instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'company_status_update',
+			'title'       => 'Company Status Updated',
+			'description' => 'Triggered when a new company status is updated',
+			'category'    => 'company',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_company_status_update',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
@@ -15,11 +15,6 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  */
 class Company_Status_Updated extends Base_Trigger {
 
-	/**
-	 * @var Automation_Workflow The Automation workflow object.
-	 */
-	protected $workflow;
-
 	/** Get the slug name of the trigger
 	 * @return string
 	 */

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-status-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
@@ -38,6 +38,7 @@ class Company_Updated extends Base_Trigger {
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
 		add_action(
 			'jpcrm_automation_company_update',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
@@ -19,16 +19,34 @@ class Company_Updated extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Company_Update instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'company_updated';
-		self::$title       = __( 'Company Updated', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a CRM company is updated', 'zero-bs-crm' );
-		self::$category    = 'company';
+	public static function get_slug(): string {
+		return 'jpcrm/company_updated';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Company Updated', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a CRM company is updated', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'company', 'zero-bs-crm' );
 	}
 
 	/**
@@ -39,10 +57,7 @@ class Company_Updated extends Base_Trigger {
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_company_update',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
@@ -51,9 +66,19 @@ class Company_Updated extends Base_Trigger {
 	 * @param array $company_data The company data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $company_data ) {
+	public function execute_workflow( $company_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $company_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_company_update',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
@@ -50,7 +50,7 @@ class Company_Updated extends Base_Trigger {
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -61,7 +61,7 @@ class Company_Updated extends Base_Trigger {
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $company_data The company data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Company_Updated extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'company', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $company_data The company data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $company_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $company_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
@@ -17,21 +17,22 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 class Company_Updated extends Base_Trigger {
 
 	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
 	 * Contructs the Company_Update instance.
 	 */
 	public function __construct() {
-		$trigger_data = array(
-			'name'        => 'company_updated',
-			'title'       => 'Company Updated',
-			'description' => 'Triggered when a CRM company is updated',
-			'category'    => 'company',
-		);
-
-		parent::__construct( $trigger_data );
+		self::$name        = 'company_updated';
+		self::$title       = __( 'Company Updated', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a CRM company is updated', 'zero-bs-crm' );
+		self::$category    = 'company';
 	}
 
 	/**
-	 * Init the trigger. Listen to the desired event
+	 * Init the trigger.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
@@ -39,11 +40,19 @@ class Company_Updated extends Base_Trigger {
 	public function init( Automation_Workflow $workflow ) {
 		add_action(
 			'jpcrm_automation_company_update',
-			function ( $contact_data ) use ( $workflow ) {
-				$workflow->execute( $this, $contact_data );
-			},
-			10,
-			2
+			array( $this, 'execute_workflow' )
 		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $company_data The company data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $company_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $company_data );
+		}
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Jetpack CRM Automation Company_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Company_Updated class.
+ */
+class Company_Updated extends Base_Trigger {
+
+	/**
+	 * Contructs the Company_Update instance.
+	 */
+	public function __construct() {
+		$trigger_data = array(
+			'name'        => 'company_updated',
+			'title'       => 'Company Updated',
+			'description' => 'Triggered when a CRM company is updated',
+			'category'    => 'company',
+		);
+
+		parent::__construct( $trigger_data );
+	}
+
+	/**
+	 * Init the trigger. Listen to the desired event
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		add_action(
+			'jpcrm_automation_company_update',
+			function ( $contact_data ) use ( $workflow ) {
+				$workflow->execute( $this, $contact_data );
+			},
+			10,
+			2
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
@@ -15,11 +15,6 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  */
 class Company_Updated extends Base_Trigger {
 
-	/**
-	 * @var Automation_Workflow The Automation workflow object.
-	 */
-	protected $workflow;
-
 	/** Get the slug name of the trigger
 	 * @return string
 	 */

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**

--- a/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
@@ -1,0 +1,145 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\CRM\Automation\Tests;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Engine;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Triggers\Company_Deleted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Company_New;
+use Automattic\Jetpack\CRM\Automation\Triggers\Company_Status_Updated;
+use Automattic\Jetpack\CRM\Automation\Triggers\Company_Updated;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '../../tools/class-automation-faker.php';
+
+/**
+ * Test Automation Workflow functionalities
+ *
+ * @covers Automattic\Jetpack\CRM\Automation
+ */
+class Company_Trigger_Test extends BaseTestCase {
+
+	private $automation_faker;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->automation_faker = Automation_Faker::instance();
+	}
+
+	/**
+	 * @testdox Test the company updated trigger executes the workflow with an action
+	 */
+	public function test_company_updated_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_updated' );
+
+		// Build a PHPUnit mock Company_Updated trigger.
+		$trigger = $this->getMockBuilder( Company_Updated::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$company_data = $this->automation_faker->company_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the company data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $company_data )
+		);
+
+		// Run the company_update action.
+		do_action( 'jpcrm_automation_company_update', $company_data );
+	}
+
+	/**
+	 * @testdox Test the company status updated trigger executes the workflow with an action
+	 */
+	public function test_company_status_updated_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_status_updated' );
+
+		// Build a PHPUnit mock Company_Status_Updated trigger.
+		$trigger = $this->getMockBuilder( Company_Status_Updated::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$company_data = $this->automation_faker->company_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the company data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $company_data )
+		);
+
+		// Run the company_status_update action.
+		do_action( 'jpcrm_automation_company_status_update', $company_data );
+	}
+
+	/**
+	 * @testdox Test the company new trigger executes the workflow with an action
+	 */
+	public function test_company_new_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_new' );
+
+		// Build a PHPUnit mock Company_New trigger.
+		$trigger = $this->getMockBuilder( Company_New::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$company_data = $this->automation_faker->company_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the company data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $company_data )
+		);
+
+		// Run the company_new action.
+		do_action( 'jpcrm_automation_company_new', $company_data );
+	}
+
+	/**
+	 * @testdox Test the company deleted trigger executes the workflow with an action
+	 */
+	public function test_company_deleted_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_delete' );
+
+		// Build a PHPUnit mock Company_Deleted trigger.
+		$trigger = $this->getMockBuilder( Company_Deleted::class )
+		->onlyMethods( array( 'execute_workflow' ) )
+		->getMock();
+
+		// Init the mocked trigger.
+		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+
+		// Fake event data.
+		$company_data = $this->automation_faker->company_data();
+
+		// We expect the trigger to be executed on execute_workflow event with the company data.
+		$trigger->expects( $this->once() )
+		->method( 'execute_workflow' )
+		->with(
+			$this->equalTo( $company_data )
+		);
+
+		// Run the company_delete action.
+		do_action( 'jpcrm_automation_company_delete', $company_data );
+	}
+
+}

--- a/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
@@ -31,7 +31,7 @@ class Company_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_company_updated_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_updated' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/company_updated' );
 
 		$trigger = new Company_Updated();
 
@@ -64,7 +64,7 @@ class Company_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_company_status_updated_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_status_updated' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/company_status_updated' );
 
 		$trigger = new Company_Status_Updated();
 
@@ -97,7 +97,7 @@ class Company_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_company_new_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_new' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/company_new' );
 
 		$trigger = new Company_New();
 
@@ -130,7 +130,7 @@ class Company_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_company_deleted_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_deleted' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/company_deleted' );
 
 		$trigger = new Company_Deleted();
 

--- a/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
@@ -33,21 +33,25 @@ class Company_Trigger_Test extends BaseTestCase {
 
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_updated' );
 
-		// Build a PHPUnit mock Company_Updated trigger.
-		$trigger = $this->getMockBuilder( Company_Updated::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Company_Updated();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Company_Updated trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$company_data = $this->automation_faker->company_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the company data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on company_update event with the company data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $company_data )
 		);
 
@@ -62,21 +66,25 @@ class Company_Trigger_Test extends BaseTestCase {
 
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_status_updated' );
 
-		// Build a PHPUnit mock Company_Status_Updated trigger.
-		$trigger = $this->getMockBuilder( Company_Status_Updated::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Company_Status_Updated();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Company_Status_Updated trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$company_data = $this->automation_faker->company_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the company data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on company_status_update event with the company data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $company_data )
 		);
 
@@ -91,21 +99,25 @@ class Company_Trigger_Test extends BaseTestCase {
 
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_new' );
 
-		// Build a PHPUnit mock Company_New trigger.
-		$trigger = $this->getMockBuilder( Company_New::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Company_New();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Company_New trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$company_data = $this->automation_faker->company_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the company data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on company_new event with the company data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $company_data )
 		);
 
@@ -118,27 +130,31 @@ class Company_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_company_deleted_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_delete' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'company_deleted' );
 
-		// Build a PHPUnit mock Company_Deleted trigger.
-		$trigger = $this->getMockBuilder( Company_Deleted::class )
-		->onlyMethods( array( 'execute_workflow' ) )
-		->getMock();
+		$trigger = new Company_Deleted();
 
-		// Init the mocked trigger.
-		$trigger->init( new Automation_Workflow( $workflow_data, new Automation_Engine() ) );
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Company_Deleted trigger.
+		$trigger->init( $workflow );
 
 		// Fake event data.
 		$company_data = $this->automation_faker->company_data();
 
-		// We expect the trigger to be executed on execute_workflow event with the company data.
-		$trigger->expects( $this->once() )
-		->method( 'execute_workflow' )
+		// We expect the workflow to be executed on company_deleted event with the company data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
 		->with(
+			$this->equalTo( $trigger ),
 			$this->equalTo( $company_data )
 		);
 
-		// Run the company_delete action.
+		// Run the company_deleted action.
 		do_action( 'jpcrm_automation_company_delete', $company_data );
 	}
 

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -207,6 +207,19 @@ class Automation_Faker {
 	}
 
 	/**
+	 * Return data for a dummy company
+	 * @return array
+	 */
+	public function company_data() {
+		return array(
+			'id'     => 1,
+			'name'   => 'Dummy Company',
+			'email'  => 'johndoe@dummycompany.com',
+			'status' => 'lead',
+		);
+	}
+
+	/**
 	 * Return a empty workflow, without triggers and initial step
 	 * @return array
 	 */


### PR DESCRIPTION
## Proposed changes:

* This PR adds Automation Company triggers. The files with triggers will likely need changes as we better understand what data is being passed in and out, but currently all triggers take company objects (with modified data depending on what was passed into the object, such as in this example: https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php#L2398)
* This PR also includes tests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3098

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).
* To test the objects that would be passed to the actions within each trigger, you can add an `error_log` within the relevant hook such as `zeroBSCRM_IA_EditCompanyWPHook` (within each case), such as `error_log('Firing the company update: ' . json_encode( $obj ) );`.
* You can then test updating / deleting / adding a new company, and then make sure the $obj from the error log you are expecting is fired in the tests that call the `do_action` hook.