### PR TITLE
CRM: Fix whitelabel 'Sorry, not allowed'error

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3137-whitelabel-error-not-allowed
+++ b/projects/plugins/crm/changelog/fix-crm-3137-whitelabel-error-not-allowed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: fix whitelabel bug with full menu layout

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.WP.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.WP.php
@@ -305,7 +305,7 @@ function zeroBSCRM_menu_buildMenu() {
 			'stylefuncs' => array( 'zeroBSCRM_global_admin_styles', 'jpcrm_support_page_styles_scripts' ),
 		);
 
-		## /WLREMOVE
+		##/WLREMOVE
 
 	}
 	/**


### PR DESCRIPTION
## Proposed changes:
* This PR fixes a whitelabel bug when full menu layout was set.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1685546719705519-slack-CL5UJ9ASE

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Testing:
1. Add a zipped copy of this branch's JPCRM to your local `app`'s `/rebrandr/_build/core-versions/` and `/rebrandr/_build/templates/`. 
2. Run `app` and go to `/rebrandr-app` to set up a template and build the white-label CRM. (more information about that in app's wiki)
3. Download the CRM bundle zip.
4. Upload the downloaded CRM zip (which is nested in a parent zip) to a test site.
5. Set the menu to full in settings.

In `trunk` an error appears.
In `fix/crm/3137-whitelabel-error-not-allowed` the CRM runs with no errors.

