### PR TITLE
Fix: generic user_id user meta value used in get_author function

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-user-author-check
+++ b/projects/plugins/jetpack/changelog/fix-user-author-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add a WP_User check in get_author method.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1395,10 +1395,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$$field = str_replace( '&amp;', '&', $$field );
 			}
 		} else {
-			if ( isset( $author->user_id ) && $author->user_id ) {
-				$author = $author->user_id;
-			} elseif ( isset( $author->user_email ) ) {
+			if ( $author instanceof WP_User || isset( $author->user_email ) ) {
 				$author = $author->ID;
+			} elseif ( isset( $author->user_id ) && $author->user_id ) {
+				$author = $author->user_id;
 			} elseif ( isset( $author->post_author ) ) {
 				// then $author is a Post Object.
 				if ( ! $author->post_author ) {

--- a/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Jetpack_JSON_API_Endpoint class unit tests.
+ * Run this test with command: jetpack docker phpunit -- --filter=WP_Test_Jetpack_Base_Json_Api_Endpoints
+ *
+ * @package automattic/jetpack
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+
+/**
+ * Generic tests for Jetpack_JSON_API_Endpoint.
+ */
+class WP_Test_Jetpack_Base_Json_Api_Endpoints extends WP_UnitTestCase {
+	/**
+	 * A super admin user used for test.
+	 *
+	 * @var int
+	 */
+	private static $super_admin_user_id;
+
+	/**
+	 * Alternative super admin user used for test.
+	 *
+	 * @var int
+	 */
+	private static $super_admin_alt_user_id;
+
+	/**
+	 * Inserts globals needed to initialize the endpoint.
+	 */
+	private function set_globals() {
+		$_SERVER['REQUEST_METHOD'] = 'Get';
+		$_SERVER['HTTP_HOST']      = '127.0.0.1';
+		$_SERVER['REQUEST_URI']    = '/';
+	}
+
+	/**
+	 * Create fixtures once, before any tests in the class have run.
+	 *
+	 * @param object $factory A factory object needed for creating fixtures.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$super_admin_user_id     = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$super_admin_alt_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * @author zaerl
+	 * @covers Jetpack_JSON_API_Endpoint::get_author
+	 * @group json-api
+	 */
+	public function test_get_author_should_trigger_error_if_a_user_not_exists() {
+		// Force the error handler to return null.
+		set_error_handler( '__return_null' );
+
+		$endpoint = $this->get_dummy_endpoint();
+		$author   = $endpoint->get_author( 0 );
+
+		$this->assertNull( $author );
+	}
+
+	/**
+	 * @author zaerl
+	 * @covers Jetpack_JSON_API_Endpoint::get_author
+	 * @group json-api
+	 */
+	public function test_get_author_should_return_the_same_user() {
+		$endpoint = $this->get_dummy_endpoint();
+		$author   = $endpoint->get_author( self::$super_admin_user_id );
+
+		$this->assertIsObject( $author );
+		$this->assertSame( self::$super_admin_user_id, $author->ID );
+	}
+
+	/**
+	 * @author zaerl
+	 * @covers Jetpack_JSON_API_Endpoint::get_author
+	 * @group json-api
+	 */
+	public function test_get_author_should_return_the_same_user_if_user_meta_is_set() {
+		$endpoint = $this->get_dummy_endpoint();
+
+		// Force a 'user_id' pointing to another user in the user meta.
+		add_user_meta( self::$super_admin_user_id, 'user_id', self::$super_admin_alt_user_id );
+
+		$user   = get_user_by( 'id', self::$super_admin_user_id );
+		$author = $endpoint->get_author( self::$super_admin_user_id );
+
+		// Check that __get magic method is working.
+		$this->assertSame( self::$super_admin_alt_user_id, (int) $user->user_id );
+
+		// The user should be the same as the one passed to the method.
+		$this->assertIsObject( $author );
+		$this->assertSame( self::$super_admin_user_id, $author->ID );
+
+		$author = $endpoint->get_author( $user );
+
+		// The user should be the same as the one passed as object to the method.
+		$this->assertIsObject( $author );
+		$this->assertSame( self::$super_admin_user_id, $author->ID );
+
+		delete_user_meta( self::$super_admin_user_id, 'user_id' );
+	}
+
+	/**
+	 * Generate a dummy endpoint
+	 */
+	private function get_dummy_endpoint() {
+		$endpoint = new Jetpack_JSON_API_Dummy_Base_Endpoint(
+			array(
+				'stat' => 'dummy',
+			)
+		);
+
+		return $endpoint;
+	}
+}
+
+/**
+ * Dummy endpoint for testing.
+ */
+class Jetpack_JSON_API_Dummy_Base_Endpoint extends Jetpack_JSON_API_Endpoint {
+	/**
+	 * Dummy result.
+	 */
+	public function result() {
+		return 'success';
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test_class.json-api-jetpack-base-endpoint.php
@@ -47,6 +47,16 @@ class WP_Test_Jetpack_Base_Json_Api_Endpoints extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Reset the environment to its original state after the test.
+	 */
+	public function tear_down() {
+		set_error_handler( null );
+		delete_user_meta( self::$super_admin_user_id, 'user_id' );
+
+		parent::tear_down();
+	}
+
+	/**
 	 * @author zaerl
 	 * @covers Jetpack_JSON_API_Endpoint::get_author
 	 * @group json-api
@@ -100,12 +110,10 @@ class WP_Test_Jetpack_Base_Json_Api_Endpoints extends WP_UnitTestCase {
 		// The user should be the same as the one passed as object to the method.
 		$this->assertIsObject( $author );
 		$this->assertSame( self::$super_admin_user_id, $author->ID );
-
-		delete_user_meta( self::$super_admin_user_id, 'user_id' );
 	}
 
 	/**
-	 * Generate a dummy endpoint
+	 * Generate a dummy endpoint.
 	 */
 	private function get_dummy_endpoint() {
 		$endpoint = new Jetpack_JSON_API_Dummy_Base_Endpoint(


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/2511 for additional information.

Fixes #https://github.com/Automattic/dotcom-forge/issues/2511

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a `$author instanceof WP_User || isset( $author->user_email )` check is moved as the first one in the `get_author` function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `http://calypso.localhost:3000/people/team/SITE` and add `danielbachhuber` as a subscriber or a user that has a `user_id: a valid WPCOM user ID` entry in `wp_usermeta`
* Make sure that the user of the list is the correct one.

