### PR TITLE
Boost: Fix concatenation initialized when the WP file system was unavailable

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -77,8 +77,13 @@ function jetpack_boost_init_filesystem() {
 
 	if ( empty( $wp_filesystem ) ) {
 		require_once ABSPATH . 'wp-admin/includes/file.php';
-		\WP_Filesystem();
+		$file_system = \WP_Filesystem();
+		if ( ! $file_system ) {
+			return false;
+		}
 	}
+
+	return $wp_filesystem;
 }
 
 /**
@@ -268,12 +273,12 @@ function jetpack_boost_minify_serve_concatenated() {
  * Jetpack photon-cdn for static JS/CSS. Automatically ensures that we don't setup
  * the cache service more than once per request.
  *
- * @return void
+ * @return bool|WP_Error
  */
 function jetpack_boost_minify_setup() {
 	static $setup_done = false;
 	if ( $setup_done ) {
-		return;
+		return $setup_done;
 	}
 	$setup_done = true;
 
@@ -293,6 +298,10 @@ function jetpack_boost_minify_setup() {
 		add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );
 
 		// Setup wp_filesystem for use.
-		jetpack_boost_init_filesystem();
+		$file_system = jetpack_boost_init_filesystem();
+		if ( ! $file_system ) {
+			$setup_done = new WP_Error( 'file-system-error', __( 'Unable to initialize file system.', 'jetpack-boost' ) );
+			return $setup_done;
+		}
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-css.php
@@ -12,7 +12,10 @@ class Minify_CSS implements Pluggable {
 	public function setup() {
 		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
 
-		jetpack_boost_minify_setup();
+		$setup = jetpack_boost_minify_setup();
+		if ( is_wp_error( $setup ) ) {
+			return false;
+		}
 
 		if ( jetpack_boost_page_optimize_bail() ) {
 			return;

--- a/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/minify/class-minify-js.php
@@ -12,7 +12,10 @@ class Minify_JS implements Pluggable {
 	public function setup() {
 		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
 
-		jetpack_boost_minify_setup();
+		$setup = jetpack_boost_minify_setup();
+		if ( is_wp_error( $setup ) ) {
+			return false;
+		}
 
 		if ( jetpack_boost_page_optimize_bail() ) {
 			return;

--- a/projects/plugins/boost/changelog/fix-boost-concat-initialized-with-broken-file-system
+++ b/projects/plugins/boost/changelog/fix-boost-concat-initialized-with-broken-file-system
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed concat service initializing when there was a problem with the WP File System.


### PR DESCRIPTION
Fixes #30791.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable CSS/JS concatenation, if the WP File System is not available.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1684733857310529-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup plugin;
* Enable CSS or JS concatenation;
* Make sure there are `_static` references in the source of the page;
* Add `define( 'FS_METHOD', 'ftpext' );` to your `wp-config.php` to force the WP File System to need FTP credentials;
* Check the page for `_static` references - there should be none.