### PR TITLE
Follow Button Widget: add localized strings for iframe title

### DIFF
--- a/projects/plugins/jetpack/changelog/add-wpcom-platform-js-localized-strings
+++ b/projects/plugins/jetpack/changelog/add-wpcom-platform-js-localized-strings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor update to keep in sync with wpcom, feature not active
+
+

--- a/projects/plugins/jetpack/modules/widgets/follow-button.php
+++ b/projects/plugins/jetpack/modules/widgets/follow-button.php
@@ -74,6 +74,14 @@ class Jetpack_Follow_Button_Widget extends WP_Widget {
 			$attributes[] = 'data-show-follower-count="true"';
 		}
 
+		$localized = array(
+			'titles' => array(
+				'timelines'    => __( 'Embeddable Timelines', 'jetpack' ),
+				'followButton' => __( 'Follow Button', 'jetpack' ),
+				'wpEmbeds'     => __( 'WordPress Embeds', 'jetpack' ),
+			),
+		);
+
 		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		?>
 
@@ -93,7 +101,7 @@ class Jetpack_Follow_Button_Widget extends WP_Widget {
 			sprintf( __( 'Follow %s on WordPress.com', 'jetpack' ), get_bloginfo( 'name' ) );
 			?>
 		</a>
-		<script type="text/javascript">(function(d){var f = d.getElementsByTagName('SCRIPT')[0], p = d.createElement('SCRIPT');p.type = 'text/javascript';p.async = true;p.src = '//widgets.wp.com/platform.js';f.parentNode.insertBefore(p,f);}(document));</script>
+		<script type="text/javascript">(function(d){window.wpcomPlatform = <?php echo wp_json_encode( $localized, JSON_HEX_TAG | JSON_HEX_AMP ); ?>;var f = d.getElementsByTagName('SCRIPT')[0], p = d.createElement('SCRIPT');p.type = 'text/javascript';p.async = true;p.src = '//widgets.wp.com/platform.js';f.parentNode.insertBefore(p,f);}(document));</script>
 
 		<?php
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
## Proposed changes:

Adds localized strings to follow button widget iframe. Replicates change in D110939-code

Note that this feature does not appear to be active in Jetpack.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See pdqkMK-12A-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Connect site to Jetpack, if needed, and enable the "Extra Sidebar Widgets" module at `/wp-admin/admin.php?page=jetpack_modules`
- Uncomment `add_action( 'widgets_init', 'follow_button_register_widget' );` on line 6 of `projects/plugins/jetpack/modules/widgets/follow-button.php`
- Switch to a legacy theme with widget areas that supports the Customizer, like Dara
- In the Customizer or Widget editor, edit a widget area, and insert a Follow Button block
- Load a page on the site that shows the widget areas
- You should see the a `title` attribute on the iframe for the follow button
- window.wpcomPlatform object should be present on the JS global scope with strings for iframe titles.