### PR TITLE
AI Assistant: add change tone menu option when post has content

### DIFF
--- a/projects/plugins/jetpack/changelog/add-assistant-change-tone-when-content
+++ b/projects/plugins/jetpack/changelog/add-assistant-change-tone-when-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Changing menu of AI assistant, not yet available

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -289,11 +289,17 @@ const ToolbarControls = ( {
 					/>
 
 					{ ! showRetry && ! contentIsLoaded && !! wholeContent?.length && (
-						<I18nDropdownControl
-							value="en"
-							label={ __( 'Translate', 'jetpack' ) }
-							onChange={ language => getSuggestionFromOpenAI( 'changeLanguage', { language } ) }
-						/>
+						<BlockControls group="block">
+							<ToneDropdownControl
+								value="neutral"
+								onChange={ tone => getSuggestionFromOpenAI( 'changeTone', { tone } ) }
+							/>
+							<I18nDropdownControl
+								value="en"
+								label={ __( 'Translate', 'jetpack' ) }
+								onChange={ language => getSuggestionFromOpenAI( 'changeLanguage', { language } ) }
+							/>
+						</BlockControls>
 					) }
 
 					{ ! showRetry && ! contentIsLoaded && (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -160,7 +160,7 @@ export function buildPrompt( {
 		case 'changeTone':
 			prompt = buildPromptTemplate( {
 				request: `Please, rewrite with a ${ options.tone } tone.`,
-				content: generatedContent,
+				content: options.contentType === 'generated' ? generatedContent : allPostContent,
 			} );
 			break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30998

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Display change tone option when the post already has content
<img width="663" alt="Screenshot 2023-05-26 at 20 38 12" src="https://github.com/Automattic/jetpack/assets/16329583/cd308b4a-2b68-4c42-ac94-97cdd22781a5">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No 
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and verify that change tone is there
* Confirm that the existing content is sent and the tone is changed

