### PR TITLE
AI Assistant: Enhance color of disabled button

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-submit-color
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-submit-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Enhance color of disabled button

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -106,13 +106,20 @@
 		color: var( --wp--preset--color--foreground );
 		text-transform: uppercase;
 		font-weight: 400;
+		user-select: none;
 
 		> SVG {
 			margin-right: 4px;
 		}
 
-		&:hover {
+		&:hover,
+		&:active {
 			color: var( --wp-components-color-accent, var( --wp-admin-theme-color ) );
+		}
+
+		&:disabled {
+			opacity: 0.6;
+			cursor: not-allowed;
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30719

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bumps up the opacity from 0.3 to 0.6 and adds a `not-allowed` cursor
* Fixes the color for the `active` state

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an AI Assistant block
* Check that the `Send` button has better visibility when disabled
* Try different themes

https://github.com/Automattic/jetpack/assets/8486249/0e74605d-c45f-45dc-94ba-c553320cedcc
