### PR TITLE
Launchpad: Add `is_enabled_callback` to existing task lists

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-task-list-is-enabled
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-task-list-is-enabled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add `is_enabled_callback` to all existing task lists with a callback function that checks launchpad_screen.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -292,9 +292,9 @@ function wpcom_register_default_launchpad_checklists() {
 	// Tasks registered, now onto the checklists.
 	wpcom_register_launchpad_task_list(
 		array(
-			'id'       => 'build',
-			'title'    => 'Build',
-			'task_ids' => array(
+			'id'                  => 'build',
+			'title'               => 'Build',
+			'task_ids'            => array(
 				'setup_general',
 				'design_selected',
 				'plan_selected',
@@ -302,14 +302,15 @@ function wpcom_register_default_launchpad_checklists() {
 				'design_edited',
 				'site_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		)
 	);
 
 	wpcom_register_launchpad_task_list(
 		array(
-			'id'       => 'free',
-			'title'    => 'Free',
-			'task_ids' => array(
+			'id'                  => 'free',
+			'title'               => 'Free',
+			'task_ids'            => array(
 				'plan_selected',
 				'setup_free',
 				'design_selected',
@@ -318,42 +319,45 @@ function wpcom_register_default_launchpad_checklists() {
 				'design_edited',
 				'site_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		)
 	);
 
 	wpcom_register_launchpad_task_list(
 		array(
-			'id'       => 'link-in-bio',
-			'title'    => 'Link In Bio',
-			'task_ids' => array(
+			'id'                  => 'link-in-bio',
+			'title'               => 'Link In Bio',
+			'task_ids'            => array(
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
 				'links_added',
 				'link_in_bio_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		)
 	);
 
 	wpcom_register_launchpad_task_list(
 		array(
-			'id'       => 'link-in-bio-tld',
-			'title'    => 'Link In Bio',
-			'task_ids' => array(
+			'id'                  => 'link-in-bio-tld',
+			'title'               => 'Link In Bio',
+			'task_ids'            => array(
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
 				'links_added',
 				'link_in_bio_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		)
 	);
 
 	wpcom_register_launchpad_task_list(
 		array(
-			'id'       => 'newsletter',
-			'title'    => 'Newsletter',
-			'task_ids' => array(
+			'id'                  => 'newsletter',
+			'title'               => 'Newsletter',
+			'task_ids'            => array(
 				'setup_newsletter',
 				'plan_selected',
 				'subscribers_added',
@@ -362,33 +366,36 @@ function wpcom_register_default_launchpad_checklists() {
 				'newsletter_plan_created',
 				'first_post_published_newsletter',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		)
 	);
 
 	wpcom_register_launchpad_task_list(
 		array(
-			'id'       => 'videopress',
-			'title'    => 'Videopress',
-			'task_ids' => array(
+			'id'                  => 'videopress',
+			'title'               => 'Videopress',
+			'task_ids'            => array(
 				'videopress_setup',
 				'plan_selected',
 				'videopress_upload',
 				'videopress_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		)
 	);
 
 	wpcom_register_launchpad_task_list(
 		array(
-			'id'       => 'write',
-			'title'    => 'Write',
-			'task_ids' => array(
+			'id'                  => 'write',
+			'title'               => 'Write',
+			'task_ids'            => array(
 				'setup_write',
 				'design_selected',
 				'plan_selected',
 				'first_post_published',
 				'site_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		)
 	);
 
@@ -408,9 +415,9 @@ function wpcom_register_default_launchpad_checklists() {
 
 	wpcom_register_launchpad_task_list(
 		array(
-			'id'       => 'design-first',
-			'title'    => 'Pick a Design',
-			'task_ids' => array(
+			'id'                  => 'design-first',
+			'title'               => 'Pick a Design',
+			'task_ids'            => array(
 				'design_selected',
 				'setup_blog',
 				'domain_upsell',
@@ -418,6 +425,7 @@ function wpcom_register_default_launchpad_checklists() {
 				'first_post_published',
 				'blog_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		)
 	);
 
@@ -890,26 +898,24 @@ function wpcom_log_launchpad_being_enabled_for_test_sites( $option, $value ) {
 }
 
 /**
- * Checks if a specific launchpad task list is enabled or if the overall launchpad is enabled.
+ * Checks if the overall launchpad is enabled. Used with `is_enabled_callback` 
+ * for backwards compatibility with established task lists 
+ * that relied on the old `launchpad_screen` option.
  *
- * @param string|false $checklist_slug The slug of the launchpad task list to check.
+ * @return bool True if the launchpad is enabled, false otherwise.
+ */
+function wpcom_get_launchpad_is_enabled() {
+	return wpcom_launchpad_checklists()->is_launchpad_enabled();
+}
+
+/**
+ * Checks if a specific launchpad task list is enabled.
+ *
+ * @param string $checklist_slug The slug of the launchpad task list to check.
  * @return bool True if the task list is enabled, false otherwise.
  */
-function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug = false ) {
-	// If the checklist slug is provided, check the status of the task list.
-	if ( false !== $checklist_slug ) {
-		$is_enabled = wpcom_launchpad_checklists()->is_task_list_enabled( $checklist_slug );
-
-		// If the status of the task list is known, return its value.
-		if ( null !== $is_enabled ) {
-			return $is_enabled;
-		}
-	}
-
-	// If the status of the task list is not known, check the status of the overall launchpad.
-	// @todo: Remove this fallback once all task lists have been migrated to the new system.
-	// https://github.com/Automattic/wp-calypso/issues/77407
-	return wpcom_launchpad_checklists()->is_launchpad_enabled();
+function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
+	return wpcom_launchpad_checklists()->is_task_list_enabled( $checklist_slug );
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -898,8 +898,8 @@ function wpcom_log_launchpad_being_enabled_for_test_sites( $option, $value ) {
 }
 
 /**
- * Checks if the overall launchpad is enabled. Used with `is_enabled_callback` 
- * for backwards compatibility with established task lists 
+ * Checks if the overall launchpad is enabled. Used with `is_enabled_callback`
+ * for backwards compatibility with established task lists
  * that relied on the old `launchpad_screen` option.
  *
  * @return bool True if the launchpad is enabled, false otherwise.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -915,7 +915,11 @@ function wpcom_get_launchpad_is_enabled() {
  * @return bool True if the task list is enabled, false otherwise.
  */
 function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
-	return wpcom_launchpad_checklists()->is_task_list_enabled( $checklist_slug );
+	if ( false !== $checklist_slug ) {
+		return wpcom_launchpad_checklists()->is_task_list_enabled( $checklist_slug );
+	}
+
+	return false;
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/77407

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `is_enabled_callback` to all registered task lists
* Point the callback parameters to `wpcom_get_launchpad_is_enabled`, which checks the value of `launchpad_screen`; this acts as a fallback for established checklists so their behavior should remain the same.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

First, confirm you get the expected values for `is_enabled` _without_ this patch:
* Visit the dev console and switch to WP REST API, `wpcom/v2`
* GET `/sites/siteslug.wordpress.com/launchpad/?checklist_slug=build`
* For a site with an incomplete Launchpad list, the value of `is_enabled` should be `true`. 
* Test other checklist types in your request: `newsletter`, `link-in-bio`, `videopress`, etc. The values for `is_enabled` should be `true`.

* Apply this patch to your sandbox and sandbox `public-api.wordpress.com`
* Visit the dev console and switch to WP REST API, `wpcom/v2`
* GET `/sites/siteslug.wordpress.com/launchpad/?checklist_slug=build`
* The value for `is_enabled` should still be `true`
* Test other `checklist_slug`s in your request: `newsletter`, `link-in-bio`, `videopress`, etc. The values for `is_enabled` should remain the same.