### PR TITLE
Stats: display links to post's stats even when not connected

### DIFF
--- a/projects/plugins/jetpack/changelog/update-stats-posts-column-access
+++ b/projects/plugins/jetpack/changelog/update-stats-posts-column-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Stats: display the links to a post's stats in the Posts list as soon as  the user has access to stats.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1636,7 +1636,7 @@ function jetpack_stats_load_admin_css() {
 }
 
 /**
- * Set header for column that allows to go to WordPress.com to see an entry's stats.
+ * Set header for column that allows to view an entry's stats.
  *
  * @param array $columns An array of column names.
  *
@@ -1645,8 +1645,22 @@ function jetpack_stats_load_admin_css() {
  * @return mixed
  */
 function jetpack_stats_post_table( $columns ) {
-	// Adds a stats link on the edit posts page.
-	if ( ! current_user_can( 'view_stats' ) || ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
+	/*
+	 * Stats can be accessed in wp-admin or in Calypso,
+	 * depending on what version of the stats screen is enabled on your site.
+	 *
+	 * In both cases, the user must be allowed to access stats.
+	 *
+	 * If the Odyssey Stats experience isn't enabled, the user will need to go to Calypso,
+	 * so they need to be connected to WordPress.com to be able to access that page.
+	 */
+	if (
+		! current_user_can( 'view_stats' )
+		|| (
+			! Stats_Options::get_option( 'enable_odyssey_stats' )
+			&& ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected()
+		)
+	) {
 		return $columns;
 	}
 


### PR DESCRIPTION
## Proposed changes:

With Odyssey stats, one can now access stats in wp-admin, even when not connected to WordPress.com, as long as their role gives them access to stats. We can consequently display the icon in the posts list as soon as the user is allowed access to stats.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site connected to WordPress.com, with the stats module active.
* Ensure you can see the little graph icon next to each post in Posts > All Posts.
* Go to Users > Add New, and create a new user with the editor role.
* Log in with that user in a new browser.
    * You should not see the icon pointing to stats in the Posts list yet.
* Back to the browser logged in as admin, go to Jetpack > Settings > Traffic and change your stats configuration to give editors access to stats.
* Back to the browser logged in as editor, you should now see the graph icon.
* Click on the icon, you should be redirected to the stats page.
* Back to the browser logged in as admin, go to Jetpack > Settings > Traffic and disable the new stats experience.
* Back to the browser logged in as editor, the graph icon next to each post should now be gone.
* Go to the Jetpack Dashboard, and connect your editor account to a WordPress.com account.
* Once the connection is complete, you should see the Graph icon next to each post.
* Click on one of them, you should be redirected to WordPress.com to see the stats in Calypso.
