### PR TITLE
CRM: Redesign Colors/Buttons to fit Jetpack Emerald style

### DIFF
--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -163,7 +163,7 @@ function jpcrm_render_company_view_page( $id = -1 ) {
 						// } When no avatar, show edit button top right
 							// no avatars yet for co - if ($avatarMode == 3 || empty($avatar)){
 						?>
-							<a class="ui button blue mini right floated" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link( 'edit', $id, 'zerobs_company', false ); ?>">
+							<a class="ui button black mini right floated" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link( 'edit', $id, 'zerobs_company', false ); ?>">
 									<?php esc_html_e( 'Edit ' . jpcrm_label_company(), 'zero-bs-crm' ); ?>
 								</a>
 								<?php
@@ -634,7 +634,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 									?>
 									<tr>
 										<td colspan="4">
-											<div class="ui info icon message" id="zbsNoInvoiceResults">
+											<div class="ui icon message" id="zbsNoInvoiceResults">
 											<div class="content">
 												<div class="header"><?php esc_html_e( 'No Invoices', 'zero-bs-crm' ); ?></div>
 												<p>
@@ -741,7 +741,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 										?>
 									<tr>
 										<td colspan="<?php echo count( $activeTransactionColumns ); ?>">
-											<div class="ui info icon message" id="zbsNoTransactionResults">
+											<div class="ui icon message" id="zbsNoTransactionResults">
 											<div class="content">
 												<div class="header"><?php esc_html_e( 'No Transactions', 'zero-bs-crm' ); ?></div>
 												<p>
@@ -845,7 +845,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 								?>
 								">
 									<td colspan="4">
-										<div class="ui info icon message" id="zbsNoFileResults">
+										<div class="ui icon message" id="zbsNoFileResults">
 										<div class="content">
 											<div class="header"><?php esc_html_e( 'No Files', 'zero-bs-crm' ); ?></div>
 											<p>
@@ -934,7 +934,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 										?>
 									<tr>
 										<td colspan="4">
-											<div class="ui info icon message" id="zbsNoTaskResults">
+											<div class="ui icon message" id="zbsNoTaskResults">
 												<div class="content">
 												<div class="header"><?php esc_html_e( 'No Tasks', 'zero-bs-crm' ); ?></div>
 												<p>

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -227,7 +227,7 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 							?>
 						<div class="action-wrap">
 						<div class="ui dropdown jpcrm-button white-bg jpcrm-dropdown"><?php esc_html_e( 'Contact Actions', 'zero-bs-crm' ); ?><i class="fa fa-angle-down"></i>
-							<div class="menu">
+							<div class="menu" style="margin: 4px;">
 								<?php foreach ( $contact_actions as $actKey => $action ) { ?>
 								<div class="item zbs-contact-action" id="zbs-contact-action-<?php echo esc_attr( $actKey ); ?>"
 																										<?php

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -153,7 +153,7 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 					?>
 					<div class="three wide column" style="text-align:center; min-width:125px;">
 						<?php echo $avatar; ?>
-						<a class="ui button green" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link( 'edit', $id, 'zerobs_customer', false ); ?>">
+						<a class="ui button black" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link( 'edit', $id, 'zerobs_customer', false ); ?>">
 							<?php esc_html_e( 'Edit Contact', 'zero-bs-crm' ); ?>
 						</a>
 
@@ -170,7 +170,7 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 						// } When no avatar, show edit button top right
 						if ( $avatar_mode == '3' || empty( $avatar ) ) {
 							?>
-							<a class="ui button green right floated" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link( 'edit', $id, 'zerobs_customer', false ); ?>">
+							<a class="ui button black right floated" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link( 'edit', $id, 'zerobs_customer', false ); ?>">
 								<?php esc_html_e( 'Edit Contact', 'zero-bs-crm' ); ?>
 								</a>
 								<?php
@@ -226,7 +226,7 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 						if ( count( $contact_actions ) > 0 ) {
 							?>
 						<div class="action-wrap">
-						<div class="ui green basic dropdown action-button"><?php esc_html_e( 'Contact Actions', 'zero-bs-crm' ); ?><i class="dropdown icon"></i>
+						<div class="ui dropdown jpcrm-button white-bg jpcrm-dropdown"><?php esc_html_e( 'Contact Actions', 'zero-bs-crm' ); ?><i class="fa fa-angle-down"></i>
 							<div class="menu">
 								<?php foreach ( $contact_actions as $actKey => $action ) { ?>
 								<div class="item zbs-contact-action" id="zbs-contact-action-<?php echo esc_attr( $actKey ); ?>"
@@ -803,7 +803,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 								?>
 							<tr>
 							<td colspan="4">
-								<div class="ui info icon message" id="zbsNoQuoteResults">
+								<div class="ui icon message" id="zbsNoQuoteResults">
 									<div class="content">
 									<div class="header"><?php esc_html_e( 'No Quotes', 'zero-bs-crm' ); ?></div>
 									<p><?php echo wp_kses( sprintf( __( 'This contact does not have any quotes yet. Do you want to <a href="%s">create one</a>?', 'zero-bs-crm' ), esc_url( $new_quote_url ) ), $zbs->acceptable_restricted_html ); ?></p>
@@ -907,7 +907,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 								?>
 							<tr>
 							<td colspan="4">
-								<div class="ui info icon message" id="zbsNoInvoiceResults">
+								<div class="ui icon message" id="zbsNoInvoiceResults">
 									<div class="content">
 									<div class="header"><?php esc_html_e( 'No Invoices', 'zero-bs-crm' ); ?></div>
 									<p><?php echo wp_kses( sprintf( __( 'This contact does not have any invoices yet. Do you want to <a href="%s">create one</a>?', 'zero-bs-crm' ), esc_url( $new_invoice_url ) ), $zbs->acceptable_restricted_html ); ?></p>
@@ -1031,7 +1031,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 								?>
 							<tr>
 							<td colspan="<?php echo count( $activeTransactionColumns ); ?>">
-								<div class="ui info icon message" id="zbsNoTransactionResults">
+								<div class="ui icon message" id="zbsNoTransactionResults">
 									<div class="content">
 									<div class="header"><?php esc_html_e( 'No Transactions', 'zero-bs-crm' ); ?></div>
 									<p><?php echo wp_kses( sprintf( __( 'This contact does not have any transactions yet. Do you want to <a href="%s">create one</a>?', 'zero-bs-crm' ), esc_url( $new_transaction_url ) ), $zbs->acceptable_restricted_html ); ?></p>
@@ -1164,7 +1164,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 									?>
 									<tr id="zbs-no-files-msg" style="display:<?php echo $hasFiles ? 'none' : 'table-row'; ?>">
 										<td colspan="4">
-											<div class="ui info icon message" id="zbsNoFileResults">
+											<div class="ui icon message" id="zbsNoFileResults">
 												<div class="content">
 												<div class="header"><?php esc_html_e( 'No Files', 'zero-bs-crm' ); ?></div>
 												<p><?php echo wp_kses( sprintf( __( 'This contact does not have any files yet.', 'zero-bs-crm' ), esc_url( $new_file_url ) ), $zbs->acceptable_restricted_html ); ?></p>
@@ -1179,7 +1179,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 									<?php
 										$jpcrm_add_file_url = admin_url( 'admin.php?page=' . $zbs->slugs['addnewfile'] ) . '&customer=' . $id;
 									?>
-									<a href="<?php echo esc_url( $jpcrm_add_file_url ); ?>" class="ui basic green button" target="_blank">
+									<a href="<?php echo esc_url( $jpcrm_add_file_url ); ?>" class="ui basic button" target="_blank" style="color: black !important; box-shadow: 0px 0px 0px 1px black inset !important;">
 									<i class="plus square outline icon"></i>
 									<?php esc_html_e( 'Add File', 'zero-bs-crm' ); ?>
 									</a>
@@ -1306,7 +1306,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 								?>
 							<tr>
 							<td colspan="4">
-								<div class="ui info icon message" id="zbsNoTaskResults">
+								<div class="ui icon message" id="zbsNoTaskResults">
 								<div class="content">
 									<div class="header"><?php esc_html_e( 'No Tasks', 'zero-bs-crm' ); ?></div>
 									<p><?php echo wp_kses( sprintf( __( 'This contact does not have any tasks yet. Do you want to <a href="%s">create one</a>?', 'zero-bs-crm' ), esc_url( $new_task_url ) ), $zbs->acceptable_restricted_html ); ?></p>

--- a/projects/plugins/crm/admin/export/main.page.php
+++ b/projects/plugins/crm/admin/export/main.page.php
@@ -171,7 +171,7 @@ function jpcrm_render_export_page() {
 
 	// select all
 	?>
-	<button type="button" class="ui blue mini button right floated all" id="zbs-export-select-all" ><span class="all"><i class="object ungroup icon"></i> <?php esc_html_e( 'Deselect All', 'zero-bs-crm' ); ?></span><span class="none" style="display:none"><i class="object group icon"></i> <?php esc_html_e( 'Select All', 'zero-bs-crm' ); ?></span></button>
+	<button type="button" class="ui black mini button right floated all" id="zbs-export-select-all" ><span class="all"><i class="object ungroup icon"></i> <?php esc_html_e( 'Deselect All', 'zero-bs-crm' ); ?></span><span class="none" style="display:none"><i class="object group icon"></i> <?php esc_html_e( 'Select All', 'zero-bs-crm' ); ?></span></button>
 
 	</div>
 	<div class="ui segment" id="zbs-export-fields">
@@ -240,7 +240,7 @@ function jpcrm_render_export_page() {
 
 	<div class="ui divider"></div>
 
-	<button class="ui green button" type="submit"><i class="download icon"></i> <?php esc_html_e( 'Export', 'zero-bs-crm' ); ?></button>
+	<button class="ui black button" type="submit"><i class="download icon"></i> <?php esc_html_e( 'Export', 'zero-bs-crm' ); ?></button>
 
 	<script type="text/javascript">
 

--- a/projects/plugins/crm/admin/settings/tax.page.php
+++ b/projects/plugins/crm/admin/settings/tax.page.php
@@ -236,8 +236,9 @@ if ( isset( $sbupdated ) ) {
 					text: '<?php echo esc_html( zeroBSCRM_slashOut( __( 'Are you sure you want to delete this tax rate? This will remove it from your database and existing transactions with this tax rate will not show properly. You cannot undo this.', 'zero-bs-crm' ) ) ); ?>',
 					type: 'warning',
 					showCancelButton: true,
-					confirmButtonColor: '#3085d6',
-					cancelButtonColor: '#d33',
+					confirmButtonColor: '#000',
+					cancelButtonColor: '#fff',
+					cancelButtonText: '<span style="color: #000">Cancel</span>',
 					confirmButtonText: '<?php echo esc_html( zeroBSCRM_slashOut( __( 'Yes, remove the tax rate.', 'zero-bs-crm' ) ) ); ?>',
 				})//.then((result) => {
 					.then(function (result) {

--- a/projects/plugins/crm/changelog/fix-crm-3105-redesign-colors-buttons-to-emerald
+++ b/projects/plugins/crm/changelog/fix-crm-3105-redesign-colors-buttons-to-emerald
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+CRM: buttons and colors to Emerald style

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -1712,7 +1712,7 @@ function zeroBSCRM_html_datatools() {
 			<p class="sbhomep">
 			<strong><?php esc_html_e( 'Free Data Tools', 'zero-bs-crm' ); ?>:</strong><br />
 			<?php if ( ! zeroBSCRM_isExtensionInstalled( 'csvpro' ) ) { ?>
-			<a class="ui button green primary" href="<?php echo esc_url( admin_url( 'admin.php?page=' . $zbs->slugs['csvlite'] ) ); ?>"><?php esc_html_e( 'Import from CSV', 'zero-bs-crm' ); ?></a>
+			<a class="ui button black primary" href="<?php echo esc_url( admin_url( 'admin.php?page=' . $zbs->slugs['csvlite'] ) ); ?>"><?php esc_html_e( 'Import from CSV', 'zero-bs-crm' ); ?></a>
 		<?php } ?>
 		</p>
 			<p class="sbhomep">
@@ -1750,12 +1750,12 @@ function zeroBSCRM_html_datatools() {
 			</p><p class="sbhomep">
 				<!-- #datatoolsales -->
 			<strong><?php esc_html_e( 'Import Tools', 'zero-bs-crm' ); ?>:</strong><br /><br />
-				<a href="<?php echo esc_url( $zbs->urls['productsdatatools'] ); ?>" target="_blank" class="ui button primary"><?php esc_html_e( 'View Available Import Tools', 'zero-bs-crm' ); ?></a>              
+				<a href="<?php echo esc_url( $zbs->urls['productsdatatools'] ); ?>" target="_blank" class="ui button black primary"><?php esc_html_e( 'View Available Import Tools', 'zero-bs-crm' ); ?></a>              
 			</p>
 			<div class="sbhomep">
 				<strong><?php esc_html_e( 'Export Tools', 'zero-bs-crm' ); ?>:</strong><br/>
 				<p><?php esc_html_e( 'Want to use the refined object exporter? ', 'zero-bs-crm' ); ?></p>
-				<p><a class="ui button" href="<?php echo esc_url( admin_url( 'admin.php?page=' . $zbs->slugs['export-tools'] . '&zbswhat=contacts' ) ); ?>">Export Tools</a></p>
+				<p><a class="ui black button" href="<?php echo esc_url( admin_url( 'admin.php?page=' . $zbs->slugs['export-tools'] . '&zbswhat=contacts' ) ); ?>">Export Tools</a></p>
 			</div>
 	</div>
 	<div class="ui grid">

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -169,7 +169,7 @@ function zeroBSCRM_CSVImporterLitepages_header( $subpage = '' ) {
 			</div>
 
 			<?php if ( ! empty( $zbs->urls['extcsvimporterpro'] ) ) { ?>
-				<a href="<?php echo esc_url( $zbs->urls['extcsvimporterpro'] ); ?>" target="_blank" class="ui button blue tiny" id="gopro"><?php esc_html_e( 'Get CSV Importer Pro', 'zero-bs-crm' ); ?></a>
+				<a href="<?php echo esc_url( $zbs->urls['extcsvimporterpro'] ); ?>" target="_blank" class="ui button black tiny" id="gopro"><?php esc_html_e( 'Get CSV Importer Pro', 'zero-bs-crm' ); ?></a>
 			<?php } ?>
 
 			</div>
@@ -829,7 +829,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 						<label class="screen-reader-text" for="zbscrmcsvfile"><?php esc_html_e( '.CSV file', 'zero-bs-crm' ); ?></label>
 						<input type="file" id="zbscrmcsvfile" name="zbscrmcsvfile">
 						<div class="csv-import__start-btn">
-							<input type="submit" name="csv-file-submit" id="csv-file-submit" class="ui button green" value="<?php esc_attr_e( 'Upload CSV file', 'zero-bs-crm' ); ?>">
+							<input type="submit" name="csv-file-submit" id="csv-file-submit" class="ui button black" value="<?php esc_attr_e( 'Upload CSV file', 'zero-bs-crm' ); ?>">
 						</div>
 					</form>
 				</div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
@@ -110,7 +110,7 @@ function zeroBSCRM_html_addEditSegment($potentialID = -1)
 
                 <div class="field" style="padding-top:0;padding-bottom: 0">
 
-                    <button class="ui icon small button primary right floated" type="button" id="zbs-segment-edit-act-add-condition">
+							<button class="ui icon small button primary black right floated" type="button" id="zbs-segment-edit-act-add-condition">
                         <?php esc_html_e('Add Condition', 'zero-bs-crm' ); ?>  <i class="plus icon"></i>
                     </button>
 
@@ -138,7 +138,7 @@ function zeroBSCRM_html_addEditSegment($potentialID = -1)
                 <h4 class="ui horizontal header divider"><?php esc_html_e('Continue', 'zero-bs-crm' ); ?></h4>
 
                 <div class="jog-on">
-                    <button class="ui submit blue large icon button" id="zbs-segment-edit-act-p2preview"><?php esc_html_e( 'Preview Segment', 'zero-bs-crm' ); ?> <i class="unhide icon"></i></button>
+							<button class="ui submit black large icon button" id="zbs-segment-edit-act-p2preview"><?php esc_html_e( 'Preview Segment', 'zero-bs-crm' ); ?> <i class="unhide icon"></i></button>
                     <?php 
 
                         // where saved, show export button, and mailpoet:
@@ -146,7 +146,7 @@ function zeroBSCRM_html_addEditSegment($potentialID = -1)
 
                             // export
                             if ( zeroBSCRM_permsExport() ){ ?>
-                                <a class="ui submit teal large icon button" href="<?php echo jpcrm_esc_link( $zbs->slugs['export-tools'] . '&segment-id=' . $segment['id'] ); ?>"><?php esc_html_e( 'Export Segment (.CSV)', 'zero-bs-crm' ); ?> <i class="icon cloud download"></i></a>
+										<a class="ui submit black large icon button" href="<?php echo jpcrm_esc_link( $zbs->slugs['export-tools'] . '&segment-id=' . $segment['id'] ); ?>"><?php esc_html_e( 'Export Segment (.CSV)', 'zero-bs-crm' ); ?> <i class="icon cloud download"></i></a>
                             <?php }
 
                             // mailpoet support

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -971,7 +971,7 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 			#} If in edit mode, add in save + view
 			if ( $key === 'edit' ) {
 				if ( $id > 0 ) {
-					$html .= '<a style="margin-right:5px;margin-left:5px;" class="ui icon button blue mini labeled" href="' . jpcrm_esc_link( 'view', $id, 'zerobs_customer' ) . '" id="zbs-nav-view"><i class="eye left icon"></i> ' . esc_html( __( 'View', 'zero-bs-crm' ) ) . '</a>';
+					$html .= '<a style="margin-right:5px;margin-left:5px;" class="ui icon button black mini labeled" href="' . jpcrm_esc_link( 'view', $id, 'zerobs_customer' ) . '" id="zbs-nav-view"><i class="eye left icon"></i> ' . esc_html( __( 'View', 'zero-bs-crm' ) ) . '</a>';
 				}
 			}
 
@@ -998,7 +998,7 @@ function zeroBSCRM_getObjNav( $id = -1, $key = '', $type = ZBS_TYPE_CONTACT ) {
 
 			// If in edit mode, add in view.
 			if ( $key === 'edit' ) {
-				$html .= '<a style="margin-left:6px;" class="ui icon button blue mini labeled" href="' . jpcrm_esc_link( 'view', $id, ZBS_TYPE_COMPANY ) . '"><i class="eye left icon"></i> ' . esc_html( __( 'View', 'zero-bs-crm' ) ) . '</a>';
+				$html .= '<a style="margin-left:6px;" class="ui icon button black mini labeled" href="' . jpcrm_esc_link( 'view', $id, ZBS_TYPE_COMPANY ) . '"><i class="eye left icon"></i> ' . esc_html( __( 'View', 'zero-bs-crm' ) ) . '</a>';
 			}
 
 			$html .= '</span>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -347,7 +347,7 @@ class zeroBSCRM_list{
 
                         <div class="column" style="max-width:364px;">
                             <div class="ui labeled input">
-                                <div class="ui teal label"><i class="table icon"></i>  <?php esc_html_e('Records per page:','zero-bs-crm'); ?></div>
+										<div class="ui label"><i class="table icon"></i>  <?php esc_html_e( 'Records per page:', 'zero-bs-crm' ); ?></div>
                                 <input type="text" style="width:70px;" class="intOnly" id="zbs-screenoptions-records-per-page" value="<?php echo esc_attr( $perPage ); ?>" />
                             </div>
                         </div>
@@ -387,7 +387,7 @@ class zeroBSCRM_list{
                     <div class="two column clearing centered row">
 
                         <div class="column" style="max-width:364px;">
-                            <button id="zbs-columnmanager-bottomsave" type="button" class="ui button positive"><i class="check square icon"></i> <?php esc_html_e('Save Options and Close','zero-bs-crm'); ?></button>
+									<button id="zbs-columnmanager-bottomsave" type="button" class="ui button black positive"><i class="check square icon"></i> <?php esc_html_e( 'Save Options and Close', 'zero-bs-crm' ); ?></button>
                         </div>
 
                     </div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
@@ -175,7 +175,7 @@
 
                     if ($zbsShowID == "1" && $companyID > 0) { ?>
                     <tr class="wh-large"><th><label><?php echo esc_html( $this->coOrgLabel ) . ' '; esc_html_e("ID","zero-bs-crm");?>:</label></th>
-                    <td style="font-size: 20px;color: green;vertical-align: top;">
+							<td style="font-size: 20px;color: black;vertical-align: top;">
                         #<?php echo esc_html( $companyID ); ?>
                     </td></tr>
                     <?php } ?>
@@ -1148,7 +1148,7 @@ class zeroBS__Metabox_CompanyTags extends zeroBS__Metabox_Tags{
 
                     <div class="zbs-company-actions-bottom zbs-objedit-actions-bottom">
 
-                        <button  class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Update","zero-bs-crm"); ?> <?php echo esc_html( $this->coOrgLabel ); ?></button>
+								<button  class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php echo esc_html( $this->coOrgLabel ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase ?></button>
 
                         <?php
 
@@ -1173,7 +1173,7 @@ class zeroBS__Metabox_CompanyTags extends zeroBS__Metabox_Tags{
 
                     <div class="zbs-company-actions-bottom zbs-objedit-actions-bottom">
                         
-                        <button  class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Save","zero-bs-crm"); ?> <?php echo esc_html( $this->coOrgLabel ); ?></button>
+							<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Save', 'zero-bs-crm' ); ?> <?php echo esc_html( $this->coOrgLabel ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase ?></button>
 
                     </div>
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -1702,9 +1702,9 @@ class zeroBS__Metabox_ContactPortal extends zeroBS__Metabox{
 
                         echo '<div id="zbs-customerportal-access-actions" class="zbs-customerportal-activeuser">';
 
-                        echo '<button type="button" id="zbs-customerportal-resetpw" class="ui mini button orange">' . esc_html( __( 'Reset Password', 'zero-bs-crm' ) ) . '</button>';
+								echo '<button type="button" id="zbs-customerportal-resetpw" class="ui mini button white">' . esc_html( __( 'Reset Password', 'zero-bs-crm' ) ) . '</button>';
 
-                        echo '<button type="button" id="zbs-customerportal-toggle" data-zbsportalaction="disable" class="ui mini button negative">' . esc_html( __( 'Disable Access', 'zero-bs-crm' ) ) . '</button>';
+								echo '<button type="button" id="zbs-customerportal-toggle" data-zbsportalaction="disable" class="ui mini button white negative">' . esc_html( __( 'Disable Access', 'zero-bs-crm' ) ) . '</button>';
 
                         echo '</div>';
 
@@ -1716,7 +1716,7 @@ class zeroBS__Metabox_ContactPortal extends zeroBS__Metabox{
                     }
 
                     echo '<hr /><div class="zbs-customerportal-activeuser-actions">';
-                    echo sprintf( '<a target="_blank" href="%s" class="ui mini button green">%s</a>', esc_url( zeroBS_portal_link() ), esc_html( __( 'Preview Portal', 'zero-bs-crm' ) ) );
+							echo sprintf( '<a target="_blank" href="%s" class="ui mini button white">%s</a>', esc_url( zeroBS_portal_link() ), esc_html( __( 'Preview Portal', 'zero-bs-crm' ) ) );
                     echo '</div>';
                 } else {
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -868,27 +868,13 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
         # https://codepen.io/kyleshockey/pen/bdeLrE 
 		if ( ! $is_new_contact ) {
 			?>
-
-        <?php #} Show avatar if avail
-        if (!empty($avatarStr)){
-
-            // if gravatar mode, don't circle
-            $segmentClass = 'ui circular segment';
-            $avatarMode = zeroBSCRM_getSetting('avatarmode');
-            if ( $avatarMode == 1 ) {
-                $segmentClass = 'ui segment';
-            }
-
-            echo '<div id="zbs-contact-edit-avatar"><div class="'. esc_attr( $segmentClass ) .'"><h2 class="ui header">'. $avatarStr .'</h2>';            
-            echo '</div></div>'; 
-        } ?>
         <script type="text/javascript">
             var zbsContactAvatarLang = {
                 'upload': '<?php esc_html_e("Upload Image","zero-bs-crm");?>',
             };
         </script>
         <div class="action-wrap">
-          <div class="ui green basic dropdown action-button"><?php esc_html_e('Contact Actions',"zero-bs-crm"); ?><i class="dropdown icon"></i>
+			<div class="ui dropdown jpcrm-button white-bg jpcrm-dropdown"><?php esc_html_e( 'Contact Actions', 'zero-bs-crm' ); ?><i class="fa fa-angle-down"></i>
              <div class="menu">
               <?php foreach ($this->actions as $actKey => $action){ 
 
@@ -956,7 +942,7 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
        <?php }
 		?>
 			<div class="zbs-contact-actions-bottom zbs-objedit-actions-bottom">
-				<button class="ui button green" type="button" id="zbs-edit-save"><?php $is_new_contact ? esc_html_e( 'Save', 'zero-bs-crm' ) : esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Contact', 'zero-bs-crm' ); ?></button>
+				<button class="jpcrm-button" type="button" id="zbs-edit-save"><?php $is_new_contact ? esc_html_e( 'Save', 'zero-bs-crm' ) : esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Contact', 'zero-bs-crm' ); ?></button>
 				<div class='clear'></div>
 			</div>
 			<?php
@@ -1757,7 +1743,7 @@ class zeroBS__Metabox_ContactPortal extends zeroBS__Metabox{
             echo '<div class="no-gen" style="text-align:center">';
             echo esc_html( __( 'No WordPress User exists with this email', 'zero-bs-crm' ) );
             echo '<br/><br/>';
-            echo '<div class="ui primary button button-primary wp-user-generate">';
+				echo '<div class="ui primary black button button-primary wp-user-generate">';
             echo esc_html( __( 'Generate WordPress User', 'zero-bs-crm' ) );
             echo '</div>';
             echo '<input type="hidden" name="newwp-ajax-nonce" id="newwp-ajax-nonce" value="' . esc_attr( wp_create_nonce( 'newwp-ajax-nonce' ) ) . '" />';
@@ -2097,7 +2083,7 @@ class zeroBS__Metabox_ContactAKA extends zeroBS__Metabox{
             ?><div id="zbs-aka-alias-input-wrap">
                 <input type="text" class="zbs-aka-alias-input" placeholder="<?php esc_attr_e('Add Alias.. e.g.', 'zero-bs-crm'); ?> mike2@domain.com" />
                 <div class="ui pointing label" style="display:none;margin-bottom: 1em;margin-top: 0;" id="zbs-aka-alias-input-msg"><?php esc_html_e('Must be a valid email','zero-bs-crm'); ?></div>
-                <button type="button" class="ui small button primary" id="zbs-aka-alias-add"><?php esc_html_e('Add Alias',"zero-bs-crm"); ?></button>
+						<button type="button" class="ui small black button primary" id="zbs-aka-alias-add"><?php esc_html_e( 'Add Alias', 'zero-bs-crm' ); ?></button>
             </div>
 
             <script type="text/javascript">

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -875,7 +875,7 @@ class zeroBS__Metabox_ContactActions extends zeroBS__Metabox{
         </script>
         <div class="action-wrap">
 			<div class="ui dropdown jpcrm-button white-bg jpcrm-dropdown"><?php esc_html_e( 'Contact Actions', 'zero-bs-crm' ); ?><i class="fa fa-angle-down"></i>
-             <div class="menu">
+				<div class="menu" style="margin: 4px;">
               <?php foreach ($this->actions as $actKey => $action){ 
 
                 // filter out 'edit' as on that page :)

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -367,7 +367,7 @@
 
                     <div class="zbs-event-actions-bottom zbs-objedit-actions-bottom">
 
-							<button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Task', 'zero-bs-crm' ); ?></button>
+							<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Task', 'zero-bs-crm' ); ?></button>
 
                         <?php
 
@@ -390,7 +390,7 @@
 
                     // NEW Event ?>
 
-						<button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e( 'Save', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Task', 'zero-bs-crm' ); ?></button>
+						<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Save', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Task', 'zero-bs-crm' ); ?></button>
 
                  <?php
 
@@ -605,11 +605,11 @@ function zeroBSCRM_task_ui_mark_complete($taskObject = array(), $taskID = -1){
     
         if ($taskObject['complete'] == 1){
 
-            $html .= "<div id='task-mark-incomplete' class='task-comp incomplete'><button class='ui button green' data-taskid='".$taskID."'><i class='ui icon check white'></i>".__('Completed','zero-bs-crm')."</button></div>";
+				$html .= "<div id='task-mark-incomplete' class='task-comp incomplete'><button class='ui button black' data-taskid='" . $taskID . "'><i class='ui icon check white'></i>" . __( 'Completed', 'zero-bs-crm' ) . '</button></div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
             $complete = "<input type='hidden' id='zbs-task-complete' value = '1' name = 'zbs-task-complete'/>";
         } else {
 				$html .= sprintf(
-					'<div id="task-mark-complete" class="task-comp complete"><button class="button button-primary button-large" data-taskid="%s"><i class="ui icon check"></i>%s</button></div>',
+					'<div id="task-mark-complete" class="task-comp complete"><button class="ui button black button-primary button-large" data-taskid="%s"><i class="ui icon check"></i>%s</button></div>',
 					$taskID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					__( 'Mark Complete', 'zero-bs-crm' )
 				);
@@ -790,7 +790,7 @@ function zeroBSCRM_task_ui_reminders($taskObject = array(), $taskID = -1){
             // add admin cog (settings) for event notification template
             if ( zeroBSCRM_isZBSAdminOrAdmin() ) {
 					$html .= sprintf(
-						'<a href="%s" class="button button-primary button-large" title="%s" target="_blank"><i class="cogs icon"></i></a>',
+						'<a href="%s" class="button button-primary button-large" style="background-color:black;border-color:black;" title="%s" target="_blank"><i class="cogs icon"></i></a>',
 						esc_url_raw( jpcrm_esc_link( 'zbs-email-templates' ) . '&zbs_template_id=' . ZBSEMAIL_EVENTNOTIFICATION ),
 						__( 'Admin: Notification Settings', 'zero-bs-crm' )
 					);

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Forms.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Forms.php
@@ -724,7 +724,7 @@
 
                     <div class="zbs-form-actions-bottom zbs-objedit-actions-bottom">
 
-                        <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Update","zero-bs-crm"); ?> <?php esc_html_e("Form","zero-bs-crm"); ?></button>
+								<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Form', 'zero-bs-crm' ); ?></button>
 
                         <?php
 
@@ -749,7 +749,7 @@
 
                     <div class="zbs-form-actions-bottom zbs-objedit-actions-bottom">
                         
-                        <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Save","zero-bs-crm"); ?> <?php esc_html_e("Form","zero-bs-crm"); ?></button>
+								<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Save', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Form', 'zero-bs-crm' ); ?></button>
 
                     </div>
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Invoices.php
@@ -801,7 +801,7 @@ class zeroBS__Metabox_InvoiceTags extends zeroBS__Metabox_Tags{
 
 
                     <div class="zbs-invoice-actions-bottom zbs-objedit-actions-bottom">
-                        <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Update","zero-bs-crm"); ?> <?php esc_html_e("Invoice","zero-bs-crm"); ?></button>
+								<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Invoice', 'zero-bs-crm' ); ?></button>
                         <?php
 
                             #} Quick ver of this: http://themeflection.com/replace-wordpress-submit-meta-box/
@@ -839,7 +839,7 @@ class zeroBS__Metabox_InvoiceTags extends zeroBS__Metabox_Tags{
 
                     <?php do_action('zbs_invpro_itemlink'); ?>
 
-                    <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Save","zero-bs-crm"); ?> <?php esc_html_e("Invoice","zero-bs-crm"); ?></button>
+							<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Save', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Invoice', 'zero-bs-crm' ); ?></button>
 
                  <?php
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Logs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Logs.php
@@ -214,7 +214,7 @@ class zeroBS__Metabox_LogsV2 extends zeroBS__Metabox {
                     
                     <tr>
 								<td><h4><span id="zbsActiveLogCount"><?php echo esc_html( zeroBSCRM_prettifyLongInts( count( $zbsLogs ) ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?></span> <?php esc_html_e( 'Logs', 'zero-bs-crm' ); ?></h4></td>
-                        <td><button type="button" class="ui primary button button-primary button-large" id="zbscrmAddLog"><?php esc_html_e("Add Log","zero-bs-crm");?></button></td>
+								<td><button type="button" class="ui button black jpcrm-button" id="zbscrmAddLog"><?php esc_html_e( 'Add Log', 'zero-bs-crm' ); ?></button></td>
                     </tr>
 
                     <!-- this line will pop/close with "add log" button -->
@@ -257,8 +257,8 @@ class zeroBS__Metabox_LogsV2 extends zeroBS__Metabox {
 
                             <div id="zbsAddLogActions">
                                 <div id="zbsAddLogUpdateMsg"></div>
-                                <button type="button" class="ui red button button-info button-large" id="zbscrmAddLogCancel"><?php esc_html_e("Cancel","zero-bs-crm");?></button>
-                                <button type="button" class="ui green button button-primary button-large" id="zbscrmAddLogSave"><?php esc_html_e("Save Log","zero-bs-crm");?></button>
+											<button type="button" class="jpcrm-button white-bg" id="zbscrmAddLogCancel"><?php esc_html_e( 'Cancel', 'zero-bs-crm' ); ?></button>
+											<button type="button" class="jpcrm-button" id="zbscrmAddLogSave"><?php esc_html_e( 'Save Log', 'zero-bs-crm' ); ?></button>
                             </div>
 
                         </div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
@@ -152,7 +152,7 @@
 
                         ##WLREMOVE
                         // template placeholder helper
-                        echo '<p style="text-align:right"><span class="ui basic blue label">'.esc_html__('Did you know: You can now use Quote Placeholders?','zero-bs-crm').' <a href="' . esc_url( $zbs->urls['kbquoteplaceholders'] ) . '" target="_blank">' . esc_html__('Read More','zero-bs-crm') . '</a></span></p>';
+								echo '<p style="text-align:right"><span class="ui basic black label">' . esc_html__( 'Did you know: You can now use Quote Placeholders?', 'zero-bs-crm' ) . ' <a href="' . esc_url( $zbs->urls['kbquoteplaceholders'] ) . '" target="_blank">' . esc_html__( 'Read More', 'zero-bs-crm' ) . '</a></span></p>';
                         ##/WLREMOVE
 
 						$content = wp_kses( $quoteTemplateContent, $zbs->acceptable_html ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -355,7 +355,7 @@
 
                     <div class="zbs-quotetemplate-actions-bottom zbs-objedit-actions-bottom">
 
-                        <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Update","zero-bs-crm"); ?> <?php esc_html_e("Template","zero-bs-crm"); ?></button>
+							<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Template', 'zero-bs-crm' ); ?></button>
 
                         <?php
 
@@ -380,7 +380,7 @@
 
                     <div class="zbs-quotetemplate-actions-bottom zbs-objedit-actions-bottom">
                         
-                        <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Save","zero-bs-crm"); ?> <?php esc_html_e("Template","zero-bs-crm"); ?></button>
+							<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Save', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Template', 'zero-bs-crm' ); ?></button>
 
                     </div>
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
@@ -320,7 +320,7 @@
                                                 jQuery('#zbs-customer-title').prepend(html); */
 
                                                 // ALSO show in header bar, if so
-                                                var navButton = '<a target="_blank" style="margin-left:6px;" class="zbs-quote-quicknav-contact ui icon button blue mini labeled" href="<?php echo jpcrm_esc_link( 'edit', -1, 'zerobs_customer', true ); ?>' + contactID + '"><i class="user icon"></i> <?php  zeroBSCRM_slashOut(__('Contact','zero-bs-crm')); ?></a>';
+																var navButton = '<a target="_blank" style="margin-left:6px;" class="zbs-quote-quicknav-contact ui icon button black mini labeled" href="<?php echo jpcrm_esc_link( 'edit', -1, 'zerobs_customer', true ); ?>' + contactID + '"><i class="user icon"></i> <?php zeroBSCRM_slashOut( __( 'Contact', 'zero-bs-crm' ) ); ?></a>';
                                                 jQuery('#zbs-quote-learn-nav').append(navButton);
 
                                                 // bind
@@ -377,7 +377,7 @@
                                     </select>
                                     <br />
                                     <p><?php esc_html_e('Create additional quote templates',"zero-bs-crm"); ?> <a href="<?php echo jpcrm_esc_link( $zbs->slugs['quote-templates'] ); ?>"><?php esc_html_e('here',"zero-bs-crm");?></a></p>
-                                    <button type="button" id="zbsQuoteBuilderStep2" class="button button-primary button-large xl"<?php if (!isset($quoteContactID) || empty($quoteContactID)){ echo ' disabled="disabled"'; } ?>><?php esc_html_e('Use Quote Builder',"zero-bs-crm");?></button>
+												<button type="button" id="zbsQuoteBuilderStep2" class="ui button button-primary black button-large xl"<?php if ( ! isset( $quoteContactID ) || empty( $quoteContactID ) ) { echo ' disabled="disabled"'; } ?>><?php esc_html_e( 'Use Quote Builder', 'zero-bs-crm' ); // phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?></button>
                                     <?php if (!isset($quoteContactID) || empty($quoteContactID)){ ?>
 									<p id="zbsQuoteBuilderStep2info">(<?php esc_html_e( "You'll need to assign this Quote to a contact to use this", 'zero-bs-crm' ); ?>);</p>
                                     <?php } ?>
@@ -818,7 +818,7 @@
 										<h4><?php esc_html_e( 'Email to Contact', 'zero-bs-crm' ); ?>:</h4>
                                         <!-- todo -->                                    
                                         <p><input type="text" class="form-control" id="zbsQuoteBuilderEmailTo" value="<?php echo esc_attr( $contactEmail ); ?>" placeholder="<?php esc_attr_e('e.g. customer@yahoo.com','zero-bs-crm'); ?>" data-quoteid="<?php echo esc_attr( $quoteID ); ?>" /></p>
-                                        <p><button type="button" id="zbsQuoteBuilderSendNotification" class="button button-primary button-large"><?php esc_html_e("Send Quote","zero-bs-crm");?></button></p>
+													<p><button type="button" id="zbsQuoteBuilderSendNotification" class="ui button black"><?php esc_html_e( 'Send Quote', 'zero-bs-crm' ); ?></button></p>
                                         <p class="small" id="zbsQuoteBuilderEmailToErr" style="display:none"><?php esc_html_e("An Email Address to send to is required","zero-bs-crm");?>!</p>
                                     </div>
 												<?php
@@ -845,7 +845,7 @@
                                                 <div class="zbsEmailOrShare">
                                                 <h4><?php esc_html_e("Download PDF","zero-bs-crm");?></h4>
                                                 <p><i class="file pdf outline icon red" style="font-size:30px;margin-top:10px;"></i></p>
-                                                <input type="button" name="jpcrm_quote_download_pdf" id="jpcrm_quote_download_pdf" class="ui button green" value="<?php esc_attr_e("Download PDF","zero-bs-crm");?>" />
+																<input type="button" name="jpcrm_quote_download_pdf" id="jpcrm_quote_download_pdf" class="ui button black" value="<?php esc_attr_e( 'Download PDF', 'zero-bs-crm' ); ?>" />
                                                
                                                 </div>
                                                 <script type="text/javascript">
@@ -1367,7 +1367,7 @@ class zeroBS__Metabox_QuoteTags extends zeroBS__Metabox_Tags{
 				?>
                     <div class="zbs-quote-actions-bottom zbs-objedit-actions-bottom">
 
-                        <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Update","zero-bs-crm"); ?> <?php esc_html_e("Quote","zero-bs-crm"); ?></button>
+								<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Update', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Quote', 'zero-bs-crm' ); ?></button>
 
                         <?php
 
@@ -1391,7 +1391,7 @@ class zeroBS__Metabox_QuoteTags extends zeroBS__Metabox_Tags{
 				// NEW quote
 				?>
 
-                    <button class="ui button green" type="button" id="zbs-edit-save"><?php esc_html_e("Save","zero-bs-crm"); ?> <?php esc_html_e("Quote","zero-bs-crm"); ?></button>
+						<button class="ui button black" type="button" id="zbs-edit-save"><?php esc_html_e( 'Save', 'zero-bs-crm' ); ?> <?php esc_html_e( 'Quote', 'zero-bs-crm' ); ?></button>
 
                  <?php
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.TagManager.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.TagManager.php
@@ -142,11 +142,11 @@
                             $link = jpcrm_esc_link('listtagged',-1,$this->postType,-1,$tag['id']);
                             ?>
                             <tr>
-                              <td><?php if (isset($tag['name'])) echo '<a href="' . esc_url( $link ) . '" class="ui large blue label">' . esc_html( $tag['name'] ) . '</a>'; ?></td>
+										<td><?php if ( isset( $tag['name'] ) ) echo '<a href="' . esc_url( $link ) . '" class="ui large label">' . esc_html( $tag['name'] ) . '</a>'; // phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed ?></td>
                               <td><?php if (isset($tag['slug'])) echo esc_html( $tag['slug'] ); ?></td>
                               <?php /* this shows 1 date as DAL2 migration... <td><?php if (isset($tag['created']) && !empty($tag['created']) && $tag['created'] !== -1) echo zeroBSCRM_locale_utsToDate($tag['created']); ?></td> */ ?>
                               <td class="center aligned"><?php if (isset($tag['count'])) echo '<a href="' . esc_url( $link ) . '">' . esc_html( zeroBSCRM_prettifyLongInts($tag['count']) ) . '</a>'; ?></td>
-                              <td class="center aligned"><button type="button" class="ui mini button orange zbs-delete-tag" data-tagid="<?php echo esc_attr( $tag['id'] ); ?>"><i class="trash alternate icon"></i> <?php esc_html_e('Delete','zero-bs-crm'); ?></button></td>
+										<td class="center aligned"><button type="button" class="ui mini button black zbs-delete-tag" data-tagid="<?php echo esc_attr( $tag['id'] ); ?>"><i class="trash alternate icon"></i> <?php esc_html_e( 'Delete', 'zero-bs-crm' ); ?></button></td>
                             </tr>
                             <?php
                           }

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Tags.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Tags.php
@@ -76,7 +76,7 @@ class zeroBS__Metabox_Tags extends zeroBS__Metabox {
                         <div class="ui action left icon fluid input">
                           <i class="tags icon"></i>
                           <input id="zbs-add-tag-value" type="text" placeholder="<?php esc_attr_e( 'Enter tags', 'zero-bs-crm' ); ?>">
-                          <button id="zbs-add-tag-action" type="button" class="ui mini blue button">
+									<button id="zbs-add-tag-action" type="button" class="ui mini black button">
                             <?php esc_html_e('Add',"zero-bs-crm"); ?>
                           </button>
                         </div>
@@ -138,7 +138,9 @@ class zeroBS__Metabox_Tags extends zeroBS__Metabox {
                                         }
 
                                         // brutal out
-                                        ?><div class="ui small basic blue teal label zbsTagSuggestion" title="<?php esc_attr_e('Add Tag','zero-bs-crm'); ?>"><?php echo esc_html( $tagSuggest['name'] ); ?></div><?php
+									?>
+													<div class="ui small basic black label zbsTagSuggestion" title="<?php esc_attr_e( 'Add Tag', 'zero-bs-crm' ); ?>"><?php echo esc_html( $tagSuggest['name'] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?></div>
+													<?php
 
 
                                         $suggestionIndx++;

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
@@ -713,7 +713,7 @@ class zeroBS__Metabox_TransactionTags extends zeroBS__Metabox_Tags{
 
                     <div class="zbs-transaction-actions-bottom zbs-objedit-actions-bottom">
 
-                        <button class="ui button green" type="button" id="zbs-edit-save"><?php echo esc_html( __( 'Update Transaction', 'zero-bs-crm' ) ); ?></button>
+							<button class="ui button black" type="button" id="zbs-edit-save"><?php echo esc_html( __( 'Update Transaction', 'zero-bs-crm' ) ); ?></button>
 
                         <?php
 
@@ -738,7 +738,7 @@ class zeroBS__Metabox_TransactionTags extends zeroBS__Metabox_Tags{
 
                     <div class="zbs-transaction-actions-bottom zbs-objedit-actions-bottom">
                     	
-                    	<button class="ui button green" type="button" id="zbs-edit-save"><?php echo esc_html( __( 'Save Transaction','zero-bs-crm' ) ); ?></button>
+						<button class="ui button black" type="button" id="zbs-edit-save"><?php echo esc_html( __( 'Save Transaction', 'zero-bs-crm' ) ); ?></button>
 
                     </div>
 

--- a/projects/plugins/crm/includes/class-learn-menu.php
+++ b/projects/plugins/crm/includes/class-learn-menu.php
@@ -804,7 +804,7 @@ class Learn_Menu {
 				'content'     => '<p></p>',
 				'video'       => 'https://www.youtube.com/watch?v=mBPjV1KUb-w',
 				'video_title' => __( "All about Forms", 'zero-bs-crm' ),
-				'add_new'     => ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_form', false ) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New',"zero-bs-crm") . '</a>'
+				'add_new'     => ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_form', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>',
 			),
 			'formnew' => array(
 				'title'       => __( "New Form", "zero-bs-crm" ),
@@ -916,7 +916,7 @@ class Learn_Menu {
 				'img'     => 'learn-quote-template.png',
 				'video'   => false,
 				'content' => '<p>' . __( 'Quote Templates save you time. You can enter placeholders so that when you generate a new Quote using the template the contact fields are automatically populated.', 'zero-bs-crm' ) . '</p>',
-				'add_new' => ' <a href="' . jpcrm_esc_link('create',-1,'zerobs_quo_template',false)  . '#free-extensions-tour" class="button ui blue tiny zbs-add-new" id="add-template">' . __('Add Template',"zero-bs-crm") . '</a>'
+				'add_new' => ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_quo_template', false ) . '#free-extensions-tour" class="button ui black tiny zbs-add-new" id="add-template">' . __( 'Add Template', 'zero-bs-crm' ) . '</a>',
 			),
 			'quotetemplatenew' => array(
 				'title'   => __( "New Quote Template", 'zero-bs-crm' ),
@@ -1095,7 +1095,7 @@ class Learn_Menu {
 				'img'     => 'learn-export-contacts.png',
 				'video'   => false,
 				'content' => "<p>" . __( "You can export your contact information here to do additional analysis outside of Jetpack CRM", 'zero-bs-crm' ) . "</p><p>" . __( "Export and use in an Excel File, or export to import into other tools you use for your business needs", 'zero-bs-crm' ) . "</p>",
-				'add_new' => '<a href="' . admin_url( 'admin.php?page=' . $zbs->slugs['export-tools'] . '&zbswhat=contacts' ) . '" class="button ui blue tiny zbs-add-new">' . __( 'Export Other Types',"zero-bs-crm") . '</a>'
+				'add_new' => '<a href="' . admin_url( 'admin.php?page=' . $zbs->slugs['export-tools'] . '&zbswhat=contacts' ) . '" class="button ui black tiny zbs-add-new">' . __( 'Export Other Types', 'zero-bs-crm' ) . '</a>',
 			),
 			'export-tools' => array(
 				'title'   => __( "Export Tools", 'zero-bs-crm' ),

--- a/projects/plugins/crm/includes/jpcrm-learn-menu-legacy-functions.php
+++ b/projects/plugins/crm/includes/jpcrm-learn-menu-legacy-functions.php
@@ -62,7 +62,7 @@ function jpcrm_contactlist_learn_menu(){
 
     // Add new
     $addNew = ''; if ( zeroBSCRM_permsCustomers() ) {
-        $addNew = ' <a href="' . jpcrm_esc_link('create',-1,'zerobs_customer',false ) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add new Contact',"zero-bs-crm") . '</a>';
+		$addNew = ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_customer', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add new Contact', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
     }
 
     $content      = $zbs->learn_menu->get_content_body( 'managecontacts' );
@@ -78,7 +78,7 @@ function jpcrm_viewcontact_learn_menu($name=''){
 
     $title        = __( 'Viewing Contact','zero-bs-crm' );
     $addNew = ''; if ( zeroBSCRM_permsCustomers() ) {
-        $addNew = ' <a href="' . jpcrm_esc_link( 'create' ,-1, 'zerobs_customer', false ) . '" id="zbs-contact-add-new" class="button ui blue tiny zbs-add-new">' . __( 'Add new Contact',"zero-bs-crm") . '</a>';
+		$addNew = ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_customer', false ) . '" id="zbs-contact-add-new" class="button ui black tiny zbs-add-new">' . __( 'Add new Contact', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
     }
     $content      = $zbs->learn_menu->get_content_body( 'viewcontact' );
     $links        = $zbs->learn_menu->get_content_urls( 'viewcontact' );	
@@ -202,7 +202,7 @@ function jpcrm_formlist_learn_menu(){
     $title      = __("Forms","zero-bs-crm");
 	$addNew = '';
 	if ( zeroBSCRM_permsQuotes() ) {
-            $addNew = ' <a href="' . jpcrm_esc_link('create',-1,'zerobs_form',false) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New',"zero-bs-crm") . '</a>';
+		$addNew = ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_form', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	} 
     $content    = $zbs->learn_menu->get_content_body( 'manageformscrm' );
     $links      = $zbs->learn_menu->get_content_urls( 'manageformscrm' );
@@ -233,9 +233,9 @@ function jpcrm_taskedit_learn_menu(){
 
     $title      = __( 'Edit Task','zero-bs-crm' );
     $addNew 	= '<div id="zbs-event-learn-nav"></div>';
-    $addNew     .= ' <a href="' . jpcrm_esc_link('create',-1,'zerobs_event',false) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New',"zero-bs-crm") . '</a>';
-	$addNew 	.= ' <a href="' . jpcrm_esc_link($zbs->slugs['manage-events']) . '" class="button ui orange tiny zbs-add-new zbs-add-new-task"><i class="calendar alternate outline icon"></i> ' . __( 'View Calendar',"zero-bs-crm") . '</a>';
-    $addNew 	.= ' <a href="' . jpcrm_esc_link($zbs->slugs['manage-events-list']) . '" class="button ui orange tiny zbs-add-new zbs-add-new-task"><i class="list alternate outline icon"></i> ' . __( 'View List',"zero-bs-crm") . '</a>';
+	$addNew .= ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_event', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$addNew .= ' <a href="' . jpcrm_esc_link( $zbs->slugs['manage-events'] ) . '" class="button ui black tiny zbs-add-new zbs-add-new-task"><i class="calendar alternate outline icon"></i> ' . __( 'View Calendar', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$addNew .= ' <a href="' . jpcrm_esc_link( $zbs->slugs['manage-events-list'] ) . '" class="button ui black tiny zbs-add-new zbs-add-new-task"><i class="list alternate outline icon"></i> ' . __( 'View List', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$content    = $zbs->learn_menu->get_content_body( 'taskedit' );
     $links      = $zbs->learn_menu->get_content_urls( 'taskedit' );	
 	$zbs->learn_menu->render_generic_learn_menu( $title,$addNew,'',true,$title,$content,$links['learn'],$links['img'],$links['vid'],'' );
@@ -250,8 +250,8 @@ function jpcrm_tasklistview_learn_menu(){
 
     $title      = __( 'Task List','zero-bs-crm' );
     $addNew 	= '<div id="zbs-event-learn-nav"></div>';
-    $addNew     .= ' <a href="' . jpcrm_esc_link('create',-1,'zerobs_event',false) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New',"zero-bs-crm") . '</a>';
-	$addNew 	.= ' <a href="' . jpcrm_esc_link($zbs->slugs['manage-events']) . '" class="button ui orange tiny zbs-add-new zbs-add-new-task"><i class="calendar alternate outline icon"></i> ' . __( 'View Calendar',"zero-bs-crm") . '</a>';
+	$addNew .= ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_event', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$addNew .= ' <a href="' . jpcrm_esc_link( $zbs->slugs['manage-events'] ) . '" class="button ui black tiny zbs-add-new zbs-add-new-task"><i class="calendar alternate outline icon"></i> ' . __( 'View Calendar', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$content    = $zbs->learn_menu->get_content_body( 'manage-events-list' );
     $links      = $zbs->learn_menu->get_content_urls( 'manage-events-list' );
 
@@ -266,8 +266,8 @@ function jpcrm_tasknew_learn_menu(){
 	global $zbs;
 
     $title      = __( 'New Task','zero-bs-crm' );
-	$addNew 	= ' <a href="' . jpcrm_esc_link($zbs->slugs['manage-events']) . '" class="button ui orange tiny zbs-add-new zbs-add-new-task"><i class="calendar alternate outline icon"></i> ' . __( 'View Calendar',"zero-bs-crm") . '</a>';
-    $addNew 	.= ' <a href="' . jpcrm_esc_link($zbs->slugs['manage-events-list']) . '" class="button ui orange tiny zbs-add-new zbs-add-new-task"><i class="list alternate outline icon"></i> ' . __( 'View List',"zero-bs-crm") . '</a>';
+	$addNew  = ' <a href="' . jpcrm_esc_link( $zbs->slugs['manage-events'] ) . '" class="button ui black tiny zbs-add-new zbs-add-new-task"><i class="calendar alternate outline icon"></i> ' . __( 'View Calendar', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$addNew .= ' <a href="' . jpcrm_esc_link( $zbs->slugs['manage-events-list'] ) . '" class="button ui black tiny zbs-add-new zbs-add-new-task"><i class="list alternate outline icon"></i> ' . __( 'View List', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
     $content    = $zbs->learn_menu->get_content_body( 'tasknew' );
     $links      = $zbs->learn_menu->get_content_urls( 'tasknew' );	
 	$zbs->learn_menu->render_generic_learn_menu( $title, $addNew,'',true,$title,$content,$links['learn'],$links['img'],$links['vid'],'' );
@@ -288,7 +288,7 @@ function jpcrm_quotelist_learn_menu(){
 	$addNew = '';
     #} Add new?
     if ( zeroBSCRM_permsCustomers() ) {
-        $addNew = ' <a href="' . jpcrm_esc_link('create',-1,'zerobs_quote',false) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New',"zero-bs-crm") . '</a>';
+		$addNew = ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_quote', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
     }  
 
 	$hideLearn = true;
@@ -327,7 +327,7 @@ function jpcrm_quoteedit_list_menu() {
 		$zbsid   = (int) sanitize_text_field( wp_unslash( $_GET['zbsid'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$content = $zbs->learn_menu->get_content_body( 'quoteedit' );
 		$links   = $zbs->learn_menu->get_content_urls( 'quoteedit' );
-		$add_new = '<div id="zbs-quote-learn-nav"></div>  <a href="' . jpcrm_esc_link( 'create', -1, ZBS_TYPE_QUOTE, false ) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>';
+		$add_new = '<div id="zbs-quote-learn-nav"></div>  <a href="' . jpcrm_esc_link( 'create', -1, ZBS_TYPE_QUOTE, false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>';
 
 	}
 
@@ -355,7 +355,7 @@ function jpcrm_translist_learn_menu(){
     $title      = __( 'Transaction List','zero-bs-crm' );
     #} Add new?
     $addNew = ''; if ( zeroBSCRM_permsCustomers() ) {
-        $addNew = ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_transaction', false ) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New',"zero-bs-crm") . '</a>';
+		$addNew = ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_transaction', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
     }
     $content    = $zbs->learn_menu->get_content_body( 'managetransactions' );
     $links      = $zbs->learn_menu->get_content_urls( 'managetransactions' );
@@ -392,7 +392,7 @@ function jpcrm_transedit_learn_menu(){
 		$links   = $zbs->learn_menu->get_content_urls( 'transedit' );
 
 		if ( zeroBSCRM_permsInvoices() ) {
-			$add_new = ' <a href="' . jpcrm_esc_link( 'create', -1, ZBS_TYPE_TRANSACTION, false ) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>';
+			$add_new = ' <a href="' . jpcrm_esc_link( 'create', -1, ZBS_TYPE_TRANSACTION, false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>';
 		}
 	}
 
@@ -420,7 +420,7 @@ function jpcrm_invoicelist_learn_menu(){
     $title      = __( 'Manage Invoices','zero-bs-crm' );
     $addNew = '';
     if ( zeroBSCRM_permsInvoices() ) {
-        $addNew =  '<a href="' . jpcrm_esc_link('create',-1,'zerobs_invoice',false) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New',"zero-bs-crm") . '</a>';
+		$addNew = '<a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_invoice', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
     }
     $content    = $zbs->learn_menu->get_content_body( 'manageinvoices' );
     $links      = $zbs->learn_menu->get_content_urls( 'manageinvoices' );
@@ -466,7 +466,7 @@ function jpcrm_invoiceedit_learn_menu(){
 		$add_new = '<div id="zbs-invoice-learn-nav">' . $also_in_add_new . '</div>'; // js adds/edits
 
 		if ( zeroBSCRM_permsInvoices() ) {
-			$add_new .= '<a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_invoice', false ) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>';
+			$add_new .= '<a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_invoice', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>';
 		}
 	}
 
@@ -493,7 +493,7 @@ function jpcrm_companylist_learn_menu(){
     $title      = __( 'Manage '.jpcrm_label_company(true),'zero-bs-crm' );
     $addNew = '';
     if ( zeroBSCRM_permsInvoices() ) {
-        $addNew =  '<a href="' .jpcrm_esc_link('create',-1,'zerobs_company',false) . '" class="button ui blue tiny zbs-add-new">' . __( 'Add New',"zero-bs-crm") . '</a>';
+		$addNew = '<a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_company', false ) . '" class="button ui black tiny zbs-add-new">' . __( 'Add New', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
     }
     $content    = $zbs->learn_menu->get_content_body( 'managecompanies' );
     $links      = $zbs->learn_menu->get_content_urls( 'managecompanies' );	
@@ -550,8 +550,8 @@ function jpcrm_tasklist_learn_menu(){
 	global $zbs;
 
     $title      = __( 'Task Calendar','zero-bs-crm' );
-    $addNew 	= ' <a href="' . jpcrm_esc_link('create',-1,'zerobs_event',false) . '" class="button ui blue tiny zbs-add-new zbs-add-new-task">' . __( 'Add New',"zero-bs-crm") . '</a>';
-    $addNew 	.= ' <a href="' . jpcrm_esc_link($zbs->slugs['manage-events-list']) . '" class="button ui orange tiny zbs-add-new zbs-add-new-task"><i class="list alternate outline icon"></i> ' . __( 'List View',"zero-bs-crm") . '</a>'; 
+	$addNew  = ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_event', false ) . '" class="button ui black tiny zbs-add-new zbs-add-new-task">' . __( 'Add New', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$addNew .= ' <a href="' . jpcrm_esc_link( $zbs->slugs['manage-events-list'] ) . '" class="button ui black tiny zbs-add-new zbs-add-new-task"><i class="list alternate outline icon"></i> ' . __( 'List View', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$content    = $zbs->learn_menu->get_content_body( 'manage-events' );
     $links      = $zbs->learn_menu->get_content_urls( 'manage-events' );	
 
@@ -615,7 +615,7 @@ function jpcrm_segmentlist_learn_menu(){
 
 	$add_new = '';
 	if ( zeroBSCRM_permsCustomers() ) {
-		$add_new = ' <a href="' . jpcrm_esc_link( 'create', -1, 'segment', false ) . '" class="button ui blue tiny zbs-add-new">' . esc_html__( 'Add New', 'zero-bs-crm' ) . '</a>';
+		$add_new = ' <a href="' . jpcrm_esc_link( 'create', -1, 'segment', false ) . '" class="button ui black tiny zbs-add-new">' . esc_html__( 'Add New', 'zero-bs-crm' ) . '</a>';
 	}
 
 	// filter strings
@@ -659,7 +659,7 @@ function jpcrm_segmentedit_learn_menu(){
     	$newSegment = false; 
     }
 
-    $filterStr = '<button class="ui icon small button positive right floated';
+	$filterStr = '<button class="ui icon small button black positive right floated'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, Generic.Formatting.MultipleStatementAlignment.NotSameWarning
     	if ($newSegment) $filterStr .= ' hidden';
     $filterStr .= '" type="button" id="zbs-segment-edit-act-save">'.__( 'Save Segment',"zero-bs-crm").'  <i class="save icon"></i></button>';
     $filterStr .= '<button class="ui button small right floated was-inverted basic" type="button" id="zbs-segment-edit-act-back">'.__( 'Back to List',"zero-bs-crm").'</button>';
@@ -737,7 +737,7 @@ function jpcrm_emails_learn_menu(){
 
     $title      = __( 'Emails','zero-bs-crm' );
 	$addNew     = '';
-	$filterStr = '<a href="'.admin_url('admin.php?page=zerobscrm-send-email').'" class="ui button blue tiny zbs-inbox-compose-email"><i class="ui icon pencil"></i> ' . __("Compose Mail", "zero-bs-crm") . '</a>';
+	$filterStr = '<a href="' . admin_url( 'admin.php?page=zerobscrm-send-email' ) . '" class="ui button black tiny zbs-inbox-compose-email"><i class="ui icon pencil"></i> ' . __( 'Compose Mail', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
     $content    = $zbs->learn_menu->get_content_body( 'emails' );
     $links      = $zbs->learn_menu->get_content_urls( 'emails' );	
 	$zbs->learn_menu->render_generic_learn_menu( $title,$addNew,$filterStr,true,$title,$content,$links['learn'],$links['img'],$links['vid'],'' );

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -349,8 +349,8 @@ function zbscrm_JS_initMenuPopups() {
 			hoverable: true,
 			on: 'hover',
 			delay: {
-				show: 300,
-				hide: 800,
+				show: 50,
+				hide: 500,
 			},
 		} );
 	}

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -2329,10 +2329,10 @@ function zeroBSCRMJS_bindGlobalContactFuncs() {
 				//text: "Are you sure you want to delete these?",
 				type: '',
 				showCancelButton: true,
-				confirmButtonColor: '#3085d6',
-				cancelButtonColor: '#d33',
+				confirmButtonColor: '#000',
+				cancelButtonColor: '#fff',
+				cancelButtonText: '<span style="color: #000">' + zeroBSCRMJS_globViewLang( 'cancel' ) + '</span>',
 				confirmButtonText: zeroBSCRMJS_globViewLang( 'send' ),
-				cancelButtonText: zeroBSCRMJS_globViewLang( 'cancel' ),
 			} ).then( function ( result ) {
 				// this check required from swal2 6.0+ https://github.com/sweetalert2/sweetalert2/issues/724
 				if ( result.value ) {

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -348,6 +348,10 @@ function zbscrm_JS_initMenuPopups() {
 			position: 'bottom center',
 			hoverable: true,
 			on: 'hover',
+			delay: {
+				show: 300,
+				hide: 800,
+			},
 		} );
 	}
 }

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -2209,8 +2209,9 @@ function zbscrmJS_sendInvoiceModal() {
 				'</div>',
 			type: 'question',
 			showCancelButton: true,
-			confirmButtonColor: '#3085d6',
-			cancelButtonColor: '#d33',
+			confirmButtonColor: '#000',
+			cancelButtonColor: '#fff',
+			cancelButtonText: '<span style="color: #000">Cancel</span>',
 			confirmButtonText: zbscrm_JS_invoice_lang( 'sendthemail' ),
 			//allowOutsideClick: false
 		} ).then( function ( result ) {

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -225,7 +225,7 @@ function zbscrm_JS_draw_invoice_actions_html( res ) {
 			html +=
 				'<a href="' +
 				res.invoiceObj.preview_link +
-				'" target="_blank" class="ui button blue" id="zbs_invoice_preview">' +
+				'" target="_blank" class="ui button black" id="zbs_invoice_preview">' +
 				zbscrm_JS_invoice_lang( 'preview' ) +
 				'</a>';
 		}
@@ -233,7 +233,7 @@ function zbscrm_JS_draw_invoice_actions_html( res ) {
 		//pdf download only displayed in PDF set.
 		if ( res.invoiceObj.pdf_installed ) {
 			html +=
-				'<button id="zbs_invoicing_download_pdf" type="button" class="ui button olive">' +
+				'<button id="zbs_invoicing_download_pdf" type="button" class="ui button black">' +
 				zbscrm_JS_invoice_lang( 'dl_pdf' ) +
 				'</button>';
 			Formhtml =
@@ -254,7 +254,7 @@ function zbscrm_JS_draw_invoice_actions_html( res ) {
 				zbscrm_JS_validateEmail( potentialEmail )
 			) {
 				html +=
-					'<button type="button" id="zbs_invoicing_send_email" class="ui button yellow">' +
+					'<button type="button" id="zbs_invoicing_send_email" class="ui button black">' +
 					zbscrm_JS_invoice_lang( 'send_email' ) +
 					'</button>';
 			}
@@ -685,7 +685,7 @@ function zbscrm_JS_draw_invoice_biz_info( res ) {
 	html += '<div id="zbs-business-info-wrapper">';
 	html += '<div class="business-info-toggle">';
 	html +=
-		'<i class="fa fa-chevron-circle-right" aria-hidden="true"></i> <span class="your-info-biz">' +
+		'<i class="fa fa-chevron-circle-right" aria-hidden="true" style="color:black;"></i> <span class="your-info-biz">' +
 		zbscrm_JS_invoice_lang( 'biz_info' ) +
 		'</span>';
 	html += '</div>';

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -1628,9 +1628,10 @@ function zeroBSCRMJS_listView_customer_bulkActionFire_delete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: 'Yes, delete!',
+		cancelButtonText: '<span style="color: #000">Cancel</span>'
 		//allowOutsideClick: false
 	} ).then( function ( result ) {
 		// this check required from swal2 6.0+
@@ -1645,11 +1646,12 @@ function zeroBSCRMJS_listView_customer_bulkActionFire_delete() {
 				extraParams,
 				function ( r ) {
 					// success ? SWAL?
-					swal(
-						zeroBSCRMJS_listViewLang( 'deleted' ),
-						zeroBSCRMJS_listViewLang( 'contactsdeleted' ),
-						'success'
-					);
+					swal({
+						title: zeroBSCRMJS_listViewLang( 'deleted' ),
+						text: zeroBSCRMJS_listViewLang( 'contactsdeleted' ),
+						confirmButtonColor: '#000',
+						type: 'success'
+					});
 				},
 				function ( r ) {
 					// fail ? SWAL?

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -1287,8 +1287,9 @@ function zeroBSCRMJS_listView_generic_bulkActionFire_addtag() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'addthesetags' ),
 		//allowOutsideClick: false,
 		onOpen: function () {
@@ -1394,9 +1395,10 @@ function zeroBSCRMJS_listView_generic_bulkActionFire_removetag() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'removethesetags' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 		onOpen: function () {
 			// bind checkboxes (this just adds nice colour effect, not that important)
@@ -1577,8 +1579,9 @@ function zeroBSCRMJS_listView_customer_bulkActionFire_changestatus() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesupdate' ),
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
@@ -1696,8 +1699,9 @@ function zeroBSCRMJS_listView_customer_bulkActionFire_merge() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesmerge' ),
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
@@ -2774,9 +2778,10 @@ function zeroBSCRMJS_listView_segment_bulkActionFire_delete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: 'Yes, delete!',
+		cancelButtonText: '<span style="color: #000">Cancel</span>'
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
 		// this check required from swal2 6.0+ https://github.com/sweetalert2/sweetalert2/issues/724
@@ -3290,9 +3295,10 @@ function zeroBSCRMJS_listView_company_bulkActionFire_delete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesdelete' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
 		// this check required from swal2 6.0+ https://github.com/sweetalert2/sweetalert2/issues/724
@@ -3373,8 +3379,9 @@ function zeroBSCRMJS_listView_company_bulkActionFire_addtag() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'addthesetags' ),
 		//allowOutsideClick: false,
 		onOpen: function () {
@@ -3488,9 +3495,10 @@ function zeroBSCRMJS_listView_company_bulkActionFire_removetag() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'removethesetags' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 		onOpen: function () {
 			// bind checkboxes (this just adds nice colour effect, not that important)
@@ -3722,8 +3730,9 @@ function zeroBSCRMJS_listView_quote_bulkActionFire_markaccepted() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'acceptyesdoit' ),
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
@@ -3771,8 +3780,9 @@ function zeroBSCRMJS_listView_quote_bulkActionFire_markunaccepted() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesproceed' ),
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
@@ -3820,9 +3830,10 @@ function zeroBSCRMJS_listView_quote_bulkActionFire_delete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesdelete' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
 		// this check required from swal2 6.0+ https://github.com/sweetalert2/sweetalert2/issues/724
@@ -3883,9 +3894,10 @@ function zeroBSCRMJS_listView_quotetemplate_bulkActionFire_delete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesdelete' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
 		// this check required from swal2 6.0+ https://github.com/sweetalert2/sweetalert2/issues/724
@@ -4132,8 +4144,9 @@ function zeroBSCRMJS_listView_invoice_bulkActionFire_changestatus() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesupdate' ),
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
@@ -4181,9 +4194,10 @@ function zeroBSCRMJS_listView_invoice_bulkActionFire_delete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesdelete' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
 		// this check required from swal2 6.0+ https://github.com/sweetalert2/sweetalert2/issues/724
@@ -4447,9 +4461,10 @@ function zeroBSCRMJS_listView_transaction_bulkActionFire_delete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesdelete' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
 		// this check required from swal2 6.0+ https://github.com/sweetalert2/sweetalert2/issues/724
@@ -4527,8 +4542,9 @@ function zeroBSCRMJS_listView_transaction_bulkActionFire_addtag() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'addthesetags' ),
 		//allowOutsideClick: false,
 		onOpen: function () {
@@ -4642,9 +4658,10 @@ function zeroBSCRMJS_listView_transaction_bulkActionFire_removetag() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'removethesetags' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 		onOpen: function () {
 			// bind checkboxes (this just adds nice colour effect, not that important)
@@ -4819,9 +4836,10 @@ function zeroBSCRMJS_listView_form_bulkActionFire_delete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesdelete' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
 		// this check required from swal2 6.0+ https://github.com/sweetalert2/sweetalert2/issues/724
@@ -5078,9 +5096,10 @@ function zeroBSCRMJS_listView_event_bulkActionFire_delete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'yesdelete' ),
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
 		// this check required from swal2 6.0+ https://github.com/sweetalert2/sweetalert2/issues/724
@@ -5124,8 +5143,9 @@ function zeroBSCRMJS_listView_event_bulkActionFire_markcomplete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'acceptyesdoit' ),
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {
@@ -5173,8 +5193,9 @@ function zeroBSCRMJS_listView_event_bulkActionFire_markincomplete() {
 		//text: "Are you sure you want to delete these?",
 		type: 'warning',
 		showCancelButton: true,
-		confirmButtonColor: '#3085d6',
-		cancelButtonColor: '#d33',
+		confirmButtonColor: '#000',
+		cancelButtonColor: '#fff',
+		cancelButtonText: '<span style="color: #000">Cancel</span>',
 		confirmButtonText: zeroBSCRMJS_listViewLang( 'acceptyesdoit' ),
 		//allowOutsideClick: false,
 	} ).then( function ( result ) {

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.quotebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.quotebuilder.js
@@ -319,8 +319,9 @@ function jpcrm_quotes_send_email_modal() {
 			html: '<div class="ui segment">' + jpcrm_quotes_lang( 'sendthisemail' ) + optsHTML + '</div>',
 			type: 'question',
 			showCancelButton: true,
-			confirmButtonColor: '#3085d6',
-			cancelButtonColor: '#d33',
+			confirmButtonColor: '#000',
+			cancelButtonColor: '#fff',
+			cancelButtonText: '<span style="color: #000">Cancel</span>',
 			confirmButtonText: jpcrm_quotes_lang( 'sendthemail' ),
 			//allowOutsideClick: false
 		} ).then( function ( result ) {

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.quotebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.quotebuilder.js
@@ -188,6 +188,7 @@ function zbscrm_getTemplatedQuote( cb, errcb ) {
 							text: 'Quote Template Populated',
 							type: 'success',
 							confirmButtonText: 'OK',
+							confirmButtonColor: '#000',
 						} );
 						setTimeout( function () {
 							zbscrm_appendTextToEditor( e.html );
@@ -236,6 +237,7 @@ function zbscrm_getTemplatedQuote( cb, errcb ) {
 				text: 'Please Choose a Contact',
 				type: 'error',
 				confirmButtonText: 'OK',
+				confirmButtonColor: '#000',
 			} );
 			window.quoteTemplateBlocker = false;
 			return false;

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.quotebuilder.wysiwygbar.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.quotebuilder.wysiwygbar.js
@@ -29,14 +29,6 @@
 
 	tinymce.PluginManager.add( 'zbsQuoteTemplates', function ( editor, url ) {
 		// This is simple button
-		/*editor.addButton( 'zbsQuoteTemplates', {
-            title: 'Scratch Card Engine',
-            image: window.wpsceURL + "i/WYSIWYG_icon.png",
-            onclick: function () {
-                 tinymce.activeEditor.execCommand("mceInsertContent", false, '[zbsQuoteTemplates]')
-            }
-        });*/
-
 		editor.addButton( 'zbsQuoteTemplates', {
 			title: 'Quote Template Placeholders',
 			image: window.zbs_root.root + 'i/WYSIWYG_icon.png',

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.tags.metabox.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.tags.metabox.js
@@ -322,8 +322,9 @@ function zeroBSCRMJS_tagManager_bindTagEditButtons() {
 					text: window.zbsTagListLang.deleteswaltext,
 					type: 'warning',
 					showCancelButton: true,
-					confirmButtonColor: '#3085d6',
-					cancelButtonColor: '#d33',
+					confirmButtonColor: '#000',
+					cancelButtonColor: '#fff',
+					cancelButtonText: '<span style="color: #000">Cancel</span>',
 					confirmButtonText: window.zbsTagListLang.deleteswalconfirm,
 					allowOutsideClick: false,
 				} ).then( function ( result ) {

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.tags.metabox.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.tags.metabox.js
@@ -57,7 +57,7 @@ function zeroBSCRMJS_buildTagsInput() {
  */
 function zbsJS_drawTag( tagStr, tagID ) {
 	var html =
-		'<div class="ui small basic label teal" data-id="' +
+		'<div class="ui small basic label black" data-id="' +
 		tagID +
 		'"><i class="window close icon zbs-remove-tag"></i> <span>' +
 		tagStr +
@@ -206,11 +206,11 @@ function zbsJS_bindTagManagerInit() {
 
 						// add to table
 						var tagTR =
-							'<tr><td><span class="ui large blue label">' +
+							'<tr><td><span class="ui large label">' +
 							ltag +
 							'</span></td><td>' +
 							newTagSlug +
-							'</td><td class="center aligned">0</td><td class="center aligned"><button type="button" class="ui mini button orange zbs-delete-tag" data-tagid="' +
+							'</td><td class="center aligned">0</td><td class="center aligned"><button type="button" class="ui mini button black zbs-delete-tag" data-tagid="' +
 							newTagID +
 							'"><i class="trash alternate icon"></i> ' +
 							window.zbsTagListLang.delete +

--- a/projects/plugins/crm/modules/mailpoet/admin/mailpoet-hub/main.page.php
+++ b/projects/plugins/crm/modules/mailpoet/admin/mailpoet-hub/main.page.php
@@ -146,7 +146,7 @@ function jpcrm_mailpoet_render_hub_page() {
 								<?php esc_html_e( 'Setup Type:', 'zero-bs-crm' ); ?> 
 								<?php esc_html_e( 'Local', 'zero-bs-crm' ); ?><br />
 								<?php echo '<span id="jpcrm-mailpoet-stat-contacts-synced">' . esc_html( $jpcrm_mailpoet_latest_stats['subscribers_synced'] ) . '</span> ' . esc_html__( 'Subscribers Synced', 'zero-bs-crm' ); ?>
-								<a href="<?php echo jpcrm_esc_link( 'manage-customers&quickfilters=mailpoet_subscriber' ); ?>" id="jpcrm-mailpoet-recap-link-to-contacts" class="ui tiny blue button<?php if ( $jpcrm_mailpoet_latest_stats['subscribers_synced'] <= 0 ){ echo ' hidden'; } ?>" style="margin-left:10px"><?php esc_html_e( 'View Subscribers in CRM', 'zero-bs-crm' ); ?></a>
+								<a href="<?php echo jpcrm_esc_link( 'manage-customers&quickfilters=mailpoet_subscriber' ); ?>" id="jpcrm-mailpoet-recap-link-to-contacts" class="ui tiny black button<?php if ( $jpcrm_mailpoet_latest_stats['subscribers_synced'] <= 0 ) { echo ' hidden'; } ?>" style="margin-left:10px"><?php esc_html_e( 'View Subscribers in CRM', 'zero-bs-crm' ); // phpcs:ignore Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?></a>
 							</p>
 							<br>
 							<span id="jpcrm-mailpoet-status-long-text"><?php esc_html_e( 'MailPoet Sync is importing subscribers...', 'zero-bs-crm' ); ?></span>

--- a/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-export-segment-to-mailpoet.php
+++ b/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-export-segment-to-mailpoet.php
@@ -58,7 +58,7 @@ class Mailpoet_Export_Segment_To_MailPoet {
 		add_action( 'jpcrm_segment_edit_export_mailpoet_button', function() {
 			// AJAX call to action 'jpcrm_segment_export_to_mailpoet'
 			?>
-			<button class="ui submit teal large icon button zbs-segment-export-mailpoet">
+			<button class="ui submit black large icon button zbs-segment-export-mailpoet">
 				<?php esc_html_e( 'Export to MailPoet', 'zero-bs-crm' ); ?> <i class="mail forward icon"></i>
 			</button>
 			<?php

--- a/projects/plugins/crm/modules/mailpoet/includes/jpcrm-mailpoet-contact-tabs.php
+++ b/projects/plugins/crm/modules/mailpoet/includes/jpcrm-mailpoet-contact-tabs.php
@@ -204,7 +204,7 @@ class MailPoet_Contact_Tabs {
 
         } else {
 
-            $html .=  '<div class="ui message info blue"><i class="ui icon info circle"></i>' . __( "This contact does not have a MailPoet subscriber.", 'zero-bs-crm' ) . '</div>';
+			$html .= '<div class="ui message"><i class="ui icon info circle"></i>' . __( 'This contact does not have a MailPoet subscriber.', 'zero-bs-crm' ) . '</div>';
         
         }
 

--- a/projects/plugins/crm/modules/woo-sync/js/jpcrm-woo-sync-settings-connections.js
+++ b/projects/plugins/crm/modules/woo-sync/js/jpcrm-woo-sync-settings-connections.js
@@ -50,10 +50,10 @@ function jpcrm_woosync_bind_add_connection() {
 			html: swal_HTML,
 			type: '',
 			showCancelButton: true,
-			confirmButtonColor: '#3085d6',
-			cancelButtonColor: '#d33',
+			confirmButtonColor: '#000',
+			cancelButtonColor: '#fff',
+			cancelButtonText: '<span style="color: #000">' + zeroBSCRMJS_globViewLang( 'cancel' ) + '</span>',
 			confirmButtonText: zeroBSCRMJS_globViewLang( 'connect-woo-go' ),
-			cancelButtonText: zeroBSCRMJS_globViewLang( 'cancel' ),
 			customClass: 'swal-wide',
 			preConfirm: function () {
 				// get value

--- a/projects/plugins/crm/modules/woo-sync/sass/jpcrm-woo-sync-hub-page.scss
+++ b/projects/plugins/crm/modules/woo-sync/sass/jpcrm-woo-sync-hub-page.scss
@@ -140,8 +140,8 @@
 				display: table;
 				min-height: 230px;
 				width: 100%;
-				border: solid 2px black !important;
-				color: black !important;
+				border: solid 2px #2185D0 !important;
+				color: #2185D0 !important;
 				background-color: #FFFFFF !important;
 
 				div.jpcrm-woosync-stat-container {

--- a/projects/plugins/crm/modules/woo-sync/sass/jpcrm-woo-sync-hub-page.scss
+++ b/projects/plugins/crm/modules/woo-sync/sass/jpcrm-woo-sync-hub-page.scss
@@ -140,8 +140,8 @@
 				display: table;
 				min-height: 230px;
 				width: 100%;
-				border: solid 2px #2185D0 !important;
-				color: #2185D0 !important;
+				border: solid 2px black !important;
+				color: black !important;
 				background-color: #FFFFFF !important;
 
 				div.jpcrm-woosync-stat-container {

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
@@ -80,7 +80,7 @@
 	#zbs-add-new-row{
 		padding: 8px;
 		background: #f5f5f5;
-		color: #238bd0;
+		color: black;
 		cursor: pointer;
 		text-align: center;
 		border: 1px solid #ddd;
@@ -234,7 +234,7 @@
 		.remove-row{
 			font-size:15px;
 			margin-top: 10px;
-			color: #238bd0;	
+			color: black;	
 		}
 		.third{
 			width: 200px !important;
@@ -751,13 +751,13 @@
 		margin-top: 20px;
 	    padding: 30px;
 	    width: 100%;
-	    background: aliceblue;
+	    background: var(--jp-gray-0);
 	    margin-bottom: 20px;
-	    border-radius: 11px;
-	    border: 1px solid #428bca;
+	    border-radius: 4px;
+	    border: 1px dashed var(--jp-gray-20);
 	    cursor:pointer;
 	    .fa{
-	    	color: #428bca;
+	    	color: black;
 	    	margin-right:5px;
 			margin-bottom:10px;
 	    	font-size:40px;
@@ -765,7 +765,7 @@
 	    }
 	    .wh-logo-text{
 		    font-weight: 300;
-		    color: #428bca;
+		    color: black;
 		    font-size: 18px;
 		    margin-left: 20px;
 		    position: absolute;

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.segmentedit.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.segmentedit.scss
@@ -64,7 +64,7 @@
 	    }
 
 	    .field>label {
-		    color: rgba(8, 0, 138, 0.87);
+		    color: black;
 		    font-size: 1em;
    		}
    		.ui p {

--- a/projects/plugins/crm/sass/_ZeroBSCRM.forms.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.forms.scss
@@ -95,7 +95,7 @@ input.zbs-prominent {
 
 // second address / main addr
 tr.zbs-field-group-tr .zbs-field-group {
-    border-left: 3px solid #c2e1ff !important;
+    border-left: 3px solid var(--jp-gray-20) !important;
     padding-left: 2% !important;
 }
 tr.zbs-field-group-tr label.zbs-field-group-label {
@@ -114,7 +114,7 @@ tr.zbs-field-group-tr label.zbs-field-group-label {
 	    width: 44% !important;
 	    margin-right: 2% !important;
 	    display: inline-block !important;
-	    border-left: 3px solid #c2e1ff !important;
+	    border-left: 3px solid var(--jp-gray-20) !important;
 	    padding-left: 2% !important;
 	}
 

--- a/projects/plugins/crm/sass/_ZeroBSCRM.genericeditpages.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.genericeditpages.scss
@@ -30,11 +30,11 @@ tr.wh-large input[type="radio"] {
 }
 tr.wh-large th, tr.wh-large td {
   padding: 6px 20px;
-  color: rgb(48, 76, 105);
+  color: black;
 }
 table.wh-metatab tr th label {
   padding: 6px 20px;
-  color: rgb(48, 76, 105);
+  color: black;
 }
 table.wh-metatab tr.wh-large th label, table.wh-metatab tr.wh-large td label {
   padding:0;
@@ -196,7 +196,7 @@ textarea.form-control{
 // id fields + autonumbers
 .zbs-field-id {
   font-size: 14px !important;
-  color: green !important;
+  color: black !important;
   vertical-align: top !important;
 }
 

--- a/projects/plugins/crm/sass/_ZeroBSCRM.logs.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.logs.scss
@@ -34,10 +34,10 @@
 	#zbsAddLogForm {
 
 	    margin: 10px;
-	    border: 1px solid #b0a1ec;
+	    border: 1px dashed var(--jp-gray-20);
 	    padding: 12px;
-	    border-radius: 5px;
-	    background: #e1e6f3;
+	    border-radius: 4px;
+	    background: var(--jp-gray-0);
 	    line-height: 32px;
 
 	    // logo ico
@@ -108,7 +108,7 @@
 	    border: 1px solid #b0a1ec;
 	    padding: 12px;
 	    border-radius: 5px;
-	    background: #e1e6f3;
+	    background: var(--jp-gray-0);
 	    line-height: 32px;
 
 	    // logo ico
@@ -182,7 +182,7 @@
 
 		    font-size: 14px;
 		    font-weight: 800;
-    		border-bottom: 2px solid rgba(9, 185, 129, 0.58);
+    		border-bottom: 2px solid var(--jp-gray-20);
 
     		// edit icos
     		.zbsLogOutEdits {
@@ -199,7 +199,7 @@
 
 			    .fa {
 							    	
-				    color: #73947c;
+				    color: var(--jp-gray-20);
 				    padding: 4px;
 				    
 

--- a/projects/plugins/crm/sass/_ZeroBSCRM.timelines.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.timelines.scss
@@ -1,7 +1,7 @@
 // lovingly adapted from
 // https://codepen.io/brady_wright/pen/NNOvrW
 
-$primary-color: #4183C4;
+$primary-color: #000000;
 $primary-color-hover: scale-color($primary-color, $lightness: 32%);
 
 /*==================================
@@ -55,7 +55,7 @@ $primary-color-hover: scale-color($primary-color, $lightness: 32%);
         top: 0; bottom: 0; left: 0;
         width: 15px;
         &:before {
-            background: black;
+            background: $primary-color;
             border: 3px solid transparent;
             border-radius: 100%;
             content: "";

--- a/projects/plugins/crm/sass/_ZeroBSCRM.timelines.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.timelines.scss
@@ -55,7 +55,7 @@ $primary-color-hover: scale-color($primary-color, $lightness: 32%);
         top: 0; bottom: 0; left: 0;
         width: 15px;
         &:before {
-            background: $primary-color;
+            background: black;
             border: 3px solid transparent;
             border-radius: 100%;
             content: "";

--- a/projects/plugins/crm/sass/emerald/_dropdown-buttons.scss
+++ b/projects/plugins/crm/sass/emerald/_dropdown-buttons.scss
@@ -1,0 +1,11 @@
+.jpcrm-dropdown {
+	font-size: 14px;
+	padding: 8px 8px 8px 16px;
+
+	i {
+		width: 20px;
+		text-align: center;
+		margin-left: 8px;
+		font-size: 18px;
+	}
+}

--- a/projects/plugins/crm/sass/jpcrm-emerald.scss
+++ b/projects/plugins/crm/sass/jpcrm-emerald.scss
@@ -11,7 +11,7 @@
 @use 'emerald/_dashcount.scss';
 @use 'emerald/_dropdown-buttons.scss';
 @use 'emerald/_listview.scss';
+@use 'emerald/_listview-footer.scss';
 @use 'emerald/_listview-header.scss';
 @use 'emerald/_listview-table.scss';
-@use 'emerald/_listview-footer.scss';
 @use 'emerald/_pagination.scss';

--- a/projects/plugins/crm/sass/jpcrm-emerald.scss
+++ b/projects/plugins/crm/sass/jpcrm-emerald.scss
@@ -4,8 +4,10 @@
 /* base file */
 @use 'emerald/_emerald_base.scss';
 
-/* components */
+/* top menu */
 @use 'emerald/_jpcrm_top_menu.scss';
+
+/* components */
 @use 'emerald/_buttons.scss';
 @use 'emerald/_dashcard.scss';
 @use 'emerald/_dashcount.scss';

--- a/projects/plugins/crm/sass/jpcrm-emerald.scss
+++ b/projects/plugins/crm/sass/jpcrm-emerald.scss
@@ -9,10 +9,9 @@
 @use 'emerald/_buttons.scss';
 @use 'emerald/_dashcard.scss';
 @use 'emerald/_dashcount.scss';
+@use 'emerald/_dropdown-buttons.scss';
 @use 'emerald/_listview.scss';
 @use 'emerald/_listview-header.scss';
 @use 'emerald/_listview-table.scss';
 @use 'emerald/_listview-footer.scss';
 @use 'emerald/_pagination.scss';
-@use 'emerald/_buttons.scss';
-@use 'emerald/_dropdown-buttons.scss';

--- a/projects/plugins/crm/sass/jpcrm-emerald.scss
+++ b/projects/plugins/crm/sass/jpcrm-emerald.scss
@@ -14,3 +14,5 @@
 @use 'emerald/_listview-table.scss';
 @use 'emerald/_listview-footer.scss';
 @use 'emerald/_pagination.scss';
+@use 'emerald/_buttons.scss';
+@use 'emerald/_dropdown-buttons.scss';


### PR DESCRIPTION
Resolves Automattic/zero-bs-crm#3105 - Redesign Colors/Buttons to fit Jetpack Emerald style

## Proposed changes:
* This PR changes most of the colors of the CRM to fit better the Jetpack Emerald colors.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3105

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Go through all pages of the CRM  and look for styles that don't seem to fit Emerald, or feel out of place.
* Changed Items:
    * Buttons
    * Popups (including popups for every bulk action available)
    * Edit page labels
    * Invoice builder
    * All listings
    * All edit pages
    * Task pages
    * Segments page
* Out of Scope:
    * Statuses shown in listings for invoices, quotes, transactions...
    * WooSync Hub
    * Mailpoet Sync Hub
    * All Settings pages



Example of Before/After:

![image](https://github.com/Automattic/jetpack/assets/37049295/09be0361-8f82-44cf-8d65-263a79430fba)

![image](https://github.com/Automattic/jetpack/assets/37049295/20f7e0d2-48e9-4f14-8156-4169cca6c2ee)

-

![image](https://github.com/Automattic/jetpack/assets/37049295/3ea63655-ea81-4ef5-a85a-36ed49fce33f)

![image](https://github.com/Automattic/jetpack/assets/37049295/e77634fa-4f87-427b-9534-8e52cb52773f)

