### PR TITLE
Backup: add loading placeholder when fetching backup plan on secondary admin flow

### DIFF
--- a/projects/packages/backup/changelog/add-backup-secondary-admin-loading
+++ b/projects/packages/backup/changelog/add-backup-secondary-admin-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add a loading placeholder while fetching backup plan when a secondary admin i(not connected) is accessing the backup page.

--- a/projects/packages/backup/changelog/add-backup-secondary-admin-loading
+++ b/projects/packages/backup/changelog/add-backup-secondary-admin-loading
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Add a loading placeholder while fetching backup plan when a secondary admin i(not connected) is accessing the backup page.
+Add a loading placeholder while fetching backup plan when a secondary admin (not connected) is accessing the backup page.

--- a/projects/packages/backup/src/js/components/Admin/hooks.js
+++ b/projects/packages/backup/src/js/components/Admin/hooks.js
@@ -23,16 +23,19 @@ export const useIsSecondaryAdminNotConnected = () => {
 export const useSiteHasBackupProduct = () => {
 	const isFullyConnected = useIsFullyConnected();
 	const [ siteHasBackupProduct, setSiteHasBackupProduct ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState( true );
 
 	useEffect( () => {
 		if ( ! isFullyConnected ) {
+			setIsLoading( false );
 			return;
 		}
 
 		apiFetch( { path: '/jetpack/v4/has-backup-plan' } ).then( res => {
 			setSiteHasBackupProduct( res );
+			setIsLoading( false );
 		} );
 	}, [ isFullyConnected ] );
 
-	return { siteHasBackupProduct };
+	return { siteHasBackupProduct, isLoadingBackupProduct: isLoading };
 };


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `isLoading` state on `useSiteHasBackupProduct`
* Add a loading placeholder while fetching backup plan when a secondary admin (not connected) is accessing the backup page.

## Demo (Before/After):
### Before
https://github.com/Automattic/jetpack/assets/1488641/a8630848-8c4f-4b9f-9bc9-896e76262f38

### After
https://github.com/Automattic/jetpack/assets/1488641/5a906aa7-4fc8-4249-82bc-383bcaedb69f

## Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- peaFOp-FV-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jurassic Ninja site with just the Jetpack VaultPress Backup plugin using this branch. You could use this link: https://jurassic.ninja/create?jetpack-beta&branches.jetpack-backup=add/backup-loading-placeholder&wp-debug-log&nojetpack
- Connect the site to Jetpack using your main WordPress.com account and add a Jetpack VaultPress Backup plan.
- Add a new user to your blog.
- In a incognito window (or a new browser), log in with the new user.
- Navigate to VaultPress Backup page.
- You should see a loading placeholder before loading the connect screen.