### PR TITLE
[Boost] Fix minify paths on sites in a subdir.

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -63,7 +63,7 @@ class Concatenate_CSS extends WP_Styles {
 				$css_url = wp_style_loader_src( $css_url, $obj->handle );
 			}
 
-			$css_url        = enqueued_to_absolute_url( $css_url );
+			$css_url        = jetpack_boost_enqueued_to_absolute_url( $css_url );
 			$css_url_parsed = wp_parse_url( $css_url );
 			$extra          = $obj->extra;
 

--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -63,7 +63,8 @@ class Concatenate_CSS extends WP_Styles {
 				$css_url = wp_style_loader_src( $css_url, $obj->handle );
 			}
 
-			$css_url_parsed = wp_parse_url( $obj->src );
+			$css_url        = enqueued_to_absolute_url( $css_url );
+			$css_url_parsed = wp_parse_url( $css_url );
 			$extra          = $obj->extra;
 
 			// Don't concat by default

--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -93,7 +93,7 @@ class Concatenate_JS extends WP_Scripts {
 			}
 
 			$obj           = $this->registered[ $handle ];
-			$js_url        = enqueued_to_absolute_url( $obj->src );
+			$js_url        = jetpack_boost_enqueued_to_absolute_url( $obj->src );
 			$js_url_parsed = wp_parse_url( $js_url );
 
 			// Don't concat by default

--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -93,14 +93,8 @@ class Concatenate_JS extends WP_Scripts {
 			}
 
 			$obj           = $this->registered[ $handle ];
-			$js_url        = $obj->src;
+			$js_url        = enqueued_to_absolute_url( $obj->src );
 			$js_url_parsed = wp_parse_url( $js_url );
-
-			// If no hostname is specified and path starts with /, it is relative to homeurl.
-			if ( empty( $js_url_parsed['host'] ) && substr( $js_url, 0, 1 ) === '/' ) {
-				$js_url        = home_url( $obj->src );
-				$js_url_parsed = wp_parse_url( $js_url );
-			}
 
 			// Don't concat by default
 			$do_concat = false;

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -70,6 +70,23 @@ function jetpack_boost_page_optimize_uninstall() {
 }
 
 /**
+ * Convert enqueued home-relative URLs to absolute ones.
+ *
+ * Enqueued script URLs which start with / are relative to WordPress' home URL.
+ * i.e.: "/wp-includes/x.js" should be "WP_HOME/wp-includes/x.js".
+ *
+ * Note: this method uses home_url, so should only be used plugin-side when
+ * generating concatenated URLs.
+ */
+function enqueued_to_absolute_url( $url ) {
+	if ( substr( $url, 0, 1 ) === '/' ) {
+		return home_url( $url );
+	}
+
+	return $url;
+}
+
+/**
  * Get the list of JS slugs to exclude from minification.
  */
 function jetpack_boost_page_optimize_js_exclude_list() {

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -78,7 +78,7 @@ function jetpack_boost_page_optimize_uninstall() {
  * Note: this method uses home_url, so should only be used plugin-side when
  * generating concatenated URLs.
  */
-function enqueued_to_absolute_url( $url ) {
+function jetpack_boost_enqueued_to_absolute_url( $url ) {
 	if ( substr( $url, 0, 1 ) === '/' ) {
 		return home_url( $url );
 	}

--- a/projects/plugins/boost/changelog/fix-minify-css-urls
+++ b/projects/plugins/boost/changelog/fix-minify-css-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed resource URLs generated on sites in a subdir


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related: pedxs5-eK-p2#comment-114

When minifying and concatenating css on a site in a subdirectory, URLs weren't being properly interpreted. URLs like `/wp-includes/*` are relative to WordPress' home URL, and were being treated as relative to the root path of the domain.

#30863 went some way towards fixing that, but only fixed it for JS URLs. This PR updates the fix to apply to both JS and CSS URLs.

## Proposed changes:
* Ensure that enqueued script and css URLs are treated as relative to WordPress home

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Use a WordPress site on a subdirectory on any domain.
* Ensure that CSS and JS are properly minfied and concatenated.