### PR TITLE
Disable newsletters on jetpack self-hosted

### DIFF
--- a/projects/plugins/jetpack/changelog/add-disable-newsletters-on-jetpack-self-hosted
+++ b/projects/plugins/jetpack/changelog/add-disable-newsletters-on-jetpack-self-hosted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Gate newsletter feature on jetpack-self-hosted

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -655,6 +655,10 @@ class Jetpack_Gutenberg {
 			$is_current_user_connected = ( new Connection_Manager( 'jetpack' ) )->is_user_connected();
 		}
 
+		$is_jetpack_self_hosted = ! (
+			( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site()
+		);
+
 		$initial_state = array(
 			'available_blocks' => self::get_availability(),
 			'jetpack'          => array(
@@ -674,7 +678,7 @@ class Jetpack_Gutenberg {
 					 *
 					 * @param bool false Enable the Paid Newsletters feature in the block editor context.
 					 */
-					apply_filters( 'jetpack_subscriptions_newsletter_feature_enabled', true )
+					apply_filters( 'jetpack_subscriptions_newsletter_feature_enabled', ! $is_jetpack_self_hosted )
 					&& class_exists( '\Jetpack_Memberships' )
 				),
 				/**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Extensions\Subscriptions;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 use Jetpack;
 use Jetpack_Gutenberg;
 use Jetpack_Memberships;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -59,13 +59,17 @@ function register_block() {
 		return;
 	}
 
+	$is_jetpack_self_hosted = ! (
+		( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site()
+	);
+
 	/**
 	 * Do not proceed if the newsletter feature is not enabled
 	 * or if the 'Jetpack_Memberships' class does not exists.
 	 */
 	if (
 		/** This filter is documented in class.jetpack-gutenberg.php */
-		! apply_filters( 'jetpack_subscriptions_newsletter_feature_enabled', true )
+		! apply_filters( 'jetpack_subscriptions_newsletter_feature_enabled', ! $is_jetpack_self_hosted )
 		|| ! class_exists( '\Jetpack_Memberships' )
 	) {
 		return;
@@ -416,9 +420,13 @@ function render_block( $attributes ) {
 		return '';
 	}
 
+	$is_jetpack_self_hosted = ! (
+		( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site()
+	);
+
 	if (
 		/** This filter is documented in class.jetpack-gutenberg.php */
-		apply_filters( 'jetpack_subscriptions_newsletter_feature_enabled', true )
+		apply_filters( 'jetpack_subscriptions_newsletter_feature_enabled', ! $is_jetpack_self_hosted )
 		&& class_exists( '\Jetpack_Memberships' )
 	) {
 		// We only want the sites that have newsletter feature enabled to be graced by this JavaScript and thickbox.


### PR DESCRIPTION
See pbNhbs-6QK-p2#comment-15819


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable the newsletter panel  on self-hosted.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* Spin up a Jurassic ninja site
* Connect JP
* Create a new post and see that:
 - the newsletter panel is not available
 - subscribe block should still be available 


https://github.com/Automattic/jetpack/assets/790558/ecf8263f-6488-4e26-9906-ecac2f018bbf


