### PR TITLE
Protect: Sort threats by severity

### DIFF
--- a/projects/plugins/protect/changelog/fix-threats-list-sorting
+++ b/projects/plugins/protect/changelog/fix-threats-list-sorting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed sorting of threats by severity.

--- a/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
+++ b/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
@@ -8,77 +8,106 @@ import {
 import { useMemo, useState } from 'react';
 import useProtectData from '../../hooks/use-protect-data';
 
-const flatData = ( data, icon ) => {
+const sortThreats = ( a, b ) => b.severity - a.severity;
+
+/**
+ * Flatten threats data
+ *
+ * Merges threat category data with each threat it contains, plus any additional data provided.
+ *
+ * @param {object} data    - The threat category data, i.e. "core", "plugins", "themes", etc.
+ * @param {object} newData - Additional data to add to each threat.
+ * @returns {object[]} Array of threats with additional properties from the threat category and function argument.
+ */
+const flattenThreats = ( data, newData ) => {
+	// If "data" has multiple entries, recursively flatten each one.
 	if ( Array.isArray( data ) ) {
-		return data.map( plugin => flatData( plugin, icon ) ).flat();
+		return data.map( extension => flattenThreats( extension, newData ) ).flat();
 	}
 
-	return data?.threats?.map( threat => ( {
+	// Merge the threat category data with each threat it contains, plus any additional data provided.
+	return data?.threats.map( threat => ( {
 		...threat,
 		...data,
-		icon,
+		...newData,
 	} ) );
 };
 
-const mergeThreats = ( { core, plugins, themes, files, database } ) => [
-	...flatData( core, coreIcon ),
-	...flatData( plugins, pluginsIcon ),
-	...flatData( themes, themesIcon ),
-	...flatData( files, filesIcon ),
-	...flatData( database, databaseIcon ),
-];
-
-const sortThreats = threats => {
-	return threats.sort( ( a, b ) => b.severity - a.severity );
-};
-
+/**
+ * Threats List Hook
+ *
+ * @typedef {object} UseThreatsList
+ * @property {object}   item        - The selected threat category.
+ * @property {object[]} list        - The list of threats to display.
+ * @property {string}   selected    - The selected threat category.
+ * @property {Function} setSelected - Sets the selected threat category.
+ * ---
+ * @returns {UseThreatsList} useThreatsList hook.
+ */
 const useThreatsList = () => {
 	const { plugins, themes, core, files, database } = useProtectData();
 
 	const [ selected, setSelected ] = useState( 'all' );
 
-	const { list, item } = useMemo( () => {
-		switch ( selected ) {
-			case 'wordpress':
+	const { unsortedList, item } = useMemo( () => {
+		// If a specific threat category is selected, filter for and flatten the category's threats.
+		if ( selected && selected !== 'all' ) {
+			// Core, files, and database data threats are already grouped together,
+			// so we just need to flatten them and add the appropriate icon.
+			switch ( selected ) {
+				case 'wordpress':
+					return {
+						list: flattenThreats( core, { icon: coreIcon } ),
+						item: core,
+					};
+				case 'files':
+					return {
+						list: flattenThreats( files, { icon: filesIcon } ),
+						item: files,
+					};
+				case 'database':
+					return {
+						list: flattenThreats( database, { icon: databaseIcon } ),
+						item: database,
+					};
+				default:
+					break;
+			}
+
+			// Extensions (i.e. plugins and themes) have entries for each individual extension,
+			// so we need to check for a matching threat in each extension.
+			const pluginsItem = plugins.find( threat => threat?.name === selected );
+			if ( pluginsItem ) {
 				return {
-					list: sortThreats( flatData( core, coreIcon ) ),
-					item: core,
+					list: flattenThreats( pluginsItem, pluginsIcon ),
+					item: pluginsItem,
 				};
-			case 'files':
+			}
+			const themesItem = themes.find( threat => threat?.name === selected );
+			if ( themesItem ) {
 				return {
-					list: sortThreats( flatData( files, filesIcon ) ),
-					item: files,
+					list: flattenThreats( themesItem, themesIcon ),
+					item: themesItem,
 				};
-			case 'database':
-				return {
-					list: sortThreats( flatData( database, databaseIcon ) ),
-					item: database,
-				};
-			default:
-				break;
+			}
 		}
 
-		const pluginsItem = plugins.find( threat => threat?.name === selected );
-		if ( pluginsItem ) {
-			return {
-				list: sortThreats( flatData( pluginsItem, pluginsIcon ) ),
-				item: pluginsItem,
-			};
-		}
-
-		const themesItem = themes.find( threat => threat?.name === selected );
-		if ( themesItem ) {
-			return {
-				list: sortThreats( flatData( themesItem, themesIcon ) ),
-				item: themesItem,
-			};
-		}
-
+		// Otherwise, return all threats.
 		return {
-			list: sortThreats( mergeThreats( { core, plugins, themes, files, database } ) ),
+			list: [
+				...flattenThreats( core, coreIcon ),
+				...flattenThreats( plugins, pluginsIcon ),
+				...flattenThreats( themes, themesIcon ),
+				...flattenThreats( files, filesIcon ),
+				...flattenThreats( database, databaseIcon ),
+			],
 			item: null,
 		};
 	}, [ core, database, files, plugins, selected, themes ] );
+
+	const list = useMemo( () => {
+		return unsortedList.sort( sortThreats );
+	}, [ unsortedList ] );
 
 	return {
 		item,

--- a/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
+++ b/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
@@ -95,11 +95,11 @@ const useThreatsList = () => {
 		// Otherwise, return all threats.
 		return {
 			unsortedList: [
-				...flattenThreats( core, coreIcon ),
-				...flattenThreats( plugins, pluginsIcon ),
-				...flattenThreats( themes, themesIcon ),
-				...flattenThreats( files, filesIcon ),
-				...flattenThreats( database, databaseIcon ),
+				...flattenThreats( core, { icon: coreIcon } ),
+				...flattenThreats( plugins, { icon: pluginsIcon } ),
+				...flattenThreats( themes, { icon: themesIcon } ),
+				...flattenThreats( files, { icon: filesIcon } ),
+				...flattenThreats( database, { icon: databaseIcon } ),
 			],
 			item: null,
 		};

--- a/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
+++ b/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
@@ -57,17 +57,17 @@ const useThreatsList = () => {
 			switch ( selected ) {
 				case 'wordpress':
 					return {
-						list: flattenThreats( core, { icon: coreIcon } ),
+						unsortedList: flattenThreats( core, { icon: coreIcon } ),
 						item: core,
 					};
 				case 'files':
 					return {
-						list: flattenThreats( files, { icon: filesIcon } ),
+						unsortedList: flattenThreats( files, { icon: filesIcon } ),
 						item: files,
 					};
 				case 'database':
 					return {
-						list: flattenThreats( database, { icon: databaseIcon } ),
+						unsortedList: flattenThreats( database, { icon: databaseIcon } ),
 						item: database,
 					};
 				default:
@@ -79,14 +79,14 @@ const useThreatsList = () => {
 			const pluginsItem = plugins.find( threat => threat?.name === selected );
 			if ( pluginsItem ) {
 				return {
-					list: flattenThreats( pluginsItem, pluginsIcon ),
+					unsortedList: flattenThreats( pluginsItem, pluginsIcon ),
 					item: pluginsItem,
 				};
 			}
 			const themesItem = themes.find( threat => threat?.name === selected );
 			if ( themesItem ) {
 				return {
-					list: flattenThreats( themesItem, themesIcon ),
+					unsortedList: flattenThreats( themesItem, themesIcon ),
 					item: themesItem,
 				};
 			}
@@ -94,7 +94,7 @@ const useThreatsList = () => {
 
 		// Otherwise, return all threats.
 		return {
-			list: [
+			unsortedList: [
 				...flattenThreats( core, coreIcon ),
 				...flattenThreats( plugins, pluginsIcon ),
 				...flattenThreats( themes, themesIcon ),

--- a/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
+++ b/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
@@ -76,18 +76,18 @@ const useThreatsList = () => {
 
 			// Extensions (i.e. plugins and themes) have entries for each individual extension,
 			// so we need to check for a matching threat in each extension.
-			const pluginsItem = plugins.find( threat => threat?.name === selected );
-			if ( pluginsItem ) {
+			const selectedPlugin = plugins.find( plugin => plugin?.name === selected );
+			if ( selectedPlugin ) {
 				return {
-					unsortedList: flattenThreats( pluginsItem, pluginsIcon ),
-					item: pluginsItem,
+					unsortedList: flattenThreats( selectedPlugin, { icon: pluginsIcon } ),
+					item: selectedPlugin,
 				};
 			}
-			const themesItem = themes.find( threat => threat?.name === selected );
-			if ( themesItem ) {
+			const selectedTheme = themes.find( theme => theme?.name === selected );
+			if ( selectedTheme ) {
 				return {
-					unsortedList: flattenThreats( themesItem, themesIcon ),
-					item: themesItem,
+					unsortedList: flattenThreats( selectedTheme, { icon: themesIcon } ),
+					item: selectedTheme,
 				};
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When displaying the full list of threats, Protect currently combines all of the threats from the categories (core, plugins, themes, etc) without any additional sorting.

This PR fixes that :+1:

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Always sort the threat list by severity.
* Optimize the `useThreatsList` hook by ensuring the threat list is only reinitialized when necessary via `useMemo()`.
* Add some JSDocs :)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new JN site:
  * Protect running this branch
  * Jetpack Debug Helper installed.
  * Scan plan active
* Set up Protect and validate you reach the "Don't worry about a thing" screen without issue.
* Add some file threats to your site via Jetpack Debug Helper.
* Install a vulnerable plugin such as WooCommerce 3.0.0
* Trigger another scan
* Validate that the threats are always sorted by severity, in both the "all" view as well as when filtered to only "files".
