### PR TITLE
Jetpack AI: Add new card in Jetpack Dashboard

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/ai.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/ai.jsx
@@ -1,10 +1,8 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import Button from 'components/button';
 import DashItem from 'components/dash-item';
 import JetpackBanner from 'components/jetpack-banner';
-import { getJetpackProductUpsellByFeature, FEATURE_VIDEOPRESS } from 'lib/plans/constants';
+import { getJetpackProductUpsellByFeature, FEATURE_AI_ASSISTANT } from 'lib/plans/constants';
 import { noop } from 'lodash';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import PropTypes from 'prop-types';
@@ -38,10 +36,10 @@ class DashJetpackAi extends Component {
 
 		const support = {
 			text: __(
-				'Engage your visitors with high-resolution, ad-free video. Save time by uploading videos directly through the WordPress editor. With Jetpack VideoPress, you can customize your video player to deliver your message without the distraction.',
+				'Your AI-Powered assistant helps you with smart text generation, dynamic image creation, content translation and more. Seamlessly integrated with WordPress.',
 				'jetpack'
 			),
-			link: getRedirectUrl( 'jetpack-support-ai' ),
+			link: getRedirectUrl( 'jetpack' ), // TODO: Add jetpack ai support link
 		};
 
 		const {
@@ -80,7 +78,7 @@ class DashJetpackAi extends Component {
 							<div className="dops-card jp-dash-item__card">
 								<p className="jp-dash-item__description">
 									{ __(
-										'VideoPress is enabled and will optimize your videos for smooth playback on any device. To add a new video, upload it to the Media Library or Post Editor.',
+										'Jetpack AI is enabled and will empower your content creation with smart text generation, dynamic image creation and more. Check it in your Post Editor.',
 										'jetpack'
 									) }
 								</p>
@@ -91,11 +89,11 @@ class DashJetpackAi extends Component {
 									callToAction={ _x( 'Upgrade', 'Call to action to buy a new plan', 'jetpack' ) }
 									title={ bannerText }
 									disableHref="false"
-									eventFeature="videopress"
+									eventFeature="ai"
 									noIcon
 									path={ 'dashboard' }
-									plan={ getJetpackProductUpsellByFeature( FEATURE_VIDEOPRESS ) }
-									feature="jetpack_videopress"
+									plan={ getJetpackProductUpsellByFeature( FEATURE_AI_ASSISTANT ) }
+									feature="ai"
 									href={ upgradeUrl }
 									trackBannerDisplay={ this.props.trackUpgradeButtonView }
 								/>
@@ -119,15 +117,14 @@ class DashJetpackAi extends Component {
 						<JetpackBanner
 							callToAction={ __( 'Connect', 'jetpack' ) }
 							title={ __(
-								'Connect your WordPress.com account to enable high-quality, ad-free video.',
+								'Connect your WordPress.com account to enable AI-Powered WordPress Assistant.',
 								'jetpack'
 							) }
 							disableHref="false"
 							onClick={ this.props.connectUser }
-							eventFeature="videopress"
+							eventFeature="ai"
 							path="dashboard"
-							plan={ getJetpackProductUpsellByFeature( FEATURE_VIDEOPRESS ) }
-							icon="video"
+							plan={ getJetpackProductUpsellByFeature( FEATURE_AI_ASSISTANT ) }
 						/>
 					)
 				}
@@ -135,14 +132,9 @@ class DashJetpackAi extends Component {
 				<p className="jp-dash-item__description">
 					{ isOffline
 						? __( 'Unavailable in Offline Mode', 'jetpack' )
-						: createInterpolateElement(
-								__(
-									'<Button>Activate</Button> to engage your visitors with high-resolution, ad-free video. Save time by uploading videos directly through the WordPress editor. Try it for free.',
-									'jetpack'
-								),
-								{
-									Button: <Button className="jp-link-button" onClick={ this.activateVideoPress } />,
-								}
+						: __(
+								'Empower your content creation with your AI-Powered WordPress Assistant. Generate text, images, translate your content and more.',
+								'jetpack'
 						  ) }
 				</p>
 			</DashItem>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/ai.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/ai.jsx
@@ -1,0 +1,172 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, _x } from '@wordpress/i18n';
+import Button from 'components/button';
+import DashItem from 'components/dash-item';
+import JetpackBanner from 'components/jetpack-banner';
+import { getJetpackProductUpsellByFeature, FEATURE_VIDEOPRESS } from 'lib/plans/constants';
+import { noop } from 'lodash';
+import { getProductDescriptionUrl } from 'product-descriptions/utils';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import {
+	connectUser,
+	hasConnectedOwner as hasConnectedOwnerSelector,
+	isOfflineMode,
+} from 'state/connection';
+import { isModuleAvailable } from 'state/modules';
+import { isFetchingSitePurchases, getSitePlan, siteHasFeature } from 'state/site';
+
+class DashJetpackAi extends Component {
+	static propTypes = {
+		hasAiFeature: PropTypes.bool.isRequired,
+		hasConnectedOwner: PropTypes.bool.isRequired,
+		isOffline: PropTypes.bool.isRequired,
+		isModuleAvailable: PropTypes.bool.isRequired,
+		trackUpgradeButtonView: PropTypes.func,
+	};
+
+	static defaultProps = {
+		trackUpgradeButtonView: noop,
+	};
+
+	activateVideoPress = () => this.props.updateOptions( { videopress: true } );
+
+	getContent() {
+		const labelName = __( 'Jetpack AI', 'jetpack' );
+
+		const support = {
+			text: __(
+				'Engage your visitors with high-resolution, ad-free video. Save time by uploading videos directly through the WordPress editor. With Jetpack VideoPress, you can customize your video player to deliver your message without the distraction.',
+				'jetpack'
+			),
+			link: getRedirectUrl( 'jetpack-support-ai' ),
+		};
+
+		const {
+			hasConnectedOwner,
+			hasAiFeature,
+			isFetching,
+			isOffline,
+			upgradeUrl,
+			videoPressStorageUsed,
+		} = this.props;
+
+		const shouldDisplayBanner = hasConnectedOwner && ! hasAiFeature && ! isOffline && ! isFetching;
+
+		const bannerText =
+			! hasAiFeature && null !== videoPressStorageUsed && 0 === videoPressStorageUsed
+				? __(
+						'1 free video available. Upgrade now to unlock more videos and 1TB of storage.',
+						'jetpack'
+				  )
+				: __(
+						'You have used your free video. Upgrade now to unlock more videos and 1TB of storage.',
+						'jetpack',
+						/* dummy arg to avoid bad minification */ 0
+				  );
+
+		if ( this.props.getOptionValue( 'ai' ) && hasConnectedOwner ) {
+			return (
+				<DashItem
+					className="jp-dash-item__videopress"
+					label={ labelName }
+					module="ai"
+					support={ support }
+					status="is-working"
+					overrideContent={
+						<>
+							<div className="dops-card jp-dash-item__card">
+								<p className="jp-dash-item__description">
+									{ __(
+										'VideoPress is enabled and will optimize your videos for smooth playback on any device. To add a new video, upload it to the Media Library or Post Editor.',
+										'jetpack'
+									) }
+								</p>
+							</div>
+							{ shouldDisplayBanner && (
+								<JetpackBanner
+									className="media__videopress-upgrade"
+									callToAction={ _x( 'Upgrade', 'Call to action to buy a new plan', 'jetpack' ) }
+									title={ bannerText }
+									disableHref="false"
+									eventFeature="videopress"
+									noIcon
+									path={ 'dashboard' }
+									plan={ getJetpackProductUpsellByFeature( FEATURE_VIDEOPRESS ) }
+									feature="jetpack_videopress"
+									href={ upgradeUrl }
+									trackBannerDisplay={ this.props.trackUpgradeButtonView }
+								/>
+							) }
+						</>
+					}
+				/>
+			);
+		}
+
+		return (
+			<DashItem
+				label={ labelName }
+				module="ai"
+				support={ support }
+				className="jp-dash-item__is-inactive"
+				noToggle={ ! hasConnectedOwner }
+				overrideContent={
+					! hasConnectedOwner &&
+					! isOffline && (
+						<JetpackBanner
+							callToAction={ __( 'Connect', 'jetpack' ) }
+							title={ __(
+								'Connect your WordPress.com account to enable high-quality, ad-free video.',
+								'jetpack'
+							) }
+							disableHref="false"
+							onClick={ this.props.connectUser }
+							eventFeature="videopress"
+							path="dashboard"
+							plan={ getJetpackProductUpsellByFeature( FEATURE_VIDEOPRESS ) }
+							icon="video"
+						/>
+					)
+				}
+			>
+				<p className="jp-dash-item__description">
+					{ isOffline
+						? __( 'Unavailable in Offline Mode', 'jetpack' )
+						: createInterpolateElement(
+								__(
+									'<Button>Activate</Button> to engage your visitors with high-resolution, ad-free video. Save time by uploading videos directly through the WordPress editor. Try it for free.',
+									'jetpack'
+								),
+								{
+									Button: <Button className="jp-link-button" onClick={ this.activateVideoPress } />,
+								}
+						  ) }
+				</p>
+			</DashItem>
+		);
+	}
+
+	render() {
+		return this.props.isModuleAvailable && this.getContent();
+	}
+}
+
+export default connect(
+	state => ( {
+		hasConnectedOwner: hasConnectedOwnerSelector( state ),
+		hasAiFeature: siteHasFeature( state, 'ai-assistant' ),
+		isModuleAvailable: isModuleAvailable( state, 'ai' ),
+		isOffline: isOfflineMode( state ),
+		isFetching: isFetchingSitePurchases( state ),
+		sitePlan: getSitePlan( state ),
+		upgradeUrl: getProductDescriptionUrl( state, 'ai' ),
+	} ),
+	dispatch => ( {
+		connectUser: () => {
+			return dispatch( connectUser() );
+		},
+	} )
+)( DashJetpackAi );

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/ai.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/ai.jsx
@@ -1,5 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import DashItem from 'components/dash-item';
 import JetpackBanner from 'components/jetpack-banner';
 import { getJetpackProductUpsellByFeature, FEATURE_AI_ASSISTANT } from 'lib/plans/constants';
@@ -23,13 +23,12 @@ class DashJetpackAi extends Component {
 		isOffline: PropTypes.bool.isRequired,
 		isModuleAvailable: PropTypes.bool.isRequired,
 		trackUpgradeButtonView: PropTypes.func,
+		aiAvailableRequests: PropTypes.number,
 	};
 
 	static defaultProps = {
 		trackUpgradeButtonView: noop,
 	};
-
-	activateVideoPress = () => this.props.updateOptions( { videopress: true } );
 
 	getContent() {
 		const labelName = __( 'Jetpack AI', 'jetpack' );
@@ -48,19 +47,20 @@ class DashJetpackAi extends Component {
 			isFetching,
 			isOffline,
 			upgradeUrl,
-			videoPressStorageUsed,
+			aiAvailableRequests,
 		} = this.props;
 
 		const shouldDisplayBanner = hasConnectedOwner && ! hasAiFeature && ! isOffline && ! isFetching;
 
 		const bannerText =
-			! hasAiFeature && null !== videoPressStorageUsed && 0 === videoPressStorageUsed
-				? __(
-						'1 free video available. Upgrade now to unlock more videos and 1TB of storage.',
-						'jetpack'
+			! hasAiFeature && null !== aiAvailableRequests && aiAvailableRequests > 0
+				? sprintf(
+						/* translators: %s is the number of requests available */
+						__( '%s requests available. Upgrade now to unlock unlimited AI requests.', 'jetpack' ),
+						aiAvailableRequests
 				  )
 				: __(
-						'You have used your free video. Upgrade now to unlock more videos and 1TB of storage.',
+						'You have used your free requests. Upgrade now to unlock unlimited requests.',
 						'jetpack',
 						/* dummy arg to avoid bad minification */ 0
 				  );
@@ -68,7 +68,6 @@ class DashJetpackAi extends Component {
 		if ( this.props.getOptionValue( 'ai' ) && hasConnectedOwner ) {
 			return (
 				<DashItem
-					className="jp-dash-item__videopress"
 					label={ labelName }
 					module="ai"
 					support={ support }
@@ -85,7 +84,6 @@ class DashJetpackAi extends Component {
 							</div>
 							{ shouldDisplayBanner && (
 								<JetpackBanner
-									className="media__videopress-upgrade"
 									callToAction={ _x( 'Upgrade', 'Call to action to buy a new plan', 'jetpack' ) }
 									title={ bannerText }
 									disableHref="false"
@@ -155,6 +153,7 @@ export default connect(
 		isFetching: isFetchingSitePurchases( state ),
 		sitePlan: getSitePlan( state ),
 		upgradeUrl: getProductDescriptionUrl( state, 'ai' ),
+		aiAvailableRequests: 20, // TODO: Implement available requests logic
 	} ),
 	dispatch => ( {
 		connectUser: () => {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/ai.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/ai.jsx
@@ -152,7 +152,7 @@ export default connect(
 		isOffline: isOfflineMode( state ),
 		isFetching: isFetchingSitePurchases( state ),
 		sitePlan: getSitePlan( state ),
-		upgradeUrl: getProductDescriptionUrl( state, 'ai' ),
+		upgradeUrl: getProductDescriptionUrl( state, 'jetpack-ai' ),
 		aiAvailableRequests: 20, // TODO: Implement available requests logic
 	} ),
 	dispatch => ( {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -29,6 +29,7 @@ import {
 import { getModuleOverride } from 'state/modules';
 import { getScanStatus, isFetchingScanStatus } from 'state/scan';
 import DashActivity from './activity';
+import DashJetpackAi from './ai';
 import DashAkismet from './akismet';
 import DashBackups from './backups';
 import DashBoost from './boost';
@@ -202,6 +203,15 @@ class AtAGlance extends Component {
 							cards={ performanceCards }
 						/>
 						{ connections }
+						<Section
+							header={ <DashSectionHeader label={ __( 'Artificial Intelligence', 'jetpack' ) } /> }
+							cards={ [
+								<DashJetpackAi
+									{ ...settingsProps }
+									trackUpgradeButtonView={ this.trackUpgradeButtonView( 'ai' ) }
+								/>,
+							] }
+						/>
 					</div>
 				</ThemeProvider>
 			);

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -25,6 +25,7 @@ import {
 	userCanManagePlugins,
 	userCanViewStats,
 	userIsSubscriber,
+	showJetpackAi,
 } from 'state/initial-state';
 import { getModuleOverride } from 'state/modules';
 import { getScanStatus, isFetchingScanStatus } from 'state/scan';
@@ -202,15 +203,19 @@ class AtAGlance extends Component {
 							header={ <DashSectionHeader label={ __( 'Performance and Growth', 'jetpack' ) } /> }
 							cards={ performanceCards }
 						/>
-						<Section
-							header={ <DashSectionHeader label={ __( 'Artificial Intelligence', 'jetpack' ) } /> }
-							cards={ [
-								<DashJetpackAi
-									{ ...settingsProps }
-									trackUpgradeButtonView={ this.trackUpgradeButtonView( 'ai' ) }
-								/>,
-							] }
-						/>
+						{ this.props.showJetpackAi && (
+							<Section
+								header={
+									<DashSectionHeader label={ __( 'Artificial Intelligence', 'jetpack' ) } />
+								}
+								cards={ [
+									<DashJetpackAi
+										{ ...settingsProps }
+										trackUpgradeButtonView={ this.trackUpgradeButtonView( 'ai' ) }
+									/>,
+								] }
+							/>
+						) }
 						{ connections }
 					</div>
 				</ThemeProvider>
@@ -264,6 +269,7 @@ export default connect( state => {
 		apiRoot: getApiRootUrl( state ),
 		apiNonce: getApiNonce( state ),
 		registrationNonce: getRegistrationNonce( state ),
+		showJetpackAi: showJetpackAi( state ),
 	};
 } )( withModuleSettingsFormHelpers( AtAGlance ) );
 

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -202,7 +202,6 @@ class AtAGlance extends Component {
 							header={ <DashSectionHeader label={ __( 'Performance and Growth', 'jetpack' ) } /> }
 							cards={ performanceCards }
 						/>
-						{ connections }
 						<Section
 							header={ <DashSectionHeader label={ __( 'Artificial Intelligence', 'jetpack' ) } /> }
 							cards={ [
@@ -212,6 +211,7 @@ class AtAGlance extends Component {
 								/>,
 							] }
 						/>
+						{ connections }
 					</div>
 				</ThemeProvider>
 			);

--- a/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
@@ -70,6 +70,7 @@ import {
 	PLAN_JETPACK_SOCIAL_ADVANCED_MONTHLY,
 	PLAN_JETPACK_BOOST,
 	PLAN_JETPACK_BOOST_MONTHLY,
+	PLAN_JETPACK_AI_MONTHLY,
 } from 'lib/plans/constants';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -99,6 +100,7 @@ const PRODUCT_ICON_MAP = {
 	[ PLAN_VIP ]: 'plans/wpcom-ecommerce.svg',
 	[ PLAN_WPCOM_SEARCH ]: 'products/product-jetpack-search.svg',
 	[ PLAN_WPCOM_SEARCH_MONTHLY ]: 'products/product-jetpack-search.svg',
+	[ PLAN_JETPACK_AI_MONTHLY ]: 'plans/jetpack.svg', // TODO: Update for Jetpack AI logo
 	[ PLAN_JETPACK_BACKUP_T0_YEARLY ]: 'products/product-jetpack-backup.svg',
 	[ PLAN_JETPACK_BACKUP_T0_MONTHLY ]: 'products/product-jetpack-backup.svg',
 	[ PLAN_JETPACK_BACKUP_T1_YEARLY ]: 'products/product-jetpack-backup.svg',

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -27,6 +27,7 @@ export const PLAN_JETPACK_PERSONAL = 'jetpack_personal';
 export const PLAN_JETPACK_PREMIUM_MONTHLY = 'jetpack_premium_monthly';
 export const PLAN_JETPACK_BUSINESS_MONTHLY = 'jetpack_business_monthly';
 export const PLAN_JETPACK_PERSONAL_MONTHLY = 'jetpack_personal_monthly';
+export const PLAN_JETPACK_AI_MONTHLY = 'jetpack_ai_monthly';
 export const PLAN_JETPACK_BACKUP_T0_YEARLY = 'jetpack_backup_t0_yearly';
 export const PLAN_JETPACK_BACKUP_T0_MONTHLY = 'jetpack_backup_t0_monthly';
 export const PLAN_JETPACK_BACKUP_T1_YEARLY = 'jetpack_backup_t1_yearly';
@@ -303,6 +304,7 @@ export const FEATURE_WORDADS_JETPACK = 'wordads-jetpack';
 export const FEATURE_GOOGLE_ANALYTICS_JETPACK = 'google-analytics-jetpack';
 export const FEATURE_SEARCH_JETPACK = 'search-jetpack';
 export const FEATURE_VIDEOPRESS = 'videopress-jetpack';
+export const FEATURE_AI_ASSISTANT = 'ai-assistant';
 
 // Upsells
 export const JETPACK_FEATURE_PRODUCT_UPSELL_MAP = {
@@ -316,6 +318,7 @@ export const JETPACK_FEATURE_PRODUCT_UPSELL_MAP = {
 	[ FEATURE_GOOGLE_ANALYTICS_JETPACK ]: PLAN_JETPACK_SECURITY_T1_YEARLY,
 	[ FEATURE_SPAM_AKISMET_PLUS ]: PLAN_JETPACK_ANTI_SPAM,
 	[ FEATURE_VIDEOPRESS ]: PLAN_JETPACK_VIDEOPRESS,
+	[ FEATURE_AI_ASSISTANT ]: PLAN_JETPACK_AI_MONTHLY,
 };
 
 /**

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/constants.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/constants.js
@@ -8,6 +8,7 @@ export const PRODUCT_DESCRIPTION_PRODUCTS = {
 	JETPACK_SECURITY: 'security',
 	JETPACK_SOCIAL: 'social',
 	JETPACK_VIDEOPRESS: 'videopress',
+	JETPACK_AI: 'jetpack-ai',
 };
 
 export const productDescriptionRoutes = [
@@ -26,6 +27,7 @@ export const myJetpackRoutes = [
 	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_SEARCH }`,
 	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_SOCIAL }`,
 	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_VIDEOPRESS }`,
+	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_AI }`,
 ];
 
 export const productIllustrations = {

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -395,6 +395,16 @@ export function showMyJetpack( state ) {
 }
 
 /**
+ * Determines if shows Jetpack AI related content.
+ *
+ * @param {object} state - Global state tree
+ * @returns {boolean} True if Jetpack AI is visible, false otherwise.
+ */
+export function showJetpackAi( state ) {
+	return get( state.jetpack.initialState.siteData, 'showJetpackAi', false );
+}
+
+/**
  * Get an array of new recommendations for this site
  *
  * @param {object} state - Global state tree

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -184,6 +184,7 @@ class Jetpack_Redux_State_Helper {
 				'showRecommendations'        => Jetpack_Recommendations::is_enabled(),
 				/** This filter is documented in my-jetpack/src/class-initializer.php */
 				'showMyJetpack'              => My_Jetpack_Initializer::should_initialize(),
+				'showJetpackAi'              => Constants::is_true( 'JETPACK_AI_ENABLED' ),
 				'isMultisite'                => is_multisite(),
 				'dateFormat'                 => get_option( 'date_format' ),
 			),

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-dashboard-card
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-dashboard-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: Add card in Jetpack Dashboard


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related with #30728 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add new section and card into `At a Glance`.
* Introduce new action to check for Jetpack AI flag.
* Introduce new feature in plans constants.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spawn a new JN site.
* Activate `JETPACK_AI` and `JETPACK_BLOCKS` to experimental through `Jetpack Constants`.
* Navigate to `At a Glance` page.
* You should see `AI` section and `Jetpack AI` card.
* Interact with it, the module should enable/disable.
* If disable the block should not be available.
* If enable the block should be available.

## Demo

| Disabled | Enabled |
| --------- | -------- |
| <img width="451" alt="image" src="https://github.com/Automattic/jetpack/assets/1663717/cbd354f3-54e2-49f9-a990-478850126c70"> | <img width="439" alt="image" src="https://github.com/Automattic/jetpack/assets/1663717/84f9fca2-0e78-471f-a6be-38129169efe1"> |


