### PR TITLE
Publicize: request wpcom for Mastodon feature check

### DIFF
--- a/projects/packages/publicize/changelog/fix-publicize-mastodon-feature-cache
+++ b/projects/packages/publicize/changelog/fix-publicize-mastodon-feature-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Always request wpcom for Mastodon feature check

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.30.0",
+	"version": "0.30.1-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1799,7 +1799,7 @@ abstract class Publicize_Base {
 	 * @return bool
 	 */
 	public function has_mastodon_connection_feature() {
-		return Current_Plan::supports( 'social-mastodon-connection' );
+		return Current_Plan::supports( 'social-mastodon-connection', true );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31079

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the `publicize` package, the value returned by `has_mastodon_connection_feature` is cached. Switching on and off the Mastodon feature in the backend has therefore no effect in the UI of the Publicize sidebar. This PR fixes it by always requesting the backend when checking for the Mastodon feature.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pdrWKz-Tm-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
- Note your test site id
- Make sure you know how to toggle the Mastodon feature on and off (D111014-code)
- Check that Social is activated

### Testing
- Create a new post
- Click on the Jetpack icon to show the Publicize sidebar
<img width="217" alt="Screenshot 2023-05-30 at 11 37 03 AM" src="https://github.com/Automattic/jetpack/assets/1620183/287a1a46-6099-4bf7-a613-093e08eb0c1e">

- If the Mastodon feature is disabled, make sure you don't see the Mastodon icon in the _Social Previews_ section or in the previews modal. If it's enabled, verify you see it.
<img width="286" alt="Screenshot 2023-05-30 at 11 25 52 AM" src="https://github.com/Automattic/jetpack/assets/1620183/c89d0ebe-9df1-4212-a194-f43d5f15c8bf">
<img width="284" alt="Screenshot 2023-05-30 at 11 25 57 AM" src="https://github.com/Automattic/jetpack/assets/1620183/0c21d947-5985-48c0-932e-490d1bff6dd7">

- Toggle the feature
- Check the presence/absence of the Mastodon icon