### PR TITLE
[Boost] Remove invalid apply_filter on minified CSS

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -193,7 +193,6 @@ class Concatenate_CSS extends WP_Styles {
 				}
 
 				$style_tag = apply_filters( 'page_optimize_style_loader_tag', $style_tag, $handles, $href, $media );
-				$style_tag = apply_filters( 'style_loader_tag', $style_tag, $handles, $href, $media );
 
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo $style_tag . "\n";

--- a/projects/plugins/boost/changelog/fix-minify-invalid-filter
+++ b/projects/plugins/boost/changelog/fix-minify-invalid-filter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: removed invalid apply_filter call
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Filter `style_loader_tag`'s [second parameter](https://developer.wordpress.org/reference/hooks/style_loader_tag/) is a string containing one tag. When minifying CSS on a site with some plugins installed which responded to `style_loader_tag`, passing in an array of handles where a single string is expected can be problematic.

This PR fixes it by removing the invalid filter call, in line with the [Page Optimize implementation](https://github.com/Automattic/page-optimize/blob/8e4c9ef79c374b25ca0ca41210f2e8feeec0685e/concat-css.php#LL186C1-L186C1).

## Proposed changes:
* Remove an invalid apply_filters call.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
* Use Boost's minify css alongside a plugin which defines a callback to `style_loader_tag`, such as wp-ocean's companion plugin.
* Ensure that it works properly.