### PR TITLE
AI Assistant: Enable for P2 editor and comments

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-server-rendering-ai-assistant
+++ b/projects/plugins/jetpack/changelog/fix-server-rendering-ai-assistant
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: enables no-post-editor build for ai-assistant-block
+
+

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -65,6 +65,7 @@
 	],
 	"experimental": [ "ai-image", "ai-paragraph", "anchor-fm" ],
 	"no-post-editor": [
+		"ai-assistant",
 		"business-hours",
 		"button",
 		"calendly",


### PR DESCRIPTION
Makes the ai-assistant block be part of the no-post-editor build


<img width="671" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/d6cc6074-7cc4-465b-8fcb-9ba08fc81185">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates index.json to include ai-assistant under no-post-editor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Checkout this branch in your sandbox
* Sandbox a p2 site
* Visit the frontend editor.
* Confirm you're able to add an AI Assistant block
* Visit any post
* Start drafting a comment
* Confirm you're able to add an AI Assistant block
