### PR TITLE
AI Assistant: Use fetch-event-source instead of EventSource

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2735,6 +2735,9 @@ importers:
       '@automattic/viewport':
         specifier: 1.0.0
         version: 1.0.0
+      '@microsoft/fetch-event-source':
+        specifier: 2.0.1
+        version: 2.0.1
       '@wordpress/base-styles':
         specifier: 4.23.0
         version: 4.23.0
@@ -6173,6 +6176,10 @@ packages:
       '@types/react': 18.0.27
       react: 18.2.0
     dev: true
+
+  /@microsoft/fetch-event-source@2.0.1:
+    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
+    dev: false
 
   /@motionone/animation@10.15.1:
     resolution: {integrity: sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==}

--- a/projects/plugins/jetpack/changelog/update-fetch-event-source
+++ b/projects/plugins/jetpack/changelog/update-fetch-event-source
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: internal refactor
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -1,3 +1,4 @@
+import { fetchEventSource } from '@microsoft/fetch-event-source';
 import apiFetch from '@wordpress/api-fetch';
 import debugFactory from 'debug';
 
@@ -121,14 +122,11 @@ export async function requestToken() {
 }
 
 /**
- * SuggestionsEventSource is a wrapper around EventSource that emits
+ * SuggestionsEventSource is a wrapper around EvenTarget that emits
  * a 'chunk' event for each chunk of data received, and a 'done' event
  * when the stream is closed.
  * It also emits a 'suggestion' event with the full suggestion received so far
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/EventSource
- * @param {string} url - The URL to connect to
- * @param {object} options - Options to pass to EventSource
  * @returns {EventSource} The event source
  * @fires suggestion - The full suggestion has been received so far
  * @fires message - A message has been received
@@ -137,13 +135,31 @@ export async function requestToken() {
  * @fires error - An error has occurred
  * @fires error_network - The EventSource connection to the server returned some error
  */
-export class SuggestionsEventSource extends EventSource {
-	constructor( url, options ) {
-		super( url, options );
+export class SuggestionsEventSource extends EventTarget {
+	constructor( url ) {
+		super();
 		this.fullMessage = '';
 		this.isPromptClear = false;
-		this.addEventListener( 'message', this.processEvent );
-		this.addEventListener( 'error', this.processErrorEvent );
+		// The AbortController is used to close the fetchEventSource connection
+		this.controller = new AbortController();
+		this.initEventSource( url );
+	}
+
+	async initEventSource( url ) {
+		const self = this;
+
+		this.source = await fetchEventSource( url.toString(), {
+			onclose() {
+				debug( 'Stream closed unexpectedly' );
+			},
+			onmessage( ev ) {
+				self.processEvent( ev );
+			},
+			onerror( err ) {
+				self.processErrorEvent( err );
+			},
+			signal: this.controller.signal,
+		} );
 	}
 
 	checkForUnclearPrompt() {
@@ -160,6 +176,10 @@ export class SuggestionsEventSource extends EventSource {
 				this.isPromptClear = true;
 			}
 		}
+	}
+
+	close() {
+		this.controller.abort();
 	}
 
 	processEvent( e ) {

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -59,6 +59,7 @@
 		"@automattic/request-external-access": "1.0.0",
 		"@automattic/social-previews": "2.0.0",
 		"@automattic/viewport": "1.0.0",
+		"@microsoft/fetch-event-source": "2.0.1",
 		"@wordpress/base-styles": "4.23.0",
 		"@wordpress/block-editor": "12.0.0",
 		"@wordpress/blocks": "12.9.0",


### PR DESCRIPTION


The package [fetch-event-source](https://www.npmjs.com/package/@microsoft/fetch-event-source) allows for better error handling and eventually will allow us to move to POST requests.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds https://www.npmjs.com/package/@microsoft/fetch-event-source as dependency
* Updates the SuggestionsEventSource to rely on fetch-event-source

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Checkout this branch
* Add an AI Assistant block
* Run a query. Confirm it works
* Run a long query.
  * Confirm the stop button works
* Try to get a 500 error - Sandbox the API and ad a syntax error or something. 
  * Confirm the error notice works as expected
* Try to get a network error (maybe block domain from the network panel on a previous request to the `jetpack-ai-query` endpoint so to make
  * Confirm the error notice works as expected 
