### PR TITLE
AI Assistant: ignore double asterisks when checking unclear prompt message

### DIFF
--- a/projects/plugins/jetpack/changelog/y
+++ b/projects/plugins/jetpack/changelog/y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: ignore double asterisks when checking unclear prompt message

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -196,8 +196,13 @@ export class SuggestionsEventSource extends EventTarget {
 
 	checkForUnclearPrompt() {
 		if ( ! this.isPromptClear ) {
-			// Sometimes the first token of the message is not received, so we check only for JETPACK_AI_ERROR, ignoring the first underscores
-			if ( this.fullMessage.replace( '__', '' ).startsWith( 'JETPACK_AI_ERROR' ) ) {
+			/*
+			 * Sometimes the first token of the message is not received,
+			 * so we check only for JETPACK_AI_ERROR, ignoring:
+			 * - the double underscores (italic markdown)
+			 * - the doouble asterisks (bold markdown)
+			 */
+			if ( this.fullMessage.replace( /__|(\*\*)/g, '' ) === 'JETPACK_AI_ERROR' ) {
 				// The unclear prompt marker was found, so we dispatch an error event
 				this.dispatchEvent( new CustomEvent( 'error_unclear_prompt' ) );
 			} else if ( 'JETPACK_AI_ERROR'.startsWith( this.fullMessage.replace( '__', '' ) ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/31071

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: ignore double asterisks when checking unclear prompt message

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/use an AI Assistant block instance
* Try to generate a not understandable request
* Confirm the app detects the unclear prompt. As mentioned in the [issue](https://github.com/Automattic/jetpack/issues/31071), sometimes the `JETAPACK_AI_ERROR` comes bolder (in markdown) from the AI service.

<img width="657" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/96f14834-5736-4ea5-9456-1beba4550730">

