### PR TITLE
CRM: Emerald polish

### DIFF
--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -961,7 +961,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 			</div>
 
-			<div class="six wide column" id="zbs-custom-quicklinks" style="padding-right: 30px;">
+			<div class="six wide column" id="zbs-custom-quicklinks">
 
 				<?php
 					// } Metaboxes

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -1364,7 +1364,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 			</div>
 
-			<div class="six wide column" id="zbs-custom-quicklinks" style="padding-right: 30px;">
+			<div class="six wide column" id="zbs-custom-quicklinks">
 
 				<?php
 					// } Metaboxes

--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -212,11 +212,11 @@ function jpcrm_render_dashboard_page() {
 						<?php
 					} else {
 						?>
-						<div class="div-message-box">
-							<div class="div-message">
+						<div class="jpcrm-div-message-box">
+							<div class="jpcrm-div-message">
 								<?php esc_html_e( 'No valid transactions were added during the last 12 months. You need transactions for your revenue chart to show. If you have transactions, check the guide for more info.', 'zero-bs-crm' ); ?>
 							</div>
-							<div class="div-message">
+							<div class="jpcrm-div-message">
 								<a href="<?php echo esc_url( $zbs->urls['kbrevoverview'] ); ?>" target="_blank" class="jpcrm-button white-bg"><?php echo esc_html__( 'Read guide', 'zero-bs-crm' ); ?></a>
 								<a href="<?php echo jpcrm_esc_link( 'create', -1, 'zerobs_transaction', false, false ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>" class="jpcrm-button"><?php esc_html_e( 'Add a transaction', 'zero-bs-crm' ); ?></a>
 							</div>
@@ -297,8 +297,8 @@ function jpcrm_render_dashboard_page() {
 						}
 					} else {
 						?>
-						<div class="div-message-box">
-							<div class="div-message">
+						<div class="jpcrm-div-message-box">
+							<div class="jpcrm-div-message">
 								<?php esc_html_e( 'No recent activity.', 'zero-bs-crm' ); ?>
 							</div>
 						</div>
@@ -366,8 +366,8 @@ function jpcrm_render_dashboard_page() {
 						<?php
 					} else {
 						?>
-						<div class="div-message-box">
-							<div class="div-message">
+						<div class="jpcrm-div-message-box">
+							<div class="jpcrm-div-message">
 								<?php esc_html_e( 'No contacts.', 'zero-bs-crm' ); ?>
 							</div>
 						</div>

--- a/projects/plugins/crm/admin/email/main.page.php
+++ b/projects/plugins/crm/admin/email/main.page.php
@@ -243,7 +243,7 @@ function jpcrm_render_emailbox() {
 			<?php
 				do_action( 'zbs_email_schedule_send_time' );
 			?>
-			<div class='zbs-send-email-thread-button ui button blue'><?php esc_html_e( 'Send', 'zero-bs-crm' ); ?></div>
+			<div class='zbs-send-email-thread-button ui button black'><?php esc_html_e( 'Send', 'zero-bs-crm' ); ?></div>
 			</div>
 
 

--- a/projects/plugins/crm/admin/email/main.page.php
+++ b/projects/plugins/crm/admin/email/main.page.php
@@ -257,6 +257,7 @@ function jpcrm_render_emailbox() {
 				// $customer_panel = zeroBSCRM_emails_customer_panel();
 
 				// defaults
+				$customer_panel                       = array();
 				$customer_panel['avatar']             = '';
 				$customer_panel['customer']['fname']  = 'John';
 				$customer_panel['customer']['lname']  = 'Doe';
@@ -272,7 +273,7 @@ function jpcrm_render_emailbox() {
 					echo "<div id='panel-customer-avatar'>" . esc_html( $customer_panel['avatar'] ) . '</div>';
 					echo "<div id='panel-name'>" . esc_html( $customer_panel['customer']['fname'] . ' ' . $customer_panel['customer']['lname'] ) . '</div>';
 
-					echo "<div id='panel-status' class='ui label " . esc_attr( $customer_panel['customer']['status'] ) . "'>" . esc_html( $customer_panel['customer']['status'] ) . '</div>';
+					echo '<div id="panel-status">' . esc_html( $customer_panel['customer']['status'] ) . '</div>';
 
 					echo "<div class='simple-actions zbs-hide'>";
 						echo "<a class='ui label circular'><i class='ui icon phone'></i></a>";

--- a/projects/plugins/crm/admin/email/main.page.php
+++ b/projects/plugins/crm/admin/email/main.page.php
@@ -495,7 +495,7 @@ function zeroBSCRM_pages_admin_sendmail() {
 
 				?>
 			<br/>
-			<input type="submit" class="ui button blue large right zbs-single-send-email-button" value="<?php esc_attr_e( 'Send Email', 'zero-bs-crm' ); ?>" />
+			<input type="submit" class="jpcrm-button" value="<?php esc_attr_e( 'Send Email', 'zero-bs-crm' ); ?>" />
 
 			<?php
 			do_action( 'zbs_single_email_schedule', $customerID );

--- a/projects/plugins/crm/admin/email/main.page.php
+++ b/projects/plugins/crm/admin/email/main.page.php
@@ -252,19 +252,18 @@ function jpcrm_render_emailbox() {
 
 		<div class='zbs-email-contact-info app-content'>
 				<?php
-				// the customer information pane - get using AJAX
-
-				// $customer_panel = zeroBSCRM_emails_customer_panel();
-
-				// defaults
-				$customer_panel                       = array();
-				$customer_panel['avatar']             = '';
-				$customer_panel['customer']['fname']  = 'John';
-				$customer_panel['customer']['lname']  = 'Doe';
-				$customer_panel['customer']['status'] = __( 'Lead', 'zero-bs-crm' );
-				$customer_panel['tasks']              = array();
-				$customer_panel['trans_value']        = 0;
-				$customer_panel['quote_value']        = 0;
+				// Placeholders
+				$customer_panel = array(
+					'avatar'      => '',
+					'customer'    => array(
+						'fname'  => 'John',
+						'lname'  => 'Doe',
+						'status' => __( 'Lead', 'zero-bs-crm' ),
+					),
+					'tasks'       => array(),
+					'trans_value' => 0,
+					'quote_value' => 0,
+				);
 
 				echo "<div class='customer-panel-header'>";
 					echo "<div class='panel-edit-contact'>";

--- a/projects/plugins/crm/admin/settings/custom-fields.page.php
+++ b/projects/plugins/crm/admin/settings/custom-fields.page.php
@@ -436,7 +436,7 @@ if ( isset( $sbupdated ) && $sbupdated ) {
 		<?php
 
 		// loading here is shown until custom fields drawn, then this loader hidden and all .zbs-generic-loaded shown
-		echo zeroBSCRM_UI2_loadingSegmentHTML( '300px', 'zbs-generic-loading' );
+		echo jpcrm_loading_container(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		// add nonce
 		wp_nonce_field( 'zbs-update-settings-customfields' );

--- a/projects/plugins/crm/admin/user-profile/user-profile.page.php
+++ b/projects/plugins/crm/admin/user-profile/user-profile.page.php
@@ -62,7 +62,7 @@ function jpcrm_render_userprofile_page() {
 		*/
 		?>
 		<div class="extra content" style="text-align: center">
-			<a href="<?php echo esc_url( get_edit_profile_url( $user_wp_id ) ); ?>" class="ui small blue icon button centered"><i class="user icon"></i>&nbsp;&nbsp;<?php esc_html_e( 'Edit Your Profile', 'zero-bs-crm' ); ?></a>        
+			<a href="<?php echo esc_url( get_edit_profile_url( $user_wp_id ) ); ?>" class="ui small black icon button centered"><i class="user icon"></i>&nbsp;&nbsp;<?php esc_html_e( 'Edit Your Profile', 'zero-bs-crm' ); ?></a>        
 		</div> 
 
 		<?php

--- a/projects/plugins/crm/changelog/fix-crm-3132-crm-emerald-polish
+++ b/projects/plugins/crm/changelog/fix-crm-3132-crm-emerald-polish
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Polish the CRM after changes from project Emerald

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -1988,7 +1988,7 @@ function zeroBSCRM_html_extensions() {
 		$bundle = true;
 	}
 
-	echo "<div class='zbs-extensions-manager' style='margin-top:1em'>";
+	echo '<div class="zbs-extensions-manager">';
 
 	// get the products, from our sites JSON custom REST endpoint - that way only need to manage there and not remember to update all the time
 	// each product has our extkey so can do the same as the built in array here ;) #progress #woop-da-woop
@@ -2401,7 +2401,7 @@ function jpcrm_html_modules() {
 
 	}
 
-	echo "<div class='zbs-extensions-manager' style='margin-top:1em'>";
+	echo '<div class="zbs-extensions-manager">';
 
 			// this block should be in here for rebranded people who want to turn on or off features.
 			echo '<div class="zbs-page-wrap free-block-wrap">';

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -2150,7 +2150,7 @@ function zeroBSCRM_html_extensions() {
 			echo '</div>';
 			echo '<div class="clear"></div>';
 		}
-			echo '<div class="ui top attached header premium-box"><h3 class="box-title">' . esc_html__( 'Premium Extensions', 'zero-bs-crm' ) . '</h3>   <a class="guides ui button blue mini" href="' . esc_url( $zbs->urls['docs'] ) . '" target="_blank"><i class="book icon"></i> ' . esc_html__( 'Knowledge-base', 'zero-bs-crm' ) . '</a> <a class="guides ui button blue basic mini" href="' . esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['modules'] ) ) . '"><i class="puzzle piece icon"></i> ' . esc_html__( 'Core Modules', 'zero-bs-crm' ) . '</a>   </div>';
+			echo '<div class="ui top attached header premium-box"><h3 class="box-title">' . esc_html__( 'Premium Extensions', 'zero-bs-crm' ) . '</h3>   <a class="guides ui button black mini" href="' . esc_url( $zbs->urls['docs'] ) . '" target="_blank"><i class="book icon"></i> ' . esc_html__( 'Knowledge-base', 'zero-bs-crm' ) . '</a> <a style="color: black !important;box-shadow: 0px 0px 0px 1px black inset !important;" class="guides ui button blue basic mini" href="' . esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['modules'] ) ) . '"><i class="puzzle piece icon"></i> ' . esc_html__( 'Core Modules', 'zero-bs-crm' ) . '</a>   </div>';
 			echo '<div class="clear"></div>';
 			echo '<div class="ui segment attached">';
 				echo '<div class="ui internally celled grid">';

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -310,7 +310,7 @@ function zeroBSCRM_pages_admin_team() {
 	</form>
 
 
-		<a style="margin-left:10px;" class="ui button right" href="<?php echo esc_url( admin_url( 'user-new.php?zbsslug=zbs-add-user' ) ); ?>">
+		<a style="margin-left:10px;" class="ui button black right" href="<?php echo esc_url( admin_url( 'user-new.php?zbsslug=zbs-add-user' ) ); ?>">
 		<i class="add icon"></i> 
 			<?php esc_html_e( 'Add New Team Member', 'zero-bs-crm' ); ?>
 		</a>
@@ -345,7 +345,7 @@ function zeroBSCRM_pages_admin_team() {
 
 			echo '<td>' . esc_html( zeroBSCRM_wpb_lastlogin( $ID ) . ' ' . __( 'ago', 'zero-bs-crm' ) ) . '</td>';
 
-			echo "<td><a href='" . esc_url( $edit_url ) . "'' data-uid='" . esc_attr( $ID ) . "' class='zbs-perm-edit ui button mini blue'>";
+			echo "<td><a href='" . esc_url( $edit_url ) . "'' data-uid='" . esc_attr( $ID ) . "' class='zbs-perm-edit ui button mini black'>"; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 			esc_html_e( 'Manage permissions', 'zero-bs-crm' );
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DashboardBoxes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DashboardBoxes.php
@@ -74,11 +74,11 @@ function zeroBS_dashboard_crm_list_growth(){
 				<?php
 			} else {
 				?>
-				<div class="div-message-box">
-					<div class="div-message">
+				<div class="jpcrm-div-message-box">
+					<div class="jpcrm-div-message">
 						<?php esc_html_e( 'No contacts were added during the last 12 months. You need contacts for your growth chart to show.', 'zero-bs-crm' ); ?>
 					</div>
-					<div class="div-message">
+					<div class="jpcrm-div-message">
 						<a href="<?php echo esc_url( $zbs->urls['kbfirstcontact'] ); ?>" target="_blank" class="jpcrm-button white-bg"><?php echo esc_html__( 'Read guide', 'zero-bs-crm' ); ?></a>
 						<a href="<?php echo jpcrm_esc_link( 'create', -1, 'zerobs_customer', false, false ); /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>" class="jpcrm-button"><?php esc_html_e( 'Add a contact', 'zero-bs-crm' ); ?></a>
 					</div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
@@ -383,7 +383,6 @@ class zeroBSCRM_Edit{
             };
             var zbsDrawEditViewBlocker = false;
             var zbsDrawEditAJAXBlocker = false;
-            var zbsDrawEditLoadingBoxHTML = '<?php echo zeroBSCRM_UI2_loadingSegmentIncTextHTML(); ?>';
 
             <?php // these are all legacy, move over to zeroBSCRMJS_obj_editLink in global js: ?>
             var zbsObjectViewLinkPrefixCustomer = '<?php echo jpcrm_esc_link( 'view', -1, 'zerobs_customer', true ); ?>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.php
@@ -348,7 +348,6 @@ class zeroBSCRM_Edit{
 
                         ?>
 
-                        <div class="ui divider"></div>
                         <?php ##WLREMOVE ?>
                         <?php echo $this->extraBoxes; ?>
                         <?php ##/WLREMOVE ?>

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -573,7 +573,6 @@ class zeroBSCRM_list{
             var zbsDrawListViewAJAXBlocker = false;
             var zbsDrawListViewColUpdateBlocker = false;
             var zbsDrawListViewColUpdateAJAXBlocker = false;
-            var zbsDrawListLoadingBoxHTML = '<?php echo zeroBSCRM_UI2_loadingSegmentIncTextHTML(); ?>';
 
             var zbsObjectEmailLinkPrefix = '<?php 
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -469,7 +469,6 @@ class zeroBSCRM_list{
 
             }
 
-
             // build options objects
             $list_view_settings = array(
 
@@ -481,7 +480,6 @@ class zeroBSCRM_list{
                 'editinline' => $allowinlineedits
 
             );
-
 
             $list_view_parameters = array(
 
@@ -502,8 +500,6 @@ class zeroBSCRM_list{
                 'pagekey' => ( isset( $zbs->pageKey ) ? esc_html( $zbs->pageKey ) : '' ),
 
             );
-
-
 
             ?>
 
@@ -690,28 +686,7 @@ class zeroBSCRM_list{
             var zbsClick2CallType = parseInt('<?php echo esc_url( zeroBSCRM_getSetting('clicktocalltype') ); ?>');
 
 			<?php
-			$jpcrm_listview_lang_labels = array(
-
-				'go_button'          => esc_html__( 'Go', 'zero-bs-crm' ),
-				/* translators: Placeholder is the number of selected rows. */
-				'rows_selected_x'    => esc_html__( 'Bulk actions (%s rows)', 'zero-bs-crm' ),
-				'rows_selected_1'    => esc_html__( 'Bulk actions (1 row)', 'zero-bs-crm' ),
-				'rows_selected_0'    => esc_html__( 'Bulk actions (no rows)', 'zero-bs-crm' ),
-				'zbs_edit'           => esc_html__( 'Edit', 'zero-bs-crm' ),
-				'today'              => esc_html__( 'Today', 'zero-bs-crm' ),
-				'days'               => esc_html__( 'days', 'zero-bs-crm' ),
-				'daysago'            => esc_html__( 'days ago', 'zero-bs-crm' ),
-				'notcontacted'       => esc_html__( 'Not Contacted', 'zero-bs-crm' ),
-				'yesterday'          => esc_html__( 'Yesterday', 'zero-bs-crm' ),
-				'filteredby'         => esc_html__( 'Filtered By', 'zero-bs-crm' ),
-				'notcontactedin'     => esc_html__( 'Not Contacted in', 'zero-bs-crm' ),
-				'containing'         => esc_html__( 'Containing', 'zero-bs-crm' ),
-				'couldntupdate'      => esc_html__( 'Could not update', 'zero-bs-crm' ),
-				'couldntupdatedeets' => esc_html__( 'This record could not be updated. Please try again, if this persists please let admin know.', 'zero-bs-crm' ),
-				/* translators: Placeholders are the range of the current record result and the total object count. */
-				'listview_counts'    => esc_html__( 'Showing %s of %s items', 'zero-bs-crm' ), // phpcs:ignore WordPress.WP.I18n.UnorderedPlaceholdersText
-
-			);
+			$jpcrm_listview_lang_labels = array();
 
 			// add any object-specific language labels
 			if ( count( $this->langLabels ) > 0 ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -748,74 +723,54 @@ class zeroBSCRM_list{
 				$zbs_tags_for_bulk_actions = wp_json_encode( $simple_tags );
 				echo ( $zbs_tags_for_bulk_actions ? $zbs_tags_for_bulk_actions : '[]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-				// phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact,Generic.WhiteSpace.ScopeIndent.Incorrect
-										?>;
-            var zbsListViewIcos = {
+				?>;
+				var zbsListViewIcos = {};
+				// gives data used by inline editor
+				var zbsListViewInlineEdit = {
 
-                    // bulk action label icos
-                    /* has to be unicode
-                    deletetransactions: '<i class="fa fa-trash" aria-hidden="true"></i>',
-                    addtags: '<i class="fa fa-tags" aria-hidden="true"></i>',
-                    removetags: '<i class="fa fa-chain-broken" aria-hidden="true"></i>',
-                    merge: '<i class="fa fa-compress" aria-hidden="true"></i>',
-                    */
+					// for now just put contacts in here
+					customer: {
+						statuses: <?php
+							// MUST be a better way than this to get customer statuses...
+							// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							global $zbsCustomerFields;
+							if ( is_array( $zbsCustomerFields['status'][3] ) ) {
+								echo wp_json_encode( $zbsCustomerFields['status'][3] );
+							} else {
+								echo '[]';
+							}
+							// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+						?>
+					},
 
-                    // ICONS playing up on semantic Select, so cut out for init.
-                    /* 
-                    deletetransactions: '&#xf1f8;',
-                    addtags: '&#xf1f8;',
-                    removetags: '&#xf1f8;',
-                    merge: '&#xf1f8;',
-                    */
-                    
-                    
+					owners: <?php
 
-            };
-            // gives data used by inline editor
-            var zbsListViewInlineEdit = {
+						// hardcoded customer perms atm
+						$possible_owners = zeroBS_getPossibleOwners( array( 'zerobs_admin', 'zerobs_customermgr' ), true );
+						if ( ! is_array( $possible_owners ) ) {
+								echo wp_json_encode( array() );
+						} else {
+							echo wp_json_encode( $possible_owners );
+						}
 
-                    // for now just put contacts in here
-                    customer: {
-                        statuses: <?php
+					?>
 
-                            // MUST be a better way than this to get customer statuses...
-                            global $zbsCustomerFields;
-                            if (is_array($zbsCustomerFields['status'][3])){
+					};
+					<?php
+					// Nonce for AJAX
+					echo 'var zbscrmjs_secToken = "' . esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ) . '";';
 
-                                echo json_encode($zbsCustomerFields['status'][3]);
-
-                            } else echo '[]';
-                        ?>
-                    },
-
-
-                    owners: <?php
-
-                        // hardcoded customer perms atm
-                        $zbsPossibleOwners = zeroBS_getPossibleOwners(array('zerobs_admin','zerobs_customermgr'),true);
-                        if (!is_array($zbsPossibleOwners))
-                            echo json_encode(array());
-                        else
-                            echo json_encode($zbsPossibleOwners);
-
-                    ?>
-                    
-
-            };
-            <?php #} Nonce for AJAX
-                echo "var zbscrmjs_secToken = '" . esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ) . "';";
-
-                // any last JS?
-                if (isset($this->extraJS) && !empty($this->extraJS)) echo $this->extraJS;
-            
-            ?></script>
+					// any last JS?
+					if ( isset( $this->extraJS ) && ! empty( $this->extraJS ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						echo $this->extraJS; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.Security.EscapeOutput.OutputNotEscaped
+					}
+					// phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact,Generic.WhiteSpace.ScopeIndent.Incorrect
+					?>
+					</script>
 
 					<?php
 					// phpcs:enable Squiz.PHP.EmbeddedPhp.ContentBeforeOpen
 					// phpcs:enable Squiz.PHP.EmbeddedPhp.ContentAfterEnd
-					?>
-
-        <?php
 
     } // /draw func
 
@@ -906,3 +861,30 @@ class zeroBSCRM_list{
 		<?php
 	}
 } // class
+
+/**
+ * Language labels for JS
+ *
+ * @param array $language_array Array of language labels.
+ */
+function jpcrm_listview_language_labels( $language_array ) { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
+	$jpcrm_listview_lang_labels = array(
+		'click_to_sort'      => esc_html__( 'Click to sort', 'zero-bs-crm' ),
+		/* translators: Placeholder is the number of selected rows. */
+		'rows_selected_x'    => esc_html__( 'Bulk actions (%s rows)', 'zero-bs-crm' ),
+		'rows_selected_1'    => esc_html__( 'Bulk actions (1 row)', 'zero-bs-crm' ),
+		'rows_selected_0'    => esc_html__( 'Bulk actions (no rows)', 'zero-bs-crm' ),
+		'zbs_edit'           => esc_html__( 'Edit', 'zero-bs-crm' ),
+		'today'              => esc_html__( 'Today', 'zero-bs-crm' ),
+		'daysago'            => esc_html__( 'days ago', 'zero-bs-crm' ),
+		'notcontacted'       => esc_html__( 'Not Contacted', 'zero-bs-crm' ),
+		'yesterday'          => esc_html__( 'Yesterday', 'zero-bs-crm' ),
+		'couldntupdate'      => esc_html__( 'Could not update', 'zero-bs-crm' ),
+		'couldntupdatedeets' => esc_html__( 'This record could not be updated. Please try again, if this persists please let admin know.', 'zero-bs-crm' ),
+		/* translators: Placeholders are the range of the current record result and the total object count. */
+		'listview_counts'    => esc_html__( 'Showing %s of %s items', 'zero-bs-crm' ), // phpcs:ignore WordPress.WP.I18n.UnorderedPlaceholdersText
+	);
+
+	return array_merge( $language_array, $jpcrm_listview_lang_labels );
+}
+add_filter( 'zbs_globaljs_lang', 'jpcrm_listview_language_labels' );

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Contacts.php
@@ -1509,7 +1509,7 @@ class zeroBS__Metabox_ContactPortal extends zeroBS__Metabox{
                 if ( zeroBSCRM_isWPAdmin() ){
                     
                     $url = admin_url('user-edit.php?user_id='.$wp_user_id);
-                    echo '<br /><a style="font-size: 12px;" href="'. esc_url( $url ) .'" target="_blank"><i class="wordpress simple icon"></i> '. esc_html__('View WordPress Profile','zero-bs-crm') .'</a>';
+							echo '<br /><a style="font-size: 12px;color:black;font-weight:600;" href="' . esc_url( $url ) . '" target="_blank"><i class="wordpress simple icon"></i> ' . esc_html__( 'View WordPress Profile', 'zero-bs-crm' ) . '</a>'; // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 
                 }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Invoices.php
@@ -528,7 +528,8 @@ class zeroBS__Metabox_Invoice extends zeroBS__Metabox {
                 var zbsMetaboxFilesLang = {
                     'err': '<?php echo esc_html( zeroBSCRM_slashOut(__('Error',"zero-bs-crm")) ); ?>',
                     'unabletodel' : '<?php echo esc_html( zeroBSCRM_slashOut(__('Unable to delete this file',"zero-bs-crm")) ); ?>',
-
+							'viewcontact' : '<?php echo esc_html__( 'View contact', 'zero-bs-crm' ); ?>',
+							'viewcompany' : '<?php echo esc_html( __( 'View', 'zero-bs-crm' ) . ' ' . jpcrm_label_company() ); ?>',
                 }
 
                 jQuery(function(){
@@ -857,48 +858,3 @@ class zeroBS__Metabox_InvoiceTags extends zeroBS__Metabox_Tags{
         // saved via main metabox
 
     }
-
-
-/* ======================================================
-  / Invoice Actions Metabox
-   ====================================================== */
-
-
-
-/*#} Currently not used. Started to get confusing. To chat through as part of v3.1+ (and Recurring Invoices work?)
- function zerBSCRM_invoice_admin_submenu(){
-     ?>
-    <div class="ui menu" id="invoice_menu_ui">
-    <div class="ui simple dropdown link item">
-        <span class="text"><?php _e("Manage Invoices","zero-bs-crm");?></span>
-        <i class="dropdown icon"></i>
-        <div class="menu">
-            <div class="item"><?php _e("Manage Invoices","zero-bs-crm");?></div>
-            <div class="item"><?php _e("Manage Recurring Invoices","zero-bs-crm");?></div>
-        </div>
-    </div>
-    <a class="item">
-        <?php _e("Create Invoice", "zero-bs-crm"); ?>
-    </a>
-    <a class="item">
-        <?php _e("Invoice Items", "zero-bs-crm"); ?>
-    </a>
-
-    <div class="ui simple dropdown item">
-        <span class="text"><?php _e("Settings","zero-bs-crm");?></span>
-        <i class="dropdown icon"></i>
-        <div class="menu">
-            <div class="item"><?php _e("Invoice Settings","zero-bs-crm");?></div>
-            <div class="item"><?php _e("Business Information","zero-bs-crm");?></div>
-            <div class="item"><?php _e("Tax Information","zero-bs-crm");?></div>
-            <div class="item"><?php _e("Templates","zero-bs-crm");?></div>
-        </div>
-    </div>
-
-    <a class="item right">
-        <i class='ui icon info circle'></i><?php _e("Help", "zero-bs-crm"); ?>
-    </a>
-
-    </div>
-     <?php
- }  */

--- a/projects/plugins/crm/includes/ZeroBSCRM.SemanticUIHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.SemanticUIHelpers.php
@@ -99,10 +99,11 @@ function zeroBSCRM_UI2_messageHTML($msgClass='',$msgHeader='',$msg='',$iconClass
 
 }
 
-function zeroBSCRM_UI2_loadingSegmentHTML($height='300px',$extraClasses=''){
-
-	return '<div class="ui loading segment '.$extraClasses.'" style="min-height:'.$height.'"><p>&nbsp;</p></div>';
-
+/**
+ * Return HTML for a spinner centered in a container
+ */
+function jpcrm_loading_container() {
+	return '<div class="empty-container-with-spinner"><div class="ui active centered inline loader"></div></div>';
 }
 
 function zeroBSCRM_UI2_squareFeedbackUpsell($title='',$desc='',$linkStr='',$linkTarget='',$extraClasses=''){

--- a/projects/plugins/crm/includes/ZeroBSCRM.SemanticUIHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.SemanticUIHelpers.php
@@ -104,16 +104,6 @@ function zeroBSCRM_UI2_loadingSegmentHTML($height='300px',$extraClasses=''){
 	return '<div class="ui loading segment '.$extraClasses.'" style="min-height:'.$height.'"><p>&nbsp;</p></div>';
 
 }
-function zeroBSCRM_UI2_loadingSegmentIncTextHTML($height='300px',$extraClasses='',$hidden=true,$id=''){
-
-	// hidden?
-	$hiddenExtraHTML = false; if ($hidden) $hiddenExtraHTML = ' style="display:none"';
-	$idStr = ''; if (!empty($id)) $idStr = ' id="'.$id.'"';
-
-	return '<div class="ui active inverted dimmer '.$extraClasses.'" style="min-height:'.$height.'"'.$hiddenExtraHTML.$idStr.'><div class="ui text loader">'.__('Loading',"zero-bs-crm").'</div></div>';
-
-}
-
 
 function zeroBSCRM_UI2_squareFeedbackUpsell($title='',$desc='',$linkStr='',$linkTarget='',$extraClasses=''){
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.SemanticUIHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.SemanticUIHelpers.php
@@ -76,27 +76,38 @@ function zeroBSCRM_getSocialIcon($key = ''){
 		 return false;
 	}
 
-#} Outputs html message, remake of zeroBSCRM_html_msg
-/*
-	$iconClass = message
-	$msgClass = warning etc.
+/**
+ * Generates HTML markup for a message box.
+ *
+ * @param string $msg_class CSS class for the message box.
+ * @param string $msg_header Optional. Header text for the message box.
+ * @param string $msg Main content of the message box.
+ * @param string $icon_class Optional. CSS class for an icon to be displayed in the message box.
+ * @param string $id Optional. ID attribute for the message box element.
+ *
+ * @return string HTML markup for the message box.
+ * @link https://semantic-ui.com/collections/message.html Semantic UI Message Documentation.
+ */
+function zeroBSCRM_UI2_messageHTML( $msg_class = '', $msg_header = '', $msg = '', $icon_class = '', $id = '' ) {
+	if ( ! empty( $icon_class ) ) {
+		$msg_class .= ' icon';
+	}
 
-	https://semantic-ui.com/collections/message.html
-*/
-function zeroBSCRM_UI2_messageHTML($msgClass='',$msgHeader='',$msg='',$iconClass='',$id=''){
-
-	if (!empty($iconClass)) $msgClass .= ' icon';
-
-	$ret = '<div class="ui '.$msgClass.' message"';
-	if (!empty($id)) $ret .= ' id="'.$id.'"';
+	$ret = '<div style="box-shadow:unset; color:black;" class="ui ' . $msg_class . ' icon message jpcrm-div-message-box"';
+	if ( ! empty( $id ) ) {
+		$ret .= ' id="' . $id . '"';
+	}
 	$ret .= '>';
-	if (!empty($iconClass)) $ret .= '<i class="'.$iconClass.' icon"></i>';
+	if ( ! empty( $icon_class ) ) {
+		$ret .= '<i class="' . $icon_class . ' icon"></i>';
+	}
 	$ret .= '<div class="content">';
-  	if (!empty($msgHeader)) $ret .= '<div class="header">'.$msgHeader.'</div>';
-  	$ret .= '<p>'.$msg.'</p></div></div>';
+	if ( ! empty( $msg_header ) ) {
+		$ret .= '<div style="color:black;" class="header">' . $msg_header . '</div>';
+	}
+	$ret .= '<p>' . $msg . '</p></div></div>';
 
-  	return $ret;
-
+	return $ret;
 }
 
 /**

--- a/projects/plugins/crm/includes/ZeroBSCRM.TagManager.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.TagManager.php
@@ -282,7 +282,6 @@ class zeroBSCRM_TagManager{
             };
             var zbsDrawEditViewBlocker = false;
             var zbsDrawEditAJAXBlocker = false;
-            var zbsDrawEditLoadingBoxHTML = '<?php echo esc_html( zeroBSCRM_UI2_loadingSegmentIncTextHTML() ); ?>';
             var zbsObjectViewLinkPrefixCustomer = '<?php echo jpcrm_esc_link( 'view', -1, 'zerobs_customer', true ); ?>';
             var zbsObjectEditLinkPrefixCustomer = '<?php echo jpcrm_esc_link( 'edit', -1, 'zerobs_customer', true ); ?>';
             var zbsObjectViewLinkPrefixCompany = '<?php echo jpcrm_esc_link( 'view', -1, 'zerobs_company', true ); ?>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.TagManager.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.TagManager.php
@@ -228,7 +228,6 @@ class zeroBSCRM_TagManager{
 
                         ?>
 
-                        <div class="ui divider"></div>
                         <?php ##WLREMOVE ?>
                         <?php echo $this->extraBoxes; ?>
                         <?php ##/WLREMOVE ?>

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.editview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.editview.js
@@ -391,7 +391,7 @@ function zeroBSCRMJS_events_showContactLinkIf( contactID ) {
 
 			// ALSO show in header bar, if so
 			var navButton =
-				'<a target="_blank" style="margin-left:6px;" class="zbs-quicknav-contact ui icon button blue mini labeled" href="' +
+				'<a target="_blank" style="margin-left:6px;" class="zbs-quicknav-contact ui icon button black mini labeled" href="' +
 				window.zbsObjectViewLinkPrefixCustomer +
 				contactID +
 				'"><i class="user icon"></i> ' +
@@ -451,7 +451,7 @@ function zeroBSCRMJS_events_showCompanyLinkIf( companyID ) {
 
 			// ALSO show in header bar, if so
 			var navButton =
-				'<a target="_blank" style="margin-left:6px;" class="zbs-quicknav-contact ui icon button blue mini labeled" href="' +
+				'<a target="_blank" style="margin-left:6px;" class="zbs-quicknav-contact ui icon button black mini labeled" href="' +
 				window.zbsObjectViewLinkPrefixCompany +
 				companyID +
 				'"><i class="user icon"></i> ' +

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.email.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.email.js
@@ -217,14 +217,6 @@ jQuery( function ( $ ) {
 				$( '.total-tasks-panel' ).html( total_tasks );
 				$( '.completed-tasks-panel' ).html( completed_tasks );
 				$( '.inprogress-tasks-panel' ).html( progress_tasks );
-
-				if ( response.customer.status == 'Customer' ) {
-					$( '#panel-status' ).removeClass( 'blue' ).addClass( 'green' );
-				}
-				if ( response.customer.status == 'Lead' ) {
-					$( '#panel-status' ).addClass( 'blue' ).removeClass( 'green' );
-				}
-
 				$( '.total-paid .the_value' ).html( response.trans_value );
 				$( '.total-due .the_value' ).html( response.quote_value );
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -1931,15 +1931,11 @@ function jpcrm_strip_scripts( s ) {
 	return div.innerHTML;
 }
 
-/* super simple switch
-HIDES: .zbs-generic-loading
-SHOWS: .zbs-generic-loaded
-*/
 /**
  *
  */
 function zeroBSCRMJS_genericLoaded() {
-	jQuery( '.zbs-generic-loading' ).hide();
+	jQuery( '.empty-container-with-spinner' ).hide();
 	jQuery( '.zbs-generic-loaded' ).show();
 }
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -1872,85 +1872,22 @@ function zbscrm_JS_bindInitialLearnLinks() {
  * @param contactID
  */
 function zeroBSCRMJS_showContactLinkIf( contactID ) {
-	// remove old
-	// NOT USING this bit jQuery('#zbs-customer-title .zbs-view-contact').remove();
 	jQuery( '#zbs-invoice-learn-nav .zbs-invoice-quicknav-contact' ).remove();
 
 	if ( typeof contactID !== 'undefined' && contactID !== null && contactID !== '' ) {
 		contactID = parseInt( contactID );
 		if ( contactID > 0 ) {
-			// seems legit, add
-
-			/* not using (from trans originally) var html = '<div class="ui right floated mini animated button zbs-view-contact">';
-						html += '<div class="visible content">' + zbscrm_JS_invoice_lang('viewcontact') + '</div>';
-							html += '<div class="hidden content">';
-						    	html += '<i class="user icon"></i>';
-						  	html += '</div>';
-						html += '</div>';
-
-				jQuery('#zbs-customer-title').prepend(html);
-
-				// bind
-				zeroBSCRMJS_bindContactLinkIf();
-				*/
-
-			// ALSO show in header bar, if so
 			var navButton =
-				'<a target="_blank" style="margin-left:6px;" class="zbs-invoice-quicknav-contact ui icon button blue mini labeled" href="' +
+				'<a target="_blank" style="margin-left:6px;" class="zbs-invoice-quicknav-contact jpcrm-button" href="' +
 				window.zbs_invoice.invoiceObj.settings.contacturlprefix +
 				contactID +
-				'"><i class="user icon"></i> ' +
-				zbscrm_JS_invoice_lang( 'contact' ) +
+				'">' +
+				window.zbsMetaboxFilesLang.viewcontact +
 				'</a>';
 			jQuery( '#zbs-invoice-learn-nav' ).prepend( navButton );
 		}
 	}
 }
-
-/* Not using, (from trans editor originally)
-// click for quicknav :)
-function zeroBSCRMJS_bindContactLinkIf(){
-
-	jQuery('#zbs-customer-title .zbs-view-contact').off('click').on( 'click', function(){
-
-		// get from hidden input
-		var contactID = parseInt(jQuery("#customer").val());//jQuery(this).attr('data-invid');
-
-		if (typeof contactID != "undefined" && contactID !== null && contactID !== ''){
-			contactID = parseInt(contactID);
-			if (contactID > 0){
-
-				var url = '<?php echo jpcrm_esc_link('edit',-1,'zerobs_customer',true); ?>' + contactID;
-
-				// bla bla https://stackoverflow.com/questions/1574008/how-to-simulate-target-blank-in-javascript
-				window.open(url,'_parent');
-			}
-		}
-
-	});
-}
-
-// click for quicknav :)
-function zeroBSCRMJS_bindCompanyLinkIf(){
-
-	jQuery('#zbs-company-title .zbs-view-company').off('click').on( 'click', function(){
-
-		// get from hidden input
-		var companyID = parseInt(jQuery("#zbsct_company").val());//jQuery(this).attr('data-invid');
-
-		if (typeof companyID != "undefined" && companyID !== null && companyID !== ''){
-			companyID = parseInt(companyID);
-			if (companyID > 0){
-
-				var url = '<?php echo jpcrm_esc_link('edit',-1,'zerobs_company',true); ?>' + companyID;
-
-				// bla bla https://stackoverflow.com/questions/1574008/how-to-simulate-target-blank-in-javascript
-				window.open(url,'_parent');
-			}
-		}
-
-	});
-}*/
 
 // if an Company is selected (against a trans) can 'quick nav' to Company
 /**
@@ -1964,29 +1901,12 @@ function zeroBSCRMJS_showCompanyLinkIf( companyID ) {
 	if ( typeof companyID !== 'undefined' && companyID !== null && companyID !== '' ) {
 		companyID = parseInt( companyID );
 		if ( companyID > 0 ) {
-			// seems like a legit inv, add
-
-			/* not using here, (orig from trans)
-				var html = '<div class="ui right floated mini animated button zbs-view-company">';
-						html += '<div class="visible content"><?php  zeroBSCRM_slashOut(__('View','zero-bs-crm')); ?></div>';
-							html += '<div class="hidden content">';
-						    	html += '<i class="building icon"></i>';
-						  	html += '</div>';
-						html += '</div>';
-
-				jQuery('#zbs-company-title').prepend(html);
-
-				// bind
-				zeroBSCRMJS_bindCompanyLinkIf();
-				*/
-
-			// ALSO show in header bar, if so
 			var navButton =
-				'<a target="_blank" style="margin-left:6px;" class="zbs-invoice-quicknav-company ui icon button blue mini labeled" href="' +
+				'<a target="_blank" style="margin-left:6px;" class="zbs-invoice-quicknav-company jpcrm-button" href="' +
 				window.zbs_invoice.invoiceObj.settings.companyurlprefix +
 				companyID +
-				'"><i class="building icon"></i> ' +
-				zbscrm_JS_invoice_lang( 'company' ) +
+				'">' +
+				window.zbsMetaboxFilesLang.viewcompany +
 				'</a>';
 			jQuery( '#zbs-invoice-learn-nav' ).prepend( navButton );
 		}

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -453,10 +453,8 @@ function zeroBSCRMJS_drawListView() {
 					} else {
 						// no lines, move this ui msg into a blank row col
 						if ( jQuery( '#zbsNoResults' ).length ) {
-							listViewHTML +=
-								'<tr><td colspan="' +
-								window.zbsListViewParams.columns.length +
-								'" id="zbs-no-results-wrap">';
+							// extra column due to checkbox
+							listViewHTML +='<tr><td colspan="' + (window.zbsListViewParams.columns.length + 1) + '" id="zbs-no-results-wrap">';
 
 							// to be fired after setTimeout jQuery('#zbsNoResults').appendTo('#zbs-no-results-wrap');
 							postHTML.nores = true;

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -400,45 +400,51 @@ function zeroBSCRMJS_listViewIco( key, fallback ) {
 /**
  *
  */
-function zeroBSCRMJS_drawListView() {
-	// if no blocker
-	if ( ! window.zbsDrawListViewBlocker ) {
-		// move this, if it's present (if was 0 results it'll be in the table, otherwise, wont be anyhow :)
-		jQuery( '#zbsNoResults' ).addClass( 'hidden' ).appendTo( '#zbs-list-warnings-wrap' );
+function zeroBSCRMJS_drawListView(reset_pagination, update_url) {
+	// if blocker, stop
+	if ( window.zbsDrawListViewBlocker ) {
+		return;
+	}
 
-		// put blocker up
-		window.zbsDrawListViewBlocker = true;
+	// reset pagination
+	if (reset_pagination) {
+		zbsListViewParams.paged = 1;
+	}
 
-		// empty table, show loading
-		jQuery( '.jpcrm-listview-table-container' ).html( '<div class="empty-container-with-spinner"><div class="ui active centered inline loader"></div></div>' );
+	// update URL
+	if (update_url) {
+		history.replaceState( null, null, jpcrm_listview_generate_current_filter_url() );
+	}
+	// move this, if it's present (if was 0 results it'll be in the table, otherwise, wont be anyhow :)
+	jQuery( '#zbsNoResults' ).addClass( 'hidden' ).appendTo( '#zbs-list-warnings-wrap' );
 
-		// check data + retrieve if empty
-		if ( ! window.zbsListViewParams.retrieved ) {
+	// put blocker up
+	window.zbsDrawListViewBlocker = true;
 
 			// hide extras until listview is loaded
 			document.querySelector('.bulk-actions-dropdown').classList.add('hidden');
 			jQuery( 'jpcrm-listview-footer' ).hide();
 			jQuery( 'jpcrm-dashcount' ).hide();
 
-			// retrieve data
-			zeroBSCRMJS_retrieveListViewData(
-				function ( d ) {
+	// check data + retrieve if empty
+	if ( ! window.zbsListViewParams.retrieved ) {
 
-					// holds event flags to fire post-draw
-					var postHTML = {};
+		// hide extras until listview is loaded
+		document.querySelector('.bulk-actions-dropdown').classList.add('hidden');
+		jQuery( 'jpcrm-listview-footer' ).hide();
+		jQuery( '#jpcrm-listview-totals-box' ).hide();
 
-					// success callback
-					var listViewHTML = '';
+		// retrieve data
+		zeroBSCRMJS_retrieveListViewData(
+			function ( d ) {
 
-					listViewHTML += jpcrm_listview_header();
+				// holds event flags to fire post-draw
+				var postHTML = {};
 
-					// show pagination at top if per page is high
-					if (zbsListViewParams.count >= 50) {
-						listViewHTML += '<div class="jpcrm-pagination-container"></div>';
-					}
+				// success callback
+				var listViewHTML = '';
 
-					// build table
-					listViewHTML += '<table class="jpcrm-listview-table">';
+				listViewHTML += jpcrm_listview_header();
 
 					// header
 					listViewHTML += jpcrm_listview_table_header();
@@ -511,8 +517,82 @@ function zeroBSCRMJS_drawListView() {
 					// fini, remove blocker
 					window.zbsDrawListViewBlocker = false;
 				}
-			);
-		}
+
+				// build table
+				listViewHTML += '<table class="jpcrm-listview-table">';
+
+				// header
+				listViewHTML += jpcrm_listview_table_header();
+				listViewHTML += '<tbody>';
+
+				// per line
+				if ( window.zbsListViewData.length > 0 ) {
+					jQuery.each( window.zbsListViewData, function ( ind, ele ) {
+						// add to html
+						listViewHTML += zeroBSCRMJS_listViewLine( ele );
+					} );
+				} else {
+					// no lines, move this ui msg into a blank row col
+					if ( jQuery( '#zbsNoResults' ).length ) {
+						// extra column due to checkbox
+						listViewHTML +='<tr><td colspan="' + (window.zbsListViewParams.columns.length + 1) + '" id="zbs-no-results-wrap">';
+
+						// to be fired after setTimeout jQuery('#zbsNoResults').appendTo('#zbs-no-results-wrap');
+						postHTML.nores = true;
+
+						listViewHTML += '</td></tr>';
+					}
+				}
+
+				listViewHTML += '</tbody>';
+
+				listViewHTML += '</table>';
+
+				// draw
+				jQuery( '.jpcrm-listview-table-container' ).html( listViewHTML );
+
+				//update counts in footer
+				jpcrm_update_listview_counts();
+
+				// update pagination
+				jpcrm_update_listview_pagination();
+
+				// catch any post-html events
+				var lPostHTML = postHTML;
+
+				// empty result set.
+				if ( typeof lPostHTML.nores ) {
+					jQuery( '#zbsNoResults' ).appendTo( '#zbs-no-results-wrap' ).removeClass( 'hidden' );
+				}
+
+				// bind any post-render (e.g. bulk action)
+				zeroBSCRMJS_listViewBinds();
+
+				// draw totals tables, if data
+				zeroBSCRMJS_listView_draw_totals_tables();
+				// fini, remove blocker
+				window.zbsDrawListViewBlocker = false;
+
+				jQuery( '#zbsCantLoadData' ).hide();
+				jQuery( '.jpcrm-listview-table-container' ).show();
+				jQuery( 'jpcrm-listview-footer' ).show();
+				jQuery( '#jpcrm-listview-totals-box' ).show();
+			},
+			function ( errd ) {
+				// err callback? show msg (prefilled by php)
+				jQuery( '#zbsCantLoadData' ).show();
+				jQuery( '.jpcrm-listview-table-container' ).hide();
+
+				//update counts in footer
+				jpcrm_update_listview_counts();
+
+				// update pagination
+				jpcrm_update_listview_pagination();
+
+				// fini, remove blocker
+				window.zbsDrawListViewBlocker = false;
+			}
+		);
 	}
 }
 
@@ -639,56 +719,24 @@ function jpcrm_listview_table_header() {
 		}
 
 		jQuery.each( window.zbsListViewParams.columns, function ( lvhInd, lvhEle ) {
-			var tdStr = lvhEle.namestr;
-
-			// sortable?
-			// This says "are not in unsortable"
-			//if (typeof window.zbsListViewParams.sort != "undefined" && window.zbsUnsortables.indexOf(lvhEle.fieldstr) < 0){
-			// but for v2.2 we'll do "in zbsSortables"(because need new db  format to properly do sort)
-			if (
-				typeof window.zbsSortables !== 'undefined' &&
-				window.zbsSortables.indexOf( lvhEle.fieldstr ) > -1
-			) {
-				if (
-					typeof window.zbsListViewParams.sort !== 'undefined' &&
-					window.zbsListViewParams.sort == lvhEle.fieldstr
-				) {
-					var sortDirection = 'down';
-					var sortDirectionUrlParam = 'asc';
-					if (
-						typeof window.zbsListViewParams.sortorder !== 'undefined' &&
-						window.zbsListViewParams.sortorder == 'asc'
-					) {
-						sortDirection = 'up';
-						sortDirectionUrlParam = 'desc';
-					}
-
-					tdStr +=
-						' <a href="' +
-						jpcrm_listview_generate_current_filter_url( true ) +
-						'&sort=' +
-						lvhEle.fieldstr +
-						'&sortdirection=' +
-						sortDirectionUrlParam +
-						'" title="Click to Sort"><i class="angle ' +
-						sortDirection +
-						' icon"></i></a>';
-				} else {
-					// use name as sort link, always defaults to desc
-					tdStr =
-						' <a href="' +
-						jpcrm_listview_generate_current_filter_url( true ) +
-						'&sort=' +
-						lvhEle.fieldstr +
-						'" title="Click to Sort">' +
-						tdStr +
-						'</a>';
+			if (zbsSortables && zbsSortables.indexOf( lvhEle.fieldstr ) > -1) {
+				sortDirectionUrlParam = 'asc';
+				var sortDirection = 'down';
+				if (zbsListViewParams.sortorder && window.zbsListViewParams.sortorder === 'asc' && zbsListViewParams.sort && zbsListViewParams.sort === lvhEle.fieldstr) {
+					sortDirection = 'up';
+					sortDirectionUrlParam = 'desc';
 				}
-			} // / is sortable
-
-			listViewHeaderHTML += '        <th>' + tdStr + '</th>';
+				listViewHeaderHTML += `<th class="jpcrm_sort_column" data-sort="${lvhEle.fieldstr}" data-sortdir="${sortDirectionUrlParam}" title="${zeroBSCRMJS_listViewLang('click_to_sort')}">`;
+				listViewHeaderHTML += `${lvhEle.namestr}`;
+				if ( zbsListViewParams.sort && zbsListViewParams.sort === lvhEle.fieldstr) {
+					listViewHeaderHTML += `<i class="angle ${sortDirection} icon"></i>`;
+				}
+				listViewHeaderHTML += `</th>`;
+			} else {
+				listViewHeaderHTML += `<th>${lvhEle.namestr}</th>`;
+			}
 		} );
-		listViewHeaderHTML += '      </tr></thead>';
+		listViewHeaderHTML += '</tr></thead>';
 	}
 
 	return listViewHeaderHTML;
@@ -778,6 +826,10 @@ function zeroBSCRMJS_listViewLine( data ) {
  *
  */
 function zeroBSCRMJS_listViewBinds() {
+
+	let sort_columns = document.querySelectorAll('.jpcrm_sort_column');
+	sort_columns.forEach( el => el.addEventListener('click',jpcrm_change_sort));
+
 
 	let row_checkboxes = document.querySelectorAll('.jpcrm-listview-table td input[type="checkbox"]');
 
@@ -5575,14 +5627,8 @@ function jpcrm_remove_listview_filter() {
 		zbsListViewParams.filters.tags = [];
 	}
 
-	// reset pagination
-	zbsListViewParams.paged = 1;
-
-	// update address bar
-	history.replaceState( null, null, jpcrm_listview_generate_current_filter_url() );
-
 	// draw new listview
-	zeroBSCRMJS_drawListView();
+	zeroBSCRMJS_drawListView(true, true);
 }
 
 function jpcrm_do_search_filter( event ) {
@@ -5594,14 +5640,19 @@ function jpcrm_do_search_filter( event ) {
 	// update listview filter settings
 	zbsListViewParams.filters.s = this.value;
 
-	// reset pagination
-	zbsListViewParams.paged = 1;
+	// draw new listview
+	zeroBSCRMJS_drawListView(true, true);
+}
 
-	// update address bar
-	history.replaceState( null, null, jpcrm_listview_generate_current_filter_url() );
+function jpcrm_change_sort() {
+
+	// update sort params
+	zbsListViewParams.sort = this.dataset.sort;
+	zbsListViewParams.sortorder = this.dataset.sortdir;
 
 	// draw new listview
-	zeroBSCRMJS_drawListView();
+	zeroBSCRMJS_drawListView(true, true);
+
 }
 
 if ( typeof module !== 'undefined' ) {
@@ -5744,6 +5795,6 @@ if ( typeof module !== 'undefined' ) {
 		zeroBSCRMJS_listView_saveInlineEdit,
 		zeroBSCRMJS_listView_customer_edit_status,
 		zeroBSCRMJS_listView_generic_edit_assigned, jpcrm_get_contact_meta,
-		jpcrm_add_listview_filter, jpcrm_remove_listview_filter, jpcrm_do_search_filter
+		jpcrm_add_listview_filter, jpcrm_remove_listview_filter, jpcrm_do_search_filter, jpcrm_change_sort
 	};
 }

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -1817,17 +1817,14 @@ function zeroBSCRMJS_listView_generic_nameavatar( dataLine ) {
 		nameStr = dataLine.email;
 	}
 
-	var td = '<td class="name-and-avatar-list"><h4 class="ui image header">';
-	td += imgStr;
-	td +=
-		'<div class="content"><a href="' +
-		editURL +
-		'">' +
-		nameStr +
-		'</a><div class="sub header">' +
-		emailStr +
-		'</div>';
-	td += '</div></h4></td>';
+	var td = `
+		<td class="jpcrm_name_and_avatar">
+			${imgStr}
+			<div class="content">
+				<a href="${editURL}">${nameStr}</a>
+				${emailStr}
+			</div>
+		</td>`;
 
 	return td;
 }
@@ -1869,10 +1866,10 @@ function zeroBSCRMJS_listView_generic_customer( dataLine ) {
 		var editURL = zeroBSCRMJS_listView_viewURL_customer( dataLine.customer.id );
 		var emailURL = zeroBSCRMJS_listView_emailURL_contact( dataLine.customer.id );
 
-		var emailStr = ''; //if (typeof custLine['email'] != "undefined" && custLine['email'] != '') emailStr = '<a href="mailto:' + custLine['email'] + '" target="_blank">' + custLine['email'] + '</a>';
+		var emailStr = '';
 		var imgStr = '';
 		if ( typeof custLine.avatar !== 'undefined' && custLine.avatar != '' ) {
-			imgStr = '<img src="' + custLine.avatar + '" class="ui mini rounded image">';
+			imgStr = '<img src="' + custLine.avatar + '">';
 		} //imgStr = '<a href="' + editURL + '"><img src="' + dataLine['avatar'] + '" class="ui mini rounded image"></a>';
 		var nameStr = '';
 		if ( typeof custLine.fullname !== 'undefined' && custLine.fullname != '' ) {
@@ -1882,17 +1879,14 @@ function zeroBSCRMJS_listView_generic_customer( dataLine ) {
 			nameStr = custLine.email;
 		}
 
-		var td = '<td class="name-and-avatar-list"><h4 class="ui image header">';
-		td += imgStr;
-		td +=
-			'<div class="content"><a href="' +
-			editURL +
-			'">' +
-			nameStr +
-			'</a><div class="sub header">' +
-			emailStr +
-			'</div>';
-		td += '</div></h4></td>';
+		var td = `
+			<td class="jpcrm_name_and_avatar">
+				${imgStr}
+				<div class="content">
+					<a href="${editURL}">${nameStr}</a>
+					${emailStr}
+				</div>
+			</td>`;
 	} else if (
 		typeof dataLine.company !== 'undefined' &&
 		dataLine.company != null &&
@@ -1907,9 +1901,13 @@ function zeroBSCRMJS_listView_generic_customer( dataLine ) {
 			nameStr = coLine.fullname;
 		}
 
-		var td = '<td class="name-and-avatar-list"><h4 class="ui header">';
-		td += '<i class="building icon"></i>';
-		td += '<div class="content"><a href="' + editURL + '">' + nameStr + '</a></div></h4></td>';
+		var td = `
+			<td class="jpcrm_name_and_avatar">
+			<i class="building icon"></i>
+				<div class="content">
+					<a href="${editURL}">${nameStr}</a>
+				</div>
+			</td>`;
 	} else {
 		td = '<td>' + zeroBSCRMJS_listViewLang( 'nocustomer' ) + '</td>';
 	}
@@ -2526,17 +2524,14 @@ function zeroBSCRMJS_listView_customer_nameavatar( dataLine ) {
 		nameStr = dataLine.email;
 	}
 
-	var td = '<td class="name-and-avatar-list"><h4 class="ui image header">';
-	td += imgStr;
-	td +=
-		'<div class="content"><a href="' +
-		editURL +
-		'">' +
-		nameStr +
-		'</a><div class="sub header">' +
-		emailStr +
-		'</div>';
-	td += '</div></h4></td>';
+	var td = `
+		<td class="jpcrm_name_and_avatar">
+			${imgStr}
+			<div class="content">
+				<a href="${editURL}">${nameStr}</a>
+				${emailStr}
+			</div>
+		</td>`;
 
 	return td;
 }
@@ -3003,17 +2998,14 @@ function zeroBSCRMJS_listView_company_nameavatar( dataLine ) {
 		nameStr = dataLine.email;
 	}
 
-	var td = '<td class="name-and-avatar-list"><h4 class="ui image header">';
-	td += imgStr;
-	td +=
-		'<div class="content"><a href="' +
-		editURL +
-		'">' +
-		nameStr +
-		'</a><div class="sub header">' +
-		emailStr +
-		'</div>';
-	td += '</div></h4></td>';
+	var td = `
+		<td class="jpcrm_name_and_avatar">
+			${imgStr}
+			<div class="content">
+				<a href="${editURL}">${nameStr}</a>
+				${emailStr}
+			</div>
+		</td>`;
 
 	return td;
 }
@@ -3517,38 +3509,6 @@ function zeroBSCRMJS_listView_company_bulkActionFire_removetag() {
 =============== Field Drawing JS - Quote List View ==================================
 ==================================================================================== */
 
-/* Now covered by generic_customer
-
-        function zeroBSCRMJS_listView_quote_customer(dataLine){
-
-            console.log('line',dataLine);
-
-            if (typeof dataLine['customer'] != "undefined" && typeof dataLine['customer']['meta'] != "undefined"){
-
-                var custLine = dataLine['customer']['meta'];
-
-                var editURL = zeroBSCRMJS_listView_viewURL_customer(dataLine['customer']['id']);
-
-                var emailStr = ''; //if (typeof custLine['email'] != "undefined" && custLine['email'] != '') emailStr = '<a href="mailto:' + custLine['email'] + '" target="_blank">' + custLine['email'] + '</a>';
-                var imgStr = ''; if (typeof custLine['avatar'] != "undefined" && custLine['avatar'] != '') imgStr = '<img src="' + custLine['avatar'] + '" class="ui mini rounded image">';//imgStr = '<a href="' + editURL + '"><img src="' + dataLine['avatar'] + '" class="ui mini rounded image"></a>';
-                var nameStr = ''; if (typeof custLine['fullname'] != "undefined" && custLine['fullname'] != '') nameStr = custLine['fullname'];
-                if (nameStr == '' && typeof custLine['email'] != "undefined" && custLine['email'] != '') nameStr = custLine['email'];
-
-                var td = '<td class="name-and-avatar-list"><h4 class="ui image header">';
-                td += imgStr;
-                td += '<div class="content"><a href="' + editURL + '">' + nameStr + '</a><div class="sub header">' + emailStr + '</div>';
-                td += '</div></h4></td>';
-
-            } else {
-
-                td = '';
-            }
-
-            return td;
-        }
-
-    */
-// Draw <td> for quote title
 /**
  * @param dataLine
  */

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -120,7 +120,7 @@ function zeroBSCRMJS_initListView() {
 								jQuery( '#zbs-col-manager-loading' ).hide();
 
 								// could not save cols
-								jQuery( '#zbsCantSaveCols' ).show();
+								jQuery( '#zbsCantSaveCols' ).css('display', 'flex');
 							}
 						);
 					},
@@ -511,7 +511,7 @@ function zeroBSCRMJS_drawListView(reset_pagination, update_url) {
 			},
 			function ( errd ) {
 				// err callback? show msg (prefilled by php)
-				jQuery( '#zbsCantLoadData' ).show();
+				jQuery( '#zbsCantLoadData' ).css('display', 'flex');
 				jQuery( '.jpcrm-listview-table-container' ).hide();
 
 				//update counts in footer

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -400,118 +400,130 @@ function zeroBSCRMJS_listViewIco( key, fallback ) {
 /**
  *
  */
-function zeroBSCRMJS_drawListView() {
-	// if no blocker
-	if ( ! window.zbsDrawListViewBlocker ) {
-		// move this, if it's present (if was 0 results it'll be in the table, otherwise, wont be anyhow :)
-		jQuery( '#zbsNoResults' ).addClass( 'hidden' ).appendTo( '#zbs-list-warnings-wrap' );
+function zeroBSCRMJS_drawListView(reset_pagination, update_url) {
+	// if blocker, stop
+	if ( window.zbsDrawListViewBlocker ) {
+		return;
+	}
 
-		// put blocker up
-		window.zbsDrawListViewBlocker = true;
+	// reset pagination
+	if (reset_pagination) {
+		zbsListViewParams.paged = 1;
+	}
+	// update URL
+	if (update_url) {
+		history.replaceState( null, null, jpcrm_listview_generate_current_filter_url() );
+	}
 
-		// empty table, show loading
-		jQuery( '.jpcrm-listview-table-container' ).html( '<div class="empty-container-with-spinner"><div class="ui active centered inline loader"></div></div>' );
+	// move this, if it's present (if was 0 results it'll be in the table, otherwise, wont be anyhow :)
+	jQuery( '#zbsNoResults' ).addClass( 'hidden' ).appendTo( '#zbs-list-warnings-wrap' );
 
-		// check data + retrieve if empty
-		if ( ! window.zbsListViewParams.retrieved ) {
+	// put blocker up
+	window.zbsDrawListViewBlocker = true;
 
-			// hide extras until listview is loaded
-			document.querySelector('.bulk-actions-dropdown').classList.add('hidden');
-			jQuery( 'jpcrm-listview-footer' ).hide();
-			jQuery( 'jpcrm-dashcount' ).hide();
+	// empty table, show loading
+	jQuery( '.jpcrm-listview-table-container' ).html( '<div class="empty-container-with-spinner"><div class="ui active centered inline loader"></div></div>' );
 
-			// retrieve data
-			zeroBSCRMJS_retrieveListViewData(
-				function ( d ) {
+	// check data + retrieve if empty
+	if ( ! window.zbsListViewParams.retrieved ) {
 
-					// holds event flags to fire post-draw
-					var postHTML = {};
+		// hide extras until listview is loaded
+		document.querySelector('.bulk-actions-dropdown').classList.add('hidden');
+		jQuery( 'jpcrm-listview-footer' ).hide();
+		jQuery( 'jpcrm-dashcount' ).hide();
 
-					// success callback
-					var listViewHTML = '';
+		// retrieve data
+		zeroBSCRMJS_retrieveListViewData(
+			function ( d ) {
 
-					listViewHTML += jpcrm_listview_header();
+				// holds event flags to fire post-draw
+				var postHTML = {};
 
-					// show pagination at top if per page is high
-					if (zbsListViewParams.count >= 50) {
-						listViewHTML += '<div class="jpcrm-pagination-container"></div>';
-					}
+				// success callback
+				var listViewHTML = '';
 
-					// build table
-					listViewHTML += '<table class="jpcrm-listview-table">';
+				listViewHTML += jpcrm_listview_header();
 
-					// header
-					listViewHTML += jpcrm_listview_table_header();
-					listViewHTML += '<tbody>';
-
-					// per line
-					if ( window.zbsListViewData.length > 0 ) {
-						jQuery.each( window.zbsListViewData, function ( ind, ele ) {
-							// add to html
-							listViewHTML += zeroBSCRMJS_listViewLine( ele );
-						} );
-					} else {
-						// no lines, move this ui msg into a blank row col
-						if ( jQuery( '#zbsNoResults' ).length ) {
-							listViewHTML +='<tr><td colspan="' + (window.zbsListViewParams.columns.length + 1) + '" id="zbs-no-results-wrap">';
-
-							// to be fired after setTimeout jQuery('#zbsNoResults').appendTo('#zbs-no-results-wrap');
-							postHTML.nores = true;
-
-							listViewHTML += '</td></tr>';
-						}
-					}
-
-					listViewHTML += '</tbody>';
-
-					listViewHTML += '</table>';
-
-					// draw
-					jQuery( '.jpcrm-listview-table-container' ).html( listViewHTML );
-
-					//update counts in footer
-					jpcrm_update_listview_counts();
-
-					// update pagination
-					jpcrm_update_listview_pagination();
-
-					// catch any post-html events
-					var lPostHTML = postHTML;
-
-					// empty result set.
-					if ( typeof lPostHTML.nores ) {
-						jQuery( '#zbsNoResults' ).appendTo( '#zbs-no-results-wrap' ).removeClass( 'hidden' );
-					}
-
-					// bind any post-render (e.g. bulk action)
-					zeroBSCRMJS_listViewBinds();
-
-					// draw totals tables, if data
-					zeroBSCRMJS_listView_draw_totals_tables();
-					// fini, remove blocker
-					window.zbsDrawListViewBlocker = false;
-
-					jQuery( '#zbsCantLoadData' ).hide();
-					jQuery( '.jpcrm-listview-table-container' ).show();
-					jQuery( 'jpcrm-listview-footer' ).show();
-					jQuery( 'jpcrm-dashcount' ).show();
-				},
-				function ( errd ) {
-					// err callback? show msg (prefilled by php)
-					jQuery( '#zbsCantLoadData' ).show();
-					jQuery( '.jpcrm-listview-table-container' ).hide();
-
-					//update counts in footer
-					jpcrm_update_listview_counts();
-
-					// update pagination
-					jpcrm_update_listview_pagination();
-
-					// fini, remove blocker
-					window.zbsDrawListViewBlocker = false;
+				// show pagination at top if per page is high
+				if (zbsListViewParams.count >= 50) {
+					listViewHTML += '<div class="jpcrm-pagination-container"></div>';
 				}
-			);
-		}
+
+				// build table
+				listViewHTML += '<table class="jpcrm-listview-table">';
+
+				// header
+				listViewHTML += jpcrm_listview_table_header();
+				listViewHTML += '<tbody>';
+
+				// per line
+				if ( window.zbsListViewData.length > 0 ) {
+					jQuery.each( window.zbsListViewData, function ( ind, ele ) {
+						// add to html
+						listViewHTML += zeroBSCRMJS_listViewLine( ele );
+					} );
+				} else {
+					// no lines, move this ui msg into a blank row col
+					if ( jQuery( '#zbsNoResults' ).length ) {
+						// extra column due to checkbox
+						listViewHTML +='<tr><td colspan="' + (window.zbsListViewParams.columns.length + 1) + '" id="zbs-no-results-wrap">';
+
+						// to be fired after setTimeout jQuery('#zbsNoResults').appendTo('#zbs-no-results-wrap');
+						postHTML.nores = true;
+
+						listViewHTML += '</td></tr>';
+					}
+				}
+
+				listViewHTML += '</tbody>';
+
+				listViewHTML += '</table>';
+
+				// draw
+				jQuery( '.jpcrm-listview-table-container' ).html( listViewHTML );
+
+				//update counts in footer
+				jpcrm_update_listview_counts();
+
+				// update pagination
+				jpcrm_update_listview_pagination();
+
+				// catch any post-html events
+				var lPostHTML = postHTML;
+
+				// empty result set.
+				if ( typeof lPostHTML.nores ) {
+					jQuery( '#zbsNoResults' ).appendTo( '#zbs-no-results-wrap' ).removeClass( 'hidden' );
+				}
+
+				// bind any post-render (e.g. bulk action)
+				zeroBSCRMJS_listViewBinds();
+
+				// draw totals tables, if data
+				zeroBSCRMJS_listView_draw_totals_tables();
+				// fini, remove blocker
+				window.zbsDrawListViewBlocker = false;
+
+				jQuery( '#zbsCantLoadData' ).hide();
+				jQuery( '.jpcrm-listview-table-container' ).show();
+				jQuery( 'jpcrm-listview-footer' ).show();
+				jQuery( 'jpcrm-dashcount' ).show();
+			},
+			function ( errd ) {
+				// err callback? show msg (prefilled by php)
+				jQuery( '#zbsCantLoadData' ).show();
+				jQuery( '.jpcrm-listview-table-container' ).hide();
+
+				//update counts in footer
+				jpcrm_update_listview_counts();
+
+				// update pagination
+				jpcrm_update_listview_pagination();
+
+				// fini, remove blocker
+				window.zbsDrawListViewBlocker = false;
+			}
+		);
 	}
 }
 
@@ -638,56 +650,24 @@ function jpcrm_listview_table_header() {
 		}
 
 		jQuery.each( window.zbsListViewParams.columns, function ( lvhInd, lvhEle ) {
-			var tdStr = lvhEle.namestr;
-
-			// sortable?
-			// This says "are not in unsortable"
-			//if (typeof window.zbsListViewParams.sort != "undefined" && window.zbsUnsortables.indexOf(lvhEle.fieldstr) < 0){
-			// but for v2.2 we'll do "in zbsSortables"(because need new db  format to properly do sort)
-			if (
-				typeof window.zbsSortables !== 'undefined' &&
-				window.zbsSortables.indexOf( lvhEle.fieldstr ) > -1
-			) {
-				if (
-					typeof window.zbsListViewParams.sort !== 'undefined' &&
-					window.zbsListViewParams.sort == lvhEle.fieldstr
-				) {
-					var sortDirection = 'down';
-					var sortDirectionUrlParam = 'asc';
-					if (
-						typeof window.zbsListViewParams.sortorder !== 'undefined' &&
-						window.zbsListViewParams.sortorder == 'asc'
-					) {
-						sortDirection = 'up';
-						sortDirectionUrlParam = 'desc';
-					}
-
-					tdStr +=
-						' <a href="' +
-						jpcrm_listview_generate_current_filter_url( true ) +
-						'&sort=' +
-						lvhEle.fieldstr +
-						'&sortdirection=' +
-						sortDirectionUrlParam +
-						'" title="Click to Sort"><i class="angle ' +
-						sortDirection +
-						' icon"></i></a>';
-				} else {
-					// use name as sort link, always defaults to desc
-					tdStr =
-						' <a href="' +
-						jpcrm_listview_generate_current_filter_url( true ) +
-						'&sort=' +
-						lvhEle.fieldstr +
-						'" title="Click to Sort">' +
-						tdStr +
-						'</a>';
+			if (zbsSortables && zbsSortables.indexOf( lvhEle.fieldstr ) > -1) {
+				sortDirectionUrlParam = 'asc';
+				var sortDirection = 'down';
+				if (zbsListViewParams.sortorder && window.zbsListViewParams.sortorder === 'asc' && zbsListViewParams.sort && zbsListViewParams.sort === lvhEle.fieldstr) {
+					sortDirection = 'up';
+					sortDirectionUrlParam = 'desc';
 				}
-			} // / is sortable
-
-			listViewHeaderHTML += '        <th>' + tdStr + '</th>';
+				listViewHeaderHTML += `<th class="jpcrm_sort_column" data-sort="${lvhEle.fieldstr}" data-sortdir="${sortDirectionUrlParam}" title="${zeroBSCRMJS_listViewLang('click_to_sort')}">`;
+				listViewHeaderHTML += `${lvhEle.namestr}`;
+				if ( zbsListViewParams.sort && zbsListViewParams.sort === lvhEle.fieldstr) {
+					listViewHeaderHTML += `<i class="angle ${sortDirection} icon"></i>`;
+				}
+				listViewHeaderHTML += `</th>`;
+			} else {
+				listViewHeaderHTML += `<th>${lvhEle.namestr}</th>`;
+			}
 		} );
-		listViewHeaderHTML += '      </tr></thead>';
+		listViewHeaderHTML += '</tr></thead>';
 	}
 
 	return listViewHeaderHTML;
@@ -777,6 +757,10 @@ function zeroBSCRMJS_listViewLine( data ) {
  *
  */
 function zeroBSCRMJS_listViewBinds() {
+
+	// bind sort column clicks
+	let sort_columns = document.querySelectorAll('.jpcrm_sort_column');
+	sort_columns.forEach( el => el.addEventListener('click',jpcrm_change_sort));
 
 	let row_checkboxes = document.querySelectorAll('.jpcrm-listview-table td input[type="checkbox"]');
 
@@ -5547,14 +5531,8 @@ function jpcrm_add_listview_filter() {
 		zbsListViewParams.filters.tags = [{id:this.value}];
 	}
 
-	// reset pagination
-	zbsListViewParams.paged = 1;
-
-	// update address bar
-	history.replaceState( null, null, jpcrm_listview_generate_current_filter_url() );
-
 	// draw new listview
-	zeroBSCRMJS_drawListView();
+	zeroBSCRMJS_drawListView(true, true);
 }
 
 function jpcrm_remove_listview_filter() {
@@ -5574,14 +5552,8 @@ function jpcrm_remove_listview_filter() {
 		zbsListViewParams.filters.tags = [];
 	}
 
-	// reset pagination
-	zbsListViewParams.paged = 1;
-
-	// update address bar
-	history.replaceState( null, null, jpcrm_listview_generate_current_filter_url() );
-
 	// draw new listview
-	zeroBSCRMJS_drawListView();
+	zeroBSCRMJS_drawListView(true, true);
 }
 
 function jpcrm_do_search_filter( event ) {
@@ -5590,17 +5562,19 @@ function jpcrm_do_search_filter( event ) {
 		return;
 	}
 
-	// update listview filter settings
-	zbsListViewParams.filters.s = this.value;
-
-	// reset pagination
-	zbsListViewParams.paged = 1;
-
 	// update address bar
 	history.replaceState( null, null, jpcrm_listview_generate_current_filter_url() );
 
 	// draw new listview
-	zeroBSCRMJS_drawListView();
+	zeroBSCRMJS_drawListView(true, true);
+}
+
+function jpcrm_change_sort() {
+	// update sort params
+	zbsListViewParams.sort = this.dataset.sort;
+	zbsListViewParams.sortorder = this.dataset.sortdir;
+	// draw new listview
+	zeroBSCRMJS_drawListView(true, true);
 }
 
 if ( typeof module !== 'undefined' ) {
@@ -5743,6 +5717,6 @@ if ( typeof module !== 'undefined' ) {
 		zeroBSCRMJS_listView_saveInlineEdit,
 		zeroBSCRMJS_listView_customer_edit_status,
 		zeroBSCRMJS_listView_generic_edit_assigned, jpcrm_get_contact_meta,
-		jpcrm_add_listview_filter, jpcrm_remove_listview_filter, jpcrm_do_search_filter
+		jpcrm_add_listview_filter, jpcrm_remove_listview_filter, jpcrm_do_search_filter, jpcrm_change_sort
 	};
 }

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -410,7 +410,7 @@ function zeroBSCRMJS_drawListView() {
 		window.zbsDrawListViewBlocker = true;
 
 		// empty table, show loading
-		jQuery( '.jpcrm-listview-table-container' ).html( window.zbsDrawListLoadingBoxHTML );
+		jQuery( '.jpcrm-listview-table-container' ).html( '<div class="empty-container-with-spinner"><div class="ui active centered inline loader"></div></div>' );
 
 		// check data + retrieve if empty
 		if ( ! window.zbsListViewParams.retrieved ) {

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -5522,8 +5522,8 @@ function jpcrm_do_search_filter( event ) {
 		return;
 	}
 
-	// update address bar
-	history.replaceState( null, null, jpcrm_listview_generate_current_filter_url() );
+	// update listview filter settings
+	zbsListViewParams.filters.s = this.value;
 
 	// draw new listview
 	zeroBSCRMJS_drawListView(true, true);

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -432,6 +432,11 @@ function zeroBSCRMJS_drawListView() {
 
 					listViewHTML += jpcrm_listview_header();
 
+					// show pagination at top if per page is high
+					if (zbsListViewParams.count >= 50) {
+						listViewHTML += '<div class="jpcrm-pagination-container"></div>';
+					}
+
 					// build table
 					listViewHTML += '<table class="jpcrm-listview-table">';
 

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.email.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.email.scss
@@ -90,21 +90,22 @@ html,body{
     padding-bottom: 10px;
     position:relative;
 }
-.zbs-email-list-item:hover{
-    background: #f7f7f7;
-    border-left: 7px solid #2085d0 !important;
-}
-.zbs-email-list .active:hover{
-    border-left: 7px solid #2085d0 !important;
-    background: #f7f7f7;
-}
-.zbs-email-list .item{
+
+.zbs-email-list .item {
     border-left:7px solid white;
 }
-.zbs-email-list .active{
-    border-left: 7px solid #2085d0;
+
+.zbs-email-list .active:hover,
+.zbs-email-list .active {
     background: #f7f7f7;
+    border-left: 7px solid var(--jp-green);
 }
+
+.zbs-email-list-item:hover {
+    background: #f7f7f7;
+    border-left: 7px solid var(--jp-green-5);
+}
+
 .zbs-email-list input[type=checkbox], input[type=radio] {
     margin: 4px 0 0;
     line-height: normal;

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.extensions-page.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.extensions-page.scss
@@ -11,9 +11,6 @@
  //wrap all in our page bodyclass so to not clash anywhere else. Is also only enqueue on that one page
 .zbs-extensions-manager{
 
-    // wh fix for bad wp margins
-    margin-left: -1em;
-
     .title{
       font-size: 17px;
       font-weight: 900;

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicebuilder.scss
@@ -837,7 +837,6 @@
 
 //ZBS invoice actions
 .zbs-invoice-actions-bottom{
-	border-top: 1px solid #ddd;
     margin-top: 20px;
     padding: 2px;
     margin-left: -12px;

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.settings.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.settings.scss
@@ -10,10 +10,6 @@
 
  // Specifically for admin settings pages
 
-.zbs-page-wrap {
-	padding-right:1em !important
-}
-
 .zbs-explainer-ico {
 	margin-top: 1em;margin-bottom: 1em;
 

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.singleview.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.singleview.scss
@@ -168,14 +168,14 @@
 
 	display:none; // init
     padding: 0.5em;
-    background: #5c97d217;
+    background: var(--jp-gray-0);
     margin-right: 2em;
     border-radius: 0.2em;
 
 }
 i.zbs-show-longdesc,
 i.zbs-hide-longdesc {
-	color: #94b4d4;
+	color: #000;
 }
 i.zbs-show-longdesc:hover,
 i.zbs-hide-longdesc:hover {

--- a/projects/plugins/crm/sass/_ZeroBSCRM.adminpages.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.adminpages.scss
@@ -675,9 +675,6 @@ div.ui.learn.button {
 // generic loading.loaded classes
 // these are toggled by js once x has loaded :)
 // see func "zeroBSCRMJS_genericLoaded()"
-.zbs-generic-loading {
-	display:block;
-}
 .zbs-generic-loaded {
 	display:none;
 }

--- a/projects/plugins/crm/sass/_ZeroBSCRM.listview.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.listview.scss
@@ -73,23 +73,6 @@
 
 //ui header stuff
 
-.ui.header>.image:not(.icon), .ui.header>img {
-    display: inline-block;
-    margin-top: 0.14285714em;
-    // WH says Nope. - breaks company avatar imgs width: 12%;
-    height: auto;
-    vertical-align: middle;
-}
-
-.ui.header > img + .content, .ui.header > .image + .content {
-    padding-left: 0.75rem;
-    vertical-align: middle;
-    max-width: 88%;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-}
-
 .ui.menu .ui.dropdown .menu > .item:hover {
     background: rgb(63, 67, 71) !important;
     color: rgb(255, 255, 255) !important;
@@ -117,17 +100,25 @@
 // avatar's fixed size 
 .jpcrm-listview-table {
 
-	.zbs-co-img img, 
-	.name-and-avatar-list h4.ui.image.header img {
+	.jpcrm_name_and_avatar {
+		display: flex;
+		align-items: center;
 
-		max-width:40px !important;
+		img {
+			max-width: 40px;
+			border-radius: 50%;
+			margin-right: 5px;
+		}
 
-	}
+		div {
+			overflow-x: hidden;
+			text-overflow: ellipsis;
+		}
 
-	// stop the over-strong display of these
-	.name-and-avatar-list h4.ui.image.header,
-	.name-and-avatar-list h4.ui.header {
-		   font-weight: normal;
+		.icon {
+			font-size: 2em;
+			padding-top: .14285714em;
+		}
 	}
 }
 

--- a/projects/plugins/crm/sass/_ZeroBSCRM.listview.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.listview.scss
@@ -167,3 +167,8 @@
 	text-align: center;
 	padding-top: 0.6em;
 }
+
+.jpcrm-listview-table-container .jpcrm-pagination-container {
+	text-align: right;
+	margin-bottom: 10px;
+}

--- a/projects/plugins/crm/sass/_ZeroBSCRM.metaboxes.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.metaboxes.scss
@@ -155,4 +155,5 @@
 #zbs-custom-quicklinks,
 #zbs-edit-sidebar-wrap {
 	box-shadow: unset;
+	padding-right: 0;
 }

--- a/projects/plugins/crm/sass/_ZeroBSCRM.metaboxes.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.metaboxes.scss
@@ -152,7 +152,7 @@
 
 }
 
-/* .zbs-metabox.segment.zbs-draggable, .zbs-metabox-head.segment.zbs-draggable {
-    opacity: 0.45;
-    color: rgba(40,40,40,0.3);
-}*/
+#zbs-custom-quicklinks,
+#zbs-edit-sidebar-wrap {
+	box-shadow: unset;
+}

--- a/projects/plugins/crm/sass/_ZeroBSCRM.mobile.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.mobile.scss
@@ -222,17 +222,6 @@
         width:100% !important;
     }
 
-    #zbsExtensionsPage .zbsExtensionGroup .zbsExtensionList .zbsExtension{
-        width:100% !important;
-    }
-
-    .zbs-page-wrap{
-        margin-right:0px !important;
-        padding-right:0px !important;
-    }
-
-
-
 }
 
 /* TINY old Mobile Style */

--- a/projects/plugins/crm/sass/_ZeroBSCRM.spinners.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.spinners.scss
@@ -42,6 +42,10 @@
 		margin-left:0;
 
 	}
+}
 
-
- }
+.empty-container-with-spinner {
+	display: flex;
+	align-items: center;
+	height: 400px;
+}

--- a/projects/plugins/crm/sass/emerald/_buttons.scss
+++ b/projects/plugins/crm/sass/emerald/_buttons.scss
@@ -22,6 +22,8 @@
 		line-height: 24px;
 	}
 
+	&:active,
+	&:focus,
 	&:hover {
 		background: var(--jp-gray-80);
 		color: var(--jp-white);

--- a/projects/plugins/crm/sass/emerald/_buttons.scss
+++ b/projects/plugins/crm/sass/emerald/_buttons.scss
@@ -43,6 +43,7 @@
 		border: 0px;
 		background: transparent;
 		color: var(--jp-black);
+		padding: 8px 0px;
 
 		&:hover {
 			background: transparent;

--- a/projects/plugins/crm/sass/emerald/_dashcard.scss
+++ b/projects/plugins/crm/sass/emerald/_dashcard.scss
@@ -69,26 +69,26 @@
 
 	.jpcrm-listview-table-container {
 		margin-top: 8px;
-
-		.div-message-box {
-			background: var(--jp-gray-0);
-			border: 1px dashed var(--jp-gray-20);
-			border-radius: 4px;
-			margin: 0px 20px 20px;
-			padding: 16px 24px 28px;
-			display: block;
-		}
-
-		.div-message {
-			text-align: center;
-			font-family: var(--jpcrm-font-family-emerald);
-			font-style: normal;
-			font-weight: 400;
-			font-size: 16px;
-			line-height: 24px;
-			text-align: center;
-			letter-spacing: -0.02em;
-			margin-top: 16px;
-		}
 	}
+}
+
+.jpcrm-div-message-box {
+	background: var(--jp-gray-0) !important;
+	border: 1px dashed var(--jp-gray-20) !important;
+	border-radius: 4px;
+	margin: 0px 20px 20px;
+	padding: 16px 24px 28px;
+	display: block;
+}
+
+.jpcrm-div-message {
+	text-align: center;
+	font-family: var(--jpcrm-font-family-emerald);
+	font-style: normal;
+	font-weight: 400;
+	font-size: 16px;
+	line-height: 24px;
+	text-align: center;
+	letter-spacing: -0.02em;
+	margin-top: 16px;
 }

--- a/projects/plugins/crm/sass/emerald/_learn-menu.scss
+++ b/projects/plugins/crm/sass/emerald/_learn-menu.scss
@@ -55,6 +55,8 @@
 
 	.jpcrm-learn-menu-subdiv-75,
 	.jpcrm-learn-menu-subdiv-25 {
+		flex-wrap: wrap;
+		flex-direction: column;
 		width: 100%;
 	}
 }

--- a/projects/plugins/crm/sass/emerald/_learn-menu.scss
+++ b/projects/plugins/crm/sass/emerald/_learn-menu.scss
@@ -17,7 +17,7 @@
 	align-items: center;
 	flex-direction: row;
 	justify-content: flex-end;
-	padding: 10px;
+	padding: 10px 0px;
 	gap: 10px;
 }
 

--- a/projects/plugins/crm/sass/emerald/_learn-menu.scss
+++ b/projects/plugins/crm/sass/emerald/_learn-menu.scss
@@ -47,3 +47,14 @@
 	flex-direction: row;
 	cursor: pointer;
 }
+
+@media (max-width: 768px) {
+	.jpcrm-learn-menu {
+		flex-wrap: wrap;
+	}
+
+	.jpcrm-learn-menu-subdiv-75,
+	.jpcrm-learn-menu-subdiv-25 {
+		width: 100%;
+	}
+}

--- a/projects/plugins/crm/sass/emerald/_listview-table.scss
+++ b/projects/plugins/crm/sass/emerald/_listview-table.scss
@@ -26,7 +26,7 @@
 
 		/* min-width except for checkbox column */
 		th:not(:first-child), td:not(:first-child) {
-			min-width: 50px;
+			min-width: 120px;
 		}
 
 		input[type="checkbox"] {

--- a/projects/plugins/crm/sass/emerald/_listview-table.scss
+++ b/projects/plugins/crm/sass/emerald/_listview-table.scss
@@ -11,6 +11,7 @@
 		thead th {
 			font-weight: 400;
 			border-bottom: 1px solid var(--jp-gray-10);
+			cursor: pointer;
 		}
 
 		a {

--- a/projects/plugins/crm/sass/emerald/_pagination.scss
+++ b/projects/plugins/crm/sass/emerald/_pagination.scss
@@ -3,7 +3,6 @@ jpcrm-pagination {
 	font-size: 16px;
 	gap: 0rem;
 	align-items: center;
-	text-align: center;
 	background: #FFFFFF;
 	border: 1px solid var(--jp-gray-5);
 	border-radius: 3px;


### PR DESCRIPTION
## Proposed changes:
* This PR addresses the last touches for our Emerald Project.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3132

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Go through the following list checking each change:

Things to consider:
* on small screen, title wraps, buttons wrap onto title (see transactions listview)
* black `jpcrm-button` has blue text on focus if `<a>`
* blue on `/wp-admin/admin.php?page=zerobscrm-team`
* blue on `/wp-admin/admin.php?page=zerobscrm-datatools`
* blue in `zbs-*-learn-nav`, `zbs-*-quicknav` (add contact or company to object)

Listview considerations:
* missing top pagination (for long results pages)
* sort and pagination use links instead of AJAX calls
* update "no results" and "loading" content

