### PR TITLE
build: Short circuit Composer 304s

### DIFF
--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -100,6 +100,26 @@ runs:
         node-version: ^${{ steps.versions.outputs.node-version }}
         cache: pnpm
 
+    - name: Configure composer 304-short-circuiting proxy
+      if: steps.versions.outputs.php-version != 'false' && steps.versions.outputs.node-version != 'false'
+      shell: bash
+      run: |
+        # Generate a self-signeed cert for the proxy
+        openssl req -new -newkey rsa:2048 -sha256 -days 1 -nodes -x509 -subj "/CN=localhost" -keyout "$HOME/cert.key" -out "$HOME/cert.crt"
+
+        # Start the proxy
+        nohup "$GITHUB_ACTION_PATH"/packagist-proxy.mjs "$HOME/cert.key" "$HOME/cert.crt" &> /dev/null &
+        disown $!
+
+        # Configure the plugin via env
+        export JP_304_PLUGIN_CERT=$HOME/cert.crt
+        echo "JP_304_PLUGIN_CERT=$JP_304_PLUGIN_CERT" >> "$GITHUB_ENV"
+
+        # Install the plugin globally
+        composer global config repositories.304-proxy-package path "$GITHUB_ACTION_PATH/composer-plugin"
+        composer global config --no-interaction allow-plugins.automattic/composer-304-plugin true
+        composer global require automattic/composer-304-plugin=@dev
+
     - name: Tool versions
       shell: bash
       run: |

--- a/.github/actions/tool-setup/composer-plugin/composer.json
+++ b/.github/actions/tool-setup/composer-plugin/composer.json
@@ -1,0 +1,18 @@
+{
+	"name": "automattic/composer-304-plugin",
+	"description": "A Composer plugin to avoid network traffic for expected 304s.",
+	"type": "composer-plugin",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"composer-plugin-api": "^2.0"
+	},
+	"autoload": {
+		"psr-4": {
+			"Automattic\\Jetpack\\Composer304Plugin\\": "src/"
+		}
+	},
+	"extra": {
+		"class": "Automattic\\Jetpack\\Composer304Plugin\\Plugin",
+		"plugin-modifies-downloads": true
+	}
+}

--- a/.github/actions/tool-setup/composer-plugin/src/Plugin.php
+++ b/.github/actions/tool-setup/composer-plugin/src/Plugin.php
@@ -1,0 +1,107 @@
+<?php // phpcs:ignore WordPress.Files.FileName
+
+/**
+ * Composer 304-short-circuiting plugin.
+ *
+ * This simple composer plugin redirects repo.packagist.org metadata URLs
+ * to a proxy that will respond with a 304 response when it has already seen
+ * the URL.
+ */
+
+namespace Automattic\Jetpack\Composer304Plugin;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginEvents;
+use Composer\Plugin\PluginInterface;
+use Composer\Plugin\PreFileDownloadEvent;
+
+/**
+ * Composer plugin.
+ */
+class Plugin implements PluginInterface, EventSubscriberInterface {
+
+	/**
+	 * Composer IOInterface
+	 *
+	 * @var IOInterface
+	 */
+	private $io;
+
+	/**
+	 * Cert file path.
+	 *
+	 * @var string
+	 */
+	private $certfile;
+
+	/**
+	 * Apply plugin modifications to Composer
+	 *
+	 * @param Composer    $composer Composer.
+	 * @param IOInterface $io IOInterface.
+	 */
+	public function activate( Composer $composer, IOInterface $io ) {
+		$this->io       = $io;
+		$this->certfile = getenv( 'JP_304_PLUGIN_CERT' );
+	}
+
+	/**
+	 * Remove any hooks from Composer
+	 *
+	 * @param Composer    $composer Composer.
+	 * @param IOInterface $io IOInterface.
+	 */
+	public function deactivate( Composer $composer, IOInterface $io ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	}
+
+	/**
+	 * Prepare the plugin to be uninstalled
+	 *
+	 * This will be called after deactivate.
+	 *
+	 * @param Composer    $composer Composer.
+	 * @param IOInterface $io IOInterface.
+	 */
+	public function uninstall( Composer $composer, IOInterface $io ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	}
+
+	/**
+	 * Tell composer to listen for events and do something with them.
+	 *
+	 * @return array List of subscribed events.
+	 */
+	public static function getSubscribedEvents() {
+		return array(
+			PluginEvents::PRE_FILE_DOWNLOAD => 'onPreFileDownload',
+		);
+	}
+
+	/**
+	 * Pre-file-download event handler.
+	 *
+	 * Detects a metadata request and redirects the URL.
+	 *
+	 * @param PreFileDownloadEvent $event Event.
+	 */
+	public function onPreFileDownload( PreFileDownloadEvent $event ) {
+		if ( $event->getType() !== 'metadata' ) {
+			return;
+		}
+
+		$url = $event->getProcessedUrl();
+		if ( substr( $url, 0, 27 ) === 'https://repo.packagist.org/' ) {
+			$newurl = 'https://localhost:3129/' . substr( $url, 27 );
+			$this->io->writeError( "Short-circuiting $url to $newurl", true, IOInterface::DEBUG );
+			$event->setProcessedUrl( $newurl );
+
+			if ( $this->certfile ) {
+				$opts                  = $event->getTransportOptions();
+				$opts['ssl']['cafile'] = $this->certfile;
+				$event->setTransportOptions( $opts );
+			}
+		}
+	}
+
+}

--- a/.github/actions/tool-setup/packagist-proxy.mjs
+++ b/.github/actions/tool-setup/packagist-proxy.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+/**
+ * Transparent proxy for repo.packagist.org
+ *
+ * This implements a simple transparent proxy for packagist.org that short-circuits
+ * requests using if-modified-since if a previous response has gone through the proxy
+ * with a last-modified header.
+ *
+ * Note it needs to be passed paths to certificate key and crt files.
+ */
+
+/* eslint-disable no-console */
+
+import * as fs from 'node:fs';
+import * as https from 'node:https';
+
+const upstreamHost = 'https://repo.packagist.org/';
+
+const server = https.createServer( {
+	key: fs.readFileSync( process.argv[ 2 ] ),
+	cert: fs.readFileSync( process.argv[ 3 ] ),
+} );
+
+const dateRegex =
+	/^\s*(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT\s*$/;
+// prettier-ignore
+const months = { Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5, Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11 };
+const parseDate = v => {
+	const m = dateRegex.exec( v );
+	return m ? Date.UTC( m[ 3 ], months[ m[ 2 ] ], m[ 1 ], m[ 4 ], m[ 5 ], m[ 6 ] ) : null;
+};
+
+let ctr = 0;
+const lastModifiedCache = {};
+
+server.on( 'request', ( req, res ) => {
+	const reqid = ++ctr;
+	console.log( `<<[${ reqid }] ${ req.method } ${ req.url } HTTP/${ req.httpVersion }` );
+	const headers = { ...req.headersDistinct };
+	delete headers.host;
+	delete headers.connection;
+
+	/*
+	for ( const [ k, vv ] of Object.entries( headers ) ) {
+		for ( const v of vv ) {
+			console.log( `<<[${ reqid }] ${ k }: ${ v }` );
+		}
+	}
+	*/
+
+	// Check if-modified-since if we have cached a last-modified date.
+	if ( lastModifiedCache[ req.url ] && headers[ 'if-modified-since' ] ) {
+		for ( const v of headers[ 'if-modified-since' ] ) {
+			const ts = parseDate( v );
+			if ( ts <= lastModifiedCache[ req.url ] ) {
+				console.log( `!![${ reqid }] Replying with cached timestamp ${ ts }` );
+				const now = new Date().toUTCString();
+				const lm = new Date( lastModifiedCache[ req.url ] ).toUTCString();
+
+				console.log( `>>[${ reqid }] HTTP/${ res.httpVersion ?? '1.1' } 304 Not Modified` );
+				/*
+				console.log( `>>[${ reqid }] date: ${ now }` );
+				console.log( `>>[${ reqid }] last-modified: ${ lm }` );
+				*/
+
+				res.writeHead( 304, 'Not Modified', {
+					date: now,
+					'last-modified': lm,
+				} );
+				res.end();
+				return;
+			}
+		}
+	}
+
+	// Make remote request.
+	const upstreamUrl = new URL( req.url, upstreamHost );
+	console.log( `!![${ reqid }] Proxying to ${ upstreamUrl }` );
+	const upstreamReq = https.request( upstreamUrl, {
+		method: req.method,
+		headers,
+	} );
+
+	upstreamReq.on( 'response', upstreamRes => {
+		console.log(
+			`>>[${ reqid }] HTTP/${ upstreamRes.httpVersion } ${ upstreamRes.statusCode } ${ upstreamRes.statusMessage }`
+		);
+
+		const resHeaders = { ...upstreamRes.headersDistinct };
+		delete resHeaders.connection;
+		for ( const [ k, vv ] of Object.entries( resHeaders ) ) {
+			for ( const v of vv ) {
+				/*
+				console.log( `>>[${ reqid }] ${ k }: ${ v }` );
+				*/
+				if ( k === 'last-modified' ) {
+					const ts = parseDate( v );
+					if ( ts ) {
+						console.log( `!![${ reqid }] Caching timestamp ${ ts }` );
+						lastModifiedCache[ req.url ] = ts;
+					}
+				}
+			}
+		}
+
+		res.writeHead( upstreamRes.statusCode, upstreamRes.statusMessage, resHeaders );
+
+		upstreamRes.pipe( res );
+
+		res.on( 'finish', cleanup );
+	} );
+
+	const onclose = () => {
+		upstreamReq.abort();
+		cleanup();
+	};
+	res.on( 'close', onclose );
+
+	const cleanup = () => {
+		res.removeListener( 'close', onclose );
+		res.removeListener( 'finish', cleanup );
+	};
+
+	req.pipe( upstreamReq );
+} );
+
+server.listen( 3129, () => {
+	const addr = server.address();
+	console.log( `Server listening on ${ addr.address }:${ addr.port }` );
+} );

--- a/.github/actions/tool-setup/packagist-proxy.mjs
+++ b/.github/actions/tool-setup/packagist-proxy.mjs
@@ -75,7 +75,7 @@ server.on( 'request', ( req, res ) => {
 	}
 
 	// Make remote request.
-	const upstreamUrl = new URL( req.url, upstreamHost );
+	const upstreamUrl = upstreamHost + req.url.replace( /^\//, '' );
 	console.log( `!![${ reqid }] Proxying to ${ upstreamUrl }` );
 	const upstreamReq = https.request( upstreamUrl, {
 		method: req.method,

--- a/tools/cli/commands/dependencies.js
+++ b/tools/cli/commands/dependencies.js
@@ -9,6 +9,9 @@ infrastructureFileSets.base = new Set( [
 	'tools/cli/commands/dependencies.js',
 	'tools/cli/helpers/dependencyAnalysis.js',
 	'.github/actions/tool-setup/action.yml',
+	'.github/actions/tool-setup/composer-plugin/composer.json',
+	'.github/actions/tool-setup/composer-plugin/src/Plugin.php',
+	'.github/actions/tool-setup/packagist-proxy.mjs',
 	'.github/files/list-changed-projects.sh',
 	'.github/versions.sh',
 	// If pnpm stuff changed, we should build/test everything since we can't know what the change will affect.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We're getting close to 100 projects in the monorepo, 84 of which don't have a composer.lock. For each one of those a part of the build is to run `composer update`, which means Composer hits packagist for every dependency's metadata to check for possible new versions, just to get back a 304 response because usually there aren't any in the few minutes since it last checked. The RTTs to get those 304s can add up to a few minutes across all those builds.

In this PR we add a simple JS transparent proxy in CI that will remember URLs that have been queried during the run and respond with an immediate 304 without hitting the network again, and a composer plugin that rewrites the metadata request URLs to fetch from the proxy.

In a local test out of 12847 metadata requests during the course of a full build only 336 had to be sent to packagist, the other 12511 were repeats that were short-circuited. Eight of the metadata files were requested 196 times each!

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build happy?
* And there shouldn't be any changes in the resulting artifacts.