### PR TITLE
Launchpad: Apply filter for keep building task list

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-apply-filter-for-keep-building-task-list
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-apply-filter-for-keep-building-task-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Apply filter to the Keep building task list

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -429,7 +429,7 @@ function wpcom_register_default_launchpad_checklists() {
 				'design_edited',
 				// @todo Add more tasks here!
 			),
-			'is_enabled_callback' => '__return_false',
+			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		)
 	);
 
@@ -910,6 +910,18 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug = false ) {
 	// @todo: Remove this fallback once all task lists have been migrated to the new system.
 	// https://github.com/Automattic/wp-calypso/issues/77407
 	return wpcom_launchpad_checklists()->is_launchpad_enabled();
+}
+
+/**
+ * Checks if the Keep building task list is enabled.
+ *
+ * This function uses the `is_launchpad_keep_building_enabled` filter to allow for overriding the
+ * default value.
+ *
+ * @return bool True if the task list is enabled, false otherwise.
+ */
+function wpcom_launchpad_is_keep_building_enabled() {
+	return apply_filters( 'is_launchpad_keep_building_enabled', false );
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We need to be able to gate the `Keep building` task list for testing purposes. Currently, we will gate the task list only for Serenity team members. The function to do so was introduced on the diff below. Now we need to apply the filter on Jetpack.

Related to D112091-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a callback for the "Keep building" task list to use the filter introduced on D112091-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1685110269138879-slack-C0Q664T29

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Sandbox the public-api and make sure your sandbox is up to date
* Apply this PR to your sandbox with the [command](https://github.com/Automattic/jetpack/pull/31113#issuecomment-1570575317) below
* Open the developer console: https://developer.wordpress.com/docs/api/console/
* Set the options to WP REST API /  wpcom/v2 and make a GET request to `/sites/:siteSlug:/launchpad?checklist_slug=keep-building`
  * If you are a Serenity team member, check the response and confirm that the `is_enabled` attribute is `true`.
    * Go to fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Snhgbznggvp%2Qshapgvbaf.cuc%3Se%3Qn046764r%231377-og on your sandbox
    * Comment out your ID and make a request again on the developer console. This time the `is_enabled` attribute should be false.
  * The `is_enabled` attribute should be false if you are not a Serenity team member.
    * Go to fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Snhgbznggvp%2Qshapgvbaf.cuc%3Se%3Qn046764r%231377-og on your sandbox
    * Add your ID to the array list and make a request again on the developer console. This time the `is_enabled` attribute should be true.