### PR TITLE
Social: Don't show the instagram notice when you have a connection. 

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-instagram-notice
+++ b/projects/js-packages/publicize-components/changelog/fix-instagram-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fixed instagram notice from showing up when you already have a connection.

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -65,7 +65,7 @@ export default function PublicizeForm( {
 	} ) );
 
 	const hasInstagramConnection = connections.some(
-		connection => connection.service_name === 'instagram'
+		connection => connection.service_name === 'instagram-business'
 	);
 	const [ shouldShowInstagramNotice, setShouldShowInstagramNotice ] = useState(
 		! hasInstagramConnection && isInstagramConnectionSupported


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1204479765123387-as-1204685051626028

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The Instagram service identifier is 'instagram-business', not 'instagram'. This PR updates it. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1685101705072889/1685096272.594729-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Be Jetpack trunk (may be boot up a JN site using Jetpack Beta) and sandbox D111103-code (take a fresh pull of the WPCOM diff as well)
* Disconnect any Instagram connection you might have
* The notice will show up in the editor if you have not previously dismissed it. 
* Create an Instagram connection. The notice will still show up. 
* Switch to this PR and ensure that the notice disappears. 