### PR TITLE
CRM: Resolves 3133 - allow quote sort by status

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3133-quote_sort_by_status
+++ b/projects/plugins/crm/changelog/fix-crm-3133-quote_sort_by_status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Quotes: sort by status now works

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Quotes.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Quotes.php
@@ -797,12 +797,12 @@ class zbsDAL_quotes extends zbsDAL_ObjectLayer {
 
             // Mapped sorts
             // This catches listview and other exception sort cases
-            $sort_map = array(
+				$sort_map = array(
+					'customer' => '(SELECT zbsol_objid_to FROM ' . $ZBSCRM_t['objlinks'] . ' WHERE zbsol_objtype_from = ' . ZBS_TYPE_QUOTE . ' AND zbsol_objtype_to = ' . ZBS_TYPE_CONTACT . ' AND zbsol_objid_from = quote.ID)', // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+					// hack to support quote statuses (for here only, 2 is accepted, 1 is unaccepted, 0 is draft)
+					'status'   => '(CASE WHEN zbsq_accepted > 0 THEN 2 WHEN zbsq_template > 0 THEN 1 ELSE 0 END)',
+				);
 
-                'customer'				=> '(SELECT zbsol_objid_to FROM '.$ZBSCRM_t['objlinks'].' WHERE zbsol_objtype_from = '.ZBS_TYPE_QUOTE.' AND zbsol_objtype_to = '.ZBS_TYPE_CONTACT.' AND zbsol_objid_from = quote.ID)',                           
-
-            );
-            
             if ( array_key_exists( $sortByField, $sort_map ) ) {
 
                 $sortByField = $sort_map[ $sortByField ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3133 - allow quote sort by status

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It seems DAL uses table fields to do sorts, with fallbacks for other fields. Since technically quotes don't have a real status and there wasn't a fallback, the query fails. This PR adds a hacky fallback sort:

`CASE WHEN zbsq_accepted > 0 THEN 2 WHEN zbsq_template > 0 THEN 1 ELSE 0 END`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to quote listview.
2. Create three quotes (one for each status: draft, unaccepted, accepted).
3. Sort by status.

In `trunk` the listview will show an error.

In the `fix/crm/3133-quote_sort_by_status` branch, the listview properly loads:

* Ascending mode: draft, unaccepted, accepted
* Descending mode: accepted, unaccepted, draft