### PR TITLE
AI Assistant: Show upgrade banner when AI query endpoint responses with quota exceeded error

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-catch-quota-exceeded-error
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-catch-quota-exceeded-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: show upgrade banner when ai query endpoint responses with quota exceeded error

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -45,6 +45,7 @@ const AIControl = ( {
 	wholeContent,
 	promptType,
 	onChange,
+	requireUpgrade,
 } ) => {
 	const promptUserInputRef = useRef( null );
 	const [ isSm ] = useBreakpointMatch( 'sm' );
@@ -56,7 +57,7 @@ const AIControl = ( {
 		}
 	};
 
-	const { requireUpgrade } = useAIFeature();
+	const { requireUpgrade: showUpgradeBanner } = useAIFeature();
 
 	const textPlaceholder = __( 'Ask Jetpack AI', 'jetpack' );
 
@@ -74,7 +75,7 @@ const AIControl = ( {
 
 	return (
 		<>
-			{ requireUpgrade && <UpgradePrompt /> }
+			{ ( showUpgradeBanner || requireUpgrade ) && <UpgradePrompt /> }
 			{ ! isWaitingState && (
 				<ToolbarControls
 					isWaitingState={ isWaitingState }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -26,7 +26,7 @@ const markdownConverter = new MarkdownIt( {
 
 export default function AIAssistantEdit( { attributes, setAttributes, clientId } ) {
 	const [ userPrompt, setUserPrompt ] = useState();
-	const [ errorMessage, setErrorMessage ] = useState( false );
+	const [ errorData, setError ] = useState( {} );
 	const [ loadingImages, setLoadingImages ] = useState( false );
 	const [ resultImages, setResultImages ] = useState( [] );
 	const [ imageModal, setImageModal ] = useState( null );
@@ -59,23 +59,23 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		attributes,
 		clientId,
 		content: attributes.content,
-		setErrorMessage,
+		setError,
 		tracks,
 		userPrompt,
 	} );
 
 	useEffect( () => {
-		if ( errorMessage ) {
+		if ( errorData ) {
 			setErrorDismissed( false );
 		}
-	}, [ errorMessage ] );
+	}, [ errorData ] );
 
 	const saveImage = async image => {
 		if ( loadingImages ) {
 			return;
 		}
 		setLoadingImages( true );
-		setErrorMessage( null );
+		setError( {} );
 
 		// First convert image to a proper blob file
 		const resp = await fetch( image );
@@ -144,14 +144,14 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 
 	const handleImageRequest = () => {
 		setResultImages( [] );
-		setErrorMessage( null );
+		setError( {} );
 
 		getImagesFromOpenAI(
 			userPrompt.trim() === '' ? __( 'What would you like to see?', 'jetpack' ) : userPrompt,
 			setAttributes,
 			setLoadingImages,
 			setResultImages,
-			setErrorMessage,
+			setError,
 			postId
 		);
 
@@ -166,9 +166,9 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				className: classNames( { 'is-waiting-response': wasCompletionJustRequested } ),
 			} ) }
 		>
-			{ errorMessage && ! errorDismissed && (
+			{ errorData && ! errorDismissed && (
 				<Notice status="info" isDismissible={ false } className="jetpack-ai-assistant__error">
-					{ errorMessage }
+					{ errorData.message }
 				</Notice>
 			) }
 			{ contentIsLoaded && (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -203,6 +203,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				wholeContent={ wholeContent }
 				promptType={ attributes.promptType }
 				onChange={ () => setErrorDismissed( true ) }
+				requireUpgrade={ errorData?.code === 'error_quota_exceeded' }
 			/>
 			{ ! loadingImages && resultImages.length > 0 && (
 				<Flex direction="column" style={ { width: '100%' } }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -166,8 +166,12 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				className: classNames( { 'is-waiting-response': wasCompletionJustRequested } ),
 			} ) }
 		>
-			{ errorData && ! errorDismissed && (
-				<Notice status="info" isDismissible={ false } className="jetpack-ai-assistant__error">
+			{ errorData?.message && ! errorDismissed && (
+				<Notice
+					status={ errorData.status }
+					isDismissible={ false }
+					className="jetpack-ai-assistant__error"
+				>
 					{ errorData.message }
 				</Notice>
 			) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -166,6 +166,15 @@ export class SuggestionsEventSource extends EventTarget {
 				if ( response.status >= 400 && response.status <= 500 && response.status !== 429 ) {
 					this.processConnectionError( response );
 				}
+
+				/*
+				 * error code 429
+				 * you exceeded your current quota please check your plan and billing details
+				 */
+				if ( response.status === 429 ) {
+					self.dispatchEvent( new CustomEvent( 'error_quota_exceeded' ) );
+				}
+
 				throw new Error();
 			},
 			signal: this.controller.signal,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -164,7 +164,7 @@ export class SuggestionsEventSource extends EventTarget {
 					return;
 				}
 				if ( response.status >= 400 && response.status <= 500 && response.status !== 429 ) {
-					this.processConnectionError( response );
+					self.processConnectionError( response );
 				}
 
 				/*

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/upgrade-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/upgrade-prompt.js
@@ -19,10 +19,7 @@ const UpgradePrompt = () => {
 			buttonText={ 'Upgrade' }
 			checkoutUrl={ `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/add-jetpack-ai` }
 			className={ 'jetpack-ai-upgrade-banner' }
-			description={ __(
-				'You have reached the limit of 20 free requests. Upgrade now to keep using Jetpack AI.',
-				'jetpack'
-			) }
+			description={ __( 'Upgrade now to keep using Jetpack AI.', 'jetpack' ) }
 			goToCheckoutPage={ () => {} }
 			isRedirecting={ false }
 			visible={ true }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -79,7 +79,7 @@ const useSuggestionsFromOpenAI = ( {
 	attributes,
 	clientId,
 	content,
-	setErrorMessage,
+	setError,
 	tracks,
 	userPrompt,
 } ) => {
@@ -167,7 +167,7 @@ const useSuggestionsFromOpenAI = ( {
 		}
 
 		setShowRetry( false );
-		setErrorMessage( false );
+		setError( {} );
 
 		let prompt = lastPrompt;
 
@@ -204,14 +204,15 @@ const useSuggestionsFromOpenAI = ( {
 			source.current = await askQuestion( prompt, postId );
 		} catch ( err ) {
 			if ( err.message ) {
-				setErrorMessage( err.message ); // Message was already translated by the backend
+				setError( { message: err.message, code: err?.code || 'unknown' } );
 			} else {
-				setErrorMessage(
-					__(
+				setError( {
+					message: __(
 						'Whoops, we have encountered an error. AI is like really, really hard and this is an experimental feature. Please try again later.',
 						'jetpack'
-					)
-				);
+					),
+					code: 'unknown',
+				} );
 			}
 			setShowRetry( true );
 			setIsLoadingCompletion( false );
@@ -226,17 +227,32 @@ const useSuggestionsFromOpenAI = ( {
 			source?.current.close();
 			setIsLoadingCompletion( false );
 			setWasCompletionJustRequested( false );
-			setErrorMessage( __( 'Your request was unclear. Mind trying again?', 'jetpack' ) );
+			setError( {
+				code: 'error_unclear_prompt',
+				message: __( 'Your request was unclear. Mind trying again?', 'jetpack' ),
+			} );
 		} );
 		source?.current.addEventListener( 'error_network', () => {
 			source?.current.close();
 			setIsLoadingCompletion( false );
 			setWasCompletionJustRequested( false );
 			setShowRetry( true );
-			setErrorMessage(
-				__( 'It was not possible to process your request. Mind trying again?', 'jetpack' )
-			);
+			setError( {
+				code: 'error_network',
+				message: __( 'It was not possible to process your request. Mind trying again?', 'jetpack' ),
+			} );
 		} );
+		source?.current.addEventListener( 'error_quota_exceeded', () => {
+			source?.current.close();
+			setIsLoadingCompletion( false );
+			setWasCompletionJustRequested( false );
+			setShowRetry( false );
+			setError( {
+				code: 'error_quota_exceeded',
+				message: __( 'You have reached the limit of requests for this site.', 'jetpack' ),
+			} );
+		} );
+
 		source?.current.addEventListener( 'suggestion', e => {
 			setWasCompletionJustRequested( false );
 			debug( 'fullMessage', e.detail );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -204,7 +204,7 @@ const useSuggestionsFromOpenAI = ( {
 			source.current = await askQuestion( prompt, postId );
 		} catch ( err ) {
 			if ( err.message ) {
-				setError( { message: err.message, code: err?.code || 'unknown' } );
+				setError( { message: err.message, code: err?.code || 'unknown', status: 'error' } );
 			} else {
 				setError( {
 					message: __(
@@ -212,6 +212,7 @@ const useSuggestionsFromOpenAI = ( {
 						'jetpack'
 					),
 					code: 'unknown',
+					status: 'error',
 				} );
 			}
 			setShowRetry( true );
@@ -230,6 +231,7 @@ const useSuggestionsFromOpenAI = ( {
 			setError( {
 				code: 'error_unclear_prompt',
 				message: __( 'Your request was unclear. Mind trying again?', 'jetpack' ),
+				status: 'info',
 			} );
 		} );
 		source?.current.addEventListener( 'error_network', () => {
@@ -240,6 +242,7 @@ const useSuggestionsFromOpenAI = ( {
 			setError( {
 				code: 'error_network',
 				message: __( 'It was not possible to process your request. Mind trying again?', 'jetpack' ),
+				status: 'warning',
 			} );
 		} );
 		source?.current.addEventListener( 'error_quota_exceeded', () => {
@@ -250,6 +253,7 @@ const useSuggestionsFromOpenAI = ( {
 			setError( {
 				code: 'error_quota_exceeded',
 				message: __( 'You have reached the limit of requests for this site.', 'jetpack' ),
+				status: 'info',
 			} );
 		} );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Part of https://github.com/Automattic/jetpack/issues/30842

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: show upgrade banner when ai query endpoint responses with quota exceeded error

### Other information:


- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

