### PR TITLE
Fix 'add paid plan' URL in newsletter access panel.

### DIFF
--- a/projects/plugins/jetpack/changelog/earn-fix-setup-plans-link
+++ b/projects/plugins/jetpack/changelog/earn-fix-setup-plans-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+The link to setup a paid plan (in the newsletter post settings) was getting set incorrectly.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -148,7 +148,7 @@ export function NewsletterNotice( {
 }
 
 function NewsletterAccessSetupNudge( { stripeConnectUrl, isStripeConnected, hasNewsletterPlans } ) {
-	const paidLink = getPaidPlanLink( true );
+	const paidLink = getPaidPlanLink( hasNewsletterPlans );
 
 	if ( ! hasNewsletterPlans && ! isStripeConnected ) {
 		return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/gold#48.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* See the code -- very simple change.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox your site
* Apply the patch: `bin/jetpack-downloader test jetpack earn/fix/setup-plans-link`
* Load a site that is newsletter enabled. Remove any plans.  Verify that the url shown below goes to the add payment plans earn page.  <br><img src="https://github.com/Automattic/jetpack/assets/6354169/471261cc-48d2-4d63-9886-f0b8184136b5" width=400>
* Add a plan.
* Text should be removed.

