### PR TITLE
Connection: allow passing a logo on ConnectScreen component

### DIFF
--- a/projects/js-packages/connection/changelog/add-connect-screen-logo-prop
+++ b/projects/js-packages/connection/changelog/add-connect-screen-logo-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add logo prop to ConnectScreen and ConnectScreenVisual  so we could use produucts logos similar to ConnectScreenRequiredPlan component.

--- a/projects/js-packages/connection/components/connect-screen/basic/index.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/index.jsx
@@ -21,6 +21,7 @@ import ConnectScreenVisual from './visual';
  * @param {object?} props.footer -- Additional page elements to show after the call to action.
  * @param {boolean?} props.skipUserConnection -- Whether to not require a user connection and just redirect after site connection.
  * @param {boolean?} props.autoTrigger -- Whether to initiate the connection process automatically upon rendering the component.
+ * @param {object?} props.logo -- The logo to display at the top of the component.
  * @returns {React.Component} The `ConnectScreen` component.
  */
 const ConnectScreen = ( {
@@ -37,6 +38,7 @@ const ConnectScreen = ( {
 	autoTrigger,
 	footer,
 	skipUserConnection,
+	logo,
 } ) => {
 	const {
 		handleRegisterSite,
@@ -72,6 +74,7 @@ const ConnectScreen = ( {
 			buttonIsLoading={ buttonIsLoading }
 			footer={ footer }
 			isOfflineMode={ isOfflineMode }
+			logo={ logo }
 		>
 			{ children }
 		</ConnectScreenVisual>
@@ -90,6 +93,7 @@ ConnectScreen.propTypes = {
 	images: PropTypes.arrayOf( PropTypes.string ),
 	assetBaseUrl: PropTypes.string,
 	skipUserConnection: PropTypes.bool,
+	logo: PropTypes.element,
 };
 
 ConnectScreen.defaultProps = {

--- a/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/visual.jsx
@@ -26,6 +26,7 @@ const ConnectScreenVisual = props => {
 		buttonIsLoading,
 		footer,
 		isOfflineMode,
+		logo,
 	} = props;
 
 	const errorMessage = isOfflineMode
@@ -49,6 +50,7 @@ const ConnectScreenVisual = props => {
 				'jp-connection__connect-screen' +
 				( isLoading ? ' jp-connection__connect-screen__loading' : '' )
 			}
+			logo={ logo }
 		>
 			<div className="jp-connection__connect-screen__content">
 				{ children }
@@ -98,6 +100,8 @@ ConnectScreenVisual.propTypes = {
 	footer: PropTypes.node,
 	/** Whether the site is in offline mode. */
 	isOfflineMode: PropTypes.bool,
+	/** The logo to display at the top of the component. */
+	logo: PropTypes.element,
 };
 
 ConnectScreenVisual.defaultProps = {

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.27.0",
+	"version": "0.27.1-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
The idea of this PR is to add a `logo` prop to `ConnectScreen` and `ConnectScreenVisual` like we have in [`ConnectScreenRequiredPlan`](https://github.com/Automattic/jetpack/blob/1a240d10414347918be280d0d9cc6ec990e696ba/projects/js-packages/connection/components/connect-screen/required-plan/index.jsx#L14), so we could use product logos, if required, instead of the default Jetpack logo.

`ConnnectScreen` and `ConnectScreenRequiredPlan` uses [`ConnectScreenLayout`](https://github.com/Automattic/jetpack/blob/1a240d10414347918be280d0d9cc6ec990e696ba/projects/js-packages/connection/components/connect-screen/layout/index.jsx#L13), which [validates if a logo is passed; otherwise it renders the Jetpack Logo](https://github.com/Automattic/jetpack/blob/1a240d10414347918be280d0d9cc6ec990e696ba/projects/js-packages/connection/components/connect-screen/layout/index.jsx#L27). 

We recently implemented the `ConnectScreen` in the backup plugin and added the VaultPress Backup logo in #30862 but is displaying the Jetpack logo. When implementing this PR, it will display the backup logo properly.

Related to #30862

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `logo` prop to `ConnectScreen` and `ConnectScreenVisual` components.

## Screenshots:
| Before | After |
|---|---|
| ![image](https://github.com/Automattic/jetpack/assets/1488641/4ca2640e-8ed4-4766-ad6e-76e9dde151bb) | ![image](https://github.com/Automattic/jetpack/assets/1488641/682ff085-d7db-4a16-80da-7060f8649444) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- peaFOp-FV-p2
- p6TEKc-6KA-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jurassic Ninja site with just the Jetpack VaultPress Backup plugin using this branch. You could use this link: https://jurassic.ninja/create?jetpack-beta&branches.jetpack-backup=add/connect-screen-logo-prop&wp-debug-log&nojetpack
- Connect the site to Jetpack using your main WordPress.com account and add a Jetpack VaultPress Backup plan.
- Add a new user to your blog.
- In a incognito window (or a new browser), log in with the new user.
- Navigate to VaultPress Backup page.
- You should see the connect screen with the VaultPress Backup logo instead of the default Jetpack.