### PR TITLE
WP Super Cache: reset the preload settings when done

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-stop_preload_when_done
+++ b/projects/plugins/super-cache/changelog/fix-stop_preload_when_done
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: reset the preload settings when done

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3283,6 +3283,11 @@ function wp_cron_preload_cache() {
 						if ( @file_exists( $cache_path . "stop_preload.txt" ) ) {
 							wp_cache_debug( 'wp_cron_preload_cache: cancelling preload. stop_preload.txt found.', 5 );
 							wpsc_reset_preload_settings();
+
+							if ( $wp_cache_preload_email_me ) {
+								// translators: Home URL of website
+								wp_mail( get_option( 'admin_email' ), sprintf( __( '[%1$s] Cache Preload Stopped', 'wp-super-cache' ), home_url(), '' ), ' ' );
+							}
 							return true;
 						}
 					}
@@ -3374,6 +3379,11 @@ function wp_cron_preload_cache() {
 			if ( @file_exists( $cache_path . "stop_preload.txt" ) ) {
 				wp_cache_debug( 'wp_cron_preload_cache: cancelling preload. stop_preload.txt found.', 5 );
 				wpsc_reset_preload_settings();
+
+				if ( $wp_cache_preload_email_me ) {
+					// translators: Home URL of website
+					wp_mail( get_option( 'admin_email' ), sprintf( __( '[%1$s] Cache Preload Stopped', 'wp-super-cache' ), home_url(), '' ), ' ' );
+				}
 				return true;
 			}
 
@@ -3413,6 +3423,7 @@ function wp_cron_preload_cache() {
 			wp_cache_debug( "wp_cron_preload_cache: clean expired cache files older than $cache_max_time seconds.", 5 );
 			wp_cache_phase2_clean_expired( $file_prefix, true ); // force cleanup of old files.
 		}
+		wpsc_reset_preload_settings();
 	}
 	@unlink( $mutex );
 }
@@ -3601,7 +3612,7 @@ function wpsc_reset_preload_counter() {
  * This function will reset all preload settings
  */
 function wpsc_reset_preload_settings() {
-	global $cache_path, $wp_cache_preload_email_me;
+	global $cache_path;
 
 	$mutex = $cache_path . 'preload_mutex.tmp';
 	wp_delete_file( $mutex );
@@ -3620,11 +3631,6 @@ function wpsc_reset_preload_settings() {
 	foreach ( $taxonomies as $taxonomy => $path ) {
 		$taxonomy_filename = $cache_path . 'taxonomy_' . $taxonomy . '.txt';
 		wp_delete_file( $taxonomy_filename );
-	}
-
-	if ( $wp_cache_preload_email_me ) {
-		// translators: Home URL of website
-		wp_mail( get_option( 'admin_email' ), sprintf( __( '[%1$s] Cache Preload Stopped', 'wp-super-cache' ), home_url(), '' ), ' ' );
 	}
 }
 


### PR DESCRIPTION
The preload wasn't finishing correctly because the transient setting we used for taxonomies wasn't deleted at the end of the preload loop.

This PR fixes that by calling wpsc_reset_preload_settings(), but I had to move the wp_mail() command out of there as it wouldn't make sense in this context.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a test site with a couple of posts and tags.
Preload the site and you will notice the preload is stuck at the last post.
The cancel button won't work either, but if you leave it ten minutes it will fix itself as the transient setting expires.
You can also run `delete_transient( 'taxonomy_preload' );` to delete it.
Apply the PR and preload. The preload should stop when it's done.
