### PR TITLE
AI Assistant: Enhance input for mobile

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-input-mobile-placeholder
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-input-mobile-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Enhance input for mobile

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useBreakpointMatch } from '@automattic/jetpack-components';
 import { BlockControls, PlainText } from '@wordpress/block-editor';
 import {
 	Button,
@@ -41,11 +42,12 @@ const AIControl = ( {
 	contentBefore,
 	postTitle,
 	wholeContent,
-	content,
 	promptType,
 	onChange,
 } ) => {
 	const promptUserInputRef = useRef( null );
+	const [ isSm ] = useBreakpointMatch( 'sm' );
+
 	const handleInputEnter = event => {
 		if ( event.key === 'Enter' && ! event.shiftKey ) {
 			event.preventDefault();
@@ -53,9 +55,7 @@ const AIControl = ( {
 		}
 	};
 
-	const textPlaceholder = ! content?.length
-		? __( 'Ask Jetpack AI for anything…', 'jetpack' )
-		: __( 'Tell AI what to do next…', 'jetpack', /* dummy arg to avoid bad minification */ 0 );
+	const textPlaceholder = __( 'Ask Jetpack AI', 'jetpack' );
 
 	let placeholder = '';
 
@@ -142,7 +142,7 @@ const AIControl = ( {
 							label={ __( 'Send request', 'jetpack' ) }
 						>
 							<Icon icon={ origamiPlane } />
-							{ __( 'Send', 'jetpack' ) }
+							{ ! isSm && __( 'Send', 'jetpack' ) }
 						</Button>
 					) : (
 						<Button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30930

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the `SEND` text on mobile
* Shortens the input placeholder so it is always visible

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the browser on mobile or simulate a mobile viewport on desktop
* Add an AI Assistant block
* Check that the input placeholder is fully visible
* Check that the `SEND` text is not displayed on mobile
* Check that the `SEND` text is displayed on normal desktop viewport

![2023-05-25_16-12-39](https://github.com/Automattic/jetpack/assets/8486249/57b62b5d-ed82-4e72-bf83-c19875b3ca8a)
![2023-05-25_16-12-24](https://github.com/Automattic/jetpack/assets/8486249/7cc8f91f-33ed-41d9-8eaa-52b1841db075)
![2023-05-25_16-12-11](https://github.com/Automattic/jetpack/assets/8486249/fbae6fa8-e324-4182-96a5-3f3ea4e57995)
