### PR TITLE
Jetpack Forms: fix a typo in the template filter

### DIFF
--- a/projects/packages/forms/changelog/fix-template_filter_name
+++ b/projects/packages/forms/changelog/fix-template_filter_name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: A typo in an unreleased filter was fixed.
+
+

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.19.0",
+	"version": "0.19.1-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.19.0';
+	const PACKAGE_VERSION = '0.19.1-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1692,7 +1692,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 *
 		 * @param string the filename of the HTML template used for response emails to the form owner.
 		 */
-		require apply_filters( 'jetpack_forms_respone_email_template', __DIR__ . '/templates/email-response.php' );
+		require apply_filters( 'jetpack_forms_response_email_template', __DIR__ . '/templates/email-response.php' );
 		$html_message = sprintf(
 			// The tabs are just here so that the raw code is correctly formatted for developers
 			// They're removed so that they don't affect the final message sent to users

--- a/projects/plugins/jetpack/changelog/fix-template_filter_name
+++ b/projects/plugins/jetpack/changelog/fix-template_filter_name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: A typo in an unreleased filter was fixed.
+
+

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -4255,7 +4255,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		 *
 		 * @param string the filename of the HTML template used for response emails to the form owner.
 		 */
-		require apply_filters( 'jetpack_forms_respone_email_template', __DIR__ . '/grunion-response-email-template.php' );
+		require apply_filters( 'jetpack_forms_response_email_template', __DIR__ . '/grunion-response-email-template.php' );
 		$html_message = sprintf(
 			// The tabs are just here so that the raw code is correctly formatted for developers
 			// They're removed so that they don't affect the final message sent to users


### PR DESCRIPTION
Note: this is a duplicate of #30944.
A filter on the template used for form responses has a small typo in it.
The filter is "jetpack_forms_respone_email_template" but it should be "jetpack_forms_response_email_template"

This PR fixes that, while maintaining the old filter, just in case someone has started using it already.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pcsBup-yo-p2#comment-452

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply the changes in this PR.
Embed a contact form in a page and then fill it out.
There shouldn't be any visible changes or PHP errors if the patch works.

You could also use the filter to create a simple template for the response email.
Create a file called wp-content/jp-forms-template.php with the following content:
```
<?php

$template = '
<!doctype html>
<html xmlns="http://www.w3.org/1999/xhtml">
<body>
<!-- title -->
<h1>%1$s</h1>

<!-- response -->
<p>%2$s</p>

<!-- link to responses page -->
<p><a href="%3$s">View Responses</a></p>

<!-- link to edit form -->
<p><a href="%4$s">Edit</a></p>

<!-- footer -->
<p>%5$s</p>
</body>
</html>';
```
Then create an mu-plugin with the following code:
```
<?php

function jp_forms_template( $filename ) {
        return ABSPATH . '/wp-content/jp-forms-template.php';
}

add_filter( 'jetpack_forms_response_email_template', 'jp_forms_template' );
```

Now fill out the contact form and wait for the response email. It should show a basic email with only the response and some metadata.