### PR TITLE
Block Editor: add connected user's email address to editor context

### DIFF
--- a/projects/packages/connection/changelog/add-email-initial-state
+++ b/projects/packages/connection/changelog/add-email-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Include the user's email in data returned from WordPress.com Connected User data query

--- a/projects/packages/connection/legacy/class-jetpack-tracks-client.php
+++ b/projects/packages/connection/legacy/class-jetpack-tracks-client.php
@@ -221,6 +221,7 @@ class Jetpack_Tracks_Client {
 
 		return array(
 			'blogid'      => Jetpack_Options::get_option( 'id', 0 ),
+			'email'       => $user_data['email'],
 			'userid'      => $user_data['ID'],
 			'username'    => $user_data['login'],
 			'user_locale' => $user_data['user_locale'],

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.52.0';
+	const PACKAGE_VERSION = '1.52.1-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/plugins/jetpack/changelog/add-email-initial-state
+++ b/projects/plugins/jetpack/changelog/add-email-initial-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Block Editor: add current connected user's email address to the data available in the editor.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -643,6 +643,7 @@ class Jetpack_Gutenberg {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$user                      = wp_get_current_user();
 			$user_data                 = array(
+				'email'    => $user->user_email,
 				'userid'   => $user->ID,
 				'username' => $user->user_login,
 			);


### PR DESCRIPTION
## Proposed changes:

This data may prove useful to display the current user's email address in the editor to demo subscription-related features.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- D110864-code
- p1685112173899369-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com.
* Go to Posts > Add New
* In your browser console, type in `Jetpack_Editor_Initial_State.tracksUserData.email`
    * You should see the current connected user's email address.
