### PR TITLE
Social: Add account name to the publicize object

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-social-account-name
+++ b/projects/js-packages/publicize-components/changelog/add-social-account-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added account_name field to the connections post field.

--- a/projects/packages/publicize/changelog/add-social-account-name
+++ b/projects/packages/publicize/changelog/add-social-account-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added account_name field to the publicize connections object.

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -94,7 +94,7 @@ class Connections_Post_Field {
 					'readonly'    => true,
 				),
 				'display_name'    => array(
-					'description' => __( 'Usually username of the connected account', 'jetpack-publicize-pkg' ),
+					'description' => __( 'Display name of the connected account', 'jetpack-publicize-pkg' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -94,6 +94,12 @@ class Connections_Post_Field {
 					'readonly'    => true,
 				),
 				'display_name'    => array(
+					'description' => __( 'Usually username of the connected account', 'jetpack-publicize-pkg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'account_name'    => array(
 					'description' => __( 'Username of the connected account', 'jetpack-publicize-pkg' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -99,7 +99,7 @@ class Connections_Post_Field {
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'account_name'    => array(
+				'username'        => array(
 					'description' => __( 'Username of the connected account', 'jetpack-publicize-pkg' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -939,7 +939,6 @@ abstract class Publicize_Base {
 				);
 			}
 		}
-		error_log( json_encode( $connection_list ) );
 
 		return $connection_list;
 	}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -537,7 +537,7 @@ abstract class Publicize_Base {
 	public function get_username( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
-		if ( 'instagram-business' === $service_name && isset( $cmeta['connection_data']['meta']['username'] ) ) {
+		if ( isset( $cmeta['connection_data']['meta']['username'] ) ) {
 			return $cmeta['connection_data']['meta']['username'];
 		}
 

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -528,6 +528,23 @@ abstract class Publicize_Base {
 	}
 
 	/**
+	 * Returns the account name for the Connection. For services like Instagram, we need both the username and the account's name.
+	 *
+	 * @param string       $service_name 'facebook', 'linkedin', etc.
+	 * @param object|array $connection The Connection object (WordPress.com) or array (Jetpack).
+	 * @return string
+	 */
+	public function get_account_display_name( $service_name, $connection ) {
+		$cmeta = $this->get_connection_meta( $connection );
+
+		if ( 'instagram-business' === $service_name && isset( $cmeta['connection_data']['meta']['username'] ) ) {
+			return $cmeta['connection_data']['meta']['username'];
+		}
+
+		return $this->get_display_name( $service_name, $connection );
+	}
+
+	/**
 	 * Returns a profile picture for the Connection
 	 *
 	 * @param object|array $connection The Connection object (WordPress.com) or array (Jetpack).
@@ -913,6 +930,7 @@ abstract class Publicize_Base {
 					'service_name'    => $service_name,
 					'service_label'   => static::get_service_label( $service_name ),
 					'display_name'    => $this->get_display_name( $service_name, $connection ),
+					'account_name'    => $this->get_account_display_name( $service_name, $connection ),
 					'profile_picture' => $this->get_profile_picture( $connection ),
 					'enabled'         => $enabled,
 					'done'            => $done,
@@ -921,6 +939,7 @@ abstract class Publicize_Base {
 				);
 			}
 		}
+		error_log( json_encode( $connection_list ) );
 
 		return $connection_list;
 	}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -534,7 +534,7 @@ abstract class Publicize_Base {
 	 * @param object|array $connection The Connection object (WordPress.com) or array (Jetpack).
 	 * @return string
 	 */
-	public function get_account_display_name( $service_name, $connection ) {
+	public function get_username( $service_name, $connection ) {
 		$cmeta = $this->get_connection_meta( $connection );
 
 		if ( 'instagram-business' === $service_name && isset( $cmeta['connection_data']['meta']['username'] ) ) {
@@ -930,7 +930,7 @@ abstract class Publicize_Base {
 					'service_name'    => $service_name,
 					'service_label'   => static::get_service_label( $service_name ),
 					'display_name'    => $this->get_display_name( $service_name, $connection ),
-					'account_name'    => $this->get_account_display_name( $service_name, $connection ),
+					'username'        => $this->get_username( $service_name, $connection ),
 					'profile_picture' => $this->get_profile_picture( $connection ),
 					'enabled'         => $enabled,
 					'done'            => $done,

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -125,7 +125,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'account_name'    => array(
+				'username'        => array(
 					'description' => __( 'Username of the connected account', 'jetpack' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -120,7 +120,7 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 					'readonly'    => true,
 				),
 				'display_name'    => array(
-					'description' => __( 'Usually username of the connected account', 'jetpack' ),
+					'description' => __( 'Display name of the connected account', 'jetpack' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -120,6 +120,12 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 					'readonly'    => true,
 				),
 				'display_name'    => array(
+					'description' => __( 'Usually username of the connected account', 'jetpack' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'account_name'    => array(
 					'description' => __( 'Username of the connected account', 'jetpack' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),

--- a/projects/plugins/jetpack/changelog/add-social-account-name
+++ b/projects/plugins/jetpack/changelog/add-social-account-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added account_name field to the connections post field


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Some services such as Instagram need both the username and the display name of the jetpack social connection. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added publicize account name to the social object. 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1685004756108959/1685004225.849949-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Facebook connection and an Instagram connection (see D111486-code if you haven't added a connection before. If you already have a connection, please make sure you disconnect and reconnect, since the meta data of the connection has been updated in the phab diff. 
* Console.log the connections in `projects/js-packages/publicize-components/src/hooks/use-social-media-connections/index.js` and confirm that the `account_name` field shows up. 