### PR TITLE
ci: When checking changelogger use, count the changelog itself

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-check-changelogger-use-count-changelog-changes
+++ b/projects/github-actions/repo-gardening/changelog/update-check-changelogger-use-count-changelog-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Don't complain about missing a changelog entry if the changelog itself is being changed.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -225,7 +225,7 @@ async function getChangelogEntries( octokit, owner, repo, number ) {
 	return affectedProjects.reduce( ( acc, project ) => {
 		const composerFile = `${ baseDir }/projects/${ project }/composer.json`;
 		const json = JSON.parse( fs.readFileSync( composerFile ) );
-		// Changelog directory could customized via .extra.changelogger.changes-dir in composer.json. Lets check for it.
+		// Changelog directory could be customized via .extra.changelogger.changes-dir in composer.json. Lets check for it.
 		const changelogDir =
 			path.relative(
 				baseDir,
@@ -235,7 +235,16 @@ async function getChangelogEntries( octokit, owner, repo, number ) {
 						'changelog'
 				)
 			) + '/';
-		const found = files.find( file => file.startsWith( changelogDir ) );
+		// Changelog file could also be customized via .extra.changelogger.changelog in composer.json. Lets check for it.
+		const changelogFile = path.relative(
+			baseDir,
+			path.resolve(
+				`${ baseDir }/projects/${ project }`,
+				( json.extra && json.extra.changelogger && json.extra.changelogger.changelog ) ||
+					'CHANGELOG.md'
+			)
+		);
+		const found = files.find( file => file === changelogFile || file.startsWith( changelogDir ) );
 		if ( ! found ) {
 			acc.push( `projects/${ project }` );
 		}

--- a/tools/check-changelogger-use.php
+++ b/tools/check-changelogger-use.php
@@ -183,7 +183,8 @@ while ( ( $line = fgets( $pipes[1] ) ) ) {
 		continue;
 	}
 	if ( $parts[3] === $changelogger_projects[ $slug ]['changelog'] ) {
-		debug( 'Ignoring changelog file %s.', $line );
+		debug( 'PR touches changelog file %s, marking %s as having a change file.', $line, $slug );
+		$ok_projects[ $slug ] = true;
 		continue;
 	}
 	if ( $parts[3] === $changelogger_projects[ $slug ]['changes-dir'] ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Our "Check changelogger use" check looks for commits that change a project without adding a change entry. This breaks in the edge case where we need to release a new build of a project that doesn't have any existing change entry files: the change to the changelog itself is ignored, but any changes to other files for version bumps will trigger the check.

Instead of ignoring the change to CHANGELOG.md, let's instead count it the same as having a change entry being touched.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/30850#issuecomment-1557683106

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a change like #30850 then run the script.
