### PR TITLE
Backup: Add loading placeholder to the backup dashboard

### DIFF
--- a/projects/packages/backup/changelog/add-backup-loading-placeholder-dashboard
+++ b/projects/packages/backup/changelog/add-backup-loading-placeholder-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add loading placeholder in backup dashboard while fetching capabilities and backup state.

--- a/projects/packages/backup/src/js/components/Admin/index.js
+++ b/projects/packages/backup/src/js/components/Admin/index.js
@@ -16,7 +16,7 @@ import useAnalytics from '../../hooks/useAnalytics';
 import useCapabilities from '../../hooks/useCapabilities';
 import useConnection from '../../hooks/useConnection';
 import { STORE_ID } from '../../store';
-import Backups from '../Backups';
+import { Backups, Loading as BackupsLoadingPlaceholder } from '../Backups';
 import BackupStorageSpace from '../backup-storage-space';
 import ReviewRequest from '../review-request';
 import Header from './header';
@@ -371,7 +371,15 @@ const LoadedState = ( {
 	}
 
 	if ( ! capabilitiesLoaded ) {
-		return null;
+		return (
+			<Container horizontalSpacing={ 5 } fluid>
+				<Col>
+					<div className="jp-wrap jp-content backup-panel">
+						<BackupsLoadingPlaceholder />
+					</div>
+				</Col>
+			</Container>
+		);
 	}
 
 	if ( hasBackupPlan ) {

--- a/projects/packages/backup/src/js/components/Backups.js
+++ b/projects/packages/backup/src/js/components/Backups.js
@@ -1,4 +1,8 @@
-import { getProductCheckoutUrl, getRedirectUrl } from '@automattic/jetpack-components';
+import {
+	getProductCheckoutUrl,
+	getRedirectUrl,
+	LoadingPlaceholder,
+} from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { getDate, dateI18n } from '@wordpress/date';
@@ -23,7 +27,7 @@ import UploadsIcon from './icons/uploads.svg';
 import WarningIcon from './icons/warning.svg';
 
 /* eslint react/react-in-jsx-scope: 0 */
-const Backups = () => {
+export const Backups = () => {
 	const { backupState, latestTime, progress, stats } = useBackupsState();
 
 	return (
@@ -74,8 +78,27 @@ const NoGoodBackups = () => {
 	);
 };
 
-const Loading = () => {
-	return <div className="jp-row"></div>;
+export const Loading = () => {
+	return (
+		<div className="jp-row">
+			<div className="lg-col-span-4 md-col-span-4 sm-col-span-4">
+				<LoadingPlaceholder width={ 344 } height={ 182 } />
+			</div>
+			<div class="lg-col-span-0 md-col-span-4 sm-col-span-0"></div>
+			<div class="lg-col-span-2 md-col-span-2 sm-col-span-2">
+				<LoadingPlaceholder width={ 160 } height={ 152 } />
+			</div>
+			<div class="lg-col-span-2 md-col-span-2 sm-col-span-2">
+				<LoadingPlaceholder width={ 160 } height={ 152 } />
+			</div>
+			<div class="lg-col-span-2 md-col-span-2 sm-col-span-2">
+				<LoadingPlaceholder width={ 160 } height={ 152 } />
+			</div>
+			<div class="lg-col-span-2 md-col-span-2 sm-col-span-2">
+				<LoadingPlaceholder width={ 160 } height={ 152 } />
+			</div>
+		</div>
+	);
 };
 
 const formatDateString = dateString => {


### PR DESCRIPTION
This PR introduces a loading placeholder to the Backup Dashboard. The placeholder appears while the plugin is fetching the backup state and site capabilities, serving as an indicator that the client's request is being processed. This enhancement aims to improve user experience by providing real-time feedback and reducing perceived wait times.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a placeholder template for the backup panel
* Show loading placeholder while capabilities are not loaded
* Show loading placeholder while fetching backup state

## Demo (Before/After):
### Before
https://github.com/Automattic/jetpack/assets/1488641/bef24476-0315-471d-9e36-7c860374db27

### After
https://github.com/Automattic/jetpack/assets/1488641/0abc544f-bd01-43a4-b339-6a0f0fd7d9ec

## Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- peaFOp-FV-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jurassic Ninja site with just the Jetpack VaultPress Backup plugin using this branch. You could use this link: https://jurassic.ninja/create?jetpack-beta&branches.jetpack-backup=add/backup-loading-placeholder-dashboard&wp-debug-log&nojetpack
- Connect the site to Jetpack and add a Jetpack VaultPress Backup plan.
- Navigate to VaultPress Backup page.
- You should see a loading placeholder similar to the `After` video shared above while fetching capabilities and backup state.