### PR TITLE
Publicize: bump social previews version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,8 +686,8 @@ importers:
         specifier: workspace:*
         version: link:../shared-extension-utils
       '@automattic/social-previews':
-        specifier: 2.0.1-beta.2
-        version: 2.0.1-beta.2(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.1-beta.3
+        version: 2.0.1-beta.3(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@wordpress/annotations':
         specifier: 2.32.0
         version: 2.32.0(react@18.2.0)
@@ -2730,8 +2730,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@automattic/social-previews':
-        specifier: 2.0.1-beta.2
-        version: 2.0.1-beta.2(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.0.1-beta.3
+        version: 2.0.1-beta.3(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@automattic/viewport':
         specifier: 1.0.0
         version: 1.0.0
@@ -3954,8 +3954,8 @@ packages:
       '@automattic/popup-monitor': 1.0.2
     dev: false
 
-  /@automattic/social-previews@2.0.1-beta.2(@babel/core@7.21.5)(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-zniVC70amWCPmpoSEE8p4RKoofEem1pe2+ifE4MmUyRzSmbJ4H1V9Lmw5kU8WhuiagKBjLR45IWjbjrqWNbxhw==}
+  /@automattic/social-previews@2.0.1-beta.3(@babel/runtime@7.21.5)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-sPwREfWShd4gbiGLd5CK9ZGw4kGFnW595LnniXH9shTapy1VnATJZdXS9XfXYY6B9zR3lzpa09N7huEyVMUS6Q==}
     peerDependencies:
       '@babel/runtime': ^7
       react: ^17.0.2 || ^18
@@ -3965,17 +3965,16 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.21.5
-      '@emotion/react': 11.4.1(@babel/core@7.21.5)(@types/react@18.0.27)(react@18.2.0)
+      '@emotion/react': 11.11.0(@types/react@18.0.27)(react@18.2.0)
       '@wordpress/components': 22.1.0(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
       '@wordpress/element': 5.11.0
       '@wordpress/i18n': 4.32.0
       classnames: 2.3.2
-      prop-types: 15.8.1
+      prop-types: 15.7.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.5.0
     transitivePeerDependencies:
-      - '@babel/core'
       - '@babel/helper-module-imports'
       - '@babel/types'
       - '@types/react'
@@ -5414,30 +5413,6 @@ packages:
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
 
-  /@emotion/react@11.4.1(@babel/core@7.21.5)(@types/react@18.0.27)(react@18.2.0):
-    resolution: {integrity: sha512-pRegcsuGYj4FCdZN6j5vqCALkNytdrKw3TZMekTzNXixRg4wkLsU5QEaBG5LC6l01Vppxlp7FE3aTHpIG5phLg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/react': '*'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.5
-      '@babel/runtime': 7.21.5
-      '@emotion/cache': 11.11.0
-      '@emotion/serialize': 1.1.2
-      '@emotion/sheet': 1.2.2
-      '@emotion/utils': 1.2.1
-      '@emotion/weak-memoize': 0.2.5
-      '@types/react': 18.0.27
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-    dev: false
-
   /@emotion/react@11.4.1(@babel/core@7.21.5)(react@18.2.0):
     resolution: {integrity: sha512-pRegcsuGYj4FCdZN6j5vqCALkNytdrKw3TZMekTzNXixRg4wkLsU5QEaBG5LC6l01Vppxlp7FE3aTHpIG5phLg==}
     peerDependencies:
@@ -5550,6 +5525,7 @@ packages:
 
   /@emotion/weak-memoize@0.2.5:
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
+    dev: true
 
   /@emotion/weak-memoize@0.3.1:
     resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
@@ -10293,7 +10269,7 @@ packages:
       '@wordpress/keycodes': 3.32.0
       memize: 1.1.0
       react: 18.2.0
-      rememo: 4.0.1
+      rememo: 4.0.2
     dev: false
 
   /@wordpress/rich-text@6.9.0(react@18.2.0):
@@ -12671,7 +12647,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.5
       compute-scroll-into-view: 1.0.20
-      prop-types: 15.8.1
+      prop-types: 15.7.2
       react: 18.2.0
       react-is: 17.0.2
       tslib: 2.5.0
@@ -18384,7 +18360,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: false
 
   /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -18618,7 +18593,7 @@ packages:
     dependencies:
       autosize: 4.0.4
       line-height: 0.3.1
-      prop-types: 15.8.1
+      prop-types: 15.7.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
@@ -18853,7 +18828,7 @@ packages:
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
       path-to-regexp: 1.8.0
-      prop-types: 15.8.1
+      prop-types: 15.7.2
       react: 18.2.0
       react-is: 16.13.1
       tiny-invariant: 1.3.1

--- a/projects/js-packages/publicize-components/changelog/update-publicize-social-previews-version
+++ b/projects/js-packages/publicize-components/changelog/update-publicize-social-previews-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Bump social-previews version

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -22,7 +22,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
-		"@automattic/social-previews": "2.0.1-beta.2",
+		"@automattic/social-previews": "2.0.1-beta.3",
 		"@wordpress/annotations": "2.32.0",
 		"@wordpress/api-fetch": "6.29.0",
 		"@wordpress/block-editor": "12.0.0",

--- a/projects/plugins/jetpack/changelog/update-publicize-social-previews-version
+++ b/projects/plugins/jetpack/changelog/update-publicize-social-previews-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Bump social-previews version

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -57,7 +57,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/request-external-access": "1.0.0",
-		"@automattic/social-previews": "2.0.1-beta.2",
+		"@automattic/social-previews": "2.0.1-beta.3",
 		"@automattic/viewport": "1.0.0",
 		"@microsoft/fetch-event-source": "2.0.1",
 		"@wordpress/base-styles": "4.23.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR uses the latest version of the `social-previews` package, that contains the Mastodon post preview.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pdrWKz-Tm-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Optionally, test that nothing break in the Publicize sidebar when writing a new post.
<img width="292" alt="Screenshot 2023-05-29 at 12 01 16 PM" src="https://github.com/Automattic/jetpack/assets/1620183/1cfd6b05-b770-4c69-9c32-b3fcd76b098c">

