### PR TITLE
AI Assistant: extended core text blocks with AI Assistant features

### DIFF
--- a/projects/plugins/jetpack/changelog/update-extended-text-blocks-with-ai-assistant
+++ b/projects/plugins/jetpack/changelog/update-extended-text-blocks-with-ai-assistant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: extended core text blocks with AI Assistant features

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/edit.tsx
@@ -24,11 +24,6 @@ export const withMultipleBlocksEdition = BlockEdit => props => {
 		};
 	}, [] );
 
-	const selectedBlocksCount = selectedBlocks.length;
-	if ( selectedBlocksCount < 2 ) {
-		return <BlockEdit { ...props } />;
-	}
-
 	return (
 		<>
 			<BlockEdit { ...props } />

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/generate-panel.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/generate-panel.tsx
@@ -71,7 +71,7 @@ export default function GenerateContentPanel( {
 		prompt: '',
 	} );
 
-	const [ combineBlocks, setCombineBlocks ] = useState( false );
+	const [ createNewBlock, setCreateNewBlock ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const { replaceBlocks, updateBlockAttributes, insertBlock } = useDispatch( blockEditorStore );
 
@@ -98,6 +98,8 @@ export default function GenerateContentPanel( {
 			} )
 			.join( '\n' );
 	}, [ blocks ] );
+
+	const isMultipleBlocksSelection = blocksIds?.length > 1;
 
 	const generateContent = useCallback( async () => {
 		const content = getContentFromSelectedBlocks();
@@ -147,32 +149,35 @@ export default function GenerateContentPanel( {
 
 		source.addEventListener( 'suggestion', e => {
 			if ( ! newBlockJustCreated ) {
-				if ( combineBlocks ) {
-					replaceBlocks( blocksIds, [ generatedBlock ] );
+				if ( ! createNewBlock ) {
+					// Replace blocks only when multiple blocks are selected
+					if ( isMultipleBlocksSelection ) {
+						replaceBlocks( blocksIds, [ generatedBlock ] );
+					}
 				} else {
 					insertBlock( generatedBlock, lastBlockIndex + 1 );
 				}
 				newBlockJustCreated = true;
 			}
 
-			updateBlockAttributes( generatedBlock.clientId, {
+			const clientId = isMultipleBlocksSelection ? generatedBlock.clientId : blocksIds[ 0 ];
+			updateBlockAttributes( clientId, {
 				content: e.detail as string,
 			} );
 		} );
 	}, [
+		isMultipleBlocksSelection,
 		getContentFromSelectedBlocks,
 		tone?.key,
 		lang?.key,
 		action,
-		combineBlocks,
+		createNewBlock,
 		replaceBlocks,
 		blocksIds,
 		insertBlock,
 		lastBlockIndex,
 		updateBlockAttributes,
 	] );
-
-	const isMultipleBlocksSelection = blocksIds?.length > 1;
 
 	return (
 		<PanelBody
@@ -234,8 +239,8 @@ export default function GenerateContentPanel( {
 							? __( 'Combine all blocks into one', 'jetpack' )
 							: __( 'Create a new block', 'jetpack' )
 					}
-					checked={ combineBlocks }
-					onChange={ setCombineBlocks }
+					checked={ createNewBlock }
+					onChange={ setCreateNewBlock }
 				/>
 			</PanelRow>
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/generate-panel.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/generate-panel.tsx
@@ -172,6 +172,8 @@ export default function GenerateContentPanel( {
 		updateBlockAttributes,
 	] );
 
+	const isMultipleBlocksSelection = blocksIds?.length > 1;
+
 	return (
 		<PanelBody
 			title={ __( 'AI Assistant', 'jetpack' ) }
@@ -227,7 +229,11 @@ export default function GenerateContentPanel( {
 			</PanelRow>
 			<PanelRow>
 				<ToggleControl
-					label={ __( 'Combine all blocks into one', 'jetpack' ) }
+					label={
+						isMultipleBlocksSelection
+							? __( 'Combine all blocks into one', 'jetpack' )
+							: __( 'Create a new block', 'jetpack' )
+					}
 					checked={ combineBlocks }
 					onChange={ setCombineBlocks }
 				/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/generate-panel.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/generate-panel.tsx
@@ -47,7 +47,11 @@ export const langOptions = Object.keys( LANGUAGE_MAP ).map( key => {
  * @param {string[]} props.blocksIds - Blocks to generate content from
  * @returns {React.ReactElement}       The component's elements.
  */
-export default function GenerateContentPanel( { blocksIds } ) {
+export default function GenerateContentPanel( {
+	blocksIds,
+}: {
+	blocksIds: string[];
+} ): React.ReactElement {
 	const [ tone, setTone ] = useState( {
 		key: '',
 		name: '',

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/generate-panel.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/generate-panel.tsx
@@ -71,7 +71,7 @@ export default function GenerateContentPanel( {
 		prompt: '',
 	} );
 
-	const [ createNewBlock, setCreateNewBlock ] = useState( false );
+	const [ createNewBlock, setCreateNewBlock ] = useState( true );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const { replaceBlocks, updateBlockAttributes, insertBlock } = useDispatch( blockEditorStore );
 
@@ -160,10 +160,12 @@ export default function GenerateContentPanel( {
 				newBlockJustCreated = true;
 			}
 
-			const clientId = isMultipleBlocksSelection ? generatedBlock.clientId : blocksIds[ 0 ];
-			updateBlockAttributes( clientId, {
-				content: e.detail as string,
-			} );
+			let clientId = generatedBlock.clientId;
+			if ( ! isMultipleBlocksSelection && ! createNewBlock ) {
+				clientId = blocksIds[ 0 ];
+			}
+
+			updateBlockAttributes( clientId, { content: e.detail as string } );
 		} );
 	}, [
 		isMultipleBlocksSelection,
@@ -234,13 +236,13 @@ export default function GenerateContentPanel( {
 			</PanelRow>
 			<PanelRow>
 				<ToggleControl
-					label={
-						isMultipleBlocksSelection
-							? __( 'Combine all blocks into one', 'jetpack' )
-							: __( 'Create a new block', 'jetpack' )
-					}
+					label={ __( 'Create a new block', 'jetpack' ) }
 					checked={ createNewBlock }
 					onChange={ setCreateNewBlock }
+					help={ __(
+						'If enable, it will create a new block with the generated content.',
+						'jetpack'
+					) }
 				/>
 			</PanelRow>
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/index.js
@@ -16,7 +16,8 @@ import Icon from './icons/ai-assistant';
  * Extend:
  * - blocks (Multiple-blocks edition)
  */
-// import './extensions/multiple-blocks-edition'; @todo: cosider to enable it in the future
+import './extensions/multiple-blocks-edition';
+
 /**
  * Style dependencies
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR extends `core/paragraph` and `core/header` with the AI Assistant feature. In short, these blocks will have the AI Assistant panel to be used individually. 
Currently, the AI assistant is only available when multiple blocks selection.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: extended core text blocks with AI Assistant features

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a few paragraphs in the post content
* Confirm the multiple blocks edition works as usual.
* Select a single paragraph block
* Confirm the AI Assistant panel is there
* Confirm you can generate the content, replacing the block
* Or...
* Confirm you can generate the content in a new AI Assistant block


https://github.com/Automattic/jetpack/assets/77539/cc33a7be-6e21-40e0-bfa5-194897b96c70
