### PR TITLE
AI Assistant: check feature availability when requesting jwt

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -321,11 +321,20 @@ class Jetpack_AI_Helper {
 			$requests_limit = \OpenAI_Limit_Usage::NUM_FREE_REQUESTS_LIMIT;
 			$requests_count = \OpenAI_Request_Count::get_count( $blog_id );
 
+			/*
+			 * Check if the site requires an upgrade,
+			 * based on the number of requests made,
+			 * the limit of free requests,
+			 * and if the site has the feature.
+			 */
+			$require_upgrade = ! $has_ai_assistant_feature && $is_over_limit;
+
 			return array(
-				'has-feature'    => $has_ai_assistant_feature,
-				'is-over-limit'  => $is_over_limit,
-				'requests-count' => $requests_count,
-				'requests-limit' => $requests_limit,
+				'has-feature'     => $has_ai_assistant_feature,
+				'is-over-limit'   => $is_over_limit,
+				'requests-count'  => $requests_count,
+				'requests-limit'  => $requests_limit,
+				'require-upgrade' => $require_upgrade,
 			);
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -773,7 +773,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * TODO: Clean me up. This is ugly hack code.
 	 */
 	public static function get_openai_jwt() {
-		$blog_id = \Jetpack_Options::get_option( 'id' );
+		$blog_id              = \Jetpack_Options::get_option( 'id' );
+		$ai_assistant_feature = (array) \Jetpack_AI_Helper::get_ai_assistance_feature();
+
+		if (
+			isset( $ai_assistant_feature['require-upgrade'] ) &&
+			(bool) $ai_assistant_feature['require-upgrade']
+		) {
+			return new \WP_Error(
+				'requests_limit_achieved',
+				__( 'Site achieved the requests limit', 'jetpack' ),
+				array(
+					'status' => 429,
+				)
+			);
+		}
 
 		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
 			"/sites/$blog_id/jetpack-openai-query/jwt",

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-check-feature-availability
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-check-feature-availability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: check feature availability when requesting jwt

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -86,7 +86,8 @@ export async function requestToken() {
 
 	if ( isJetpackSite ) {
 		data = await apiFetch( {
-			path: '/jetpack/v4/jetpack-ai-jwt?_cacheBuster=' + Date.now(),
+			path:
+				'/jetpack/v4/jetpack-ai-jwt?_cacheBuster=' + Date.now() + '&check-feature-available=true',
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/upgrade-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/upgrade-prompt.js
@@ -19,10 +19,7 @@ const UpgradePrompt = () => {
 			buttonText={ 'Upgrade' }
 			checkoutUrl={ `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/add-jetpack-ai` }
 			className={ 'jetpack-ai-upgrade-banner' }
-			description={ __(
-				'You have reached the limit of 20 free requests. Upgrade now to keep using Jetpack AI.',
-				'jetpack'
-			) }
+			description={ __( 'Upgrade now to keep using Jetpack AI.', 'jetpack' ) }
 			goToCheckoutPage={ () => {} }
 			isRedirecting={ false }
 			visible={ true }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We are checking if the site requires an upgrade when the block renders, but it should be done dynamically, considering the requests count changes while the user interacts with the block.

This PR checks the feature availability when the app requests a `jwt`. Taking this path, we reduce the requests performed by the client, avoiding unnecessarily hitting other endpoints.

Regarding the UI/UX, the block shows an error when the site needs an upgrade. We will continue with follow-up tasks

Fixes #
Part of https://github.com/Automattic/jetpack/issues/30842

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: check feature availability when requesting jwt

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Endpoint changes

It introduces the `require-upgrade` property into the response. You can check it by hitting the `/wpcom/v2/sites/$site/jetpack-ai/ai-assistant-feature` endpoint.

<img width="311" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/5d06934b-63e5-4adf-9a1b-d0a64845e555">

* Go to the block editor
* Get an AI Assistant block instance
* Test with a site without the `AI Assistant` feature
* Use the block. You can check the request number by hitting the endpoint mentioned above
* Confirm the error shows up when the site archives the requests limit, and when it doesn't support the AI Assistant feature.

<img width="710" alt="Screenshot 2023-05-26 at 10 45 33" src="https://github.com/Automattic/jetpack/assets/77539/a0fc4830-9d0c-4d9e-b996-06c712180139">

