### PR TITLE
Add boost score bars to jetpack dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2834,6 +2834,9 @@ importers:
       markdown-it-footnote:
         specifier: 3.0.3
         version: 3.0.3
+      md5-es:
+        specifier: 1.8.2
+        version: 1.8.2
       photon:
         specifier: 4.0.0
         version: 4.0.0
@@ -16446,7 +16449,6 @@ packages:
 
   /md5-es@1.8.2:
     resolution: {integrity: sha512-LKq5jmKMhJYhsBFUh2w+J3C4bMiC5uQie/UYJ429UATmMnFr6iANO2uQq5HXAZSIupGp0WO2mH3sNfxR4XO40Q==}
-    dev: true
 
   /mdast-util-definitions@4.0.0:
     resolution: {integrity: sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2705,6 +2705,9 @@ importers:
       '@automattic/jetpack-api':
         specifier: workspace:*
         version: link:../../js-packages/api
+      '@automattic/jetpack-boost-score-api':
+        specifier: workspace:*
+        version: link:../../js-packages/boost-score-api
       '@automattic/jetpack-components':
         specifier: workspace:*
         version: link:../../js-packages/components

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2834,9 +2834,6 @@ importers:
       markdown-it-footnote:
         specifier: 3.0.3
         version: 3.0.3
-      md5-es:
-        specifier: 1.8.2
-        version: 1.8.2
       photon:
         specifier: 4.0.0
         version: 4.0.0
@@ -10925,7 +10922,7 @@ packages:
   /axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.2(debug@4.3.4)
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -13862,15 +13859,6 @@ packages:
       tabbable: 5.3.3
     dev: false
 
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -13881,7 +13869,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
-    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -16449,6 +16436,7 @@ packages:
 
   /md5-es@1.8.2:
     resolution: {integrity: sha512-LKq5jmKMhJYhsBFUh2w+J3C4bMiC5uQie/UYJ429UATmMnFr6iANO2uQq5HXAZSIupGp0WO2mH3sNfxR4XO40Q==}
+    dev: true
 
   /mdast-util-definitions@4.0.0:
     resolution: {integrity: sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==}

--- a/projects/js-packages/components/changelog/add-boost-score-bars-to-jetpack-dashboard
+++ b/projects/js-packages/components/changelog/add-boost-score-bars-to-jetpack-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix ternary issue with translations that were failing builds

--- a/projects/js-packages/components/components/boost-score-bar/index.tsx
+++ b/projects/js-packages/components/components/boost-score-bar/index.tsx
@@ -20,8 +20,8 @@ export const BoostScoreBar: FunctionComponent< BoostScoreBarProps > = ( {
 	}
 
 	const prevScoreOffset = ( prevScore / score ) * 100;
-	const iconLabel =
-		scoreBarType === 'desktop' ? __( 'Desktop score', 'jetpack' ) : __( 'Mobile score', 'jetpack' );
+	const desktopIconLabel = __( 'Desktop score', 'jetpack' );
+	const mobileIconLabel = __( 'Mobile score', 'jetpack' );
 
 	const getIcon = () => {
 		if ( scoreBarType === 'desktop' ) {
@@ -53,7 +53,7 @@ export const BoostScoreBar: FunctionComponent< BoostScoreBarProps > = ( {
 		<div className={ classNames( 'jb-score-bar', `jb-score-bar--${ scoreBarType }` ) }>
 			<div className="jb-score-bar__label">
 				{ getIcon() }
-				<div>{ iconLabel }</div>
+				<div>{ scoreBarType === 'desktop' ? desktopIconLabel : mobileIconLabel }</div>
 			</div>
 
 			<div className="jb-score-bar__bounds">

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -541,7 +541,7 @@ const CriticalCssInfoPopover = () => {
 					) }
 				</p>
 				<ul className="boost-critical-css-info__list">
-					<li>{ __( 'Making theme changes.', 'jetpack' ) }</li>
+					<li>{ __( 'Making theme changes', 'jetpack' ) }</li>
 					<li>{ __( 'Writing a new post/page', 'jetpack' ) }</li>
 					<li>{ __( 'Editing a post/page', 'jetpack' ) }</li>
 					<li>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -1,9 +1,8 @@
 import restApi from '@automattic/jetpack-api';
-import {
-	getScoreLetter,
-	// requestSpeedScores,
-	// didScoresChange,
-} from '@automattic/jetpack-boost-score-api';
+// import {
+// 	// getScoreLetter,
+// 	// requestSpeedScores,
+// } from '@automattic/jetpack-boost-score-api';
 import { BoostScoreBar, getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -37,9 +36,9 @@ const BOOST_PLUGIN_SLUG = 'jetpack-boost';
 const DashBoost = ( {
 	siteAdminUrl,
 	siteConnectionStatus,
-	//	siteUrl,
-	//	apiRoot,
-	//	apiNonce,
+	//siteUrl,
+	//apiRoot,
+	//apiNonce,
 	fetchPluginsData,
 	fetchingPluginsData,
 	isBoostInstalled,
@@ -56,20 +55,28 @@ const DashBoost = ( {
 	const [ mobileSpeedScore, setMobileSpeedScore ] = useState( 0 );
 	const [ desktopSpeedScore, setDesktopSpeedScore ] = useState( 0 );
 
-	const getSpeedScores = () => {
+	const getSpeedScores = async () => {
 		if ( isSiteOffline ) {
 			return;
 		}
 
 		setIsLoading( true );
+		// placeholders
+		setSpeedLetterGrade( 'C' );
+		setDaysSinceTested( 1 );
+		setMobileSpeedScore( 70 );
+		setDesktopSpeedScore( 80 );
 
-		setTimeout( () => {
-			setMobileSpeedScore( 60 );
-			setDesktopSpeedScore( 75 );
-			setSpeedLetterGrade( getScoreLetter( 60, 75 ) );
-			setDaysSinceTested( 0 );
-			setIsLoading( false );
-		}, 1500 );
+		// try {
+		// 	const scores = await requestSpeedScores( false, apiRoot, siteUrl, apiNonce );
+		// 	const scoreLetter = getScoreLetter( scores.current.mobile, scores.current.desktop );
+		// 	setSpeedLetterGrade( scoreLetter );
+		// 	setMobileSpeedScore( scores.current.mobile );
+		// 	setDesktopSpeedScore( scores.current.desktop );
+		// 	setDaysSinceTested( 0 );
+		// } catch ( err ) {
+		// 	console.log( err );
+		// }
 	};
 
 	useEffect( () => {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -8,6 +8,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import PluginInstallSection from 'components/plugin-install-section';
+import SectionHeader from 'components/section-header';
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
@@ -61,10 +62,6 @@ const DashBoost = ( {
 		getSpeedScores();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
-
-	if ( ( isBoostInstalled && isBoostActive ) || fetchingPluginsData ) {
-		return null;
-	}
 
 	const getSpeedScoreText = () => {
 		switch ( speedLetterGrade ) {
@@ -130,66 +127,72 @@ const DashBoost = ( {
 		}
 	};
 
+	// Don't show score bars until we know if they already have boost install, the site is online, and we have the scores.
+	const shouldShowScoreBars =
+		( ! isBoostActive || ! isBoostInstalled ) &&
+		! isSiteOffline &&
+		! isLoading &&
+		! fetchingPluginsData;
+	const pluginName = _x(
+		'Boost',
+		'The Jetpack Boost product name, without the Jetpack prefix',
+		'jetpack'
+	);
+
 	return (
 		<div className="dash-boost-speed-score">
-			<div className="dash-boost-speed-score__summary">
-				<div>
-					{ isLoading ? (
-						<>
-							<span className="dash-boost-speed-score__summary-grade">
-								{ sprintf(
-									// translators: %s is the letter grade of the site's speed performance.
-									__( 'Your site’s speed performance score: %s', 'jetpack' ),
-									speedLetterGrade
-								) }
-							</span>
-
-							<p
-								className={ classnames(
-									'dash-boost-speed-score__score-text',
-									[ 'C', 'D', 'F' ].includes( speedLetterGrade ) ? 'warning' : ''
-								) }
-							>
-								{ getSpeedScoreText() }
-							</p>
-						</>
-					) : (
+			{ shouldShowScoreBars ? (
+				<div className="dash-boost-speed-score__summary">
+					<div>
 						<span className="dash-boost-speed-score__summary-grade">
-							{ __( 'Loading…', 'jetpack' ) }
+							{ sprintf(
+								// translators: %s is the letter grade of the site's speed performance.
+								__( 'Your site’s speed performance score: %s', 'jetpack' ),
+								speedLetterGrade
+							) }
 						</span>
-					) }
+
+						<p
+							className={ classnames(
+								'dash-boost-speed-score__score-text',
+								[ 'C', 'D', 'F' ].includes( speedLetterGrade ) ? 'warning' : ''
+							) }
+						>
+							{ getSpeedScoreText() }
+						</p>
+					</div>
+
+					<div>
+						<p className="dash-boost-speed-score__last-tested">{ getSinceTestedText() }</p>
+					</div>
 				</div>
+			) : (
+				<SectionHeader className="dash-boost-speed-score__section-header" label={ pluginName } />
+			) }
 
-				<div>
-					<p className="dash-boost-speed-score__last-tested">{ getSinceTestedText() }</p>
+			{ shouldShowScoreBars && (
+				<div className="dash-boost-speed-score__score-bars">
+					<BoostScoreBar
+						score={ mobileSpeedScore }
+						active={ true }
+						isLoading={ isLoading }
+						showPrevScores={ false }
+						scoreBarType="mobile"
+					/>
+
+					<BoostScoreBar
+						score={ desktopSpeedScore }
+						active={ true }
+						isLoading={ isLoading }
+						showPrevScores={ false }
+						scoreBarType="desktop"
+					/>
 				</div>
-			</div>
-
-			<div className="dash-boost-speed-score__score-bars">
-				<BoostScoreBar
-					score={ mobileSpeedScore }
-					active={ true }
-					isLoading={ isLoading }
-					showPrevScores={ false }
-					scoreBarType="mobile"
-				/>
-
-				<BoostScoreBar
-					score={ desktopSpeedScore }
-					active={ true }
-					isLoading={ isLoading }
-					showPrevScores={ false }
-					scoreBarType="desktop"
-				/>
-			</div>
+			) }
 
 			<div>
 				<PluginInstallSection
-					pluginName={ _x(
-						'Boost',
-						'The Jetpack Boost product name, without the Jetpack prefix',
-						'jetpack'
-					) }
+					pluginName={ pluginName }
 					pluginSlug={ BOOST_PLUGIN_SLUG }
 					pluginFiles={ BOOST_PLUGIN_FILES }
 					pluginLink={ siteAdminUrl + BOOST_PLUGIN_DASH }

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -59,6 +59,17 @@ const DashBoost = ( {
 	const [ desktopSpeedScore, setDesktopSpeedScore ] = useState( 0 );
 	const [ isSpeedScoreError, setIsSpeedScoreError ] = useState( false );
 
+	const hasBoost = isBoostInstalled && isBoostActive;
+
+	// Don't show score bars until we know if they already have boost installed and activated, the site is online, and we have the scores.
+	const shouldShowScoreBars =
+		! hasBoost && ! isSiteOffline && ! fetchingPluginsData && ! isSpeedScoreError;
+	const pluginName = _x(
+		'Boost',
+		'The Jetpack Boost product name, without the Jetpack prefix',
+		'jetpack'
+	);
+
 	const setScoresFromCache = () => {
 		setMobileSpeedScore( latestSpeedScores.scores.mobile );
 		setDesktopSpeedScore( latestSpeedScores.scores.desktop );
@@ -69,7 +80,8 @@ const DashBoost = ( {
 	};
 
 	const getSpeedScores = async () => {
-		if ( isSiteOffline ) {
+		// Don't get speed scores if site is offline or the user already has boost
+		if ( isSiteOffline || hasBoost ) {
 			return;
 		}
 
@@ -112,7 +124,7 @@ const DashBoost = ( {
 	};
 
 	useEffect( () => {
-		// Only update speedscore if the previous one is more than 3 weeks ago
+		// Use cache scores if they are less than 21 days old.
 		if ( latestSpeedScores && calculateDaysSince( latestSpeedScores.timestamp * 1000 ) < 21 ) {
 			setScoresFromCache();
 		} else {
@@ -185,17 +197,6 @@ const DashBoost = ( {
 				};
 		}
 	};
-
-	const hasBoost = isBoostInstalled && isBoostActive;
-
-	// Don't show score bars until we know if they already have boost installed and activated, the site is online, and we have the scores.
-	const shouldShowScoreBars =
-		! hasBoost && ! isSiteOffline && ! fetchingPluginsData && ! isSpeedScoreError;
-	const pluginName = _x(
-		'Boost',
-		'The Jetpack Boost product name, without the Jetpack prefix',
-		'jetpack'
-	);
 
 	const getPluginInstallSectionText = () => {
 		if ( hasActiveBoostPurchase ) {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -3,7 +3,7 @@ import {
 	// requestSpeedScores,
 	// didScoresChange,
 } from '@automattic/jetpack-boost-score-api';
-import { BoostScoreBar } from '@automattic/jetpack-components';
+import { BoostScoreBar, getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -360,16 +360,47 @@ const ConversionLossPopover = () => {
 };
 
 const CriticalCssInfoPopover = () => {
+	const criticalCssUrl = getRedirectUrl( 'jetpack-boost-critical-css' );
+
+	const trackInfoClick = useCallback( () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'boost-critical-css-info-button',
+			feature: 'boost',
+		} );
+	}, [] );
+
+	const trackCriticalCSSLinkClick = useCallback( () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'boost-critical-css-info-link',
+			feature: 'boost',
+		} );
+	}, [] );
+
 	return (
 		<div className="boost-critical-css-info">
-			<InfoPopover screenReaderText={ __( 'Learn more about how critical CSS works', 'jetpack' ) }>
+			<InfoPopover
+				onClick={ trackInfoClick }
+				screenReaderText={ __( 'Learn more about how critical CSS works', 'jetpack' ) }
+			>
 				<h3 className="boost-critical-css-info__title">
 					{ __( 'Regenerate Critical CSS', 'jetpack' ) }
 				</h3>
 				<p>
-					{ __(
-						'You should regenerate Critical CSS to optimize speed whenever your site’s HTML or CSS structure changes after:',
-						'jetpack'
+					{ createInterpolateElement(
+						__(
+							'You should regenerate <ExternalLink>Critical CSS</ExternalLink> to optimize speed whenever your site’s HTML or CSS structure changes after:',
+							'jetpack'
+						),
+						{
+							ExternalLink: (
+								<ExternalLink
+									onClick={ trackCriticalCSSLinkClick }
+									href={ criticalCssUrl }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						}
 					) }
 				</p>
 				<ul className="boost-critical-css-info__list">

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -1,8 +1,5 @@
 import restApi from '@automattic/jetpack-api';
-// import {
-// 	// getScoreLetter,
-// 	// requestSpeedScores,
-// } from '@automattic/jetpack-boost-score-api';
+import { getScoreLetter, requestSpeedScores } from '@automattic/jetpack-boost-score-api';
 import { BoostScoreBar, getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -36,9 +33,9 @@ const BOOST_PLUGIN_SLUG = 'jetpack-boost';
 const DashBoost = ( {
 	siteAdminUrl,
 	siteConnectionStatus,
-	//siteUrl,
-	//apiRoot,
-	//apiNonce,
+	siteUrl,
+	apiRoot,
+	apiNonce,
 	fetchPluginsData,
 	fetchingPluginsData,
 	isBoostInstalled,
@@ -61,22 +58,18 @@ const DashBoost = ( {
 		}
 
 		setIsLoading( true );
-		// placeholders
-		setSpeedLetterGrade( 'C' );
-		setDaysSinceTested( 1 );
-		setMobileSpeedScore( 70 );
-		setDesktopSpeedScore( 80 );
 
-		// try {
-		// 	const scores = await requestSpeedScores( false, apiRoot, siteUrl, apiNonce );
-		// 	const scoreLetter = getScoreLetter( scores.current.mobile, scores.current.desktop );
-		// 	setSpeedLetterGrade( scoreLetter );
-		// 	setMobileSpeedScore( scores.current.mobile );
-		// 	setDesktopSpeedScore( scores.current.desktop );
-		// 	setDaysSinceTested( 0 );
-		// } catch ( err ) {
-		// 	console.log( err );
-		// }
+		try {
+			const scores = await requestSpeedScores( false, apiRoot, siteUrl, apiNonce );
+			const scoreLetter = getScoreLetter( scores.current.mobile, scores.current.desktop );
+			setSpeedLetterGrade( scoreLetter );
+			setMobileSpeedScore( scores.current.mobile );
+			setDesktopSpeedScore( scores.current.desktop );
+			setDaysSinceTested( 0 );
+			setIsLoading( false );
+		} catch ( err ) {
+			return err;
+		}
 	};
 
 	useEffect( () => {
@@ -151,7 +144,7 @@ const DashBoost = ( {
 	const hasBoost = isBoostInstalled && isBoostActive;
 
 	// Don't show score bars until we know if they already have boost installed and activated, the site is online, and we have the scores.
-	const shouldShowScoreBars = ! hasBoost && ! isSiteOffline && ! isLoading && ! fetchingPluginsData;
+	const shouldShowScoreBars = ! hasBoost && ! isSiteOffline && ! fetchingPluginsData;
 	const pluginName = _x(
 		'Boost',
 		'The Jetpack Boost product name, without the Jetpack prefix',

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -546,7 +546,7 @@ const CriticalCssInfoPopover = () => {
 					<li>{ __( 'Editing a post/page', 'jetpack' ) }</li>
 					<li>
 						{ __(
-							'Activating, Deactivating, or updating plugins that impact your site layout.',
+							'Activating, deactivating, or updating plugins that impact your site layout',
 							'jetpack'
 						) }
 					</li>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -224,13 +224,9 @@ const DashBoost = ( {
 
 		if ( isInstalling ) {
 			linkText = __( 'Installing…', 'jetpack' );
-		}
-
-		if ( isActivating ) {
+		} else if ( isActivating ) {
 			linkText = __( 'Activating…', 'jetpack' );
-		}
-
-		if ( isBoostInstalled ) {
+		} else if ( isBoostInstalled ) {
 			linkText = __( 'Activate Boost to run instant tests', 'jetpack' );
 		}
 
@@ -273,38 +269,46 @@ const DashBoost = ( {
 		<div className="dash-boost-speed-score">
 			{ shouldShowScoreBars ? (
 				<>
-					<div className="dash-boost-speed-score__summary">
-						<div>
-							<span className="dash-boost-speed-score__summary-grade">
-								{ sprintf(
-									// translators: %s is the letter grade of the site's speed performance.
-									__( 'Your site’s speed performance score: %s', 'jetpack' ),
-									speedLetterGrade
-								) }
-								<GradeInfoPopover />
-							</span>
+					{ /* If only loading scores, show score bars but hide score grade and message */ }
+					{ isLoading ? (
+						<SectionHeader
+							className="dash-boost-speed-score__section-header"
+							label={ pluginName }
+						/>
+					) : (
+						<div className="dash-boost-speed-score__summary">
+							<div>
+								<span className="dash-boost-speed-score__summary-grade">
+									{ sprintf(
+										// translators: %s is the letter grade of the site's speed performance.
+										__( 'Your site’s speed performance score: %s', 'jetpack' ),
+										speedLetterGrade
+									) }
+									<GradeInfoPopover />
+								</span>
 
-							<p
-								className={ classnames(
-									'dash-boost-speed-score__score-text',
-									[ 'C', 'D', 'E', 'F' ].includes( speedLetterGrade ) ? 'warning' : ''
-								) }
-							>
-								{ getSpeedScoreText() }
-							</p>
-						</div>
+								<p
+									className={ classnames(
+										'dash-boost-speed-score__score-text',
+										[ 'C', 'D', 'E', 'F' ].includes( speedLetterGrade ) ? 'warning' : ''
+									) }
+								>
+									{ getSpeedScoreText() }
+								</p>
+							</div>
 
-						<div>
-							<p className="dash-boost-speed-score__last-tested">{ getSinceTestedText() }</p>
-							<button
-								className="dash-boost-speed-score__install-button-link"
-								onClick={ activateOrInstallBoost }
-								disabled={ isInstalling || isActivating }
-							>
-								{ getInstallLinkText() }
-							</button>
+							<div>
+								<p className="dash-boost-speed-score__last-tested">{ getSinceTestedText() }</p>
+								<button
+									className="dash-boost-speed-score__install-button-link"
+									onClick={ activateOrInstallBoost }
+									disabled={ isInstalling || isActivating }
+								>
+									{ getInstallLinkText() }
+								</button>
+							</div>
 						</div>
-					</div>
+					) }
 
 					<div className="dash-boost-speed-score__score-bars">
 						<BoostScoreBar

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -142,52 +142,52 @@ const DashBoost = ( {
 	return (
 		<div className="dash-boost-speed-score">
 			{ shouldShowScoreBars ? (
-				<div className="dash-boost-speed-score__summary">
-					<div>
-						<span className="dash-boost-speed-score__summary-grade">
-							{ sprintf(
-								// translators: %s is the letter grade of the site's speed performance.
-								__( 'Your site’s speed performance score: %s', 'jetpack' ),
-								speedLetterGrade
-							) }
-						</span>
+				<>
+					<div className="dash-boost-speed-score__summary">
+						<div>
+							<span className="dash-boost-speed-score__summary-grade">
+								{ sprintf(
+									// translators: %s is the letter grade of the site's speed performance.
+									__( 'Your site’s speed performance score: %s', 'jetpack' ),
+									speedLetterGrade
+								) }
+							</span>
 
-						<p
-							className={ classnames(
-								'dash-boost-speed-score__score-text',
-								[ 'C', 'D', 'F' ].includes( speedLetterGrade ) ? 'warning' : ''
-							) }
-						>
-							{ getSpeedScoreText() }
-						</p>
+							<p
+								className={ classnames(
+									'dash-boost-speed-score__score-text',
+									[ 'C', 'D', 'F' ].includes( speedLetterGrade ) ? 'warning' : ''
+								) }
+							>
+								{ getSpeedScoreText() }
+							</p>
+						</div>
+
+						<div>
+							<p className="dash-boost-speed-score__last-tested">{ getSinceTestedText() }</p>
+						</div>
 					</div>
 
-					<div>
-						<p className="dash-boost-speed-score__last-tested">{ getSinceTestedText() }</p>
+					<div className="dash-boost-speed-score__score-bars">
+						<BoostScoreBar
+							score={ mobileSpeedScore }
+							active={ true }
+							isLoading={ isLoading }
+							showPrevScores={ false }
+							scoreBarType="mobile"
+						/>
+
+						<BoostScoreBar
+							score={ desktopSpeedScore }
+							active={ true }
+							isLoading={ isLoading }
+							showPrevScores={ false }
+							scoreBarType="desktop"
+						/>
 					</div>
-				</div>
+				</>
 			) : (
 				<SectionHeader className="dash-boost-speed-score__section-header" label={ pluginName } />
-			) }
-
-			{ shouldShowScoreBars && (
-				<div className="dash-boost-speed-score__score-bars">
-					<BoostScoreBar
-						score={ mobileSpeedScore }
-						active={ true }
-						isLoading={ isLoading }
-						showPrevScores={ false }
-						scoreBarType="mobile"
-					/>
-
-					<BoostScoreBar
-						score={ desktopSpeedScore }
-						active={ true }
-						isLoading={ isLoading }
-						showPrevScores={ false }
-						scoreBarType="desktop"
-					/>
-				</div>
 			) }
 
 			<div>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -169,23 +169,25 @@ const DashBoost = ( {
 	};
 
 	const getInstallLinkText = () => {
+		let linkText;
+
 		if ( hasBoost ) {
 			return;
 		}
 
 		if ( isInstalling ) {
-			return __( 'Installing…', 'jetpack' );
+			linkText = __( 'Installing…', 'jetpack' );
 		}
 
 		if ( isActivating ) {
-			return __( 'Activating…', 'jetpack' );
+			linkText = __( 'Activating…', 'jetpack' );
 		}
 
 		if ( isBoostInstalled ) {
-			return __( 'Activate Boost to run instant tests', 'jetpack' );
+			linkText = __( 'Activate Boost to run instant tests', 'jetpack' );
 		}
 
-		return __( 'Install Boost to run instant tests', 'jetpack' );
+		return linkText ?? __( 'Install Boost to run instant tests', 'jetpack' );
 	};
 
 	const activateOrInstallBoost = useCallback( () => {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -1,10 +1,20 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
+import {
+	getScoreLetter,
+	// requestSpeedScores,
+	// didScoresChange,
+} from '@automattic/jetpack-boost-score-api';
+import { BoostScoreBar } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
-import PluginDashItem from 'components/plugin-dash-item';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import classnames from 'classnames';
+import PluginInstallSection from 'components/plugin-install-section';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import { getSiteConnectionStatus } from 'state/connection';
+import { getApiRootUrl, getApiNonce, getSiteRawUrl } from 'state/initial-state';
+import { isFetchingPluginsData, isPluginInstalled, isPluginActive } from 'state/site/plugins';
+import './style.scss';
 
 const BOOST_PLUGIN_DASH = 'admin.php?page=jetpack-boost';
 const BOOST_PLUGIN_FILES = [
@@ -13,35 +23,212 @@ const BOOST_PLUGIN_FILES = [
 ];
 const BOOST_PLUGIN_SLUG = 'jetpack-boost';
 
-class DashBoost extends Component {
-	static propTypes = {
-		siteAdminUrl: PropTypes.string.isRequired,
+const DashBoost = ( {
+	siteAdminUrl,
+	siteConnectionStatus,
+	//	siteUrl,
+	//	apiRoot,
+	//	apiNonce,
+	fetchingPluginsData,
+	isBoostInstalled,
+	isBoostActive,
+} ) => {
+	const isSiteOffline = siteConnectionStatus === 'offline';
+
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ speedLetterGrade, setSpeedLetterGrade ] = useState( 'C' );
+	const [ daysSinceTested, setDaysSinceTested ] = useState( 1 );
+	const [ mobileSpeedScore, setMobileSpeedScore ] = useState( 0 );
+	const [ desktopSpeedScore, setDesktopSpeedScore ] = useState( 0 );
+
+	const getSpeedScores = () => {
+		if ( isSiteOffline ) {
+			return;
+		}
+
+		setIsLoading( true );
+
+		setTimeout( () => {
+			setMobileSpeedScore( 60 );
+			setDesktopSpeedScore( 75 );
+			setSpeedLetterGrade( getScoreLetter( 60, 75 ) );
+			setDaysSinceTested( 0 );
+			setIsLoading( false );
+		}, 1500 );
 	};
 
-	render() {
-		return (
-			<PluginDashItem
-				pluginName={ _x(
-					'Boost',
-					'The Jetpack Boost product name, without the Jetpack prefix',
-					'jetpack'
-				) }
-				pluginFiles={ BOOST_PLUGIN_FILES }
-				pluginSlug={ BOOST_PLUGIN_SLUG }
-				pluginLink={ this.props.siteAdminUrl + BOOST_PLUGIN_DASH }
-				installOrActivatePrompt={ createInterpolateElement(
-					__(
-						'Improve your site’s performance and SEO in a few clicks with the free Jetpack Boost plugin.<br /><ExternalLink>Learn more</ExternalLink>',
+	useEffect( () => {
+		getSpeedScores();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	if ( ( isBoostInstalled && isBoostActive ) || fetchingPluginsData ) {
+		return null;
+	}
+
+	const getSpeedScoreText = () => {
+		switch ( speedLetterGrade ) {
+			case 'A':
+				return __( 'Your site is fast! But maintaining a high speed isn’t easy.', 'jetpack' );
+			case 'B':
+				return __( 'You are one step away from making your site blazing fast.', 'jetpack' );
+			default:
+				return __( 'Your site needs performance improvements!', 'jetpack' );
+		}
+	};
+
+	const getSinceTestedText = () => {
+		switch ( daysSinceTested ) {
+			case 0:
+				return __( 'Your site was tested today', 'jetpack' );
+			case 1:
+				return __( 'Your site was tested yesterday', 'jetpack' );
+			default:
+				return sprintf(
+					// translators: %s is the number of days since the site was last tested.
+					__( 'Your site was tested %s days ago', 'jetpack' ),
+					daysSinceTested
+				);
+		}
+	};
+
+	const getSlowSiteInfoText = () => {
+		switch ( speedLetterGrade ) {
+			case 'A':
+				return {
+					top: __(
+						'A one-second delay in loading times can reduce your site traffic by 10%.',
 						'jetpack'
 					),
-					{
-						ExternalLink: <ExternalLink href={ getRedirectUrl( 'stats-nudges-boost-learn' ) } />,
-						br: <br />,
-					}
-				) }
-			/>
-		);
-	}
-}
+					bottom: __(
+						'Use Boost’s automated acceleration tools to optimize your performance on the go.',
+						'jetpack'
+					),
+				};
+			case 'B':
+				return {
+					top: __(
+						'A one-second improvement in loading times can increase your site traffic by 10%.',
+						'jetpack'
+					),
+					bottom: __(
+						'Jetpack Boost enhance your site’s performance like top websites, no developer needed.',
+						'jetpack'
+					),
+				};
+			default:
+				return {
+					top: __(
+						'You can lose 10% of your visitors for every additional second your site takes to load.',
+						'jetpack'
+					),
+					bottom: __(
+						'Make your site blazing fast for free with Boost’s simple dashboard and acceleration tools.',
+						'jetpack'
+					),
+				};
+		}
+	};
 
-export default DashBoost;
+	return (
+		<div className="dash-boost-speed-score">
+			<div className="dash-boost-speed-score__summary">
+				<div>
+					{ isLoading ? (
+						<>
+							<span className="dash-boost-speed-score__summary-grade">
+								{ sprintf(
+									// translators: %s is the letter grade of the site's speed performance.
+									__( 'Your site’s speed performance score: %s', 'jetpack' ),
+									speedLetterGrade
+								) }
+							</span>
+
+							<p
+								className={ classnames(
+									'dash-boost-speed-score__score-text',
+									[ 'C', 'D', 'F' ].includes( speedLetterGrade ) ? 'warning' : ''
+								) }
+							>
+								{ getSpeedScoreText() }
+							</p>
+						</>
+					) : (
+						<span className="dash-boost-speed-score__summary-grade">
+							{ __( 'Loading…', 'jetpack' ) }
+						</span>
+					) }
+				</div>
+
+				<div>
+					<p className="dash-boost-speed-score__last-tested">{ getSinceTestedText() }</p>
+				</div>
+			</div>
+
+			<div className="dash-boost-speed-score__score-bars">
+				<BoostScoreBar
+					score={ mobileSpeedScore }
+					active={ true }
+					isLoading={ isLoading }
+					showPrevScores={ false }
+					scoreBarType="mobile"
+				/>
+
+				<BoostScoreBar
+					score={ desktopSpeedScore }
+					active={ true }
+					isLoading={ isLoading }
+					showPrevScores={ false }
+					scoreBarType="desktop"
+				/>
+			</div>
+
+			<div>
+				<PluginInstallSection
+					pluginName={ _x(
+						'Boost',
+						'The Jetpack Boost product name, without the Jetpack prefix',
+						'jetpack'
+					) }
+					pluginSlug={ BOOST_PLUGIN_SLUG }
+					pluginFiles={ BOOST_PLUGIN_FILES }
+					pluginLink={ siteAdminUrl + BOOST_PLUGIN_DASH }
+					installOrActivatePrompt={ createInterpolateElement(
+						sprintf(
+							'<b>%1$s</b><br />%2$s',
+							getSlowSiteInfoText().top,
+							getSlowSiteInfoText().bottom
+						),
+						{
+							br: <br />,
+							b: <b />,
+						}
+					) }
+				/>
+			</div>
+		</div>
+	);
+};
+
+DashBoost.propTypes = {
+	// Passed props
+	siteAdminUrl: PropTypes.string.isRequired,
+	// State connected props
+	siteConnectionStatus: PropTypes.string.isRequired,
+	siteUrl: PropTypes.string.isRequired,
+	apiRoot: PropTypes.string.isRequired,
+	apiNonce: PropTypes.string.isRequired,
+	fetchingPluginsData: PropTypes.bool.isRequired,
+	isBoostInstalled: PropTypes.bool.isRequired,
+	isBoostActive: PropTypes.bool.isRequired,
+};
+
+export default connect( state => ( {
+	siteConnectionStatus: getSiteConnectionStatus( state ),
+	siteUrl: getSiteRawUrl( state ),
+	apiRoot: getApiRootUrl( state ),
+	apiNonce: getApiNonce( state ),
+	fetchingPluginsData: isFetchingPluginsData( state ),
+	isBoostInstalled: BOOST_PLUGIN_FILES.some( pluginFile => isPluginInstalled( state, pluginFile ) ),
+	isBoostActive: BOOST_PLUGIN_FILES.some( pluginFile => isPluginActive( state, pluginFile ) ),
+} ) )( DashBoost );

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
@@ -1,0 +1,73 @@
+@import '../../scss/calypso-colors.scss';
+
+$border: 1px solid $gray-5;
+
+.dash-boost-speed-score {
+    background-color: $white;
+    border: $border;
+    color: $gray-80;
+    border-radius: 0.25rem;
+
+    .dops-card {
+        margin-bottom: 0;
+    }
+
+    .dops-banner__title {
+        line-height: 1.57;
+        color: $gray-80;
+    }
+
+    .jb-score-bar {
+        margin: 0;
+    }
+
+    .jb-score-bar__label {
+        background-color: $gray-0;
+    }
+
+    .jb-score-bar__filler.fill-loading {
+        background-color: $gray-0;
+    }
+
+    .warning {
+        color: $orange-warning;
+    }
+
+    &__score-bars,
+    &__summary {
+        border-bottom: $border;
+    }
+
+    &__summary {
+        display: flex;
+        justify-content: space-between;
+        
+        padding: 1rem;
+    }
+
+    &__score-text {
+        margin: 0;
+        line-height: 1.57;
+        font-size: 0.875rem;
+    }
+
+    &__last-tested {
+        color: $gray-30;
+    }
+
+    &__summary-grade {
+        display: block;
+        font-weight: bold;
+        font-size: 1.125rem;
+        line-height: 1.17;
+        margin-bottom: 0.25rem;
+    }
+
+    &__score-bars {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+
+        padding: 1.5rem 1rem;
+    }
+}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
@@ -45,6 +45,11 @@ $border: 1px solid $gray-5;
         padding: 1rem;
     }
 
+    &__section-header {
+        width: 100%;
+        margin-bottom: 0;
+    }
+
     &__score-text {
         margin: 0;
         line-height: 1.57;

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
@@ -105,7 +105,32 @@ $border: 1px solid $gray-5;
     }
 
     &__last-tested {
+        margin: 0 0 0.25rem 0;
+        
         color: $gray-30;
+        text-align: right;
+    }
+
+    &__install-button-link {
+        background: none;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+
+        cursor: pointer;
+
+        color: $black;
+        text-decoration: underline;
+        text-align: right;
+
+        &:hover {
+            text-decoration-thickness: 3px;
+        }
+
+        &:disabled {
+            text-decoration: none;
+            cursor: default;
+        }
     }
 
     &__summary-grade {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
@@ -3,6 +3,47 @@
 
 $border: 1px solid $gray-5;
 
+.boost-grade-info,
+.boost-conversion-loss-info,
+.boost-critical-css-info {
+    display: inline-block;
+    position: relative;
+    margin-left: 0.35rem;
+    top: 2px;
+}
+
+.boost-grade-info {
+    &__grades-description {
+        margin-top: 0;
+    }
+
+    &__grades-table {
+        display: flex;
+        gap: 2rem;
+    }
+}
+
+.boost-conversion-loss-info {
+    &__source {
+        margin: 0;
+    }
+}
+
+.boost-critical-css-info {
+    &__title {
+        margin-top: 0;
+    }
+
+    &__list {
+        list-style: unset;
+        padding-left: 1.5rem;
+    }
+
+    &__bottom-text {
+        margin-bottom: 0;
+    }
+}
+
 .dash-boost-speed-score {
     background-color: $white;
     border: $border;
@@ -11,6 +52,7 @@ $border: 1px solid $gray-5;
 
     .dops-card {
         margin-bottom: 0;
+        border-radius: 0.25rem;
     }
 
     .dops-banner__title {
@@ -67,7 +109,6 @@ $border: 1px solid $gray-5;
     }
 
     &__summary-grade {
-        display: block;
         font-weight: bold;
         font-size: 1.125rem;
         line-height: 1.17;

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
@@ -108,7 +108,7 @@ $border: 1px solid $gray-5;
         margin: 0 0 0.25rem 0;
         
         color: $gray-30;
-        text-align: right;
+        text-align: left;
     }
 
     &__install-button-link {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
@@ -1,4 +1,5 @@
 @import '../../scss/calypso-colors.scss';
+@import '../../scss/mixin_breakpoint.scss';
 
 $border: 1px solid $gray-5;
 
@@ -21,12 +22,13 @@ $border: 1px solid $gray-5;
         margin: 0;
     }
 
-    .jb-score-bar__label {
-        background-color: $gray-0;
-    }
-
+    .jb-score-bar__label,
     .jb-score-bar__filler.fill-loading {
         background-color: $gray-0;
+
+        @include breakpoint( "<782px" ) {
+            background-color: $white;
+        }
     }
 
     .warning {
@@ -43,6 +45,10 @@ $border: 1px solid $gray-5;
         justify-content: space-between;
         
         padding: 1rem;
+
+        @include breakpoint( "<660px" ) {
+            flex-direction: column;
+        }
     }
 
     &__section-header {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -126,6 +126,7 @@ class AtAGlance extends Component {
 			const canDisplaybundleCard =
 				! this.props.multisite && ! this.props.isOfflineMode && this.props.hasConnectedOwner;
 			const performanceCards = [];
+
 			if ( 'inactive' !== this.props.getModuleOverride( 'photon' ) ) {
 				performanceCards.push( <DashPhoton { ...settingsProps } /> );
 			}
@@ -147,10 +148,7 @@ class AtAGlance extends Component {
 			}
 
 			if ( this.props.userCanManagePlugins ) {
-				performanceCards.push(
-					<DashBoost siteAdminUrl={ this.props.siteAdminUrl } />,
-					<DashCRM siteAdminUrl={ this.props.siteAdminUrl } />
-				);
+				performanceCards.push( <DashCRM siteAdminUrl={ this.props.siteAdminUrl } /> );
 			}
 
 			const redeemPartnerCoupon = ! this.props.isOfflineMode && this.props.partnerCoupon && (
@@ -180,6 +178,12 @@ class AtAGlance extends Component {
 				</div>
 			) : null;
 
+			const boostSpeedScore = (
+				<div className="jp-at-a-glance__pinned-bundle">
+					<DashBoost siteAdminUrl={ this.props.siteAdminUrl } />
+				</div>
+			);
+
 			return (
 				<ThemeProvider>
 					<div className="jp-at-a-glance">
@@ -200,6 +204,7 @@ class AtAGlance extends Component {
 						<Section
 							header={ <DashSectionHeader label={ __( 'Performance and Growth', 'jetpack' ) } /> }
 							cards={ performanceCards }
+							pinnedBundle={ boostSpeedScore }
 						/>
 						{ connections }
 					</div>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -178,11 +178,11 @@ class AtAGlance extends Component {
 				</div>
 			) : null;
 
-			const boostSpeedScore = (
+			const boostSpeedScore = this.props.userCanManagePlugins ? (
 				<div className="jp-at-a-glance__pinned-bundle">
 					<DashBoost siteAdminUrl={ this.props.siteAdminUrl } />
 				</div>
-			);
+			) : undefined;
 
 			return (
 				<ThemeProvider>

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/README.md
@@ -59,6 +59,12 @@ Link to an admin page for the plugin. Used in the "manage" link for the card aft
 
 React prompt to show when Plugin is un-installed or un-activated.
 
+### installedPrompt
+- **Type:** `Element`
+- **Required:** `no`
+
+React prompt to show when Plugin is installed and activated
+
 ### iconAlt
 - **Type:** `String`
 - **Required:** `no`

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/index.jsx
@@ -1,142 +1,26 @@
-import restApi from '@automattic/jetpack-api';
-import { Spinner } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
-import Card from 'components/card';
-import JetpackBanner from 'components/jetpack-banner';
+import PluginInstallSection from 'components/plugin-install-section';
 import SectionHeader from 'components/section-header';
-import analytics from 'lib/analytics';
 import PropTypes from 'prop-types';
-import React, { useCallback, useState } from 'react';
-import { connect } from 'react-redux';
-import {
-	fetchPluginsData as dispatchFetchPluginsData,
-	isPluginActive,
-	isPluginInstalled,
-	isFetchingPluginsData as getIsFetchingPluginsData,
-} from 'state/site/plugins';
 
 import './style.scss';
 
 export const PluginDashItem = ( {
-	fetchPluginsData,
 	installOrActivatePrompt,
-	isFetchingPluginsData,
-	aPluginIsActive,
-	aPluginIsInstalled,
 	pluginLink,
 	pluginName,
 	pluginSlug,
+	pluginFiles,
 } ) => {
-	const [ isActivating, setIsActivating ] = useState( false );
-	const [ isInstalling, setIsInstalling ] = useState( false );
-
-	const activateOrInstallPlugin = useCallback( () => {
-		if ( ! aPluginIsInstalled ) {
-			setIsInstalling( true );
-		} else if ( ! aPluginIsActive ) {
-			setIsActivating( true );
-		} else if ( aPluginIsInstalled && aPluginIsActive ) {
-			// do not try to do anything to an installed, active plugin
-			return Promise.resolve();
-		}
-		analytics.tracks.recordJetpackClick( {
-			target: 'plugin_dash_item',
-			type: aPluginIsInstalled ? 'install' : 'activate',
-			feature: pluginSlug,
-		} );
-		return (
-			restApi
-				.installPlugin( pluginSlug, 'active' )
-				// take a little break to avoid any race conditions with plugin data being updated
-				.then( () => new Promise( resolve => setTimeout( resolve, 2500 ) ) )
-				.then( () => {
-					return fetchPluginsData();
-				} )
-				.finally( () => {
-					setIsActivating( false );
-					setIsInstalling( false );
-				} )
-		);
-	}, [ fetchPluginsData, aPluginIsActive, aPluginIsInstalled, pluginSlug ] );
-
-	const renderContent = () => {
-		if ( isFetchingPluginsData ) {
-			return (
-				<Card className="plugin-dash-item__content">
-					<p>{ __( 'Loading…', 'jetpack' ) }</p>
-				</Card>
-			);
-		} else if ( isInstalling ) {
-			return (
-				<Card className="plugin-dash-item__content">
-					<Spinner />
-					<p>
-						{ sprintf(
-							/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
-							__( 'Installing %s', 'jetpack' ),
-							pluginName
-						) }
-					</p>
-				</Card>
-			);
-		} else if ( isActivating ) {
-			return (
-				<Card className="plugin-dash-item__content">
-					<Spinner />
-					<p>
-						{ sprintf(
-							/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
-							__( 'Activating %s', 'jetpack' ),
-							pluginName
-						) }
-					</p>
-				</Card>
-			);
-		} else if ( ! aPluginIsInstalled ) {
-			return (
-				<JetpackBanner
-					callToAction={ sprintf(
-						/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
-						__( 'Install %s', 'jetpack' ),
-						pluginName
-					) }
-					title={ installOrActivatePrompt }
-					onClick={ activateOrInstallPlugin }
-					noIcon
-				/>
-			);
-		} else if ( ! aPluginIsActive ) {
-			return (
-				<JetpackBanner
-					callToAction={ sprintf(
-						/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
-						__( 'Activate %s', 'jetpack' ),
-						pluginName
-					) }
-					title={ installOrActivatePrompt }
-					onClick={ activateOrInstallPlugin }
-					noIcon
-				/>
-			);
-		}
-		return (
-			<JetpackBanner
-				callToAction={ sprintf(
-					/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
-					__( 'Manage %s', 'jetpack' ),
-					pluginName
-				) }
-				title={ __( 'Plugin is installed & active.', 'jetpack' ) }
-				href={ pluginLink }
-				noIcon
-			/>
-		);
-	};
-
 	return (
 		<div className="plugin-dash-item">
 			<SectionHeader className="plugin-dash-item__section-header" label={ pluginName } />
-			{ renderContent() }
+			<PluginInstallSection
+				pluginName={ pluginName }
+				pluginSlug={ pluginSlug }
+				pluginLink={ pluginLink }
+				pluginFiles={ pluginFiles }
+				installOrActivatePrompt={ installOrActivatePrompt }
+			/>
 		</div>
 	);
 };
@@ -147,20 +31,6 @@ PluginDashItem.propTypes = {
 	pluginSlug: PropTypes.string.isRequired,
 	pluginLink: PropTypes.string.isRequired,
 	installOrActivatePrompt: PropTypes.element.isRequired,
-	iconAlt: PropTypes.string,
-	iconSrc: PropTypes.string,
-
-	// connected properties
-	isFetchingPluginsData: PropTypes.bool,
-	aPluginIsActive: PropTypes.bool,
-	aPluginIsInstalled: PropTypes.bool,
 };
 
-export default connect(
-	( state, { pluginFiles } ) => ( {
-		isFetchingPluginsData: getIsFetchingPluginsData( state ),
-		aPluginIsInstalled: pluginFiles.some( pluginFile => isPluginInstalled( state, pluginFile ) ),
-		aPluginIsActive: pluginFiles.some( pluginFile => isPluginActive( state, pluginFile ) ),
-	} ),
-	dispatch => ( { fetchPluginsData: () => dispatch( dispatchFetchPluginsData() ) } )
-)( PluginDashItem );
+export default PluginDashItem;

--- a/projects/plugins/jetpack/_inc/client/components/plugin-install-section/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-install-section/index.jsx
@@ -22,6 +22,7 @@ const PluginInstallSection = ( {
 	pluginSlug,
 	pluginLink,
 	installOrActivatePrompt,
+	installedPrompt,
 } ) => {
 	const [ isActivating, setIsActivating ] = useState( false );
 	const [ isInstalling, setIsInstalling ] = useState( false );
@@ -121,7 +122,7 @@ const PluginInstallSection = ( {
 				__( 'Manage %s', 'jetpack' ),
 				pluginName
 			) }
-			title={ __( 'Plugin is installed & active.', 'jetpack' ) }
+			title={ installedPrompt ?? __( 'Plugin is installed & active.', 'jetpack' ) }
 			href={ pluginLink }
 			noIcon
 		/>

--- a/projects/plugins/jetpack/_inc/client/components/plugin-install-section/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-install-section/index.jsx
@@ -1,0 +1,140 @@
+import restApi from '@automattic/jetpack-api';
+import { Spinner } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import Card from 'components/card';
+import JetpackBanner from 'components/jetpack-banner';
+import analytics from 'lib/analytics';
+import { useState, useCallback } from 'react';
+import { connect } from 'react-redux';
+import {
+	fetchPluginsData as dispatchFetchPluginsData,
+	isPluginActive,
+	isPluginInstalled,
+	isFetchingPluginsData as getIsFetchingPluginsData,
+} from 'state/site/plugins';
+
+const PluginInstallSection = ( {
+	fetchPluginsData,
+	isFetchingPluginsData,
+	aPluginIsActive,
+	aPluginIsInstalled,
+	pluginName,
+	pluginSlug,
+	pluginLink,
+	installOrActivatePrompt,
+} ) => {
+	const [ isActivating, setIsActivating ] = useState( false );
+	const [ isInstalling, setIsInstalling ] = useState( false );
+
+	const activateOrInstallPlugin = useCallback( () => {
+		if ( ! aPluginIsInstalled ) {
+			setIsInstalling( true );
+		} else if ( ! aPluginIsActive ) {
+			setIsActivating( true );
+		} else if ( aPluginIsInstalled && aPluginIsActive ) {
+			// do not try to do anything to an installed, active plugin
+			return Promise.resolve();
+		}
+		analytics.tracks.recordJetpackClick( {
+			target: 'plugin_dash_item',
+			type: aPluginIsInstalled ? 'install' : 'activate',
+			feature: pluginSlug,
+		} );
+		return (
+			restApi
+				.installPlugin( pluginSlug, 'active' )
+				// take a little break to avoid any race conditions with plugin data being updated
+				.then( () => new Promise( resolve => setTimeout( resolve, 2500 ) ) )
+				.then( () => {
+					return fetchPluginsData();
+				} )
+				.finally( () => {
+					setIsActivating( false );
+					setIsInstalling( false );
+				} )
+		);
+	}, [ fetchPluginsData, aPluginIsActive, aPluginIsInstalled, pluginSlug ] );
+
+	if ( isFetchingPluginsData ) {
+		return (
+			<Card className="plugin-dash-item__content">
+				<p>{ __( 'Loading…', 'jetpack' ) }</p>
+			</Card>
+		);
+	} else if ( isInstalling ) {
+		return (
+			<Card className="plugin-dash-item__content">
+				<Spinner />
+				<p>
+					{ sprintf(
+						/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
+						__( 'Installing %s', 'jetpack' ),
+						pluginName
+					) }
+				</p>
+			</Card>
+		);
+	} else if ( isActivating ) {
+		return (
+			<Card className="plugin-dash-item__content">
+				<Spinner />
+				<p>
+					{ sprintf(
+						/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
+						__( 'Activating %s', 'jetpack' ),
+						pluginName
+					) }
+				</p>
+			</Card>
+		);
+	} else if ( ! aPluginIsInstalled ) {
+		return (
+			<JetpackBanner
+				callToAction={ sprintf(
+					/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
+					__( 'Install %s', 'jetpack' ),
+					pluginName
+				) }
+				title={ installOrActivatePrompt }
+				onClick={ activateOrInstallPlugin }
+				noIcon
+			/>
+		);
+	} else if ( ! aPluginIsActive ) {
+		return (
+			<JetpackBanner
+				callToAction={ sprintf(
+					/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
+					__( 'Activate %s', 'jetpack' ),
+					pluginName
+				) }
+				title={ installOrActivatePrompt }
+				onClick={ activateOrInstallPlugin }
+				noIcon
+			/>
+		);
+	}
+	return (
+		<JetpackBanner
+			callToAction={ sprintf(
+				/* translators: "%s" is the name of the plugin. i.e. Boost, CRM, etc. */
+				__( 'Manage %s', 'jetpack' ),
+				pluginName
+			) }
+			title={ __( 'Plugin is installed & active.', 'jetpack' ) }
+			href={ pluginLink }
+			noIcon
+		/>
+	);
+};
+
+export default connect(
+	( state, { pluginFiles } ) => ( {
+		isFetchingPluginsData: getIsFetchingPluginsData( state ),
+		aPluginIsInstalled: pluginFiles.some( pluginFile => isPluginInstalled( state, pluginFile ) ),
+		aPluginIsActive: pluginFiles.some( pluginFile => isPluginActive( state, pluginFile ) ),
+	} ),
+	dispatch => ( {
+		fetchPluginsData: () => dispatch( dispatchFetchPluginsData() ),
+	} )
+)( PluginInstallSection );

--- a/projects/plugins/jetpack/_inc/client/components/plugin-install-section/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-install-section/test/component.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen } from 'test/test-utils';
-import { PluginDashItem } from '../index';
+import PluginInstallSection from '../index';
 
-describe( 'PluginDashItem', () => {
+describe( 'PluginInstallSection', () => {
 	const testProps = {
 		pluginName: 'Test',
 		pluginFiles: [ 'test/test.php' ],
@@ -31,29 +31,47 @@ describe( 'PluginDashItem', () => {
 					},
 				},
 			},
+			pluginsData: {
+				items: {
+					'test/test.php': {
+						active: false,
+					},
+				},
+				requests: {
+					isFetchingPluginsData: true,
+				},
+			},
 		},
 	};
 
 	it( 'should render loading while isFetching', () => {
 		const localTestProps = { ...testProps, isFetchingPluginsData: true };
-		render( <PluginDashItem { ...localTestProps } />, { initialState } );
-		expect( screen.getByText( 'Loading…' ) ).toBeInTheDocument();
-	} );
 
-	it( 'should render install prompt if plugin is not installed', () => {
-		render( <PluginDashItem { ...testProps } />, { initialState } );
-		expect( screen.getByRole( 'button', { name: 'Install Test' } ) ).toBeInTheDocument();
+		render( <PluginInstallSection { ...localTestProps } />, { initialState } );
+		expect( screen.getByText( 'Loading…' ) ).toBeInTheDocument();
+
+		initialState.jetpack.pluginsData.requests.isFetchingPluginsData = false;
 	} );
 
 	it( 'should render activate prompt if plugin is installed but not active', () => {
 		const localTestProps = { ...testProps, aPluginIsInstalled: true };
-		render( <PluginDashItem { ...localTestProps } />, { initialState } );
+
+		render( <PluginInstallSection { ...localTestProps } />, { initialState } );
 		expect( screen.getByRole( 'button', { name: 'Activate Test' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'should render manage prompt if plugin is installed and active', () => {
+		initialState.jetpack.pluginsData.items[ 'test/test.php' ].active = true;
+
 		const localTestProps = { ...testProps, aPluginIsInstalled: true, aPluginIsActive: true };
-		render( <PluginDashItem { ...localTestProps } />, { initialState } );
+		render( <PluginInstallSection { ...localTestProps } />, { initialState } );
 		expect( screen.getByRole( 'link', { name: 'Manage Test' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render install prompt if plugin is not installed', () => {
+		initialState.jetpack.pluginsData.items = {};
+
+		render( <PluginInstallSection { ...testProps } />, { initialState } );
+		expect( screen.getByRole( 'button', { name: 'Install Test' } ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/scss/calypso-colors.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/calypso-colors.scss
@@ -48,6 +48,7 @@ $gray-darken-30:  darken( $gray, 30% );  // #3d596d
 // Oranges
 $orange-jazzy:           #f0821e;
 $orange-fire:            #d63638;
+$orange-warning:         #e68b28;
 
 $red-50:                 #D63638;
 

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -238,6 +238,16 @@ export function isSiteVisibleToSearchEngines( state ) {
 	return get( state.jetpack.initialState.siteData, [ 'siteVisibleToSearchEngines' ], true );
 }
 
+/**
+ * Returns the site's boost speed scores from the last time it was checked
+ *
+ * @param {object} state - Global state tree
+ * @returns {object}        the boost speed scores and timestamp
+ */
+export function getLatestBoostSpeedScores( state ) {
+	return get( state.jetpack.initialState.siteData, [ 'latestBoostSpeedScores' ] );
+}
+
 export function getApiNonce( state ) {
 	return get( state.jetpack.initialState, 'WP_API_nonce' );
 }

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	getPlanClass,
 	isJetpackBackup,
+	isJetpackBoost,
 	isJetpackProduct,
 	isJetpackSearch,
 	isJetpackSecurityBundle,
@@ -424,6 +425,28 @@ export function getActiveAntiSpamPurchase( state ) {
  */
 export function hasActiveAntiSpamPurchase( state ) {
 	return !! getActiveAntiSpamPurchase( state );
+}
+
+/**
+ * Searches active products for an active Boost product.
+ *
+ * @param {*} state - Global state tree
+ * @returns {object} An active Boost product if one was found, undefined otherwise.
+ */
+export function getActiveBoostPurchase( state ) {
+	return find( getActiveProductPurchases( state ), product =>
+		isJetpackBoost( product.product_slug )
+	);
+}
+
+/**
+ * Determines if the site has an active Boost product purchase
+ *
+ * @param {*} state - Global state tree
+ * @returns {boolean} True if the site has an active Boost product purchase, false otherwise.
+ */
+export function hasActiveBoostPurchase( state ) {
+	return !! getActiveBoostPurchase( state );
 }
 
 /**

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -6,6 +6,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Boost_Speed_Score\Speed_Score_History;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
 use Automattic\Jetpack\Connection\REST_Connector;
@@ -126,6 +127,8 @@ class Jetpack_Redux_State_Helper {
 
 		$host = new Host();
 
+		$speed_score_history = new Speed_Score_History( wp_parse_url( get_site_url(), PHP_URL_HOST ) );
+
 		return array(
 			'WP_API_root'                 => esc_url_raw( rest_url() ),
 			'WP_API_nonce'                => wp_create_nonce( 'wp_rest' ),
@@ -186,6 +189,7 @@ class Jetpack_Redux_State_Helper {
 				'showMyJetpack'              => My_Jetpack_Initializer::should_initialize(),
 				'isMultisite'                => is_multisite(),
 				'dateFormat'                 => get_option( 'date_format' ),
+				'latestBoostSpeedScores'     => $speed_score_history->latest(),
 			),
 			'themeData'                   => array(
 				'name'      => $current_theme->get( 'Name' ),

--- a/projects/plugins/jetpack/changelog/add-boost-score-bars-to-jetpack-dashboard
+++ b/projects/plugins/jetpack/changelog/add-boost-score-bars-to-jetpack-dashboard
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+Update boost dash item to include scorebars

--- a/projects/plugins/jetpack/class.jetpack-boost-modules.php
+++ b/projects/plugins/jetpack/class.jetpack-boost-modules.php
@@ -1,0 +1,55 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+/**
+ * Jetpack Boost Active Modules
+ *
+ * Since the speed scores API will only be used in the Jetpack plugin if Jetpack Boost is uninstalled
+ * all we need is to pass along this placeholder class for the modules that essentially tells the API
+ * the user doesn't have any Boost modules active.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Jetpack Boost Modules
+ */
+class Jetpack_Boost_Modules {
+
+	/**
+	 * Holds the singleton instance of the class
+	 *
+	 * @var Jetpack_Boost_Modules
+	 */
+	private static $instance = false;
+
+	/**
+	 * Singleton
+	 *
+	 * @static
+	 * @return Jetpack_Boost_Modules
+	 */
+	public static function init() {
+		if ( ! self::$instance ) {
+			self::$instance = new Jetpack_Boost_Modules();
+		}
+
+		return self::$instance;
+	}
+	/**
+	 * Returns status of all active boost modules
+	 *
+	 * @return array - An empty array. The user will never have active modules when using the Boost Score API
+	 */
+	public function get_status() {
+		return array();
+	}
+
+	/**
+	 * Returns whether or not the user has active modules
+	 *
+	 * @return false - The user will never have active modules when using the Boost Score API
+	 */
+	public function have_enabled_modules() {
+		return false;
+	}
+}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -9,6 +9,7 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
+use Automattic\Jetpack\Boost_Speed_Score\Speed_Score;
 use Automattic\Jetpack\Config;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
@@ -947,6 +948,10 @@ class Jetpack {
 
 		Partner::init();
 		My_Jetpack_Initializer::init();
+
+		// Initialize Boost Speed Score
+		$modules = Jetpack_Boost_Modules::init();
+		new Speed_Score( $modules );
 
 		/**
 		 * Fires when Jetpack is fully loaded and ready. This is the point where it's safe

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -19,7 +19,7 @@
 		"automattic/jetpack-backup": "@dev",
 		"automattic/jetpack-blaze": "@dev",
 		"automattic/jetpack-blocks": "@dev",
-		"automattic/jetpack-boost-speed-score": "0.1.x-dev",
+		"automattic/jetpack-boost-speed-score": "@dev",
 		"automattic/jetpack-compat": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-config": "@dev",

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -19,6 +19,7 @@
 		"automattic/jetpack-backup": "@dev",
 		"automattic/jetpack-blaze": "@dev",
 		"automattic/jetpack-blocks": "@dev",
+		"automattic/jetpack-boost-speed-score": "0.1.x-dev",
 		"automattic/jetpack-compat": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-config": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a800a7d9255b399ad0483fde34059c6f",
+    "content-hash": "aa3d96fdf2e7d12fc26b8cc80d9e3790",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba6324747aebe0a369723e8d352f0754",
+    "content-hash": "a800a7d9255b399ad0483fde34059c6f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -568,6 +568,75 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Register and manage blocks within a plugin. Used to manage block registration, enqueues, and more.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-boost-speed-score",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/boost-speed-score",
+                "reference": "9a2190a5dc074cc04b2204a4874777498f4996ab"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "brain/monkey": "^2.6",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-boost-speed-score",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-boost-speed-score/compare/v${old}...v${new}"
+                },
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-boost-speed-score",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-boost-speed-score.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Boost_Speed_Score\\Tests\\": "./tests/php"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A package that handles the API to generate the speed score.",
             "transport-options": {
                 "relative": true
             }
@@ -5562,6 +5631,7 @@
         "automattic/jetpack-backup": 20,
         "automattic/jetpack-blaze": 20,
         "automattic/jetpack-blocks": 20,
+        "automattic/jetpack-boost-speed-score": 20,
         "automattic/jetpack-compat": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -29,6 +29,7 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-client-server.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-user-agent.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-post-images.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-heartbeat.php';
+require_once JETPACK__PLUGIN_DIR . 'class.jetpack-boost-modules.php';
 require_once JETPACK__PLUGIN_DIR . 'class.photon.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.photon.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.global.php';

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -49,6 +49,7 @@
 		"@automattic/format-currency": "1.0.1",
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-api": "workspace:*",
+		"@automattic/jetpack-boost-score-api": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-licensing": "workspace:*",


### PR DESCRIPTION
Add Jetpack Boost module to Jetpack Dashboard

## Proposed changes:

This PR imports several packages into the Jetpack plugin ( The Boost Score Bar React component, the Boost client side API package, and the boost backend score package ) to add a new module to the dashboard to show users without boost their site score.

This modules:
 * Shows scores to users without boost
 * Allows them to install the plugin from the module
 * Does not show the score bars at all if the API errors out ( or shows previous scores if they exist )
 * Has several information icons that help give context to Boost to the user
 * Shows the user the last time their site score was tested from this module

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-k9o-p2
Design: WOl1tRuvUmDecQ0Yj0Wh5G-fi-3013%3A4333

## Does this pull request change what data or activity we track or use?

Yes, Installing from the link below the "days since tested" text, and clicks on the information icons and the links in them. The added tracks are 
 * `boost_instant_tests_install`
 * `boost-grade-info-button`
 * `boost-conversion-loss-info-button`
 * `boost-conversion-loss-info-source`
 * `boost-critical-css-info-button`
 * `boost-critical-css-info-link`

## Testing instructions:

1. Checkout this branch locally or with the jetpack beta plugin
2. Without Boost installed or activated, go to the Jetpack dashboard: `/wp-admin/admin.php?page=jetpack#/dashboard`
3. Scroll to the Performance and Growth section. You should see the module loading like this
![image](https://github.com/Automattic/jetpack/assets/65001528/b4f2d6ea-cc2b-43dd-a971-691bcddc3627)
4. Once the plugins data is loaded, you should see the boost scores loading if this is your first time loading them from the API
![image](https://github.com/Automattic/jetpack/assets/65001528/b3b65a10-4de4-46ad-8bde-cef53901e273)
5. Once they are fully loaded, you should see something like this. Make sure the info icon buttons work correctly
![image](https://github.com/Automattic/jetpack/assets/65001528/85f8845b-62f9-486c-8643-784c3b3b1d06)
6. Click Install Boost from either the CTA or the `Activate Boost to run instant tests` link. You should see the CTA text or the Install text change into a verb such as "installing..." or "activating..."
![image](https://github.com/Automattic/jetpack/assets/65001528/298f9cce-97a6-4b9c-aad4-49da914ac089)
7. Once installed and activated without a paid Boost plan, you should see this, which lets users know about automated critical CSS with the paid plan. Make sure info icon button and CTA work correctly.
![image](https://github.com/Automattic/jetpack/assets/65001528/7d70ecc8-832b-4f19-8fa6-4c3905419e48)
8. Go to `/wp-admin/plugins.php` and disable boost (do not uninstall)
9. Go back to `/wp-admin/admin.php?page=jetpack#/dashboard` and you should now see something like this
![image](https://github.com/Automattic/jetpack/assets/65001528/529861e2-5d0a-4893-a642-4c4a6d5e3f84)
10. Click to Activate the plugin and once that is complete, you should see this again
![image](https://github.com/Automattic/jetpack/assets/65001528/5aca7744-e826-472f-aab9-dd9703d8bb8b)
11. Now go purchase a paid Boost plan via `https://wordpress.com/checkout/{your_site}/jetpack_boost_yearly`
12. Go back to  `/wp-admin/admin.php?page=jetpack#/dashboard` and you should see this
![image](https://github.com/Automattic/jetpack/assets/65001528/c6635f01-cb05-4685-aa74-afd43c1d5fc6)

Bonus: There are different messages that are used depending on what the scores are, if you are testing this locally, feel free to manually input the scores in `projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx` here to make sure the right ones pop up