### PR TITLE
Publicize: add Mastodon post preview

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-publicize-mastodon-preview
+++ b/projects/js-packages/publicize-components/changelog/add-publicize-mastodon-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Mastodon post preview

--- a/projects/js-packages/publicize-components/src/components/social-previews/mastodon.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/mastodon.js
@@ -1,0 +1,45 @@
+import { MastodonPreviews } from '@automattic/social-previews';
+import { useSelect } from '@wordpress/data';
+import useSocialMediaConnections from '../../hooks/use-social-media-connections';
+import useSocialMediaMessage from '../../hooks/use-social-media-message';
+import { shouldUploadAttachedMedia } from '../../store/selectors';
+
+const MastodonPreview = props => {
+	const { connections } = useSocialMediaConnections();
+	const { message } = useSocialMediaMessage();
+	const { content, siteName } = useSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getSite } = select( 'core' );
+
+		return {
+			content: getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
+			siteName: getSite().title,
+		};
+	} );
+	const isSocialPost = shouldUploadAttachedMedia();
+	const connection = connections?.find( conn => conn.service_name === 'mastodon' );
+
+	let user;
+
+	if ( connection ) {
+		user = {
+			displayName: connection.display_name,
+			userName: connection.user_name?.replace( '@mastodon.social', '' ),
+			avatarUrl: connection.profile_picture,
+		};
+	}
+
+	return (
+		<MastodonPreviews
+			{ ...props }
+			siteName={ siteName }
+			user={ user }
+			description={ content }
+			customText={ message }
+			customImage={ props.media?.[ 0 ]?.url }
+			isSocialPost={ isSocialPost }
+		/>
+	);
+};
+
+export default MastodonPreview;

--- a/projects/js-packages/publicize-components/src/components/social-previews/mastodon.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/mastodon.js
@@ -24,7 +24,7 @@ const MastodonPreview = props => {
 	if ( connection ) {
 		user = {
 			displayName: connection.display_name,
-			userName: connection.user_name?.replace( '@mastodon.social', '' ),
+			userName: connection.username?.replace( '@mastodon.social', '' ),
 			avatarUrl: connection.profile_picture,
 		};
 	}

--- a/projects/js-packages/publicize-components/src/components/social-previews/mastodon.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/mastodon.js
@@ -24,8 +24,8 @@ const MastodonPreview = props => {
 	if ( connection ) {
 		user = {
 			displayName: connection.display_name,
-			userName: connection.username?.replace( '@mastodon.social', '' ),
 			avatarUrl: connection.profile_picture,
+			address: connection.username,
 		};
 	}
 

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
@@ -13,7 +13,6 @@
 
 	.components-modal__content {
 		padding: 0;
-		overflow: hidden;
 	}
 }
 
@@ -103,6 +102,14 @@
 
 	.facebook-preview {
 		width: 100%;
+	}
+
+	// Mastodon
+
+	.components-tab-panel__tab-content {
+		.mastodon-preview {
+			max-width: 578px;
+		}
 	}
 }
 

--- a/projects/js-packages/publicize-components/src/components/social-previews/useAvailableServices.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/useAvailableServices.js
@@ -6,6 +6,7 @@ import FacebookPreview from './facebook';
 import GoogleSearch from './google-search';
 import { Instagram } from './instagram';
 import { LinkedIn } from './linkedin';
+import MastodonPreview from './mastodon';
 import TumblrPreview from './tumblr';
 import Twitter from './twitter';
 
@@ -60,12 +61,12 @@ export function useAvailableSerivces() {
 					name: 'tumblr',
 					preview: TumblrPreview,
 				},
-				/* {
+				{
 					title: __( 'Mastodon', 'jetpack' ),
 					icon: props => <SocialServiceIcon serviceName="mastodon" { ...props } />,
-					name: 'mastadon',
-					preview: () => null,
-				}, */
+					name: 'mastodon',
+					preview: MastodonPreview,
+				},
 			].filter( Boolean ),
 		[ isInstagramSupported ]
 	);

--- a/projects/js-packages/publicize-components/src/components/social-previews/useAvailableServices.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/useAvailableServices.js
@@ -16,9 +16,14 @@ import Twitter from './twitter';
  * @returns {Array<{title: string, icon: React.Component, name: string, preview: React.Component}>} The list of available services.
  */
 export function useAvailableSerivces() {
-	const isInstagramSupported = useSelect( select =>
-		select( 'jetpack/publicize' ).isInstagramConnectionSupported()
-	);
+	const { isInstagramSupported, isMastodonSupported } = useSelect( select => {
+		const store = select( 'jetpack/publicize' );
+
+		return {
+			isInstagramSupported: store.isInstagramConnectionSupported(),
+			isMastodonSupported: store.isMastodonConnectionSupported(),
+		};
+	} );
 
 	return useMemo(
 		() =>
@@ -61,13 +66,15 @@ export function useAvailableSerivces() {
 					name: 'tumblr',
 					preview: TumblrPreview,
 				},
-				{
-					title: __( 'Mastodon', 'jetpack' ),
-					icon: props => <SocialServiceIcon serviceName="mastodon" { ...props } />,
-					name: 'mastodon',
-					preview: MastodonPreview,
-				},
+				isMastodonSupported
+					? {
+							title: __( 'Mastodon', 'jetpack' ),
+							icon: props => <SocialServiceIcon serviceName="mastodon" { ...props } />,
+							name: 'mastodon',
+							preview: MastodonPreview,
+					  }
+					: null,
 			].filter( Boolean ),
-		[ isInstagramSupported ]
+		[ isInstagramSupported, isMastodonSupported ]
 	);
 }

--- a/projects/js-packages/publicize-components/src/store/effects.js
+++ b/projects/js-packages/publicize-components/src/store/effects.js
@@ -41,6 +41,7 @@ export async function refreshConnectionTestResults() {
 			const { done, enabled, toggleable } = prevConnection ?? defaults;
 			const connection = {
 				display_name: freshConnection.display_name,
+				user_name: freshConnection.user_name,
 				service_name: freshConnection.service_name,
 				id: freshConnection.id,
 				profile_picture: freshConnection.profile_picture,

--- a/projects/js-packages/publicize-components/src/store/effects.js
+++ b/projects/js-packages/publicize-components/src/store/effects.js
@@ -41,7 +41,7 @@ export async function refreshConnectionTestResults() {
 			const { done, enabled, toggleable } = prevConnection ?? defaults;
 			const connection = {
 				display_name: freshConnection.display_name,
-				user_name: freshConnection.user_name,
+				username: freshConnection.username,
 				service_name: freshConnection.service_name,
 				id: freshConnection.id,
 				profile_picture: freshConnection.profile_picture,

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -645,3 +645,12 @@ export function getImageGeneratorPostSettings() {
 export function isInstagramConnectionSupported() {
 	return !! getJetpackData()?.social?.isInstagramConnectionSupported;
 }
+
+/**
+ * Checks if the Mastodon connection is supported.
+ *
+ * @returns {boolean} Whether the Mastodon connection is supported
+ */
+export function isMastodonConnectionSupported() {
+	return !! getJetpackData()?.social?.isMastodonConnectionSupported;
+}

--- a/projects/packages/publicize/changelog/add-publicize-mastodon-preview
+++ b/projects/packages/publicize/changelog/add-publicize-mastodon-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Mastodon post preview

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -506,6 +506,10 @@ abstract class Publicize_Base {
 	public function get_display_name( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
+		if ( 'mastodon' === $service_name && isset( $cmeta['external_name'] ) ) {
+			return $cmeta['external_name'];
+		}
+
 		if ( isset( $cmeta['connection_data']['meta']['display_name'] ) ) {
 			return $cmeta['connection_data']['meta']['display_name'];
 		}
@@ -537,6 +541,10 @@ abstract class Publicize_Base {
 	public function get_username( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
+		if ( 'mastodon' === $service_name && isset( $cmeta['external_display'] ) ) {
+			return $cmeta['external_display'];
+		}
+		
 		if ( isset( $cmeta['connection_data']['meta']['username'] ) ) {
 			return $cmeta['connection_data']['meta']['username'];
 		}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -544,7 +544,7 @@ abstract class Publicize_Base {
 		if ( 'mastodon' === $service_name && isset( $cmeta['external_display'] ) ) {
 			return $cmeta['external_display'];
 		}
-		
+
 		if ( isset( $cmeta['connection_data']['meta']['username'] ) ) {
 			return $cmeta['connection_data']['meta']['username'];
 		}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1794,6 +1794,15 @@ abstract class Publicize_Base {
 	}
 
 	/**
+	 * Check if Mastodon connection is enabled.
+	 *
+	 * @return bool
+	 */
+	public function has_mastodon_connection_feature() {
+		return Current_Plan::supports( 'social-mastodon-connection' );
+	}
+
+	/**
 	 * Call the WPCOM REST API to calculate the scheduled shares.
 	 *
 	 * @param string $blog_id The blog_id.

--- a/projects/plugins/jetpack/changelog/add-publicize-mastodon-preview
+++ b/projects/plugins/jetpack/changelog/add-publicize-mastodon-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Mastodon post preview

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -713,6 +713,7 @@ class Jetpack_Gutenberg {
 				'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
 				'dismissedNotices'                => $publicize->get_dismissed_notices(),
 				'isInstagramConnectionSupported'  => $publicize->has_instagram_connection_feature(),
+				'isMastodonConnectionSupported'   => $publicize->has_mastodon_connection_feature(),
 			);
 		}
 

--- a/projects/plugins/social/changelog/update-publicizie-mastodon-feature-guard
+++ b/projects/plugins/social/changelog/update-publicizie-mastodon-feature-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added feature flag for Mastodon preview

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -240,6 +240,7 @@ class Jetpack_Social {
 						'isEnhancedPublishingEnabled'    => $publicize->has_enhanced_publishing_feature(),
 						'dismissedNotices'               => $publicize->get_dismissed_notices(),
 						'isInstagramConnectionSupported' => $publicize->has_instagram_connection_feature(),
+						'isMastodonConnectionSupported'  => $publicize->has_mastodon_connection_feature(),
 					),
 					'connectionData'               => array(
 						'connections' => $publicize->get_all_connections_for_user(), // TODO: Sanitize the array
@@ -335,6 +336,7 @@ class Jetpack_Social {
 					'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
 					'dismissedNotices'                => $publicize->get_dismissed_notices(),
 					'isInstagramConnectionSupported'  => $publicize->has_instagram_connection_feature(),
+					'isMastodonConnectionSupported'   => $publicize->has_mastodon_connection_feature(),
 				),
 			)
 		);

--- a/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
+++ b/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
@@ -8,6 +8,7 @@ const jetpackSettingSelectors = {
 		! ( state.jetpackSettings?.isEnhancedPublishingEnabled ?? false ),
 	getDismissedNotices: state => state.jetpackSettings?.dismissedNotices,
 	isInstagramConnectionSupported: state => state.jetpackSettings?.isInstagramConnectionSupported,
+	isMastodonConnectionSupported: state => state.jetpackSettings?.isMastodonConnectionSupported,
 };
 
 export default jetpackSettingSelectors;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30918

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This diff adds the Mastodon preview to Publicize.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pdrWKz-Tm-p2

## Does this pull request change what data or activity we track or use?
No.
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
* Checkout this branch
* Checkout the `trunk` branch in calypso
* In `wp-calypso/packages/social-previews/` directory, run `pnpm link --global` to expose the package to global `node_modules` for `pnpm`
* In `jetpack/projects/js-packages/publicize-components/` directory, run `pnpm link --global @automattic/social-previews`
* In `wp-calypso` root, run `yarn` and then `yarn workspace @automattic/social-previews run build`
* In Jetpack, run `jetpack build plugins/jetpack --no-pnpm-install`

### Testing
* Start writing a new post with JT site via Jetpack
* Click Jetpack icon on the top of the sidebar
* Under "Social Previews", click on "Preview"
<img width="147" alt="Screenshot 2023-05-25 at 7 46 21 AM" src="https://github.com/Automattic/jetpack/assets/1620183/7435da3d-c1ab-4aa9-a839-1044b906dc61">

* Check that you see the new Mastodon preview and that there's no error in the console
* Once you are done, run `pnpm unlink` in Jetpack
