### PR TITLE
WP Super Cache: don't delete child taxonomies during preload

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super_cache_deleting_child_taxonomy
+++ b/projects/plugins/super-cache/changelog/fix-super_cache_deleting_child_taxonomy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: don't delete child taxonomies during preload

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3271,8 +3271,8 @@ function wp_cron_preload_cache() {
 						$dir = get_supercache_dir() . $url_info[ 'path' ];
 						wp_cache_debug( "wp_cron_preload_cache: delete $dir", 5 );
 						wpsc_delete_files( $dir );
-						prune_super_cache( $dir . 'feed/', true );
-						prune_super_cache( $dir . 'page/', true );
+						prune_super_cache( trailingslashit( $dir ) . 'feed/', true );
+						prune_super_cache( trailingslashit( $dir ) . 'page/', true );
 						$fp = @fopen( $permalink_counter_msg, 'w' );
 						if ( $fp ) {
 							@fwrite( $fp, "$taxonomy: $url" );

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3270,7 +3270,9 @@ function wp_cron_preload_cache() {
 						$url_info = parse_url( $url );
 						$dir = get_supercache_dir() . $url_info[ 'path' ];
 						wp_cache_debug( "wp_cron_preload_cache: delete $dir", 5 );
-						prune_super_cache( $dir );
+						wpsc_delete_files( $dir );
+						prune_super_cache( $dir . 'feed/', true );
+						prune_super_cache( $dir . 'page/', true );
 						$fp = @fopen( $permalink_counter_msg, 'w' );
 						if ( $fp ) {
 							@fwrite( $fp, "$taxonomy: $url" );


### PR DESCRIPTION
The preload system in WP Super Cache allows a site owner to prime the cache by visiting taxonomy archives and post/page URLs.
The original cached page would have to be deleted before the new page was fetched. Unfortunately, the taxonomy loop deleted a taxonomy, and any sub directories which had the effect of deleting the cached pages for child taxonomies.

This PR fixes that by only deleting files in the taxonomy directory, and then deleting the feed and page directories separately.

ref: https://wordpress.org/support/topic/preload-mode-skips-caching-pages-or-deletes-already-cached-pages/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
To test this you'll need to create child taxonomies on a test blog.
Enable debugging and when it's done, verify that the cache pages for the child taxonomies still exist.


