### PR TITLE
CRM: Resolves 3122 - PHP notices in listview when using invalid filter

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3122-php_notices_in_listview
+++ b/projects/plugins/crm/changelog/fix-crm-3122-php_notices_in_listview
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Catch PHP notices when using an invalid filter name.
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -865,7 +865,7 @@ class zeroBSCRM_list{
 		);
 
 		$current_quickfilter       = ( ! empty( $listview_filters['quickfilters'][0] ) ? $listview_filters['quickfilters'][0] : '' );
-		$current_quickfilter_label = ( ! empty( $current_quickfilter ) ? $all_quickfilters[ $current_quickfilter ][0] : '' );
+		$current_quickfilter_label = ( ! empty( $all_quickfilters[ $current_quickfilter ][0] ) ? $all_quickfilters[ $current_quickfilter ][0] : '' );
 		$current_tag               = ( ! empty( $listview_filters['tags'][0] ) ? $listview_filters['tags'][0]['name'] : '' );
 		$current_search            = ( ! empty( $listview_filters['s'] ) ? $listview_filters['s'] : '' );
 		?>
@@ -881,13 +881,13 @@ class zeroBSCRM_list{
 				<?php
 				// add quickfilters filter if current object has quickfilters
 				if ( count( $all_quickfilters ) > 0 ) {
-					echo '<select class="filter-dropdown' . ( ! empty( $current_quickfilter ) ? ' hidden' : '' ) . '" data-filtertype="quickfilters">';
+					echo '<select class="filter-dropdown' . ( ! empty( $current_quickfilter_label ) ? ' hidden' : '' ) . '" data-filtertype="quickfilters">';
 					echo '<option disabled selected>' . esc_html__( 'Select filter', 'zero-bs-crm' ) . '</option>';
 					foreach ( $all_quickfilters as $filter_slug => $filter_data ) {
 						echo '<option value="' . esc_attr( $filter_slug ) . '">' . esc_html( $filter_data[0] ) . '</option>';
 					}
 					echo '</select>';
-					echo '<div class="jpcrm-current-filter' . ( empty( $current_quickfilter ) ? ' hidden' : '' ) . '">';
+					echo '<div class="jpcrm-current-filter' . ( empty( $current_quickfilter_label ) ? ' hidden' : '' ) . '">';
 					echo '<button class="dashicons dashicons-remove" title="' . esc_attr__( 'Remove filter', 'zero-bs-crm' ) . '"></button>';
 					echo esc_html__( 'Filter', 'zero-bs-crm' ) . ': ';
 					echo '<span>' . esc_html( $current_quickfilter_label ) . '</span>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3122 - PHP notices in listview when using invalid filter

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
See description; it's an issue introduced by recently-merged #30939. We access a key on a key that might not exist. This PR ensures the key exists before using it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Go to `/wp-admin/admin.php?page=manage-customers&quickfilters=asdf`. In `trunk` you'll get these PHP notices:
```
[25-May-2023 16:38:16 UTC] PHP Notice:  Undefined index: asdf in /includes/ZeroBSCRM.List.php on line 868
[25-May-2023 16:38:16 UTC] PHP Notice:  Trying to access array offset on value of type null in /includes/ZeroBSCRM.List.php on line 868
```

In `fix/crm/3122-php_notices_in_listview` the notices are handled.