### PR TITLE
AI Assistant: register endpoint also for Jetpack sites

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -35,6 +35,14 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
 		}
 
+		// Register routes that don't require Jetpack AI to be enabled.
+		add_action( 'rest_api_init', array( $this, 'register_basic_routes' ) );
+
+		if ( ! \Jetpack_AI_Helper::is_enabled() ) {
+			return;
+		}
+
+		// Register routes that require Jetpack AI to be enabled.
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
@@ -92,7 +100,12 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 				),
 			)
 		);
+	}
 
+	/**
+	 * Register routes that don't require Jetpack AI to be enabled.
+	 */
+	public function register_basic_routes() {
 		register_rest_route(
 			$this->namespace,
 			$this->rest_base . '/ai-assistant-feature',

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -35,10 +35,6 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
 		}
 
-		if ( ! \Jetpack_AI_Helper::is_enabled() ) {
-			return;
-		}
-
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-register-endpoints-even-for-jetpack-sites
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-register-endpoints-even-for-jetpack-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: register endpoint also for Jetpack sites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a method to register "public" AI endpoints.
These endpoints will be registered even if the AI Assistant feature is not enabled.
Currently, there is only one `ai-assistant-feature` endpoint.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: register endpoint also for Jetpack sites

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a JN site
* Confirm the `wpcom/v2/jetpack-ai/ai-assistant-feature` are available.
* Confirm the `404` client error disappears.

<img width="572" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/74bc3115-7ef6-4606-8772-4bd24300bd7e">

* Confirm you see the `ai-assistant-feature` response

<img width="486" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/6a0b4e03-9634-4de0-8245-27e1d30c1c07">


