### PR TITLE
AI Assistant: rely on ai-assistant-feature to show upgrade banner

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-handle-require-upgrade-cross-site-types
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-handle-require-upgrade-cross-site-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Assistant: rely on ai-assistant-feature to show upgrade banner

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -61,8 +61,7 @@ const AIControl = ( {
 	};
 
 	const connected = isUserConnected();
-
-	const { requireUpgrade: showUpgradeBanner } = useAIFeature();
+	const { requireUpgrade: siteRequireUpgrade } = useAIFeature();
 
 	const textPlaceholder = __( 'Ask Jetpack AI', 'jetpack' );
 
@@ -80,7 +79,7 @@ const AIControl = ( {
 
 	return (
 		<>
-			{ ( showUpgradeBanner || requireUpgrade ) && <UpgradePrompt /> }
+			{ ( siteRequireUpgrade || requireUpgrade ) && <UpgradePrompt /> }
 			{ ! connected && <ConnectPrompt /> }
 			{ ! isWaitingState && connected && (
 				<ToolbarControls
@@ -142,7 +141,9 @@ const AIControl = ( {
 					onKeyPress={ handleInputEnter }
 					placeholder={ placeholder }
 					className="jetpack-ai-assistant__input"
-					disabled={ isWaitingState || loadingImages || ! connected }
+					disabled={
+						isWaitingState || loadingImages || ! connected || siteRequireUpgrade || requireUpgrade
+					}
 					ref={ promptUserInputRef }
 				/>
 
@@ -152,7 +153,9 @@ const AIControl = ( {
 							className="jetpack-ai-assistant__prompt_button"
 							onClick={ () => handleGetSuggestion( 'userPrompt' ) }
 							isSmall={ true }
-							disabled={ ! userPrompt?.length || ! connected }
+							disabled={
+								! userPrompt?.length || ! connected || siteRequireUpgrade || requireUpgrade
+							}
 							label={ __( 'Send request', 'jetpack' ) }
 						>
 							<Icon icon={ origamiPlane } />

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -9,6 +9,7 @@ type SiteAIAssistantFeatureEndpointResponseProps = {
 	'is-over-limit': boolean;
 	'requests-count': number;
 	'requests-limit': number;
+	'site-require-upgrade': boolean;
 };
 
 const NUM_FREE_REQUESTS_LIMIT = 20;
@@ -29,16 +30,12 @@ export default function useAIFeature() {
 			} );
 
 			try {
-				const hasFeature = !! response[ 'has-feature' ];
-				const isOverLimit = !! response[ 'is-over-limit' ];
-				const requireUpgrade = ! hasFeature && isOverLimit;
-
 				setData( {
-					hasFeature,
-					isOverLimit,
+					hasFeature: !! response[ 'has-feature' ],
+					isOverLimit: !! response[ 'is-over-limit' ],
 					requestsCount: response[ 'requests-count' ],
 					requestsLimit: response[ 'requests-limit' ],
-					requireUpgrade,
+					requireUpgrade: !! response[ 'site-require-upgrade' ],
 				} );
 			} catch ( error ) {
 				console.error( error ); // eslint-disable-line no-console


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Depends on https://github.com/Automattic/jetpack/pull/31018

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: rely on ai-assistant-feature to show upgrade banner

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up your sandbox dev environment
* Confirm you see the `ai-assistant-feature` endpoint

<img width="789" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/71a9383e-5b5c-4a86-b4a3-7bb383858f6c">

<img width="647" alt="Screenshot 2023-05-29 at 09 44 36" src="https://github.com/Automattic/jetpack/assets/77539/adb5a0aa-fbc1-477a-9043-bc80bfe614fc">

* Based on the following table, confirm the banner shows up only for Jetpack sites without a plan, and once the requests limit is achieved

Requests limit achieved? | Has Plan? | Simple | Atomic | Jetpack
-------------------------|------------|--------|--------|---------|
NO                                     | NO              | 🍏         | 🍏         | 🍏          |
YES                                    | NO              | 🍏         | 🍏         | 🍎         |         
YES                                    | YES             | 🍏         | 🍏         | 🍏          |

You should see the banner a few minutes after the block instance is created:

<img width="660" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/f21e0816-e30d-4293-93ae-df6baa25b20c">

