### PR TITLE
AI Assistant: Fix partial AI error string check

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-error-check
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-error-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Fix partial AI error string check

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -202,10 +202,11 @@ export class SuggestionsEventSource extends EventTarget {
 			 * - the double underscores (italic markdown)
 			 * - the doouble asterisks (bold markdown)
 			 */
-			if ( this.fullMessage.replace( /__|(\*\*)/g, '' ) === 'JETPACK_AI_ERROR' ) {
+			const replacedMessage = this.fullMessage.replace( /__|(\*\*)/g, '' );
+			if ( replacedMessage === 'JETPACK_AI_ERROR' ) {
 				// The unclear prompt marker was found, so we dispatch an error event
 				this.dispatchEvent( new CustomEvent( 'error_unclear_prompt' ) );
-			} else if ( 'JETPACK_AI_ERROR'.startsWith( this.fullMessage.replace( '__', '' ) ) ) {
+			} else if ( 'JETPACK_AI_ERROR'.startsWith( replacedMessage ) ) {
 				// Partial unclear prompt marker was found, so we wait for more data and print a debug message without dispatching an event
 				debug( this.fullMessage );
 			} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #31075
Sometimes the `JETPACK_AI_ERROR` sent back in bold is still displayed.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the same regex used in the full error check to the partial error check

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an AI Assistant block
* Make some nonsense request like "dhjsdmn"
* Check that `JETPACK_AI_ERROR` is not displayed
