### PR TITLE
Add tracks event for boost score error

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -97,7 +97,7 @@ const DashBoost = ( {
 			setIsLoading( false );
 		} catch ( err ) {
 			analytics.tracks.recordEvent( 'jetpack_boost_speed_score_error', {
-				feature: 'boost',
+				feature: BOOST_PLUGIN_SLUG,
 				position: 'at-a-glance',
 				error: err,
 			} );

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -96,6 +96,12 @@ const DashBoost = ( {
 			setDaysSinceTested( 0 );
 			setIsLoading( false );
 		} catch ( err ) {
+			analytics.tracks.recordEvent( 'jetpack_boost_speed_score_error', {
+				feature: 'boost',
+				position: 'at-a-glance',
+				error: err,
+			} );
+
 			// If error, use cached speed scores if they exist
 			if ( latestSpeedScores && latestSpeedScores.scores ) {
 				setScoresFromCache();

--- a/projects/plugins/jetpack/changelog/add-tracks-event-for-boost-score-error
+++ b/projects/plugins/jetpack/changelog/add-tracks-event-for-boost-score-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add track for speed score API errors


### PR DESCRIPTION
## Proposed changes:

Add track event that is recorded when the boost speed score API returns an error

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p8oabR-1e4-p2#comment-7341

## Does this pull request change what data or activity we track or use?

Yes, new event named `jetpack_boost_speed_score_error` that triggers when a speed score request returns an error

## Testing instructions:

**This will have to be done locally as 2 lines of code need to be edited**

1. Checkout these changes locally
2. Go to the file `projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx` and update line 134 to the following (this will force the speed scores to update and not use the cached results)
```jsx
if ( ! latestSpeedScores && calculateDaysSince( latestSpeedScores.timestamp * 1000 ) < 21 ) {
```
3. Go to the file `projects/packages/boost-speed-score/src/class-speed-score.php` and update line 94 to the following to simulate an error
```php
if ( isset( $params['url'] ) ) {
```
4. Without Boost installed, go to `/wp-admin/admin.php?page=jetpack#/dashboard` and wait for the Boost module to load. After loading it should look like this
![image](https://github.com/Automattic/jetpack/assets/65001528/eb4d2db5-4bfa-4e9b-b1d6-23f906ecb8ed)
5. In Tracks Vigilante, you should see this event
![image](https://github.com/Automattic/jetpack/assets/65001528/0a195710-92eb-4281-bc1c-7d0d92bffc50)
