### PR TITLE
tools: Fix deploy-to-svn.sh stable tag handling

### DIFF
--- a/tools/deploy-to-svn.sh
+++ b/tools/deploy-to-svn.sh
@@ -173,13 +173,26 @@ fi
 
 cd "$DIR"
 
-STABLE_TAG="$(sed -n -E -e 's/^Stable tag: +([^ ]+) *$/\1/p' trunk/readme.txt)"
-if [[ "$SVNTAG" == "$STABLE_TAG" ]]; then
-	warn "The stable tag in trunk/readme.txt is already $STABLE_TAG!"
-	echo "Usually we wait until a final, manual step to update the stable tag."
-	proceed_p ""
-else
-	debug "Stable tag in trunk/readme.txt is $STABLE_TAG. Good, that's !== $SVNTAG."
+# Check that the stable tag in trunk/readme.txt is not being changed. If it is, try to undo the change.
+CHECK="$(svn diff trunk/readme.txt | grep '^[+-]Stable tag:' || true)"
+if [[ -n "$CHECK" ]]; then
+	LINE="$(grep --line-number --max-count=1 '^Stable tag:' trunk/readme.txt)"
+	if grep -q '^+' <<<"$CHECK" && ! grep -q '^-' <<<"$CHECK"; then
+		# On the initial commit, it seems there's no way to specify not to immediately have that commit served as the stable version.
+		# So just print a notice pointing that out in case anyone is looking and leave it as-is.
+		warn "This appears to be the initial release of the plugin, which will unavoidably set the stable tag to the version being released now."
+	elif [[ -n "$LINE" ]]; then
+		warn "Stable tag must be updated manually! Update would change it, attempting to undo the change."
+		nl=$'\n'
+		patch -R trunk/readme.txt <<<"@@ -${LINE%%:*},1 +${LINE%%:*},1 @@$nl$CHECK"
+		CHECK2="$(svn diff trunk/readme.txt | grep '^[+-]Stable tag:' || true)"
+		if [[ -n "$CHECK2" ]]; then
+			die "Attempt to revert stable tag change failed! Remaining diff:$nl$nl$CHECK2"
+		fi
+	else
+		nl=$'\n'
+		die "Stable tag must be updated manually! Update would change it.$nl$nl$CHECK"
+	fi
 fi
 
 proceed_p "We're ready to update trunk and tag $SVNTAG!" "Do it?"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When we update the stable tag in w.org SVN, we usually forget to bring that back to the monorepo. This can then too easily result in the stable tag getting accidentally downgraded on a future deploy.

We already handle this correctly in [the wp-svn-autopublish action](https://github.com/Automattic/jetpack/blob/614c751e23dcb7326e68564e21192088024294bb/.github/files/gh-wp-svn-autopublish/files/wp-svn-autopublish.sh#L72-L93), let's use the same logic here to ensure that the tag in `trunk/readme.txt` is never changed by the script.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Relevant to p1685470667664939-slack-C0299DMPG

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You might comment out lines 136–138, then try running the script for some existing tag.