### PR TITLE
CRM: Change page layout to fit better Emerald

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -125,7 +125,7 @@ function jpcrm_render_dashboard_page() {
 
 	<div id="zbs-date-picker-background">
 	<div class='month-selector'>
-		<div id="reportrange" class="pull-right jpcrm-date-range" style="cursor: pointer; padding: 5px 10px; border: 1px solid #ccc; width: 100%;margin-top:-3px;width:220px;">
+		<div id="reportrange" class="pull-right jpcrm-date-range" style="cursor: pointer; padding: 5px 10px; border: 1px solid #ccc; width: 100%;margin-top:-3px;width:240px;">
 		<i class="fa fa-calendar"></i>&nbsp;
 		<span></span> <b class="caret"></b>
 		</div>

--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -319,7 +319,7 @@ function jpcrm_render_dashboard_page() {
 							?>
 								<div class="feed-item">
 									<img class="ui avatar img img-rounded" alt="<?php esc_attr_e( 'Contact Image', 'zero-bs-crm' ); ?>" src="<?php echo esc_url( $avatar ); ?>"/>
-									<div class="content text">
+									<div>
 										<?php echo esc_html( $logmetatype ); ?>
 										<div><?php echo wp_kses( $logmetashot, array( 'i' => array( 'class' => true ) ) ); ?></div>
 									</div>

--- a/projects/plugins/crm/changelog/fix-crm-3120-change-CRM-page-layout-to-emerald
+++ b/projects/plugins/crm/changelog/fix-crm-3120-change-CRM-page-layout-to-emerald
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+CRM: page layout now has a max width of 1551px

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -134,6 +134,21 @@ background:white;
 
 		.feed-item {
 			padding-left: 10px;
+			display: flex;
+			align-items: center;
+			margin-bottom:10px;
+			margin-top:10px;
+
+			.ui.avatar.img.img-rounded {
+					margin-right: 10px;
+			}
+
+			.content.text {
+					display: flex;
+					flex-direction: column;
+					justify-content: center;
+					height: 100%;
+			}			
 		}
 	}
 }

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.homedash.scss
@@ -142,13 +142,6 @@ background:white;
 			.ui.avatar.img.img-rounded {
 					margin-right: 10px;
 			}
-
-			.content.text {
-					display: flex;
-					flex-direction: column;
-					justify-content: center;
-					height: 100%;
-			}			
 		}
 	}
 }

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
@@ -839,7 +839,6 @@
 //ZBS invoice actions
 .zbs-invoice-actions-bottom{
 	border-top: 1px solid #ddd;
-    background: #f5f5f5;
     margin-top: 20px;
     padding: 2px;
     margin-left: -12px;

--- a/projects/plugins/crm/sass/emerald/_emerald_base.scss
+++ b/projects/plugins/crm/sass/emerald/_emerald_base.scss
@@ -8,16 +8,15 @@ body.jpcrm-admin {
 		display:none !important;
 	}
 
-	#wpbody {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		max-width: 1551px;
-		margin: 0 auto;
-	}
-
 	#wpcontent {
 		padding-left: 0;
+
+		#wpbody {
+			display: flex;
+			align-items: center;
+			max-width: 1551px;
+			margin: 0 auto;
+		}
 	}
 
 	.alternating-colors tr:nth-child(even) {

--- a/projects/plugins/crm/sass/emerald/_emerald_base.scss
+++ b/projects/plugins/crm/sass/emerald/_emerald_base.scss
@@ -1,11 +1,19 @@
 /* Remove left padding from WP page content */
 body.jpcrm-admin {
 	background: var(--jp-white-off);
-	font-family: "Lato", "Helvetica Neue", Arial, Helvetica, sans-serif;
-
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu',
+		'Cantarell', 'Helvetica Neue', sans-serif;
 	/* Shows weird arrow if using an input with a list attribute */
 	::-webkit-calendar-picker-indicator {
 		display:none !important;
+	}
+
+	#wpbody {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		max-width: 1551px;
+		margin: 0 auto;
 	}
 
 	#wpcontent {


### PR DESCRIPTION
## Proposed changes:
This PR sets a max-width of the CRM's content to 1551px and centers it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pbhBOz-3Ah-p2#comment-4339

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open up the CRM
* The content should have a max width of 1551px and be centered.

Before:
![image](https://github.com/Automattic/jetpack/assets/37049295/4705b85d-e272-4b2b-a160-f9b50a412f4b)

After:
![image](https://github.com/Automattic/jetpack/assets/37049295/37d9b73b-e4a2-422f-9859-abe7f4225564)
