### PR TITLE
CRM: Adding Automation invoice triggers 

### DIFF
--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
@@ -1549,6 +1549,8 @@ class zbsDAL_invoices extends zbsDAL_ObjectLayer {
                 #} Check if obj exists (here) - for now just brutal update (will error when doesn't exist)
                 $originalStatus = $this->getInvoiceStatus($id);
 
+					$previous_invoice_obj = $this->getInvoice( $id );
+
                 // log any change of status
                 if (isset($dataArr['zbsi_status']) && !empty($dataArr['zbsi_status']) && !empty($originalStatus) && $dataArr['zbsi_status'] != $originalStatus){
 
@@ -1735,7 +1737,8 @@ class zbsDAL_invoices extends zbsDAL_ObjectLayer {
                                         'againstids'=>array(), //$againstIDs,
                                         'extsource'=>false, //$approvedExternalSource
                                         'automatorpassthrough'=>$automatorPassthrough, #} This passes through any custom log titles or whatever into the Internal automator recipe.
-                                        'extraMeta'=>$confirmedExtraMeta #} This is the "extraMeta" passed (as saved)
+									'extraMeta'      => $confirmedExtraMeta, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Also this is the "extraMeta" passed (as saved)
+									'prev_invoice'   => $previous_invoice_obj,
                                     ));
 
                                 

--- a/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomatorRecipes.php
@@ -65,6 +65,8 @@
 	zeroBSCRM_AddInternalAutomatorRecipe('quote.accepted','zeroBSCRM_IA_AcceptedQuoteWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('quote.delete','zeroBSCRM_IA_DeleteQuoteWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('invoice.new','zeroBSCRM_IA_NewInvoiceWPHook',array());
+	zeroBSCRM_AddInternalAutomatorRecipe( 'invoice.update', 'zeroBSCRM_IA_EditInvoiceWPHook', array() );
+	zeroBSCRM_AddInternalAutomatorRecipe( 'invoice.status.update', 'zeroBSCRM_IA_EditInvoiceWPHook', array() );
 	zeroBSCRM_AddInternalAutomatorRecipe('invoice.delete','zeroBSCRM_IA_DeleteInvoiceWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('transaction.new','zeroBSCRM_IA_NewTransactionWPHook',array());
 	zeroBSCRM_AddInternalAutomatorRecipe('transaction.delete','zeroBSCRM_IA_DeleteTransactionWPHook',array());
@@ -1407,18 +1409,49 @@ function zeroBSCRM_IA_DeleteCustomerWPHook( $obj = array() ) {
 		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) do_action('zbs_delete_quote', $obj['id']);
 
 	}
-   	#} Fires on 'invoice.new' IA 
-	function zeroBSCRM_IA_NewInvoiceWPHook($obj=array()){
 
-		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) do_action('zbs_new_invoice', $obj['id']);
+/**
+ * Fires on 'invoice.new' IA.
+ *
+ * @param array $obj An array holding invoice object data.
+ */
+function zeroBSCRM_IA_NewInvoiceWPHook( $obj = array() ) {
 
+	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
+		do_action( 'jpcrm_automation_invoice_new', $obj );
+		do_action( 'zbs_new_invoice', $obj['id'] );
 	}
-   	#} Fires on 'invoice.delete' IA 
-	function zeroBSCRM_IA_DeleteInvoiceWPHook($obj=array()){
+}
 
-		if (is_array($obj) && isset($obj['id']) && !empty($obj['id'])) do_action('zbs_delete_invoice', $obj['id']);
-
+/**
+ * Fires on 'invoice.update' and 'invoice.status.update' IA.
+ *
+ * @param array $obj An array holding invoice object data.
+ */
+function zeroBSCRM_IA_EditInvoiceWPHook( $obj = array() ) {
+	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
+		do_action( 'jpcrm_automation_invoice_update', $obj );
+		do_action( 'zbs_new_invoice', $obj['id'] );
+		// If the invoice status has been updated.
+		if ( isset( $obj['from'] ) && ! empty( $obj['from'] ) ) {
+			do_action( 'jpcrm_automation_invoice_status_update', $obj );
+		}
 	}
+}
+
+/**
+ * Fires on 'invoice.delete' IA.
+ *
+ * @param array $obj An array holding invoice object data.
+ */
+function zeroBSCRM_IA_DeleteInvoiceWPHook( $obj = array() ) {
+
+	if ( is_array( $obj ) && isset( $obj['id'] ) && ! empty( $obj['id'] ) ) {
+		do_action( 'jpcrm_automation_invoice_delete', $obj );
+		do_action( 'zbs_delete_invoice', $obj['id'] );
+	}
+}
+
    	#} Fires on 'transaction.new' IA 
 	function zeroBSCRM_IA_NewTransactionWPHook($obj=array()){
 

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
@@ -19,41 +19,66 @@ class Invoice_Deleted extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Invoice_Delete instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'invoice_delete';
-		self::$title       = __( 'Delete Invoice', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when an invoice is deleted', 'zero-bs-crm' );
-		self::$category    = 'invoice';
+	public static function get_slug(): string {
+		return 'jpcrm/invoice_delete';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Delete Invoice', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when an invoice is deleted', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'invoice', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_invoice_delete',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $invoice_data The invoice data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $invoice_data ) {
+	public function execute_workflow( $invoice_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $invoice_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_invoice_delete',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Invoice_Deleted extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'invoice', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $invoice_data The invoice data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $invoice_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $invoice_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Jetpack CRM Automation Invoice_Deleted trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Invoice_Deleted class.
+ */
+class Invoice_Deleted extends Base_Trigger {
+
+	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
+	 * Contructs the Invoice_Delete instance.
+	 */
+	public function __construct() {
+		self::$name        = 'invoice_delete';
+		self::$title       = __( 'Delete Invoice', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when an invoice is deleted', 'zero-bs-crm' );
+		self::$category    = 'invoice';
+	}
+
+	/**
+	 * Init the trigger.
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
+		add_action(
+			'jpcrm_automation_invoice_delete',
+			array( $this, 'execute_workflow' )
+		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $invoice_data The invoice data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $invoice_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $invoice_data );
+		}
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-deleted.php
@@ -15,11 +15,6 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  */
 class Invoice_Deleted extends Base_Trigger {
 
-	/**
-	 * @var Automation_Workflow The Automation workflow object.
-	 */
-	protected $workflow;
-
 	/** Get the slug name of the trigger
 	 * @return string
 	 */

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Invoice_New extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'invoice', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $invoice_data The invoice data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $invoice_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $invoice_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Jetpack CRM Automation Invoice_New trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Invoice_New class.
+ */
+class Invoice_New extends Base_Trigger {
+
+	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
+	 * Contructs the Invoice_New instance.
+	 */
+	public function __construct() {
+		self::$name        = 'invoice_new';
+		self::$title       = __( 'New Invoice', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when a new invoice is added', 'zero-bs-crm' );
+		self::$category    = 'invoice';
+	}
+
+	/**
+	 * Init the trigger.
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
+		add_action(
+			'jpcrm_automation_invoice_new',
+			array( $this, 'execute_workflow' )
+		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $invoice_data The invoice data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $invoice_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $invoice_data );
+		}
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
@@ -19,41 +19,66 @@ class Invoice_New extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Invoice_New instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'invoice_new';
-		self::$title       = __( 'New Invoice', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when a new invoice is added', 'zero-bs-crm' );
-		self::$category    = 'invoice';
+	public static function get_slug(): string {
+		return 'jpcrm/invoice_new';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'New Invoice', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a new invoice status is added', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'invoice', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_invoice_new',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $invoice_data The invoice data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $invoice_data ) {
+	public function execute_workflow( $invoice_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $invoice_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_invoice_new',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-new.php
@@ -15,11 +15,6 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  */
 class Invoice_New extends Base_Trigger {
 
-	/**
-	 * @var Automation_Workflow The Automation workflow object.
-	 */
-	protected $workflow;
-
 	/** Get the slug name of the trigger
 	 * @return string
 	 */

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Jetpack CRM Automation Invoice_Status_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Invoice_Status_Updated class.
+ */
+class Invoice_Status_Updated extends Base_Trigger {
+
+	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
+	 * Contructs the Invoice_Status_Updated instance.
+	 */
+	public function __construct() {
+		self::$name        = 'invoice_status_updated';
+		self::$title       = __( 'Invoice Status Updated', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when an invoice status is updated', 'zero-bs-crm' );
+		self::$category    = 'invoice';
+	}
+
+	/**
+	 * Init the trigger.
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
+		add_action(
+			'jpcrm_automation_invoice_status_update',
+			array( $this, 'execute_workflow' )
+		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $invoice_data The invoice data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $invoice_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $invoice_data );
+		}
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
@@ -19,41 +19,66 @@ class Invoice_Status_Updated extends Base_Trigger {
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Invoice_Status_Updated instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'invoice_status_updated';
-		self::$title       = __( 'Invoice Status Updated', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when an invoice status is updated', 'zero-bs-crm' );
-		self::$category    = 'invoice';
+	public static function get_slug(): string {
+		return 'jpcrm/invoice_status_updated';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Invoice Status Updated', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when an invoice status is updated', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'invoice', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_invoice_status_update',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $invoice_data The invoice data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $invoice_data ) {
+	public function execute_workflow( $invoice_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $invoice_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_invoice_status_update',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Invoice_Status_Updated extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'invoice', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $invoice_data The invoice data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $invoice_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $invoice_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-status-updated.php
@@ -15,11 +15,6 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  */
 class Invoice_Status_Updated extends Base_Trigger {
 
-	/**
-	 * @var Automation_Workflow The Automation workflow object.
-	 */
-	protected $workflow;
-
 	/** Get the slug name of the trigger
 	 * @return string
 	 */

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
@@ -47,29 +46,6 @@ class Invoice_Updated extends Base_Trigger {
 	 */
 	public static function get_category(): ?string {
 		return __( 'invoice', 'zero-bs-crm' );
-	}
-
-	/**
-	 * Initialize the trigger to listen to the desired event.
-	 *
-	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function init( Automation_Workflow $workflow ) {
-		$this->workflow = $workflow;
-		$this->listen_to_event();
-	}
-
-	/**
-	 * Execute the workflow.
-	 *
-	 * @param array $invoice_data The invoice data to be included in the workflow.
-	 * @throws Automation_Exception Throws a 'class not found' or general error.
-	 */
-	public function execute_workflow( $invoice_data = null ) {
-		if ( $this->workflow ) {
-			$this->workflow->execute( $this, $invoice_data );
-		}
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
@@ -15,49 +15,70 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  * Adds the Invoice_Updated class.
  */
 class Invoice_Updated extends Base_Trigger {
-	/**
-	 * @var array The invoice object before update.
-	 */
-	private $invoice_before_update = array();
 
 	/**
 	 * @var Automation_Workflow The Automation workflow object.
 	 */
-	private $workflow;
+	protected $workflow;
 
-	/**
-	 * Contructs the Invoice_Updated instance.
+	/** Get the slug name of the trigger
+	 * @return string
 	 */
-	public function __construct() {
-		self::$name        = 'invoice_updated';
-		self::$title       = __( 'Invoice Updated', 'zero-bs-crm' );
-		self::$description = __( 'Triggered when an invoice is updated', 'zero-bs-crm' );
-		self::$category    = 'invoice';
+	public static function get_slug(): string {
+		return 'jpcrm/invoice_updated';
+	}
+
+	/** Get the title of the trigger
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Invoice Updated', 'zero-bs-crm' );
+	}
+
+	/** Get the description of the trigger
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when an invoice is updated', 'zero-bs-crm' );
+	}
+
+	/** Get the category of the trigger
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'invoice', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Init the trigger.
+	 * Initialize the trigger to listen to the desired event.
 	 *
 	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
 	public function init( Automation_Workflow $workflow ) {
 		$this->workflow = $workflow;
-		add_action(
-			'jpcrm_automation_invoice_update',
-			array( $this, 'execute_workflow' )
-		);
+		$this->listen_to_event();
 	}
 
 	/**
-	 * Execute the workflow. Listen to the desired event
+	 * Execute the workflow.
 	 *
 	 * @param array $invoice_data The invoice data to be included in the workflow.
 	 * @throws Automation_Exception Throws a 'class not found' or general error.
 	 */
-	public function execute_workflow( $invoice_data ) {
+	public function execute_workflow( $invoice_data = null ) {
 		if ( $this->workflow ) {
 			$this->workflow->execute( $this, $invoice_data );
 		}
+	}
+
+	/**
+	 * Listen to the desired event
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_automation_invoice_update',
+			array( $this, 'execute_workflow' )
+		);
 	}
 }

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Jetpack CRM Automation Invoice_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Invoice_Updated class.
+ */
+class Invoice_Updated extends Base_Trigger {
+	/**
+	 * @var array The invoice object before update.
+	 */
+	private $invoice_before_update = array();
+
+	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	private $workflow;
+
+	/**
+	 * Contructs the Invoice_Updated instance.
+	 */
+	public function __construct() {
+		self::$name        = 'invoice_updated';
+		self::$title       = __( 'Invoice Updated', 'zero-bs-crm' );
+		self::$description = __( 'Triggered when an invoice is updated', 'zero-bs-crm' );
+		self::$category    = 'invoice';
+	}
+
+	/**
+	 * Init the trigger.
+	 *
+	 * @param Automation_Workflow $workflow The workflow to which the trigger belongs.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function init( Automation_Workflow $workflow ) {
+		$this->workflow = $workflow;
+		add_action(
+			'jpcrm_automation_invoice_update',
+			array( $this, 'execute_workflow' )
+		);
+	}
+
+	/**
+	 * Execute the workflow. Listen to the desired event
+	 *
+	 * @param array $invoice_data The invoice data to be included in the workflow.
+	 * @throws Automation_Exception Throws a 'class not found' or general error.
+	 */
+	public function execute_workflow( $invoice_data ) {
+		if ( $this->workflow ) {
+			$this->workflow->execute( $this, $invoice_data );
+		}
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-updated.php
@@ -15,11 +15,6 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
  */
 class Invoice_Updated extends Base_Trigger {
 
-	/**
-	 * @var Automation_Workflow The Automation workflow object.
-	 */
-	protected $workflow;
-
 	/** Get the slug name of the trigger
 	 * @return string
 	 */

--- a/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
@@ -31,7 +31,7 @@ class Invoice_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_invoice_updated_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'invoice_updated' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/invoice_updated' );
 
 		$trigger = new Invoice_Updated();
 
@@ -64,7 +64,7 @@ class Invoice_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_invoice_status_updated_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'invoice_status_updated' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/invoice_status_updated' );
 
 		$trigger = new Invoice_Status_Updated();
 
@@ -97,7 +97,7 @@ class Invoice_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_invoice_new_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'invoice_new' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/invoice_new' );
 
 		$trigger = new Invoice_New();
 
@@ -130,7 +130,7 @@ class Invoice_Trigger_Test extends BaseTestCase {
 	 */
 	public function test_invoice_deleted_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'invoice_deleted' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/invoice_deleted' );
 
 		$trigger = new Invoice_Deleted();
 

--- a/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
@@ -1,0 +1,161 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\CRM\Automation\Tests;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Engine;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Deleted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Invoice_New;
+use Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Status_Updated;
+use Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Updated;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '../../tools/class-automation-faker.php';
+
+/**
+ * Test Automation Workflow functionalities
+ *
+ * @covers Automattic\Jetpack\CRM\Automation
+ */
+class Invoice_Trigger_Test extends BaseTestCase {
+
+	private $automation_faker;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->automation_faker = Automation_Faker::instance();
+	}
+
+	/**
+	 * @testdox Test the invoice updated trigger executes the workflow with an action
+	 */
+	public function test_invoice_updated_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'invoice_updated' );
+
+		$trigger = new Invoice_Updated();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Invoice_Updated trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$invoice_data = $this->automation_faker->invoice_data();
+
+		// We expect the workflow to be executed on invoice_update event with the invoice data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $invoice_data )
+		);
+
+		// Run the invoice_update action.
+		do_action( 'jpcrm_automation_invoice_update', $invoice_data );
+	}
+
+	/**
+	 * @testdox Test the invoice status updated trigger executes the workflow with an action
+	 */
+	public function test_invoice_status_updated_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'invoice_status_updated' );
+
+		$trigger = new Invoice_Status_Updated();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Invoice_Updated trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$invoice_data = $this->automation_faker->invoice_data();
+
+		// We expect the workflow to be executed on invoice_status_update event with the invoice data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $invoice_data )
+		);
+
+		// Run the invoice_status_update action.
+		do_action( 'jpcrm_automation_invoice_status_update', $invoice_data );
+	}
+
+	/**
+	 * @testdox Test the invoice new trigger executes the workflow with an action
+	 */
+	public function test_invoice_new_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'invoice_new' );
+
+		$trigger = new Invoice_New();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Invoice_New trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$invoice_data = $this->automation_faker->invoice_data();
+
+		// We expect the workflow to be executed on invoice_new event with the invoice data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $invoice_data )
+		);
+
+		// Run the invoice_new action.
+		do_action( 'jpcrm_automation_invoice_new', $invoice_data );
+	}
+
+	/**
+	 * @testdox Test the invoice deleted trigger executes the workflow with an action
+	 */
+	public function test_invoice_deleted_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'invoice_deleted' );
+
+		$trigger = new Invoice_Deleted();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Invoice_Deleted trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$invoice_data = $this->automation_faker->invoice_data();
+
+		// We expect the workflow to be executed on invoice_deleted event with the invoice data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $invoice_data )
+		);
+
+		// Run the invoice_deleted action.
+		do_action( 'jpcrm_automation_invoice_delete', $invoice_data );
+	}
+
+}

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -206,6 +206,29 @@ class Automation_Faker {
 		);
 	}
 
+	public function invoice_data() {
+		return array(
+			'id'   => 1,
+			'data' => array(
+				'id_override' => '1',
+				'parent'      => '',
+				'status'      => 'Unpaid',
+				'hash'        => 'ISSQndSUjlhJ8feWj2v',
+				'lineitems'   => array(
+					array(
+						'net'      => 3.75,
+						'desc'     => 'Dummy product',
+						'quantity' => '3',
+						'price'    => '1.25',
+						'total'    => 3.75,
+					),
+				),
+				'contacts'    => array( 1 ),
+				'created'     => -1,
+			),
+		);
+	}
+
 	/**
 	 * Return a empty workflow, without triggers and initial step
 	 * @return array


### PR DESCRIPTION
## Proposed changes:

* This PR adds Automation Invoice triggers. The files with triggers will likely need changes as we better understand what data is being passed in and out, but currently all triggers take invoice objects (with modified data depending on what was passed into the object, such as in this example: https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php#L1732 )
* This PR also includes tests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3099

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).
* To test the objects that would be passed to the actions within each trigger, you can add an `error_log` within the relevant hook such as `zeroBSCRM_IA_EditInvoiceWPHook` (within each case), such as `error_log('Firing the invoice update: ' . json_encode( $obj ) );`.
* You can then test updating (status / any invoice field) / deleting / adding a new invoice and then make sure the `$obj` from the error log you are expecting is fired.