### PR TITLE
CRM: Temporarily disabling tests in trunk

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-temporarily-disabling-tests-in-trunk
+++ b/projects/plugins/crm/changelog/fix-crm-temporarily-disabling-tests-in-trunk
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Temporarily disable tests in trunk

--- a/projects/plugins/crm/tests/action-skip-test-php.sh
+++ b/projects/plugins/crm/tests/action-skip-test-php.sh
@@ -4,3 +4,9 @@ if php -r 'exit( version_compare( PHP_VERSION, "7.2.0", "<" ) ? 0 : 1 );'; then
 	echo "PHP version is too old to run tests. 7.2 is required, but $(php -r 'echo PHP_VERSION;') is installed. Skipping.";
 	exit 3
 fi
+
+# TODO Fix the bug and remove this
+if [[ "$WP_BRANCH" == 'trunk' ]]; then
+    echo "Temporarily disabling tests against WP trunk until we get around to updating our codeception DB image."
+    exit 3
+fi


### PR DESCRIPTION
This PR disables temporarily tests in trunk because they are failing due to a DB Update.
We are going to leave it disabled as we work on updating CRM's test suite.

## Proposed changes:
* Disables CRM tests in trunk

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1684954976974969/1684954743.887389-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure tests are disabled in trunk.