### PR TITLE
AI Assistant: Add "Accept" button so the user can accept partially generated content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-accept-button-for-partial-content
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-accept-button-for-partial-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Add Accept button so the user can accept a partially generated content.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { image, pencil, update, closeSmall } from '@wordpress/icons';
+import { image, pencil, update, closeSmall, check } from '@wordpress/icons';
 /*
  * Internal dependencies
  */
@@ -284,7 +284,11 @@ const ToolbarControls = ( {
 							/>
 						</BlockControls>
 					) }
-
+					{ showRetry && contentIsLoaded && (
+						<ToolbarButton icon={ check } onClick={ handleAcceptContent }>
+							{ __( 'Accept', 'jetpack' ) }
+						</ToolbarButton>
+					) }
 					{ showRetry && (
 						<ToolbarButton icon={ update } onClick={ retryRequest }>
 							{ __( 'Retry', 'jetpack' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31038.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add Accept button so the user can accept a partially generated content
* The button will be shown anytime the Retry button would appear, but only when there is at least one piece of content to accept
* One of the use cases is when a network error happens

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add an AI Assistant block
* Open your browser console on the network activity tab
* Throttle your connection to simulate a slow 3G connection:

<img width="200" alt="Screen Shot 2023-05-30 at 18 05 00" src="https://github.com/Automattic/jetpack/assets/6760046/c6f4696f-2092-44ae-92f3-b93f00999d6c">

* Write a prompt that will probably result on a long response from the assistant, like "5 paragraphs on [your subject]"
* Execute the prompt and, while the response is being rendered, change your network throttling settings to "offline"; this way we can simulate a network issue
* Notice that an error message is shown by the block, as well as a "Retry" button and the new "Accept" button
* Try clicking the "Accept" button; it will insert the partial content on the editor
* The section below describes the before and after behavior

**Before:**

<img width="400" alt="Screen Shot 2023-05-30 at 17 58 58" src="https://github.com/Automattic/jetpack/assets/6760046/c8f5bfff-6846-451d-8b39-161461a82fbf">

* There was no way to use the partial content.

---

**After:**

<img width="400" alt="Screen Shot 2023-05-30 at 17 55 30" src="https://github.com/Automattic/jetpack/assets/6760046/06e6421a-5772-40af-9e30-548abbe35031">

* If accepted, the content is inserted regularly:

<img width="400" alt="Screen Shot 2023-05-30 at 17 56 46" src="https://github.com/Automattic/jetpack/assets/6760046/b2734455-e8a7-4f66-8879-11d4046d6b4a">

* If there is no content before the error, the button will not show up:

<img width="400" alt="Screen Shot 2023-05-30 at 18 03 18" src="https://github.com/Automattic/jetpack/assets/6760046/a1151922-8675-4e17-b0d6-cf3990b4354c">