### PR TITLE
AI Assistant: hide image generation part

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-disable-image-generation-part
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-disable-image-generation-part
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: hide image generation part

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -132,7 +132,7 @@ const AIControl = ( {
 export default AIControl;
 
 // Consider to enable when we have image support
-const isImageEnabled = false;
+const isImageGenerationEnabled = false;
 
 const ToolbarControls = ( {
 	contentIsLoaded,
@@ -289,7 +289,7 @@ const ToolbarControls = ( {
 						</ToolbarButton>
 					) }
 				</ToolbarGroup>
-				{ isImageEnabled && ! showRetry && ! contentIsLoaded && (
+				{ isImageGenerationEnabled && ! showRetry && ! contentIsLoaded && (
 					// Image/text toggle
 					<ToolbarGroup>
 						<ToolbarButton icon={ image } onClick={ handleImageRequest }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -131,6 +131,9 @@ const AIControl = ( {
 
 export default AIControl;
 
+// Consider to enable when we have image support
+const isImageEnabled = false;
+
 const ToolbarControls = ( {
 	contentIsLoaded,
 	getSuggestionFromOpenAI,
@@ -286,7 +289,7 @@ const ToolbarControls = ( {
 						</ToolbarButton>
 					) }
 				</ToolbarGroup>
-				{ ! showRetry && ! contentIsLoaded && (
+				{ isImageEnabled && ! showRetry && ! contentIsLoaded && (
 					// Image/text toggle
 					<ToolbarGroup>
 						<ToolbarButton icon={ image } onClick={ handleImageRequest }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/30874

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: hide image generation part

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/edit an AI Assistant block instance
* Confirm the Image generation part is not sown

before|after
------|------
<img width="686" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/b47bb3c9-5d63-4752-ac19-d392daa968de">| <img width="690" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/da60527a-0610-4577-89ef-d72e11a6673b">

