### PR TITLE
Boost: Fix Minify concat not working when WP is running from a subdirectory on the server

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -96,6 +96,12 @@ class Concatenate_JS extends WP_Scripts {
 			$js_url        = $obj->src;
 			$js_url_parsed = wp_parse_url( $js_url );
 
+			// If no hostname is specified and path starts with /, it is relative to homeurl.
+			if ( empty( $js_url_parsed['host'] ) && substr( $js_url, 0, 1 ) === '/' ) {
+				$js_url        = home_url( $obj->src );
+				$js_url_parsed = wp_parse_url( $js_url );
+			}
+
 			// Don't concat by default
 			$do_concat = false;
 

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -198,6 +198,12 @@ function jetpack_boost_page_optimize_bail() {
 function jetpack_boost_page_optimize_cache_bust_mtime( $path, $siteurl ) {
 	static $dependency_path_mapping;
 
+	// Absolute paths should dump the path component of siteurl.
+	if ( substr( $path, 0, 1 ) === '/' ) {
+		$parts   = wp_parse_url( $siteurl );
+		$siteurl = $parts['scheme'] . '://' . $parts['host'];
+	}
+
 	$url = $siteurl . $path;
 
 	if ( strpos( $url, '?m=' ) ) {
@@ -244,10 +250,14 @@ function jetpack_boost_page_optimize_cache_bust_mtime( $path, $siteurl ) {
 function jetpack_boost_minify_serve_concatenated() {
 	// Potential improvement: Make concat URL dir configurable
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	if ( isset( $_SERVER['REQUEST_URI'] ) && '/_static/' === substr( wp_unslash( $_SERVER['REQUEST_URI'] ), 0, 9 ) ) {
-		require_once __DIR__ . '/functions-service.php';
-		jetpack_boost_page_optimize_service_request();
-		exit;
+	if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$request_path = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) )[0];
+		if ( '/_static/' === substr( $request_path, -9, 9 ) ) {
+			require_once __DIR__ . '/functions-service.php';
+			jetpack_boost_page_optimize_service_request();
+			exit;
+		}
 	}
 }
 

--- a/projects/plugins/boost/changelog/fix-boost-concat-broken-in-nested-wp
+++ b/projects/plugins/boost/changelog/fix-boost-concat-broken-in-nested-wp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed concatenation not working when WordPress is installed in a sub-directory on the server.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes JS an CSS concatenation not working on nested WP instances.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test that it breaks
* Setup the version from `trunk` on a WordPress site, running in a sub-directory on your server;
* Enable JS or CSS concatenation;
* Open the front-page and you should see 404 for concatenated URLs (they contain `_static`).

### Test that it works
* Setup the version from this PR on a WordPress site, running in a sub-directory on your server;
* Enable JS or CSS concatenation;
* Open the front-page and there should be no 404 for concatenated URLs.