### PR TITLE
Mention `l()` in Jetpack Docker docs

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -386,6 +386,10 @@ add_filter( 'jetpack_docker_avoided_plugins', 'jetpack_docker_disable_gutenberg_
 
 ## Debugging
 
+### Debug helper functions
+
+Helpful function `l()` for logging, some timer functions, etc are available in your Docker setup. [See the file more more](https://github.com/Automattic/jetpack/blob/trunk/tools/docker/mu-plugins/debug.php).
+
 ### Accessing logs
 
 Logs are stored in your file system under `./tools/docker/logs` directory.


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds mention of `l()` and [other debug functions](https://github.com/Automattic/jetpack/blob/trunk/tools/docker/mu-plugins/debug.php) in Jetpack Docker docs.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

