### PR TITLE
CRM:  Change edit pages to fit Jetpack Emerald style

### DIFF
--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -139,46 +139,15 @@ function jpcrm_render_company_view_page( $id = -1 ) {
 					// 1 column, no avatar card
 				?>
 					<div class="sixteen wide column zbs-view-card">
-					<?php
-					/*
-					} else {
-
-					// normal, 2 column 'contact card'
-					?><div class="three wide column" style="text-align:center">
-						<?php echo $avatar; ?>
-						<a class="ui button blue mini" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link('edit',$id,'zerobs_customer',false);?>">
-							<?php _e("Edit Contact", "zero-bs-crm"); ?>
-						</a>
-
-					</div>
-					<div class="thirteen wide column zbs-view-card"><?php
-
-
-					}*/
-					?>
-
 						<h3>
 						<?php echo esc_html( zeroBS_companyName( '', $company, false, false ) ); ?>
-						<?php
-						// } When no avatar, show edit button top right
-							// no avatars yet for co - if ($avatarMode == 3 || empty($avatar)){
-						?>
-							<a class="ui button black mini right floated" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link( 'edit', $id, 'zerobs_company', false ); ?>">
-									<?php esc_html_e( 'Edit ' . jpcrm_label_company(), 'zero-bs-crm' ); ?>
-								</a>
-								<?php
-								// no avatars yet for co - }
-								?>
 						</h3>
-						<?php
-						/*
-						<p class="zbs-email">
-						<?php zeroBSCRM_html_sendemailto($id,$contactEmail,false); ?>
-						</p> */
-						?>
 						<p class="zbs-sentence">
 							<?php echo zeroBSCRM_html_companyIntroSentence( $company ); ?>
 						</p>
+						<a class="ui button black" style="margin-top:0.8em" href="<?php echo jpcrm_esc_link( 'edit', $id, 'zerobs_company', false ); ?>">
+								<?php esc_html_e( 'Edit ' . jpcrm_label_company(), 'zero-bs-crm' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText ?>
+						</a>
 
 
 						<?php

--- a/projects/plugins/crm/admin/settings/field-options.page.php
+++ b/projects/plugins/crm/admin/settings/field-options.page.php
@@ -197,7 +197,7 @@ if ( isset( $sbupdated ) ) {
 								<p style="margin-top:4px">
 								<?php
 								echo esc_html(
-									printf(
+									sprintf(
 										/* Translators: %s: is the company label */
 										__( 'Choose whether to show or hide Contact/%s ID on contact record and manage pages', 'zero-bs-crm' ),
 										jpcrm_label_company()

--- a/projects/plugins/crm/changelog/fix-crm-3124-change-crm-edit-pages-to-emerald
+++ b/projects/plugins/crm/changelog/fix-crm-3124-change-crm-edit-pages-to-emerald
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+CRM: edit pages changed to match Jetpack Emerald style

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1281,74 +1281,104 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 
    			global $zbs;
 
-	        switch ($fieldVal[0]){
-
-	            case 'text':
-
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
-	                	<div class="zbs-text-input <?php echo esc_attr( $fieldKey ); ?>">
-
-	                    	<input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control widetext zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
-
+		switch ( $fieldVal[0] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			case 'text':
+				?>
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
+						<div class="zbs-text-input <?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>">
+								<input
+									type="text"
+									name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+									id="<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+									class="form-control widetext zbs-dc<?php echo esc_attr( $inputClasses ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+									placeholder="<?php if ( isset( $fieldVal[2] ) ) echo esc_attr__( $fieldVal[2], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText, Generic.ControlStructures.InlineControlStructure.NotAllowed ?>"
+									value="<?php if ( $value !== -99 ) echo esc_attr( $value ); else echo esc_attr( $default ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, Generic.ControlStructures.InlineControlStructure.NotAllowed, Generic.Formatting.DisallowMultipleStatements.SameLine, Squiz.PHP.EmbeddedPhp.MultipleStatements ?>"
+									autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+								/>
 	                    </div>
-	                </td></tr><?php
+						</div>
+				<?php
 
 	                break;
 
 	            case 'price':
 
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
-
-	                    <?php echo esc_html( zeroBSCRM_getCurrencyChr() ); ?> <input style="width: 130px;display: inline-block;" type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control numbersOnly zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default );  ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
-
-	                </td></tr><?php
+				?>
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
+						<div class="jpcrm-form-input-group">
+								<?php echo esc_html( zeroBSCRM_getCurrencyChr() ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>
+								<input
+									type="text"
+									name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+									id="<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+									class="form-control numbersOnly zbs-dc<?php echo esc_attr( $inputClasses ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+									placeholder="<?php if ( isset( $fieldVal[2] ) ) echo esc_attr__( $fieldVal[2], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText, Generic.ControlStructures.InlineControlStructure.NotAllowed ?>"
+									value="<?php if ( $value !== -99 ) echo esc_attr( $value ); else echo esc_attr( $default ); // phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed, Generic.Formatting.DisallowMultipleStatements.SameLine, Squiz.PHP.EmbeddedPhp.MultipleStatements ?>"
+									autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+								/>
+						</div>
+					</div>
+				<?php
 
 	                break;
 
                 case 'numberfloat':
 
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
-
-	                    <input style="width: 130px;display: inline-block;" type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control numbersOnly zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
-
-	                </td></tr><?php
+				?>
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
+						<input
+							type="text"
+							name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+							id="<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+							class="form-control numbersOnly zbs-dc<?php echo esc_attr( $inputClasses ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+							placeholder="<?php if ( isset( $fieldVal[2] ) ) echo esc_attr__( $fieldVal[2], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText, Generic.ControlStructures.InlineControlStructure.NotAllowed ?>"
+							value="<?php if ( $value !== -99 ) echo esc_attr( $value ); else echo esc_attr( $default ); // phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed, Generic.Formatting.DisallowMultipleStatements.SameLine, Squiz.PHP.EmbeddedPhp.MultipleStatements ?>"
+							autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+						/>
+						</div>
+						<?php
 
 	                break;
 
                 case 'numberint':
 
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
-
-	                    <input style="width: 130px;display: inline-block;" type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control intOnly zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
-
-	                </td></tr><?php
-
-	                break;
-
+				?>
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
+								<input
+									type="text"
+									name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+									id="<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+									class="form-control intOnly zbs-dc<?php echo esc_attr( $inputClasses ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+									placeholder="<?php if ( isset( $fieldVal[2] ) ) echo esc_attr__( $fieldVal[2], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText, Generic.ControlStructures.InlineControlStructure.NotAllowed ?>"
+									value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); // phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed, Generic.Formatting.DisallowMultipleStatements.SameLine, Squiz.PHP.EmbeddedPhp.MultipleStatements ?>"
+									autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"
+								/>
+						</div>
+				<?php
+					break;
 
 			case 'date':
 				$datevalue = '';
-
 				if ( $value !== -99 ) {
-					$datevalue = jpcrm_uts_to_date_str( $value, 'Y-m-d', true );
+					$datevalue = $value;
+					$datevalue = zeroBSCRM_date_i18n( -1, $datevalue, false, true );
 				}
-
-				// if this is a custom field, and is unset, we let it get passed as empty (gh-56)
 				if ( isset( $fieldVal['custom-field'] ) && ( $value === -99 || $value === '' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					$datevalue = '';
+				} elseif ( $value === -99 ) {
+					$inputClasses = ' zbs-empty-start'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				}
-				// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				?>
-				<tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); ?>:</label></th>
-				<td>
-				<input type="date" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" placeholder="yyyy-mm-dd" value="<?php echo esc_attr( $datevalue ); ?>"/>
-				</td></tr>
-				<?php
-				// phpcs:enable WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
+							<input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control jpcrm-date zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if ( isset( $fieldVal[2] ) ) echo esc_attr__( $fieldVal[2], 'zero-bs-crm' ); ?>" value="<?php echo esc_attr( $datevalue ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText, Generic.ControlStructures.InlineControlStructure.NotAllowed ?>" />
+						</div>
+						<?php
+
 				break;
 
 
@@ -1359,12 +1389,12 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 	            	// if DAL3 we need to use translated dates here :)
 	            	if ($zbs->isDAL3()) $datevalue = zeroBSCRM_date_i18n_plusTime(-1,$datevalue,true);
 
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
-
+				?>
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control jpcrm-date-time zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php echo esc_attr( $datevalue ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
-
-	                </td></tr><?php
+						</div>
+						<?php
 
 	                break;
 
@@ -1374,8 +1404,9 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 										break;
 									}
 
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
+				?>
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <select name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-watch-input zbs-dc<?php echo esc_attr( $inputClasses ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>">
 	                        <?php
                                 // pre DAL 2 = $fieldV[3], DAL2 = $fieldV[2]
@@ -1417,7 +1448,8 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 	                        ?>
 	                    </select>
                         <input type="hidden" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" id="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" value="0" />
-	                </td></tr><?php
+						</div>
+						<?php
 
 	                break;
 
@@ -1426,8 +1458,10 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 			        // Click 2 call?
 			        $click2call = $zbs->settings->get('clicktocall');
 
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td class="zbs-tel-wrap">
+				?>
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
+						<span class="zbs-tel-wrap">
 
 	                    <input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-tel zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
 	                     <?php if ($click2call == "1" && $value !== -99 && !empty($value)) echo '<a href="' . esc_attr( zeroBSCRM_clickToCallPrefix() . $value ) . '" class="button"><i class="fa fa-phone"></i> ' . esc_html( $value ) . '</a>'; ?>
@@ -1450,7 +1484,9 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
                                             }
 
                                             ?>
-	                </td></tr><?php
+						</span>
+						</div>
+						<?php
 
 	                break;
 
@@ -1460,23 +1496,27 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
                     // ... via js <div class="zbs-text-input">
                     // removed from email for now zbs-text-input
 
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
+				?>
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                	<div class="<?php echo esc_attr( $fieldKey ); ?>">
 
 	                    	<input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-email zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
 
 	                    </div>
-	                </td></tr><?php
+						</div>
+						<?php
 
 	                break;
 
 	            case 'textarea':
 
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
+				?>
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <textarea name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>"><?php if ($value !== -99) echo esc_textarea( $value ); else echo esc_textarea( $default ); ?></textarea>
-	                </td></tr><?php
+						</div>
+						<?php
 
 	                break;
 
@@ -1485,8 +1525,9 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 
 	                $countries = zeroBSCRM_loadCountryList();
 
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
+				?>
+						<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <select name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-dc<?php echo esc_attr( $inputClasses ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>">
 	                        <?php
 
@@ -1519,7 +1560,8 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 
 	                        ?>
 	                    </select>
-	                </td></tr><?php
+						</div>
+						<?php
 
 	                break;
 
@@ -1529,8 +1571,10 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 	                // auto number - can't actually edit autonumbers, so its just outputting :)
 		            case 'autonumber':
 
-		                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-		                <td class="zbs-field-id">
+				?>
+						<div class="jpcrm-form-group">
+								<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
+								<span class="zbs-field-id">
 		                	<?php
 
 		                		// output any saved autonumber for this obj
@@ -1549,15 +1593,18 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		                		echo '<input type="hidden" value="' . esc_attr( $str ) . '" name="'. esc_attr( $postPrefix.$fieldKey ) .'" />';
 
 		                	?>
-		                </td></tr><?php
+							</span>							
+							</div>
+						<?php
 
 		                break;
 
 		            // radio
 		            case 'radio':
 
-		                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-		                <td>
+				?>
+						<div class="jpcrm-form-group">
+								<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 		                    <div class="zbs-field-radio-wrap">
 		                        <?php
 
@@ -1581,26 +1628,28 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		                                	echo '<div class="zbs-radio"><input type="radio" name="'. esc_attr( $postPrefix.$fieldKey ) .'" id="'. esc_attr( $fieldKey.'-'.$optIndex ) .'" value="' . esc_attr( $opt ) . '"';
 
 		                                    if ($value !== -99 && $value == $opt) echo ' checked="checked"'; 
-		                                    echo ' /> <label for="'. esc_attr( $fieldKey.'-'.$optIndex ) .'">' . esc_html( $opt ) . '</label></div>';
+														echo ' /> <label class="jpcrm-form-label" for="' . esc_attr( $fieldKey . '-' . $optIndex ) . '">' . esc_html( $opt ) . '</label></div>'; //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		                                    $optIndex++;
 
 		                                }
 
-		                            } else echo '<label for="'. esc_attr( $fieldKey ) .'-0">'. esc_attr__('No Options','zero-bs-crm').'!</label>'; //<input type="radio" name="'.$postPrefix.$fieldKey.'" id="'.$fieldKey.'-0" value="" checked="checked" /> 
-
+						} else {
+												echo '<label class="jpcrm-form-label" for="' . esc_attr( $fieldKey ) . '-0">' . esc_attr__( 'No Options', 'zero-bs-crm' ) . '!</label>'; //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+						}
 		                        ?>
 		                    </div>
 	                        <input type="hidden" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" id="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" value="0" />
-		                </td></tr><?php
+								</div>
+								<?php
 
 		                break;
 
 		            // checkbox
 		            case 'checkbox':
-
-		                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-		                <td>
+				?>
+								<div class="jpcrm-form-group">
+								<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 		                    <div class="zbs-field-checkbox-wrap">
 		                        <?php
 
@@ -1629,26 +1678,29 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 
 		                                	echo '<div class="ui checkbox"><input type="checkbox" name="'. esc_attr( $postPrefix.$fieldKey.'-'.$optIndex ).'" id="'. esc_attr( $fieldKey.'-'.$optIndex ) .'" value="' . esc_attr( $opt ) . '"';
 		                                    if (in_array($opt, $dataOpts)) echo ' checked="checked"'; 
-		                                    echo ' /><label for="'. esc_attr( $fieldKey.'-'.$optIndex ) .'">' . esc_html( $opt ) . '</label></div>';
+														echo ' /><label class="jpcrm-form-label" for="' . esc_attr( $fieldKey . '-' . $optIndex ) . '">' . esc_html( $opt ) . '</label></div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		                                    $optIndex++;
 
 		                                }
 
-		                            } else echo '<label for="'. esc_attr( $fieldKey ).'-0">'. esc_html__('No Options','zero-bs-crm').'!</label>';
+						} else {
+												echo '<label class="jpcrm-form-label" for="' . esc_attr( $fieldKey ) . '-0">' . esc_html__( 'No Options', 'zero-bs-crm' ) . '!</label>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+						}
 
 		                        ?>
 		                    </div>
 	                        <input type="hidden" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" id="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" value="0" />
-		                </td></tr><?php
+								</div>
+								<?php
 
 		                break;
 
 		            // tax
 		            case 'tax':
-
-	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
-	                <td>
+				?>
+							<div class="jpcrm-form-group">
+							<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <select name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-watch-input zbs-dc<?php echo esc_attr( $inputClasses ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>">
 	                        <?php
 
@@ -1683,7 +1735,8 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 	                        ?>
 	                    </select>
                         <input type="hidden" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" id="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" value="0" />
-	                </td></tr><?php
+						</div>
+						<?php
 
 	                break;
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1216,7 +1216,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
    // puts out edit field for an object (e.g. quotes)
    // centralisd/genericified 20/7/18 wh 2.91+
    function zeroBSCRM_html_editField($dataArr=array(), $fieldKey = false, $fieldVal = false, $postPrefix = 'zbs_'){
-
+		// phpcs:disable
    	/* debug
    	if ($fieldKey == 'house-type') {
    		echo '<tr><td colspan="2">'.$fieldKey.'<pre>'.print_r(array($fieldVal,$dataArr),1).'</pre></td></tr>';
@@ -1742,7 +1742,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 	        } // switch
 
     	} // if is legit params
-
+		// phpcs:enable
    }
 
 	// TODO: Refactor invoice edit fields.

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1743,7 +1743,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 
     	} // if is legit params
 		// phpcs:enable
-   }
+}
 
 	// TODO: Refactor invoice edit fields.
 	// phpcs:disable

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1284,7 +1284,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		switch ( $fieldVal[0] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			case 'text':
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 						<div class="zbs-text-input <?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>">
 								<input
@@ -1305,7 +1305,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 	            case 'price':
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 						<div class="jpcrm-form-input-group">
 								<?php echo esc_html( zeroBSCRM_getCurrencyChr() ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>
@@ -1327,7 +1327,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
                 case 'numberfloat':
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 						<input
 							type="text"
@@ -1346,7 +1346,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
                 case 'numberint':
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 								<input
 									type="text"
@@ -1372,7 +1372,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 					$datevalue = '';
 				}
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 							<input type="date" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" placeholder="yyyy-mm-dd" value="<?php echo esc_attr( $datevalue ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"/>
 						</div>
@@ -1389,7 +1389,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 	            	if ($zbs->isDAL3()) $datevalue = zeroBSCRM_date_i18n_plusTime(-1,$datevalue,true);
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control jpcrm-date-time zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php echo esc_attr( $datevalue ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
 						</div>
@@ -1404,7 +1404,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 									}
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <select name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-watch-input zbs-dc<?php echo esc_attr( $inputClasses ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>">
 	                        <?php
@@ -1458,7 +1458,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 			        $click2call = $zbs->settings->get('clicktocall');
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 						<span class="zbs-tel-wrap">
 
@@ -1496,7 +1496,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
                     // removed from email for now zbs-text-input
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                	<div class="<?php echo esc_attr( $fieldKey ); ?>">
 
@@ -1511,7 +1511,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 	            case 'textarea':
 
 				?>
-						<div class="jpcrm-form-group jpcrm-form-group-span-2">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2 jpcrm-form-group jpcrm-form-group-span-2-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <textarea name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>"><?php if ($value !== -99) echo esc_textarea( $value ); else echo esc_textarea( $default ); ?></textarea>
 						</div>
@@ -1525,7 +1525,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 	                $countries = zeroBSCRM_loadCountryList();
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <select name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-dc<?php echo esc_attr( $inputClasses ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>">
 	                        <?php
@@ -1571,7 +1571,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		            case 'autonumber':
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 								<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 								<span class="zbs-field-id">
 		                	<?php
@@ -1602,7 +1602,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		            case 'radio':
 
 				?>
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 								<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 		                    <div class="zbs-field-radio-wrap">
 		                        <?php
@@ -1647,7 +1647,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		            // checkbox
 		            case 'checkbox':
 				?>
-								<div class="jpcrm-form-group">
+								<div class="jpcrm-form-group jpcrm-form-group-span-2">
 								<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 		                    <div class="zbs-field-checkbox-wrap">
 		                        <?php
@@ -1698,7 +1698,7 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 		            // tax
 		            case 'tax':
 				?>
-							<div class="jpcrm-form-group">
+							<div class="jpcrm-form-group jpcrm-form-group-span-2">
 							<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
 	                    <select name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-watch-input zbs-dc<?php echo esc_attr( $inputClasses ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>">
 	                        <?php

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1746,6 +1746,470 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 
    }
 
+	// TODO: Refactor invoice edit fields.
+	// phpcs:disable
+   function zeroBSCRM_html_editField_for_invoices($dataArr=array(), $fieldKey = false, $fieldVal = false, $postPrefix = 'zbs_') {
+
+   	/* debug
+   	if ($fieldKey == 'house-type') {
+   		echo '<tr><td colspan="2">'.$fieldKey.'<pre>'.print_r(array($fieldVal,$dataArr),1).'</pre></td></tr>';
+   	} */
+
+   		if (!empty($fieldKey) && is_array($fieldVal)){
+
+	   		// infer a default (Added post objmodels v3.0 as a potential.)
+	   		$default = ''; if (is_array($fieldVal) && isset($fieldVal['default'])) $default = $fieldVal['default'];
+
+	   		// get a value (this allows field-irrelevant global tweaks, like the addr catch below...)
+	   		// -99 = notset
+	   		$value = -99; if (isset($dataArr[$fieldKey])) $value = $dataArr[$fieldKey];
+
+	   		// custom classes for inputs
+	   		$inputClasses = isset($fieldVal['custom-field']) ? ' zbs-custom-field' : '';
+
+	   			// contacts got stuck in limbo as we upgraded db in 2 phases. 
+	   			// following catches old str and modernises to v3.0
+	   			// make addresses their own objs 3.0+ and do away with this.
+	   			// ... hard typed to avoid custom field collisions, hacky at best.
+	   			switch ($fieldKey){
+
+	   				case 'secaddr1':
+	   					 if (isset($dataArr['secaddr_addr1'])) $value = $dataArr['secaddr_addr1'];
+	   					 break;
+
+	   				case 'secaddr2':
+	   					 if (isset($dataArr['secaddr_addr2'])) $value = $dataArr['secaddr_addr2'];
+	   					 break;
+
+	   				case 'seccity':
+	   					 if (isset($dataArr['secaddr_city'])) $value = $dataArr['secaddr_city'];
+	   					 break;
+
+	   				case 'seccounty':
+	   					 if (isset($dataArr['secaddr_county'])) $value = $dataArr['secaddr_county'];
+	   					 break;
+
+	   				case 'seccountry':
+	   					 if (isset($dataArr['secaddr_country'])) $value = $dataArr['secaddr_country'];
+	   					 break;
+
+	   				case 'secpostcode':
+	   					 if (isset($dataArr['secaddr_postcode'])) $value = $dataArr['secaddr_postcode'];
+	   					 break;
+	   			}
+   			global $zbs;
+
+	        switch ($fieldVal[0]){
+
+	            case 'text':
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+	                	<div class="zbs-text-input <?php echo esc_attr( $fieldKey ); ?>">
+
+	                    	<input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control widetext zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
+
+	                    </div>
+	                </td></tr><?php
+
+	                break;
+
+	            case 'price':
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+
+	                    <?php echo esc_html( zeroBSCRM_getCurrencyChr() ); ?> <input style="width: 130px;display: inline-block;" type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control numbersOnly zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default );  ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
+
+	                </td></tr><?php
+
+	                break;
+
+                case 'numberfloat':
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+
+	                    <input style="width: 130px;display: inline-block;" type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control numbersOnly zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
+
+	                </td></tr><?php
+
+	                break;
+
+                case 'numberint':
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+
+	                    <input style="width: 130px;display: inline-block;" type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control intOnly zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
+
+	                </td></tr><?php
+
+	                break;
+
+
+			case 'date':
+				$datevalue = '';
+
+				if ( $value !== -99 ) {
+					$datevalue = jpcrm_uts_to_date_str( $value, 'Y-m-d', true );
+				}
+
+				// if this is a custom field, and is unset, we let it get passed as empty (gh-56)
+				if ( isset( $fieldVal['custom-field'] ) && ( $value === -99 || $value === '' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					$datevalue = '';
+				}
+				?>
+				<tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); ?>:</label></th>
+				<td>
+				<input type="date" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" placeholder="yyyy-mm-dd" value="<?php echo esc_attr( $datevalue ); ?>"/>
+				</td></tr>
+				<?php
+				break;
+
+
+	            case 'datetime':
+
+	            	$datevalue = ''; if ($value !== -99) $datevalue = $value; 
+
+	            	// if DAL3 we need to use translated dates here :)
+	            	if ($zbs->isDAL3()) $datevalue = zeroBSCRM_date_i18n_plusTime(-1,$datevalue,true);
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+
+	                    <input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control jpcrm-date-time zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php echo esc_attr( $datevalue ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
+
+	                </td></tr><?php
+
+	                break;
+
+	            case 'select':
+									//don't load prefix select if prefix is hidden in settings
+									if ($zbs->settings->get('showprefix') == 0 && $fieldKey == 'prefix') {
+										break;
+									}
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+	                    <select name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-watch-input zbs-dc<?php echo esc_attr( $inputClasses ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>">
+	                        <?php
+                                // pre DAL 2 = $fieldV[3], DAL2 = $fieldV[2]
+                                $options = false; 
+                                if (isset($fieldVal[3]) && is_array($fieldVal[3])) {
+                                    $options = $fieldVal[3];
+                                } else {
+                                    // DAL2 these don't seem to be auto-decompiled?
+                                    // doing here for quick fix, maybe fix up the chain later.
+                                    if (isset($fieldVal[2])) $options = explode(',', $fieldVal[2]);
+                                }
+
+	                            //if (isset($fieldVal[3]) && count($fieldVal[3]) > 0){
+                                if (isset($options) && is_array($options) && count($options) > 0 && $options[0] != ''){
+
+                                	// if $default, use that
+                                	$selectVal = '';
+	                                if ($value !== -99 && !empty($value)){
+	                                	$selectVal = $value;
+	                                } elseif (!empty($default))
+                                		$selectVal = $default;
+
+	                                //catcher
+																	echo '<option value=""' . ($fieldKey == 'prefix' ? '' :' disabled="disabled"');
+	                                if (empty($default) && ($value == -99 || ($value !== -99 && empty($value)))) echo ' selected="selected"';
+	                                echo '>'. esc_html__('Select','zero-bs-crm').'</option>';
+
+	                                foreach ($options as $opt){
+
+	                                    echo '<option value="' . esc_attr( $opt ) . '"';
+
+	                                    if ($selectVal == $opt) echo ' selected="selected"'; 
+	                                    echo '>' . esc_html( $opt ) . '</option>';
+
+	                                }
+
+	                            } else echo '<option value="">'. esc_html__('No Options','zero-bs-crm').'!</option>';
+
+	                        ?>
+	                    </select>
+                        <input type="hidden" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" id="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" value="0" />
+	                </td></tr><?php
+
+	                break;
+
+	            case 'tel':
+
+			        // Click 2 call?
+			        $click2call = $zbs->settings->get('clicktocall');
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td class="zbs-tel-wrap">
+
+	                    <input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-tel zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
+	                     <?php if ($click2call == "1" && $value !== -99 && !empty($value)) echo '<a href="' . esc_attr( zeroBSCRM_clickToCallPrefix() . $value ) . '" class="button"><i class="fa fa-phone"></i> ' . esc_html( $value ) . '</a>'; ?>
+
+                                        <?php 
+
+                                            if ($fieldKey == 'mobtel'){
+
+                                                $sms_class = 'send-sms-none';
+                                                $sms_class = apply_filters('zbs_twilio_sms', $sms_class); 
+                                                do_action('zbs_twilio_nonce');
+
+                                                $customerMob = ''; 
+                                                // wh genericified 
+                                                //if (is_array($dataArr) && isset($dataArr[$fieldKey]) && isset($dataArr['id'])) $customerMob = zeroBS_customerMobile($dataArr['id'],$dataArr);
+                                                if ($value !== -99) $customerMob = $value;
+                                                
+                                                if (!empty($customerMob)) echo '<a class="' . esc_attr( $sms_class ) . ' button" data-smsnum="' . esc_attr( $customerMob ) .'"><i class="mobile alternate icon"></i> '. esc_html__('SMS','zero-bs-crm').': ' . esc_html( $customerMob ) . '</a>';
+
+                                            }
+
+                                            ?>
+	                </td></tr><?php
+
+	                break;
+
+	            case 'email':
+
+                    // added zbs-text-input class 5/1/18 - this allows "linkify" automatic linking
+                    // ... via js <div class="zbs-text-input">
+                    // removed from email for now zbs-text-input
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+	                	<div class="<?php echo esc_attr( $fieldKey ); ?>">
+
+	                    	<input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-email zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" value="<?php if ($value !== -99) echo esc_attr( $value ); else echo esc_attr( $default ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>" />
+
+	                    </div>
+	                </td></tr><?php
+
+	                break;
+
+	            case 'textarea':
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+	                    <textarea name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if (isset($fieldVal[2])) echo esc_attr__($fieldVal[2],'zero-bs-crm'); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>"><?php if ($value !== -99) echo esc_textarea( $value ); else echo esc_textarea( $default ); ?></textarea>
+	                </td></tr><?php
+
+	                break;
+
+	            #} Added 1.1.19 
+	            case 'selectcountry':
+
+	                $countries = zeroBSCRM_loadCountryList();
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+	                    <select name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-dc<?php echo esc_attr( $inputClasses ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>">
+	                        <?php
+
+	                            #if (isset($fieldVal[3]) && count($fieldVal[3]) > 0){
+	                            if (isset($countries) && count($countries) > 0){
+
+	                                //catcher
+	                                echo '<option value=""';
+	                                if (empty($default) && ($value == -99 || ($value !== -99 && empty($value)))) echo ' selected="selected"';
+	                                echo '>'. esc_html__('Select','zero-bs-crm').'</option>';
+
+	                                foreach ($countries as $countryKey => $country){
+
+	                                        // temporary fix for people storing "United States" but also "US"
+	                                        // needs a migration to iso country code, for now, catch the latter (only 1 user via api)
+
+
+	                                    echo '<option value="' . esc_attr( $country ) . '"';
+	                                    if ($value !== -99 && (
+	                                                strtolower($value) == strtolower($country)
+	                                                ||
+	                                                strtolower($value) == strtolower($countryKey)
+	                                            )) echo ' selected="selected"'; 
+	                                    echo '>' . esc_html( $country ) . '</option>';
+
+	                                }
+	                                
+
+	                            } else echo '<option value="">'. esc_html__('No Countries Loaded','zero-bs-crm').'</option>';
+
+	                        ?>
+	                    </select>
+	                </td></tr><?php
+
+	                break;
+
+
+	                // 2.98.5 added autonumber, checkbox, radio
+
+	                // auto number - can't actually edit autonumbers, so its just outputting :)
+		            case 'autonumber':
+
+		                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+		                <td class="zbs-field-id">
+		                	<?php
+
+		                		// output any saved autonumber for this obj
+		                		$str = ''; if ($value !== -99) $str = $value;
+
+		                		// we strip the hashes saved in db for easy separation later
+		                		$str = str_replace('#','',$str);
+
+		                		// then output...
+		                		if (empty($str)) 
+		                			echo '~';
+		                		else
+		                			echo esc_html( $str );
+
+		                		// we also output as input, which stops any overwriting + makes new ones for new records
+		                		echo '<input type="hidden" value="' . esc_attr( $str ) . '" name="'. esc_attr( $postPrefix.$fieldKey ) .'" />';
+
+		                	?>
+		                </td></tr><?php
+
+		                break;
+
+		            // radio
+		            case 'radio':
+
+		                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+		                <td>
+		                    <div class="zbs-field-radio-wrap">
+		                        <?php
+
+	                                // pre DAL 2 = $fieldV[3], DAL2 = $fieldV[2]
+	                                $options = false; 
+	                                if (isset($fieldVal[3]) && is_array($fieldVal[3])) {
+	                                    $options = $fieldVal[3];
+	                                } else {
+	                                    // DAL2 these don't seem to be auto-decompiled?
+	                                    // doing here for quick fix, maybe fix up the chain later.
+	                                    if (isset($fieldVal[2])) $options = explode(',', $fieldVal[2]);
+	                                }
+
+		                            //if (isset($fieldVal[3]) && count($fieldVal[3]) > 0){
+	                                if (isset($options) && is_array($options) && count($options) > 0 && $options[0] != ''){
+
+	                                	$optIndex = 0;
+
+		                                foreach ($options as $opt){
+
+		                                	echo '<div class="zbs-radio"><input type="radio" name="'. esc_attr( $postPrefix.$fieldKey ) .'" id="'. esc_attr( $fieldKey.'-'.$optIndex ) .'" value="' . esc_attr( $opt ) . '"';
+
+		                                    if ($value !== -99 && $value == $opt) echo ' checked="checked"'; 
+		                                    echo ' /> <label for="'. esc_attr( $fieldKey.'-'.$optIndex ) .'">' . esc_html( $opt ) . '</label></div>';
+
+		                                    $optIndex++;
+
+		                                }
+
+		                            } else echo '<label for="'. esc_attr( $fieldKey ) .'-0">'. esc_attr__('No Options','zero-bs-crm').'!</label>'; //<input type="radio" name="'.$postPrefix.$fieldKey.'" id="'.$fieldKey.'-0" value="" checked="checked" /> 
+
+		                        ?>
+		                    </div>
+	                        <input type="hidden" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" id="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" value="0" />
+		                </td></tr><?php
+
+		                break;
+
+		            // checkbox
+		            case 'checkbox':
+
+		                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+		                <td>
+		                    <div class="zbs-field-checkbox-wrap">
+		                        <?php
+
+	                                // pre DAL 2 = $fieldV[3], DAL2 = $fieldV[2]
+	                                $options = false; 
+	                                if (isset($fieldVal[3]) && is_array($fieldVal[3])) {
+	                                    $options = $fieldVal[3];
+	                                } else {
+	                                    // DAL2 these don't seem to be auto-decompiled?
+	                                    // doing here for quick fix, maybe fix up the chain later.
+	                                    if (isset($fieldVal[2])) $options = explode(',', $fieldVal[2]);
+	                                }	
+	                                
+	                                // split fields (multi select)
+	                                $dataOpts = array();
+	                                if ($value !== -99 && !empty($value)){
+	                                	$dataOpts = explode(',', $value);
+	                                }
+
+		                            //if (isset($fieldVal[3]) && count($fieldVal[3]) > 0){
+	                                if (isset($options) && is_array($options) && count($options) > 0 && $options[0] != ''){
+
+	                                	$optIndex = 0;
+
+		                                foreach ($options as $opt){
+
+		                                	echo '<div class="ui checkbox"><input type="checkbox" name="'. esc_attr( $postPrefix.$fieldKey.'-'.$optIndex ).'" id="'. esc_attr( $fieldKey.'-'.$optIndex ) .'" value="' . esc_attr( $opt ) . '"';
+		                                    if (in_array($opt, $dataOpts)) echo ' checked="checked"'; 
+		                                    echo ' /><label for="'. esc_attr( $fieldKey.'-'.$optIndex ) .'">' . esc_html( $opt ) . '</label></div>';
+
+		                                    $optIndex++;
+
+		                                }
+
+		                            } else echo '<label for="'. esc_attr( $fieldKey ).'-0">'. esc_html__('No Options','zero-bs-crm').'!</label>';
+
+		                        ?>
+		                    </div>
+	                        <input type="hidden" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" id="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" value="0" />
+		                </td></tr><?php
+
+		                break;
+
+		            // tax
+		            case 'tax':
+
+	                ?><tr class="wh-large"><th><label for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e($fieldVal[1],"zero-bs-crm"); ?>:</label></th>
+	                <td>
+	                    <select name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control zbs-watch-input zbs-dc<?php echo esc_attr( $inputClasses ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); ?>">
+	                        <?php
+
+	                        	// retrieve tax rates + cache
+	                        	global $zbsTaxRateTable; if (!isset($zbsTaxRateTable)) $zbsTaxRateTable = zeroBSCRM_taxRates_getTaxTableArr();
+
+	                            // if got em
+                                if (isset($zbsTaxRateTable) && is_array($zbsTaxRateTable) && count($zbsTaxRateTable) > 0){
+
+                                	// if $default, use that
+                                	$selectVal = '';
+	                                if ($value !== -99 && !empty($value)){
+	                                	$selectVal = $value;
+	                                } elseif (!empty($default))
+                                		$selectVal = $default;
+
+	                                //catcher
+	                                echo '<option value=""';
+	                                if (empty($default) && ($value == -99 || ($value !== -99 && empty($value)))) echo ' selected="selected"';
+	                                echo '>' . esc_html( __( 'None', 'zero-bs-crm' ) ) . '</option>';
+
+	                                foreach ($zbsTaxRateTable as $taxRate){
+
+	                                    echo '<option value="'. esc_attr( $taxRate['id'] ) .'"';
+	                                    if ($selectVal == $taxRate['id']) echo ' selected="selected"'; 
+	                                    echo '>' . esc_html( $taxRate['name'] . ' (' . $taxRate['rate'] . '%)' ) . '</option>';
+
+	                                }
+
+	                            } else echo '<option value="">'. esc_html__('No Tax Rates Defined','zero-bs-crm').'!</option>';
+
+	                        ?>
+	                    </select>
+                        <input type="hidden" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" id="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>_dirtyflag" value="0" />
+	                </td></tr><?php
+
+	                break;
+
+	        } // switch
+
+    	} // if is legit params
+
+   }
+	// phpcs:enable
+
 /* ======================================================
   /	Edit Pages Field outputter
    ====================================================== */

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -1364,18 +1364,17 @@ function zeroBSCRM_outputEmailHistory( $user_id = -1 ) { // phpcs:ignore WordPre
 			case 'date':
 				$datevalue = '';
 				if ( $value !== -99 ) {
-					$datevalue = $value;
-					$datevalue = zeroBSCRM_date_i18n( -1, $datevalue, false, true );
+					$datevalue = jpcrm_uts_to_date_str( $value, 'Y-m-d', true );
 				}
+
+				// if this is a custom field, and is unset, we let it get passed as empty (gh-56)
 				if ( isset( $fieldVal['custom-field'] ) && ( $value === -99 || $value === '' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					$datevalue = '';
-				} elseif ( $value === -99 ) {
-					$inputClasses = ' zbs-empty-start'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				}
 				?>
 						<div class="jpcrm-form-group">
 						<label class="jpcrm-form-label" for="<?php echo esc_attr( $fieldKey ); ?>"><?php esc_html_e( $fieldVal[1], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText ?>:</label>
-							<input type="text" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" class="form-control jpcrm-date zbs-dc<?php echo esc_attr( $inputClasses ); ?>" placeholder="<?php if ( isset( $fieldVal[2] ) ) echo esc_attr__( $fieldVal[2], 'zero-bs-crm' ); ?>" value="<?php echo esc_attr( $datevalue ); ?>" autocomplete="zbs-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( $fieldKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText, Generic.ControlStructures.InlineControlStructure.NotAllowed ?>" />
+							<input type="date" name="<?php echo esc_attr( $postPrefix ); ?><?php echo esc_attr( $fieldKey ); ?>" id="<?php echo esc_attr( $fieldKey ); ?>" placeholder="yyyy-mm-dd" value="<?php echo esc_attr( $datevalue ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>"/>
 						</div>
 						<?php
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
@@ -169,16 +169,16 @@
 					 * when we have a group (e.g. addresses), they should start in
 					 * the first column. We are using only two columns.
 					 */
-					$is_first_collumn = false;
+					$is_first_column = false;
 					foreach ( $fields as $field_key => $field_value ) {
-						$is_first_collumn = ! $is_first_collumn;
-						$show_field       = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-						$show_field       = isset( $fields_to_hide['company'] )
+						$is_first_column = ! $is_first_column;
+						$show_field      = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+						$show_field      = isset( $fields_to_hide['company'] )
 							&& is_array( $fields_to_hide['company'] )
 							&& in_array( $field_key, $fields_to_hide['company'] ) // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 							? false
 							: $show_field;
-						$show_field       = isset( $field_value[0] )
+						$show_field      = isset( $field_value[0] )
 							&& 'selectcountry' === $field_value[0]
 							&& 0 === $show_country_fields
 							? false
@@ -188,7 +188,7 @@
 							if ( $show_addresses !== 1 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 								continue;
 							} elseif ( $field_group === '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-								if ( ! $is_first_collumn ) {
+								if ( ! $is_first_column ) {
 									echo '<div class="jpcrm-empty-form-group">&nbsp;</div>';
 								}
 								echo '<div class="jpcrm-form-grid" style="padding:0px;grid-template-columns: 1fr;">';

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
@@ -126,10 +126,10 @@
 					$fields               = $zbsCompanyFields; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					$show_id              = (int) $zbs->settings->get( 'showid' );
 					$fields_to_hide       = $zbs->settings->get( 'fieldhides' );
-					$show_addresses       = (int) zeroBSCRM_getSetting( 'showaddress' );
-					$show_second_address  = (int) zeroBSCRM_getSetting( 'secondaddress' );
-					$show_country_fields  = zeroBSCRM_getSetting( 'countries' );
-					$second_address_label = zeroBSCRM_getSetting( 'secondaddresslabel' );
+					$show_addresses       = (int) $zbs->settings->get( 'showaddress' );
+					$show_second_address  = (int) $zbs->settings->get( 'secondaddress' );
+					$show_country_fields  = $zbs->settings->get( 'countries' );
+					$second_address_label = $zbs->settings->get( 'secondaddresslabel' );
                 if ( empty( $second_address_label ) ) {
                   $second_address_label = __( 'Second Address', 'zero-bs-crm' );
                 }

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
@@ -150,7 +150,7 @@
 				if ( $show_id === 1 && $companyID > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					?>
 							<div class="jpcrm-form-group">
-								<label class="jpcrm-form-label" for="maintel"><?php echo esc_html( $this->coOrgLabel ) . ' '; esc_html_e( 'ID', 'zero-bs-crm' ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase, Squiz.PHP.EmbeddedPhp.MultipleStatements ?>:</label>
+								<label class="jpcrm-form-label"><?php echo esc_html( $this->coOrgLabel ) . ' '; esc_html_e( 'ID', 'zero-bs-crm' ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase, Squiz.PHP.EmbeddedPhp.MultipleStatements ?>:</label>
 								<b>#<?php echo isset( $companyID ) ? esc_html( $companyID ) : ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?></b>
 							</div>
 							<div class="jpcrm-form-group">

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
@@ -115,8 +115,6 @@
                 #} Rather than reload all the time :)
                 global $zbsCompanyEditing; 
 
-                #} retrieve
-                //$zbsCustomer = get_post_meta($company['id'], 'zbs_customer_meta', true);
                 if (!isset($zbsCompanyEditing)){
                     $zbsCompany = zeroBS_getCompany($companyID,false);
                     $zbsCompanyEditing = $zbsCompany;
@@ -124,41 +122,18 @@
                     $zbsCompany = $zbsCompanyEditing;
                 }
 
-                // Get field Hides...
-                $fieldHideOverrides = $zbs->settings->get('fieldhides');
-                $zbsShowID = $zbs->settings->get('showid');
-
-                // Click 2 call?
-                $click2call = $zbs->settings->get('clicktocall');
-
-                global $zbsCompanyName; $zbsCompanyName = ''; if (isset($zbsCompany['name'])) $zbsCompanyName = $zbsCompany['name'];
-
-                global $zbsCompanyFields; $fields = $zbsCompanyFields;
-
-                #} Address settings
-                $showAddresses = zeroBSCRM_getSetting('showaddress');
-                $showSecondAddress = zeroBSCRM_getSetting('secondaddress');
-                $showCountryFields = zeroBSCRM_getSetting('countries');
-                $second_address_label = zeroBSCRM_getSetting( 'secondaddresslabel' );
+					global $zbsCompanyFields; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					$fields               = $zbsCompanyFields; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					$show_id              = (int) $zbs->settings->get( 'showid' );
+					$fields_to_hide       = $zbs->settings->get( 'fieldhides' );
+					$show_addresses       = (int) zeroBSCRM_getSetting( 'showaddress' );
+					$show_second_address  = (int) zeroBSCRM_getSetting( 'secondaddress' );
+					$show_country_fields  = zeroBSCRM_getSetting( 'countries' );
+					$second_address_label = zeroBSCRM_getSetting( 'secondaddresslabel' );
                 if ( empty( $second_address_label ) ) {
                   $second_address_label = __( 'Second Address', 'zero-bs-crm' );
                 }
-
-               // PerfTest: zeroBSCRM_performanceTest_finishTimer('custmetabox-dataget');
-               // PerfTest: zeroBSCRM_performanceTest_startTimer('custmetabox-draw');
-            
-                //sticky tape some CSS until new UI!!
             ?>
-                <style>
-                    #post-body-content{
-                        display:none;
-                    }
-                        @media all and (max-width:699px){
-                        table.wh-metatab{
-                            min-width:100% !important;
-                        }
-                    }  
-                </style>
                 <script type="text/javascript">var zbscrmjs_secToken = '<?php echo esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ); ?>';</script>
 
                 <?php #} Pass this if it's a new customer (for internal automator) - note added this above with DEFINE for simpler.
@@ -166,227 +141,90 @@
                     if (gettype($zbsCompany) != "array") echo '<input type="hidden" name="zbscrm_newcompany" value="1" />';
 
                 ?>
-
-
-                <table class="form-table wh-metatab wptbp" id="wptbpMetaBoxMainItem">
+			<div>
+				<div class="jpcrm-form-grid" id="wptbpMetaBoxMainItem">
 
                     <?php #} WH Hacky quick addition for MVP 
                     # ... further hacked
 
-                    if ($zbsShowID == "1" && $companyID > 0) { ?>
-                    <tr class="wh-large"><th><label><?php echo esc_html( $this->coOrgLabel ) . ' '; esc_html_e("ID","zero-bs-crm");?>:</label></th>
-							<td style="font-size: 20px;color: black;vertical-align: top;">
-                        #<?php echo esc_html( $companyID ); ?>
-                    </td></tr>
+				if ( $show_id === 1 && $companyID > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					?>
+							<div class="jpcrm-form-group">
+								<label class="jpcrm-form-label" for="maintel"><?php echo esc_html( $this->coOrgLabel ) . ' '; esc_html_e( 'ID', 'zero-bs-crm' ); // phpcs:ignore Generic.Formatting.DisallowMultipleStatements.SameLine, WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase, Squiz.PHP.EmbeddedPhp.MultipleStatements ?>:</label>
+								<b>#<?php echo isset( $companyID ) ? esc_html( $companyID ) : ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?></b>
+							</div>
+							<div class="jpcrm-form-group">
+							</div>
                     <?php } ?>
 
 					<?php
-					$potential_statuses = zeroBSCRM_getCompanyStatuses();
-					$current_status     = '';
-					if ( is_array( $company ) && isset( $company['status'] ) ) {
-						$current_status = $company['status'];
+					global $zbsFieldsEnabled; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					if ( $show_second_address === 1 ) {
+						$zbsFieldsEnabled['secondaddress'] = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					}
+					$field_group = '';
+
+					/*
+					 * We need to know if we are in the first column or not because
+					 * when we have a group (e.g. addresses), they should start in
+					 * the first column. We are using only two columns.
+					 */
+					$is_first_collumn = false;
+					foreach ( $fields as $field_key => $field_value ) {
+						$is_first_collumn = ! $is_first_collumn;
+						$show_field       = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+						$show_field       = isset( $fields_to_hide['company'] )
+							&& is_array( $fields_to_hide['company'] )
+							&& in_array( $field_key, $fields_to_hide['company'] ) // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+							? false
+							: $show_field;
+						$show_field       = isset( $field_value[0] )
+							&& 'selectcountry' === $field_value[0]
+							&& 0 === $show_country_fields
+							? false
+							: $show_field;
+
+						if ( isset( $field_value['area'] ) && $field_value['area'] !== '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							if ( $show_addresses !== 1 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+								continue;
+							} elseif ( $field_group === '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+								if ( ! $is_first_collumn ) {
+									echo '<div class="jpcrm-empty-form-group">&nbsp;</div>';
+								}
+								echo '<div class="jpcrm-form-grid" style="padding:0px;grid-template-columns: 1fr;">';
+								echo '<div class="jpcrm-form-group"><label>';
+								echo esc_html__( $field_value['area'], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText
+								echo '</label></div>';
+							} elseif ( $field_group !== $field_value['area'] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+								echo '</div>';
+								echo '<div class="jpcrm-form-grid" style="padding:0px;grid-template-columns: 1fr;">';
+								echo '<div class="jpcrm-form-group"><label>';
+								echo $show_field ? esc_html( $second_address_label ) : '';
+								echo '</label></div>';
+							}
+							$field_group = $field_value['area']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText
+						}
+
+						if ( $field_group !== '' && ( ! isset( $field_value['area'] ) || $field_value['area'] === '' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							$field_group = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							echo '</div>';
+							echo '<div class="jpcrm-form-group jpcrm-form-group-span-2">&nbsp;</div>';
+						}
+
+						if ( $show_field ) {
+							if ( isset( $field_value[0] ) ) {
+								if ( $field_group === 'Second Address' ) {
+									$field_value[1] = str_replace( ' (' . $second_address_label . ')', '', $field_value[1] );
+								}
+								zeroBSCRM_html_editField( $zbsCompany, $field_key, $field_value, 'zbsc_' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							}
+						}
 					}
 					?>
-							<tr class="wh-large">
-							<th>
-								<label for="zbsco_status"><?php echo esc_html( $this->coOrgLabel ) . ' ' . esc_html__( 'Status', 'zero-bs-crm' ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase ?>: </label>
-							</th>
-							<td>
-								<select id="zbsco_status" name="zbsco_status">
-					<?php
-					foreach ( $potential_statuses as $status ) {
-						$sel = $status === $current_status ? ' selected' : '';
-						echo '<option value="' .
-						esc_attr( $status ) .
-						'"' .
-						esc_attr( $sel ) .
-						'>' .
-						esc_html( $status ) .
-						'</option>';
-					}
-					?>
-								</select>
-							</td>
-							</tr>
-
-							<?php
-                    #} This global holds "enabled/disabled" for specific fields... ignore unless you're WH or ask
-                    global $zbsFieldsEnabled; if ($showSecondAddress == '1') $zbsFieldsEnabled['secondaddress'] = true;
-                    
-                    #} This is the grouping :)
-                    $zbsFieldGroup = ''; $zbsOpenGroup = false;
-
-                    foreach ($fields as $fieldK => $fieldV){
-
-                        $showField = true;
-
-                        #} Check if not hard-hidden by opt override (on off for second address, mostly)
-                        if (isset($fieldV['opt']) && (!isset($zbsFieldsEnabled[$fieldV['opt']]) || !$zbsFieldsEnabled[$fieldV['opt']])) $showField = false;
+				</div>
+			</div>
 
 
-                        // or is hidden by checkbox? 
-                        if (isset($fieldHideOverrides['company']) && is_array($fieldHideOverrides['company'])){
-                            if (in_array($fieldK, $fieldHideOverrides['company'])){
-                              $showField = false;
-                            }
-                        }
-
-                        // 'show/hide Countries' setting:
-                        if (isset($fieldV[0]) && $fieldV[0] == 'selectcountry' && $showCountryFields == 0) $showField = false;
-
-
-                        // ++ We hide status, because it's now in the 'company action' box
-                        if ($fieldK == 'status') $showField = false;
-
-
-                        // ==================================================================================
-                        // Following grouping code needed moving out of ifShown loop:
-
-                            #} Whatever prev fiedl group was, if this is diff, close (post group)
-                            if (
-                                $zbsOpenGroup &&
-                                    #} diff group
-                                    ( 
-                                        (isset($fieldV['area']) && $fieldV['area'] != $zbsFieldGroup) ||
-                                        #} No group
-                                         !isset($fieldV['area']) && $zbsFieldGroup != ''
-                                    )
-                                ){
-
-                                    #} Special cases... gross
-                                    $zbsCloseTable = true; if ($zbsFieldGroup == 'Main Address') $zbsCloseTable = false;
-
-                                    #} Close it
-                                    echo '</table></div>';
-                                    if ($zbsCloseTable) echo '</td></tr>';
-
-                            }
-
-                            #} Any groupings?
-                            if (isset($fieldV['area'])){
-
-                                #} First in a grouping? (assumes in sequential grouped order)
-                                if ($zbsFieldGroup != $fieldV['area']){
-
-                                    #} set it
-                                    $zbsFieldGroup = $fieldV['area'];
-                                    $fieldGroupLabel = str_replace(' ','_',$zbsFieldGroup); $fieldGroupLabel = strtolower($fieldGroupLabel);
-
-                                    #} Special cases... gross
-                                    $zbsOpenTable = true; if ($zbsFieldGroup == 'Second Address') $zbsOpenTable = false;
-
-
-                                    #} Make class for hiding address (this form output is weird) <-- classic mike saying my code is weird when it works fully. Ask if you don't know!
-                                    $zbsLineClass = ''; $zbsGroupClass = '';
-
-                                    // if addresses turned off, hide the lot
-                                    if ($showAddresses != "1") {
-
-                                        // addresses turned off
-                                        $zbsLineClass = 'zbs-hide';
-                                        $zbsGroupClass = 'zbs-hide';
-
-                                    } else { 
-
-                                        // addresses turned on
-                                        if ($zbsFieldGroup == 'Second Address'){
-
-                                            // if we're in second address grouping:
-
-                                                // if second address turned off
-                                                if ($showSecondAddress != "1"){
-
-                                                    $zbsLineClass = 'zbs-hide';
-                                                    $zbsGroupClass = 'zbs-hide';
-
-                                                }
-
-                                        }
-
-                                    }
-                                    // / address  modifiers
-
-
-                                    #} add group div + label
-                                    if ($zbsOpenTable) echo '<tr class="wh-large zbs-field-group-tr '.esc_attr($zbsLineClass).'"><td colspan="2">';
-
-                                    if( $fieldV['area'] == 'Second Address' ) {
-                                        echo '<div class="zbs-field-group zbs-fieldgroup-'.esc_attr($fieldGroupLabel).' '. esc_attr($zbsGroupClass) .'"><label class="zbs-field-group-label">'. esc_html( $second_address_label ) .'</label>';
-                                    } else {
-                                        echo '<div class="zbs-field-group zbs-fieldgroup-'.esc_attr($fieldGroupLabel).' '. esc_attr($zbsGroupClass) .'"><label class="zbs-field-group-label">'. esc_html__( $fieldV['area'], 'zero-bs-crm' ).'</label>';
-                                    }
-
-                                    echo '<table class="form-table wh-metatab wptbp" id="wptbpMetaBoxGroup-'.esc_attr($fieldGroupLabel).'">';
-                                    
-                                    #} Set this (need to close)
-                                    $zbsOpenGroup = true;
-
-                                }
-
-
-                            } else {
-
-                                #} No groupings!
-                                $zbsFieldGroup = '';
-
-                            }
-
-                        // / grouping
-                        // ==================================================================================
-
-                        #} If show...
-                        if ($showField) {
-
-                            if (isset($fieldV[0])){
-                                if ($zbsFieldGroup == 'Second Address') {
-                                    $fieldV[1] = str_replace( ' (' . $second_address_label . ')', '', $fieldV[1] );
-                                }
-                                // we now put these out via the centralised func (2.95.3+)
-                                //... rather than distinct switch below
-                                zeroBSCRM_html_editField($zbsCompany, $fieldK, $fieldV, $postPrefix = 'zbsco_');
-
-                            }
-
-                        } #} / if show
-
-
-                        // ==================================================================================
-                        // Following grouping code needed moving out of ifShown loop:
-
-                            #} Closing field?
-                            if (
-                                $zbsOpenGroup &&
-                                    #} diff group
-                                    ( 
-                                        (isset($fieldV['area']) && $fieldV['area'] != $zbsFieldGroup) ||
-                                        #} No group
-                                         !isset($fieldV['area']) && $zbsFieldGroup != ''
-                                    )
-                                ){
-
-                                    #} Special cases... gross
-                                    $zbsCloseTable = true; if ($zbsFieldGroup == 'Main Address') $zbsCloseTable = false;
-
-                                    #} Close it
-                                    echo '</table></div>';
-                                    if ($zbsCloseTable) echo '</td></tr>';
-
-                            }
-                        // / grouping
-                        // ==================================================================================
-
-                    }
-
-                    ?>
-                    
-            </table>
-
-
-            <style type="text/css">
-                #submitdiv {
-                    display:none;
-                }
-            </style>
             <script type="text/javascript">
 
                 jQuery(function(){
@@ -653,31 +491,7 @@ class zeroBS__Metabox_CompanyContacts extends zeroBS__Metabox{
 
                 <tr class="wh-large"><th>
                     <?php
-
                         if (count($contacts) > 0){
-
-                            /* WH modified to use more semantic friendly markup v3.0 25/4/19
-
-                            echo '<div id="zbs-co-contacts">';
-
-                            foreach ($contacts as $contact){
-
-                                echo '<div class="zbs-co-contact">';
-
-                                #} Img or ico 
-                                echo zeroBS_getCustomerIcoHTML($contact['id']);
-
-                                #} new view link
-                                $url = jpcrm_esc_link('view',$contact['id'],'zerobs_customer');
-
-                                echo '<strong><a href="'.$url.'">'.zeroBS_customerName($contact['id'],$contact,false,false).'</a></strong><br />';
-
-                                echo '</div>';
-
-                            } 
-                            echo '</div>';
-                            */
-
                             echo '<div id="zbs-co-contacts" class="ui cards">';
 
                             foreach ($contacts as $contact){

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -166,327 +166,159 @@
 
         }
 
-        public function html( $contact, $metabox ) {
-
-                //echo '<pre>'; print_r(array($contact,$metabox)); echo '</pre>';
-
-               // PerfTest: zeroBSCRM_performanceTest_startTimer('custmetabox-dataget');
-
-                global $zbs;
-
-                #} Rather than reload all the time :)
-                global $zbsContactEditing; 
-
-                #} retrieve
-                //$zbsCustomer = get_post_meta($contact['id'], 'zbs_customer_meta', true);
-                if (!isset($zbsContactEditing) && isset($contact['id'])){
-                    $zbsCustomer = zeroBS_getCustomer($contact['id'],false,false,false);
-                    $zbsContactEditing = $zbsCustomer;
-                } else {
-                    $zbsCustomer = $zbsContactEditing;
-                }
-
-                // Get field Hides...
-                $fieldHideOverrides = $zbs->settings->get('fieldhides');
-                $zbsShowID = $zbs->settings->get('showid');
-
-                // Click 2 call?
-                $click2call = $zbs->settings->get('clicktocall');
-
-       
-                global $zbsCustomerFields;
-                $fields = $zbsCustomerFields;
-
-                /* debug 
-                echo 'zbsCustomer<pre>'.print_r($zbsCustomer,1).'</pre>'; 
-                echo 'zbsCustomerFields<pre>'.print_r($zbsCustomerFields,1).'</pre>'; exit();
-                */
-
-
-                #} Address settings
-                $showAddresses = zeroBSCRM_getSetting('showaddress');
-                $showSecondAddress = zeroBSCRM_getSetting('secondaddress');
-                $showCountryFields = zeroBSCRM_getSetting('countries');
-                $second_address_label = zeroBSCRM_getSetting( 'secondaddresslabel' );
-                if ( empty( $second_address_label ) ) {
-                  $second_address_label = __( 'Second Address', 'zero-bs-crm' );
-                }
-
-
-               // PerfTest: zeroBSCRM_performanceTest_finishTimer('custmetabox-dataget');
-               // PerfTest: zeroBSCRM_performanceTest_startTimer('custmetabox-draw');
-            
-                //sticky tape some CSS until new UI!!
-            ?>
-                <style>
-                    #post-body-content{
-                        display:none;
-                    }
-                        @media all and (max-width:699px){
-                        table.wh-metatab{
-                            min-width:100% !important;
-                        }
-                    }  
-                </style>
-                <script type="text/javascript">var zbscrmjs_secToken = '<?php echo esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ); ?>';</script>
-
-                <?php #} Pass this if it's a new customer (for internal automator) - note added this above with DEFINE for simpler.
-
-                    if (gettype($zbsCustomer) != "array") echo '<input type="hidden" name="zbscrm_newcustomer" value="1" />';
-
-                ?>
-
-
-
-                <table class="form-table wh-metatab wptbp" id="wptbpMetaBoxMainItem">
-                    <?php
-                       $avatar_mode = zeroBSCRM_getSetting( 'avatarmode' );
-							  // The only mode allowed to change images is Custom Images
-                       // (avatar_mode == "2") => Custom Images mode
-                       if ( $avatar_mode == "2" ) :
-                    ?>
-                    <tr class="wh-large"><th style="vertical-align: middle;"><label><?php esc_html_e('Profile Picture',"zero-bs-crm");?>:</label></th>
-                    <td class="zbs-field-id">
-                    <?php
-                        $avatar_url       = isset( $contact['id'] ) ? $zbs->DAL->contacts->getContactAvatar( $contact['id'] ) : zeroBSCRM_getDefaultContactAvatar();
-                        $empty_avatar_url = zeroBSCRM_getDefaultContactAvatar();
-                    ?>
-                    <div class="jpcrm-customer-profile-picture-container" style="margin-right:10px;">
-                        <img src="<?php echo esc_attr( $avatar_url ); ?>" id="profile-picture-img" class="jpcrm-customer-profile-picture" />
-                        <img src="<?php echo esc_attr( $empty_avatar_url ); ?>" id="empty-profile-picture" class="jpcrm-customer-profile-picture" style="display:none;" />
-                    <br />
-                    <label for="zbsc_profile-picture-file" class="jpcrm-customer-file-upload">
-                        <?php esc_html_e( 'Change Picture', 'zero-bs-crm' ); ?>
-                        <input id="zbsc_profile-picture-file" type="file" name="zbsc_profile-picture-file" class="jpcrm-customer-input-file"/>
-                    </label>
-                    <label id="zbsc_remove-profile-picture-button" class="jpcrm-customer-file-upload-remove">
-                        <?php esc_html_e( 'Remove', 'zero-bs-crm' ); ?>
-                        <input type="hidden" id="zbsc_remove-profile-picture" name="zbsc_remove-profile-picture" value="0" />
-                    </label>
-                    <?php 
-                        endif; 
-                    ?>
-
-                    <?php #} WH Hacky quick addition for MVP 
-                    # ... further hacked
-
-                    if ($zbsShowID == "1" && isset($contact['id']) && !empty($contact['id'])) { ?>
-							<tr class="wh-large"><th><label><?php esc_html_e( 'Contact ID', 'zero-bs-crm' ); ?>:</label></th>
-                    <td class="zbs-field-id">
-                        #<?php if (isset($contact['id'])) echo esc_html( $contact['id'] ); ?>
-                    </td></tr>
-                    <?php }
-
-            
-                    #} This global holds "enabled/disabled" for specific fields... ignore unless you're WH or ask
-                    global $zbsFieldsEnabled; if ($showSecondAddress == "1") $zbsFieldsEnabled['secondaddress'] = true;                    
-
-                    // WH: some people reporting second address still showing so applied a SECONDARY fix as couldn't replicate
-                    // see #2NDADDR below 
-                    
-                    #} This is the grouping :)
-                    $zbsFieldGroup = ''; $zbsOpenGroup = false;
-
-                    foreach ($fields as $fieldK => $fieldV){
-                        
-                        $showField = true;
-
-                        #} Check if not hard-hidden by opt override (on off for second address, mostly)
-                        if (isset($fieldV['opt']) && (!isset($zbsFieldsEnabled[$fieldV['opt']]) || !$zbsFieldsEnabled[$fieldV['opt']])) $showField = false;
-
-
-                        // or is hidden by checkbox? 
-                        if (isset($fieldHideOverrides['customer']) && is_array($fieldHideOverrides['customer'])){
-                            if (in_array($fieldK, $fieldHideOverrides['customer'])){
-                              $showField = false;
-                            }
-                        }
-
-                        // 'show/hide Countries' setting:
-                        if (isset($fieldV[0]) && $fieldV[0] == 'selectcountry' && $showCountryFields == 0 ) $showField = false;
-
-
-                        // ==================================================================================
-                        // Following grouping code needed moving out of ifShown loop:
-
-                            #} Whatever prev field group was, if this is diff, close (post group)
-                            if (
-                                $zbsOpenGroup &&
-                                    #} diff group
-                                    ( 
-                                        (isset($fieldV['area']) && $fieldV['area'] != $zbsFieldGroup) ||
-                                        #} No group
-                                         !isset($fieldV['area']) && $zbsFieldGroup != ''
-                                    )
-                                ){
-
-                                    #} Special cases... gross
-                                    $zbsCloseTable = true; if ($zbsFieldGroup == 'Main Address') $zbsCloseTable = false;
-
-                                    #} Close it
-                                    echo '</table></div>';
-                                    if ($zbsCloseTable) echo '</td></tr>';
-
-                            }
-
-                            #} Any groupings?
-                            if (isset($fieldV['area'])){
-
-                                #} First in a grouping? (assumes in sequential grouped order)
-                                if ($zbsFieldGroup != $fieldV['area']){
-
-                                    #} set it
-                                    $zbsFieldGroup = $fieldV['area'];
-                                    $fieldGroupLabel = str_replace(' ','_',$zbsFieldGroup); $fieldGroupLabel = strtolower($fieldGroupLabel);
-
-                                    #} Special cases... gross
-                                    $zbsOpenTable = true; if ($zbsFieldGroup == 'Second Address') $zbsOpenTable = false;
-
-                                    #} Make class for hiding address (this form output is weird) <-- classic mike saying my code is weird when it works fully. Ask if you don't know!
-                                    $zbsLineClass = ''; $zbsGroupClass = '';
-
-                                    // if addresses turned off, hide the lot
-                                    if ($showAddresses != "1") {
-
-                                        // addresses turned off
-                                        $zbsLineClass = 'zbs-hide';
-                                        $zbsGroupClass = 'zbs-hide';
-
-                                    } else { 
-
-                                        // addresses turned on
-                                        if ($zbsFieldGroup == 'Second Address'){
-
-                                            // if we're in second address grouping:
-
-                                                // if second address turned off
-                                                if ($showSecondAddress != "1"){
-
-                                                    $zbsLineClass = 'zbs-hide';
-                                                    $zbsGroupClass = 'zbs-hide';
-
-                                                }
-
-                                        }
-
-                                    }
-
-                                    // / address  modifiers
-
-                                    #} add group div + label
-                                    if ($zbsOpenTable) echo '<tr class="wh-large zbs-field-group-tr ' . esc_attr( $zbsLineClass ) . '"><td colspan="2">';
-
-                                    if( $fieldV['area'] == 'Second Address' ) {
-                                        echo '<div class="zbs-field-group zbs-fieldgroup-'. esc_attr( $fieldGroupLabel ) .' '. esc_attr( $zbsGroupClass ) .'"><label class="zbs-field-group-label">'. esc_html( $second_address_label ) .'</label>';
-                                    } else {
-                                        echo '<div class="zbs-field-group zbs-fieldgroup-'.esc_attr($fieldGroupLabel).' '. esc_attr($zbsGroupClass) .'"><label class="zbs-field-group-label">'. esc_html__( $fieldV['area'], 'zero-bs-crm' ).'</label>';
-                                    }
-
-                                    echo '<table class="form-table wh-metatab wptbp" id="wptbpMetaBoxGroup-'.esc_attr($fieldGroupLabel).'">';
-                                    
-                                    #} Set this (need to close)
-                                    $zbsOpenGroup = true;
-
-                                }
-
-
-                            } else {
-
-                                #} No groupings!
-                                $zbsFieldGroup = '';
-                                $zbsOpenGroup = false;
-
-                            }
-
-                        // / grouping
-                        // ==================================================================================
-                        
-
-
-                        #} If show...
-                        if ($showField) {
-
-                            if (isset($fieldV[0])){
-                                if ($zbsFieldGroup == 'Second Address') {
-                                    $fieldV[1] = str_replace( ' (' . $second_address_label . ')', '', $fieldV[1] );
-                                }
-                                // we now put these out via the centralised func (2.95.3+)
-                                //... rather than distinct switch below 
-                                zeroBSCRM_html_editField($zbsCustomer, $fieldK, $fieldV, $postPrefix = 'zbsc_');
-
-                            }
-
-                        } #} / if show
-
-                        // ==================================================================================
-                        // Following grouping code needed moving out of ifShown loop:
-
-
-                        // / grouping
-                        // ==================================================================================
-                        
-
-
-                        // new home for Company Add
-
-
-
-
-                    }
-
-
-                    #} Close group if still open after loop
-                    if ( $zbsOpenGroup ){
-
-                            #} Special cases... gross
-                            $zbsCloseTable = true; if ($zbsFieldGroup == 'Main Address') $zbsCloseTable = false;
-
-                            #} Close it
-                            echo '</table></div>';
-                            if ($zbsCloseTable) echo '</td></tr>';
-
-                    }
-
-                    /* Debug <tr><td colspan="2"><pre><?php print_r($zbsCustomer) ?></pre></td></tr> */
-
-                    ?>
-
-                    
-            </table>
-
-
-            <style type="text/css">
-            <?php   #2NDADDR - hard override of this if setting says off, hide it, whatever!
-                    if ($showSecondAddress != "1"){
-
-                        ?>.zbs-fieldgroup-second_address {display:none;}<?php 
-                    }
-            ?>
-                #submitdiv {
-                    display:none;
-                }
-            </style>
-            <script type="text/javascript">
-
-                jQuery(function(){
-
-                    // bastard override of wp terminology:
-                    jQuery('#submitdiv h2 span').html('<?php esc_html_e('Save',"zero-bs-crm");?>');
-                    if (jQuery('#submitdiv #publish').val() == 'Publish')
-                        jQuery('#submitdiv #publish').val('<?php esc_html_e('Save',"zero-bs-crm");?>');
-                    jQuery('#submitdiv').show();
-
-                    // turn off auto-complete on customer records via form attr... should be global for all ZBS record pages
-                    jQuery('#post').attr('autocomplete','off');
-
-                });
-
-
-            </script>
-               
-            <?php
-            // PerfTest: zeroBSCRM_performanceTest_finishTimer('custmetabox-draw');
-        }
+	/**
+	 * This method generates HTML content for contact and metadata.
+	 *
+	 * It contains a series of operations to format and display contact data
+	 * and metadata according to the parameters. This includes information retrieval,
+	 * settings configuration, field hiding, address display and others.
+	 *
+	 * @param array $contact An associative array containing contact details.
+	 * @param array $metabox Metabox information.
+	 *
+	 * @return  void
+	 */
+	public function html( $contact, $metabox ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		global $zbs; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		global $zbsContactEditing;  // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		global $zbsCustomerFields; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+		if ( ! isset( $zbsContactEditing ) && isset( $contact['id'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$customer          = zeroBS_getCustomer( $contact['id'], false, false, false );
+			$zbsContactEditing = $customer; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		} else {
+			$customer = $zbsContactEditing; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		}
+
+		$fields_to_hide       = $zbs->settings->get( 'fieldhides' );
+		$show_id              = $zbs->settings->get( 'showid' );
+		$fields               = $zbsCustomerFields; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$show_addresses       = zeroBSCRM_getSetting( 'showaddress' );
+		$show_second_address  = zeroBSCRM_getSetting( 'secondaddress' );
+		$show_country_fields  = zeroBSCRM_getSetting( 'countries' );
+		$second_address_label = zeroBSCRM_getSetting( 'secondaddresslabel' );
+		if ( empty( $second_address_label ) ) {
+			$second_address_label = __( 'Second Address', 'zero-bs-crm' );
+		}
+		?>
+
+<script type="text/javascript">var zbscrmjs_secToken = '<?php echo esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ); ?>';</script>
+
+		<?php
+		if ( gettype( $customer ) !== 'array' ) {
+			echo '<input type="hidden" name="zbscrm_newcustomer" value="1" />';
+		}
+		?>
+			<div>
+				<div class="jpcrm-form-grid" id="wptbpMetaBoxMainItem">
+		<?php
+		$avatar_mode = zeroBSCRM_getSetting( 'avatarmode' );
+		if ( $avatar_mode === '2' ) :
+			?>
+					<div class="jpcrm-form-group jpcrm-form-group-span-2">
+						<label class="jpcrm-form-label"><?php esc_html_e( 'Profile Picture', 'zero-bs-crm' ); ?>:</label>
+			<?php
+							$avatar_url       = isset( $contact['id'] ) ? $zbs->DAL->contacts->getContactAvatar( $contact['id'] ) : zeroBSCRM_getDefaultContactAvatar(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+							$empty_avatar_url = zeroBSCRM_getDefaultContactAvatar();
+			?>
+								<div class="zbs-text-input">
+									<div class="jpcrm-customer-profile-picture-container" style="margin-right:10px;">
+											<img src="<?php echo esc_attr( $avatar_url ); ?>" id="profile-picture-img" class="jpcrm-customer-profile-picture" />
+											<img src="<?php echo esc_attr( $empty_avatar_url ); ?>" id="empty-profile-picture" class="jpcrm-customer-profile-picture" style="display:none;" />
+									<br />
+									<label for="zbsc_profile-picture-file" class="jpcrm-customer-file-upload">
+											<?php esc_html_e( 'Change Picture', 'zero-bs-crm' ); ?>
+											<input id="zbsc_profile-picture-file" type="file" name="zbsc_profile-picture-file" class="jpcrm-customer-input-file"/>
+									</label>
+									<label id="zbsc_remove-profile-picture-button" class="jpcrm-customer-file-upload-remove">
+											<?php esc_html_e( 'Remove', 'zero-bs-crm' ); ?>
+											<input type="hidden" id="zbsc_remove-profile-picture" name="zbsc_remove-profile-picture" value="0" />
+									</label>
+									</div>
+								</div>
+							</div>
+
+			<?php
+		endif;
+
+		if ( $show_id === '1' && isset( $contact['id'] ) && ! empty( $contact['id'] ) ) :
+			?>
+							<div class="jpcrm-form-group">
+								<label class="jpcrm-form-label" for="maintel"><?php esc_html_e( 'Contact ID', 'zero-bs-crm' ); ?>:</label>
+								<b>#<?php echo isset( $contact['id'] ) ? esc_html( $contact['id'] ) : ''; ?></b>
+							</div>
+							<div class="jpcrm-form-group">
+							</div>
+			<?php
+		endif;
+
+		global $zbsFieldsEnabled; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		if ( $show_second_address === '1' ) {
+			$zbsFieldsEnabled['secondaddress'] = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		}
+		$field_group = '';
+
+		/*
+			* We need to know if we are in the first column or not because
+			* when we have a group (e.g. addresses), they should start in
+			* the first column. We are using only two columns.
+			*/
+		$is_first_collumn = false;
+		foreach ( $fields as $field_key => $field_value ) {
+			$is_first_collumn = ! $is_first_collumn;
+			$show_field       = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$show_field       = isset( $fields_to_hide['customer'] )
+				&& is_array( $fields_to_hide['customer'] )
+				&& in_array( $field_key, $fields_to_hide['customer'] ) // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
+				? false
+				: $show_field;
+			$show_field       = isset( $field_value[0] )
+				&& 'selectcountry' === $field_value[0]
+				&& 0 === $show_country_fields
+				? false
+				: $show_field;
+
+			if ( isset( $field_value['area'] ) && $field_value['area'] !== '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				if ( $show_addresses !== 1 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					continue;
+				} elseif ( $field_group === '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					if ( ! $is_first_collumn ) {
+						echo '<div class="jpcrm-empty-form-group">&nbsp;</div>';
+					}
+					echo '<div class="jpcrm-form-grid" style="padding:0px;grid-template-columns: 1fr;">';
+					echo '<div class="jpcrm-form-group"><label>';
+					echo esc_html__( $field_value['area'], 'zero-bs-crm' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText
+					echo '</label></div>';
+				} elseif ( $field_group !== $field_value['area'] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					echo '</div>';
+					echo '<div class="jpcrm-form-grid" style="padding:0px;grid-template-columns: 1fr;">';
+					echo '<div class="jpcrm-form-group"><label>';
+					echo $show_field ? esc_html( $second_address_label ) : '';
+					echo '</label></div>';
+				}
+				$field_group = $field_value['area']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.WP.I18n.NonSingularStringLiteralText
+			}
+
+			if ( $field_group !== '' && ( ! isset( $field_value['area'] ) || $field_value['area'] === '' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				$field_group = ''; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				echo '</div>';
+				echo '<div class="jpcrm-form-group jpcrm-form-group-span-2">&nbsp;</div>';
+			}
+
+			if ( $show_field ) {
+				if ( isset( $field_value[0] ) ) {
+					if ( $field_group === 'Second Address' ) {
+						$field_value[1] = str_replace( ' (' . $second_address_label . ')', '', $field_value[1] );
+					}
+					zeroBSCRM_html_editField( $customer, $field_key, $field_value, 'zbsc_' );
+				}
+			}
+		}
+		?>
+					</div>
+				</div>
+		<?php
+	}
 
         public function save_data( $contact_id, $contact ) {
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -244,7 +244,7 @@
 		if ( $show_id === 1 && isset( $contact['id'] ) && ! empty( $contact['id'] ) ) :
 			?>
 							<div class="jpcrm-form-group">
-								<label class="jpcrm-form-label" for="maintel"><?php esc_html_e( 'Contact ID', 'zero-bs-crm' ); ?>:</label>
+								<label class="jpcrm-form-label"><?php esc_html_e( 'Contact ID', 'zero-bs-crm' ); ?>:</label>
 								<b>#<?php echo isset( $contact['id'] ) ? esc_html( $contact['id'] ) : ''; ?></b>
 							</div>
 							<div class="jpcrm-form-group">

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -263,16 +263,16 @@
 			* when we have a group (e.g. addresses), they should start in
 			* the first column. We are using only two columns.
 			*/
-		$is_first_collumn = false;
+		$is_first_column = false;
 		foreach ( $fields as $field_key => $field_value ) {
-			$is_first_collumn = ! $is_first_collumn;
-			$show_field       = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			$show_field       = isset( $fields_to_hide['customer'] )
+			$is_first_column = ! $is_first_column;
+			$show_field      = ! isset( $field_value['opt'] ) || isset( $zbsFieldsEnabled[ $field_value['opt'] ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$show_field      = isset( $fields_to_hide['customer'] )
 				&& is_array( $fields_to_hide['customer'] )
 				&& in_array( $field_key, $fields_to_hide['customer'] ) // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 				? false
 				: $show_field;
-			$show_field       = isset( $field_value[0] )
+			$show_field      = isset( $field_value[0] )
 				&& 'selectcountry' === $field_value[0]
 				&& 0 === $show_country_fields
 				? false
@@ -282,7 +282,7 @@
 				if ( $show_addresses !== 1 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					continue;
 				} elseif ( $field_group === '' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-					if ( ! $is_first_collumn ) {
+					if ( ! $is_first_column ) {
 						echo '<div class="jpcrm-empty-form-group">&nbsp;</div>';
 					}
 					echo '<div class="jpcrm-form-grid" style="padding:0px;grid-template-columns: 1fr;">';

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -191,10 +191,10 @@
 		}
 
 		$fields_to_hide       = $zbs->settings->get( 'fieldhides' );
-		$show_id              = $zbs->settings->get( 'showid' );
+		$show_id              = (int) $zbs->settings->get( 'showid' );
 		$fields               = $zbsCustomerFields; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		$show_addresses       = zeroBSCRM_getSetting( 'showaddress' );
-		$show_second_address  = zeroBSCRM_getSetting( 'secondaddress' );
+		$show_second_address  = (int) zeroBSCRM_getSetting( 'secondaddress' );
 		$show_country_fields  = zeroBSCRM_getSetting( 'countries' );
 		$second_address_label = zeroBSCRM_getSetting( 'secondaddresslabel' );
 		if ( empty( $second_address_label ) ) {
@@ -212,8 +212,8 @@
 			<div>
 				<div class="jpcrm-form-grid" id="wptbpMetaBoxMainItem">
 		<?php
-		$avatar_mode = zeroBSCRM_getSetting( 'avatarmode' );
-		if ( $avatar_mode === '2' ) :
+		$avatar_mode = (int) zeroBSCRM_getSetting( 'avatarmode' );
+		if ( $avatar_mode === 2 ) :
 			?>
 					<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label"><?php esc_html_e( 'Profile Picture', 'zero-bs-crm' ); ?>:</label>
@@ -241,7 +241,7 @@
 			<?php
 		endif;
 
-		if ( $show_id === '1' && isset( $contact['id'] ) && ! empty( $contact['id'] ) ) :
+		if ( $show_id === 1 && isset( $contact['id'] ) && ! empty( $contact['id'] ) ) :
 			?>
 							<div class="jpcrm-form-group">
 								<label class="jpcrm-form-label" for="maintel"><?php esc_html_e( 'Contact ID', 'zero-bs-crm' ); ?>:</label>
@@ -253,7 +253,7 @@
 		endif;
 
 		global $zbsFieldsEnabled; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		if ( $show_second_address === '1' ) {
+		if ( $show_second_address === 1 ) {
 			$zbsFieldsEnabled['secondaddress'] = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		}
 		$field_group = '';

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Events.php
@@ -327,43 +327,8 @@
             // localise ID & content
             $eventID = -1; if (is_array($event) && isset($event['id'])) $eventID = (int)$event['id'];
 
-            #} if a saved event...
             if ($eventID > 0){
-
-                 // existing
-            
-                /* Event's dont use statuses for now.. 
-
-                        // hard typed for now.
-                        $acceptableQuoteStatuses = array(
-                            "draft" => __('Draft','zero-bs-crm'),
-                            "published" => __('Published, Unaccepted','zero-bs-crm'),
-                            "accepted" => __('Accepted','zero-bs-crm')
-                        );
-
-                        // status
-                        $status = __('Draft','zero-bs-crm');
-                        if (is_array($quote) && isset($quote['status'])){
-                            if ($quote['status'] == -2) $status = __('Published, Unaccepted','zero-bs-crm');
-                            if ($quote['status'] == 1) $status = __('Accepted','zero-bs-crm');
-                        }
-                        ?>
-                        <div>
-                            <label for="quote_status"><?php _e('Status',"zero-bs-crm"); ?>: </label>
-                            <select id="quote_status" name="quote_status">
-                                <?php foreach($acceptableQuoteStatuses as $statusOpt => $statusStr){
-
-                                    $sel = '';
-                                    if ($statusStr == $status) $sel = ' selected="selected"';
-                                    echo '<option value="'.$statusOpt.'"'. $sel .'>'.__($statusStr,"zero-bs-crm").'</option>';
-
-                                } ?>
-                            </select>
-                        </div>
-
-                        <div class="clear"></div>
-                    
-                    */ ?>
+				?>
 
                     <div class="zbs-event-actions-bottom zbs-objedit-actions-bottom">
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Invoices.php
@@ -156,7 +156,7 @@ class zeroBS__Metabox_Invoice extends zeroBS__Metabox {
 				// 1) copy the fields into the UI
 				foreach ( $customFields as $cfK => $cF ) {
 
-					zeroBSCRM_html_editField( $invoice, $cfK, $cF, 'zbsi_' );
+					zeroBSCRM_html_editField_for_invoices( $invoice, $cfK, $cF, 'zbsi_' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 				}
 				?>

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
@@ -140,33 +140,31 @@
                         )
                 );
 
-                ?><table class="form-table wh-metatab wptbp" id="wptbpMetaBoxMainItem"><?php
+				?>
+					<div>
+						<div class="jpcrm-form-grid" id="wptbpMetaBoxMainItem">
+					<?php
 
                     // output fields
                     $skipFields = array('content'); // dealt with below
                     zeroBSCRM_html_editFields($quoteTemplate,$fields,'zbsqt_',$skipFields);
-                    
-                    // Content Box
-                    ?><tr class="wh-large">
-                    <td colspan="2"><?php
-
                         ##WLREMOVE
                         // template placeholder helper
-								echo '<p style="text-align:right"><span class="ui basic black label">' . esc_html__( 'Did you know: You can now use Quote Placeholders?', 'zero-bs-crm' ) . ' <a href="' . esc_url( $zbs->urls['kbquoteplaceholders'] ) . '" target="_blank">' . esc_html__( 'Read More', 'zero-bs-crm' ) . '</a></span></p>';
+								echo '<div class="jpcrm-form-group jpcrm-form-group-span-2" style="text-align:end;"><span class="ui basic black label">' . esc_html__( 'Did you know: You can now use Quote Placeholders?', 'zero-bs-crm' ) . ' <a href="' . esc_url( $zbs->urls['kbquoteplaceholders'] ) . '" target="_blank">' . esc_html__( 'Read More', 'zero-bs-crm' ) . '</a></span></div>';
                         ##/WLREMOVE
 
 						$content = wp_kses( $quoteTemplateContent, $zbs->acceptable_html ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
+								echo '<div class="jpcrm-form-group jpcrm-form-group-span-2">';
                         // remove "Add contact form" button from Jetpack
                         remove_action( 'media_buttons', 'grunion_media_button', 999 );
                         wp_editor( $content, 'zbs_quotetemplate_content', array(
                             'editor_height' => 580
                         ));
-
-                    ?></td></tr><?php
-
-
-                ?></table><?php 
+								echo '</div>';
+					?>
+					</div></div>
+					<?php
               
         }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
@@ -172,42 +172,33 @@
                     // we pass the hash along the chain here too :)
                     echo '<input type="hidden" name="zbscq_hash" id="zbscq_hash" value="' . (isset($quote['hash']) ? esc_attr( $quote['hash'] ) : '') . '" />';
                 ?>
-                <style>
-                    @media all and (max-width:699px){
-                        table.wh-metatab{
-                            min-width:100% !important;
-                        }
-                    }  
-                </style>
-                <table class="form-table wh-metatab wptbp" id="wptbpMetaBoxMainItem">
-
+					<div>
+						<div class="jpcrm-form-grid" id="wptbpMetaBoxMainItem">
                     <?php 
 
                     // DAL3 only show after saved, easier
                     if (!empty($quoteID) && $quoteID > 0){
-
-                        // QUOTE ID is seperate / unchangable
-                        ?><tr class="wh-large"><th><label><?php esc_html_e('Quote (ID)',"zero-bs-crm");?>:</label></th>
-                        <td>
-                            <div class="zbs-prominent"><?php 
-
-                            if (empty($quoteID)) $quoteID = zeroBSCRM_getNextQuoteID();
-
-                            echo esc_html( $quoteID );
-
-                            ?><input type="hidden" name="zbsquoteid" value="<?php echo esc_attr( $quoteID ); ?>" /></div>
-                        </td></tr><?php
+					?>
+								<div class="jpcrm-form-group jpcrm-form-group-span-2">
+									<label class="jpcrm-form-label"><?php esc_html_e( 'Quote (ID)', 'zero-bs-crm' ); ?>:</label>
+								<?php
+							if ( empty( $quoteID ) ) { //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+								$quoteID = zeroBSCRM_getNextQuoteID(); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							}
+									echo '<b>' . esc_html( $quoteID ) . '</b>'; //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							?>
+									<input type="hidden" name="zbsquoteid" value="<?php echo esc_attr( $quoteID ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>" />
+								</div>
+								<?php
 
                     }
 					// Quote status.
 				if ( $quoteID > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					?>
 				
-					<tr class="wh-large"><th><label for="quote_status"><?php esc_html_e( 'Status', 'zero-bs-crm' ); ?>:</label></th>
-						<td>
-							<div class="zbs-prominent">
-
-							<select id="quote_status" name="quote_status">
+					<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="quote_status"><?php esc_html_e( 'Status', 'zero-bs-crm' ); ?>:</label>
+						<select class="form-control" id="quote_status" name="quote_status">
 							<?php
 							foreach ( $acceptable_quote_statuses as $status_opt => $status_str ) {
 								$sel = '';
@@ -218,16 +209,22 @@
 								echo '<option value="' . esc_attr( $status_opt ) . '"' . esc_attr( $sel ) . '>' . esc_html( sprintf( __( '%s', 'zero-bs-crm' ), $status_str ) ) . '</option>'; // phpcs:ignore WordPress.WP.I18n.NoEmptyStrings
 							}
 							?>
-							</select>
-							
-						</div>
-						</td></tr>
+						</select>
+					</div>
+					<div class="jpcrm-form-group"></div>
 						<?php
 				} // end if
 
-                    #} ALSO customer assigning is seperate:
-                    ?><tr class="wh-large"><th><label><?php esc_html_e('Contact',"zero-bs-crm");?>:</label></th>
-                    <td><?php
+				?>
+						<style>
+							.zbstypeaheadwrap {
+								padding-top: 0px;
+								padding-bottom: 0px;
+							}
+						</style>
+						<div class="jpcrm-form-group  jpcrm-form-group-span-2">
+						<label class="jpcrm-form-label"><?php esc_html_e( 'Contact', 'zero-bs-crm' ); ?>:</label>
+						<?php
 
                         #} 27/09/16 - switched select for typeahead
 
@@ -331,8 +328,8 @@
                                 }
 
                             </script>
-                    </td>
-                    </tr><?php
+							</div>
+						<?php
 
 
                     // wh centralised 20/7/18 - 2.91+ skipFields
@@ -341,10 +338,8 @@
                     #} if enabled, and new quote, or one which hasn't had the 'templated' meta key added.
                     if ($useQuoteBuilder == 1 && !isset($quote['template'])){
 
-                        ?><tr class="wh-large" id="zbs-quote-builder-step-1">
-
-                            <th colspan="2">
-
+							?>
+								<div class="jpcrm-form-group jpcrm-form-group-span-2">
                                 <div class="zbs-move-on-wrap">
 
                                     <!-- infoz -->
@@ -383,14 +378,13 @@
                                     <?php } ?>
 
                                 </div>
-
-                            </th>
-
-                        </tr><?php
+									</div>
+								<?php
 
                     } ?>
 
-            </table><?php 
+				</div></div>
+				<?php
               
         }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
@@ -182,9 +182,6 @@
 								<div class="jpcrm-form-group jpcrm-form-group-span-2">
 									<label class="jpcrm-form-label"><?php esc_html_e( 'Quote (ID)', 'zero-bs-crm' ); ?>:</label>
 								<?php
-							if ( empty( $quoteID ) ) { //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-								$quoteID = zeroBSCRM_getNextQuoteID(); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-							}
 									echo '<b>' . esc_html( $quoteID ) . '</b>'; //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 							?>
 									<input type="hidden" name="zbsquoteid" value="<?php echo esc_attr( $quoteID ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase ?>" />

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
@@ -212,13 +212,7 @@
 				} // end if
 
 				?>
-						<style>
-							.zbstypeaheadwrap {
-								padding-top: 0px;
-								padding-bottom: 0px;
-							}
-						</style>
-						<div class="jpcrm-form-group  jpcrm-form-group-span-2">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2 jpcrm-override-typeahead-padding">
 						<label class="jpcrm-form-label"><?php esc_html_e( 'Contact', 'zero-bs-crm' ); ?>:</label>
 						<?php
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Quotes.php
@@ -196,7 +196,7 @@
 				if ( $quoteID > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 					?>
 				
-					<div class="jpcrm-form-group">
+					<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="quote_status"><?php esc_html_e( 'Status', 'zero-bs-crm' ); ?>:</label>
 						<select class="form-control" id="quote_status" name="quote_status">
 							<?php
@@ -211,7 +211,6 @@
 							?>
 						</select>
 					</div>
-					<div class="jpcrm-form-group"></div>
 						<?php
 				} // end if
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
@@ -180,7 +180,7 @@
 					<div>
 						<div class="jpcrm-form-grid" id="wptbpMetaBoxMainItem">
 					
-						<div class="jpcrm-form-group">
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 							<label class="jpcrm-form-label" for="ref"><?php echo esc_html( __( 'Transaction unique ID', 'zero-bs-crm' ) ); ?>:</label>
 							<input type="text" id="ref" name="zbst_ref" class="form-control" value="<?php echo esc_attr( isset( $transaction['ref'] ) ? $transaction['ref'] : zeroBSCRM_uniqueID() ); ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( wp_rand( 0, 100 ) ); ?>" /></td>
 						</div>
@@ -222,7 +222,7 @@
 				}
 
 				?>
-					<div class="jpcrm-form-group">
+					<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="zbst_status"><?php echo esc_html( __( 'Transaction Status:', 'zero-bs-crm' ) ); ?></label>
 						<select class="form-control" id="zbst_status" name="zbst_status">
 							<?php
@@ -240,14 +240,14 @@
 						</select>
 					</div>
 
-					<div class="jpcrm-form-group">
+					<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="title"><?php echo esc_html( __( 'Transaction Name:', 'zero-bs-crm' ) ); ?>
 							<span class="zbs-infobox"><?php echo esc_html( __( 'If possible, keep these the same if you routinely use common products here (they are used in the transaction index)', 'zero-bs-crm' ) ); ?></span>
 						</label>
 						<td><input id="title" type="text" name="zbst_title" value="<?php if(isset($transaction['title'])){ echo esc_attr( $transaction['title'] ); }?>" class="form-control widetext" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); // phpcs:ignore ?>" /></td>
 					</div>
 
-					<div class="jpcrm-form-group">
+					<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="total"><?php echo esc_html( __( 'Transaction Value', 'zero-bs-crm' ) ); ?><?php echo ' (' . esc_html( zeroBSCRM_getCurrencyChr() ) . "):"; // phpcs:ignore Squiz.Strings.DoubleQuoteUsage.NotRequired ?></label></th>
 						<input class="form-control" type="text" id="total" name="zbst_total" value="<?php if ( isset( $transaction['total'] ) ) { echo esc_attr( $transaction['total'] ); } else echo '0.00'; ?>" class="form-control numbersOnly" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( wp_rand( 0, 100 ) ); // phpcs:ignore Squiz.PHP.EmbeddedPhp.MultipleStatements, Generic.Formatting.DisallowMultipleStatements.SameLine, Generic.ControlStructures.InlineControlStructure.NotAllowed, Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>" />
 					</div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
@@ -160,17 +160,6 @@
 
 				?>
                 <script type="text/javascript">var zbscrmjs_secToken = '<?php echo esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ); ?>';</script>
-               
-                <style>
-						.zbs-infobox {
-							margin: 0px !important;
-							padding: 0px !important;
-						}
-
-						.zbs-infobox.zbs-live i.zbs-help-ico {
-							font-size: unset;
-						}
-                </style>
 	    		<?php
 
                     // New transaction?
@@ -242,7 +231,7 @@
 
 					<div class="jpcrm-form-group jpcrm-form-group-span-2">
 						<label class="jpcrm-form-label" for="title"><?php echo esc_html( __( 'Transaction Name:', 'zero-bs-crm' ) ); ?>
-							<span class="zbs-infobox"><?php echo esc_html( __( 'If possible, keep these the same if you routinely use common products here (they are used in the transaction index)', 'zero-bs-crm' ) ); ?></span>
+							<span class="zbs-infobox zbs-infobox-transaction"><?php echo esc_html( __( 'If possible, keep these the same if you routinely use common products here (they are used in the transaction index)', 'zero-bs-crm' ) ); ?></span>
 						</label>
 						<td><input id="title" type="text" name="zbst_title" value="<?php if(isset($transaction['title'])){ echo esc_attr( $transaction['title'] ); }?>" class="form-control widetext" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); // phpcs:ignore ?>" /></td>
 					</div>
@@ -255,7 +244,7 @@
 					<div class="jpcrm-form-group">
 						<label class="jpcrm-form-label">
 							<?php echo esc_html( __( 'Transaction Date', 'zero-bs-crm' ) ); ?>:
-							<span class="zbs-infobox"><?php echo esc_html( __( 'The transaction date will default to the initial save date if left blank.', 'zero-bs-crm' ) ); ?></span>
+							<span class="zbs-infobox zbs-infobox-transaction"><?php echo esc_html( __( 'The transaction date will default to the initial save date if left blank.', 'zero-bs-crm' ) ); ?></span>
 						</label>
 						<input class="form-control" type="date" name="zbst_date_datepart" id="transactionDate" value="<?php echo isset( $transaction['date'] ) ? esc_attr( jpcrm_uts_to_date_str( $transaction['date'], 'Y-m-d' ) ) : ''; ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( wp_rand( 0, 100 ) ); ?>" >
 					</div>
@@ -307,7 +296,7 @@
 						<tr class="wh-large">
 							<th>
 								<label><?php echo esc_html( __( 'Date Paid', 'zero-bs-crm' ) );?>:</label>
-								<span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'This will default to the transaction date if left blank.', 'zero-bs-crm' ) );?></span>
+								<span class="zbs-infobox zbs-infobox-transaction"><?php echo esc_html( __( 'This will default to the transaction date if left blank.', 'zero-bs-crm' ) ); ?></span>
 							</th>
 							<td>
 								<input type="date" name="zbst_date_paid_datepart" value="<?php echo isset( $transaction['date_paid'] ) ? esc_attr( jpcrm_uts_to_date_str( $transaction['date_paid'], 'Y-m-d' ) ) : ''; ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" >
@@ -319,7 +308,7 @@
 						<tr class="wh-large">
 							<th>
 								<label><?php echo esc_html( __( 'Date Completed', 'zero-bs-crm' ) );?>:</label>
-								<span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'This will default to the transaction date if left blank.', 'zero-bs-crm' ) );?></span>
+								<span class="zbs-infobox zbs-infobox-transaction"><?php echo esc_html( __( 'This will default to the transaction date if left blank.', 'zero-bs-crm' ) ); ?></span>
 							</th>
 							<td>
 								<input type="date" name="zbst_date_completed_datepart" value="<?php echo isset( $transaction['date_completed'] ) ? esc_attr( jpcrm_uts_to_date_str( $transaction['date_completed'], 'Y-m-d' ) ) : ''; ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" >
@@ -405,7 +394,7 @@
 
 		                    		// mikes inv selector
 								?>
-									<div class="assignInvToCust" style="display:none;max-width:658px;" id="invoiceSelectionTitle"><label><?php echo esc_html( __( 'Contact invoice:', 'zero-bs-crm' ) ); ?></label><span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'Is this transaction a payment for an invoice? If so, enter the Invoice ID. Otherwise leave blank.', 'zero-bs-crm' ) ); ?></span></div>
+									<div class="assignInvToCust" style="display:none;max-width:658px;" id="invoiceSelectionTitle"><label><?php echo esc_html( __( 'Contact invoice:', 'zero-bs-crm' ) ); ?></label><span class="zbs-infobox zbs-infobox-transaction" style="margin-top:3px"><?php echo esc_html( __( 'Is this transaction a payment for an invoice? If so, enter the Invoice ID. Otherwise leave blank.', 'zero-bs-crm' ) ); ?></span></div>
 		                    		<div id="invoiceFieldWrap" style="position:relative;display:none;max-width:658px" class="assignInvToCust"><input style="max-width:200px" id="invoice_id" name="invoice_id" value="<?php if(isset($transaction['invoice_id'])){ echo esc_attr( $transaction['invoice_id'] ); } ?>" class="form-control" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" /></div><?php
 
 		                    	} else {

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
@@ -244,12 +244,12 @@
 						<label class="jpcrm-form-label" for="title"><?php echo esc_html( __( 'Transaction Name:', 'zero-bs-crm' ) ); ?>
 							<span class="zbs-infobox"><?php echo esc_html( __( 'If possible, keep these the same if you routinely use common products here (they are used in the transaction index)', 'zero-bs-crm' ) ); ?></span>
 						</label>
-						<td><input id="title" name="zbst_title" value="<?php if(isset($transaction['title'])){ echo esc_attr( $transaction['title'] ); }?>" class="form-control widetext" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" /></td>
+						<td><input id="title" type="text" name="zbst_title" value="<?php if(isset($transaction['title'])){ echo esc_attr( $transaction['title'] ); }?>" class="form-control widetext" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); // phpcs:ignore ?>" /></td>
 					</div>
 
 					<div class="jpcrm-form-group">
 						<label class="jpcrm-form-label" for="total"><?php echo esc_html( __( 'Transaction Value', 'zero-bs-crm' ) ); ?><?php echo ' (' . esc_html( zeroBSCRM_getCurrencyChr() ) . "):"; // phpcs:ignore Squiz.Strings.DoubleQuoteUsage.NotRequired ?></label></th>
-						<input class="form-control" id="total" name="zbst_total" value="<?php if ( isset( $transaction['total'] ) ) { echo esc_attr( $transaction['total'] ); } else echo '0.00'; ?>" class="form-control numbersOnly" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( wp_rand( 0, 100 ) ); // phpcs:ignore Squiz.PHP.EmbeddedPhp.MultipleStatements, Generic.Formatting.DisallowMultipleStatements.SameLine, Generic.ControlStructures.InlineControlStructure.NotAllowed, Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>" />
+						<input class="form-control" type="text" id="total" name="zbst_total" value="<?php if ( isset( $transaction['total'] ) ) { echo esc_attr( $transaction['total'] ); } else echo '0.00'; ?>" class="form-control numbersOnly" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( wp_rand( 0, 100 ) ); // phpcs:ignore Squiz.PHP.EmbeddedPhp.MultipleStatements, Generic.Formatting.DisallowMultipleStatements.SameLine, Generic.ControlStructures.InlineControlStructure.NotAllowed, Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>" />
 					</div>
 
 					<div class="jpcrm-form-group">

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Transactions.php
@@ -162,11 +162,14 @@
                 <script type="text/javascript">var zbscrmjs_secToken = '<?php echo esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ); ?>';</script>
                
                 <style>
-                        @media all and (max-width:699px){
-                        table.wh-metatab{
-                            min-width:100% !important;
-                        }
-                    }  
+						.zbs-infobox {
+							margin: 0px !important;
+							padding: 0px !important;
+						}
+
+						.zbs-infobox.zbs-live i.zbs-help-ico {
+							font-size: unset;
+						}
                 </style>
 	    		<?php
 
@@ -174,12 +177,13 @@
                     if (gettype($transaction) != "array") echo '<input type="hidden" name="zbscrm_newtransaction" value="1" />';
 
                 ?>
-				<table class="form-table wh-metatab wptbp" id="wptbpMetaBoxMainItem">
-
-					<tr class="wh-large">
-						<th style="min-width:240px"><label for="ref"><?php echo esc_html( __( 'Transaction unique ID', 'zero-bs-crm' ) );?>:</label></th>
-						<td><input type="text" id="ref" name="zbst_ref" class="form-control" value="<?php echo esc_attr( isset( $transaction['ref'] ) ? $transaction['ref'] : zeroBSCRM_uniqueID() ); ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" /></td>
-					</tr>
+					<div>
+						<div class="jpcrm-form-grid" id="wptbpMetaBoxMainItem">
+					
+						<div class="jpcrm-form-group">
+							<label class="jpcrm-form-label" for="ref"><?php echo esc_html( __( 'Transaction unique ID', 'zero-bs-crm' ) ); ?>:</label>
+							<input type="text" id="ref" name="zbst_ref" class="form-control" value="<?php echo esc_attr( isset( $transaction['ref'] ) ? $transaction['ref'] : zeroBSCRM_uniqueID() ); ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( wp_rand( 0, 100 ) ); ?>" /></td>
+						</div>
 
 					<?php
 
@@ -197,26 +201,15 @@
 						$parent_ref = $zbs->DAL->transactions->get_transaction_ref( $transaction['parent'] );
 
 						?>
-						<tr class="wh-large">
-							<th></th>
-							<td>
+						<div class="jpcrm-form-group jpcrm-form-group-span-2">
 								<p style="text-align: center;">
 									<?php echo esc_html( sprintf( __( 'This transaction is a refund against transaction #%s', 'zero-bs-crm' ), $parent_ref ) ); ?>
 									<a href="<?php echo jpcrm_esc_link( 'edit', $transaction['parent'], ZBS_TYPE_TRANSACTION ); ?>" class="ui compact teal button" style="margin-left:10px"><?php echo esc_html( __( 'View Original Transaction', 'zero-bs-crm' ) ); ?></a>
 								</p>
-							</td>
-						</tr>
+						</div>
 						<?php
 
 					}
-
-					?>
-
-					<tr>
-						<td colspan="2"><hr /></td>
-					</tr>
-
-				<?php
 
 				// get transaction statuses
 				$available_statuses = zeroBSCRM_getTransactionsStatuses( true );
@@ -229,11 +222,9 @@
 				}
 
 				?>
-					<tr class="wh-large">
-						<th><label for="zbst_status"><?php echo esc_html( __( 'Transaction Status:', 'zero-bs-crm' ) ); ?></label>
-						</th>
-						<td>
-						<select id="zbst_status" name="zbst_status">
+					<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="zbst_status"><?php echo esc_html( __( 'Transaction Status:', 'zero-bs-crm' ) ); ?></label>
+						<select class="form-control" id="zbst_status" name="zbst_status">
 							<?php
 						foreach ( $available_statuses as $status ) {
 							$sel = $status === $transaction['status'] ? ' selected' : '';
@@ -247,31 +238,31 @@
 						}
 						?>
 						</select>
-					</tr>
+					</div>
 
-					<tr class="wh-large">
-						<th><label for="title"><?php echo esc_html( __( 'Transaction Name:', 'zero-bs-crm' ) ); ?></label>
-							<span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'If possible, keep these the same if you routinely use common products here (they are used in the transaction index)', 'zero-bs-crm' ) );?></span>
-						</th>
+					<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="title"><?php echo esc_html( __( 'Transaction Name:', 'zero-bs-crm' ) ); ?>
+							<span class="zbs-infobox"><?php echo esc_html( __( 'If possible, keep these the same if you routinely use common products here (they are used in the transaction index)', 'zero-bs-crm' ) ); ?></span>
+						</label>
 						<td><input id="title" name="zbst_title" value="<?php if(isset($transaction['title'])){ echo esc_attr( $transaction['title'] ); }?>" class="form-control widetext" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" /></td>
-					</tr>
+					</div>
 
-					<tr class="wh-large">
-						<th><label for="total"><?php echo esc_html( __( 'Transaction Value', 'zero-bs-crm' ) ); ?><?php echo ' ('. esc_html( zeroBSCRM_getCurrencyChr() ) . "):"; ?></label></th>
-						<td><input id="total" name="zbst_total" value="<?php if(isset($transaction['total'])){ echo esc_attr( $transaction['total'] ); } else echo '0.00'; ?>" class="form-control numbersOnly" style="width: 130px;display: inline-block;" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" /></td>
-					</tr>
+					<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label" for="total"><?php echo esc_html( __( 'Transaction Value', 'zero-bs-crm' ) ); ?><?php echo ' (' . esc_html( zeroBSCRM_getCurrencyChr() ) . "):"; // phpcs:ignore Squiz.Strings.DoubleQuoteUsage.NotRequired ?></label></th>
+						<input class="form-control" id="total" name="zbst_total" value="<?php if ( isset( $transaction['total'] ) ) { echo esc_attr( $transaction['total'] ); } else echo '0.00'; ?>" class="form-control numbersOnly" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( wp_rand( 0, 100 ) ); // phpcs:ignore Squiz.PHP.EmbeddedPhp.MultipleStatements, Generic.Formatting.DisallowMultipleStatements.SameLine, Generic.ControlStructures.InlineControlStructure.NotAllowed, Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace ?>" />
+					</div>
 
-					<tr class="wh-large">
-						<th>
-							<label><?php echo esc_html( __( 'Transaction Date', 'zero-bs-crm' ) );?>:</label>
-							<span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'The transaction date will default to the initial save date if left blank.', 'zero-bs-crm' ) );?></span>
-						</th>
-						<td>
-							<input type="date" name="zbst_date_datepart" id="transactionDate" value="<?php echo isset( $transaction['date'] ) ? esc_attr( jpcrm_uts_to_date_str( $transaction['date'], 'Y-m-d' ) ) : ''; ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" >
-							@
-							<input type="time" name="zbst_date_timepart" value="<?php echo isset( $transaction['date'] ) ? esc_attr( jpcrm_uts_to_time_str( $transaction['date'], 'H:i' ) ) : ''; ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" >
-						</td>
-					</tr>
+					<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label">
+							<?php echo esc_html( __( 'Transaction Date', 'zero-bs-crm' ) ); ?>:
+							<span class="zbs-infobox"><?php echo esc_html( __( 'The transaction date will default to the initial save date if left blank.', 'zero-bs-crm' ) ); ?></span>
+						</label>
+						<input class="form-control" type="date" name="zbst_date_datepart" id="transactionDate" value="<?php echo isset( $transaction['date'] ) ? esc_attr( jpcrm_uts_to_date_str( $transaction['date'], 'Y-m-d' ) ) : ''; ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( wp_rand( 0, 100 ) ); ?>" >
+					</div>
+					<div class="jpcrm-form-group">
+						<label class="jpcrm-form-label">&nbsp;</label>
+						<input class="form-control" type="time" name="zbst_date_timepart" value="<?php echo isset( $transaction['date'] ) ? esc_attr( jpcrm_uts_to_time_str( $transaction['date'], 'H:i' ) ) : ''; ?>" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( wp_rand( 0, 100 ) ); ?>" >
+					</div>
 
 					<?php
 					// Custom Fields
@@ -341,7 +332,8 @@
 
 					?>
 
-				</table>
+					</div>
+				</div>
 
 			    <?php // ========== Line Items 
 			    if (isset($transactions['lineitems']) && is_array($transaction['lineitems'])){ ?>
@@ -413,7 +405,7 @@
 
 		                    		// mikes inv selector
 								?>
-									<div class="assignInvToCust" style="display:none;max-width:658px" id="invoiceSelectionTitle"><label><?php echo esc_html( __( 'Contact invoice:', 'zero-bs-crm' ) ); ?></label><span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'Is this transaction a payment for an invoice? If so, enter the Invoice ID. Otherwise leave blank.', 'zero-bs-crm' ) ); ?></span></div>
+									<div class="assignInvToCust" style="display:none;max-width:658px;" id="invoiceSelectionTitle"><label><?php echo esc_html( __( 'Contact invoice:', 'zero-bs-crm' ) ); ?></label><span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'Is this transaction a payment for an invoice? If so, enter the Invoice ID. Otherwise leave blank.', 'zero-bs-crm' ) ); ?></span></div>
 		                    		<div id="invoiceFieldWrap" style="position:relative;display:none;max-width:658px" class="assignInvToCust"><input style="max-width:200px" id="invoice_id" name="invoice_id" value="<?php if(isset($transaction['invoice_id'])){ echo esc_attr( $transaction['invoice_id'] ); } ?>" class="form-control" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" /></div><?php
 
 		                    	} else {
@@ -433,10 +425,12 @@
 			                    		
 			                    		// mikes inv selector
 										?>
-										<div class="assignInvToCust" style="display:none;max-width:658px" id="invoiceSelectionTitle"><label><?php echo esc_html( __( 'Contact invoice:', 'zero-bs-crm' ) ); ?></label><span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'Is this transaction a payment for an invoice? If so, enter the Invoice ID. Otherwise leave blank.', 'zero-bs-crm' ) ); ?></span></div>
+										<div class="assignInvToCust" style="display:none;max-width:658px;margin-top:21px;margin-bottom:10px;" id="invoiceSelectionTitle"><label><?php echo esc_html( __( 'Contact invoice:', 'zero-bs-crm' ) ); ?>&nbsp;</label><span class="zbs-infobox" style="margin-top:3px"><?php echo esc_html( __( 'Is this transaction a payment for an invoice? If so, enter the Invoice ID. Otherwise leave blank.', 'zero-bs-crm' ) ); ?></span></div>
 			                    		<div id="invoiceFieldWrap" style="position:relative;display:none;max-width:658px" class="assignInvToCust"><input style="max-width:200px" id="invoice_id" name="invoice_id" value="<?php if(isset($transaction['invoice_id'])){ echo esc_attr( $transaction['invoice_id'] ); } ?>" class="form-control" autocomplete="zbstra-<?php echo esc_attr( time() ); ?>-<?php echo esc_attr( rand(0,100) ); ?>" /></div><?php
 
-			                    		 ?></div><div class="two wide column centered"><?php echo esc_html( __( 'Or', 'zero-bs-crm' ) ); ?></div><div class="seven wide column"><div id="zbs-company-title"><label><?php echo esc_html( jpcrm_label_company() ); ?></label></div><?php
+										?>
+												</div><div class="two wide column centered" style="text-align:center;"><?php echo esc_html( __( 'Or', 'zero-bs-crm' ) ); ?></div><div class="seven wide column"><div id="zbs-company-title"><label><?php echo esc_html( jpcrm_label_company() ); ?></label></div>
+											<?php
 
 			                    		// company
 				                       	echo zeroBSCRM_CompanyTypeList('zbscrmjs_transaction_setCompany',$companyName,true,'zbscrmjs_transaction_unsetCompany'); 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.transactioneditor.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.transactioneditor.js
@@ -354,7 +354,7 @@ function zeroBSCRMJS_showContactLinkIf( contactID ) {
 
 			// ALSO show in header bar, if so
 			var navButton =
-				'<a target="_blank" style="margin-left:6px;" class="zbs-trans-quicknav-contact ui icon button blue mini labeled" href="' +
+				'<a target="_blank" style="margin-left:6px;" class="zbs-trans-quicknav-contact ui icon button black mini labeled" href="' +
 				url +
 				'"><i class="user icon"></i> ' +
 				zeroBSCRMJS_transEditLang( 'contact', 'Contact' ) +

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.transactioneditor.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.transactioneditor.js
@@ -414,7 +414,7 @@ function zeroBSCRMJS_showCompanyLinkIf( companyID ) {
 
 			// ALSO show in header bar, if so
 			var navButton =
-				'<a target="_blank" style="margin-left:6px;" class="zbs-trans-quicknav-company ui icon button blue mini labeled" href="' +
+				'<a target="_blank" style="margin-left:6px;" class="zbs-trans-quicknav-company ui icon button black mini labeled" href="' +
 				window.zeroBSCRMJS_transactionedit_links.editcompanyprefix +
 				companyID +
 				'"><i class="building icon"></i> ' +

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
@@ -581,7 +581,6 @@
 	}
 	#zbs_invoice_actions{
 		padding: 15px 10px 15px 10px;
-	    background: #f5f5f5;
 	    margin-left: -12px;
 	    margin-right: -12px;
 	    margin-top: -6px;

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.quotebuilder.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.quotebuilder.scss
@@ -87,3 +87,12 @@
         margin-bottom:0;
     }
 }
+
+.jpcrm-override-typeahead-padding {
+
+	.zbstypeaheadwrap {
+		padding-top: 0px;
+		padding-bottom: 0px;
+	}
+
+}

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.transactionedit.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.transactionedit.scss
@@ -30,3 +30,12 @@
 		width: 100%;
 	}
 }
+
+.zbs-infobox-transaction {
+	margin: 0px !important;
+	padding: 0px !important;
+
+	.zbs-live i.zbs-help-ico {
+		font-size: unset;
+	}
+}

--- a/projects/plugins/crm/sass/_ZeroBSCRM.adminpages.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.adminpages.scss
@@ -655,8 +655,7 @@ div.ui.learn.button {
 #zbs-invoice-learn-nav,
 #zbs-transaction-learn-nav,
 #zbs-event-learn-nav {
-    display: inline-block;
-    float: right;
+    display: flex;
 }
 
 //UI tweak for contact fiew

--- a/projects/plugins/crm/sass/_ZeroBSCRM.forms.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.forms.scss
@@ -160,6 +160,7 @@ tr.zbs-field-group-tr label.zbs-field-group-label {
     padding: 6px 12px !important;
     cursor: pointer;
 	 width: initial;
+	 font-weight: 500;
 }
 
 .jpcrm-customer-file-upload:hover, 

--- a/projects/plugins/crm/sass/_ZeroBSCRM.genericeditpages.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.genericeditpages.scss
@@ -166,7 +166,6 @@ textarea.form-control{
 
 // telephone - for clickable links :)
 .zbs-tel-wrap .form-control.zbs-tel {
-    max-width: 180px;
     display: inline-block;
 }
 .zbs-tel-wrap a {
@@ -188,7 +187,6 @@ textarea.form-control{
 // date fields
 .form-control.jpcrm-date, .form-control.zbs-date {
     display: inline-block;
-    width: auto;
 }
 
 

--- a/projects/plugins/crm/sass/emerald/_edit-page.scss
+++ b/projects/plugins/crm/sass/emerald/_edit-page.scss
@@ -1,0 +1,66 @@
+.jpcrm-form-grid {
+	display: grid;
+	gap: 1rem;
+	padding: 1rem;
+	overflow: auto;
+
+	select,
+	input {
+		box-sizing: border-box;
+		width: 100%;
+		max-width: 100%;
+		margin:0px;
+	}
+
+	&.one-column {
+		grid-template-columns: 1fr;
+		padding: 0px;
+	}
+}
+
+.jpcrm-form-label {
+	display: block;
+	font-weight: normal;
+	line-height: 1.4;
+	margin-bottom: calc(8px);
+	padding: 0px;
+}
+
+.jpcrm-form-input, .jpcrm-form-select {
+	width: 100%;
+	max-width: unset !important;
+}
+
+.jpcrm-form-input-group {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+}
+
+.jpcrm-input-text {
+	font-size: 13px;
+}
+
+.jpcrm-input-select {
+	max-width: unset !important;
+}
+
+@media (min-width: 768px) {
+	.jpcrm-form-grid {
+		grid-template-columns: 1fr 1fr;
+	}
+
+	.jpcrm-form-group-span-2 {
+		grid-column: span 2;
+	}
+}
+
+@media (max-width: 767px) {
+	.jpcrm-form-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.jpcrm-empty-form-group {
+		display: none;
+	}
+}

--- a/projects/plugins/crm/sass/emerald/_jpcrm_vars.scss
+++ b/projects/plugins/crm/sass/emerald/_jpcrm_vars.scss
@@ -1,0 +1,4 @@
+:root {
+	--jpcrm-font-family-emerald: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu',
+		'Cantarell', 'Helvetica Neue', sans-serif;
+}

--- a/projects/plugins/crm/sass/jpcrm-emerald.scss
+++ b/projects/plugins/crm/sass/jpcrm-emerald.scss
@@ -1,5 +1,6 @@
 /* JP vars */
 @use 'emerald/_jp_vars.scss';
+@use 'emerald/_jpcrm_vars.scss';
 
 /* base file */
 @use 'emerald/_emerald_base.scss';
@@ -12,6 +13,7 @@
 @use 'emerald/_dashcard.scss';
 @use 'emerald/_dashcount.scss';
 @use 'emerald/_dropdown-buttons.scss';
+@use 'emerald/_edit-page.scss';
 @use 'emerald/_learn-menu.scss';
 @use 'emerald/_listview.scss';
 @use 'emerald/_listview-footer.scss';


### PR DESCRIPTION
## Proposed changes:
* This PR changes the following pages to fit Jetpack Emerald style:
    * Edit Contact
    * Edit Company
    * Edit Quote
    * Edit Quote Template
    * Edit Transactions 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
[Change CRM edit pages to fit the Emerald style#3124](https://github.com/Automattic/zero-bs-crm/issues/3124)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Go to the following pages and make sure it fits the latest Jetpack Emerald style:
 _(Note: test it while editing existing content, and also adding new content)_
    * Edit Contact
    * Edit Company
    * Edit Quote
    * Edit Quote Template
    * Edit Transactions 

## Old vs New screenshots:

![image](https://github.com/Automattic/jetpack/assets/37049295/1503bf61-781c-4aa4-8c25-c7d7b2b2b14b)
![image](https://github.com/Automattic/jetpack/assets/37049295/9af9acdf-1dc3-4cf6-a59c-a70201db6e89)

![image](https://github.com/Automattic/jetpack/assets/37049295/3b90ec6b-cf60-4179-b8a8-ac92bcc47d47)
![image](https://github.com/Automattic/jetpack/assets/37049295/f1718d2c-eb0e-4a6b-85b7-d1f64158a9b8)

![image](https://github.com/Automattic/jetpack/assets/37049295/d3d75e01-aa67-4c03-8fbf-a2f4e6b6b233)
![image](https://github.com/Automattic/jetpack/assets/37049295/3f9ac4b5-ec40-4d8f-99c6-06279d723b03)

![image](https://github.com/Automattic/jetpack/assets/37049295/da25ac76-e37e-431f-8672-f8bc2676d898)
![image](https://github.com/Automattic/jetpack/assets/37049295/ba6add7b-3c10-4fcd-ae5a-24d2750be1c0)

![image](https://github.com/Automattic/jetpack/assets/37049295/abcda520-32cf-4068-b88a-b6e4e8364d56)
![image](https://github.com/Automattic/jetpack/assets/37049295/7de53db3-4d47-4b58-bebd-ebd03732fd5d)