### PR TITLE
Social Previews: Fix comments from #29803 review

### DIFF
--- a/projects/js-packages/base-styles/changelog/fix-social-previews-pr-29803
+++ b/projects/js-packages/base-styles/changelog/fix-social-previews-pr-29803
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added the jp-highlight colour for use with the social previews

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.5.0",
+	"version": "0.5.1-alpha",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/root-variables.scss
+++ b/projects/js-packages/base-styles/root-variables.scss
@@ -67,4 +67,6 @@
   --jp-button-radius: 4px;
 
   --jp-gap: 16px;
+
+  --jp-highlight: #3858e9;
 }

--- a/projects/js-packages/publicize-components/changelog/fix-social-previews-pr-29803
+++ b/projects/js-packages/publicize-components/changelog/fix-social-previews-pr-29803
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social Previews: Update the LinkedIn default profile image and make the text translatable

--- a/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/linkedin.js
@@ -1,4 +1,5 @@
 import { LinkedInPreviews } from '@automattic/social-previews';
+import { __ } from '@wordpress/i18n';
 import React from 'react';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { getLinkedInDetails } from '../../store/selectors';
@@ -21,7 +22,7 @@ export function LinkedIn( props ) {
 
 	return (
 		<LinkedInPreviews
-			jobTitle="Job Title (Company Name)"
+			jobTitle={ __( 'Job Title (Company Name)', 'jetpack' ) }
 			image={ image }
 			name={ name }
 			profileImage={ profileImage }

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.scss
@@ -2,10 +2,8 @@
  * Modal styles for Social Previews
  */
 
+@import '@automattic/jetpack-base-styles/root-variables';
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
-
-$jp-gray: #dcdcde;
-$highlight-color: #3858e9;
 
 // Styles shared between modals
 .jetpack-social-previews__modal {
@@ -43,7 +41,7 @@ $highlight-color: #3858e9;
 		justify-content: center;
 		height: 3rem;
 		max-width: none;
-		border-bottom: 1px solid $jp-gray;
+		border-bottom: 1px solid var( --jp-gray );
 
 		.components-button {
 			outline: 0;
@@ -59,12 +57,12 @@ $highlight-color: #3858e9;
 
 			&.is-active::after {
 				height: 0px;
-				border-bottom: 1px solid $highlight-color;
+				border-bottom: 1px solid var( --jp-highlight );
 				margin-bottom: -1px;
 			}
 
 			&:not( :disabled ):not( [aria-disabled='true'] ):not( .is-secondary ):not( .is-primary ):not( .is-tertiary ):not( .is-link ):hover::after {
-				border-bottom: 1px solid $highlight-color;
+				border-bottom: 1px solid var( --jp-highlight );
 				margin-bottom: -1px;
 			}
 		}

--- a/projects/js-packages/publicize-components/src/store/selectors.js
+++ b/projects/js-packages/publicize-components/src/store/selectors.js
@@ -58,7 +58,8 @@ export function getLinkedInDetails( { forceDefaults = false } = {} ) {
 
 	return {
 		name: __( 'Account Name', 'jetpack' ),
-		profileImage: 'https://static.licdn.com/sc/h/1c5u578iilxfi4m4dvc4q810q',
+		profileImage:
+			"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128' id='person-accent-4'%3E%3Cpath fill='%23e7e2dc' d='M0 0h128v128H0z'/%3E%3Cpath d='M88.41 84.67a32 32 0 10-48.82 0 66.13 66.13 0 0148.82 0z' fill='%23788fa5'/%3E%3Cpath d='M88.41 84.67a32 32 0 01-48.82 0A66.79 66.79 0 000 128h128a66.79 66.79 0 00-39.59-43.33z' fill='%239db3c8'/%3E%3Cpath d='M64 96a31.93 31.93 0 0024.41-11.33 66.13 66.13 0 00-48.82 0A31.93 31.93 0 0064 96z' fill='%2356687a'/%3E%3C/svg%3E",
 	};
 }
 


### PR DESCRIPTION
These fixes the three comments made by @jeherve on #29803

## Proposed changes:

- Adds the highlight colour to the root-variables and updates the CSS to the jp- vars.
- Makes the job title text for the LinkedIn preview translatable
- Updates the default profile image for LinkedIn to use a data URI

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/29803#pullrequestreview-1445678445

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

* Open the social previews modal from the Jetpack sidebar in either the Jetpack or Social plugin
* Check that the styling still looks the same - the border colours of the top tab bar etc.
* Check the default LinkedIn profile image looks the same

