### PR TITLE
Launchpad: Include "Choose a plan" task in other flows

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-choose-plan
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-choose-plan
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Include "Choose a plan" task in other flows

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -262,9 +262,9 @@ function wpcom_register_default_launchpad_checklists() {
 			'id'       => 'free',
 			'title'    => 'Free',
 			'task_ids' => array(
+				'plan_selected',
 				'setup_free',
 				'design_selected',
-				'plan_selected',
 				'domain_upsell',
 				'first_post_published',
 				'design_edited',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -34,6 +34,7 @@ function wpcom_register_default_launchpad_checklists() {
 			'title'                => __( 'Choose a plan', 'jetpack-mu-wpcom' ),
 			'subtitle'             => 'wpcom_get_plan_selected_subtitle',
 			'is_complete_callback' => '__return_true',
+			'badge_text_callback'  => 'wpcom_get_plan_selected_badge_text',
 		)
 	);
 
@@ -248,6 +249,7 @@ function wpcom_register_default_launchpad_checklists() {
 			'task_ids' => array(
 				'setup_general',
 				'design_selected',
+				'plan_selected',
 				'first_post_published',
 				'design_edited',
 				'site_launched',
@@ -262,6 +264,7 @@ function wpcom_register_default_launchpad_checklists() {
 			'task_ids' => array(
 				'setup_free',
 				'design_selected',
+				'plan_selected',
 				'domain_upsell',
 				'first_post_published',
 				'design_edited',
@@ -334,6 +337,7 @@ function wpcom_register_default_launchpad_checklists() {
 			'task_ids' => array(
 				'setup_write',
 				'design_selected',
+				'plan_selected',
 				'first_post_published',
 				'site_launched',
 			),
@@ -489,13 +493,26 @@ function wpcom_get_plan_selected_subtitle() {
 
 	return wpcom_global_styles_in_use() && wpcom_should_limit_global_styles()
 		? __(
-			'Your site contains custom colors that will only be visible once you upgrade to a Premium plan.',
+			'Your site contains custom styles. Upgrade now to publish them and unlock tons of other features.',
 			'jetpack-mu-wpcom'
 		) : '';
 }
 
 /**
  * Returns the badge text for the plan selected task
+ *
+ * @return string Badge text
+ */
+function wpcom_get_plan_selected_badge_text() {
+	if ( ! function_exists( 'wpcom_global_styles_in_use' ) || ! function_exists( 'wpcom_should_limit_global_styles' ) ) {
+		return '';
+	}
+
+	return wpcom_global_styles_in_use() && wpcom_should_limit_global_styles() ? __( 'Upgrade plan', 'jetpack-mu-wpcom' ) : '';
+}
+
+/**
+ * Returns the badge text for the domain upsell task
  *
  * @return string Badge text
  */


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/2262

## Proposed changes:
- Includes the "Choose a plan" task in the `build`, `write`, and `free` flows so we can add a notice to it when Global Styles are limited.
- The wording of the limited Global Styles notice has been improved (prior to this PR, it was only visible in the Newsletter flow).

Flow | Before | After
--- | --- | ---
Newsletter | <img width="200" alt="newsletter - before" src="https://github.com/Automattic/jetpack/assets/1233880/bdb6e374-ef08-41c3-8216-fe04dc7dfc75"> | <img width="200" alt="Screenshot 2023-05-25 at 12 35 36" src="https://github.com/Automattic/jetpack/assets/1233880/0a15d379-2817-4558-871a-a9dab9e5f181">
Free | <img width="200" alt="free - before" src="https://github.com/Automattic/jetpack/assets/1233880/1f210737-351e-4c76-8c4a-13849161ca6a"> | <img width="200" alt="Screenshot 2023-05-25 at 12 36 45" src="https://github.com/Automattic/jetpack/assets/1233880/3392afd2-d8cb-44de-9772-5d7324529d7f">
Build | <img width="200" alt="build - before" src="https://github.com/Automattic/jetpack/assets/1233880/e199d1d5-6145-4ae2-8fa6-18ea62dd80a1"> | <img width="200" alt="Screenshot 2023-05-25 at 12 37 42" src="https://github.com/Automattic/jetpack/assets/1233880/f774e8fc-122d-4fb1-ab4b-18c5ed6e4801">
Write |  <img width="200" alt="write - before" src="https://github.com/Automattic/jetpack/assets/1233880/f2d83ad9-911f-4685-a8e1-7fff2f75792b"> | <img width="200" alt="Screenshot 2023-05-25 at 12 38 09" src="https://github.com/Automattic/jetpack/assets/1233880/ca9bd092-cb44-4f48-b842-9947a16a4183">





### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pekYwv-1ax-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Apply these changes to your WP.com sandbox.
- Sandbox the API.
- Test different onboarding flows:
  - Write: go to `wordpress.com/start` and select "Write & Publish" as the site goal.
  - Build:  go to `wordpress.com/start` and select "Other" as the site goal. 
  - Free: go to `wordpress.com/setup/free`.
  - Newsletter: go to `wordpress.com/setup/newsletter`.
- Select a custom style during the onboarding and remain on the Free plan.
- Once you get to the Launchpad, you should the "Choose a plan" task in all the flows.
- Make sure the wording is clear.
- Make sure the badge text says "Upgrade plan".