### PR TITLE
AI Assistant: expose AI Assistant feature data in the Jetpack global state

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-extend-when-possible
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-extend-when-possible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: do not extend when site requires upgrading

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -700,6 +700,7 @@ class Jetpack_Gutenberg {
 			'wpcomBlogId'      => $blog_id,
 			'allowedMimeTypes' => wp_get_mime_types(),
 			'siteLocale'       => str_replace( '_', '-', get_locale() ),
+			'ai-assistant'     => Jetpack_AI_Helper::get_ai_assistance_feature(),
 		);
 
 		if ( Jetpack::is_module_active( 'publicize' ) && function_exists( 'publicize_init' ) ) {

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -658,7 +658,10 @@ class Jetpack_Gutenberg {
 		// AI Assistant
 		$ai_assistant_state = Jetpack_AI_Helper::get_ai_assistance_feature();
 		if ( is_wp_error( $ai_assistant_state ) ) {
-			$ai_assistant_state = array();
+			$ai_assistant_state = array(
+				'error-message' => $ai_assistant_state->get_error_message(),
+				'error-code'    => $ai_assistant_state->get_error_code(),
+			);
 		}
 
 		$initial_state = array(

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -655,6 +655,12 @@ class Jetpack_Gutenberg {
 			$is_current_user_connected = ( new Connection_Manager( 'jetpack' ) )->is_user_connected();
 		}
 
+		// AI Assistant
+		$ai_assistant_state = Jetpack_AI_Helper::get_ai_assistance_feature();
+		if ( is_wp_error( $ai_assistant_state ) ) {
+			$ai_assistant_state = array();
+		}
+
 		$initial_state = array(
 			'available_blocks' => self::get_availability(),
 			'jetpack'          => array(
@@ -700,7 +706,7 @@ class Jetpack_Gutenberg {
 			'wpcomBlogId'      => $blog_id,
 			'allowedMimeTypes' => wp_get_mime_types(),
 			'siteLocale'       => str_replace( '_', '-', get_locale() ),
-			'ai-assistant'     => Jetpack_AI_Helper::get_ai_assistance_feature(),
+			'ai-assistant'     => $ai_assistant_state,
 		);
 
 		if ( Jetpack::is_module_active( 'publicize' ) && function_exists( 'publicize_init' ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/index.ts
@@ -5,6 +5,7 @@ import { addFilter } from '@wordpress/hooks';
 /*
  * Internal dependencies
  */
+import { AI_Assistant_Initial_State } from '../../hooks/use-ai-feature';
 import { isUserConnected } from '../../lib/connection';
 import withMultipleBlocksEdition from './edit';
 
@@ -12,6 +13,10 @@ const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading' ];
 
 function multipleBlocksEdition( settings, name ) {
 	const connected = isUserConnected();
+
+	if ( AI_Assistant_Initial_State.requireUpgrade ) {
+		return settings;
+	}
 
 	if ( ! connected ) {
 		return settings;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/multiple-blocks-edition/index.ts
@@ -12,16 +12,23 @@ import withMultipleBlocksEdition from './edit';
 const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading' ];
 
 function multipleBlocksEdition( settings, name ) {
+	// Do not extend the block if the site is not connected.
 	const connected = isUserConnected();
-
-	if ( AI_Assistant_Initial_State.requireUpgrade ) {
-		return settings;
-	}
-
 	if ( ! connected ) {
 		return settings;
 	}
 
+	// Do not extend the block if the site requires an upgrade.
+	if ( AI_Assistant_Initial_State.requireUpgrade ) {
+		return settings;
+	}
+
+	// Do not extend if there is an error getting the feature.
+	if ( AI_Assistant_Initial_State.errorCode ) {
+		return settings;
+	}
+
+	// Only extend the blocks in the list.
 	if ( ! EXTENDED_BLOCKS.includes( name ) ) {
 		return settings;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/global.d.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/global.d.ts
@@ -1,3 +1,5 @@
+import { SiteAIAssistantFeatureEndpointResponseProps } from './hooks/use-ai-feature';
+
 export {};
 
 declare global {
@@ -47,6 +49,7 @@ declare global {
 		};
 		Jetpack_Editor_Initial_State: {
 			adminUrl: string;
+			'ai-assistant': SiteAIAssistantFeatureEndpointResponseProps;
 		};
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/Readme.md
@@ -1,4 +1,4 @@
-# useAIFeature
+# useAIFeature()
 
 React custom hook that provides valuable data about AI requests for the site.
 
@@ -17,3 +17,11 @@ function UpgradePlan() {
 	);
 }
 ```
+
+# getAIFeature()
+
+Async helper function that performes and returns relevant data about the AI Assistant feature
+
+# AI_Assistant_Initial_State
+
+Constant with the initial state of the AI Assistant feature

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -4,7 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from 'react';
 
-type SiteAIAssistantFeatureEndpointResponseProps = {
+export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'has-feature': boolean;
 	'is-over-limit': boolean;
 	'requests-count': number;
@@ -12,35 +12,52 @@ type SiteAIAssistantFeatureEndpointResponseProps = {
 	'site-require-upgrade': boolean;
 };
 
+type AIFeatureProps = {
+	hasFeature: boolean;
+	isOverLimit: boolean;
+	requestsCount: number;
+	requestsLimit: number;
+	requireUpgrade: boolean;
+};
+
 const NUM_FREE_REQUESTS_LIMIT = 20;
 
-export default function useAIFeature() {
-	const [ data, setData ] = useState( {
-		hasFeature: true,
-		isOverLimit: false,
-		requestsCount: 0,
-		requestsLimit: NUM_FREE_REQUESTS_LIMIT,
-		requireUpgrade: false,
+export const AI_Assistant_Initial_State = {
+	hasFeature: window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'has-feature' ] || true,
+	isOverLimit:
+		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-over-limit' ] || false,
+	requestsCount:
+		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'requests-count' ] || 0,
+	requestsLimit:
+		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'requests-limit' ] ||
+		NUM_FREE_REQUESTS_LIMIT,
+	requireUpgrade:
+		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'site-require-upgrade' ] || false,
+};
+
+export async function getAIFeatures(): Promise< AIFeatureProps > {
+	const response: SiteAIAssistantFeatureEndpointResponseProps = await apiFetch( {
+		path: '/wpcom/v2/jetpack-ai/ai-assistant-feature',
 	} );
 
-	useEffect( () => {
-		( async () => {
-			const response: SiteAIAssistantFeatureEndpointResponseProps = await apiFetch( {
-				path: '/wpcom/v2/jetpack-ai/ai-assistant-feature',
-			} );
+	try {
+		return {
+			hasFeature: !! response[ 'has-feature' ],
+			isOverLimit: !! response[ 'is-over-limit' ],
+			requestsCount: response[ 'requests-count' ],
+			requestsLimit: response[ 'requests-limit' ],
+			requireUpgrade: !! response[ 'site-require-upgrade' ],
+		};
+	} catch ( error ) {
+		console.error( error ); // eslint-disable-line no-console
+	}
+}
 
-			try {
-				setData( {
-					hasFeature: !! response[ 'has-feature' ],
-					isOverLimit: !! response[ 'is-over-limit' ],
-					requestsCount: response[ 'requests-count' ],
-					requestsLimit: response[ 'requests-limit' ],
-					requireUpgrade: !! response[ 'site-require-upgrade' ],
-				} );
-			} catch ( error ) {
-				console.error( error ); // eslint-disable-line no-console
-			}
-		} )();
+export default function useAIFeature() {
+	const [ data, setData ] = useState< AIFeatureProps >( AI_Assistant_Initial_State );
+
+	useEffect( () => {
+		getAIFeatures().then( setData );
 	}, [] );
 
 	return data;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -10,6 +10,8 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'requests-count': number;
 	'requests-limit': number;
 	'site-require-upgrade': boolean;
+	'error-message': string;
+	'error-code': string;
 };
 
 type AIFeatureProps = {
@@ -33,6 +35,8 @@ export const AI_Assistant_Initial_State = {
 		NUM_FREE_REQUESTS_LIMIT,
 	requireUpgrade:
 		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'site-require-upgrade' ] || false,
+	errorMessage: window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'error-message' ] || '',
+	errorCode: window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'error-code' ],
 };
 
 export async function getAIFeatures(): Promise< AIFeatureProps > {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -20,6 +20,8 @@ type AIFeatureProps = {
 	requestsCount: number;
 	requestsLimit: number;
 	requireUpgrade: boolean;
+	errorMessage: string;
+	errorCode: string;
 };
 
 const NUM_FREE_REQUESTS_LIMIT = 20;
@@ -51,6 +53,8 @@ export async function getAIFeatures(): Promise< AIFeatureProps > {
 			requestsCount: response[ 'requests-count' ],
 			requestsLimit: response[ 'requests-limit' ],
 			requireUpgrade: !! response[ 'site-require-upgrade' ],
+			errorMessage: response[ 'error-message' ],
+			errorCode: response[ 'error-code' ],
 		};
 	} catch ( error ) {
 		console.error( error ); // eslint-disable-line no-console


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR checks if the site requires an upgrade.

* It populates the Jetpack global object with the `ai-assistant` key
* It updates the `useAIFeature()` hook to provide immediately relevant about the feature
* Additionally, it does not extend the core/paragraph and core/header blocks when the site requires upgrading

If something fails when requesting feature data, the initial state object will be populated with the `error-messages` and `error-code` keys. When this happens, the app doesn't extend the blocks either.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: expose AI Assistant feature data in the Jetpack global state

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a site that requires an upgrade (No plan, Requests limit achieved)
* Go to the block editor
* Confirm you see the AI Assistant object in the global initial state object

<img width="361" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/609a583b-ae83-413e-8dcc-cd42fe1122d4">

* Create a new AI Assistant block instance
* Confirm the block shows the banner right after it renders

<img width="657" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/28008550-bb29-4fd2-829d-60d12fef7973">

