### PR TITLE
AI Assistant: add a Done button to the main-area of the block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-iterate-over-block-actions
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-iterate-over-block-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: add a Done button to the main-area of the block

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -182,20 +182,20 @@ const AIControl = ( {
 								className="jetpack-ai-assistant__prompt_button"
 								onClick={ handleAcceptTitle }
 								isSmall={ true }
-								label={ __( 'Apply title', 'jetpack' ) }
+								label={ __( 'Accept title', 'jetpack' ) }
 							>
 								<Icon icon={ check } />
-								{ __( 'Apply title', 'jetpack' ) }
+								{ __( 'Accept title', 'jetpack' ) }
 							</Button>
 						) : (
 							<Button
 								className="jetpack-ai-assistant__prompt_button"
 								onClick={ handleAcceptContent }
 								isSmall={ true }
-								label={ __( 'Apply', 'jetpack' ) }
+								label={ __( 'Accept', 'jetpack' ) }
 							>
 								<Icon icon={ check } />
-								{ __( 'Apply', 'jetpack' ) }
+								{ __( 'Accept', 'jetpack' ) }
 							</Button>
 						) ) }
 				</div>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -174,6 +174,18 @@ const AIControl = ( {
 							{ __( 'Stop', 'jetpack' ) }
 						</Button>
 					) }
+
+					{ contentIsLoaded && ! isWaitingState && (
+						<Button
+							className="jetpack-ai-assistant__prompt_button"
+							onClick={ handleAcceptContent }
+							isSmall={ true }
+							label={ __( 'Done', 'jetpack' ) }
+						>
+							<Icon icon={ check } />
+							{ __( 'Done', 'jetpack' ) }
+						</Button>
+					) }
 				</div>
 			</div>
 		</>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -214,14 +214,12 @@ const ToolbarControls = ( {
 	getSuggestionFromOpenAI,
 	retryRequest,
 	handleAcceptContent,
-	handleAcceptTitle,
 	handleImageRequest,
 	handleTryAgain,
 	showRetry,
 	contentBefore,
 	hasPostTitle,
 	wholeContent,
-	promptType,
 	setUserPrompt,
 	recordEvent,
 } ) => {
@@ -295,20 +293,9 @@ const ToolbarControls = ( {
 
 				<ToolbarGroup>
 					{ ! showRetry && contentIsLoaded && (
-						<>
-							{ promptType === 'generateTitle' ? (
-								<ToolbarButton onClick={ handleAcceptTitle }>
-									{ __( 'Accept title', 'jetpack' ) }
-								</ToolbarButton>
-							) : (
-								<ToolbarButton onClick={ handleAcceptContent }>
-									{ __( 'Done', 'jetpack' ) }
-								</ToolbarButton>
-							) }
-							<ToolbarButton onClick={ handleTryAgain }>
-								{ __( 'Try Again', 'jetpack' ) }
-							</ToolbarButton>
-						</>
+						<ToolbarButton onClick={ handleTryAgain }>
+							{ __( 'Try Again', 'jetpack' ) }
+						</ToolbarButton>
 					) }
 
 					{ ! showRetry && ! contentIsLoaded && !! wholeContent?.length && (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -182,20 +182,20 @@ const AIControl = ( {
 								className="jetpack-ai-assistant__prompt_button"
 								onClick={ handleAcceptTitle }
 								isSmall={ true }
-								label={ __( 'Accept title', 'jetpack' ) }
+								label={ __( 'Apply title', 'jetpack' ) }
 							>
 								<Icon icon={ check } />
-								{ __( 'Accept title', 'jetpack' ) }
+								{ __( 'Apply title', 'jetpack' ) }
 							</Button>
 						) : (
 							<Button
 								className="jetpack-ai-assistant__prompt_button"
 								onClick={ handleAcceptContent }
 								isSmall={ true }
-								label={ __( 'Done', 'jetpack' ) }
+								label={ __( 'Apply', 'jetpack' ) }
 							>
 								<Icon icon={ check } />
-								{ __( 'Done', 'jetpack' ) }
+								{ __( 'Apply', 'jetpack' ) }
 							</Button>
 						) ) }
 				</div>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -175,17 +175,29 @@ const AIControl = ( {
 						</Button>
 					) }
 
-					{ contentIsLoaded && ! isWaitingState && (
-						<Button
-							className="jetpack-ai-assistant__prompt_button"
-							onClick={ handleAcceptContent }
-							isSmall={ true }
-							label={ __( 'Done', 'jetpack' ) }
-						>
-							<Icon icon={ check } />
-							{ __( 'Done', 'jetpack' ) }
-						</Button>
-					) }
+					{ contentIsLoaded &&
+						! isWaitingState &&
+						( promptType === 'generateTitle' ? (
+							<Button
+								className="jetpack-ai-assistant__prompt_button"
+								onClick={ handleAcceptTitle }
+								isSmall={ true }
+								label={ __( 'Accept title', 'jetpack' ) }
+							>
+								<Icon icon={ check } />
+								{ __( 'Accept title', 'jetpack' ) }
+							</Button>
+						) : (
+							<Button
+								className="jetpack-ai-assistant__prompt_button"
+								onClick={ handleAcceptContent }
+								isSmall={ true }
+								label={ __( 'Done', 'jetpack' ) }
+							>
+								<Icon icon={ check } />
+								{ __( 'Done', 'jetpack' ) }
+							</Button>
+						) ) }
 				</div>
 			</div>
 		</>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -99,8 +99,7 @@ ${ job }. Do this by following rules set in "Rules".
 Rules:
 - If you do not understand this request, regardless of language or any other rule, always answer exactly and without any preceding content with the following term and nothing else: __JETPACK_AI_ERROR__.
 - Do not use the term __JETPACK_AI_ERROR__ in any other context.
-${ extraRulePromptPart }- Do not include a top level heading by default.
-- Output the generated content in markdown format.
+${ extraRulePromptPart }- Output the generated content in markdown format.
 - Do not include a top level heading by default.
 - Only output generated content ready for publishing.
 - Segment the content into paragraphs as deemed suitable.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -115,6 +115,7 @@
 	align-items: center;
 
 	.jetpack-ai-assistant__prompt_button {
+		white-space: nowrap;
 		color: var( --jp-gray-80 );
 		text-transform: uppercase;
 		font-size: 11px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR:

* Add a `Done` / `Accept title` button to the main block area when the block gets content
* Remove the `Done` button from the block toolbar

Fixes https://github.com/Automattic/jetpack/issues/31106

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: add a Done button to the main-area of the block

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block edtior
* Create an AI Assistant block instance
* Confirm the block shows a `Done` button in the primary area of the block when the block gets content
* Confirm the block creates post content by clicking on the `Done` button
* Confirm the `Send`/`Stop` buttons work as expected 
* Confirm the `Done` button has been removed from the block toolbar 

<img width="683" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/147cf9f0-c326-44b4-b99f-2fedcbcd20a4">

<img width="672" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/7fd95b5e-b0df-410a-821e-64b24bdc3247">
