### PR TITLE
Social: Include username in publicize connection test results

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -75,6 +75,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 				'type'        => 'string',
 			),
 			'display_name'         => array(
+				'description' => __( 'Display name of the connected account', 'jetpack' ),
+				'type'        => 'string',
+			),
+			'username'             => array(
 				'description' => __( 'Username of the connected account', 'jetpack' ),
 				'type'        => 'string',
 			),
@@ -131,6 +135,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 					'connection_id'        => (string) $publicize->get_connection_id( $connection ),
 					'service_name'         => $service_name,
 					'display_name'         => $publicize->get_display_name( $service_name, $connection ),
+					'username'             => $publicize->get_username( $service_name, $connection ),
 					'profile_display_name' => ! empty( $connection_meta['profile_display_name'] ) ? $connection_meta['profile_display_name'] : '',
 					'profile_picture'      => ! empty( $connection_meta['profile_picture'] ) ? $connection_meta['profile_picture'] : '',
 					// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- We expect an integer, but do loose comparison below in case some other type is stored.

--- a/projects/plugins/jetpack/changelog/fix-username-connection-test-results
+++ b/projects/plugins/jetpack/changelog/fix-username-connection-test-results
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add username to publicize connection test results.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include username in the connection test results schema

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1685108345251429/1685009328.266869-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You can test this only on the Jetpack plugin and not the Jetpack Social plugin, since the latter calls the endpoint via WPCOM. 
* Without this PR applied, you won't see a 'username' being returned by the `connection-test-results` endpoint.
* With this PR applied, you will see a 'username' being returned by the `connection-test-results` endpoint.