### PR TITLE
SEO Tools: suggest a specific SEO description maximum length

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-seo-desc-length
+++ b/projects/plugins/jetpack/changelog/fix-seo-desc-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO Tools: suggest a specific SEO description maximum length.

--- a/projects/plugins/jetpack/extensions/blocks/seo/description-panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/seo/description-panel.js
@@ -17,6 +17,7 @@ class SeoDescriptionPanel extends Component {
 				onChange={ this.onMessageChange }
 				label={ __( 'SEO Description', 'jetpack' ) }
 				placeholder={ __( 'Write a description…', 'jetpack' ) }
+				suggestedLimit={ 156 }
 				rows={ 4 }
 			/>
 		);


### PR DESCRIPTION
See #30889

## Proposed changes:

This should fix the first part of #30889. It's recommended that SEO descriptions should not be [longer than 156 characters](https://yoast.com/meta-descriptions/#1-keep-it-up-to-155-characters). Let's indicate that in our component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Traffic and enable the SEO feature.
* Go to Posts > Add New
* Open the Jetpack Sidebar, and expand the SEO panel.
* Start typing in the SEO description, and notice the UI changes once you reach 156 chars.
