### PR TITLE
CRM: Resolves 3131 - Emerald totals table on contact listview

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3131-emerald_totals_table
+++ b/projects/plugins/crm/changelog/fix-crm-3131-emerald_totals_table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Listview: use Emerald style on totals table

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -401,10 +401,10 @@ class zeroBSCRM_list{
 			</div>
 			<?php
 
-			// if totals, show the wrapper
-			if ( $zbs->settings->get( 'show_totals_table' ) === 1 ) {
+			// If totals, show the wrapper. Currently only implemented in contacts
+			if ( $zbs->settings->get( 'show_totals_table' ) === 1 && $this->objType === 'customer' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				?>
-				<div id="jpcrm-listview-totals-box"></div>
+				<jpcrm-dashcount></jpcrm-dashcount>
 				<?php
 			}
 			##WLREMOVE

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -418,7 +418,7 @@ function zeroBSCRMJS_drawListView() {
 			// hide extras until listview is loaded
 			document.querySelector('.bulk-actions-dropdown').classList.add('hidden');
 			jQuery( 'jpcrm-listview-footer' ).hide();
-			jQuery( '#jpcrm-listview-totals-box' ).hide();
+			jQuery( 'jpcrm-dashcount' ).hide();
 
 			// retrieve data
 			zeroBSCRMJS_retrieveListViewData(
@@ -492,7 +492,7 @@ function zeroBSCRMJS_drawListView() {
 					jQuery( '#zbsCantLoadData' ).hide();
 					jQuery( '.jpcrm-listview-table-container' ).show();
 					jQuery( 'jpcrm-listview-footer' ).show();
-					jQuery( '#jpcrm-listview-totals-box' ).show();
+					jQuery( 'jpcrm-dashcount' ).show();
 				},
 				function ( errd ) {
 					// err callback? show msg (prefilled by php)
@@ -1158,72 +1158,49 @@ function zeroBSCRMJS_listView_url_export_segment( id ) {
  *
  */
 function zeroBSCRMJS_listView_draw_totals_tables() {
-	// clear any previous
-	jQuery( '#jpcrm-listview-totals-box' ).html( '' );
 
-	if ( typeof window.jpcrm_totals_table !== 'undefined' && window.jpcrm_totals_table !== null ) {
-		var table_body_html = '';
-		var table_footer_html = '';
-
-		if (
-			typeof window.jpcrm_totals_table.quotes_total_formatted !== 'undefined' &&
-			window.jpcrm_totals_table.quotes_total_formatted !== null
-		) {
-			table_body_html +=
-				'<tr><td>' +
-				zeroBSCRMJS_listViewLang( 'quotes' ) +
-				'</td><td>' +
-				window.jpcrm_totals_table.quotes_total_formatted +
-				'</td></tr>';
-		}
-
-		if (
-			typeof window.jpcrm_totals_table.invoices_total_formatted !== 'undefined' &&
-			window.jpcrm_totals_table.invoices_total_formatted !== null
-		) {
-			table_body_html +=
-				'<tr><td>' +
-				zeroBSCRMJS_listViewLang( 'invoices' ) +
-				'</td><td>' +
-				window.jpcrm_totals_table.invoices_total_formatted +
-				'</td></tr>';
-		}
-
-		if (
-			typeof window.jpcrm_totals_table.transactions_total_formatted !== 'undefined' &&
-			window.jpcrm_totals_table.transactions_total_formatted !== null
-		) {
-			table_body_html +=
-				'<tr><td>' +
-				zeroBSCRMJS_listViewLang( 'transactions' ) +
-				'</td><td>' +
-				window.jpcrm_totals_table.transactions_total_formatted +
-				'</td></tr>';
-		}
-		if (
-			typeof window.jpcrm_totals_table.total_sum_formatted !== 'undefined' &&
-			window.jpcrm_totals_table.total_sum_formatted !== null
-		) {
-			table_footer_html =
-				'<tfoot><tr><td>' +
-				zeroBSCRMJS_listViewLang( 'total' ) +
-				'</td><td>' +
-				window.jpcrm_totals_table.total_sum_formatted +
-				'</td></tr></tfoot>';
-		}
-
-		if ( table_body_html !== '' ) {
-			jQuery( '#jpcrm-listview-totals-box' ).html(
-				'<h4>' +
-					zeroBSCRMJS_listViewLang( 'totals' ) +
-					'</h4><table class="ui compact definition table"><tbody>' +
-					table_body_html +
-					'</tbody>' +
-					table_footer_html +
-					'</table>'
-			);
-		}
+	if (!jpcrm_totals_table) {
+		return;
 	}
+
+	let html = '';
+
+	if (jpcrm_totals_table.quotes_total_formatted) {
+			html += `<jpcrm-dashcount-card>
+				<h3>${zeroBSCRMJS_listViewLang( 'quotes' )}</h3>
+				<div>
+					<span class="range_total">${jpcrm_totals_table.quotes_total_formatted}</span>
+				</div>
+			</jpcrm-dashcount-card>`;
+	}
+
+	if (jpcrm_totals_table.invoices_total_formatted) {
+			html += `<jpcrm-dashcount-card>
+				<h3>${zeroBSCRMJS_listViewLang( 'invoices' )}</h3>
+				<div>
+					<span class="range_total">${jpcrm_totals_table.invoices_total_formatted}</span>
+				</div>
+			</jpcrm-dashcount-card>`;
+	}
+
+	if (jpcrm_totals_table.transactions_total_formatted) {
+			html += `<jpcrm-dashcount-card>
+				<h3>${zeroBSCRMJS_listViewLang( 'transactions' )}</h3>
+				<div>
+					<span class="range_total">${jpcrm_totals_table.transactions_total_formatted}</span>
+				</div>
+			</jpcrm-dashcount-card>`;
+	}
+	if (jpcrm_totals_table.total_sum_formatted) {
+			html += `<jpcrm-dashcount-card>
+				<h3>${zeroBSCRMJS_listViewLang( 'total' )}</h3>
+				<div>
+					<span class="range_total">${jpcrm_totals_table.total_sum_formatted}</span>
+				</div>
+			</jpcrm-dashcount-card>`;
+	}
+
+	jQuery( 'jpcrm-dashcount' ).html( html );
 }
 
 /* ====================================================================================

--- a/projects/plugins/crm/sass/_ZeroBSCRM.listview.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.listview.scss
@@ -37,10 +37,6 @@
 
 }
 
-#jpcrm-listview-totals-box table tfoot td {
-	border-top: 2px solid #a2a2a2;
-}
-
 // ==========  bulk actions bits
 
 // this corrects a glitch in labels + checkboxes

--- a/projects/plugins/crm/sass/emerald/_dashcount.scss
+++ b/projects/plugins/crm/sass/emerald/_dashcount.scss
@@ -2,7 +2,7 @@ jpcrm-dashcount {
 	box-sizing: content-box;
 	margin: 10px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, 250px);
+  grid-template-columns: repeat(auto-fit, 300px);
   counter-reset: grid-items;
 	grid-gap: 10px 20px;
 	


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm/issues/3131 - Emerald totals table on contact listview

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This updates the totals table to use Emerald styles (dashcount). Note that I made the dashcount cards slightly wider to accommodate larger numbers; this could be made prettier at some point (e.g. shrink cards to fit content) but it's good enough for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before:
![image](https://github.com/Automattic/jetpack/assets/32492176/22e95a09-5728-4c03-967f-c8ca6b1ef9c6)

After:
![image](https://github.com/Automattic/jetpack/assets/32492176/5e30ae4f-b561-4e71-bb5e-3dc34cd0fab6)
