### PR TITLE
Protect: Add license check filtering

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-license-check-filtering
+++ b/projects/plugins/protect/changelog/add-protect-license-check-filtering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add filtering for unattached and unrevoked licenses within upgrade flow check

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -346,7 +346,15 @@ class Jetpack_Protect {
 
 		$license_found = false;
 
-		foreach ( $licenses as $license ) {
+		// Filter for unnattached and unrevoked licenses.
+		$valid_licenses = array_filter(
+			$licenses,
+			function ( $license ) {
+				return $license->attached_at === null && $license->revoked_at === null;
+			}
+		);
+
+		foreach ( $valid_licenses as $license ) {
 			if ( in_array( $license->product_id, self::JETPACK_SCAN_PRODUCT_IDS, true ) ) {
 				$license_found = true;
 				break;

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -331,11 +331,11 @@ class Jetpack_Protect {
 	}
 
 	/**
-	 * Check for user licenses.
+	 * Check if the user has an available license that includes Jetpack Scan.
 	 *
-	 * @param  boolean $has_license Check if user has a license.
-	 * @param  object  $licenses List of licenses.
-	 * @param string  $plugin_slug The plugin that initiated the flow.
+	 * @param boolean  $has_license  Whether a license was already found.
+	 * @param object[] $licenses     Unattached licenses belonging to the user.
+	 * @param string   $plugin_slug  Slug of the plugin that initiated the flow.
 	 *
 	 * @return boolean
 	 */
@@ -346,15 +346,11 @@ class Jetpack_Protect {
 
 		$license_found = false;
 
-		// Filter for unnattached and unrevoked licenses.
-		$valid_licenses = array_filter(
-			$licenses,
-			function ( $license ) {
-				return $license->attached_at === null && $license->revoked_at === null;
+		foreach ( $licenses as $license ) {
+			if ( $license->attached_at || $license->revoked_at ) {
+				continue;
 			}
-		);
 
-		foreach ( $valid_licenses as $license ) {
 			if ( in_array( $license->product_id, self::JETPACK_SCAN_PRODUCT_IDS, true ) ) {
 				$license_found = true;
 				break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Description:
Currently, the array of user licenses we are provided using the `jetpack_connection_user_has_license` filter includes all historical licenses (attached, unattached, and revoked). Within Protect, we then check if any licenses are of a particular product ID and if so redirect to the My Jetpack `#/add-license` page. We only want to redirect if there are unattached and unrevoked licenses that match our set product IDs. This PR address this.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Applies additional filtering to the user licenses array within the `jetpack_connection_user_has_license` filter callback to only review unattached and unrevoked licenses.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- 1201069996155224-as-1204681745241083
 
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Recreating the issue:
* Proceed to the Dev API Console and make a `GET `request to `wpcom/v2/jetpack-licensing/user/licenses` to verify that your current user has attached/unattached but revoked scan licenses
* Ensure that you do not have any unattached and unrevoked licenses
* Start up your Jurassic Tube on `trunk`
* Install and activate Protect and proceed through the upgrade flow
* Verify that you are incorrectly redirected to the My Jetpack `#/add-license` page

Verifying the fix:
* Deactivate and disconnect Protect
* Checkout this branch and install and build `plugins/protect`
* Reactivate Protect and proceed again through the upgrade process
* Ensure that you are appropriately redirected to checkout with a scan level plan
* Ditch the checkout, and disable Protect once again
* Purchase a standalone license for a plan that includes scan from`https://cloud.jetpack.com/pricing` but do not attach it to a site
* Return to `/wp-admin` again, enable Protect, and proceed through the upgrade flow
* Verify that you are redirected appropriately to the `#/add-license` page in My Jetpack
   * Note that you will then be provided a list of all available licenses, filtering to be applied here as well if/when #31088 
is approved/merged