### PR TITLE
[Doc] Clarify the use of getPaidPlanLink()

### DIFF
--- a/projects/plugins/jetpack/changelog/add-small-doc
+++ b/projects/plugins/jetpack/changelog/add-small-doc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add some documention to getPaidPlanLink()

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/utils.js
@@ -22,9 +22,10 @@ export const encodeValueForShortcodeAttribute = value => {
 		.replace( /\u200b/g, '&#x200b;' );
 };
 
-export const getPaidPlanLink = forNewsletterPlans => {
+export const getPaidPlanLink = alreadyHasNewsletterPlans => {
 	const link = 'https://wordpress.com/earn/payments-plans/' + location.hostname;
-	return forNewsletterPlans ? link : link + '#add-newsletter-payment-plan';
+	// We force the "Newsletters plan" link only if there is no plans already created
+	return alreadyHasNewsletterPlans ? link : link + '#add-newsletter-payment-plan';
 };
 
 export const isNewsletterFeatureEnabled = () => {


### PR DESCRIPTION
Just a very small add of documentation to clarify and enhance wording: the parameter **forNewsletterPlans** for `getPaidPlanLink` was misnamed and could potentially cause confusion in the future.
