### PR TITLE
AI Assistant: POC - Send array of messages instead of question

### DIFF
--- a/projects/plugins/jetpack/changelog/update-question-messages-jetpack-assistant-ai
+++ b/projects/plugins/jetpack/changelog/update-question-messages-jetpack-assistant-ai
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Switch ai assistant block to send an array of messages and not a question

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -43,7 +43,11 @@ export async function askQuestion( question, postId = null, fromCache = false ) 
 	const { token } = await requestToken();
 
 	const url = new URL( 'https://public-api.wordpress.com/wpcom/v2/jetpack-ai-query' );
-	url.searchParams.append( 'question', question );
+	if ( Array.isArray( question ) ) {
+		url.searchParams.append( 'messages', JSON.stringify( question ) );
+	} else {
+		url.searchParams.append( 'question', question );
+	}
 	url.searchParams.append( 'token', token );
 
 	if ( fromCache ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -180,6 +180,7 @@ const useSuggestionsFromOpenAI = ( {
 				currentPostTitle,
 				options,
 				prompt,
+				returnArray: true,
 				userPrompt,
 				type,
 			} );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -180,7 +180,6 @@ const useSuggestionsFromOpenAI = ( {
 				currentPostTitle,
 				options,
 				prompt,
-				returnArray: true,
 				userPrompt,
 				type,
 			} );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Makes buildPrompt and BuildPromptFromTemplate accept a `returnArray` argument for forging an array with the following structure and return it:

  ```
	const messages = [
		{
			role: 'system',
			content:
				'You are an AI assistant block, ... [etc etc ]',
		},
		{
			role: 'user',
			content:
				'A haiku',
		},		
	];
  ```
* Sends that array json-encoded as a string in a `messages` GET param

This makes the backend be able to interpret context more accurately.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*