### PR TITLE
[Boost] Avoid double-prefixing url() values in minified CSS

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -119,6 +119,20 @@ function jetpack_boost_page_optimize_service_request() {
 }
 
 /**
+ * Strip matching parent paths off a string. Returns $path without $parent_path.
+ */
+function jetpack_boost_strip_parent_path( $parent_path, $path ) {
+	$trimmed_parent = ltrim( $parent_path, '/' );
+	$trimmed_path   = ltrim( $path, '/' );
+
+	if ( substr( $trimmed_path, 0, strlen( $trimmed_parent ) === $trimmed_parent ) ) {
+		$trimmed_path = substr( $trimmed_path, strlen( $trimmed_parent ) );
+	}
+
+	return substr( $trimmed_path, 0, 1 ) === '/' ? $trimmed_path : '/' . $trimmed_path;
+}
+
+/**
  * Generate a combined and minified output for the current request.
  */
 function jetpack_boost_page_optimize_build_output() {
@@ -239,7 +253,7 @@ function jetpack_boost_page_optimize_build_output() {
 		}
 
 		if ( 'text/css' === $mime_type ) {
-			$dirpath = '/' . ltrim( $subdir_path_prefix . dirname( $uri ), '/' );
+			$dirpath = jetpack_boost_strip_parent_path( $subdir_path_prefix, dirname( $uri ) );
 
 			// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
 			$buf = jetpack_boost_page_optimize_relative_path_replace( $buf, $dirpath );

--- a/projects/plugins/boost/changelog/fix-subdir-css-fonts
+++ b/projects/plugins/boost/changelog/fix-subdir-css-fonts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed relative-paths used when minifying CSS url() values
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When minifying CSS for a WordPress site in a subdirectory, the subdirectory name gets added twice to `url()` entries in the CSS when trying to absolute-ify the paths.

This fix prevents that by stripping the site's dir prefix out of the css url() prefix (if present).

## Proposed changes:
* Prevent double-prefixing of CSS paths in WordPress sites inside a subdirectory.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
* Create a WordPress site in a subdirectory.
* Use a theme which imports its own custom fonts, or otherwise uses url() elements pointing to other resources in the site directory (not external resources)
* Verify that with this patch, these resources are loaded properly.

