### PR TITLE
Publicize: add feature flag for Mastodon preview

### DIFF
--- a/projects/js-packages/publicize-components/src/components/social-previews/useAvailableServices.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/useAvailableServices.js
@@ -16,9 +16,14 @@ import Twitter from './twitter';
  * @returns {Array<{title: string, icon: React.Component, name: string, preview: React.Component}>} The list of available services.
  */
 export function useAvailableSerivces() {
-	const isInstagramSupported = useSelect( select =>
-		select( 'jetpack/publicize' ).isInstagramConnectionSupported()
-	);
+	const { isInstagramSupported, isMastodonSupported } = useSelect( select => {
+		const store = select( 'jetpack/publicize' );
+
+		return {
+			isInstagramSupported: store.isInstagramConnectionSupported(),
+			isMastodonSupported: store.isMastodonConnectionSupported(),
+		};
+	} );
 
 	return useMemo(
 		() =>
@@ -61,13 +66,15 @@ export function useAvailableSerivces() {
 					name: 'tumblr',
 					preview: TumblrPreview,
 				},
-				{
-					title: __( 'Mastodon', 'jetpack' ),
-					icon: props => <SocialServiceIcon serviceName="mastodon" { ...props } />,
-					name: 'mastodon',
-					preview: MastodonPreview,
-				},
+				isMastodonSupported
+					? {
+							title: __( 'Mastodon', 'jetpack' ),
+							icon: props => <SocialServiceIcon serviceName="mastodon" { ...props } />,
+							name: 'mastodon',
+							preview: MastodonPreview,
+					  }
+					: null,
 			].filter( Boolean ),
-		[ isInstagramSupported ]
+		[ isInstagramSupported, isMastodonSupported ]
 	);
 }

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -645,3 +645,12 @@ export function getImageGeneratorPostSettings() {
 export function isInstagramConnectionSupported() {
 	return !! getJetpackData()?.social?.isInstagramConnectionSupported;
 }
+
+/**
+ * Checks if the Mastodon connection is supported.
+ *
+ * @returns {boolean} Whether the Mastodon connection is supported
+ */
+export function isMastodonConnectionSupported() {
+	return !! getJetpackData()?.social?.isMastodonConnectionSupported;
+}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1794,6 +1794,15 @@ abstract class Publicize_Base {
 	}
 
 	/**
+	 * Check if Mastodon connection is enabled.
+	 *
+	 * @return bool
+	 */
+	public function has_mastodon_connection_feature() {
+		return Current_Plan::supports( 'social-mastodon-connection' );
+	}
+
+	/**
 	 * Call the WPCOM REST API to calculate the scheduled shares.
 	 *
 	 * @param string $blog_id The blog_id.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -713,6 +713,7 @@ class Jetpack_Gutenberg {
 				'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
 				'dismissedNotices'                => $publicize->get_dismissed_notices(),
 				'isInstagramConnectionSupported'  => $publicize->has_instagram_connection_feature(),
+				'isMastodonConnectionSupported'   => $publicize->has_mastodon_connection_feature(),
 			);
 		}
 

--- a/projects/plugins/social/changelog/update-publicizie-mastodon-feature-guard
+++ b/projects/plugins/social/changelog/update-publicizie-mastodon-feature-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added feature flag for Mastodon preview

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -240,6 +240,7 @@ class Jetpack_Social {
 						'isEnhancedPublishingEnabled'    => $publicize->has_enhanced_publishing_feature(),
 						'dismissedNotices'               => $publicize->get_dismissed_notices(),
 						'isInstagramConnectionSupported' => $publicize->has_instagram_connection_feature(),
+						'isMastodonConnectionSupported'  => $publicize->has_mastodon_connection_feature(),
 					),
 					'connectionData'               => array(
 						'connections' => $publicize->get_all_connections_for_user(), // TODO: Sanitize the array
@@ -335,6 +336,7 @@ class Jetpack_Social {
 					'isSocialImageGeneratorEnabled'   => $sig_settings->is_enabled(),
 					'dismissedNotices'                => $publicize->get_dismissed_notices(),
 					'isInstagramConnectionSupported'  => $publicize->has_instagram_connection_feature(),
+					'isMastodonConnectionSupported'   => $publicize->has_mastodon_connection_feature(),
 				),
 			)
 		);

--- a/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
+++ b/projects/plugins/social/src/js/store/selectors/jetpack-settings.js
@@ -8,6 +8,7 @@ const jetpackSettingSelectors = {
 		! ( state.jetpackSettings?.isEnhancedPublishingEnabled ?? false ),
 	getDismissedNotices: state => state.jetpackSettings?.dismissedNotices,
 	isInstagramConnectionSupported: state => state.jetpackSettings?.isInstagramConnectionSupported,
+	isMastodonConnectionSupported: state => state.jetpackSettings?.isMastodonConnectionSupported,
 };
 
 export default jetpackSettingSelectors;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30993

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR makes sure the Mastodon post preview implemented in #30919 is only available when a site has the Mastodon feature enabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Context: p1685021258869219/1685017559.277849-slack-C055TKELKK6

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
* Checkout this branch
* Checkout the `trunk` branch in calypso
* In `wp-calypso/packages/social-previews/` directory, run `pnpm link --global` to expose the package to global `node_modules` for `pnpm`
* In `jetpack/projects/js-packages/publicize-components/` directory, run `pnpm link --global @automattic/social-previews`
* In `wp-calypso` root, run `yarn` and then `yarn workspace @automattic/social-previews run build`
* In Jetpack, run `jetpack build plugins/jetpack --no-pnpm-install`

### Testing
* Make sure your site doesn't have the Mastodon feature enabled (follow the instructions [here](D111014-code) to disable it)
* Start writing a new post in WPadmin
* Click the Jetpack icon on the top of the sidebar
* Under "Social Previews", click on "Preview"
* Check that you don't see Mastodon in the preview foldable card or panel
* Add the Mastodon feature to your site (follow the instructions [here](D111014-code))
* Check that you **do** see Mastodon in the preview foldable card or panel
<img width="150" alt="Screenshot 2023-05-25 at 7 46 21 AM" src="https://github.com/Automattic/jetpack/assets/1620183/7435da3d-c1ab-4aa9-a839-1044b906dc61">
<img width="150" alt="Screenshot 2023-05-26 at 12 15 02 PM" src="https://github.com/Automattic/jetpack/assets/1620183/b4df6bf2-14c3-4b1c-af8e-01ec7231f409">

* Once you are done, run `pnpm unlink` in Jetpack