### PR TITLE
Jetpack Backup: Fix/backup storage over space alert

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-storage-over-space-alert
+++ b/projects/packages/backup/changelog/fix-backup-storage-over-space-alert
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix "Over storage space" message for sites with plans that have no storage limit

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-levels.ts
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-levels.ts
@@ -31,6 +31,10 @@ export const getUsageLevel = (
 		return null;
 	}
 
+	if ( available === null || used === null ) {
+		return null;
+	}
+
 	if (
 		!! minDaysOfBackupsAllowed &&
 		!! daysOfBackupsAllowed &&


### PR DESCRIPTION
Fix "Over storage space" message for sites with plans that have no storage limit

<img width="352" alt="Screenshot 2023-05-23 at 20 33 32" src="https://github.com/Automattic/jetpack/assets/2747834/4b612999-6afc-416e-bbf6-2e43ecb1290b">


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the evaluation of the storage in used considering the used and available storage can be null

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Asana task: 1203958262767124-as-1204652209047215

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
* Create a Jurassic Ninja site with this branch
* Create a site with a backup plan with a storage limit and a plant without a storage limit. 
* * Confirm that in the site without a storage limit, there is no message that storage is over space.
* * In the site with storage limit confirm you see a normal message and the storage in use. 
* * * Set in you vpshell a size over the limit to see the message that storage is over space
```
vp_cache_set('site_last_backup_size_<site_id>', 536870912);
vp_cache_set('site_used_storage_<site_id>', 536870912);
```