### PR TITLE
AI Assistant: Do not show notice if the problem is due to quota exceeded

### DIFF
--- a/projects/plugins/jetpack/changelog/update-hide-notice-if-error-is-quote-exceeded
+++ b/projects/plugins/jetpack/changelog/update-hide-notice-if-error-is-quote-exceeded
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: not neded
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -166,7 +166,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				className: classNames( { 'is-waiting-response': wasCompletionJustRequested } ),
 			} ) }
 		>
-			{ errorData?.message && ! errorDismissed && (
+			{ errorData?.message && ! errorDismissed && errorData?.code !== 'error_quota_exceeded' && (
 				<Notice
 					status={ errorData.status }
 					isDismissible={ false }


### PR DESCRIPTION
Makes the error notice not shown if we're going to show the upgrade prompt

#### After

<img width="582" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/933a3854-7c90-47e9-8c61-ea501b1c85d3">


#### Before

<img width="593" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/2f7e15a8-851a-46d2-9af1-61689837e951">


Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
NO
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* on a site with the request quota exceeded
* add an AI Assistant block
* Attempt to run a query
* Confirm the upgrade prompt is shown but not the otice

