### PR TITLE
AI Assistant: remove title generation as follow-up option

### DIFF
--- a/projects/plugins/jetpack/changelog/modify-ai-assistant-title-generation
+++ b/projects/plugins/jetpack/changelog/modify-ai-assistant-title-generation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Insignificant menu change of non-published feature
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -189,11 +189,6 @@ const ToolbarControls = ( {
 								onClick: () =>
 									getSuggestionFromOpenAI( 'correctSpelling', { contentType: 'generated' } ),
 							},
-							{
-								title: __( 'Generate a post title', 'jetpack' ),
-								onClick: () =>
-									getSuggestionFromOpenAI( 'generateTitle', { contentType: 'generated' } ),
-							},
 						] }
 					/>
 				</BlockControls>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30899 





## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes this option on content not yet accepted (this option deletes the content and creates a title):
<img width="692" alt="Screenshot 2023-05-24 at 17 51 09" src="https://github.com/Automattic/jetpack/assets/16329583/f4f91720-649d-4641-bf92-8714d34a041a">

The title generation option is still available on a fresh new block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the PR on a site with the block enabled
* Verify that the option is not available for follow-ups
* Verify that the option is still available on new blocks for posts with content

