### PR TITLE
Launchpad: Add "is enabled" callback support to the task list definition

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-is-enabled-callback
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-is-enabled-callback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a new is_enabled logic to the launchpad endpoint to determine whether the task list is enabled for a site.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -129,6 +129,18 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
+	 * Check if a task list is enabled by checking its is_enabled_callback callback.
+	 *
+	 * @param string $id Task List id.
+	 * @return bool|null True if enabled, false if not, null if not found.
+	 */
+	public function is_task_list_enabled( $id ) {
+		$task_list = $this->get_task_list( $id );
+
+		return $this->load_value_from_callback( $task_list, 'is_enabled_callback', null );
+	}
+
+	/**
 	 * Get all registered Launchpad Task Lists.
 	 *
 	 * @return array All registered Launchpad Task Lists.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -877,6 +877,29 @@ function wpcom_log_launchpad_being_enabled_for_test_sites( $option, $value ) {
 	);
 }
 
+/**
+ * Checks if a specific launchpad task list is enabled or if the overall launchpad is enabled.
+ *
+ * @param string|false $checklist_slug The slug of the launchpad task list to check.
+ * @return bool True if the task list is enabled, false otherwise.
+ */
+function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug = false ) {
+	// If the checklist slug is provided, check the status of the task list.
+	if ( false !== $checklist_slug ) {
+		$is_enabled = wpcom_launchpad_checklists()->is_task_list_enabled( $checklist_slug );
+
+		// If the status of the task list is known, return its value.
+		if ( null !== $is_enabled ) {
+			return $is_enabled;
+		}
+	}
+
+	// If the status of the task list is not known, check the status of the overall launchpad.
+	// @todo: Remove this fallback once all task lists have been migrated to the new system.
+	// https://github.com/Automattic/wp-calypso/issues/77407
+	return wpcom_launchpad_checklists()->is_launchpad_enabled();
+}
+
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.
 if ( class_exists( 'WPCOM_Launchpad' ) ) {
 	remove_action( 'plugins_loaded', array( WPCOM_Launchpad::get_instance(), 'init' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -122,7 +122,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
 			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
-			'is_enabled'         => wpcom_launchpad_checklists()->is_launchpad_enabled(),
+			'is_enabled'         => wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes https://github.com/Automattic/wp-calypso/issues/77270

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new `is_enabled` logic to the launchpad endpoint to determine whether the task list is enabled for a site. We should have more flexibility and control over the task list to better define its availability throughout the WPCOM.
* We are aiming to add a new callback called `is_enabled_callback` to the task list definition.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-is-enabled-callback` to build and sync this branch to your sandbox.
* Sandbox the public API
* Navigate to https://developer.wordpress.com/docs/api/console/
* Update the two toggles in the top left to `WP REST API` and `wpcom/v2`, but leave the `HTTP` action as `GET`
* Make some requests to the existing task lists to ensure it continue working as expected: `/sites/vlorran45.wordpress.com/launchpad?checklist_slug={TASK_LIST}`
  * link-in-bio
  * build
  * free
  * link-in-bio-tld
* Now, edit the `launchpad.php` file and add the `is_enabled_callback` to one of the task lists:
```php
wpcom_register_launchpad_task_list(
	array(
		'id'       => 'build',
		'title'    => 'Build',
		'is_enabled_callback' => '__return_false',
		'task_ids' => array(
			'setup_general',
			'design_selected',
			'first_post_published',
			'design_edited',
			'site_launched',
		),
	)
);
```
* Make a request again to the task list and verify that the `is_enabled` key is set to `false` in the response.

