### PR TITLE
Launchpad: Refactor launchpad task completion for future tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/try-refactor-launchpad-task-completion
+++ b/projects/packages/jetpack-mu-wpcom/changelog/try-refactor-launchpad-task-completion
@@ -1,4 +1,4 @@
 Significance: minor
-Type: enhancement
+Type: changed
 
 Launchpad: Refactor task definitions

--- a/projects/packages/jetpack-mu-wpcom/changelog/try-refactor-launchpad-task-completion
+++ b/projects/packages/jetpack-mu-wpcom/changelog/try-refactor-launchpad-task-completion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Launchpad: Refactor task definitions

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -141,6 +141,15 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
+	 * See if the task list registry has any task lists.
+	 *
+	 * @return bool True if there are task lists, false if not.
+	 */
+	public function has_task_lists() {
+		return is_countable( $this->task_list_registry ) && count( $this->task_list_registry ) > 0;
+	}
+
+	/**
 	 * Get all registered Launchpad Task Lists.
 	 *
 	 * @return array All registered Launchpad Task Lists.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -249,7 +249,7 @@ function wpcom_mark_launchpad_task_complete( $task_id ) {
 /**
  * Initialize the Launchpad task listener callbacks.
  *
- * @param array $task_definitions
+ * @param array $task_definitions The tasks to initialize.
  */
 function wpcom_launchpad_init_listeners( $task_definitions ) {
 	require_once WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -38,7 +38,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
 		),
 		'first_post_published'            => array(
-			'get_title'            => function () {
+			'get_title'             => function () {
 				return __( 'Write your first post', 'jetpack-mu-wpcom' );
 			},
 			'add_listener_callback' => function () {
@@ -75,10 +75,10 @@ function wpcom_launchpad_get_task_definitions() {
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 		),
 		'verify_email'                    => array(
-			'get_title'            => function () {
+			'get_title'           => function () {
 				return __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' );
 			},
-			'is_visible_callback'  => 'wpcom_launchpad_is_email_unverified',
+			'is_visible_callback' => 'wpcom_launchpad_is_email_unverified',
 		),
 
 		// Newsletter tasks.
@@ -92,10 +92,10 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 		'newsletter_plan_created'         => array(
-			'get_title'            => function () {
+			'get_title'           => function () {
 				return __( 'Create paid Newsletter', 'jetpack-mu-wpcom' );
 			},
-			'is_visible_callback'  => 'wpcom_has_goal_paid_subscribers',
+			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
 		),
 		'setup_newsletter'                => array(
 			'id'                   => 'setup_newsletter',
@@ -105,10 +105,10 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => '__return_true',
 		),
 		'set_up_payments'                 => array(
-			'get_title'            => function () {
+			'get_title'           => function () {
 				return __( 'Set up payment method', 'jetpack-mu-wpcom' );
 			},
-			'is_visible_callback'  => 'wpcom_has_goal_paid_subscribers',
+			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
 		),
 		'subscribers_added'               => array(
 			'get_title'            => function () {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -7,7 +7,7 @@
 
 /**
  * Get the task definitions for the Launchpad.
- * 
+ *
  * @return array
  */
 function wpcom_launchpad_get_task_definitions() {
@@ -210,36 +210,36 @@ function wpcom_launchpad_get_task_definitions() {
 
 /**
  * Mark a task as complete.
- * 
+ *
  * @param string $task_id The task ID.
  * @return bool True if the task was marked as complete, false otherwise.
  */
 function wpcom_mark_launchpad_task_complete( $task_id ) {
 	$task_definitions = wpcom_launchpad_get_task_definitions();
-	
+
 	// If the task ID isn't defined, return false.
 	if ( ! isset( $task_definitions[ $task_id ] ) ) {
 		return false;
 	}
- 
+
 	// If the task has an id_map, use that instead.
 	$key = $task_id;
 	if ( isset( $task_definitions[ $task_id ]['id_map'] ) ) {
 		$key = $task_definitions[ $task_id ]['id_map'];
 	}
- 
+
 	$statuses         = get_option( 'launchpad_checklist_tasks_statuses', array() );
 	$statuses[ $key ] = true;
 	$result           = update_option( 'launchpad_checklist_tasks_statuses', $statuses );
- 
+
 	// Record the completion event in Tracks if we're running on WP.com.
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		require_lib( 'tracks/client' );
-		
-		tracks_record_event( 
-			wp_get_current_user(), 
-			'launchpad_mark_task_completed', 
-			array( 'task_id' => $key ) 
+
+		tracks_record_event(
+			wp_get_current_user(),
+			'launchpad_mark_task_completed',
+			array( 'task_id' => $key )
 		);
 	}
 
@@ -248,7 +248,7 @@ function wpcom_mark_launchpad_task_complete( $task_id ) {
 
 /**
  * Initialize the Launchpad task listener callbacks.
- * 
+ *
  * @param array $task_definitions
  */
 function wpcom_launchpad_init_listeners( $task_definitions ) {
@@ -257,7 +257,7 @@ function wpcom_launchpad_init_listeners( $task_definitions ) {
 	foreach ( $task_definitions as $task_id => $task_definition ) {
 		if ( isset( $task_definition['add_listener_callback'] ) && is_callable( $task_definition['add_listener_callback'] ) ) {
 			$task_data = array_merge( $task_definition, array( 'id' => $task_id ) );
-			
+
 			try {
 				call_user_func( $task_definition['add_listener_callback'], $task_data ); // Current callbacks expect the built, registered task for the second parameter, which won't work in this case.
 			} catch ( Exception $e ) {
@@ -286,7 +286,7 @@ function wpcom_launchpad_init_listeners( $task_definitions ) {
  */
 function wpcom_launchpad_init_task_definitions() {
 	$task_definitions = wpcom_launchpad_get_task_definitions();
- 
+
 	wpcom_launchpad_init_listeners( $task_definitions );
 }
 add_action( 'init', 'wpcom_launchpad_init_task_definitions', 11 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -232,14 +232,16 @@ function wpcom_mark_launchpad_task_complete( $task_id ) {
 	$statuses[ $key ] = true;
 	$result           = update_option( 'launchpad_checklist_tasks_statuses', $statuses );
  
-	// Record the completion event in Tracks.
-	require_lib( 'tracks/client' );
-	
-	tracks_record_event( 
-		wp_get_current_user(), 
-		'launchpad_mark_task_completed', 
-		array( 'task_id' => $key ) 
-	);
+	// Record the completion event in Tracks if we're running on WP.com.
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		require_lib( 'tracks/client' );
+		
+		tracks_record_event( 
+			wp_get_current_user(), 
+			'launchpad_mark_task_completed', 
+			array( 'task_id' => $key ) 
+		);
+	}
 
 	return $result;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -13,7 +13,7 @@
 function wpcom_launchpad_get_task_definitions() {
 	$task_definitions = array(
 		// Core tasks.
-		'design_edited' => array(
+		'design_edited'                   => array(
 			'get_title'             => function () {
 				return __( 'Edit site design', 'jetpack-mu-wpcom' );
 			},
@@ -22,14 +22,14 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
 			},
 		),
-		'design_selected' => array(
+		'design_selected'                 => array(
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
 			'is_disabled_callback' => 'wpcom_is_design_step_enabled',
 		),
-		'domain_upsell' => array(
+		'domain_upsell'                   => array(
 			'id_map'               => 'domain_upsell_deferred',
 			'get_title'            => function () {
 				return __( 'Choose a domain', 'jetpack-mu-wpcom' );
@@ -37,22 +37,22 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_is_domain_upsell_completed',
 			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
 		),
-		'first_post_published' => array(
+		'first_post_published'            => array(
 			'get_title'            => function () {
 				return __( 'Write your first post', 'jetpack-mu-wpcom' );
 			},
 			'add_listener_callback' => function () {
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
-			}
+			},
 		),
-		'plan_completed' => array(
+		'plan_completed'                  => array(
 			'get_title'            => function () {
 				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
 			},
 			'subtitle'             => 'wpcom_get_plan_completed_subtitle', // This callback doesn't seem to exist.
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 		),
-		'plan_selected' => array(
+		'plan_selected'                   => array(
 			'get_title'            => function () {
 				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
 			},
@@ -60,21 +60,21 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => '__return_true',
 			'badge_text_callback'  => 'wpcom_get_plan_selected_badge_text',
 		),
-		'setup_general' => array(
+		'setup_general'                   => array(
 			'get_title'            => function () {
 				return __( 'Set up your site', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
 			'is_disabled_callback' => '__return_true',
 		),
-		'site_launched' => array(
+		'site_launched'                   => array(
 			'get_title'             => function () {
 				return __( 'Launch your site', 'jetpack-mu-wpcom' );
 			},
 			'isLaunchTask'          => true,
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 		),
-		'verify_email' => array(
+		'verify_email'                    => array(
 			'get_title'            => function () {
 				return __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' );
 			},
@@ -89,28 +89,28 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'add_listener_callback' => function () {
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
-			}
+			},
 		),
-		'newsletter_plan_created' => array(
+		'newsletter_plan_created'         => array(
 			'get_title'            => function () {
 				return __( 'Create paid Newsletter', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback'  => 'wpcom_has_goal_paid_subscribers',
 		),
-		'setup_newsletter' => array(
+		'setup_newsletter'                => array(
 			'id'                   => 'setup_newsletter',
 			'get_title'            => function () {
 				return __( 'Personalize newsletter', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
 		),
-		'set_up_payments' => array(
+		'set_up_payments'                 => array(
 			'get_title'            => function () {
 				return __( 'Set up payment method', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback'  => 'wpcom_has_goal_paid_subscribers',
 		),
-		'subscribers_added' => array(
+		'subscribers_added'               => array(
 			'get_title'            => function () {
 				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
 			},
@@ -118,7 +118,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Link in bio tasks.
-		'link_in_bio_launched' => array(
+		'link_in_bio_launched'            => array(
 			'get_title'             => function () {
 				return __( 'Launch your site', 'jetpack-mu-wpcom' );
 			},
@@ -126,7 +126,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_disabled_callback'  => 'wpcom_is_link_in_bio_launch_disabled',
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 		),
-		'links_added' => array(
+		'links_added'                     => array(
 			'get_title'             => function () {
 				return __( 'Add links', 'jetpack-mu-wpcom' );
 			},
@@ -135,7 +135,7 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
 			},
 		),
-		'setup_link_in_bio' => array(
+		'setup_link_in_bio'               => array(
 			'get_title'            => function () {
 				return __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' );
 			},
@@ -143,7 +143,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Videopress tasks.
-		'videopress_launched' => array(
+		'videopress_launched'             => array(
 			'id_map'                => 'site_launched',
 			'get_title'             => function () {
 				return __( 'Launch site', 'jetpack-mu-wpcom' );
@@ -151,13 +151,13 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_disabled_callback'  => 'wpcom_is_videopress_launch_disabled',
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 		),
-		'videopress_setup' => array(
+		'videopress_setup'                => array(
 			'get_title'            => function () {
 				return __( 'Set up your video site', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
 		),
-		'videopress_upload' => array(
+		'videopress_upload'               => array(
 			'id_map'                => 'video_uploaded',
 			'get_title'             => function () {
 				return __( 'Upload your first video', 'jetpack-mu-wpcom' );
@@ -169,14 +169,14 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Blog tasks.
-		'blog_launched' => array(
+		'blog_launched'                   => array(
 			'get_title'             => function () {
 				return __( 'Launch your blog', 'jetpack-mu-wpcom' );
 			},
 			'isLaunchTask'          => true,
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 		),
-		'setup_blog' => array(
+		'setup_blog'                      => array(
 			'get_title'            => function () {
 				return __( 'Name your blog', 'jetpack-mu-wpcom' );
 			},
@@ -184,7 +184,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Free plan tasks.
-		'setup_free' => array(
+		'setup_free'                      => array(
 			'get_title'            => function () {
 				return __( 'Personalize your site', 'jetpack-mu-wpcom' );
 			},
@@ -192,7 +192,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Write tasks.
-		'setup_write' => array(
+		'setup_write'                     => array(
 			'get_title'            => function () {
 				return __( 'Set up your site', 'jetpack-mu-wpcom' );
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1,0 +1,495 @@
+<?php
+/**
+ * Launchpad: Task definitions and helpers
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Get the task definitions for the Launchpad.
+ * 
+ * @return array
+ */
+function wpcom_launchpad_get_task_definitions() {
+	$task_definitions = array(
+		// Core tasks.
+		'design_edited' => array(
+			'get_title'             => function () {
+				return __( 'Edit site design', 'jetpack-mu-wpcom' );
+			},
+			'id_map'                => 'site_edited',
+			'add_listener_callback' => function () {
+				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
+			},
+		),
+		'design_selected' => array(
+			'get_title'            => function () {
+				return __( 'Select a design', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => '__return_true',
+			'is_disabled_callback' => 'wpcom_is_design_step_enabled',
+		),
+		'domain_upsell' => array(
+			'id_map'               => 'domain_upsell_deferred',
+			'get_title'            => function () {
+				return __( 'Choose a domain', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_is_domain_upsell_completed',
+			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
+		),
+		'first_post_published' => array(
+			'get_title'            => function () {
+				return __( 'Write your first post', 'jetpack-mu-wpcom' );
+			},
+			'add_listener_callback' => function () {
+				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
+			}
+		),
+		'plan_completed' => array(
+			'get_title'            => function () {
+				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
+			},
+			'subtitle'             => 'wpcom_get_plan_completed_subtitle', // This callback doesn't seem to exist.
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
+		),
+		'plan_selected' => array(
+			'get_title'            => function () {
+				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
+			},
+			'subtitle'             => 'wpcom_get_plan_selected_subtitle',
+			'is_complete_callback' => '__return_true',
+			'badge_text_callback'  => 'wpcom_get_plan_selected_badge_text',
+		),
+		'setup_general' => array(
+			'get_title'            => function () {
+				return __( 'Set up your site', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => '__return_true',
+			'is_disabled_callback' => '__return_true',
+		),
+		'site_launched' => array(
+			'get_title'             => function () {
+				return __( 'Launch your site', 'jetpack-mu-wpcom' );
+			},
+			'isLaunchTask'          => true,
+			'add_listener_callback' => 'wpcom_add_site_launch_listener',
+		),
+		'verify_email' => array(
+			'get_title'            => function () {
+				return __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' );
+			},
+			'is_visible_callback'  => 'wpcom_launchpad_is_email_unverified',
+		),
+
+		// Newsletter tasks.
+		'first_post_published_newsletter' => array(
+			'id_map'                => 'first_post_published',
+			'get_title'             => function () {
+				return __( 'Start writing', 'jetpack-mu-wpcom' );
+			},
+			'add_listener_callback' => function () {
+				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
+			}
+		),
+		'newsletter_plan_created' => array(
+			'get_title'            => function () {
+				return __( 'Create paid Newsletter', 'jetpack-mu-wpcom' );
+			},
+			'is_visible_callback'  => 'wpcom_has_goal_paid_subscribers',
+		),
+		'setup_newsletter' => array(
+			'id'                   => 'setup_newsletter',
+			'get_title'            => function () {
+				return __( 'Personalize newsletter', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => '__return_true',
+		),
+		'set_up_payments' => array(
+			'get_title'            => function () {
+				return __( 'Set up payment method', 'jetpack-mu-wpcom' );
+			},
+			'is_visible_callback'  => 'wpcom_has_goal_paid_subscribers',
+		),
+		'subscribers_added' => array(
+			'get_title'            => function () {
+				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => '__return_true',
+		),
+
+		// Link in bio tasks.
+		'link_in_bio_launched' => array(
+			'get_title'             => function () {
+				return __( 'Launch your site', 'jetpack-mu-wpcom' );
+			},
+			'id_map'                => 'site_launched',
+			'is_disabled_callback'  => 'wpcom_is_link_in_bio_launch_disabled',
+			'add_listener_callback' => 'wpcom_add_site_launch_listener',
+		),
+		'links_added' => array(
+			'get_title'             => function () {
+				return __( 'Add links', 'jetpack-mu-wpcom' );
+			},
+			'id_map'                => 'links_edited',
+			'add_listener_callback' => function () {
+				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
+			},
+		),
+		'setup_link_in_bio' => array(
+			'get_title'            => function () {
+				return __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => '__return_true',
+		),
+
+		// Videopress tasks.
+		'videopress_launched' => array(
+			'id_map'                => 'site_launched',
+			'get_title'             => function () {
+				return __( 'Launch site', 'jetpack-mu-wpcom' );
+			},
+			'is_disabled_callback'  => 'wpcom_is_videopress_launch_disabled',
+			'add_listener_callback' => 'wpcom_add_site_launch_listener',
+		),
+		'videopress_setup' => array(
+			'get_title'            => function () {
+				return __( 'Set up your video site', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => '__return_true',
+		),
+		'videopress_upload' => array(
+			'id_map'                => 'video_uploaded',
+			'get_title'             => function () {
+				return __( 'Upload your first video', 'jetpack-mu-wpcom' );
+			},
+			'is_disabled_callback'  => 'wpcom_is_videopress_upload_disabled',
+			'add_listener_callback' => function () {
+				add_action( 'add_attachment', 'wpcom_track_video_uploaded_task' );
+			},
+		),
+
+		// Blog tasks.
+		'blog_launched' => array(
+			'get_title'             => function () {
+				return __( 'Launch your blog', 'jetpack-mu-wpcom' );
+			},
+			'isLaunchTask'          => true,
+			'add_listener_callback' => 'wpcom_add_site_launch_listener',
+		),
+		'setup_blog' => array(
+			'get_title'            => function () {
+				return __( 'Name your blog', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
+		),
+
+		// Free plan tasks.
+		'setup_free' => array(
+			'get_title'            => function () {
+				return __( 'Personalize your site', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => '__return_true',
+		),
+
+		// Write tasks.
+		'setup_write' => array(
+			'get_title'            => function () {
+				return __( 'Set up your site', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => '__return_true',
+			'is_disabled_callback' => '__return_true',
+		),
+
+		// @todo Add Keep Building tasks.
+	);
+
+	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );
+
+	return array_merge( $extended_task_definitions, $task_definitions );
+}
+
+/**
+ * Mark a task as complete.
+ * 
+ * @param string $task_id The task ID.
+ * @return bool True if the task was marked as complete, false otherwise.
+ */
+function wpcom_mark_launchpad_task_complete( $task_id ) {
+	$task_definitions = wpcom_launchpad_get_task_definitions();
+	
+	// If the task ID isn't defined, return false.
+	if ( ! isset( $task_definitions[ $task_id ] ) ) {
+		return false;
+	}
+ 
+	// If the task has an id_map, use that instead.
+	$key = $task_id;
+	if ( isset( $task_definitions[ $task_id ]['id_map'] ) ) {
+		$key = $task_definitions[ $task_id ]['id_map'];
+	}
+ 
+	$statuses         = get_option( 'launchpad_checklist_tasks_statuses', array() );
+	$statuses[ $key ] = true;
+	$result           = update_option( 'launchpad_checklist_tasks_statuses', $statuses );
+ 
+	// @todo: Add Tracks event for task completion.
+ 
+	return $result;
+}
+
+/**
+ * Initialize the Launchpad task listener callbacks.
+ * 
+ * @param array $task_definitions
+ */
+function wpcom_launchpad_init_listeners( $task_definitions ) {
+	foreach ( $task_definitions as $task_id => $task_definition ) {
+		if ( isset( $task_definition['add_listener_callback'] ) && is_callable( $task_definition['add_listener_callback'] ) ) {
+			$task_data = array_merge( $task_definition, array( 'id' => $task_id ) );
+			
+			try {
+				call_user_func( $task_definition['add_listener_callback'], $task_data ); // Current callbacks expect the built, registered task for the second parameter, which won't work in this case
+			} catch ( Throwable $throwable ) {
+				// @todo: Log error and continue
+			}
+		}
+	}
+}
+
+/**
+ * Initialize the Launchpad task definitions.
+ *
+ * @return void
+ */
+function wpcom_launchpad_init_task_definitions() {
+	$task_definitions = wpcom_launchpad_get_task_definitions();
+ 
+	wpcom_launchpad_init_listeners( $task_definitions );
+}
+add_action( 'init', 'wpcom_launchpad_init_task_definitions', 11 );
+
+/**
+ * Task callbacks.
+ */
+
+/**
+ * Marks a task as complete if it is active for this site. This is a bit of a hacky way to be able to share a callback
+ * among several tasks, calling several completion IDs from the same callback.
+ *
+ * @param string $task_id The task ID.
+ * @return bool True if successful, false if not.
+ */
+function wpcom_mark_launchpad_task_complete_if_active( $task_id ) {
+	return wpcom_launchpad_checklists()->mark_task_complete_if_active( $task_id );
+}
+
+/**
+ * Callback for completing edit site task.
+ *
+ * @return void
+ */
+function wpcom_track_edit_site_task() {
+	wpcom_mark_launchpad_task_complete_if_active( 'links_added' );
+	wpcom_mark_launchpad_task_complete_if_active( 'design_edited' );
+}
+
+/**
+ * Callback for design task enabled state
+ *
+ * @return boolean
+ */
+function wpcom_is_design_step_enabled() {
+	return ! wpcom_can_update_design_selected_task();
+}
+
+/**
+ * Determines whether or not domain upsell task is completed.
+ *
+ * @param array $task    The Task object.
+ * @param mixed $default The default value.
+ * @return bool True if domain upsell task is completed.
+ */
+function wpcom_is_domain_upsell_completed( $task, $default ) {
+	if ( wpcom_site_has_feature( 'custom-domain' ) ) {
+		return true;
+	}
+	return $default;
+}
+
+/**
+ * Returns the badge text for the domain upsell task
+ *
+ * @return string Badge text
+ */
+function wpcom_get_domain_upsell_badge_text() {
+	// Never run `wpcom_is_checklist_task_complete` within a is_complete_callback unless you are fond of infinite loops.
+	return wpcom_is_checklist_task_complete( 'domain_upsell' ) ? '' : __( 'Upgrade plan', 'jetpack-mu-wpcom' );
+}
+
+/**
+ * Callback for completing first post published task.
+ *
+ * @return void
+ */
+function wpcom_track_publish_first_post_task() {
+	// Ensure that Headstart posts don't mark this as complete
+	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+		return;
+	}
+	// Since we share the same callback for generic first post and newsletter-specific, we mark both.
+	wpcom_mark_launchpad_task_complete_if_active( 'first_post_published' );
+	wpcom_mark_launchpad_task_complete_if_active( 'first_post_published_newsletter' );
+}
+
+/**
+ * Returns the option value for a task and false if no option exists.
+ *
+ * @param array $task The Task object.
+ * @return bool True if the blog was named.
+ */
+function wpcom_is_task_option_completed( $task ) {
+	$checklist = get_option( 'launchpad_checklist_tasks_statuses', array() );
+	if ( ! empty( $checklist[ $task['id'] ] ) ) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Returns the subtitle for the plan selected task
+ *
+ * @return string Subtitle text
+ */
+function wpcom_get_plan_selected_subtitle() {
+	if ( ! function_exists( 'wpcom_global_styles_in_use' ) || ! function_exists( 'wpcom_should_limit_global_styles' ) ) {
+		return '';
+	}
+
+	return wpcom_global_styles_in_use() && wpcom_should_limit_global_styles()
+		? __(
+			'Your site contains custom styles. Upgrade now to publish them and unlock tons of other features.',
+			'jetpack-mu-wpcom'
+		) : '';
+}
+
+/**
+ * Returns the badge text for the plan selected task
+ *
+ * @return string Badge text
+ */
+function wpcom_get_plan_selected_badge_text() {
+	if ( ! function_exists( 'wpcom_global_styles_in_use' ) || ! function_exists( 'wpcom_should_limit_global_styles' ) ) {
+		return '';
+	}
+
+	return wpcom_global_styles_in_use() && wpcom_should_limit_global_styles() ? __( 'Upgrade plan', 'jetpack-mu-wpcom' ) : '';
+}
+
+/**
+ * Callback for completing site launched task.
+ *
+ * @return void
+ */
+function wpcom_track_site_launch_task() {
+	// it would be ideal if the registry was smart enough to map based on id_map but it isn't.
+	// So we mark them all. We'd avoid this if we had dedicated callbacks for each task.
+	wpcom_mark_launchpad_task_complete_if_active( 'site_launched' );
+	wpcom_mark_launchpad_task_complete_if_active( 'link_in_bio_launched' );
+	wpcom_mark_launchpad_task_complete_if_active( 'videopress_launched' );
+	wpcom_mark_launchpad_task_complete_if_active( 'blog_launched' );
+}
+
+/**
+ * Callback that conditionally adds the site launch listener based on platform.
+ *
+ * @return void
+ */
+function wpcom_add_site_launch_listener() {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		add_action( 'wpcom_site_launched', 'wpcom_track_site_launch_task' );
+	} else {
+		add_action( 'update_option_blog_public', 'wpcom_launch_task_listener_atomic', 10, 2 );
+	}
+}
+
+/**
+ * Callback that fires when `blog_public` is updated.
+ *
+ * @param string $old_value The updated option value.
+ * @param string $new_value The previous option value.
+ * @return void
+ */
+function wpcom_launch_task_listener_atomic( $old_value, $new_value ) {
+	$blog_public = (int) $new_value;
+	// 'blog_public' is set to '1' when a site is launched.
+	if ( $blog_public === 1 ) {
+		wpcom_track_site_launch_task();
+	}
+}
+
+/**
+ * Callback for email verification visibility.
+ *
+ * @return bool True if email is unverified, false otherwise.
+ */
+function wpcom_launchpad_is_email_unverified() {
+	// TODO: handle the edge case where an Atomic user can be unverified.
+	if ( ! class_exists( 'Email_Verification' ) ) {
+		return false;
+	}
+
+	return Email_Verification::is_email_unverified();
+}
+
+/**
+ * If the site has a paid-subscriber goal.
+ *
+ * @return bool True if the site has a paid-subscriber goal, false otherwise.
+ */
+function wpcom_has_goal_paid_subscribers() {
+	return in_array( 'paid-subscribers', get_option( 'site_goals', array() ), true );
+}
+
+/**
+ * Determines whether or not the link-in-bio launch task is enabled
+ *
+ * @return boolean True if link-in-bio launch task is enabled
+ */
+function wpcom_is_link_in_bio_launch_disabled() {
+	return ! wpcom_is_checklist_task_complete( 'links_added' );
+}
+
+/**
+ * Determines whether or not the videopress launch task is enabled
+ *
+ * @return boolean True if videopress launch task is enabled
+ */
+function wpcom_is_videopress_launch_disabled() {
+	return ! wpcom_is_checklist_task_complete( 'videopress_upload' );
+}
+
+/**
+ * Determines whether or not the videopress upload task is enabled
+ *
+ * @return boolean True if videopress upload task is enabled
+ */
+function wpcom_is_videopress_upload_disabled() {
+	return wpcom_is_checklist_task_complete( 'videopress_upload' );
+}
+
+/**
+ * Update Launchpad's video_uploaded task.
+ *
+ * Only updated for videopress flows currently.
+ *
+ * @param string $post_id The id of the post being udpated.
+ * @return void
+ */
+function wpcom_track_video_uploaded_task( $post_id ) {
+	// Not using `wp_attachment_is` because it requires the actual file
+	// which is not the case for Atomic VideoPress.
+	if ( 0 !== strpos( get_post_mime_type( $post_id ), 'video/' ) ) {
+		return;
+	}
+	wpcom_mark_launchpad_task_complete( 'videopress_upload' );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -25,8 +25,8 @@ require_once __DIR__ . '/launchpad-task-definitions.php';
 function wpcom_launchpad_get_task_list_definitions() {
 	$core_task_list_definitions = array(
 		'build'           => array(
-			'title'    => 'Build',
-			'task_ids' => array(
+			'title'               => 'Build',
+			'task_ids'            => array(
 				'setup_general',
 				'design_selected',
 				'plan_selected',
@@ -34,10 +34,11 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'design_edited',
 				'site_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'free'            => array(
-			'title'    => 'Free',
-			'task_ids' => array(
+			'title'               => 'Free',
+			'task_ids'            => array(
 				'plan_selected',
 				'setup_free',
 				'design_selected',
@@ -46,30 +47,33 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'design_edited',
 				'site_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'link-in-bio'     => array(
-			'title'    => 'Link In Bio',
-			'task_ids' => array(
+			'title'               => 'Link In Bio',
+			'task_ids'            => array(
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
 				'links_added',
 				'link_in_bio_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'link-in-bio-tld' => array(
-			'title'    => 'Link In Bio',
-			'task_ids' => array(
+			'title'               => 'Link In Bio',
+			'task_ids'            => array(
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
 				'links_added',
 				'link_in_bio_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'newsletter'      => array(
-			'title'    => 'Newsletter',
-			'task_ids' => array(
+			'title'               => 'Newsletter',
+			'task_ids'            => array(
 				'setup_newsletter',
 				'plan_selected',
 				'subscribers_added',
@@ -78,39 +82,43 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'newsletter_plan_created',
 				'first_post_published_newsletter',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'videopress'      => array(
-			'title'    => 'Videopress',
-			'task_ids' => array(
+			'title'               => 'Videopress',
+			'task_ids'            => array(
 				'videopress_setup',
 				'plan_selected',
 				'videopress_upload',
 				'videopress_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'write'           => array(
-			'title'    => 'Write',
-			'task_ids' => array(
+			'title'               => 'Write',
+			'task_ids'            => array(
 				'setup_write',
 				'design_selected',
 				'plan_selected',
 				'first_post_published',
 				'site_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'start-writing'   => array(
-			'title'    => 'Start Writing',
-			'task_ids' => array(
+			'title'               => 'Start Writing',
+			'task_ids'            => array(
 				'first_post_published',
 				'setup_blog',
 				'domain_upsell',
 				'plan_completed',
 				'blog_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'design-first'    => array(
-			'title'    => 'Pick a Design',
-			'task_ids' => array(
+			'title'               => 'Pick a Design',
+			'task_ids'            => array(
 				'design_selected',
 				'setup_blog',
 				'domain_upsell',
@@ -118,6 +126,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'first_post_published',
 				'blog_launched',
 			),
+			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'keep-building'   => array(
 			'title'               => 'Keep Building',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -136,33 +136,26 @@ function wpcom_launchpad_get_task_list_definitions() {
 }
 
 /**
- * Get a task list, falling back to site_intent option if no checklist slug is provided.
+ * Get a registered task list.
  *
- * @param string $checklist_slug
+ * @param string $checklist_slug The checklist slug to get the task list for.
  *
  * @return array
  */
 function wpcom_launchpad_get_task_list( $checklist_slug = null ) {
-	$task_list_definitions = wpcom_launchpad_get_task_list_definitions();
-
-	// If we don't have a checklist slug, fall back to the site intent.
+	// If we don't have a checklist slug, fall back to the site intent option.
 	$checklist_slug = $checklist_slug ? $checklist_slug : get_option( 'site_intent' );
 	if ( ! $checklist_slug ) {
 		return array();
 	}
 
-	// If the checklist slug isn't defined, return an empty array.
-	if ( ! isset( $task_list_definitions[ $checklist_slug ] ) ) {
-		return array();
-	}
-
-	return $task_list_definitions[ $checklist_slug ];
+	return wpcom_launchpad_checklists()->get_task_list( $checklist_slug);
 }
 
 /**
  * Register all tasks and task lists from definitions
  *
- * @param bool $rebuild Whether to rebuild the task lists or not
+ * @param bool $rebuild Whether to rebuild the task lists or not.
  *
  * @return array
  */
@@ -192,6 +185,11 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
 	return wpcom_launchpad_checklists()->get_all_task_lists();
 }
 
+/**
+ * Load all registered task lists on init.
+ *
+ * @return null
+ */
 function wpcom_register_default_launchpad_checklists() {
 	wpcom_launchpad_get_task_lists();
 	wpcom_add_active_task_listener_hooks_to_correct_action();

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -24,7 +24,7 @@ require_once __DIR__ . '/launchpad-task-definitions.php';
  */
 function wpcom_launchpad_get_task_list_definitions() {
 	$core_task_list_definitions = array(
-		'build'          => array(
+		'build'           => array(
 			'title'    => 'Build',
 			'task_ids' => array(
 				'setup_general',
@@ -35,7 +35,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'site_launched',
 			),
 		),
-		'free'           => array(
+		'free'            => array(
 			'title'    => 'Free',
 			'task_ids' => array(
 				'plan_selected',
@@ -47,7 +47,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'site_launched',
 			),
 		),
-		'link-in-bio'    => array(
+		'link-in-bio'     => array(
 			'title'    => 'Link In Bio',
 			'task_ids' => array(
 				'design_selected',
@@ -67,7 +67,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'link_in_bio_launched',
 			),
 		),
-		'newsletter'     => array(
+		'newsletter'      => array(
 			'title'    => 'Newsletter',
 			'task_ids' => array(
 				'setup_newsletter',
@@ -79,7 +79,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'first_post_published_newsletter',
 			),
 		),
-		'videopress'     => array(
+		'videopress'      => array(
 			'title'    => 'Videopress',
 			'task_ids' => array(
 				'videopress_setup',
@@ -88,7 +88,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'videopress_launched',
 			),
 		),
-		'write'          => array(
+		'write'           => array(
 			'title'    => 'Write',
 			'task_ids' => array(
 				'setup_write',
@@ -98,7 +98,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'site_launched',
 			),
 		),
-		'start-writing'  => array(
+		'start-writing'   => array(
 			'title'    => 'Start Writing',
 			'task_ids' => array(
 				'first_post_published',
@@ -108,7 +108,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'blog_launched',
 			),
 		),
-		'design-first'   => array(
+		'design-first'    => array(
 			'title'    => 'Pick a Design',
 			'task_ids' => array(
 				'design_selected',
@@ -119,7 +119,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'blog_launched',
 			),
 		),
-		'keep-building' => array(
+		'keep-building'   => array(
 			'title'               => 'Keep Building',
 			'task_ids'            => array(
 				'design_edited',
@@ -149,7 +149,7 @@ function wpcom_launchpad_get_task_list( $checklist_slug = null ) {
 		return array();
 	}
 
-	return wpcom_launchpad_checklists()->get_task_list( $checklist_slug);
+	return wpcom_launchpad_checklists()->get_task_list( $checklist_slug );
 }
 
 /**
@@ -167,7 +167,7 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
 
 	$task_definitions = wpcom_launchpad_get_task_definitions();
 
-	// Register all tasks
+	// Register all tasks.
 	foreach ( $task_definitions as $task_id => $task_definition ) {
 		$task_data = array_merge( $task_definition, array( 'id' => $task_id ) );
 		wpcom_register_launchpad_task( $task_data );
@@ -175,20 +175,18 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
 
 	$task_list_definitions = wpcom_launchpad_get_task_list_definitions();
 
-	// Register all task lists
+	// Register all task lists.
 	foreach ( $task_list_definitions as $task_list_id => $task_list_definition ) {
 		$task_list_data = array_merge( $task_list_definition, array( 'id' => $task_list_id ) );
 		wpcom_register_launchpad_task_list( $task_list_data );
 	}
 
-	// Assuming the reference is good, just return all checklists
+	// Assuming the reference is good, just return all checklists.
 	return wpcom_launchpad_checklists()->get_all_task_lists();
 }
 
 /**
- * Load all registered task lists on init.
- *
- * @return null
+ * Register all tasks and task lists on init.
  */
 function wpcom_register_default_launchpad_checklists() {
 	wpcom_launchpad_get_task_lists();

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -18,283 +18,14 @@ require_once __DIR__ . '/class-launchpad-task-lists.php';
 
 /**
  * Registers all default launchpad checklists
+ * 
+ * @return array
  */
-function wpcom_register_default_launchpad_checklists() {
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'setup_newsletter',
-			'get_title'            => function () {
-				return __( 'Personalize newsletter', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'plan_selected',
-			'get_title'            => function () {
-				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
-			},
-			'subtitle'             => 'wpcom_get_plan_selected_subtitle',
-			'is_complete_callback' => '__return_true',
-			'badge_text_callback'  => 'wpcom_get_plan_selected_badge_text',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'plan_completed',
-			'get_title'            => function () {
-				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
-			},
-			'subtitle'             => 'wpcom_get_plan_completed_subtitle',
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'subscribers_added',
-			'get_title'            => function () {
-				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                    => 'first_post_published',
-			'get_title'             => function () {
-				return __( 'Write your first post', 'jetpack-mu-wpcom' );
-			},
-			'add_listener_callback' => function () {
-				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
-			},
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                    => 'first_post_published_newsletter',
-			'id_map'                => 'first_post_published',
-			'get_title'             => function () {
-				return __( 'Start writing', 'jetpack-mu-wpcom' );
-			},
-			'add_listener_callback' => function () {
-				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
-			},
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'design_selected',
-			'get_title'            => function () {
-				return __( 'Select a design', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-			'is_disabled_callback' => 'wpcom_is_design_step_enabled',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'setup_link_in_bio',
-			'get_title'            => function () {
-				return __( 'Personalize Link in Bio', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                    => 'links_added',
-			'id_map'                => 'links_edited',
-			'get_title'             => function () {
-				return __( 'Add links', 'jetpack-mu-wpcom' );
-			},
-			'add_listener_callback' => function () {
-				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
-			},
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                    => 'link_in_bio_launched',
-			'id_map'                => 'site_launched',
-			'get_title'             => function () {
-				return __( 'Launch your site', 'jetpack-mu-wpcom' );
-			},
-			'is_disabled_callback'  => 'wpcom_is_link_in_bio_launch_disabled',
-			'add_listener_callback' => 'wpcom_add_site_launch_listener',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'videopress_setup',
-			'get_title'            => function () {
-				return __( 'Set up your video site', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                    => 'videopress_upload',
-			'id_map'                => 'video_uploaded',
-			'get_title'             => function () {
-				return __( 'Upload your first video', 'jetpack-mu-wpcom' );
-			},
-			'is_disabled_callback'  => 'wpcom_is_videopress_upload_disabled',
-			'add_listener_callback' => function () {
-				add_action( 'add_attachment', 'wpcom_track_video_uploaded_task' );
-			},
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                    => 'videopress_launched',
-			'id_map'                => 'site_launched',
-			'get_title'             => function () {
-				return __( 'Launch site', 'jetpack-mu-wpcom' );
-			},
-			'is_disabled_callback'  => 'wpcom_is_videopress_launch_disabled',
-			'add_listener_callback' => 'wpcom_add_site_launch_listener',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'setup_free',
-			'get_title'            => function () {
-				return __( 'Personalize your site', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'setup_blog',
-			'get_title'            => function () {
-				return __( 'Name your blog', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'setup_general',
-			'get_title'            => function () {
-				return __( 'Set up your site', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-			'is_disabled_callback' => '__return_true',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                    => 'design_edited',
-			'get_title'             => function () {
-				return __( 'Edit site design', 'jetpack-mu-wpcom' );
-			},
-			'id_map'                => 'site_edited',
-			'add_listener_callback' => function () {
-				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
-			},
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                    => 'site_launched',
-			'get_title'             => function () {
-				return __( 'Launch your site', 'jetpack-mu-wpcom' );
-			},
-			'isLaunchTask'          => true,
-			'add_listener_callback' => 'wpcom_add_site_launch_listener',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                    => 'blog_launched',
-			'get_title'             => function () {
-				return __( 'Launch your blog', 'jetpack-mu-wpcom' );
-			},
-			'isLaunchTask'          => true,
-			'add_listener_callback' => 'wpcom_add_site_launch_listener',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'setup_write',
-			'get_title'            => function () {
-				return __( 'Set up your site', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => '__return_true',
-			'is_disabled_callback' => '__return_true',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                   => 'domain_upsell',
-			'id_map'               => 'domain_upsell_deferred',
-			'get_title'            => function () {
-				return __( 'Choose a domain', 'jetpack-mu-wpcom' );
-			},
-			'is_complete_callback' => 'wpcom_is_domain_upsell_completed',
-			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                  => 'verify_email',
-			'get_title'           => function () {
-				return __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' );
-			},
-			'is_visible_callback' => 'wpcom_launchpad_is_email_unverified',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                  => 'set_up_payments',
-			'get_title'           => function () {
-				return __( 'Set up payment method', 'jetpack-mu-wpcom' );
-			},
-			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
-		)
-	);
-
-	wpcom_register_launchpad_task(
-		array(
-			'id'                  => 'newsletter_plan_created',
-			'get_title'           => function () {
-				return __( 'Create paid Newsletter', 'jetpack-mu-wpcom' );
-			},
-			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
-		)
-	);
-
-	// Tasks registered, now onto the checklists.
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'                  => 'build',
-			'title'               => 'Build',
-			'task_ids'            => array(
+function wpcom_launchpad_get_task_list_definitions() {
+	$core_task_list_definitions = array(
+		'build' => array(
+			'title'    => 'Build',
+			'task_ids' => array(
 				'setup_general',
 				'design_selected',
 				'plan_selected',
@@ -302,15 +33,10 @@ function wpcom_register_default_launchpad_checklists() {
 				'design_edited',
 				'site_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
-		)
-	);
-
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'                  => 'free',
-			'title'               => 'Free',
-			'task_ids'            => array(
+		),
+		'free' => array(
+			'title'    => 'Free',
+			'task_ids' => array(
 				'plan_selected',
 				'setup_free',
 				'design_selected',
@@ -319,45 +45,30 @@ function wpcom_register_default_launchpad_checklists() {
 				'design_edited',
 				'site_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
-		)
-	);
-
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'                  => 'link-in-bio',
-			'title'               => 'Link In Bio',
-			'task_ids'            => array(
+		),
+		'link-in-bio' => array(
+			'title'    => 'Link In Bio',
+			'task_ids' => array(
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
 				'links_added',
 				'link_in_bio_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
-		)
-	);
-
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'                  => 'link-in-bio-tld',
-			'title'               => 'Link In Bio',
-			'task_ids'            => array(
+		),
+		'link-in-bio-tld' => array(
+			'title'    => 'Link In Bio',
+			'task_ids' => array(
 				'design_selected',
 				'setup_link_in_bio',
 				'plan_selected',
 				'links_added',
 				'link_in_bio_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
-		)
-	);
-
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'                  => 'newsletter',
-			'title'               => 'Newsletter',
-			'task_ids'            => array(
+		),
+		'newsletter' => array(
+			'title'    => 'Newsletter',
+			'task_ids' => array(
 				'setup_newsletter',
 				'plan_selected',
 				'subscribers_added',
@@ -366,42 +77,27 @@ function wpcom_register_default_launchpad_checklists() {
 				'newsletter_plan_created',
 				'first_post_published_newsletter',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
-		)
-	);
-
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'                  => 'videopress',
-			'title'               => 'Videopress',
-			'task_ids'            => array(
+		),
+		'videopress' => array(
+			'title'    => 'Videopress',
+			'task_ids' => array(
 				'videopress_setup',
 				'plan_selected',
 				'videopress_upload',
 				'videopress_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
-		)
-	);
-
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'                  => 'write',
-			'title'               => 'Write',
-			'task_ids'            => array(
+		),
+		'write' => array(
+			'title'    => 'Write',
+			'task_ids' => array(
 				'setup_write',
 				'design_selected',
 				'plan_selected',
 				'first_post_published',
 				'site_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
-		)
-	);
-
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'       => 'start-writing',
+		),
+		'start-writing' => array(
 			'title'    => 'Start Writing',
 			'task_ids' => array(
 				'first_post_published',
@@ -410,14 +106,10 @@ function wpcom_register_default_launchpad_checklists() {
 				'plan_completed',
 				'blog_launched',
 			),
-		)
-	);
-
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'                  => 'design-first',
-			'title'               => 'Pick a Design',
-			'task_ids'            => array(
+		),
+		'design-first' => array(
+			'title'    => 'Pick a Design',
+			'task_ids' => array(
 				'design_selected',
 				'setup_blog',
 				'domain_upsell',
@@ -425,29 +117,85 @@ function wpcom_register_default_launchpad_checklists() {
 				'first_post_published',
 				'blog_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
-		)
-	);
-
-	wpcom_register_launchpad_task_list(
-		array(
-			'id'                  => 'keep-building',
+		),
+		'keep-building' => array(
 			'title'               => 'Keep Building',
 			'task_ids'            => array(
 				'design_edited',
 				// @todo Add more tasks here!
 			),
-			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
-		)
+			'is_enabled_callback' => '__return_false',
+		),
 	);
-
-	// This is the hook that allows other plugins to register their own checklists.
-	do_action( 'wpcom_register_launchpad_tasks' );
-
-	wpcom_add_active_task_listener_hooks_to_correct_action();
+ 
+	$extended_task_list_definitions = apply_filters( 'wpcom_launchpad_extended_task_list_definitions', array() );
+ 
+	// As for tasks, we can decide what overrides we allow later.
+	return array_merge( $extended_task_list_definitions, $core_task_list_definitions );
 }
 
-// Running on priority 11 will allow anything that adds hooks on init with default priority 10 to add their hooks to the `wpcom_register_launchpad_tasks` action.
+/**
+ * Get a task list, falling back to site_intent option if no checklist slug is provided.
+ * 
+ * @param string $checklist_slug
+ * 
+ * @return array
+ */
+function wpcom_launchpad_get_task_list( $checklist_slug = null ) {
+	$task_list_definitions = wpcom_launchpad_get_task_list_definitions();
+	
+	// If we don't have a checklist slug, fall back to the site intent.
+	$checklist_slug = $checklist_slug ? $checklist_slug : get_option( 'site_intent' );
+	if ( ! $checklist_slug ) {
+		return array();
+	}
+
+	// If the checklist slug isn't defined, return an empty array.
+	if ( ! isset( $task_list_definitions[ $checklist_slug ] ) ) {
+		return array();
+	}
+
+	return $task_list_definitions[ $checklist_slug ];
+}
+
+/**
+ * Register all tasks and task lists from definitions
+ * 
+ * @param bool $rebuild Whether to rebuild the task lists or not
+ * 
+ * @return array
+ */
+function wpcom_launchpad_get_task_lists( $rebuild = false ) {
+	// If we already have task lists registered and we don't want to rebuild, return all task lists.
+	if ( ! $rebuild && $launchpad_instance->has_task_lists() ) {
+		return wpcom_launchpad_checklists()->get_all_task_lists();
+	}
+
+	require_once( dirname( __FILE__ ) . '/launchpad-task-definitions.php' );
+ 
+	$task_definitions = wpcom_launchpad_get_task_definitions();
+ 
+	// Register all tasks
+	foreach ( $task_definitions as $task_id => $task_definition ) {
+		$task_data = array_merge( $task_definition, array( 'id' => $task_id ) );
+		wpcom_register_launchpad_task( $task_data );
+	}
+ 
+	$task_list_definitions = wpcom_launchpad_get_task_list_definitions();
+ 
+	// Register all task lists
+	foreach ( $task_list_definitions as $task_list_id => $task_list_definition ) {
+		$task_list_data = array_merge( $task_list_definition, array( 'id' => $task_list_id ) );
+		wpcom_register_launchpad_task_list( $task_list_data );
+	}
+ 
+	// Assuming the reference is good, just return all checklists
+	return wpcom_launchpad_checklists()->get_all_task_lists();
+}
+
+function wpcom_register_default_launchpad_checklists() {
+	wpcom_add_active_task_listener_hooks_to_correct_action();
+}
 add_action( 'init', 'wpcom_register_default_launchpad_checklists', 11 );
 
 /**
@@ -476,33 +224,6 @@ function wpcom_launchpad_add_active_task_listeners() {
 }
 
 /**
- * Determines whether or not the videopress upload task is enabled
- *
- * @return boolean True if videopress upload task is enabled
- */
-function wpcom_is_videopress_upload_disabled() {
-	return wpcom_is_checklist_task_complete( 'videopress_upload' );
-}
-
-/**
- * Determines whether or not the videopress launch task is enabled
- *
- * @return boolean True if videopress launch task is enabled
- */
-function wpcom_is_videopress_launch_disabled() {
-	return ! wpcom_is_checklist_task_complete( 'videopress_upload' );
-}
-
-/**
- * Determines whether or not the link-in-bio launch task is enabled
- *
- * @return boolean True if link-in-bio launch task is enabled
- */
-function wpcom_is_link_in_bio_launch_disabled() {
-	return ! wpcom_is_checklist_task_complete( 'links_added' );
-}
-
-/**
  * Determines whether or not design selected task is enabled
  *
  * @return boolean True if design selected task is enabled
@@ -510,83 +231,6 @@ function wpcom_is_link_in_bio_launch_disabled() {
 function wpcom_can_update_design_selected_task() {
 	$site_intent = get_option( 'site_intent' );
 	return $site_intent === 'free' || $site_intent === 'build' || $site_intent === 'write' || $site_intent === 'design-first';
-}
-
-/**
- * Callback for design task enabled state
- *
- * @return boolean
- */
-function wpcom_is_design_step_enabled() {
-	return ! wpcom_can_update_design_selected_task();
-}
-
-/**
- * Determines whether or not domain upsell task is completed.
- *
- * @param array $task    The Task object.
- * @param mixed $default The default value.
- * @return bool True if domain upsell task is completed.
- */
-function wpcom_is_domain_upsell_completed( $task, $default ) {
-	if ( wpcom_site_has_feature( 'custom-domain' ) ) {
-		return true;
-	}
-	return $default;
-}
-
-/**
- * Returns the option value for a task and false if no option exists.
- *
- * @param array $task The Task object.
- * @return bool True if the blog was named.
- */
-function wpcom_is_task_option_completed( $task ) {
-	$checklist = get_option( 'launchpad_checklist_tasks_statuses', array() );
-	if ( ! empty( $checklist[ $task['id'] ] ) ) {
-		return true;
-	}
-	return false;
-}
-
-/**
- * Returns the subtitle for the plan selected task
- *
- * @return string Subtitle text
- */
-function wpcom_get_plan_selected_subtitle() {
-	if ( ! function_exists( 'wpcom_global_styles_in_use' ) || ! function_exists( 'wpcom_should_limit_global_styles' ) ) {
-		return '';
-	}
-
-	return wpcom_global_styles_in_use() && wpcom_should_limit_global_styles()
-		? __(
-			'Your site contains custom styles. Upgrade now to publish them and unlock tons of other features.',
-			'jetpack-mu-wpcom'
-		) : '';
-}
-
-/**
- * Returns the badge text for the plan selected task
- *
- * @return string Badge text
- */
-function wpcom_get_plan_selected_badge_text() {
-	if ( ! function_exists( 'wpcom_global_styles_in_use' ) || ! function_exists( 'wpcom_should_limit_global_styles' ) ) {
-		return '';
-	}
-
-	return wpcom_global_styles_in_use() && wpcom_should_limit_global_styles() ? __( 'Upgrade plan', 'jetpack-mu-wpcom' ) : '';
-}
-
-/**
- * Returns the badge text for the domain upsell task
- *
- * @return string Badge text
- */
-function wpcom_get_domain_upsell_badge_text() {
-	// Never run `wpcom_is_checklist_task_complete` within a is_complete_callback unless you are fond of infinite loops.
-	return wpcom_is_checklist_task_complete( 'domain_upsell' ) ? '' : __( 'Upgrade plan', 'jetpack-mu-wpcom' );
 }
 
 /**
@@ -651,119 +295,12 @@ function wpcom_register_launchpad_task( $task ) {
 }
 
 /**
- * Marks a task as complete.
- *
- * @param string $task_id The task ID.
- * @return bool True if successful, false if not.
- */
-function wpcom_mark_launchpad_task_complete( $task_id ) {
-	return wpcom_launchpad_checklists()->mark_task_complete( $task_id );
-}
-
-/**
- * Marks a task as complete if it is active for this site. This is a bit of a hacky way to be able to share a callback
- * among several tasks, calling several completion IDs from the same callback.
- *
- * @param string $task_id The task ID.
- * @return bool True if successful, false if not.
- */
-function wpcom_mark_launchpad_task_complete_if_active( $task_id ) {
-	return wpcom_launchpad_checklists()->mark_task_complete_if_active( $task_id );
-}
-
-/**
  * Helper function to return a `Launchpad_Task_Lists` instance.
  *
  * @return object Launchpad_Task_Lists instance.
  */
 function wpcom_launchpad_checklists() {
 	return Launchpad_Task_Lists::get_instance();
-}
-
-/*** Update logic callbacks  ***/
-
-/**
- * Callback for completing first post published task.
- *
- * @return void
- */
-function wpcom_track_publish_first_post_task() {
-	// Ensure that Headstart posts don't mark this as complete
-	if ( defined( 'HEADSTART' ) && HEADSTART ) {
-		return;
-	}
-	// Since we share the same callback for generic first post and newsletter-specific, we mark both.
-	wpcom_mark_launchpad_task_complete_if_active( 'first_post_published' );
-	wpcom_mark_launchpad_task_complete_if_active( 'first_post_published_newsletter' );
-}
-
-/**
- * Callback for completing edit site task.
- *
- * @return void
- */
-function wpcom_track_edit_site_task() {
-	wpcom_mark_launchpad_task_complete_if_active( 'links_added' );
-	wpcom_mark_launchpad_task_complete_if_active( 'design_edited' );
-}
-
-/**
- * Callback that conditionally adds the site launch listener based on platform.
- *
- * @return void
- */
-function wpcom_add_site_launch_listener() {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		add_action( 'wpcom_site_launched', 'wpcom_track_site_launch_task' );
-	} else {
-		add_action( 'update_option_blog_public', 'wpcom_launch_task_listener_atomic', 10, 2 );
-	}
-}
-
-/**
- * Callback that fires when `blog_public` is updated.
- *
- * @param string $old_value The updated option value.
- * @param string $new_value The previous option value.
- * @return void
- */
-function wpcom_launch_task_listener_atomic( $old_value, $new_value ) {
-	$blog_public = (int) $new_value;
-	// 'blog_public' is set to '1' when a site is launched.
-	if ( $blog_public === 1 ) {
-		wpcom_track_site_launch_task();
-	}
-}
-
-/**
- * Callback for completing site launched task.
- *
- * @return void
- */
-function wpcom_track_site_launch_task() {
-	// it would be ideal if the registry was smart enough to map based on id_map but it isn't.
-	// So we mark them all. We'd avoid this if we had dedicated callbacks for each task.
-	wpcom_mark_launchpad_task_complete_if_active( 'site_launched' );
-	wpcom_mark_launchpad_task_complete_if_active( 'link_in_bio_launched' );
-	wpcom_mark_launchpad_task_complete_if_active( 'videopress_launched' );
-	wpcom_mark_launchpad_task_complete_if_active( 'blog_launched' );
-}
-
-/**
- * Update Launchpad's video_uploaded task.
- *
- * Only updated for videopress flows currently.
- *
- * @param string $post_id The id of the post being udpated.
- * @return void
- */
-function wpcom_track_video_uploaded_task( $post_id ) {
-	// Not using `wp_attachment_is` because it requires the actual file
-	// which is not the case for Atomic VideoPress.
-	if ( 0 !== strpos( get_post_mime_type( $post_id ), 'video/' ) ) {
-		return;
-	}
-	wpcom_mark_launchpad_task_complete( 'videopress_upload' );
 }
 
 /**
@@ -788,29 +325,6 @@ function wpcom_hacky_track_video_uploaded_task( $post_id ) {
 	wpcom_track_video_uploaded_task( $post_id );
 }
 add_action( 'add_attachment', 'wpcom_hacky_track_video_uploaded_task' );
-
-/**
- * Callback for email verification visibility.
- *
- * @return bool True if email is unverified, false otherwise.
- */
-function wpcom_launchpad_is_email_unverified() {
-	// TODO: handle the edge case where an Atomic user can be unverified.
-	if ( ! class_exists( 'Email_Verification' ) ) {
-		return false;
-	}
-
-	return Email_Verification::is_email_unverified();
-}
-
-/**
- * If the site has a paid-subscriber goal.
- *
- * @return bool True if the site has a paid-subscriber goal, false otherwise.
- */
-function wpcom_has_goal_paid_subscribers() {
-	return in_array( 'paid-subscribers', get_option( 'site_goals', array() ), true );
-}
 
 //
 // Misc other Launchpad-related functionality below.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -194,6 +194,7 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
 }
 
 function wpcom_register_default_launchpad_checklists() {
+	wpcom_launchpad_get_task_lists();
 	wpcom_add_active_task_listener_hooks_to_correct_action();
 }
 add_action( 'init', 'wpcom_register_default_launchpad_checklists', 11 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -134,7 +134,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'design_edited',
 				// @todo Add more tasks here!
 			),
-			'is_enabled_callback' => '__return_false',
+			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -24,7 +24,7 @@ require_once __DIR__ . '/launchpad-task-definitions.php';
  */
 function wpcom_launchpad_get_task_list_definitions() {
 	$core_task_list_definitions = array(
-		'build' => array(
+		'build'          => array(
 			'title'    => 'Build',
 			'task_ids' => array(
 				'setup_general',
@@ -35,7 +35,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'site_launched',
 			),
 		),
-		'free' => array(
+		'free'           => array(
 			'title'    => 'Free',
 			'task_ids' => array(
 				'plan_selected',
@@ -47,7 +47,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'site_launched',
 			),
 		),
-		'link-in-bio' => array(
+		'link-in-bio'    => array(
 			'title'    => 'Link In Bio',
 			'task_ids' => array(
 				'design_selected',
@@ -67,7 +67,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'link_in_bio_launched',
 			),
 		),
-		'newsletter' => array(
+		'newsletter'     => array(
 			'title'    => 'Newsletter',
 			'task_ids' => array(
 				'setup_newsletter',
@@ -79,7 +79,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'first_post_published_newsletter',
 			),
 		),
-		'videopress' => array(
+		'videopress'     => array(
 			'title'    => 'Videopress',
 			'task_ids' => array(
 				'videopress_setup',
@@ -88,7 +88,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'videopress_launched',
 			),
 		),
-		'write' => array(
+		'write'          => array(
 			'title'    => 'Write',
 			'task_ids' => array(
 				'setup_write',
@@ -98,7 +98,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'site_launched',
 			),
 		),
-		'start-writing' => array(
+		'start-writing'  => array(
 			'title'    => 'Start Writing',
 			'task_ids' => array(
 				'first_post_published',
@@ -108,7 +108,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'blog_launched',
 			),
 		),
-		'design-first' => array(
+		'design-first'   => array(
 			'title'    => 'Pick a Design',
 			'task_ids' => array(
 				'design_selected',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -19,7 +19,7 @@ require_once __DIR__ . '/launchpad-task-definitions.php';
 
 /**
  * Registers all default launchpad checklists
- * 
+ *
  * @return array
  */
 function wpcom_launchpad_get_task_list_definitions() {
@@ -128,23 +128,23 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => '__return_false',
 		),
 	);
- 
+
 	$extended_task_list_definitions = apply_filters( 'wpcom_launchpad_extended_task_list_definitions', array() );
- 
+
 	// As for tasks, we can decide what overrides we allow later.
 	return array_merge( $extended_task_list_definitions, $core_task_list_definitions );
 }
 
 /**
  * Get a task list, falling back to site_intent option if no checklist slug is provided.
- * 
+ *
  * @param string $checklist_slug
- * 
+ *
  * @return array
  */
 function wpcom_launchpad_get_task_list( $checklist_slug = null ) {
 	$task_list_definitions = wpcom_launchpad_get_task_list_definitions();
-	
+
 	// If we don't have a checklist slug, fall back to the site intent.
 	$checklist_slug = $checklist_slug ? $checklist_slug : get_option( 'site_intent' );
 	if ( ! $checklist_slug ) {
@@ -161,9 +161,9 @@ function wpcom_launchpad_get_task_list( $checklist_slug = null ) {
 
 /**
  * Register all tasks and task lists from definitions
- * 
+ *
  * @param bool $rebuild Whether to rebuild the task lists or not
- * 
+ *
  * @return array
  */
 function wpcom_launchpad_get_task_lists( $rebuild = false ) {
@@ -171,23 +171,23 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
 	if ( ! $rebuild && wpcom_launchpad_checklists()->has_task_lists() ) {
 		return wpcom_launchpad_checklists()->get_all_task_lists();
 	}
- 
+
 	$task_definitions = wpcom_launchpad_get_task_definitions();
- 
+
 	// Register all tasks
 	foreach ( $task_definitions as $task_id => $task_definition ) {
 		$task_data = array_merge( $task_definition, array( 'id' => $task_id ) );
 		wpcom_register_launchpad_task( $task_data );
 	}
- 
+
 	$task_list_definitions = wpcom_launchpad_get_task_list_definitions();
- 
+
 	// Register all task lists
 	foreach ( $task_list_definitions as $task_list_id => $task_list_definition ) {
 		$task_list_data = array_merge( $task_list_definition, array( 'id' => $task_list_id ) );
 		wpcom_register_launchpad_task_list( $task_list_data );
 	}
- 
+
 	// Assuming the reference is good, just return all checklists
 	return wpcom_launchpad_checklists()->get_all_task_lists();
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -15,6 +15,7 @@
  */
 
 require_once __DIR__ . '/class-launchpad-task-lists.php';
+require_once __DIR__ . '/launchpad-task-definitions.php';
 
 /**
  * Registers all default launchpad checklists
@@ -170,8 +171,6 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
 	if ( ! $rebuild && wpcom_launchpad_checklists()->has_task_lists() ) {
 		return wpcom_launchpad_checklists()->get_all_task_lists();
 	}
-
-	require_once( dirname( __FILE__ ) . '/launchpad-task-definitions.php' );
  
 	$task_definitions = wpcom_launchpad_get_task_definitions();
  

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -167,7 +167,7 @@ function wpcom_launchpad_get_task_list( $checklist_slug = null ) {
  */
 function wpcom_launchpad_get_task_lists( $rebuild = false ) {
 	// If we already have task lists registered and we don't want to rebuild, return all task lists.
-	if ( ! $rebuild && $launchpad_instance->has_task_lists() ) {
+	if ( ! $rebuild && wpcom_launchpad_checklists()->has_task_lists() ) {
 		return wpcom_launchpad_checklists()->get_all_task_lists();
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/wp-calypso#77278

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Based on @daledupreez suggestions in paYKcK-30u-p2, this PR attempts to put these ideas into play for real. :)
* Decouple task definitions from task registrations.
* Decouple task list definitions from task list registrations.
* Put task definitions and their callbacks in their own file.
* Add a `wpcom_get_launchpad_task_list` function that fetches a single registered task list in lieu of fetching all task lists at once.
* Add a `has_task_lists` method on the `Launchpad_Task_Lists` singleton that checks to see if we have already registered any task lists.
* Refactor `wpcom_mark_launchpad_task_complete`, allowing us to mark a task as complete by directly interfacing with the task definition and the site options table rather than waiting for the task to be registered.
* Fire a Tracks event when marking a task as complete with the new function.
* Initialize deprecated `add_listener_callback`s for existing tasks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox `public-api.wordpress.com`
* Visit the dev console and select WP REST API, `wpcom/v2`
* Make a GET request to `/sites/[siteSlug]/launchpad?checklist_slug=[slug]`, replacing [slug] with the following task list slugs:
- newsletter
- link-in-bio
- link-in-bio-tld
- build
- write
- start-writing
- design-first
- free
- keep-building
- videopress
* Make sure the correct tasks are still returned for each list based on the definitions in `launchpad.php`
* Make sure you can still mark tasks as complete when viewing the Launchpad at `/setup/[flow]/launchpad?siteSlug=[siteSlug]`