### PR TITLE
AI Assistant: Fix notice and action button colors

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-colors
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Fix notice and action button colors

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -116,6 +116,7 @@ const AIControl = ( {
 
 				<div className="jetpack-ai-assistant__controls">
 					<Button
+						className="jetpack-ai-assistant__prompt_button"
 						onClick={ () => handleGetSuggestion( 'userPrompt' ) }
 						isSmall={ true }
 						disabled={ isWaitingState || ! userPrompt?.length }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -27,6 +27,7 @@
 
 .jetpack-ai-assistant__error {
 	margin: 0 0 8px 0;
+	color: var( --wp--preset--color--black );
 }
 
 .jetpack-ai-assistant__loading-spinner {
@@ -37,7 +38,7 @@
 .jetpack-ai-assistant__input-wrapper {
 	display: flex;
 	padding: 4px 4px;
-	box-shadow: var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 0px 1px, var( --wp--preset--color--cyan-bluish-gray ) 0px 3px 6px, var( --wp--preset--color--cyan-bluish-gray ) 0px 9px 24px;
+	box-shadow: var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 0px 1px, var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 8px;
 
 	textarea {
 		width: 100%;
@@ -55,6 +56,8 @@
 		&::placeholder {
 			text-overflow:ellipsis;
 			white-space: nowrap;
+			color: var( --wp--preset--color--foreground );
+			opacity: 0.75;
 		}
 	}
 
@@ -74,6 +77,14 @@
 .jetpack-ai-assistant__controls {
 	display: flex;
 	align-items: center;
+
+	.jetpack-ai-assistant__prompt_button {
+		color: var( --wp--preset--color--foreground );
+
+		&:hover {
+			color: var( --wp-components-color-accent, var( --wp-admin-theme-color ) );
+		}
+	}
 }
 
 .jetpack-ai-assistant__accept {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #30836

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets colors and simplifies the box-shadow so it works on different themes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an AI Assistant block
* Check that the placeholder, action button and unclear prompt notice are all visible
* Check different themes

The loader will be fixed in a follow-up

https://github.com/Automattic/jetpack/assets/8486249/bc522b81-68ce-44d6-a749-d7d7145e7527
