### PR TITLE
Launchpad: Add is completed callback to launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-is-completed-callback-to-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-is-completed-callback-to-launchpad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Move the completion check logic out of the task list availability status

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -278,6 +278,116 @@ function wpcom_register_launchpad_task_list( $task_list ) {
 }
 
 /**
+ * Retrieves the required tasks from a given set of tasks.
+ *
+ * This function filters the provided tasks array and returns only the tasks that are marked as required,
+ * based on the specified array of required task IDs. It's worth noting that some tasks may not be
+ * visible to the user, so we are going to return all tasks that are marked as required, regardless
+ *
+ * @param array $required_task_ids An array of task IDs that are considered required.
+ * @param array $tasks An array of tasks to filter.
+ * @return array An array containing only the required tasks from the provided task list.
+ */
+function wpcom_launchpad_get_required_tasks( $required_task_ids, $tasks ) {
+	return array_filter(
+		$tasks,
+		function ( $task ) use ( $required_task_ids ) {
+			return in_array( $task['id'], $required_task_ids, true );
+		}
+	);
+}
+
+/**
+ * Get all tasks that are marked as launch tasks.
+ *
+ * @param array $tasks Array of tasks.
+ * @return array Array of launch tasks.
+ */
+function wpcom_launchpad_get_launch_tasks( $tasks ) {
+	return array_filter(
+		$tasks,
+		function ( $task ) {
+			if ( isset( $task['isLaunchTask'] ) ) {
+				return $task['isLaunchTask'];
+			}
+			return false;
+		}
+	);
+}
+
+/**
+ * Check if all the given tasks are completed.
+ *
+ * @param array $tasks Array of tasks to check if they are completed.
+ * @return bool True if all tasks are completed, false otherwise.
+ */
+function wpcom_launchpad_are_all_tasks_completed( $tasks ) {
+	return array_reduce(
+		$tasks,
+		function ( $carry, $launch_task ) {
+			return $carry && $launch_task['completed'];
+		},
+		true
+	);
+}
+
+/**
+ * Determine the completion status of a task list based on its tasks.
+ *
+ * This function identifies any required tasks within the task list. If there are required tasks, the task list is considered complete
+ * only if all required tasks are completed. In the absence of required tasks, a secondary check is performed on tasks flagged with
+ * "isLaunchTask" to determine completion based on whether all of those tasks are complete. If there are no required tasks and no
+ * launch tasks, the task list's completion is determined by checking whether all tasks are complete. However, if there are incomplete
+ * tasks in this scenario, the completion status is based on whether the last task was completed. It is possible to control this behavior
+ * using a flag, as the default approach might be confusing for task lists where the steps may not be sequential. By default, the task
+ * list is marked as incomplete to align with most use cases that focus on user guidance and next steps rather than a specific end goal.
+ *
+ * @param array $task_list An array of tasks within the task list.
+ * @return bool True if the task list is considered complete, false otherwise.
+ */
+function wpcom_default_launchpad_task_list_completed( $task_list ) {
+	$task_list_id      = $task_list['id'];
+	$required_task_ids = wpcom_launchpad_checklists()->get_required_task_ids( $task_list_id );
+	$all_visible_tasks = wpcom_launchpad_checklists()->build( $task_list_id );
+
+	// If there are required tasks, check if they are all completed.
+	if ( ! empty( $required_task_ids ) ) {
+		$required_tasks = wpcom_launchpad_get_required_tasks( $required_task_ids, $all_visible_tasks );
+		return wpcom_launchpad_are_all_tasks_completed( $required_tasks );
+	}
+
+	// If there are no required tasks, check if there are any launch tasks.
+	$launch_tasks = wpcom_launchpad_get_launch_tasks( $all_visible_tasks );
+	if ( ! empty( $launch_tasks ) ) {
+		return wpcom_launchpad_are_all_tasks_completed( $launch_tasks );
+	}
+
+	// If there are no required tasks and no launch tasks, check if all tasks are completed.
+	if ( wpcom_launchpad_are_all_tasks_completed( $all_visible_tasks ) ) {
+		return true;
+	}
+
+	// If there are incomplete tasks, check if the last task was completed.
+	$require_last_task_completion = wpcom_launchpad_checklists()->get_require_last_task_completion( $task_list_id );
+	$last_task                    = end( $all_visible_tasks );
+	if ( $require_last_task_completion && $last_task['completed'] ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Callback to determine the completion status of a task list.
+ *
+ * @param string $task_list_id The task list ID.
+ * @return bool True if the task list is considered complete, false otherwise.
+ */
+function wpcom_launchpad_is_task_list_completed( $task_list_id ) {
+	return wpcom_launchpad_checklists()->is_task_list_completed( $task_list_id );
+}
+
+/**
  * Wrapper that registers a launchpad checklist.
  *
  * @param Task $tasks Collection of Task definitions.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-list-validation-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-list-validation-test.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Test class for Launchpad_Task_Lists.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Test class for Launchpad_Task_Lists.
+ *
+ * @coversDefaultClass Launchpad_Task_Lists
+ */
+class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Data provider for test_validate_task_list.
+	 *
+	 * @return array
+	 */
+	public function provide_validate_task_list_test_cases() {
+		return array(
+			'Valid task list with required task IDs and last task completion' => array(
+				array(
+					'id'                           => 'task_list_1',
+					'task_ids'                     => array( 'task_1', 'task_2' ),
+					'required_task_ids'            => array( 'task_1' ),
+					'require_last_task_completion' => true,
+				),
+				true,
+			),
+			'Valid task list with last task completion'   => array(
+				array(
+					'id'                           => 'task_list_1',
+					'task_ids'                     => array( 'task_1', 'task_2' ),
+					'require_last_task_completion' => true,
+				),
+				true,
+			),
+			'Valid task list with only required task IDs' => array(
+				array(
+					'id'                => 'task_list_1',
+					'task_ids'          => array( 'task_1', 'task_2' ),
+					'required_task_ids' => array( 'task_1' ),
+				),
+				true,
+			),
+			'Valid task list with minimal validation'     => array(
+				array(
+					'id'       => 'task_list_1',
+					'task_ids' => array( 'task_1', 'task_2' ),
+				),
+				true,
+			),
+			'Invalid task list with no id'                => array(
+				array(
+					'task_ids'                     => array( 'task_1', 'task_2' ),
+					'required_task_ids'            => array( 'task_1' ),
+					'require_last_task_completion' => true,
+				),
+				false,
+			),
+			'Invalid task list with no task_ids'          => array(
+				array(
+					'id'                           => 'task_list_1',
+					'required_task_ids'            => array( 'task_1' ),
+					'require_last_task_completion' => true,
+				),
+				false,
+			),
+			'Invalid task list with invalid required_task_ids' => array(
+				array(
+					'id'                => 'task_list_1',
+					'task_ids'          => array( 'task_1', 'task_2' ),
+					'required_task_ids' => 'task_1',
+				),
+				false,
+			),
+			'Invalid task list with invalid require_last_task_completion' => array(
+				array(
+					'id'                           => 'task_list_1',
+					'task_ids'                     => array( 'task_1', 'task_2' ),
+					'required_task_ids'            => array( 'task_1' ),
+					'require_last_task_completion' => 'true',
+				),
+				false,
+			),
+		);
+	}
+
+	/**
+	 * Test several task list validation scenarios.
+	 *
+	 * @param array $task_list       Task list to validate.
+	 * @param bool  $expected_result Expected validation result.
+	 * @dataProvider provide_validate_task_list_test_cases
+	 */
+	public function test_validate_task_list( $task_list, $expected_result ) {
+		$result = Launchpad_Task_Lists::validate_task_list( $task_list );
+
+		$this->assertSame( $expected_result, $result );
+	}
+}
+

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -12,6 +12,13 @@
  */
 class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		wpcom_register_default_launchpad_checklists();
+	}
+	/**
 	 * Make sure that ::build() doesn't create a PHP warning when it doesn't get a valid ID.
 	 *
 	 * @covers ::build
@@ -21,5 +28,108 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Data provider for {@see test_task_list_is_completed()}.
+	 */
+	public function provider_test_task_list_is_completed() {
+		$incomplete_task = array();
+		$completed_task  = array(
+			'is_complete_callback' => '__return_true',
+		);
+
+		$launch_task_incomplete = array(
+			'isLaunchTask' => true,
+		);
+
+		$launch_task_completed = array(
+			'isLaunchTask'         => true,
+			'is_complete_callback' => '__return_true',
+		);
+
+		return array(
+			// tasks, expected, task_list_options
+			'all tasks incomplete should be incomplete using default options'
+				=> array( array( $incomplete_task, $incomplete_task ), false ),
+			'all tasks complete should be complete using default options'
+				=> array( array( $completed_task, $completed_task ), true ),
+			'incomplete task and incomplete launch task should be incomplete using default options'
+				=> array( array( $incomplete_task, $launch_task_incomplete ), false ),
+			'having the launch task completed should make the task list complete'
+				=> array( array( $incomplete_task, $launch_task_completed ), true ),
+			'with the require_last_task_completion option, the last task being complete should make the task list complete'
+				=> array( array( $incomplete_task, $completed_task ), true, array( 'require_last_task_completion' => true ) ),
+			'with the require_last_task_completion option, the last task being incomplete should make the task list incomplete'
+				=> array( array( $completed_task, $incomplete_task ), false, array( 'require_last_task_completion' => true ) ),
+			'with the required_task_ids option, the task list should be complete if the required task is complete'
+				=> array( array( $completed_task, $incomplete_task ), true, array( 'required_task_ids' => array( 'task_0' ) ) ),
+			'with the required_task_ids option, the task list should be incomplete if the required task is incomplete'
+				=> array( array( $incomplete_task, $incomplete_task ), false, array( 'required_task_ids' => array( 'task_0' ) ) ),
+			'with the required_task_ids and require_last_task_completion options and the last task complete, the task list should be incomplete if the required task is incomplete'
+				=> array(
+					array( $incomplete_task, $completed_task ),
+					false,
+					array(
+						'required_task_ids'            => array( 'task_0' ),
+						'require_last_task_completion' => true,
+					),
+				),
+			'the launch task completion should not mark the task list complete if the required task is incomplete'
+				=> array( array( $incomplete_task, $launch_task_completed ), false, array( 'required_task_ids' => array( 'task_0' ) ) ),
+			'overriding the is_completed_callback should be the only thing that matters'
+				=> array( array( $incomplete_task, $incomplete_task ), true, array( 'is_completed_callback' => '__return_true' ) ),
+			'custom is_completed_callback should be able to check if first task is complete'
+				=> array(
+					array( $completed_task, $incomplete_task ),
+					true,
+					array(
+						'is_completed_callback' => function ( $task_list ) {
+									$first_task = reset( wpcom_launchpad_checklists()->build( $task_list['id'] ) );
+									return $first_task['completed'];
+						},
+					),
+				),
+		);
+	}
+
+	/**
+	 * Tests wpcom_launchpad_is_task_list_completed().
+	 *
+	 * @dataProvider provider_test_task_list_is_completed
+	 *
+	 * @param array $tasks             Array of tasks to register.
+	 * @param bool  $expected          Expected result of wpcom_launchpad_is_task_list_completed().
+	 * @param array $task_list_options Optional. Array of options to pass to wpcom_register_launchpad_task_list().
+	 */
+	public function test_task_list_is_completed( $tasks, $expected, $task_list_options = array() ) {
+		$task_ids = array();
+		foreach ( $tasks as $key => $task ) {
+			$task_id    = 'task_' . $key;
+			$task_ids[] = $task_id;
+			wpcom_launchpad_checklists()->unregister_task( $task_id );
+			wpcom_register_launchpad_task(
+				array_merge(
+					array(
+						'id'    => $task_id,
+						'title' => 'Task ' . $key,
+					),
+					$task
+				)
+			);
+		}
+
+		wpcom_launchpad_checklists()->unregister_task_list( 'task-list-test' );
+		wpcom_register_launchpad_task_list(
+			array_merge(
+				array(
+					'id'       => 'task-list-test',
+					'title'    => 'Simple testing task list',
+					'task_ids' => $task_ids,
+				),
+				$task_list_options
+			)
+		);
+		$this->assertEquals( $expected, wpcom_launchpad_is_task_list_completed( 'task-list-test' ) );
 	}
 }


### PR DESCRIPTION
Currently, how we check if the Launchpad is completed is tied to its availability status(enabled/disabled). I believe we need to have a separate status to define whether the Launchpad is completed. So we can have more flexibility in future implementations of the Launchpad in other contexts.

Closes https://github.com/Automattic/wp-calypso/issues/77494

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add support to a new `is_completed_callback` to the task list.
* Add a default callback to the task lists with the current behavior 
* Add the `required_task_ids` attribute to the task list definition. This attributes defines which tasks need to be completed to mark the task list as completed.
* Add the `require_last_task_completion` flag to the task list. This attribute flags if concluding the last task is enough to mark the task list as completed.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
paYKcK-30Q-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Run the unit tests with the following command:
```bash
cd projects/packages/jetpack-mu-wpcom; ./vendor/bin/phpunit --filter=Launchpad_Task_Lists_Test; cd -
```
* Now tests your changes on WPCOM, run the following command on your sandbox to apply these changes:
```bash
bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/is-completed-callback-to-launchpad
```
* Create a new free site and go through the launchpad making sure it continues to work as expected.