### PR TITLE
Fix site preview in SEO settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -1,7 +1,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import {
-	FacebookPreviews,
-	TwitterPreviews,
+	FacebookLinkPreview,
+	TwitterLinkPreview,
 	GoogleSearchPreview,
 } from '@automattic/social-previews';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
@@ -70,6 +70,7 @@ export const SEO = withModuleSettingsFormHelpers(
 
 		SocialPreviewGoogle = siteData => (
 			<GoogleSearchPreview
+				siteTitle={ siteData.title }
 				title={ siteData.title }
 				url={ siteData.url }
 				description={ siteData.frontPageMetaDescription }
@@ -77,20 +78,20 @@ export const SEO = withModuleSettingsFormHelpers(
 		);
 
 		SocialPreviewFacebook = siteData => (
-			<FacebookPreviews
+			<FacebookLinkPreview
 				title={ siteData.title }
 				url={ siteData.url }
 				type="website"
+				imageMode="landscape"
 				description={ siteData.frontPageMetaDescription }
 				image={ siteData.image }
 			/>
 		);
 
 		SocialPreviewTwitter = siteData => (
-			<TwitterPreviews
+			<TwitterLinkPreview
 				title={ siteData.title }
 				url={ siteData.url }
-				type="summary"
 				description={ siteData.frontPageMetaDescription }
 				image={ siteData.image }
 			/>

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -150,14 +150,28 @@
 	}
 }
 
+$previews-max-width: 550px;
+$twitter-pofile-image-padding: 17px;
+
 .jp-seo-social-previews {
 	margin-bottom: 0;
 
 	.search-preview,
-	.facebook-preview,
-	.twitter-preview {
+	.facebook-preview__post,
+	.twitter-preview__wrapper {
 		margin-top: 1rem;
 		margin-bottom: 1rem;
+		// Avoid center alignment of the preview.
+		margin-inline: 0;
+		max-width: $previews-max-width;
+	}
+	.twitter-preview__wrapper {
+		// Remove padding for twitter preview
+		padding: 0;
+		// Compensate for the padding for profile image
+		margin-inline-start: -$twitter-pofile-image-padding;
+		// Add the extra width lost for the profile image
+		max-width: $previews-max-width + $twitter-pofile-image-padding;
 	}
 
 	&-container {

--- a/projects/plugins/jetpack/changelog/fix-site-preview-in-seo-settings
+++ b/projects/plugins/jetpack/changelog/fix-site-preview-in-seo-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed the site preview in SEO settings.


### PR DESCRIPTION
Fixes #30959
Completes 1204479765123387-as-1204665149016898/f

## Proposed changes:
* Fix the site preview in SEO settings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
#30959

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to `/wp-admin/admin.php?page=jetpack#/traffic`
* Scroll down to "Search engine optimization" section
* Click on "Expand to preview how the SEO settings will look for your homepage on Google, Facebook, and Twitter."
* Confirm that the previews are not broken and work as expected

| Production | `trunk` | This PR |
|--------|--------|--------|
| <img width="1045" alt="Screenshot 2023-05-26 at 11 50 20 AM" src="https://github.com/Automattic/jetpack/assets/18226415/09c23c1b-504b-494c-99a5-c39fa585170a"> | <img width="1046" alt="Screenshot 2023-05-26 at 11 44 47 AM" src="https://github.com/Automattic/jetpack/assets/18226415/fc372203-3361-4d84-9fad-f8e598e20f48"> | <img width="1049" alt="Screenshot 2023-05-26 at 11 41 34 AM" src="https://github.com/Automattic/jetpack/assets/18226415/8d7aa078-586e-4a13-8250-a1d3e49721b2"> |