### PR TITLE
My Jetpack: Add `Jetpack AI` card.

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -110,6 +110,7 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 			isFetching={ isFetching }
 			isInstallingStandalone={ installingStandalone }
 			isDeactivatingStandalone={ deactivatingStandalone }
+			isManageDisabled={ ! manageUrl }
 			onDeactivate={ deactivate }
 			slug={ slug }
 			onActivate={ handleActivate }

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
@@ -22,6 +22,7 @@ const ActionButton = ( {
 	isFetching,
 	isInstallingStandalone,
 	isDeactivatingStandalone,
+	isManageDisabled,
 	className,
 	onAdd,
 } ) => {
@@ -79,6 +80,7 @@ const ActionButton = ( {
 			return (
 				<Button
 					{ ...buttonState }
+					disabled={ isManageDisabled || buttonState?.disabled }
 					size="small"
 					weight="regular"
 					variant="secondary"

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -320,6 +320,7 @@ ProductCard.propTypes = {
 	isFetching: PropTypes.bool,
 	isInstallingStandalone: PropTypes.bool,
 	isDeactivatingStandalone: PropTypes.bool,
+	isManageDisabled: PropTypes.bool,
 	onManage: PropTypes.func,
 	onFixConnection: PropTypes.func,
 	onActivate: PropTypes.func,

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ProductCard from '../connected-product-card';
+
+const AiCard = ( { admin } ) => {
+	return <ProductCard admin={ admin } slug="jetpack-ai" />;
+};
+
+AiCard.propTypes = {
+	admin: PropTypes.bool.isRequired,
+};
+
+export default AiCard;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -1,5 +1,6 @@
 import { Container, Col } from '@automattic/jetpack-components';
 import React from 'react';
+import AiCard from './ai-card';
 import AntiSpamCard from './anti-spam-card';
 import BackupCard from './backup-card';
 import BoostCard from './boost-card';
@@ -16,6 +17,8 @@ import VideopressCard from './videopress-card';
  * @returns {object} ProductCardsSection React component.
  */
 const ProductCardsSection = () => {
+	const { myJetpackFlags } = window?.myJetpackInitialState || {};
+
 	return (
 		<Container fluid horizontalSpacing={ 0 } horizontalGap={ 3 }>
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
@@ -43,7 +46,7 @@ const ProductCardsSection = () => {
 				<SocialCard admin={ true } />
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<ExtrasCard admin={ true } />
+				{ myJetpackFlags?.jetpackAi ? <AiCard admin={ true } /> : <ExtrasCard admin={ true } /> }
 			</Col>
 		</Container>
 	);

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-mj-card
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-mj-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: Add new Jetpack AI card

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.14.0",
+	"version": "2.14.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.14.0';
+	const PACKAGE_VERSION = '2.14.1-alpha';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -199,6 +199,7 @@ class Initializer {
 	public static function get_my_jetpack_flags() {
 		$flags = array(
 			'videoPressStats' => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
+			'jetpackAi'       => Jetpack_Constants::is_true( 'JETPACK_AI_ENABLED' ),
 		);
 
 		return $flags;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related with #30728 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `AiCard` and load based on `JETPACK_AI_ENABLED`.
* Load `jetpackAi` flag from `JETPACK_AI_ENABLED` constant.
* Add `isManageDisabled` prop in `ProductCard`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spawn new JN site.
* Navigate to `My Jetpack` page and check that `Extras` card is there.
* Goes to `Jetpack Constants` in `Settings` and enable `Jetpack Ai`.
* Navigate back to `My Jetpack`, now it should have `Jetpack Ai` card.
* Play with it :) 

### Demo

![CleanShot 2023-05-24 at 12 30 29](https://github.com/Automattic/jetpack/assets/1663717/01fc21bb-8a9d-4f39-ab1a-a699e9393afe)


