### PR TITLE
Fix links to the cache directory when a site isn't at "/"

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-path_to_cache_directory
+++ b/projects/plugins/super-cache/changelog/fix-path_to_cache_directory
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: fix links to cache directory on sites that are in a sub directory

--- a/projects/plugins/super-cache/inc/preload-notification.php
+++ b/projects/plugins/super-cache/inc/preload-notification.php
@@ -8,7 +8,7 @@ function wpsc_preload_notification_scripts() {
 		@file_exists( $cache_path . 'preload_permalink.txt' )
 	) {
 		wp_enqueue_script( 'preload-notification', plugins_url( '/preload-notification.js', __FILE__ ), array('jquery'), '1.0', 1 );
-		wp_localize_script( 'preload-notification', 'wpsc_preload_ajax', array( 'preload_permalink_url' => home_url( str_replace( $_SERVER['DOCUMENT_ROOT'], '', $cache_path ) . '/preload_permalink.txt' ) ) );
+		wp_localize_script( 'preload-notification', 'wpsc_preload_ajax', array( 'preload_permalink_url' => home_url( str_replace( get_home_path(), '', $cache_path ) . '/preload_permalink.txt' ) ) );
 	}
 }
 add_action( 'admin_enqueue_scripts', 'wpsc_preload_notification_scripts' );

--- a/projects/plugins/super-cache/partials/debug.php
+++ b/projects/plugins/super-cache/partials/debug.php
@@ -11,10 +11,9 @@ if ( ! isset( $wp_cache_debug_log ) || $wp_cache_debug_log == '' ) {
 	extract( wpsc_create_debug_log() ); // $wp_cache_debug_log, $wp_cache_debug_username
 }
 
-$server_root = isset( $_SERVER['DOCUMENT_ROOT'] ) ? esc_url_raw( wp_unslash( $_SERVER['DOCUMENT_ROOT'] ) ) : ABSPATH;
-// $wp_cache_home_path and $cache_path are declared when this file is included.
+// $cache_path and $wp_cache_debug_log is declared when this file is included.
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-$log_file_link = "<a href='" . home_url( str_replace( $server_root . $wp_cache_home_path, '', "{$cache_path}view_{$wp_cache_debug_log}?wp-admin=1&wp-json=1&filter=" ) ) . "'>$wp_cache_debug_log</a>";
+$log_file_link = "<a href='" . home_url( str_replace( get_home_path(), '', "{$cache_path}view_{$wp_cache_debug_log}?wp-admin=1&wp-json=1&filter=" ) ) . "'>$wp_cache_debug_log</a>";
 
 if ( $wp_super_cache_debug == 1 ) {
 	echo "<p>" . sprintf( __( 'Currently logging to: %s', 'wp-super-cache' ), $log_file_link ) . "</p>";


### PR DESCRIPTION
If a site doesn't live at /, then the debug log link and preload notification status update didn't work properly.

This PR fixes that by using get_home_path() to find the path to the homepage of the site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Install the plugin on a site hosted in a sub directory. Go to the debug settings page and see the link to the debug log is broken and has a duplicate of the directory name in the URL. The notification on the preload won't work either.
Apply the changes in this PR.
The debug log link will be fixed, and the preload notification works again.
