### PR TITLE
Changelogger checks: handle missing require or require-dev

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-no-require
+++ b/projects/github-actions/repo-gardening/changelog/fix-no-require
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Changelogger checks: do not error out when require or require-dev are not set.

--- a/projects/github-actions/repo-gardening/src/utils/get-affected-changelogger-projects.js
+++ b/projects/github-actions/repo-gardening/src/utils/get-affected-changelogger-projects.js
@@ -15,8 +15,8 @@ function getChangeloggerProjects() {
 		if (
 			// include changelogger package and any other packages that use changelogger package.
 			file.endsWith( '/projects/packages/changelogger/composer.json' ) ||
-			json.require[ 'automattic/jetpack-changelogger' ] ||
-			json[ 'require-dev' ][ 'automattic/jetpack-changelogger' ]
+			json.require?.[ 'automattic/jetpack-changelogger' ] ||
+			json[ 'require-dev' ]?.[ 'automattic/jetpack-changelogger' ]
 		) {
 			projects.push( getProject( file ).fullName );
 		}


### PR DESCRIPTION
## Proposed changes:

Projects may not have any require, or require-dev. Our task should support that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1685028935299929/1685025625.097009-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here until this gets merged, but this should avoid the errors like the one that happened in the linked Slack discussion above.
