### PR TITLE
AI Assistant: tweak box layout and styles

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-tweak-prompt-input
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-tweak-prompt-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: tweak box layout and styles

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -80,7 +80,7 @@
 		width: 100%;
 		flex-grow: 1;
 		padding: 6px 8px;
-		margin: 1px 0px 1px 0px;
+		margin: 1px 0px;
 		border-radius: 2px;
 
 		resize: none !important;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -41,7 +41,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: 0 4px 0 8px;
+	margin-left: 8px;
 	
 	.jetpack-ai-assistant__input-icon {
 		// Brand green regardless of theme
@@ -65,7 +65,8 @@
 
 .jetpack-ai-assistant__input-wrapper {
 	display: flex;
-	padding: 6px 9px;
+	padding: 6px;
+	gap: 8px;
 	box-shadow: var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 0px 1px, var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 8px;
 
 	&.is-disconnected {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -67,20 +67,35 @@
 	display: flex;
 	padding: 6px;
 	gap: 8px;
+	color: var( --jp-gray-80 );
+	background-color: var( --jp-white );
 	box-shadow: var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 0px 1px, var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 8px;
 
 	&.is-disconnected {
 		opacity: 0.4;
 	}
 
-	textarea {
+	textarea.jetpack-ai-assistant__input {
 		width: 100%;
+		flex-grow: 1;
 		padding: 6px 8px;
-		font-size: 16px;
-		line-height: normal;
-		transition: box-shadow 0.1s linear 0s;
+		margin: 1px 0px 1px 0px;
 		border-radius: 2px;
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
+		resize: none !important;
+		border: none;
+		box-shadow: none;
+
+		font-size: 13px;
+		font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		font-weight: 400;
+		line-height: 20px;
+
+		transition: box-shadow 0.1s linear 0s;
+
+		&:focus {
+			box-shadow: none;
+		}
 
 		@media (min-width: 600px) {
 			font-size: 13px;
@@ -89,20 +104,7 @@
 		&::placeholder {
 			text-overflow:ellipsis;
 			white-space: nowrap;
-			color: var( --wp--preset--color--foreground );
 			opacity: 0.75;
-		}
-	}
-
-	textarea.jetpack-ai-assistant__input {
-		flex-grow: 1;
-		margin: 1px 0px 1px 0px;
-		resize: none !important;
-		border: none;
-		box-shadow: none;
-
-		&:focus {
-			box-shadow: none;
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -70,6 +70,7 @@
 	color: var( --jp-gray-80 );
 	background-color: var( --jp-white );
 	box-shadow: var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 0px 1px, var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 8px;
+	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 
 	&.is-disconnected {
 		opacity: 0.4;
@@ -87,7 +88,6 @@
 		box-shadow: none;
 
 		font-size: 13px;
-		font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-weight: 400;
 		line-height: 20px;
 
@@ -116,7 +116,9 @@
 	.jetpack-ai-assistant__prompt_button {
 		color: var( --wp--preset--color--foreground );
 		text-transform: uppercase;
-		font-weight: 400;
+		font-size: 11px;
+		font-weight: 600;
+		line-height: 16px;
 		user-select: none;
 
 		> SVG {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -86,6 +86,7 @@
 		resize: none !important;
 		border: none;
 		box-shadow: none;
+		color: var( --jp-gray-80 );
 
 		font-size: 13px;
 		font-weight: 400;
@@ -114,7 +115,7 @@
 	align-items: center;
 
 	.jetpack-ai-assistant__prompt_button {
-		color: var( --wp--preset--color--foreground );
+		color: var( --jp-gray-80 );
 		text-transform: uppercase;
 		font-size: 11px;
 		font-weight: 600;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/31083

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: tweak box layout and styles

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create/use an AI Assistant block instance 
* Check the styles/layout changes in the block
* Test with different themes

Theme | Before | After
------|------|------
Twenty Twenty-Three | <img width="592" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/924dff9d-2ced-4d2c-a612-868f4023d3f1"> | <img width="596" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/de0b6c48-f7e3-4d1c-a65f-02077a22581e">
Twenty Twenty-Three | <img width="587" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/10be24c1-a8a5-4c09-a4f8-ac41bd5774fa"> | <img width="604" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/0a41a37a-cd37-48a0-bd8f-c3388696f73b">
Twenty Twenty-Three | <img width="576" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/1c68adcf-e7f4-4463-8536-f860fba1f986"> | <img width="584" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/f8497638-b941-463e-90c7-1e19be62ef65">
Video Maker | <img width="599" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/54018cd6-7a5f-43ce-a269-4b07660a0d50"> | <img width="589" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/183070ed-1605-4e1f-898a-407a3e371e56">
Twenty Twenty-Two | <img width="587" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/0bd82a3e-2d4b-4e9c-b178-57eaeaf3ad41"> | <img width="589" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/5e632633-38e0-41da-a459-24fd1a68c20e">




