### PR TITLE
Fix translation for launchpad tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-translation-for-launchpad-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-translation-for-launchpad-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: use callbacks for task titles to pick up the user locale

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "2.3.x-dev"
+			"dev-trunk": "2.4.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "2.3.0",
+	"version": "2.4.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '2.3.0';
+	const PACKAGE_VERSION = '2.4.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -213,9 +213,15 @@ class Launchpad_Task_Lists {
 	 */
 	private function build_task( $task ) {
 		$built_task                 = array(
-			'id'    => $task['id'],
-			'title' => $task['title'],
+			'id' => $task['id'],
 		);
+
+		$default_title = '';
+		if ( isset( $task['title'] ) ) {
+			$default_title = $task['title'];
+		}
+
+		$built_task['title']        = $this->load_value_from_callback( $task, 'get_title', $default_title );
 		$built_task['completed']    = $this->is_task_complete( $task );
 		$built_task['disabled']     = $this->is_task_disabled( $task );
 		$built_task['subtitle']     = $this->load_subtitle( $task );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -212,16 +212,11 @@ class Launchpad_Task_Lists {
 	 * @return Task Task with current state.
 	 */
 	private function build_task( $task ) {
-		$built_task                 = array(
+		$built_task = array(
 			'id' => $task['id'],
 		);
 
-		$default_title = '';
-		if ( isset( $task['title'] ) ) {
-			$default_title = $task['title'];
-		}
-
-		$built_task['title']        = $this->load_value_from_callback( $task, 'get_title', $default_title );
+		$built_task['title']        = $this->load_title( $task );
 		$built_task['completed']    = $this->is_task_complete( $task );
 		$built_task['disabled']     = $this->is_task_disabled( $task );
 		$built_task['subtitle']     = $this->load_subtitle( $task );
@@ -244,6 +239,26 @@ class Launchpad_Task_Lists {
 			return call_user_func_array( $task[ $callback ], array( $task, $default ) );
 		}
 		return $default;
+	}
+
+	/**
+	 * Loads a title for a task, calling the 'get_title' callback if it exists,
+	 * or falling back on the value for the 'title' key if it is set.
+	 *
+	 * @param Task $task A task definition.
+	 * @return string The title for the task.
+	 */
+	private function load_title( $task ) {
+		$title = $this->load_value_from_callback( $task, 'get_title' );
+		if ( ! empty( $title ) ) {
+			return $title;
+		}
+
+		if ( isset( $task['title'] ) ) {
+			return $task['title'];
+		}
+
+		return '';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -490,8 +490,11 @@ class Launchpad_Task_Lists {
 			return false;
 		}
 
-		if ( ! isset( $task['title'] ) ) {
-			_doing_it_wrong( 'validate_task', 'The Launchpad task being registered requires a "title" attribute', '6.1' );
+		// For now, allow the 'title' attribute.
+		$has_valid_title = isset( $task['title'] ) || ( isset( $task['get_title'] ) && is_callable( $task['get_title'] ) );
+
+		if ( ! $has_valid_title ) {
+			_doing_it_wrong( 'validate_task', 'The Launchpad task being registered requires a "title" attribute or a "get_title" callback', '6.2' );
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -244,6 +244,8 @@ class Launchpad_Task_Lists {
 	/**
 	 * Loads a title for a task, calling the 'get_title' callback if it exists,
 	 * or falling back on the value for the 'title' key if it is set.
+	 * We prefer the callback so we can defer the translation until after the
+	 * user's locale has been set up.
 	 *
 	 * @param Task $task A task definition.
 	 * @return string The title for the task.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -23,7 +23,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'setup_newsletter',
-			'title'                => __( 'Personalize newsletter', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Personalize newsletter', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => '__return_true',
 		)
 	);
@@ -31,7 +33,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'plan_selected',
-			'title'                => __( 'Choose a plan', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
+			},
 			'subtitle'             => 'wpcom_get_plan_selected_subtitle',
 			'is_complete_callback' => '__return_true',
 			'badge_text_callback'  => 'wpcom_get_plan_selected_badge_text',
@@ -41,7 +45,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'plan_completed',
-			'title'                => __( 'Choose a plan', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
+			},
 			'subtitle'             => 'wpcom_get_plan_completed_subtitle',
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 		)
@@ -50,7 +56,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'subscribers_added',
-			'title'                => __( 'Add subscribers', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => '__return_true',
 		)
 	);
@@ -58,7 +66,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                    => 'first_post_published',
-			'title'                 => __( 'Write your first post', 'jetpack-mu-wpcom' ),
+			'get_title'             => function () {
+				return __( 'Write your first post', 'jetpack-mu-wpcom' );
+			},
 			'add_listener_callback' => function () {
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
 			},
@@ -68,8 +78,10 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                    => 'first_post_published_newsletter',
-			'title'                 => __( 'Start writing', 'jetpack-mu-wpcom' ),
 			'id_map'                => 'first_post_published',
+			'get_title'             => function () {
+				return __( 'Start writing', 'jetpack-mu-wpcom' );
+			},
 			'add_listener_callback' => function () {
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
 			},
@@ -79,7 +91,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'design_selected',
-			'title'                => __( 'Select a design', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Select a design', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => '__return_true',
 			'is_disabled_callback' => 'wpcom_is_design_step_enabled',
 		)
@@ -88,7 +102,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'setup_link_in_bio',
-			'title'                => __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => '__return_true',
 		)
 	);
@@ -96,8 +112,10 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                    => 'links_added',
-			'title'                 => __( 'Add links', 'jetpack-mu-wpcom' ),
 			'id_map'                => 'links_edited',
+			'get_title'             => function () {
+				return __( 'Add links', 'jetpack-mu-wpcom' );
+			},
 			'add_listener_callback' => function () {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
 			},
@@ -107,8 +125,10 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                    => 'link_in_bio_launched',
-			'title'                 => __( 'Launch your site', 'jetpack-mu-wpcom' ),
 			'id_map'                => 'site_launched',
+			'get_title'             => function () {
+				return __( 'Launch your site', 'jetpack-mu-wpcom' );
+			},
 			'is_disabled_callback'  => 'wpcom_is_link_in_bio_launch_disabled',
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 		)
@@ -117,7 +137,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'videopress_setup',
-			'title'                => __( 'Set up your video site', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Set up your video site', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => '__return_true',
 		)
 	);
@@ -125,8 +147,10 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                    => 'videopress_upload',
-			'title'                 => __( 'Upload your first video', 'jetpack-mu-wpcom' ),
 			'id_map'                => 'video_uploaded',
+			'get_title'             => function () {
+				return __( 'Upload your first video', 'jetpack-mu-wpcom' );
+			},
 			'is_disabled_callback'  => 'wpcom_is_videopress_upload_disabled',
 			'add_listener_callback' => function () {
 				add_action( 'add_attachment', 'wpcom_track_video_uploaded_task' );
@@ -137,8 +161,10 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                    => 'videopress_launched',
-			'title'                 => __( 'Launch site', 'jetpack-mu-wpcom' ),
 			'id_map'                => 'site_launched',
+			'get_title'             => function () {
+				return __( 'Launch site', 'jetpack-mu-wpcom' );
+			},
 			'is_disabled_callback'  => 'wpcom_is_videopress_launch_disabled',
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 		)
@@ -147,7 +173,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'setup_free',
-			'title'                => __( 'Personalize your site', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Personalize your site', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => '__return_true',
 		)
 	);
@@ -155,7 +183,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'setup_blog',
-			'title'                => __( 'Name your blog', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Name your blog', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 		)
 	);
@@ -163,7 +193,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'setup_general',
-			'title'                => __( 'Set up your site', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Set up your site', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => '__return_true',
 			'is_disabled_callback' => '__return_true',
 		)
@@ -172,7 +204,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                    => 'design_edited',
-			'title'                 => __( 'Edit site design', 'jetpack-mu-wpcom' ),
+			'get_title'             => function () {
+				return __( 'Edit site design', 'jetpack-mu-wpcom' );
+			},
 			'id_map'                => 'site_edited',
 			'add_listener_callback' => function () {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
@@ -183,7 +217,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                    => 'site_launched',
-			'title'                 => __( 'Launch your site', 'jetpack-mu-wpcom' ),
+			'get_title'             => function () {
+				return __( 'Launch your site', 'jetpack-mu-wpcom' );
+			},
 			'isLaunchTask'          => true,
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 		)
@@ -192,7 +228,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                    => 'blog_launched',
-			'title'                 => __( 'Launch your blog', 'jetpack-mu-wpcom' ),
+			'get_title'             => function () {
+				return __( 'Launch your blog', 'jetpack-mu-wpcom' );
+			},
 			'isLaunchTask'          => true,
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 		)
@@ -201,7 +239,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                   => 'setup_write',
-			'title'                => __( 'Set up your site', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Set up your site', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => '__return_true',
 			'is_disabled_callback' => '__return_true',
 		)
@@ -211,7 +251,9 @@ function wpcom_register_default_launchpad_checklists() {
 		array(
 			'id'                   => 'domain_upsell',
 			'id_map'               => 'domain_upsell_deferred',
-			'title'                => __( 'Choose a domain', 'jetpack-mu-wpcom' ),
+			'get_title'            => function () {
+				return __( 'Choose a domain', 'jetpack-mu-wpcom' );
+			},
 			'is_complete_callback' => 'wpcom_is_domain_upsell_completed',
 			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
 		)
@@ -220,7 +262,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                  => 'verify_email',
-			'title'               => __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' ),
+			'get_title'           => function () {
+				return __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' );
+			},
 			'is_visible_callback' => 'wpcom_launchpad_is_email_unverified',
 		)
 	);
@@ -228,7 +272,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                  => 'set_up_payments',
-			'title'               => __( 'Set up payment method', 'jetpack-mu-wpcom' ),
+			'get_title'           => function () {
+				return __( 'Set up payment method', 'jetpack-mu-wpcom' );
+			},
 			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
 		)
 	);
@@ -236,7 +282,9 @@ function wpcom_register_default_launchpad_checklists() {
 	wpcom_register_launchpad_task(
 		array(
 			'id'                  => 'newsletter_plan_created',
-			'title'               => __( 'Create paid Newsletter', 'jetpack-mu-wpcom' ),
+			'get_title'           => function () {
+				return __( 'Create paid Newsletter', 'jetpack-mu-wpcom' );
+			},
 			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
 		)
 	);

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-dependency
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-dependency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated jetpack-mu-wpcom

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_2_6"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_3_0_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "34f4f6e5c2dbd916d24b290cb46d878dac94604a"
+                "reference": "de856cd8874c1685dc35b66d80abe1052c3e77a0"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "2.3.x-dev"
+                    "dev-trunk": "2.4.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {
@@ -78,7 +78,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "6e45a8dd0df385b87369efa5d74afe338e505dc9"
+                "reference": "30070e39a17fa33ac68d7cacee619edf51bc2469"
             },
             "require": {
                 "php": ">=5.6",

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -78,7 +78,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/changelogger",
-                "reference": "30070e39a17fa33ac68d7cacee619edf51bc2469"
+                "reference": "6e45a8dd0df385b87369efa5d74afe338e505dc9"
             },
             "require": {
                 "php": ">=5.6",

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.2.6
+ * Version: 1.3.0-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.2.6",
+	"version": "1.3.0-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the Launchpad task code to use a `get_title` callback to retrieve task titles, as using inline calls to `__()` would run the translation before the user's locale had been set. More specifically, the PR includes the following specific changes:
   - We now support a new `get_title` callable attribute for task definitions, in addition to the existing `title` attribute, but we prefer the `get_title` callback. This also involved creating a new `load_title()` helper and updating the task validation.
   - Existing launchpad tasks in the package have all been updated to use the new `get_title` approach.

This work was sparked by the following internal discussion and exploration: p1684883448623069-slack-C057AH42XQD

**Note:** The primary APIs in use for the checklist are via our general `public-api.wordpress.com` REST APIs, so we want to make sure we address that in this PR. We also verify that the API works when accessed directly, but that's not our primary use case.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This is primarily a WordPress.com change

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### For WordPress.com Simple sites

* Apply this patch to your WordPress.com developer sandbox, and ensure requests to `public-api.wordpress.com` are routed to your sandbox
* Open the [WordPress.com developer console](https://developer.wordpress.com/docs/api/console/)
* Update the two toggles in the top left to `WP REST API` and `wpcom/v2`, but leave the HTTP action as `GET`
* In the main text/URL input, type in `/sites/:siteSlug/launchpad?checklist_slug=newsletter&_locale=es`
* Submit the request
* Verify that the items in the `checklist` key have translated `title` values

### For WordPress.com Atomic sites

* Set up a WoA dev site without this patch applied
* While on that site, visit `/wp-admin/users.php`
* Select your user and click on the "Edit" link
* Scroll down and create a new application password for your user -- keep the new password somewhere accessible
* From a local terminal, run the following `curl` command to confirm that you can get the checklist data:
```
curl --user "yourusername:your app password" https://your-site-url.wpcomstaging.com/wp-json/wpcom/v2/launchpad?checklist_slug=newsletter&_locale=es
```
* Verify that you get a response back that is untranslated.
* Apply the changed files from this PR to `wp-content/mu-plugins/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/` - you can use `rsync` or `sftp` to do so
* Re-run the `curl` command from your local terminal:
```
curl --user "yourusername:your app password" https://your-site-url.wpcomstaging.com/wp-json/wpcom/v2/launchpad?checklist_slug=newsletter&_locale=es
```
* Verify that you get _un-translated_ content back successfully -- we don't include the translated strings AFAIK, so we're testing that we didn't break anything