### PR TITLE
Change CTA on backup recommendation card to inform about first year discount

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -20,7 +20,7 @@ import { isFeatureActive } from '../state/recommendations';
 import {
 	getSiteProduct,
 	getSiteProductMonthlyCost,
-	getSiteProductDiscount,
+	getSiteProductYearlyDiscount,
 	isFetchingSiteProducts,
 } from '../state/site-products';
 
@@ -586,7 +586,7 @@ export const getStepContent = ( state, stepSlug ) => {
 			};
 		case 'vaultpress-backup': {
 			const siteRawUrl = getSiteRawUrl( state );
-			const discount = getSiteProductDiscount( state, PLAN_JETPACK_BACKUP_T1_YEARLY );
+			const discount = getSiteProductYearlyDiscount( state, PLAN_JETPACK_BACKUP_T1_YEARLY );
 
 			const getCtaText = () => {
 				if ( isFetchingSiteProducts( state ) ) {
@@ -595,8 +595,8 @@ export const getStepContent = ( state, stepSlug ) => {
 
 				return discount > 0
 					? sprintf(
-							/* translators: %(discount): is a discount percentage. e.g. 50 */
-							__( 'Get %(discount)%% off your first year', 'jetpack' ),
+							/* translators: %(discount)s: is a discount percentage. e.g. 50 */
+							__( 'Get %(discount)s%% off your first year', 'jetpack' ),
 							{ discount }
 					  )
 					: __( 'Get VaultPress Backup', 'jetpack' );

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -20,6 +20,7 @@ import { isFeatureActive } from '../state/recommendations';
 import {
 	getSiteProduct,
 	getSiteProductMonthlyCost,
+	getSiteProductDiscount,
 	isFetchingSiteProducts,
 } from '../state/site-products';
 
@@ -585,16 +586,21 @@ export const getStepContent = ( state, stepSlug ) => {
 			};
 		case 'vaultpress-backup': {
 			const siteRawUrl = getSiteRawUrl( state );
-			const monthlyPrice = getSiteProductMonthlyCost( state, PLAN_JETPACK_BACKUP_T1_YEARLY );
-			const product = getSiteProduct( state, PLAN_JETPACK_BACKUP_T1_YEARLY );
-			const price = formatCurrency( monthlyPrice, product?.currency_code );
-			const ctaText = isFetchingSiteProducts( state )
-				? __( 'Try for 30 days', 'jetpack' )
-				: sprintf(
-						/* translators: %s: is a formatted currency. e.g. $1 */
-						__( 'Try for %s for 30 days', 'jetpack' ),
-						price
-				  );
+			const discount = getSiteProductDiscount( state, PLAN_JETPACK_BACKUP_T1_YEARLY );
+
+			const getCtaText = () => {
+				if ( isFetchingSiteProducts( state ) ) {
+					return __( 'Get a discount for your first year', 'jetpack' );
+				}
+
+				return discount > 0
+					? sprintf(
+							/* translators: %(discount): is a discount percentage. e.g. 50 */
+							__( 'Get %(discount)%% off your first year', 'jetpack' ),
+							{ discount }
+					  )
+					: __( 'Get VaultPress Backup', 'jetpack' );
+			};
 
 			return {
 				progressValue: 100,
@@ -618,7 +624,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					),
 					__( 'VaultPress Backup is so easy to use; no developer required.', 'jetpack' ),
 				],
-				ctaText: ctaText,
+				ctaText: getCtaText(),
 				ctaLink: getRedirectUrl( 'jetpack-recommendations-product-checkout', {
 					site: siteRawUrl,
 					path: PLAN_JETPACK_BACKUP_T1_YEARLY,

--- a/projects/plugins/jetpack/_inc/client/state/site-products/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site-products/reducer.js
@@ -77,3 +77,17 @@ export function getSiteProductMonthlyCost( state, slug ) {
 
 	return Math.ceil( ( price / 12 ) * 100 ) / 100;
 }
+
+/**
+ * Returns the discount of a product price. It bases the discount on intro offers.
+ *
+ * @param   {object} state - Global state tree
+ * @param   {string} slug  - Product slug
+ * @returns {number}  Discount of a product price
+ */
+export function getSiteProductDiscount( state, slug ) {
+	const product = getSiteProduct( state, slug );
+	const price = product?.introductory_offer?.cost_per_interval;
+
+	return price ? Math.ceil( ( price / product?.cost ) * 100 ) : 0;
+}

--- a/projects/plugins/jetpack/_inc/client/state/site-products/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site-products/reducer.js
@@ -79,15 +79,18 @@ export function getSiteProductMonthlyCost( state, slug ) {
 }
 
 /**
- * Returns the discount of a product price. It bases the discount on intro offers.
+ * Returns the discount of a product price. It bases the discount on intro offers with a yearly interval
  *
  * @param   {object} state - Global state tree
  * @param   {string} slug  - Product slug
- * @returns {number}  Discount of a product price
+ * @returns {number}  Discount of a product price or 0 if there is no discount
  */
-export function getSiteProductDiscount( state, slug ) {
+export function getSiteProductYearlyDiscount( state, slug ) {
 	const product = getSiteProduct( state, slug );
 	const price = product?.introductory_offer?.cost_per_interval;
+	const isYearDiscount =
+		product?.introductory_offer?.interval_unit === 'year' &&
+		product?.introductory_offer?.interval_count === 1;
 
-	return price ? Math.ceil( ( price / product?.cost ) * 100 ) : 0;
+	return isYearDiscount && price ? Math.ceil( ( price / product?.cost ) * 100 ) : 0;
 }

--- a/projects/plugins/jetpack/_inc/client/state/site-products/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site-products/reducer.js
@@ -83,7 +83,7 @@ export function getSiteProductMonthlyCost( state, slug ) {
  *
  * @param   {object} state - Global state tree
  * @param   {string} slug  - Product slug
- * @returns {number}  Discount of a product price or 0 if there is no discount
+ * @returns {number} Discount of a product price or 0 if there is no discount
  */
 export function getSiteProductYearlyDiscount( state, slug ) {
 	const product = getSiteProduct( state, slug );

--- a/projects/plugins/jetpack/changelog/update-backup-recommendation-cta
+++ b/projects/plugins/jetpack/changelog/update-backup-recommendation-cta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Change CTA on backup recommendation card to inform about first year discount

--- a/tools/e2e-commons/pages/wp-admin/recommendations.js
+++ b/tools/e2e-commons/pages/wp-admin/recommendations.js
@@ -58,7 +58,7 @@ export default class RecommendationsPage extends WpPage {
 	}
 
 	get tryVaultPressBackup() {
-		return 'a[href*="jetpack-recommendations-product-checkout"] >> text=Try for';
+		return 'a[href*="jetpack-recommendations-product-checkout"] >> text=Get';
 	}
 
 	get skipVaultPressBackup() {


### PR DESCRIPTION
## Proposed changes:
- Add dynamic CTA based on first year discount to backup recommendation

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create JS or Ephermal site with Jetpack Backup
* Choose this branch (`update/backup-recommendation-cta`) as a source of the main Jetpack plugin
* Set up Jetpack connection
* Go to `/wp-admin/admin.php?page=jetpack#/recommendations/vaultpress-backup`
* The recommendation card should have CTA "Get 50% off your first year":

<img width="1074" alt="CleanShot 2023-05-24 at 14 48 08@2x" src="https://github.com/Automattic/jetpack/assets/8419292/3e6adb06-8055-46fa-8c7d-f9c5f5c5cf37">


