### PR TITLE
Fix warning in WP Super Cache taxonomy preload loop

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super_cache_taxonomy_loop
+++ b/projects/plugins/super-cache/changelog/fix-super_cache_taxonomy_loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: A small fix to the counter used in the preload loop.

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3256,7 +3256,7 @@ function wp_cron_preload_cache() {
 				} else {
 					$details = explode( "\n", file_get_contents( $taxonomy_filename ) );
 				}
-				if ( count( $details ) != 1 && $details[ 0 ] != '' ) {
+				if ( count( $details ) > 0 && $details[0] !== '' ) {
 					$rows = array_splice( $details, 0, WPSC_PRELOAD_POST_COUNT );
 					if ( $wp_cache_preload_email_me && $wp_cache_preload_email_volume === 'many' ) {
 						// translators: 1: Site URL, 2: Taxonomy name, 3: Number of posts done, 4: Number of posts to preload
@@ -3295,7 +3295,7 @@ function wp_cron_preload_cache() {
 
 				if (
 					$preload_more_taxonomies === false &&
-					count( $details ) !== 1 &&
+					count( $details ) > 0 &&
 					$details[0] !== ''
 				) {
 					$preload_more_taxonomies = true;


### PR DESCRIPTION
This is a tiny code change to fix a PHP warning in the taxonomy preload loop reported on the forum here: https://wordpress.org/support/topic/wpsc-1-10-0-alpha-warning/

## Proposed changes:
Check that the $details array has more than 0 elements in it, instead of checking that it hasn't got 1 element. If it has 0 elements, the next check on $details[0] generates a warning.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
None.