### PR TITLE
AI Assistant: share post content when user sends manual prompt

### DIFF
--- a/projects/plugins/jetpack/changelog/modify-prompt-logic-for-user-input
+++ b/projects/plugins/jetpack/changelog/modify-prompt-logic-for-user-input
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Change prompt for openAI request
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -55,6 +55,9 @@ export const buildPromptTemplate = ( {
 		job += 'respond to the request below, under "Request"';
 	} else if ( ! request && !! content ) {
 		job += 'modify the content below, under "Content"';
+	} else if ( !! request && !! content ) {
+		job +=
+			'respond to the request below, under "Request". The content of the current post is under "Content"';
 	} else {
 		job +=
 			'modify the content shared below, under "Content", based on the request below, under "Request"';
@@ -226,6 +229,16 @@ export function buildPrompt( {
 			prompt = buildPromptTemplate( {
 				request: `Please, rewrite the content below in the following language: ${ options.language }.`,
 				content: options.contentType === 'generated' ? generatedContent : allPostContent,
+			} );
+			break;
+
+		/**
+		 * Open ended prompt from user
+		 */
+		case 'userPrompt':
+			prompt = buildPromptTemplate( {
+				request: userPrompt,
+				content: allPostContent || generatedContent,
 			} );
 			break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31010 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
For prompts written by the user, share post content in the request whenever there's post content. Currently we don't do so, and the AI Assistant lacks context when asking about something related to the post.

Before:
<img width="381" alt="Screenshot 2023-05-27 at 21 03 05" src="https://github.com/Automattic/jetpack/assets/16329583/eca5b1e0-045e-4e8e-86f2-ac5ef2803fbc">


After:
![image](https://github.com/Automattic/jetpack/assets/16329583/dfb34a5a-5670-4008-9f8e-377345eb845c)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to editor
* Add content to the post
* Confirm that the content is shared in requests

