### PR TITLE
Fix/paid subscribers on self hosted

### DIFF
--- a/projects/plugins/jetpack/changelog/earn-newsletters-fix-undefined-counts
+++ b/projects/plugins/jetpack/changelog/earn-newsletters-fix-undefined-counts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes the check for falsy values in the `getReachForAccessLevelKey` function

--- a/projects/plugins/jetpack/changelog/earn-newsletters-fix-undefined-counts
+++ b/projects/plugins/jetpack/changelog/earn-newsletters-fix-undefined-counts
@@ -1,4 +1,6 @@
 Significance: patch
 Type: bugfix
 
-Fixes the check for falsy values in the `getReachForAccessLevelKey` function
+Fixes the check for falsy values in the `getReachForAccessLevelKey` function,
+removing the `socialFollowers` and updating the subscription count API endpoints
+to return paid-subscribers.

--- a/projects/plugins/jetpack/changelog/earn-test-31009-review
+++ b/projects/plugins/jetpack/changelog/earn-test-31009-review
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-This doesn't solve the issue.  Only posting this for testing purposes.

--- a/projects/plugins/jetpack/changelog/earn-test-31009-review
+++ b/projects/plugins/jetpack/changelog/earn-test-31009-review
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+This doesn't solve the issue.  Only posting this for testing purposes.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -208,7 +208,6 @@ function NewsletterPostPublishSettingsPanel( {
 			<NewsletterNotice
 				isPostPublishPanel={ true }
 				accessLevel={ accessLevel }
-				socialFollowers={ socialFollowers }
 				emailSubscribers={ emailSubscribers }
 				paidSubscribers={ paidSubscribers }
 				showMisconfigurationWarning={ showMisconfigurationWarning }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -179,7 +179,6 @@ function NewsletterPrePublishSettingsPanel( {
 
 function NewsletterPostPublishSettingsPanel( {
 	accessLevel,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	isModuleActive,
@@ -289,7 +288,6 @@ export default function SubscribePanels() {
 			<NewsletterPostPublishSettingsPanel
 				accessLevel={ accessLevel }
 				setPostMeta={ setPostMeta }
-				socialFollowers={ socialFollowers }
 				emailSubscribers={ emailSubscribers }
 				paidSubscribers={ paidSubscribers }
 				isModuleActive={ isModuleActive }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -183,7 +183,6 @@ function NewsletterAccessSetupNudge( { stripeConnectUrl, isStripeConnected, hasN
 function NewsletterAccessRadioButtons( {
 	onChange,
 	accessLevel,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	hasNewsletterPlans,
@@ -262,7 +261,6 @@ function NewsletterAccessRadioButtons( {
 export function NewsletterAccessDocumentSettings( {
 	accessLevel,
 	setPostMeta,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	showMisconfigurationWarning,
@@ -336,7 +334,6 @@ export function NewsletterAccessDocumentSettings( {
 											<NewsletterAccessRadioButtons
 												onChange={ setPostMetaAndClose( onClose ) }
 												accessLevel={ _accessLevel }
-												socialFollowers={ socialFollowers }
 												emailSubscribers={ emailSubscribers }
 												paidSubscribers={ paidSubscribers }
 												stripeConnectUrl={ stripeConnectUrl }
@@ -372,7 +369,6 @@ export function NewsletterAccessDocumentSettings( {
 export function NewsletterAccessPrePublishSettings( {
 	accessLevel,
 	setPostMeta,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	showMisconfigurationWarning,
@@ -413,7 +409,6 @@ export function NewsletterAccessPrePublishSettings( {
 									<NewsletterAccessRadioButtons
 										onChange={ setPostMeta }
 										accessLevel={ _accessLevel }
-										socialFollowers={ socialFollowers }
 										emailSubscribers={ emailSubscribers }
 										paidSubscribers={ paidSubscribers }
 										stripeConnectUrl={ stripeConnectUrl }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -35,7 +35,10 @@ function getReachForAccessLevelKey(
 	paidSubscribers,
 	socialFollowers
 ) {
-	if ( emailSubscribers === null || paidSubscribers === null || socialFollowers === null ) {
+	const isFalsy = value => {
+		return value === null || value === undefined || value === '';
+	};
+	if ( [ emailSubscribers, paidSubscribers, socialFollowers ].filter( isFalsy ).length > 0 ) {
 		return 0;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -35,20 +35,17 @@ function getReachForAccessLevelKey(
 	paidSubscribers,
 	socialFollowers
 ) {
-	const isFalsy = value => {
-		return value === null || value === undefined || value === '';
-	};
-	if ( [ emailSubscribers, paidSubscribers, socialFollowers ].filter( isFalsy ).length > 0 ) {
+	if ( ! socialFollowers ) {
 		return 0;
 	}
 
 	switch ( accessOptions[ accessLevelKey ].key ) {
 		case accessOptions.everybody.key:
-			return emailSubscribers;
+			return emailSubscribers || 0;
 		case accessOptions.subscribers.key:
-			return emailSubscribers;
+			return emailSubscribers || 0;
 		case accessOptions.paid_subscribers.key:
-			return paidSubscribers;
+			return paidSubscribers || 0;
 		default:
 			return 0;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -29,16 +29,7 @@ function Link( { href, children } ) {
 	);
 }
 
-function getReachForAccessLevelKey(
-	accessLevelKey,
-	emailSubscribers,
-	paidSubscribers,
-	socialFollowers
-) {
-	if ( ! socialFollowers ) {
-		return 0;
-	}
-
+function getReachForAccessLevelKey( accessLevelKey, emailSubscribers, paidSubscribers ) {
 	switch ( accessOptions[ accessLevelKey ].key ) {
 		case accessOptions.everybody.key:
 			return emailSubscribers || 0;
@@ -69,7 +60,6 @@ function NewsletterLearnMore() {
 
 export function NewsletterNotice( {
 	accessLevel,
-	socialFollowers,
 	emailSubscribers,
 	paidSubscribers,
 	showMisconfigurationWarning,
@@ -80,12 +70,7 @@ export function NewsletterNotice( {
 	);
 
 	// Get the reach count for the access level
-	let reachCount = getReachForAccessLevelKey(
-		accessLevel,
-		emailSubscribers,
-		paidSubscribers,
-		socialFollowers
-	);
+	let reachCount = getReachForAccessLevelKey( accessLevel, emailSubscribers, paidSubscribers );
 
 	// If there is a misconfiguration, we do not show the NewsletterNotice
 	if ( showMisconfigurationWarning ) {
@@ -241,12 +226,7 @@ function NewsletterAccessRadioButtons( {
 						{ /* Do not show subscriber numbers in the PrePublish panel */ }
 						{ ! isPrePublishPanel &&
 							' (' +
-								getReachForAccessLevelKey(
-									key,
-									emailSubscribers,
-									paidSubscribers,
-									socialFollowers
-								) +
+								getReachForAccessLevelKey( key, emailSubscribers, paidSubscribers ) +
 								( key === accessOptions.everybody.key ? '+' : '' ) +
 								')' }
 					</label>
@@ -262,7 +242,6 @@ function NewsletterAccessRadioButtons( {
 						<p className="pre-public-panel-notice-reach">
 							<NewsletterNotice
 								accessLevel={ accessLevel }
-								socialFollowers={ socialFollowers }
 								emailSubscribers={ emailSubscribers }
 								paidSubscribers={ paidSubscribers }
 								showMisconfigurationWarning={ showMisconfigurationWarning }
@@ -375,7 +354,6 @@ export function NewsletterAccessDocumentSettings( {
 
 						<NewsletterNotice
 							accessLevel={ _accessLevel }
-							socialFollowers={ socialFollowers }
 							emailSubscribers={ emailSubscribers }
 							paidSubscribers={ paidSubscribers }
 							showMisconfigurationWarning={ showMisconfigurationWarning }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -173,7 +173,7 @@ function fetch_subscriber_counts() {
 	$subs_count = 0;
 	if ( is_wpcom() ) {
 		$subs_count = array(
-			'value' => \wpcom_fetch_subs_counts( false ),
+			'value' => \wpcom_fetch_subs_counts( true ),
 		);
 	} else {
 		$cache_key  = 'wpcom_subscribers_totals';
@@ -190,6 +190,7 @@ function fetch_subscriber_counts() {
 					'value'   => ( isset( $subs_count['value'] ) ) ? $subs_count['value'] : array(
 						'email_subscribers' => 0,
 						'social_followers'  => 0,
+						'paid_subscribers'  => 0,
 					),
 				);
 			} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/30986

## Proposed changes:
* Merges [PR #31094](https://github.com/Automattic/jetpack/pull/31094) and [PR #31009](https://github.com/Automattic/jetpack/pull/31009)
* Create a proper test instructions based on @n3f 's previous work

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Nope

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a jurassic ninja with `https://jurassic.ninja/create?jetpack-beta&branches.jetpack=fix/paid-subscribers-on-self-hosted&wp-debug-log`
* Push this code on your sandbox
```
bin/jetpack-downloader test jetpack fix/paid-subscribers-on-self-hosted
bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/paid-subscribers-on-self-hosted

```
* Point your newly created machine to your sandbox from https://respectable-horseshoe.jurassic.ninja/wp-admin/options-general.php?page=companion_settings
`{USER}.SANBOX_URL`
* On your sandbox, put your sandbox in sandbox mode and sandbox the async job counting the paid subscribers
```
function sandbox_async_jobs( $sandboxed, $type ) {
	return in_array( $type, array(
		'wpcom_subs_update_total_paid_subscribers',
	) );
}

[...]

define( 'USE_STORE_SANDBOX', true );
```
* Start the watcher `$ ./async-jobs/watcher.php`
* Open your sandbox to the outside world `sudo global-http enable`
* Congrats! Now, your ninja instance will call your sandbox.
* Set up jetpack (on Free plan is enough)
* Enable subscriptions in https://condemned-marmot.jurassic.ninja/wp-admin/admin.php?page=jetpack#/discussion
<img width="300" alt="Screenshot 2023-06-01 at 16 47 13" src="https://github.com/Automattic/jetpack/assets/790558/f4febf98-7268-46d2-88f3-16860626ec36">

* Create a new post. 
* Go to Earn via the Newsletter Access panel and set stripe and a paid plan
<img width="300" alt="Screenshot 2023-06-01 at 16 48 25" src="https://github.com/Automattic/jetpack/assets/790558/cb9df862-14db-486c-abb7-fbe2fcc11930">


#### Ready to test
* Create a new post
* Notice the 0 and NO `undefined` in the panel

<img width="300" alt="Screenshot 2023-06-01 at 16 49 28" src="https://github.com/Automattic/jetpack/assets/790558/9a35ea3c-52e0-4263-96ea-44d0527f8cc8">

* Create a subscribe block and publish the post. https://condemned-marmot.jurassic.ninja/2023/06/01/9/
* Open a new incognito window and pay the subscription
<img width="300" alt="Screenshot 2023-06-01 at 16 51 52" src="https://github.com/Automattic/jetpack/assets/790558/2d0908f0-fb61-4e82-8ae8-0bd3e9539554">

* With test card it is fine
<img width="300" alt="Screenshot 2023-06-01 at 16 52 31" src="https://github.com/Automattic/jetpack/assets/790558/d777f86f-1a51-4b59-9322-55739970ac89">

* Notice the async-job was launched
<img width="300" alt="Screenshot 2023-06-01 at 16 53 59" src="https://github.com/Automattic/jetpack/assets/790558/c2c58149-e4ab-4157-8f40-61bb28c40b7a">

* Now notice a new post has one more paid-subscriber 🥳 
<img width="300" alt="Screenshot 2023-06-01 at 17 04 30" src="https://github.com/Automattic/jetpack/assets/790558/cc75b4ac-4a0e-4db3-8866-ecd76041035b">

* If you see `0`. It could be that the production job has overwritten the sandbox job
* You can re-write it with
```
~/public_html (trunk) $ wpsh
> print(get_blog_id_from_url('condemned-marmot.jurassic.ninja'))
219683543
> $blog_id=219683543
> require('async-jobs/includes/wpcom-subscriptions.php')
> jobs_wpcom_subs_update_total_paid_subscribers((object)['data'=>['blog_id'=>$blog_id]])
```
* And check:
```
 > gpr SELECT * FROM subscription_counts WHERE blog_id=219683543
+-----------------------+-------------------+------------+-----------+---------+--------------------+
| subscription_count_id | subscription_type | user_type  | blog_id   | post_id | subscription_count |
+-----------------------+-------------------+------------+-----------+---------+--------------------+
| 174889426             | posts             | wpcom      | 219683543 |         | 2                  |
| 174889427             | posts             | wpcom      | 219683543 |         | 2                  |
| 174889740             | posts             | wpcom_paid | 219683543 |         | 1                  |
+-----------------------+-------------------+------------+-----------+---------+--------------------+

```
* Now reload the new post page and it should be good