### PR TITLE
AI Assistant: Introduce SuggestionsEventSource

### DIFF
--- a/projects/plugins/jetpack/changelog/add-eventsource-abstraction-ai-assistant
+++ b/projects/plugins/jetpack/changelog/add-eventsource-abstraction-ai-assistant
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: not needed. refactor
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -150,7 +150,6 @@ export class SuggestionsEventSource extends EventSource {
 		const chunk = data.choices[ 0 ].delta.content;
 		if ( chunk ) {
 			this.fullMessage += chunk;
-			debug( this.fullMessage );
 
 			if ( this.fullMessage.startsWith( '__JETPACK_AI_ERROR__' ) ) {
 				// The error is confirmed

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -14,7 +14,6 @@ const JWT_TOKEN_EXPIRATION_TIME = 2 * 60 * 1000;
  * @returns {string} The event source
  */
 export async function askJetpack( question ) {
-	let fullMessage;
 	let source;
 	try {
 		source = await askQuestion( question );
@@ -26,19 +25,8 @@ export async function askJetpack( question ) {
 		debug( 'Error', err );
 	} );
 
-	source.addEventListener( 'message', e => {
-		if ( e.data === '[DONE]' ) {
-			source.close();
-			debug( 'Done. Full message: ' + fullMessage );
-			return;
-		}
-
-		const data = JSON.parse( e.data );
-		const chunk = data.choices[ 0 ].delta.content;
-		if ( chunk ) {
-			fullMessage += chunk;
-			debug( chunk );
-		}
+	source.addEventListener( 'suggestion', e => {
+		debug( 'fullMessage', e );
 	} );
 	return source;
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -207,16 +207,14 @@ const useSuggestionsFromOpenAI = ( {
 			source.close();
 			setIsLoadingCompletion( false );
 			setAttributes( { content: e.detail } );
-			return;
 		} );
 		source.addEventListener( 'error_unclear_prompt', () => {
 			source.close();
 			setIsLoadingCompletion( false );
 			setErrorMessage( __( 'Your request was unclear. Mind trying again?', 'jetpack' ) );
-			return;
 		} );
 		source.addEventListener( 'suggestion', e => {
-			debug( 'fullMessage', e );
+			debug( 'fullMessage', e.detail );
 			setAttributes( { content: e.detail } );
 		} );
 		return source;


### PR DESCRIPTION
Introduces SuggestionsEventSource so we don't have to do all the heavy lifting multiple times when trying to consume the streaming endpoint

Fires these events

All events have a `.detail` property to be consumed

* `suggestion` Fired with every chunk received. Carries the full content received so far in `.detail`
* `done` when the stream finished writing. Carries the full content in `.detail`
* `error_unclear_prompt` when we couldn't process the prompt'

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds SuggestionsEventSource interface
* Refactors AskJetpack and askQUestion to use this

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Checkout this branch
* Add an AI assistant block. run a query
* Expect it to work the same as before
* Add a weird query like "asdfasdf"
* Expect the error handling notice to work
