### PR TITLE
Fix jetpack/v4 API settings to return default values and correctly save booleans

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -990,8 +990,14 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				default:
-					// If option value was the same, consider it done.
-					$updated = get_option( $option ) != $value // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual -- ensure we support scalars or strings saved by update_option.
+					// Boolean values are stored as 1 or 0.
+					if ( isset( $options[ $option ]['type'] ) && 'boolean' === $options[ $option ]['type'] ) {
+						$value = (int) $value;
+					}
+
+					// If option value was the same as it's current value, or it's default, consider it done.
+					$default = isset( $options[ $option ]['default'] ) ? $options[ $option ]['default'] : false;
+					$updated = get_option( $option, $default ) != $value // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual -- ensure we support scalars or strings saved by update_option.
 						? update_option( $option, $value )
 						: true;
 					break;

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -506,7 +506,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				default:
-					$response[ $setting ] = Jetpack_Core_Json_Api_Endpoints::cast_value( get_option( $setting ), $settings[ $setting ] );
+					$default              = isset( $settings[ $setting ]['default'] ) ? $settings[ $setting ]['default'] : false;
+					$response[ $setting ] = Jetpack_Core_Json_Api_Endpoints::cast_value( get_option( $setting, $default ), $settings[ $setting ] );
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/changelog/fix-api-settings-use-defaults
+++ b/projects/plugins/jetpack/changelog/fix-api-settings-use-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack API Settings: use default values, when set

--- a/projects/plugins/jetpack/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -48,6 +48,23 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_Jetpack_
 	}
 
 	/**
+	 * Tests default value returned for settings in the Jetpack_Core_API_Data::get_all_options() method.
+	 */
+	public function test_options_use_defaults_for_options_when_not_set() {
+		// wpcom_reader_views_enabled should default to true, when not set.
+		$option_name = 'wpcom_reader_views_enabled';
+
+		// make sure option is not present
+		delete_option( $option_name );
+
+		$endpoint = new Jetpack_Core_API_Data();
+		$settings = $endpoint->get_all_options();
+
+		$this->assertTrue( isset( $settings->data[ $option_name ] ) );
+		$this->assertTrue( $settings->data[ $option_name ] );
+	}
+
+	/**
 	 * Tests the update of a comment subscription setting in the Jetpack_Core_API_Data::update_data() method.
 	 *
 	 * @param int         $new_value The new value of the comment subscription setting.

--- a/projects/plugins/jetpack/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -50,7 +50,7 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_Jetpack_
 	/**
 	 * Tests that the default value is used for settings returned by the Jetpack_Core_API_Data::get_all_options() method.
 	 */
-	public function test_options_use_defaults_for_options_when_not_set() {
+	public function test_options_use_defaults_when_not_set() {
 		// wpcom_reader_views_enabled should default to true when not set.
 		// @see Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list
 		$option_name = 'wpcom_reader_views_enabled';

--- a/projects/plugins/jetpack/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -55,7 +55,7 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_Jetpack_
 		// @see Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list
 		$option_name = 'wpcom_reader_views_enabled';
 
-		// make sure option is not present
+		// Make sure the option is not present.
 		delete_option( $option_name );
 
 		$endpoint = new Jetpack_Core_API_Data();
@@ -63,6 +63,33 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_Jetpack_
 
 		$this->assertTrue( isset( $settings->data[ $option_name ] ) );
 		$this->assertTrue( $settings->data[ $option_name ] );
+	}
+
+	/**
+	 * Tests updating an option that doesn't currently exist with a value of false.
+	 *
+	 * The Core function update_option will not work with the boolean false value, so it needs to be coerced
+	 * into null or 0.
+	 */
+	public function test_update_boolean_option_when_first_value_is_false() {
+		// wpcom_reader_views_enabled defaults to true, so it's first saved value will normally be false.
+		$option_name = 'wpcom_reader_views_enabled';
+
+		// Make sure the option is not present.
+		delete_option( $option_name );
+
+		$request = new WP_REST_Request();
+		$request->set_body_params(
+			array(
+				$option_name => false,
+			)
+		);
+
+		$result = ( new Jetpack_Core_API_Data() )->update_data( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( 'success', $result->get_data()['code'] );
+		$this->assertSame( 0, get_option( $option_name ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -48,10 +48,11 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_Jetpack_
 	}
 
 	/**
-	 * Tests default value returned for settings in the Jetpack_Core_API_Data::get_all_options() method.
+	 * Tests that the default value is used for settings returned by the Jetpack_Core_API_Data::get_all_options() method.
 	 */
 	public function test_options_use_defaults_for_options_when_not_set() {
-		// wpcom_reader_views_enabled should default to true, when not set.
+		// wpcom_reader_views_enabled should default to true when not set.
+		// @see Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list
 		$option_name = 'wpcom_reader_views_enabled';
 
 		// make sure option is not present


### PR DESCRIPTION
## Proposed changes:

After landing https://github.com/Automattic/jetpack/pull/30800, I noticed there's a bug in that the `wpcom_reader_views_enabled` option value is not showing up as true by default in the Jetpack stats settings.

I found these 2 issues with the jetpack/v4 settings endpoint

* GET Default settings values are not used, if the setting has not been saved yet (this didn't show up before because all of the non-module specific settings until now have defaulted to false or 0).
* POST Saving a boolean value of `false` triggers an error, as the value is not coerced correctly before being saved. 

This change fixes these issues by updating the endpoint settings code.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

Note that here are the settings (from jp-group `settings`) returned by `Jetpack_Core_API_Data()::get_all_options()`, and their default values defined in `Jetpack_Core_Json_Api_Endpoints::get_updateable_data_list`, for reference in testing.

```
jetpack_blocks_disabled FALSE
jetpack_waf_ip_allow_list ''
has_jetpack_search_product 0
wpcom_reader_views_enabled 1
akismet_show_user_comments_approved 0
dismiss_empty_stats_card 0
dismiss_dash_backup_getting_started 0
dismiss_dash_agencies_learn_more 0
```

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- On a WP.com connected Jetpack site with the Stats module enabled
- Delete the `wpcom_reader_views_enabled' option, if present
- Go to `/wp-admin/admin.php?page=jetpack#/traffic` and click on the "Jetpack Stats" settings section
- See that "Show post views for this site." is true, be default.
- Toggle the the settings and see that it saves correctly
- Reload the page, and see that the setting value remains toggled off.

