### PR TITLE
Carousel: stop auto-scrolling to top when advancing slides

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-scroll-on-slide
+++ b/projects/plugins/jetpack/changelog/update-carousel-scroll-on-slide
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: stop auto-scrolling to top when advancing slides.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -770,18 +770,6 @@
 
 			var current = carousel.currentSlide;
 			var attachmentId = current.attrs.attachmentId;
-			var infoIcon = carousel.info.querySelector( '.jp-carousel-icon-info' );
-			var commentsIcon = carousel.info.querySelector( '.jp-carousel-icon-comments' );
-
-			// If the comment/info section is toggled open, it's kept open, but scroll to top of the next slide.
-			if (
-				( infoIcon && infoIcon.classList.contains( 'jp-carousel-selected' ) ) ||
-				( commentsIcon && commentsIcon.classList.contains( 'jp-carousel-selected' ) )
-			) {
-				if ( carousel.overlay.scrollTop !== 0 ) {
-					domUtil.scrollToElement( carousel.overlay, carousel.overlay );
-				}
-			}
 
 			loadFullImage( carousel.slides[ index ] );
 


### PR DESCRIPTION
Fixes #30773

## Proposed changes:

When advancing Carousel slides with the metadata/comment sections open, no longer scroll the carousel to top as to avoid UX confusion discussed in #30773

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
#30773

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

**Pre-patch:**

* Make sure the Carousel feature is enabled (with metadata and comments as well) in: `/wp-admin/admin.php?page=jetpack#/writing`
* Create or view an existing gallery on your test site. When viewing an image in the carousel, click the "Info" icon to expand the metadata section below the image.
* Without fully scrolling back to the top of the carousel, advance the slide.
* When the slide advances, you should automatically be scrolled to the top of the carousel.
* Notice that the Info icon is still active and metadata visible for the next/subsequent slides.

**Post-patch:**

* After patching with PR changes, similarly open the carousel again.
* Click the Info icon to expand the metadata section, then advance the slide without scrolling to top fully.
* You'll notice that now, no automatic scrolling to top is being done.
* The metadata/comments sections should still remain active when clicked when advancing slides to avoid having to open them manually for each slide.