### PR TITLE
AI Assistant: introduce blog post relevant data block into prompt

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-populate-prompt-with-title
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-populate-prompt-with-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: introduce blog post relevant data block into the prompt

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
+import { select } from '@wordpress/data';
 import debugFactory from 'debug';
+/**
+ * Internal dependencies
+ */
 import { LANGUAGE_MAP } from './i18n-dropdown-control';
 
 // Maximum number of characters we send from the content
@@ -29,10 +33,20 @@ export const buildPromptTemplate = ( {
 	content = null,
 	language = null,
 	locale = null,
+	addBlogPostData = true,
 } ) => {
 	if ( ! request && ! content ) {
 		throw new Error( 'You must provide either a request or content' );
 	}
+
+	const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' );
+	const blogPostData = addBlogPostData
+		? `
+Blog post relevant data:
+- Title: ${ postTitle }
+----------
+`
+		: '';
 
 	// Language and Locale
 	let langLocatePromptPart = language
@@ -91,8 +105,8 @@ ${ extraRulePromptPart }- Do not include a top level heading by default.
 - Segment the content into paragraphs as deemed suitable.
 ` +
 		langLocatePromptPart +
-		`-----------
-		` +
+		`-----------` +
+		blogPostData +
 		requestPromptBlock +
 		contextPromptPart +
 		`

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -40,13 +40,14 @@ export const buildPromptTemplate = ( {
 	}
 
 	const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' );
-	const blogPostData = addBlogPostData
-		? `
+	const blogPostData =
+		addBlogPostData && postTitle?.length
+			? `
 Blog post relevant data:
 - Title: ${ postTitle }
 ----------
 `
-		: '';
+			: '';
 
 	// Language and Locale
 	let langLocatePromptPart = language


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR populates the prompt with the `blog post relevant data` block with, for now, the post title. We can collect other data such as categories, tags, etc.
The idea behind of this implementations is providing more context to the assistant.

Fixes https://github.com/Automattic/jetpack/issues/31047

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: introduce blog post relevant data block into the prompt

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/use an AI Assistant block instance
* Request something
* Take a look at the prompt
* Confirm the blog post text block is there

<img width="592" alt="Screenshot 2023-05-30 at 09 57 20" src="https://github.com/Automattic/jetpack/assets/77539/0ab5e2c0-bf56-4ad3-928d-e2705dc3bccd">

* Confirm that, when no title, the blog post text block is not added to the prompt

