### PR TITLE
Blocks: add links to read more to Stripe connection banners

### DIFF
--- a/projects/plugins/jetpack/changelog/add-read-me-link-to-stripe-banner
+++ b/projects/plugins/jetpack/changelog/add-read-me-link-to-stripe-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Add "Read me" links to Stripe connection banners in blocks.

--- a/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
@@ -47,14 +47,16 @@ export default function BlockNudge( {
 				{ icon }
 				<span className="jetpack-block-nudge__text-container">
 					<span className="jetpack-block-nudge__title">{ title }</span>
-					{ ( subtitle || readMoreUrl ) && (
+					{ subtitle && (
 						<span className="jetpack-block-nudge__message">
 							{ subtitle }
-							{ subtitle && readMoreUrl && <br /> }
 							{ readMoreUrl && (
-								<ExternalLink href={ readMoreUrl }>
-									{ __( 'Learn more about the block and fees', 'jetpack' ) }
-								</ExternalLink>
+								<>
+									<br />
+									<ExternalLink href={ readMoreUrl }>
+										{ __( 'Learn more about the block and fees', 'jetpack' ) }
+									</ExternalLink>
+								</>
 							) }
 						</span>
 					) }

--- a/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
@@ -1,5 +1,6 @@
 import { Warning } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import useAutosaveAndRedirect from '../../../shared/use-autosave-and-redirect/index';
 
@@ -8,12 +9,13 @@ import './style.scss';
 export default function BlockNudge( {
 	blockName,
 	buttonLabel,
+	className,
 	href,
 	icon,
 	onClick,
+	readMoreUrl,
 	subtitle,
 	title,
-	className,
 } ) {
 	const { autosaveAndRedirect } = useAutosaveAndRedirect( href );
 
@@ -45,7 +47,14 @@ export default function BlockNudge( {
 				{ icon }
 				<span className="jetpack-block-nudge__text-container">
 					<span className="jetpack-block-nudge__title">{ title }</span>
-					{ subtitle && <span className="jetpack-block-nudge__message">{ subtitle }</span> }
+					{ ( subtitle || readMoreUrl ) && (
+						<span className="jetpack-block-nudge__message">
+							{ subtitle && subtitle + ' ' }
+							{ readMoreUrl && (
+								<ExternalLink href={ readMoreUrl }>{ __( 'Read more', 'jetpack' ) }</ExternalLink>
+							) }
+						</span>
+					) }
 				</span>
 			</span>
 		</Warning>

--- a/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
@@ -52,7 +52,9 @@ export default function BlockNudge( {
 							{ subtitle }
 							{ subtitle && readMoreUrl && <br /> }
 							{ readMoreUrl && (
-								<ExternalLink href={ readMoreUrl }>{ __( 'Read more', 'jetpack' ) }</ExternalLink>
+								<ExternalLink href={ readMoreUrl }>
+									{ __( 'Learn more about the block and fees', 'jetpack' ) }
+								</ExternalLink>
 							) }
 						</span>
 					) }

--- a/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/block-nudge/index.jsx
@@ -49,7 +49,8 @@ export default function BlockNudge( {
 					<span className="jetpack-block-nudge__title">{ title }</span>
 					{ ( subtitle || readMoreUrl ) && (
 						<span className="jetpack-block-nudge__message">
-							{ subtitle && subtitle + ' ' }
+							{ subtitle }
+							{ subtitle && readMoreUrl && <br /> }
 							{ readMoreUrl && (
 								<ExternalLink href={ readMoreUrl }>{ __( 'Read more', 'jetpack' ) }</ExternalLink>
 							) }

--- a/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/index.jsx
@@ -32,16 +32,16 @@ export const StripeNudge = ( { blockName } ) => {
 	switch ( blockName ) {
 		case 'payment-buttons':
 			readMoreUrl = isWpcom
-				? getRedirectUrl( 'jetpack-support-jetpack-blocks-simple-payments-block' ) // @TODO correct link
-				: getRedirectUrl( 'jetpack-support-jetpack-blocks-simple-payments-block' );
+				? getRedirectUrl( 'wpcom-support-wordpress-editor-blocks-payments-block' )
+				: getRedirectUrl( 'jetpack-support-jetpack-blocks-payments-block' );
 		case 'donations':
 			readMoreUrl = isWpcom
 				? getRedirectUrl( 'wpcom-support-wordpress-editor-blocks-donations-block' )
 				: getRedirectUrl( 'jetpack-support-jetpack-blocks-donations-block' );
 		case 'premium-content':
 			readMoreUrl = isWpcom
-				? getRedirectUrl( 'wpcom-support-wordpress-editor-blocks-donations-block' ) // @TODO correct link
-				: getRedirectUrl( 'jetpack-support-jetpack-blocks-donations-block' ); // @TODO correct link
+				? getRedirectUrl( 'wpcom-support-wordpress-editor-blocks-premium-content-block' )
+				: getRedirectUrl( 'jetpack-support-jetpack-blocks-premium-content-block' );
 	}
 
 	return (

--- a/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/stripe-nudge/index.jsx
@@ -1,4 +1,9 @@
-import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import {
+	isAtomicSite,
+	isSimpleSite,
+	useAnalytics,
+} from '@automattic/jetpack-shared-extension-utils';
 import { select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import GridiconStar from 'gridicons/dist/star';
@@ -11,6 +16,7 @@ export const StripeNudge = ( { blockName } ) => {
 	const store = select( membershipProductsStore );
 	const stripeConnectUrl = store.getConnectUrl();
 	const { tracks } = useAnalytics();
+	const isWpcom = isAtomicSite() || isSimpleSite();
 
 	const recordTracksEvent = () =>
 		tracks.recordEvent( 'jetpack_editor_block_stripe_connect_click', {
@@ -19,6 +25,23 @@ export const StripeNudge = ( { blockName } ) => {
 
 	if ( ! stripeConnectUrl ) {
 		return null;
+	}
+
+	let readMoreUrl;
+
+	switch ( blockName ) {
+		case 'payment-buttons':
+			readMoreUrl = isWpcom
+				? getRedirectUrl( 'jetpack-support-jetpack-blocks-simple-payments-block' ) // @TODO correct link
+				: getRedirectUrl( 'jetpack-support-jetpack-blocks-simple-payments-block' );
+		case 'donations':
+			readMoreUrl = isWpcom
+				? getRedirectUrl( 'wpcom-support-wordpress-editor-blocks-donations-block' )
+				: getRedirectUrl( 'jetpack-support-jetpack-blocks-donations-block' );
+		case 'premium-content':
+			readMoreUrl = isWpcom
+				? getRedirectUrl( 'wpcom-support-wordpress-editor-blocks-donations-block' ) // @TODO correct link
+				: getRedirectUrl( 'jetpack-support-jetpack-blocks-donations-block' ); // @TODO correct link
 	}
 
 	return (
@@ -35,6 +58,7 @@ export const StripeNudge = ( { blockName } ) => {
 				/>
 			}
 			href={ stripeConnectUrl }
+			readMoreUrl={ readMoreUrl }
 			onClick={ recordTracksEvent }
 			title={ __( 'Connect to Stripe to use this block on your site', 'jetpack' ) }
 			subtitle={ __(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds "Read me" links to Stripe connection banners in blocks. Links to docs for each block across Jetpack/WPcom envs. Those docs have more info about why Stripe connection is needed, about commission fees, etc.

Note that paid content (aka premium content) block links to WP.com for both Jetpack and WP.com, since Jetpack docs don't exist just yet. We'll update the link in redirect tool once docs are live.

<img width="726" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/463a06a2-0522-4c74-9d50-509ecd8e7d79">


## Proposed changes:
* Adds "Read more" links to Stripe banner in donations, payments and paid content blocks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Suggested to add the link in pbNhbs-6QK-p2/#comment-15833

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- With self hosted Jetpack without stripe connection
- Add Donations & payments block
- Note stripe banner and readme links pointing to correct Jetpack docs 
- Do the same in Jetpack Atomic or simple, note docs links pointing to WP.com instead

