### PR TITLE
Change agency discount value on WPA

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -838,7 +838,7 @@ class Main extends React.Component {
 
 					{ this.renderMainContent( this.props.location.pathname ) }
 					{ this.shouldShowAgenciesCard() && (
-						<AgenciesCard path={ this.props.location.pathname } discountPercentage={ 25 } />
+						<AgenciesCard path={ this.props.location.pathname } discountPercentage={ 60 } />
 					) }
 					{ this.shouldShowSupportCard() && <SupportCard path={ this.props.location.pathname } /> }
 					{ this.shouldShowAppsCard() && <AppsCard /> }

--- a/projects/plugins/jetpack/changelog/update-agency-discount-wpa
+++ b/projects/plugins/jetpack/changelog/update-agency-discount-wpa
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Change agency discount value on WPA


### PR DESCRIPTION
## Proposed changes:
The current discount for Agencies is 60% instead of 25% (as listed on [landing page](https://jetpack.com/for/agencies/)). We need to update the Agency card to mention the updated discount as well.

## Testing instructions:
* Run Jurassic Ninja with Jetpack Beta
* Source Jetpack main plugin with this branch `update/agency-discount-wpa`
* Setup Jetpack on the site
* Go to the Jetpack dashboard (`/wp-admin/admin.php?page=jetpack#/dashboard`) and see updated Agency card:

<img width="1106" alt="CleanShot 2023-05-26 at 18 42 33@2x" src="https://github.com/Automattic/jetpack/assets/8419292/d376f38b-eba9-49e1-9226-6cc7fd842fee">


