### PR TITLE
[RNMobile] Show "No title"/"No description" placeholder for not belonged videos

### DIFF
--- a/projects/packages/videopress/changelog/rnmobile-videopress-no-description-placeholder
+++ b/projects/packages/videopress/changelog/rnmobile-videopress-no-description-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+RNMobile: Display no title and no description placeholder for not belonged videos

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.14.5",
+	"version": "0.14.6-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.14.5';
+	const PACKAGE_VERSION = '0.14.6-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/index.native.js
@@ -19,6 +19,9 @@ import VideoNotOwnedWarning from '../video-not-owned-warning';
  */
 export default function DetailsPanel( { attributes, setAttributes, videoBelongToSite } ) {
 	const { title, description } = attributes;
+	const titlePlaceholder = videoBelongToSite
+		? __( 'Add title', 'jetpack-videopress-pkg' )
+		: __( 'No title', 'jetpack-videopress-pkg' );
 	const descriptionPlaceholder = videoBelongToSite
 		? __( 'Add description', 'jetpack-videopress-pkg' )
 		: __( 'No description', 'jetpack-videopress-pkg' );
@@ -28,7 +31,7 @@ export default function DetailsPanel( { attributes, setAttributes, videoBelongTo
 			<TextControl
 				value={ title || '' }
 				onChange={ value => setAttributes( { title: value } ) }
-				placeholder={ __( 'Add title', 'jetpack-videopress-pkg' ) }
+				placeholder={ titlePlaceholder }
 				label={ __( 'Title', 'jetpack-videopress-pkg' ) }
 				disabled={ ! videoBelongToSite }
 			/>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/index.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/details-panel/index.native.js
@@ -19,6 +19,9 @@ import VideoNotOwnedWarning from '../video-not-owned-warning';
  */
 export default function DetailsPanel( { attributes, setAttributes, videoBelongToSite } ) {
 	const { title, description } = attributes;
+	const descriptionPlaceholder = videoBelongToSite
+		? __( 'Add description', 'jetpack-videopress-pkg' )
+		: __( 'No description', 'jetpack-videopress-pkg' );
 
 	return (
 		<PanelBody title={ __( 'Details', 'jetpack-videopress-pkg' ) }>
@@ -32,7 +35,7 @@ export default function DetailsPanel( { attributes, setAttributes, videoBelongTo
 			<BottomSheetTextControl
 				initialValue={ description }
 				onChange={ value => setAttributes( { description: value } ) }
-				placeholder={ __( 'Add description', 'jetpack-videopress-pkg' ) }
+				placeholder={ descriptionPlaceholder }
 				label={ __( 'Description', 'jetpack-videopress-pkg' ) }
 				disabled={ ! videoBelongToSite }
 			/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up on https://github.com/Automattic/jetpack/pull/30759.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* For not belonged videos that have an empty title and/or description, instead of displaying the placeholder `Add title`/`Add description`, show `No title`/`No description` to avoid confusion.

| Empty title and description | With title and description |
|--------|--------|
| <img src=https://github.com/Automattic/jetpack/assets/14905380/9d574ab1-e7b6-4e44-8274-9ece631e15db width=300> | <img src=https://github.com/Automattic/jetpack/assets/14905380/9e4a2e24-37b5-46db-9fea-32a3e155f9c2 width=300> | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Open a post/page.
- Add a VideoPress block.
- Add a video that doesn't belong to the site and has an empty title and description (e.g. insert the video from an URL - https://videopress.com/v/XBqrRFxJ).
- Open the block settings.
- Observe that the title and description settings are disabled.
- Observe that the title field displays a placeholder with the text `No title`.
- Observe that the description field displays a placeholder with the text `No description`.
- Replace the video with another one that doesn't belong to the site, but has a title and description. (e.g. insert the video from an URL - https://videopress.com/v/E6So1Wpf).
- Observe that the title and description settings are disabled.
- Observe that the title field displays the title of the video.
- Observe that the description field displays the description of the video.

