### PR TITLE
CRM: Resolves 3129 - catch PHP errors

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3129-php_errors
+++ b/projects/plugins/crm/changelog/fix-crm-3129-php_errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Extensions: catch PHP notice if offline

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -2167,8 +2167,7 @@ function zeroBSCRM_html_extensions() {
 
 			// We want to prioritize the top 5 Woo modules in the list if 'woosync' is active, but otherwise alphabetize everything.
 			foreach ( $extensions->paid as $extension ) {
-
-				if ( $has_woosync && in_array( $extension->slug, $top_woo_extension_slugs, true ) ) {
+				if ( $has_woosync && ! empty( $extension->slug ) && in_array( $extension->slug, $top_woo_extension_slugs, true ) ) {
 					$top_woo_extensions[] = $extension;
 					continue;
 				}

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -828,8 +828,8 @@ class zeroBSCRM_list{
 	public function draw_listview_header( $listview_filters ) {
 		global $zbs;
 
-		$filter_var       = 'zeroBSCRM_filterbuttons_' . $this->objType; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$all_quickfilters = $GLOBALS[ $filter_var ]['all'];
+		$filter_var       = 'zeroBSCRM_filterbuttons_a' . $this->objType; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$all_quickfilters = ( empty( $GLOBALS[ $filter_var ]['all'] ) ? array() : $GLOBALS[ $filter_var ]['all'] );
 		$all_tags         = $zbs->DAL->getTagsForObjType( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			array(
 				'objtypeid'    => $this->objTypeID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -868,7 +868,7 @@ class zeroBSCRM_list{
 				}
 
 				// add tags filter if current object has tags
-				if ( count( $all_tags ) > 0 ) {
+				if ( is_array( $all_tags ) && count( $all_tags ) > 0 ) {
 					echo '<select class="filter-dropdown' . ( ! empty( $current_tag ) ? ' hidden' : '' ) . '" data-filtertype="tags">';
 					echo '<option disabled selected>' . esc_html__( 'Select tag', 'zero-bs-crm' ) . '</option>';
 					foreach ( $all_tags as $tag ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3129 - catch PHP errors

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This catches two minor PHP notices:

* If loading the listview but there were no tags or quickfilters (e.g. Mail Campaigns listviews) it would try to access a non-existent index.
* If offline, the extensions page tries to access the non-existent `slug` property when processing extensions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to `/wp-admin/admin.php?page=manage-campaigns`.
2. Turn off internet and go to `/wp-admin/admin.php?page=zerobscrm-extensions`.

In `trunk`, both of these URLs will cause PHP notices.

In `fix/crm/3129-php_errors`, the notices are no more.