### PR TITLE
Fix Docker when data/plugins not present

### DIFF
--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -96,6 +96,7 @@ if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	fi
 
 	# Symlink jetpack into wordpress-develop for WP >= 5.6-beta1
+	mkdir --parents /tmp/wordpress-develop/tests/phpunit/data/plugins/
 	WP_TESTS_JP_DIR="/tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack"
 	if [ ! -L $WP_TESTS_JP_DIR ] || [ ! -e $WP_TESTS_JP_DIR ]; then
 		ln -s /var/www/html/wp-content/plugins/jetpack $WP_TESTS_JP_DIR


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When trying to start up Docker today, I started hitting an error that caused the `wordpress` container to fail that we couldn't `ln` `wordpress-develop/tests/phpunit/data/plugins/jetpack` because the directory wasn't available. Looking on my filesystem, there is a `data/blocks`, but no `plugins`. Manually adding it resolved the issue.

My proposed solution is to run `mkdir --parents` to ensure the holding directory is present without worrying about an error if it does.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `mkdir --parents` before attempting the `ln`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
no

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `jetpack docker down && jetpack docker clean && jetpack docker up`
*  Does it successfully load?

