### PR TITLE
AI Assistant: Fix toolbar action menu position on mobile

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-mobile-toolbar
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-mobile-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Fix toolbar action menu position on mobile

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -4,6 +4,10 @@
  * Editor styles for Jetpack AI Assistant
  */
 
+.block-editor-block-toolbar__slot {
+	flex-shrink: 0;
+}
+
 .wp-block-ai-generate-suggestion {
 	padding: 0;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30876

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets `flex-shrink` to 0 in the preceding toolbar slot

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an AI Assistant block
* Check it on mobile or simulate mobile dimensions in the browser
* Check that the menu is displayed at the right place

Before | After
-|-
![2023-05-24_17-31-25](https://github.com/Automattic/jetpack/assets/8486249/64bf96d4-572b-40cb-8fe7-a5c845ec9954) ![2023-05-24_17-30-32](https://github.com/Automattic/jetpack/assets/8486249/95f70c71-72dc-4aa5-a698-429e285e4e0a)|![2023-05-24_17-21-31](https://github.com/Automattic/jetpack/assets/8486249/e82fa973-7783-499f-94ed-1f24364d2602) ![2023-05-24_17-29-45](https://github.com/Automattic/jetpack/assets/8486249/c14ee0ef-f849-4043-9b8c-d86016232cc8)
