### PR TITLE
[Newsletters] Fix issue with Premium-content blocks on self-hosted

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-issue-with-self-hosted
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-issue-with-self-hosted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Allow Premium content block to production and prevent potential issue on self-hosted installations

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -25,29 +25,26 @@ const FEATURE_NAME = 'premium-content/container';
  * registration if we need to.
  */
 function register_block() {
-	// Only load this block on WordPress.com.
-	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site() ) {
-		// Determine required `context` key based on Gutenberg version.
-		$deprecated = function_exists( 'gutenberg_get_post_from_context' );
-		$provides   = $deprecated ? 'providesContext' : 'provides_context';
+	// Determine required `context` key based on Gutenberg version.
+	$deprecated = function_exists( 'gutenberg_get_post_from_context' );
+	$provides   = $deprecated ? 'providesContext' : 'provides_context';
 
-		Blocks::jetpack_register_block(
-			FEATURE_NAME,
-			array(
-				'render_callback' => __NAMESPACE__ . '\render_block',
-				'attributes'      => array(
-					'isPremiumContentChild' => array(
-						'type'    => 'boolean',
-						'default' => true,
-					),
+	Blocks::jetpack_register_block(
+		FEATURE_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_block',
+			'attributes'      => array(
+				'isPremiumContentChild' => array(
+					'type'    => 'boolean',
+					'default' => true,
 				),
-				$provides         => array(
-					'premium-content/planId' => 'selectedPlanId',
-					'isPremiumContentChild'  => 'isPremiumContentChild',
-				),
-			)
-		);
-	}
+			),
+			$provides         => array(
+				'premium-content/planId' => 'selectedPlanId',
+				'isPremiumContentChild'  => 'isPremiumContentChild',
+			),
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -23,6 +23,7 @@
 		"payments",
 		"pinterest",
 		"podcast-player",
+		"premium-content",
 		"publicize",
 		"rating-star",
 		"recurring-payments",
@@ -61,7 +62,7 @@
 		"v6-video-frame-poster",
 		"videopress/video-chapters"
 	],
-	"experimental": [ "ai-assistant", "ai-image", "ai-paragraph", "anchor-fm", "premium-content" ],
+	"experimental": [ "ai-assistant", "ai-image", "ai-paragraph", "anchor-fm" ],
 	"no-post-editor": [
 		"business-hours",
 		"button",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/40

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow Premium-content blocks on production and do not gate on self-hosted environments

## Jetpack product discussion
p1684310694056649-slack-C01B6KEJ5GE

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
I am not really sure on how to test this...