### PR TITLE
AI Assistant: set fade effect when just requested completion

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-tweak-asking-content
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-tweak-asking-content
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Assistant: set fade effect when just requested completion

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -8,6 +8,7 @@ import { Flex, FlexBlock, Modal, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { RawHTML, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 import MarkdownIt from 'markdown-it';
 import { useEffect } from 'react';
 /**
@@ -47,6 +48,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	const {
 		isLoadingCategories,
 		isLoadingCompletion,
+		wasCompletionJustRequested,
 		getSuggestionFromOpenAI,
 		showRetry,
 		contentBefore,
@@ -154,7 +156,11 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	};
 
 	return (
-		<div { ...useBlockProps() }>
+		<div
+			{ ...useBlockProps( {
+				className: classNames( { 'is-waiting-response': wasCompletionJustRequested } ),
+			} ) }
+		>
 			{ errorMessage && ! errorDismissed && (
 				<Notice status="info" isDismissible={ false } className="jetpack-ai-assistant__error">
 					{ errorMessage }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -15,6 +15,16 @@
 	margin: 10px;
 }
 
+.wp-block-jetpack-ai-assistant {
+	.jetpack-ai-assistant__content {
+		opacity: 1;
+		transition: opacity 0.2s ease-in-out;
+	}
+	&.is-waiting-response .jetpack-ai-assistant__content {
+		opacity: 0.5;
+	}
+}
+
 .jetpack-ai-assistant__error {
 	margin: 0 0 8px 0;
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -77,6 +77,7 @@ const useSuggestionsFromOpenAI = ( {
 } ) => {
 	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
 	const [ isLoadingCompletion, setIsLoadingCompletion ] = useState( false );
+	const [ wasCompletionJustRequested, setWasCompletionJustRequested ] = useState( false );
 	const [ showRetry, setShowRetry ] = useState( false );
 	const [ lastPrompt, setLastPrompt ] = useState( '' );
 
@@ -187,6 +188,7 @@ const useSuggestionsFromOpenAI = ( {
 		let source;
 		try {
 			setIsLoadingCompletion( true );
+			setWasCompletionJustRequested( true );
 			source = await askQuestion( prompt, postId );
 		} catch ( err ) {
 			if ( err.message ) {
@@ -201,19 +203,23 @@ const useSuggestionsFromOpenAI = ( {
 			}
 			setShowRetry( true );
 			setIsLoadingCompletion( false );
+			setWasCompletionJustRequested( false );
 		}
 
 		source.addEventListener( 'done', e => {
 			source.close();
 			setIsLoadingCompletion( false );
+			setWasCompletionJustRequested( false );
 			setAttributes( { content: e.detail } );
 		} );
 		source.addEventListener( 'error_unclear_prompt', () => {
 			source.close();
 			setIsLoadingCompletion( false );
+			setWasCompletionJustRequested( false );
 			setErrorMessage( __( 'Your request was unclear. Mind trying again?', 'jetpack' ) );
 		} );
 		source.addEventListener( 'suggestion', e => {
+			setWasCompletionJustRequested( false );
 			debug( 'fullMessage', e.detail );
 			setAttributes( { content: e.detail } );
 		} );
@@ -223,6 +229,7 @@ const useSuggestionsFromOpenAI = ( {
 	return {
 		isLoadingCategories,
 		isLoadingCompletion,
+		wasCompletionJustRequested,
 		setIsLoadingCategories,
 		setShowRetry,
 		showRetry,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


Based on the following feedback...

> It feels like the text should fade out a bit or some other visual cue while the thing is processing as an indication that it’s acting on the whole chunk of text.

p1683892486076719/1683890690.532879-slack-C054LN8RNVA

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: set fade effect when just requested completion

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create an AI Assistant block instance
* Generate content
* Iterate over the block content. For instance, change the tone, language, etc
* Confirm the block fades the content while the request starts
* Confirm the opacity gets removed once the block starts filling its content with new text.

https://github.com/Automattic/jetpack/assets/77539/8ab61b0d-93a2-4d13-b9a7-c76cdfc277c6

