### PR TITLE
AI Assistant: Update image generation button to directly generate an image instead of being a toggle

### DIFF
--- a/projects/plugins/jetpack/changelog/update-generate-image-button
+++ b/projects/plugins/jetpack/changelog/update-generate-image-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Make the AI Assistant image generation button generate the image right awways instead of being a toggle

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -20,7 +20,6 @@ import ToneDropdownControl from './tone-dropdown-control';
 import UpgradePrompt from './upgrade-prompt';
 
 const AIControl = ( {
-	aiType,
 	contentIsLoaded,
 	getSuggestionFromOpenAI,
 	retryRequest,
@@ -28,9 +27,9 @@ const AIControl = ( {
 	handleAcceptTitle,
 	handleTryAgain,
 	handleGetSuggestion,
+	handleImageRequest,
 	isWaitingState,
 	loadingImages,
-	setAiType,
 	userPrompt,
 	setUserPrompt,
 	showRetry,
@@ -48,16 +47,8 @@ const AIControl = ( {
 		}
 	};
 
-	const toggleAIType = () => {
-		if ( aiType === 'text' ) {
-			setAiType( 'image' );
-		} else {
-			setAiType( 'text' );
-		}
-	};
-
 	const textPlaceholder = ! content?.length
-		? __( 'Ask AI to write anything…', 'jetpack' )
+		? __( 'Ask Jetpack AI for anything…', 'jetpack' )
 		: __( 'Tell AI what to do next…', 'jetpack', /* dummy arg to avoid bad minification */ 0 );
 
 	let placeholder = '';
@@ -68,14 +59,8 @@ const AIControl = ( {
 		} else {
 			placeholder = __( 'AI writing', 'jetpack' );
 		}
-	} else if ( aiType === 'text' ) {
-		placeholder = textPlaceholder;
 	} else {
-		placeholder = __(
-			'What would you like to see?',
-			'jetpack',
-			/* dummy arg to avoid bad minification */ 0
-		);
+		placeholder = textPlaceholder;
 	}
 
 	return (
@@ -83,7 +68,6 @@ const AIControl = ( {
 			{ false && <UpgradePrompt /> }
 			{ ! isWaitingState && (
 				<ToolbarControls
-					aiType={ aiType }
 					isWaitingState={ isWaitingState }
 					contentIsLoaded={ contentIsLoaded }
 					getSuggestionFromOpenAI={ getSuggestionFromOpenAI }
@@ -91,9 +75,9 @@ const AIControl = ( {
 					handleAcceptContent={ handleAcceptContent }
 					handleAcceptTitle={ handleAcceptTitle }
 					handleGetSuggestion={ handleGetSuggestion }
+					handleImageRequest={ handleImageRequest }
 					handleTryAgain={ handleTryAgain }
 					showRetry={ showRetry }
-					toggleAIType={ toggleAIType }
 					contentBefore={ contentBefore }
 					hasPostTitle={ !! postTitle?.length }
 					wholeContent={ wholeContent }
@@ -133,15 +117,14 @@ const AIControl = ( {
 export default AIControl;
 
 const ToolbarControls = ( {
-	aiType,
 	contentIsLoaded,
 	getSuggestionFromOpenAI,
 	retryRequest,
 	handleAcceptContent,
 	handleAcceptTitle,
+	handleImageRequest,
 	handleTryAgain,
 	showRetry,
-	toggleAIType,
 	contentBefore,
 	hasPostTitle,
 	wholeContent,
@@ -202,110 +185,98 @@ const ToolbarControls = ( {
 			) }
 
 			<BlockControls>
-				{ aiType === 'text' && (
-					// Text controls
-					<ToolbarGroup>
-						{ ! showRetry && contentIsLoaded && (
-							<>
-								{ promptType === 'generateTitle' ? (
-									<ToolbarButton onClick={ handleAcceptTitle }>
-										{ __( 'Accept title', 'jetpack' ) }
-									</ToolbarButton>
-								) : (
-									<ToolbarButton onClick={ handleAcceptContent }>
-										{ __( 'Done', 'jetpack' ) }
-									</ToolbarButton>
-								) }
-								<ToolbarButton onClick={ handleTryAgain }>
-									{ __( 'Try Again', 'jetpack' ) }
+				{ /* Text controls */ }
+				<ToolbarGroup>
+					{ ! showRetry && contentIsLoaded && (
+						<>
+							{ promptType === 'generateTitle' ? (
+								<ToolbarButton onClick={ handleAcceptTitle }>
+									{ __( 'Accept title', 'jetpack' ) }
 								</ToolbarButton>
-							</>
-						) }
-
-						{ !! ( ! showRetry && ! contentIsLoaded && contentBefore?.length ) && (
-							<ToolbarButton
-								icon={ pencil }
-								onClick={ () => getSuggestionFromOpenAI( 'continue' ) }
-							>
-								{ __( 'Continue writing', 'jetpack' ) }
+							) : (
+								<ToolbarButton onClick={ handleAcceptContent }>
+									{ __( 'Done', 'jetpack' ) }
+								</ToolbarButton>
+							) }
+							<ToolbarButton onClick={ handleTryAgain }>
+								{ __( 'Try Again', 'jetpack' ) }
 							</ToolbarButton>
-						) }
+						</>
+					) }
 
-						{ ! showRetry && ! contentIsLoaded && ! contentBefore?.length && hasPostTitle && (
-							<ToolbarButton
-								icon={ title }
-								onClick={ () => getSuggestionFromOpenAI( 'titleSummary' ) }
-							>
-								{ __( 'Write a summary based on title', 'jetpack' ) }
-							</ToolbarButton>
-						) }
+					{ !! ( ! showRetry && ! contentIsLoaded && contentBefore?.length ) && (
+						<ToolbarButton icon={ pencil } onClick={ () => getSuggestionFromOpenAI( 'continue' ) }>
+							{ __( 'Continue writing', 'jetpack' ) }
+						</ToolbarButton>
+					) }
 
-						{ ! showRetry && ! contentIsLoaded && !! wholeContent?.length && (
-							<I18nDropdownControl
-								value="en"
-								label={ __( 'Translate', 'jetpack' ) }
-								onChange={ language => getSuggestionFromOpenAI( 'changeLanguage', { language } ) }
-							/>
-						) }
+					{ ! showRetry && ! contentIsLoaded && ! contentBefore?.length && hasPostTitle && (
+						<ToolbarButton
+							icon={ title }
+							onClick={ () => getSuggestionFromOpenAI( 'titleSummary' ) }
+						>
+							{ __( 'Write a summary based on title', 'jetpack' ) }
+						</ToolbarButton>
+					) }
 
-						{ ! showRetry && ! contentIsLoaded && (
-							<ToolbarDropdownMenu
-								icon={ chevronDown }
-								label="More"
-								controls={ [
-									{
-										title: __( 'Summarize', 'jetpack' ),
-										onClick: () => getSuggestionFromOpenAI( 'summarize' ),
-										isDisabled: ! wholeContent?.length,
-									},
-									{
-										title: __( 'Write a summary based on title', 'jetpack' ),
-										onClick: () => getSuggestionFromOpenAI( 'titleSummary' ),
-										isDisabled: ! hasPostTitle,
-									},
-									{
-										title: __( 'Expand on preceding content', 'jetpack' ),
-										onClick: () => getSuggestionFromOpenAI( 'continue' ),
-										isDisabled: ! contentBefore?.length,
-									},
-									{
-										title: __( 'Correct spelling and grammar of preceding content', 'jetpack' ),
-										onClick: () => getSuggestionFromOpenAI( 'correctSpelling' ),
-										isDisabled: ! contentBefore?.length,
-									},
-									{
-										title: __( 'Simplify preceding content', 'jetpack' ),
-										onClick: () => getSuggestionFromOpenAI( 'simplify' ),
-										isDisabled: ! contentBefore?.length,
-									},
-									{
-										title: __( 'Generate a post title', 'jetpack' ),
-										onClick: () => getSuggestionFromOpenAI( 'generateTitle' ),
-										isDisabled: ! wholeContent?.length,
-									},
-								] }
-							/>
-						) }
-						{ showRetry && (
-							<ToolbarButton icon={ update } onClick={ retryRequest }>
-								{ __( 'Retry', 'jetpack' ) }
-							</ToolbarButton>
-						) }
-					</ToolbarGroup>
-				) }
+					{ ! showRetry && ! contentIsLoaded && !! wholeContent?.length && (
+						<I18nDropdownControl
+							value="en"
+							label={ __( 'Translate', 'jetpack' ) }
+							onChange={ language => getSuggestionFromOpenAI( 'changeLanguage', { language } ) }
+						/>
+					) }
+
+					{ ! showRetry && ! contentIsLoaded && (
+						<ToolbarDropdownMenu
+							icon={ chevronDown }
+							label="More"
+							controls={ [
+								{
+									title: __( 'Summarize', 'jetpack' ),
+									onClick: () => getSuggestionFromOpenAI( 'summarize' ),
+									isDisabled: ! wholeContent?.length,
+								},
+								{
+									title: __( 'Write a summary based on title', 'jetpack' ),
+									onClick: () => getSuggestionFromOpenAI( 'titleSummary' ),
+									isDisabled: ! hasPostTitle,
+								},
+								{
+									title: __( 'Expand on preceding content', 'jetpack' ),
+									onClick: () => getSuggestionFromOpenAI( 'continue' ),
+									isDisabled: ! contentBefore?.length,
+								},
+								{
+									title: __( 'Correct spelling and grammar of preceding content', 'jetpack' ),
+									onClick: () => getSuggestionFromOpenAI( 'correctSpelling' ),
+									isDisabled: ! contentBefore?.length,
+								},
+								{
+									title: __( 'Simplify preceding content', 'jetpack' ),
+									onClick: () => getSuggestionFromOpenAI( 'simplify' ),
+									isDisabled: ! contentBefore?.length,
+								},
+								{
+									title: __( 'Generate a post title', 'jetpack' ),
+									onClick: () => getSuggestionFromOpenAI( 'generateTitle' ),
+									isDisabled: ! wholeContent?.length,
+								},
+							] }
+						/>
+					) }
+					{ showRetry && (
+						<ToolbarButton icon={ update } onClick={ retryRequest }>
+							{ __( 'Retry', 'jetpack' ) }
+						</ToolbarButton>
+					) }
+				</ToolbarGroup>
 				{ ! showRetry && ! contentIsLoaded && (
 					// Image/text toggle
 					<ToolbarGroup>
-						{ aiType === 'text' && (
-							<ToolbarButton icon={ image } onClick={ toggleAIType }>
-								{ __( 'Ask AI for an image', 'jetpack' ) }
-							</ToolbarButton>
-						) }
-						{ aiType === 'image' && (
-							<ToolbarButton icon={ pencil } onClick={ toggleAIType }>
-								{ __( 'Ask AI to write', 'jetpack' ) }
-							</ToolbarButton>
-						) }
+						<ToolbarButton icon={ image } onClick={ handleImageRequest }>
+							{ __( 'Ask AI for an image', 'jetpack' ) }
+						</ToolbarButton>
 					</ToolbarGroup>
 				) }
 			</BlockControls>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -27,7 +27,6 @@ const markdownConverter = new MarkdownIt( {
 export default function AIAssistantEdit( { attributes, setAttributes, clientId } ) {
 	const [ userPrompt, setUserPrompt ] = useState();
 	const [ errorMessage, setErrorMessage ] = useState( false );
-	const [ aiType, setAiType ] = useState( 'text' );
 	const [ loadingImages, setLoadingImages ] = useState( false );
 	const [ resultImages, setResultImages ] = useState( [] );
 	const [ imageModal, setImageModal ] = useState( null );
@@ -133,14 +132,14 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	};
 
 	const handleGetSuggestion = type => {
-		if ( aiType === 'text' ) {
-			getSuggestionFromOpenAI( type );
-			return;
-		}
+		getSuggestionFromOpenAI( type );
+		return;
+	};
 
-		setLoadingImages( false );
+	const handleImageRequest = () => {
 		setResultImages( [] );
 		setErrorMessage( null );
+
 		getImagesFromOpenAI(
 			userPrompt.trim() === '' ? __( 'What would you like to see?', 'jetpack' ) : userPrompt,
 			setAttributes,
@@ -149,6 +148,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			setErrorMessage,
 			postId
 		);
+
 		tracks.recordEvent( 'jetpack_ai_dalle_generation', {
 			post_id: postId,
 		} );
@@ -173,7 +173,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				</>
 			) }
 			<AIControl
-				aiType={ aiType }
 				content={ attributes.content }
 				contentIsLoaded={ contentIsLoaded }
 				getSuggestionFromOpenAI={ getSuggestionFromOpenAI }
@@ -181,11 +180,11 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				handleAcceptContent={ handleAcceptContent }
 				handleAcceptTitle={ handleAcceptTitle }
 				handleGetSuggestion={ handleGetSuggestion }
+				handleImageRequest={ handleImageRequest }
 				handleTryAgain={ handleTryAgain }
 				isWaitingState={ isWaitingState }
 				loadingImages={ loadingImages }
 				showRetry={ showRetry }
-				setAiType={ setAiType }
 				setUserPrompt={ setUserPrompt }
 				contentBefore={ contentBefore }
 				postTitle={ postTitle }


### PR DESCRIPTION
Fixes #30610
Fixes #30837

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes aiType mode toggle behavior
* Make the button just generate the image
* Updates placeholder to `Ask Jetpack AI for anything`.

https://github.com/Automattic/jetpack/assets/746152/a946d4c7-0f8d-4fd2-a52c-c0db5e70c621

### Other information:




- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* Add an AI Assistant block
* Write a prompt 
* Click the Ask AI to for an image button.
* Expect to get an image generated.

