### PR TITLE
Boost: Update CSS regen notice UX

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -77,7 +77,7 @@
 		<button
 			type="button"
 			class="components-button"
-			class:is-link={! $suggestRegenerate}
+			class:is-link={! $suggestRegenerate || $modulesState.cloud_css?.available}
 			on:click={regenerateCriticalCss}
 		>
 			<RefreshIcon />

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -87,9 +87,6 @@
 </div>
 
 <style lang="scss">
-	@use '../../../../css/main/mixins.scss' as *;
-	@use '../../../../css/main/variables.scss' as *;
-
 	:global( .components-button:not( .is-link ) .gridicon ) {
 		display: none;
 	}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/CriticalCssStatus.svelte
@@ -8,6 +8,7 @@
 		regenerateCriticalCss,
 	} from '../../../stores/critical-css-state';
 	import { criticalCssIssues } from '../../../stores/critical-css-state-errors';
+	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
 	import { modulesState } from '../../../stores/modules';
 	import InfoIcon from '../../../svg/info.svg';
 	import RefreshIcon from '../../../svg/refresh.svg';
@@ -17,6 +18,7 @@
 	export let generateText = '';
 	export let generateMoreText = '';
 	const { navigate } = routerHistory;
+	const suggestRegenerate = suggestRegenerateDS.store;
 
 	$: successCount = $criticalCssState.providers.filter(
 		provider => provider.status === 'success'
@@ -72,9 +74,35 @@
 		{/if}
 	</div>
 	{#if $criticalCssState.status !== 'pending'}
-		<button type="button" class="components-button is-link" on:click={regenerateCriticalCss}>
+		<button
+			type="button"
+			class="components-button"
+			class:is-link={! $suggestRegenerate}
+			on:click={regenerateCriticalCss}
+		>
 			<RefreshIcon />
 			{__( 'Regenerate', 'jetpack-boost' )}
 		</button>
 	{/if}
 </div>
+
+<style lang="scss">
+	@use '../../../../css/main/mixins.scss' as *;
+	@use '../../../../css/main/variables.scss' as *;
+
+	:global( .components-button:not( .is-link ) .gridicon ) {
+		display: none;
+	}
+
+	.components-button:not( .is-link ) {
+		color: #fff !important;
+		background-color: #000;
+		border-radius: 4px;
+		border: none;
+		font-size: 12px;
+		height: 28px;
+		padding: 7px 10px;
+		text-decoration: none;
+		display: inline-block;
+	}
+</style>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -94,6 +94,7 @@
 			<ReactComponent
 				this={RegenerateCriticalCssSuggestion}
 				show={$suggestRegenerate && $criticalCssState.status !== 'pending'}
+				type={$suggestRegenerate}
 			/>
 		</div>
 

--- a/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssSuggestion.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssSuggestion.tsx
@@ -1,6 +1,6 @@
 import { Notice } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import { suggestRegenerateDS } from '../stores/data-sync-client';
+import { suggestRegenerateDS, type RegenReason } from '../stores/data-sync-client';
 
 export const RegenerateCriticalCssSuggestion = ( { show, type } ) => {
 	if ( ! show ) {
@@ -12,7 +12,7 @@ export const RegenerateCriticalCssSuggestion = ( { show, type } ) => {
 			level="info"
 			title={ __( 'Regenerate Critical CSS', 'jetpack-boost' ) }
 			onClose={ () => {
-				suggestRegenerateDS.store.set( '' );
+				suggestRegenerateDS.store.set( null );
 			} }
 			hideCloseButton={ true }
 		>
@@ -27,7 +27,7 @@ export const RegenerateCriticalCssSuggestion = ( { show, type } ) => {
 	);
 };
 
-function GetSuggestionMessage( type: string ) {
+function GetSuggestionMessage( type: RegenReason | null ) {
 	let message;
 	if ( 'page_saved' === type ) {
 		message = __(

--- a/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssSuggestion.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/RegenerateCriticalCssSuggestion.tsx
@@ -2,7 +2,7 @@ import { Notice } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import { suggestRegenerateDS } from '../stores/data-sync-client';
 
-export const RegenerateCriticalCssSuggestion = ( { show } ) => {
+export const RegenerateCriticalCssSuggestion = ( { show, type } ) => {
 	if ( ! show ) {
 		return null;
 	}
@@ -12,16 +12,11 @@ export const RegenerateCriticalCssSuggestion = ( { show } ) => {
 			level="info"
 			title={ __( 'Regenerate Critical CSS', 'jetpack-boost' ) }
 			onClose={ () => {
-				suggestRegenerateDS.store.set( false );
+				suggestRegenerateDS.store.set( '' );
 			} }
 			hideCloseButton={ true }
 		>
-			<p>
-				{ __(
-					'We noticed some updates to your site that may have changed your HTML/CSS structure.',
-					'jetpack-boost'
-				) }
-			</p>
+			<p>{ GetSuggestionMessage( type ) }</p>
 			<p>
 				{ __(
 					'Please regenerate your Critical CSS to maintain optimal site performance.',
@@ -31,3 +26,35 @@ export const RegenerateCriticalCssSuggestion = ( { show } ) => {
 		</Notice>
 	);
 };
+
+function GetSuggestionMessage( type: string ) {
+	let message;
+	if ( 'page_saved' === type ) {
+		message = __(
+			"We noticed you've recently published a new page on your site that may affect its HTML/CSS structure.",
+			'jetpack-boost'
+		);
+	} else if ( 'post_saved' === type ) {
+		message = __(
+			"We noticed you've recently published a new post on your site that may affect its HTML/CSS structure.",
+			'jetpack-boost'
+		);
+	} else if ( 'switched_theme' === type ) {
+		message = __(
+			"We noticed you've recently updated your theme that may affect your site's HTML/CSS structure.",
+			'jetpack-boost'
+		);
+	} else if ( 'plugin_change' === type ) {
+		message = __(
+			"We noticed you've recently updated a plugin that may affect your site's HTML/CSS structure.",
+			'jetpack-boost'
+		);
+	} else {
+		message = __(
+			'We noticed some updates to your site that may have changed your HTML/CSS structure.',
+			'jetpack-boost'
+		);
+	}
+
+	return message;
+}

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
@@ -153,7 +153,7 @@ export const refreshCriticalCssState = async () => {
 
 export const regenerateCriticalCss = async () => {
 	// Clear regeneration suggestions
-	suggestRegenerateDS.store.set( false );
+	suggestRegenerateDS.store.set( '' );
 
 	// This will clear the CSS from the database
 	// And return fresh nonce, provider and viewport data.

--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-state.ts
@@ -153,7 +153,7 @@ export const refreshCriticalCssState = async () => {
 
 export const regenerateCriticalCss = async () => {
 	// Clear regeneration suggestions
-	suggestRegenerateDS.store.set( '' );
+	suggestRegenerateDS.store.set( null );
 
 	// This will clear the CSS from the database
 	// And return fresh nonce, provider and viewport data.

--- a/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
@@ -21,16 +21,16 @@ export const JSONSchema: z.ZodType< JSONValue > = z.lazy( () =>
  * Data Sync Stores
  */
 
-const allowedSuggestions = [ '1', 'page_saved', 'post_saved', 'switched_theme', 'plugin_change' ];
+const allowedSuggestions = [
+	'1',
+	'page_saved',
+	'post_saved',
+	'switched_theme',
+	'plugin_change',
+] as const;
+export type RegenReason = ( typeof allowedSuggestions )[ number ];
 
 export const suggestRegenerateDS = jetpack_boost_ds.createAsyncStore(
 	'critical_css_suggest_regenerate',
-	z
-		.custom( value => {
-			if ( typeof value === 'string' && allowedSuggestions.includes( value ) ) {
-				return value;
-			}
-			return null;
-		} )
-		.catch( null )
+	z.enum( allowedSuggestions ).nullable()
 );

--- a/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
@@ -20,7 +20,17 @@ export const JSONSchema: z.ZodType< JSONValue > = z.lazy( () =>
 /*
  * Data Sync Stores
  */
+
+const allowedSuggestions = [ '1', 'page_saved', 'post_saved', 'switched_theme', 'plugin_change' ];
+
 export const suggestRegenerateDS = jetpack_boost_ds.createAsyncStore(
 	'critical_css_suggest_regenerate',
-	z.coerce.string().catch( '' )
+	z
+		.custom( value => {
+			if ( typeof value === 'string' && allowedSuggestions.includes( value ) ) {
+				return value;
+			}
+			return null;
+		} )
+		.catch( null )
 );

--- a/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
@@ -22,5 +22,5 @@ export const JSONSchema: z.ZodType< JSONValue > = z.lazy( () =>
  */
 export const suggestRegenerateDS = jetpack_boost_ds.createAsyncStore(
 	'critical_css_suggest_regenerate',
-	z.coerce.boolean().catch( false )
+	z.coerce.string().catch( '' )
 );

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -194,9 +194,9 @@ class Jetpack_Boost {
 	public function handle_environment_change( $is_major_change, $change_type ) {
 		if ( $is_major_change ) {
 			Regenerate_Admin_Notice::enable();
-		} else {
-			jetpack_boost_ds_set( 'critical_css_suggest_regenerate', $change_type );
 		}
+
+		jetpack_boost_ds_set( 'critical_css_suggest_regenerate', $change_type );
 	}
 
 	/**

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -25,6 +25,7 @@ use Automattic\Jetpack_Boost\Lib\CLI;
 use Automattic\Jetpack_Boost\Lib\Connection;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Setup;
+use Automattic\Jetpack_Boost\Lib\Site_Health;
 use Automattic\Jetpack_Boost\Modules\Modules_Setup;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Config_State;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Site_Urls;
@@ -116,6 +117,9 @@ class Jetpack_Boost {
 
 		// Register the core Image CDN hooks.
 		Image_CDN_Core::setup();
+
+		// Setup Site Health panel functionality.
+		Site_Health::init();
 	}
 
 	/**

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -105,7 +105,7 @@ class Jetpack_Boost {
 
 		add_action( 'init', array( $this, 'init_textdomain' ) );
 
-		add_action( 'handle_environment_change', array( $this, 'handle_environment_change' ) );
+		add_action( 'handle_environment_change', array( $this, 'handle_environment_change' ), 10, 2 );
 
 		// Fired when plugin ready.
 		do_action( 'jetpack_boost_loaded', $this );
@@ -191,11 +191,11 @@ class Jetpack_Boost {
 	 * This is done here so even if the Critical CSS module is switched off we can
 	 * still capture the change of environment event and flag Critical CSS for a rebuild.
 	 */
-	public function handle_environment_change( $is_major_change ) {
+	public function handle_environment_change( $is_major_change, $change_type ) {
 		if ( $is_major_change ) {
 			Regenerate_Admin_Notice::enable();
 		} else {
-			jetpack_boost_ds_set( 'critical_css_suggest_regenerate', true );
+			jetpack_boost_ds_set( 'critical_css_suggest_regenerate', $change_type );
 		}
 	}
 

--- a/projects/plugins/boost/app/lib/Boost_Health.php
+++ b/projects/plugins/boost/app/lib/Boost_Health.php
@@ -11,11 +11,11 @@ class Boost_Health {
 
 	public function __construct() {
 		if ( self::critical_css_needs_regeneration() ) {
-			$this->issues[] = 'Outdated Critical CSS';
+			$this->issues[] = __( 'Outdated Critical CSS', 'jetpack-boost' );
 		}
 
 		if ( self::critical_css_has_errors() ) {
-			$this->issues[] = 'Failed to generate Critical CSS';
+			$this->issues[] = __( 'Failed to generate Critical CSS', 'jetpack-boost' );
 		}
 	}
 

--- a/projects/plugins/boost/app/lib/Boost_Health.php
+++ b/projects/plugins/boost/app/lib/Boost_Health.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\Lib;
 
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
 
 class Boost_Health {
@@ -11,6 +12,10 @@ class Boost_Health {
 	public function __construct() {
 		if ( self::critical_css_needs_regeneration() ) {
 			$this->issues[] = 'Outdated Critical CSS';
+		}
+
+		if ( self::critical_css_has_errors() ) {
+			$this->issues[] = 'Failed to generate Critical CSS';
 		}
 	}
 
@@ -30,5 +35,9 @@ class Boost_Health {
 		$suggest_regenerate = jetpack_boost_ds_get( 'critical_css_suggest_regenerate' );
 
 		return in_array( $suggest_regenerate, Environment_Change_Detector::get_available_env_change_statuses(), true );
+	}
+
+	public static function critical_css_has_errors() {
+		return ( new Critical_CSS_State() )->has_errors();
 	}
 }

--- a/projects/plugins/boost/app/lib/Boost_Health.php
+++ b/projects/plugins/boost/app/lib/Boost_Health.php
@@ -5,10 +5,23 @@ namespace Automattic\Jetpack_Boost\Lib;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
 
+/**
+ * Class Boost_Health
+ *
+ * Represents the health of the Jetpack Boost plugin.
+ */
 class Boost_Health {
 
+	/**
+	 * @var array List of issues affecting the health of the plugin.
+	 */
 	private $issues = array();
 
+	/**
+	 * Boost_Health constructor.
+	 *
+	 * Initializes the Boost_Health object and checks for any health issues.
+	 */
 	public function __construct() {
 		if ( self::critical_css_needs_regeneration() ) {
 			$this->issues[] = __( 'Outdated Critical CSS', 'jetpack-boost' );
@@ -19,14 +32,29 @@ class Boost_Health {
 		}
 	}
 
+	/**
+	 * Get the total number of issues affecting the health of the plugin.
+	 *
+	 * @return int Total number of issues.
+	 */
 	public function get_total_issues() {
 		return count( $this->issues );
 	}
 
+	/**
+	 * Get all the issues affecting the health of the plugin.
+	 *
+	 * @return array List of issues.
+	 */
 	public function get_all_issues() {
 		return $this->issues;
 	}
 
+	/**
+	 * Check if Critical CSS needs regeneration.
+	 *
+	 * @return bool True if regeneration is needed, false otherwise.
+	 */
 	public static function critical_css_needs_regeneration() {
 		if ( Cloud_CSS::is_available() ) {
 			return false;
@@ -37,6 +65,11 @@ class Boost_Health {
 		return in_array( $suggest_regenerate, Environment_Change_Detector::get_available_env_change_statuses(), true );
 	}
 
+	/**
+	 * Check if Critical CSS generation has errors.
+	 *
+	 * @return bool True if errors are present, false otherwise.
+	 */
 	public static function critical_css_has_errors() {
 		return ( new Critical_CSS_State() )->has_errors();
 	}

--- a/projects/plugins/boost/app/lib/Boost_Health.php
+++ b/projects/plugins/boost/app/lib/Boost_Health.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Lib;
+
+use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
+
+class Boost_Health {
+
+	private $issues = array();
+
+	public function __construct() {
+		if ( self::critical_css_needs_regeneration() ) {
+			$this->issues[] = 'Outdated Critical CSS';
+		}
+	}
+
+	public function get_total_issues() {
+		return count( $this->issues );
+	}
+
+	public function get_all_issues() {
+		return $this->issues;
+	}
+
+	public static function critical_css_needs_regeneration() {
+		if ( Cloud_CSS::is_available() ) {
+			return false;
+		}
+
+		$suggest_regenerate = jetpack_boost_ds_get( 'critical_css_suggest_regenerate' );
+
+		return in_array( $suggest_regenerate, Environment_Change_Detector::get_available_env_change_statuses(), true );
+	}
+}

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -14,6 +14,12 @@ namespace Automattic\Jetpack_Boost\Lib;
  */
 class Environment_Change_Detector {
 
+	const ENV_CHANGE_LEGACY         = '1';
+	const ENV_CHANGE_PAGE_SAVED     = 'page_saved';
+	const ENV_CHANGE_POST_SAVED     = 'post_saved';
+	const ENV_CHANGE_SWITCHED_THEME = 'switched_theme';
+	const ENV_CHANGE_PLUGIN_CHANGE  = 'plugin_change';
+
 	/**
 	 * Initialize the change detection hooks.
 	 */
@@ -41,20 +47,20 @@ class Environment_Change_Detector {
 		}
 
 		if ( 'page' === $post->post_type ) {
-			$change_type = 'page_saved';
+			$change_type = $this::ENV_CHANGE_PAGE_SAVED;
 		} else {
-			$change_type = 'post_saved';
+			$change_type = $this::ENV_CHANGE_POST_SAVED;
 		}
 
 		$this->do_action( false, $change_type );
 	}
 
 	public function handle_theme_change() {
-		$this->do_action( true, 'switched_theme' );
+		$this->do_action( true, $this::ENV_CHANGE_SWITCHED_THEME );
 	}
 
 	public function handle_plugin_change() {
-		$this->do_action( false, 'plugin_change' );
+		$this->do_action( false, $this::ENV_CHANGE_PLUGIN_CHANGE );
 	}
 
 	/**
@@ -65,6 +71,15 @@ class Environment_Change_Detector {
 	 */
 	public function do_action( $is_major_change, $change_type ) {
 		do_action( 'handle_environment_change', $is_major_change, $change_type );
+	}
+
+	public static function get_available_env_change_statuses() {
+		return array(
+			self::ENV_CHANGE_PAGE_SAVED,
+			self::ENV_CHANGE_POST_SAVED,
+			self::ENV_CHANGE_SWITCHED_THEME,
+			self::ENV_CHANGE_PLUGIN_CHANGE,
+		);
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -40,7 +40,13 @@ class Environment_Change_Detector {
 			return;
 		}
 
-		$this->do_action( false, 'post_saved' );
+		if ( 'page' === $post->post_type ) {
+			$change_type = 'page_saved';
+		} else {
+			$change_type = 'post_saved';
+		}
+
+		$this->do_action( false, $change_type );
 	}
 
 	public function handle_theme_change() {

--- a/projects/plugins/boost/app/lib/Site_Health.php
+++ b/projects/plugins/boost/app/lib/Site_Health.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Lib;
+
+/**
+ * Site_Health.
+ *
+ * Displays performance issues in WordPress site health page.
+ */
+class Site_Health {
+
+	/**
+	 * Initialize hooks
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public static function init() {
+		if ( ! has_filter( 'site_status_tests', array( __CLASS__, 'add_check' ) ) ) {
+			add_filter( 'site_status_tests', array( __CLASS__, 'add_check' ), 99 );
+		}
+	}
+
+	/**
+	 * Add site-health page tests.
+	 *
+	 * @param array $checks Core checks.
+	 *
+	 * @access public
+	 * @return array
+	 */
+	public static function add_check( $checks ) {
+		$checks['direct']['jetpack_boost_checks'] = array(
+			'label' => __( 'Jetpack Boost checks', 'jetpack-boost' ),
+			'test'  => array( __CLASS__, 'do_checks' ),
+		);
+
+		return $checks;
+	}
+
+	/**
+	 * Do site-health page checks
+	 *
+	 * @access public
+	 * @return array
+	 */
+	public static function do_checks() {
+		$health       = new Boost_Health();
+		$total_issues = $health->get_total_issues();
+		$issues       = $health->get_all_issues();
+
+		/**
+		 * Default, no issues found
+		 */
+		$result = array(
+			'label'       => __( 'No issues found', 'jetpack-boost' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'Performance', 'jetpack-boost' ),
+				'color' => 'gray',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				__( 'Jetpack Boost did not find any known performance issues with your site.', 'jetpack-boost' )
+			),
+			'actions'     => '',
+			'test'        => 'jetpack_boost_checks',
+		);
+
+		/**
+		 * If issues found.
+		 */
+		if ( $total_issues ) {
+			$result['status'] = 'critical';
+			/* translators: $d is the number of performance issues found. */
+			$result['label']       = sprintf( _n( 'Your site is affected by %d performance issue', 'Your site is affected by %d performance issues', $total_issues, 'jetpack-boost' ), $total_issues );
+			$result['description'] = __( 'Jetpack Boost detected the following performance issues in your site:', 'jetpack-boost' );
+
+			foreach ( $issues as $issue ) {
+				$result['description'] .= '<p>';
+				$result['description'] .= "<span class='dashicons dashicons-warning' style='color: crimson;'></span> &nbsp";
+				$result['description'] .= wp_kses( $issue, array( 'a' => array( 'href' => array() ) ) ); // Only allow a href HTML tags.
+				$result['description'] .= '</p>';
+			}
+			$result['description'] .= '<p>';
+			$result['description'] .= sprintf(
+				wp_kses(
+					/* translators: Link to Jetpack Boost. */
+					__( 'Visit <a href="%s">Boost settings page</a> for more information.', 'jetpack-boost' ),
+					array(
+						'a' => array( 'href' => array() ),
+					)
+				),
+				esc_url( admin_url( 'admin.php?page=jetpack-boost' ) )
+			);
+			$result['description'] .= '</p>';
+		}
+
+		return $result;
+	}
+}

--- a/projects/plugins/boost/app/lib/Site_Health.php
+++ b/projects/plugins/boost/app/lib/Site_Health.php
@@ -74,7 +74,7 @@ class Site_Health {
 			$result['status'] = 'critical';
 			/* translators: $d is the number of performance issues found. */
 			$result['label']       = sprintf( _n( 'Your site is affected by %d performance issue', 'Your site is affected by %d performance issues', $total_issues, 'jetpack-boost' ), $total_issues );
-			$result['description'] = __( 'Jetpack Boost detected the following performance issues in your site:', 'jetpack-boost' );
+			$result['description'] = __( 'Jetpack Boost detected the following performance issues with your site:', 'jetpack-boost' );
 
 			foreach ( $issues as $issue ) {
 				$result['description'] .= '<p>';

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
@@ -6,6 +6,7 @@
  */
 namespace Automattic\Jetpack_Boost\Lib\Critical_CSS;
 
+use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS_Followup;
 
 /**
@@ -21,6 +22,7 @@ class Critical_CSS_Invalidator {
 	public static function init() {
 		add_action( 'jetpack_boost_deactivate', array( __CLASS__, 'clear_data' ) );
 		add_action( 'handle_environment_change', array( __CLASS__, 'handle_environment_change' ) );
+		add_filter( 'jetpack_boost_total_problem_count', array( __CLASS__, 'update_boost_problem_count' ) );
 	}
 
 	/**
@@ -45,6 +47,15 @@ class Critical_CSS_Invalidator {
 
 			do_action( 'critical_css_invalidated' );
 		}
+	}
+
+	public static function update_boost_problem_count( $count ) {
+		$suggest_regenerate = jetpack_boost_ds_get( 'critical_css_suggest_regenerate' );
+		if ( in_array( $suggest_regenerate, Environment_Change_Detector::get_available_env_change_statuses() ) ) {
+			++$count;
+		}
+
+		return $count;
 	}
 
 }

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
@@ -6,7 +6,7 @@
  */
 namespace Automattic\Jetpack_Boost\Lib\Critical_CSS;
 
-use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
+use Automattic\Jetpack_Boost\Lib\Boost_Health;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS_Followup;
 
 /**
@@ -50,8 +50,8 @@ class Critical_CSS_Invalidator {
 	}
 
 	public static function update_boost_problem_count( $count ) {
-		$suggest_regenerate = jetpack_boost_ds_get( 'critical_css_suggest_regenerate' );
-		if ( in_array( $suggest_regenerate, Environment_Change_Detector::get_available_env_change_statuses(), true ) ) {
+		$css_needs_regeneration = Boost_Health::critical_css_needs_regeneration();
+		if ( $css_needs_regeneration ) {
 			++$count;
 		}
 

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_Invalidator.php
@@ -51,7 +51,7 @@ class Critical_CSS_Invalidator {
 
 	public static function update_boost_problem_count( $count ) {
 		$suggest_regenerate = jetpack_boost_ds_get( 'critical_css_suggest_regenerate' );
-		if ( in_array( $suggest_regenerate, Environment_Change_Detector::get_available_env_change_statuses() ) ) {
+		if ( in_array( $suggest_regenerate, Environment_Change_Detector::get_available_env_change_statuses(), true ) ) {
 			++$count;
 		}
 

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -122,7 +122,19 @@ class Critical_CSS_State {
 	}
 
 	public function has_errors() {
-		return self::GENERATION_STATES['error'] === $this->state['status'];
+		// Check if any of the providers have errors as well.
+		$any_provider_has_error = in_array(
+			'error',
+			array_unique(
+				wp_list_pluck(
+					$this->state['providers'],
+					'status'
+				)
+			),
+			true
+		);
+
+		return self::GENERATION_STATES['error'] === $this->state['status'] || $any_provider_has_error;
 	}
 
 	public function is_requesting() {

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
@@ -6,6 +6,7 @@ use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Admin_Bar_Compatibility;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Invalidator;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Display_Critical_CSS;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
@@ -48,6 +49,7 @@ class Critical_CSS implements Pluggable, Has_Endpoints {
 	 */
 	public function setup() {
 		add_action( 'wp', array( $this, 'display_critical_css' ) );
+		add_filter( 'jetpack_boost_total_problem_count', array( $this, 'update_total_problem_count' ) );
 
 		if ( Generator::is_generating_critical_css() ) {
 			add_action( 'wp_head', array( $this, 'display_generate_meta' ), 0 );
@@ -131,5 +133,9 @@ class Critical_CSS implements Pluggable, Has_Endpoints {
 			Critical_CSS_Insert::class,
 			Critical_CSS_Start::class,
 		);
+	}
+
+	public function update_total_problem_count( $count ) {
+		return ( new Critical_CSS_State() )->has_errors() ? ++$count : $count;
 	}
 }

--- a/projects/plugins/boost/changelog/update-boost-css-regen-notice-more-descriptive
+++ b/projects/plugins/boost/changelog/update-boost-css-regen-notice-more-descriptive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update CSS regeneration notice to include a more descriptive text, based on what triggered it to show.

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -124,11 +124,21 @@ $critical_css_state_schema = Schema::as_assoc_array(
 	)
 );
 
+$critical_css_suggest_regenerate_schema = Schema::enum(
+	array(
+		'1', // Old versions of Boost stored a boolean in the DB.
+		'page_saved',
+		'post_saved',
+		'switched_theme',
+		'plugin_change',
+	)
+)->nullable();
+
 /**
  * Register Data Sync Stores
  */
 jetpack_boost_register_option( 'critical_css_state', $critical_css_state_schema );
-jetpack_boost_register_option( 'critical_css_suggest_regenerate', Schema::as_string()->fallback( '' ) );
+jetpack_boost_register_option( 'critical_css_suggest_regenerate', $critical_css_suggest_regenerate_schema );
 
 $modules_state_schema = Schema::as_array(
 	Schema::as_assoc_array(

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -128,7 +128,7 @@ $critical_css_state_schema = Schema::as_assoc_array(
  * Register Data Sync Stores
  */
 jetpack_boost_register_option( 'critical_css_state', $critical_css_state_schema );
-jetpack_boost_register_option( 'critical_css_suggest_regenerate', Schema::as_boolean()->fallback( false ) );
+jetpack_boost_register_option( 'critical_css_suggest_regenerate', Schema::as_string()->fallback( '' ) );
 
 $modules_state_schema = Schema::as_array(
 	Schema::as_assoc_array(


### PR DESCRIPTION
Addresses https://github.com/Automattic/boost-cloud/issues/217

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update DB value used to check if regen is necessary, to include what triggered it;
* Update the regenerate Critical CSS notice to include a more descriptive text based on what triggered it;
* Update `Regenerate` button to a CTA when regen is necessary (reverts back to the original after regen is done);
* Add issue to Site Health panel in case a Critical CSS regen is necessary;
* Add issue to Site Health panel in case there was a problem generating Critical CSS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/boost-cloud/issues/217

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Note about Site Health panel issues
* The Site Health menu item does not change the issue count until you visit the page and wait for all checks to finish;
* The same goes for when an error gets fixed - you need to visit the Site Health panel and wait for the checks to finish, so it can properly update its count.
* To observe this - make sure you don't have any issues in your Site Health panel.
* Close the page, and open another WP admin page (the main WP Dashboard for example).
* Now enable WP_DEBUG on your website.
* Refresh the page you were on.
* Note, that the Site Health panel doesn't show that as an issue.
* Now visit the Site Health panel and wait for all checks to finish.
* You should see an issue about debug being visible to visitors.
* Visit another WP admin page and hover over `Tools -> Site Health` to see, that it shows 1 issue.
* Disable WP_DEBUG, but don't visit the Site Health panel.
* Open any other WP Admin page, and note, that it still shows 1 issue.
* Now open the Site Health panel and wait for the checks to finish.
* It should no longer show issues.

### Test regen notice description change, notification bubble, Regenerate link appearance change and Site Health issue
* Setup this version of Boost (free mode);
* Navigate to the Boost dashboard and wait for it to generate Critical CSS;
* After that's done, add a new page to your website;
* Check the Boost dashboard again you should see a notice to regenerate Critical CSS;
* The `Regenerate` link should also change appearance while the notice is visible;

<details>
<summary>Screenshot</summary>
<img width="715" alt="CleanShot 2023-06-02 at 13 00 19@2x" src="https://github.com/Automattic/jetpack/assets/11799079/a7769ec4-8d7b-47c8-bd76-acfbe9fbdd63">
</details>

* There should also be a notification bubble next to the Boost menu item in the sidebar;

<details>
<summary>Screenshot</summary>
<img width="165" alt="CleanShot 2023-06-02 at 13 01 55@2x" src="https://github.com/Automattic/jetpack/assets/11799079/03ad18c4-18d4-41de-a2ca-1be54562e8cf">
</details>

* Add a post;
* Check the Boost dashboard again and the notice text should change accordingly;

<details>
<summary>Screenshot</summary>
<img width="698" alt="CleanShot 2023-06-02 at 13 18 21@2x" src="https://github.com/Automattic/jetpack/assets/11799079/7beed7d0-440c-49e5-ac31-895d986528e1">
</details>

* You also see the notice description change after activating/deactivating a plugin;

<details>
<summary>Screenshot</summary>
<img width="699" alt="CleanShot 2023-06-02 at 13 19 23@2x" src="https://github.com/Automattic/jetpack/assets/11799079/1055ca6c-839f-400c-83b4-c54eb06e85ea">
</details>

* Doing any of the changes, should also render an issue in the Site Health panel.

<details>
<summary>Screenshot</summary>
<img width="810" alt="CleanShot 2023-06-02 at 13 16 34@2x" src="https://github.com/Automattic/jetpack/assets/11799079/f7663072-b5cd-4fed-9c7d-718640f82690">
</details>

### Test if Site Health panel shows Critical CSS generation failure issue
* Continuing from the above tests...
* While the website is in free mode, setup Boost Developer plugin;
* Make sure you don't have Boost Cloud running locally;
* Change `Critical CSS Mode` to `Cloud CSS`;
* Navigate to the Boost dashboard and wait for Critical CSS to fail;

<details>
<summary>Screenshot</summary>
<img width="787" alt="CleanShot 2023-06-02 at 13 08 47@2x" src="https://github.com/Automattic/jetpack/assets/11799079/1c071801-c27f-45fb-841f-afd88bf522b4">
</details>

* Check the Site Health panel to see if there's an issue about the failure.

<details>
<summary>Screenshot</summary>
<img width="813" alt="CleanShot 2023-06-02 at 13 15 26@2x" src="https://github.com/Automattic/jetpack/assets/11799079/c7b0e4c2-6ac9-4680-a580-a6ba69515b24">
</details>
