### PR TITLE
[Earn] Fix paid subscribers

### DIFF
--- a/projects/plugins/jetpack/changelog/earn-newsletters-fix-undefined-counts
+++ b/projects/plugins/jetpack/changelog/earn-newsletters-fix-undefined-counts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes the check for falsy values in the `getReachForAccessLevelKey` function

--- a/projects/plugins/jetpack/changelog/earn-test-31009-review
+++ b/projects/plugins/jetpack/changelog/earn-test-31009-review
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+This doesn't solve the issue.  Only posting this for testing purposes.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -208,7 +208,6 @@ function NewsletterPostPublishSettingsPanel( {
 			<NewsletterNotice
 				isPostPublishPanel={ true }
 				accessLevel={ accessLevel }
-				socialFollowers={ socialFollowers }
 				emailSubscribers={ emailSubscribers }
 				paidSubscribers={ paidSubscribers }
 				showMisconfigurationWarning={ showMisconfigurationWarning }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -179,7 +179,6 @@ function NewsletterPrePublishSettingsPanel( {
 
 function NewsletterPostPublishSettingsPanel( {
 	accessLevel,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	isModuleActive,
@@ -289,7 +288,6 @@ export default function SubscribePanels() {
 			<NewsletterPostPublishSettingsPanel
 				accessLevel={ accessLevel }
 				setPostMeta={ setPostMeta }
-				socialFollowers={ socialFollowers }
 				emailSubscribers={ emailSubscribers }
 				paidSubscribers={ paidSubscribers }
 				isModuleActive={ isModuleActive }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -189,7 +189,6 @@ function NewsletterAccessSetupNudge( { stripeConnectUrl, isStripeConnected, hasN
 function NewsletterAccessRadioButtons( {
 	onChange,
 	accessLevel,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	hasNewsletterPlans,
@@ -268,7 +267,6 @@ function NewsletterAccessRadioButtons( {
 export function NewsletterAccessDocumentSettings( {
 	accessLevel,
 	setPostMeta,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	showMisconfigurationWarning,
@@ -342,7 +340,6 @@ export function NewsletterAccessDocumentSettings( {
 											<NewsletterAccessRadioButtons
 												onChange={ setPostMetaAndClose( onClose ) }
 												accessLevel={ _accessLevel }
-												socialFollowers={ socialFollowers }
 												emailSubscribers={ emailSubscribers }
 												paidSubscribers={ paidSubscribers }
 												stripeConnectUrl={ stripeConnectUrl }
@@ -378,7 +375,6 @@ export function NewsletterAccessDocumentSettings( {
 export function NewsletterAccessPrePublishSettings( {
 	accessLevel,
 	setPostMeta,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	showMisconfigurationWarning,
@@ -419,7 +415,6 @@ export function NewsletterAccessPrePublishSettings( {
 									<NewsletterAccessRadioButtons
 										onChange={ setPostMeta }
 										accessLevel={ _accessLevel }
-										socialFollowers={ socialFollowers }
 										emailSubscribers={ emailSubscribers }
 										paidSubscribers={ paidSubscribers }
 										stripeConnectUrl={ stripeConnectUrl }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -35,7 +35,10 @@ function getReachForAccessLevelKey(
 	paidSubscribers,
 	socialFollowers
 ) {
-	if ( emailSubscribers === null || paidSubscribers === null || socialFollowers === null ) {
+	const isFalsy = value => {
+		return value === null || value === undefined || value === '';
+	};
+	if ( [ emailSubscribers, paidSubscribers, socialFollowers ].filter( isFalsy ).length > 0 ) {
 		return 0;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -29,16 +29,7 @@ function Link( { href, children } ) {
 	);
 }
 
-function getReachForAccessLevelKey(
-	accessLevelKey,
-	emailSubscribers,
-	paidSubscribers,
-	socialFollowers
-) {
-	if ( ! socialFollowers ) {
-		return 0;
-	}
-
+function getReachForAccessLevelKey( accessLevelKey, emailSubscribers, paidSubscribers ) {
 	switch ( accessOptions[ accessLevelKey ].key ) {
 		case accessOptions.everybody.key:
 			return emailSubscribers || 0;
@@ -75,7 +66,6 @@ function NewsletterLearnMore() {
 
 export function NewsletterNotice( {
 	accessLevel,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	showMisconfigurationWarning,
@@ -86,12 +76,7 @@ export function NewsletterNotice( {
 	);
 
 	// Get the reach count for the access level
-	let reachCount = getReachForAccessLevelKey(
-		accessLevel,
-		emailSubscribers,
-		paidSubscribers,
-		socialFollowers
-	);
+	let reachCount = getReachForAccessLevelKey( accessLevel, emailSubscribers, paidSubscribers );
 
 	// If there is a misconfiguration, we do not show the NewsletterNotice
 	if ( showMisconfigurationWarning ) {
@@ -247,12 +232,7 @@ function NewsletterAccessRadioButtons( {
 						{ /* Do not show subscriber numbers in the PrePublish panel */ }
 						{ ! isPrePublishPanel &&
 							' (' +
-								getReachForAccessLevelKey(
-									key,
-									emailSubscribers,
-									paidSubscribers,
-									socialFollowers
-								) +
+								getReachForAccessLevelKey( key, emailSubscribers, paidSubscribers ) +
 								( key === accessOptions.everybody.key ? '+' : '' ) +
 								')' }
 					</label>
@@ -268,7 +248,6 @@ function NewsletterAccessRadioButtons( {
 						<p className="pre-public-panel-notice-reach">
 							<NewsletterNotice
 								accessLevel={ accessLevel }
-								socialFollowers={ socialFollowers }
 								emailSubscribers={ emailSubscribers }
 								paidSubscribers={ paidSubscribers }
 								showMisconfigurationWarning={ showMisconfigurationWarning }
@@ -381,7 +360,6 @@ export function NewsletterAccessDocumentSettings( {
 
 						<NewsletterNotice
 							accessLevel={ _accessLevel }
-							socialFollowers={ socialFollowers }
 							emailSubscribers={ emailSubscribers }
 							paidSubscribers={ paidSubscribers }
 							showMisconfigurationWarning={ showMisconfigurationWarning }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -35,20 +35,17 @@ function getReachForAccessLevelKey(
 	paidSubscribers,
 	socialFollowers
 ) {
-	const isFalsy = value => {
-		return value === null || value === undefined || value === '';
-	};
-	if ( [ emailSubscribers, paidSubscribers, socialFollowers ].filter( isFalsy ).length > 0 ) {
+	if ( ! socialFollowers ) {
 		return 0;
 	}
 
 	switch ( accessOptions[ accessLevelKey ].key ) {
 		case accessOptions.everybody.key:
-			return emailSubscribers;
+			return emailSubscribers || 0;
 		case accessOptions.subscribers.key:
-			return emailSubscribers;
+			return emailSubscribers || 0;
 		case accessOptions.paid_subscribers.key:
-			return paidSubscribers;
+			return paidSubscribers || 0;
 		default:
 			return 0;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -173,7 +173,7 @@ function fetch_subscriber_counts() {
 	$subs_count = 0;
 	if ( is_wpcom() ) {
 		$subs_count = array(
-			'value' => \wpcom_fetch_subs_counts( false ),
+			'value' => \wpcom_fetch_subs_counts( true ),
 		);
 	} else {
 		$cache_key  = 'wpcom_subscribers_totals';
@@ -190,6 +190,7 @@ function fetch_subscriber_counts() {
 					'value'   => ( isset( $subs_count['value'] ) ) ? $subs_count['value'] : array(
 						'email_subscribers' => 0,
 						'social_followers'  => 0,
+						'paid_subscribers'  => 0,
 					),
 				);
 			} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/30986

## Proposed changes:
* Merges [PR #31094](https://github.com/Automattic/jetpack/pull/31094) and [PR #31009](https://github.com/Automattic/jetpack/pull/31009)
* Create a proper test instructions base don @n3f 's previous work

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

