### PR TITLE
Add tests to boost score api package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       jest:
         specifier: 29.5.0
         version: 29.5.0
+      jest-environment-jsdom:
+        specifier: 29.4.3
+        version: 29.4.3
       ts-loader:
         specifier: 9.4.2
         version: 9.4.2(typescript@5.0.4)(webpack@5.76.0)

--- a/projects/js-packages/boost-score-api/changelog/add-tests-to-boost-score-api-package
+++ b/projects/js-packages/boost-score-api/changelog/add-tests-to-boost-score-api-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add tests

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.0",
+	"version": "0.1.1-alpha",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -28,6 +28,7 @@
 		"@typescript-eslint/parser": "5.59.0",
 		"eslint": "8.39.0",
 		"jest": "29.5.0",
+		"jest-environment-jsdom": "29.4.3",
 		"ts-loader": "9.4.2",
 		"typescript": "5.0.4",
 		"webpack": "5.76.0",
@@ -45,5 +46,8 @@
 		}
 	},
 	"main": "./build/index.js",
-	"types": "./build/index.d.ts"
+	"types": "./build/index.d.ts",
+	"jest": {
+		"testEnvironment": "jsdom"
+	}
 }

--- a/projects/js-packages/boost-score-api/tests/index.test.js
+++ b/projects/js-packages/boost-score-api/tests/index.test.js
@@ -57,16 +57,18 @@ describe( 'didScoresChange', () => {
 	} );
 
 	it( 'should return true if scores changed', () => {
-		mockData.scores.noBoost.desktop = 60;
-		mockData.scores.noBoost.mobile = 50;
+		const changedMockData = Object.assign( {}, mockData );
+		changedMockData.scores.noBoost.desktop = 60;
+		changedMockData.scores.noBoost.mobile = 50;
 
-		expect( didScoresChange( mockData.scores ) ).toBe( true );
+		expect( didScoresChange( changedMockData.scores ) ).toBe( true );
 	} );
 } );
 
 describe( 'getScoreMovementPercentage', () => {
 	it( 'returns the correct percentage of scores moved', () => {
-		const mockScores = {
+		const changedMockData = Object.assign( {}, mockData );
+		const newScores = {
 			current: {
 				desktop: 90,
 				mobile: 80,
@@ -76,11 +78,12 @@ describe( 'getScoreMovementPercentage', () => {
 				mobile: 80,
 			},
 		};
+		changedMockData.scores = newScores;
 
-		expect( getScoreMovementPercentage( mockScores ) ).toBe( 0 );
+		expect( getScoreMovementPercentage( changedMockData.scores ) ).toBe( 0 );
 
-		( mockScores.noBoost.desktop = 80 ), ( mockScores.noBoost.mobile = 70 );
+		( changedMockData.scores.noBoost.desktop = 80 ), ( changedMockData.scores.noBoost.mobile = 70 );
 
-		expect( getScoreMovementPercentage( mockScores ) ).toBe( 13 );
+		expect( getScoreMovementPercentage( changedMockData.scores ) ).toBe( 13 );
 	} );
 } );

--- a/projects/js-packages/boost-score-api/tests/index.test.js
+++ b/projects/js-packages/boost-score-api/tests/index.test.js
@@ -1,8 +1,86 @@
-import { requestSpeedScores } from '../src/index';
+import api from '../src/api';
+import {
+	requestSpeedScores,
+	getScoreLetter,
+	didScoresChange,
+	getScoreMovementPercentage,
+} from '../src/index';
 
-// This is a placeholder test, new tests will be added soon
+const mockData = {
+	status: 'success',
+	timestamp: 123456789,
+	scores: {
+		current: {
+			desktop: 90,
+			mobile: 80,
+		},
+		noBoost: {
+			desktop: 90,
+			mobile: 80,
+		},
+		isStale: true,
+	},
+	theme: '',
+};
+
 describe( 'requestSpeedScores', () => {
-	it( 'should be a function', () => {
-		expect( typeof requestSpeedScores ).toBe( 'function' );
+	beforeEach( () => {
+		jest.spyOn( api, 'post' );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'should return speed scores', async () => {
+		api.post.mockResolvedValue( mockData );
+
+		const scores = await requestSpeedScores( 'https://example.com' );
+		expect( scores ).toEqual( mockData.scores );
+	} );
+} );
+
+describe( 'getScoreLetter', () => {
+	it( 'Should return the correct score', () => {
+		expect( getScoreLetter( 90, 91 ) ).toBe( 'A' );
+		expect( getScoreLetter( 90, 83 ) ).toBe( 'B' );
+		expect( getScoreLetter( 90, 60 ) ).toBe( 'C' );
+		expect( getScoreLetter( 45, 50 ) ).toBe( 'D' );
+		expect( getScoreLetter( 26, 30 ) ).toBe( 'E' );
+		expect( getScoreLetter( 0, 0 ) ).toBe( 'F' );
+	} );
+} );
+
+describe( 'didScoresChange', () => {
+	it( 'Should return false if scores did not change', () => {
+		expect( didScoresChange( mockData.scores ) ).toBe( false );
+	} );
+
+	it( 'should return true if scores changed', () => {
+		mockData.scores.noBoost.desktop = 60;
+		mockData.scores.noBoost.mobile = 50;
+
+		expect( didScoresChange( mockData.scores ) ).toBe( true );
+	} );
+} );
+
+describe( 'getScoreMovementPercentage', () => {
+	it( 'returns the correct percentage of scores moved', () => {
+		const mockScores = {
+			current: {
+				desktop: 90,
+				mobile: 80,
+			},
+			noBoost: {
+				desktop: 90,
+				mobile: 80,
+			},
+		};
+
+		expect( getScoreMovementPercentage( mockScores ) ).toBe( 0 );
+
+		( mockScores.noBoost.desktop = 80 ), ( mockScores.noBoost.mobile = 70 );
+
+		expect( getScoreMovementPercentage( mockScores ) ).toBe( 13 );
 	} );
 } );


### PR DESCRIPTION
## Proposed changes:
Adds tests for the boost-score-api `js-package` 

### Other information:

N/A

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. You can just make sure tests pass and it should be good to go

If you want to test them locally

2. Checkout this branch
3. Go to the `projects/js-packages/boost-score-api` directory and run `pnpm run test`
4. Make sure all tests pass
