### PR TITLE
Jetpack Boost: Add a proxy to the Image Guide so it can load remote images

### DIFF
--- a/projects/js-packages/image-guide/changelog/fix-proxy_image_guide_images
+++ b/projects/js-packages/image-guide/changelog/fix-proxy_image_guide_images
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Boost: add a proxy to Image Guide so it can load remote images.

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-image-guide",
-	"version": "0.3.0",
+	"version": "0.4.0-alpha",
 	"description": "Go through the dom to analyze image size on screen vs actual file size.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/image-guide/#readme",
 	"type": "module",

--- a/projects/js-packages/image-guide/src/MeasurableImage.ts
+++ b/projects/js-packages/image-guide/src/MeasurableImage.ts
@@ -11,7 +11,7 @@ export class MeasurableImage {
 	readonly node: HTMLElement | HTMLImageElement;
 	private getURLCallback: SourceCallbackFn;
 
-	public fetch = fetch;
+	public fetch = window.fetch;
 
 	/**
 	 * Constructor.

--- a/projects/js-packages/image-guide/src/MeasurableImage.ts
+++ b/projects/js-packages/image-guide/src/MeasurableImage.ts
@@ -99,18 +99,8 @@ export class MeasurableImage {
 			console.log( `Can't get image size for ${ url } likely due to a CORS error.` );
 			return -1;
 		}
-		let size = '';
-		if ( response.headers.get( 'content-type' ).indexOf( 'text/html' ) !== -1 ) {
-			size = await response.text();
-		} else {
-			size = response.headers.get( 'content-length' );
-		}
 
-		if ( size ) {
-			return parseInt( size, 10 ) / 1024;
-		}
-
-		return -1;
+		return parseInt( response.headers.get( 'content-length' ), 10 ) / 1024;
 	}
 
 	/**

--- a/projects/js-packages/image-guide/src/MeasurableImage.ts
+++ b/projects/js-packages/image-guide/src/MeasurableImage.ts
@@ -18,7 +18,7 @@ export class MeasurableImage {
 	 *
 	 * @param {HTMLElement | HTMLImageElement} node -  The DOM Element that contains the image.
 	 * @param {SourceCallbackFn} getURL             -  A function that takes in the node and returns the URL of the image.
-	 * @param {(input: string, init?: Array) => Promise<Response>} fetchFn                               -  A function that fetches a URL and returns a Promise.
+	 * @param {(input: string, init?: Array) => Promise<Response>} fetchFn -  A function that fetches a URL and returns a Promise.
 	 */
 	constructor( node: HTMLElement | HTMLImageElement, getURL: SourceCallbackFn, fetchFn = fetch ) {
 		this.node = node;

--- a/projects/js-packages/image-guide/src/MeasurableImage.ts
+++ b/projects/js-packages/image-guide/src/MeasurableImage.ts
@@ -2,6 +2,8 @@ export type SourceCallbackFn = ( node: HTMLElement ) => string | null;
 export type Dimensions = { width: number; height: number };
 export type Weight = { weight: number };
 
+type FetchFn = ( input: URL | RequestInfo, init?: RequestInit ) => Promise< Response >;
+
 /**
  * A class that represents a DOM Element that
  * has an image that should be measured and
@@ -16,11 +18,15 @@ export class MeasurableImage {
 	/**
 	 * Constructor.
 	 *
-	 * @param {HTMLElement | HTMLImageElement} node                        -  The DOM Element that contains the image.
-	 * @param {SourceCallbackFn} getURL                                    -  A function that takes in the node and returns the URL of the image.
-	 * @param {(input: string, init?: Array) => Promise<Response>} fetchFn -  A function that fetches a URL and returns a Promise.
+	 * @param {HTMLElement | HTMLImageElement} node -  The DOM Element that contains the image.
+	 * @param {SourceCallbackFn} getURL             -  A function that takes in the node and returns the URL of the image.
+	 * @param {FetchFn} fetchFn                     -  A function that fetches a URL and returns a Promise.
 	 */
-	constructor( node: HTMLElement | HTMLImageElement, getURL: SourceCallbackFn, fetchFn = fetch ) {
+	constructor(
+		node: HTMLElement | HTMLImageElement,
+		getURL: SourceCallbackFn,
+		fetchFn: FetchFn = fetch
+	) {
 		this.node = node;
 		this.getURLCallback = getURL;
 		this.fetch = fetchFn;

--- a/projects/js-packages/image-guide/src/MeasurableImage.ts
+++ b/projects/js-packages/image-guide/src/MeasurableImage.ts
@@ -16,8 +16,8 @@ export class MeasurableImage {
 	/**
 	 * Constructor.
 	 *
-	 * @param {HTMLElement | HTMLImageElement} node -  The DOM Element that contains the image.
-	 * @param {SourceCallbackFn} getURL             -  A function that takes in the node and returns the URL of the image.
+	 * @param {HTMLElement | HTMLImageElement} node                        -  The DOM Element that contains the image.
+	 * @param {SourceCallbackFn} getURL                                    -  A function that takes in the node and returns the URL of the image.
 	 * @param {(input: string, init?: Array) => Promise<Response>} fetchFn -  A function that fetches a URL and returns a Promise.
 	 */
 	constructor( node: HTMLElement | HTMLImageElement, getURL: SourceCallbackFn, fetchFn = fetch ) {

--- a/projects/js-packages/image-guide/src/find-image-elements.ts
+++ b/projects/js-packages/image-guide/src/find-image-elements.ts
@@ -56,14 +56,15 @@ export function backgroundImageSource( node: HTMLElement ) {
  * and remove any nodes that can't be measured.
  *
  * @param {Element[]} domNodes - A list of nodes to measure
+ * @param {(input: string, init?: Array) => Promise<Response>} fetchFn -  A function that fetches a URL and returns a Promise.
  * @returns {MeasurableImage[]} - A list of MeasurableImage objects.
  */
-export function getMeasurableImages( domNodes: Element[] ): MeasurableImage[] {
+export function getMeasurableImages( domNodes: Element[], fetchFn = fetch ): MeasurableImage[] {
 	const nodes = findMeasurableElements( domNodes );
 	return nodes
 		.map( node => {
 			if ( node instanceof HTMLImageElement ) {
-				return new MeasurableImage( node, imageTagSource );
+				return new MeasurableImage( node, imageTagSource, fetchFn );
 			} else if ( node instanceof HTMLElement ) {
 				if ( ! backgroundImageSource( node ) ) {
 					/**

--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -14,6 +14,11 @@ declare global {
 		nonce: string;
 	};
 
+	const jbImageGuide: {
+		proxyNonce: string;
+		ajax_url: string;
+	};
+
 	// Constants provided by the plugin.
 	const Jetpack_Boost: {
 		preferences: {

--- a/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
@@ -14,7 +14,7 @@ class AdminAjaxError extends Error {
  * Prepare a wp-ajax request, returning a raw Response object.
  *
  * @param {Record< string, string >} payload   Key/value pairs to send with the request.
- * @param                            wpajaxurl
+ * @param {string}                   wpajaxurl
  */
 export async function prepareAdminAjaxRequest(
 	payload: Record< string, string >,

--- a/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/make-admin-ajax-request.ts
@@ -13,10 +13,12 @@ class AdminAjaxError extends Error {
 /**
  * Prepare a wp-ajax request, returning a raw Response object.
  *
- * @param {Record< string, string >} payload Key/value pairs to send with the request.
+ * @param {Record< string, string >} payload   Key/value pairs to send with the request.
+ * @param                            wpajaxurl
  */
 export async function prepareAdminAjaxRequest(
-	payload: Record< string, string >
+	payload: Record< string, string >,
+	wpajaxurl = ajaxurl
 ): Promise< Response > {
 	const args = {
 		method: 'post',
@@ -26,7 +28,7 @@ export async function prepareAdminAjaxRequest(
 		},
 	};
 
-	const response = await fetch( ajaxurl, args );
+	const response = await fetch( wpajaxurl, args );
 	if ( ! response.ok ) {
 		throw new AdminAjaxError(
 			sprintf(

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
@@ -17,6 +17,10 @@ class Image_Guide implements Pluggable {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$override = isset( $_GET['jb-debug-ig'] );
 
+		if ( is_admin() || is_user_logged_in() || current_user_can( 'manage_options' ) ) {
+			Image_Guide_Proxy::init();
+		}
+
 		// Show the UI only when the user is logged in, with sufficient permissions and isn't looking at the dashboard.
 		if ( true !== $override && ( is_admin() || ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) ) {
 			return;
@@ -54,6 +58,14 @@ class Image_Guide implements Pluggable {
 			'jetpackBoostAnalytics',
 			array(
 				'tracksData' => Analytics::get_tracking_data(),
+			)
+		);
+		wp_localize_script(
+			'jetpack-boost-guide',
+			'jbImageGuide',
+			array(
+				'proxyNonce' => wp_create_nonce( Image_Guide_Proxy::NONCE_ACTION ),
+				'ajax_url'   => admin_url( 'admin-ajax.php' ),
 			)
 		);
 	}

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -18,28 +18,27 @@ class Image_Guide_Proxy {
 	public static function handle_proxy() {
 		// Verify valid nonce.
 		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), self::NONCE_ACTION ) ) {
-			die( 'bad nonce' );
+			wp_send_json_error( 'bad nonce', 400 );
 		}
 
 		// Make sure currently logged in as admin.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			die( 'not admin' );
+			wp_send_json_error( 'not admin', 400 );
 		}
 
 		// Validate URL and fetch.
 		$proxy_url = filter_var( wp_unslash( isset( $_POST['proxy_url'] ) ? $_POST['proxy_url'] : null ), FILTER_VALIDATE_URL );
 		if ( ! wp_http_validate_url( $proxy_url ) ) {
-			die( 'Invalid URL' );
+			wp_send_json_error( 'Invalid URL', 400 );
 		}
 
 		$response = wp_remote_get( $proxy_url );
 		if ( is_wp_error( $response ) ) {
-			die( 'error' );
+			wp_send_json_error( 'error', 400 );
 		}
 
-		header( 'Content-type: text/html' );
-		echo (int) $response['headers']['content-length'];
-
+		header( 'Content-type: application/json' );
+		wp_send_json_success( iterator_to_array( wp_remote_retrieve_headers( $response ) ) );
 		die();
 	}
 }

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -19,12 +19,12 @@ class Image_Guide_Proxy {
 	public function handle_ig_proxy() {
 		// Verify valid nonce.
 		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), self::NONCE_ACTION ) ) {
-			wp_die( 'bad nonce', 400 );
+			die( 'bad nonce' );
 		}
 
 		// Make sure currently logged in as admin.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( 'not admin', 400 );
+			die( 'not admin' );
 		}
 
 		// Validate URL and fetch.
@@ -35,7 +35,6 @@ class Image_Guide_Proxy {
 
 		$response = wp_remote_get( $proxy_url );
 		if ( is_wp_error( $response ) ) {
-			// TODO: Nicer error handling.
 			die( 'error' );
 		}
 

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -37,7 +37,6 @@ class Image_Guide_Proxy {
 			wp_send_json_error( 'error', 400 );
 		}
 
-		header( 'Content-type: application/json' );
 		wp_send_json_success( iterator_to_array( wp_remote_retrieve_headers( $response ) ) );
 		die();
 	}

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Modules\Image_Guide;
+
+/**
+ * Add an ajax endpoint to proxy external CSS files.
+ */
+class Image_Guide_Proxy {
+	const NONCE_ACTION = 'jb-ig-proxy-nonce';
+
+	public static function init() {
+		$instance = new self();
+		add_action( 'wp_ajax_boost_proxy_ig', array( $instance, 'handle_ig_proxy' ) );
+	}
+
+	/**
+	 * AJAX handler to handle proxying of external image resources.
+	 */
+	public function handle_ig_proxy() {
+		// Verify valid nonce.
+		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), self::NONCE_ACTION ) ) {
+			wp_die( 'bad nonce', 400 );
+		}
+
+		// Make sure currently logged in as admin.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( 'not admin', 400 );
+		}
+
+		// Validate URL and fetch.
+		$proxy_url = filter_var( wp_unslash( isset( $_POST['proxy_url'] ) ? $_POST['proxy_url'] : null ), FILTER_VALIDATE_URL );
+		if ( ! wp_http_validate_url( $proxy_url ) ) {
+			die( 'Invalid URL' );
+		}
+
+		$response = wp_remote_get( $proxy_url );
+		if ( is_wp_error( $response ) ) {
+			// TODO: Nicer error handling.
+			die( 'error' );
+		}
+
+		header( 'Content-type: text/html' );
+		echo (int) $response['headers']['content-length'];
+
+		die();
+	}
+}

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -9,14 +9,13 @@ class Image_Guide_Proxy {
 	const NONCE_ACTION = 'jb-ig-proxy-nonce';
 
 	public static function init() {
-		$instance = new self();
-		add_action( 'wp_ajax_boost_proxy_ig', array( $instance, 'handle_ig_proxy' ) );
+		add_action( 'wp_ajax_boost_proxy_ig', 'Automattic\Jetpack_Boost\Modules\Image_Guide\Image_Guide_Proxy::handle_proxy' );
 	}
 
 	/**
 	 * AJAX handler to handle proxying of external image resources.
 	 */
-	public function handle_ig_proxy() {
+	public static function handle_proxy() {
 		// Verify valid nonce.
 		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), self::NONCE_ACTION ) ) {
 			die( 'bad nonce' );

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -9,7 +9,7 @@ class Image_Guide_Proxy {
 	const NONCE_ACTION = 'jb-ig-proxy-nonce';
 
 	public static function init() {
-		add_action( 'wp_ajax_boost_proxy_ig', 'Automattic\Jetpack_Boost\Modules\Image_Guide\Image_Guide_Proxy::handle_proxy' );
+		add_action( 'wp_ajax_boost_proxy_ig', array( __CLASS__, 'handle_proxy' ) );
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/image-guide/src/index.ts
+++ b/projects/plugins/boost/app/modules/image-guide/src/index.ts
@@ -29,9 +29,16 @@ function discardSmallImages( images: MeasurableImage[] ) {
 	return elements;
 }
 
+/**
+ * Fetches the weight of a resource using a proxy if the resource is not on the same origin.
+ * This function is passed to MeasurableImageStore to be used when fetching the file size of images.
+ *
+ * @param url The URL of the resource to fetch.
+ * @return A Promise that resolves to a Response object.
+ */
 async function fetchWeightUsingProxy( url: string ): Promise< Response > {
 	if ( ! isSameOrigin( url ) ) {
-		return prepareAdminAjaxRequest(
+		const response = await prepareAdminAjaxRequest(
 			{
 				action: 'boost_proxy_ig',
 				proxy_url: url,
@@ -39,8 +46,32 @@ async function fetchWeightUsingProxy( url: string ): Promise< Response > {
 			},
 			jbImageGuide.ajax_url
 		);
+
+		if (
+			response.headers.get( 'content-type' ) &&
+			response.headers.get( 'content-type' ).indexOf( 'application/json' ) !== -1
+		) {
+			const json = await response.clone().json();
+			if ( json && json.data[ 'content-length' ] ) {
+				// If the JSON data contains the content length, create a new response object with the JSON headers and the original response body.
+				const headers = new Headers();
+				for ( const key in json.data ) {
+					if ( json.data.hasOwnProperty( key ) ) {
+						headers.set( key, json.data[ key ] );
+					}
+				}
+
+				const newResponse = new Response( response.body, {
+					status: response.status,
+					statusText: response.statusText,
+					headers,
+				} );
+				return newResponse;
+			}
+		}
 	}
 
+	// If the resource is on the same origin or the response is not JSON, fetch the resource using a HEAD request with no-cors mode.
 	return await fetch( url, { method: 'HEAD', mode: 'no-cors' } );
 }
 

--- a/projects/plugins/boost/app/modules/image-guide/src/ui/Popup.svelte
+++ b/projects/plugins/boost/app/modules/image-guide/src/ui/Popup.svelte
@@ -175,12 +175,6 @@
 					{/if}
 				</div>
 			</div>
-			{#if imageOrigin !== origin}
-				<div class="info">
-					Unable to estimate file size savings because the image is hosted on a different domain.
-				</div>
-			{/if}
-
 			<div class="info">
 				<a class="documentation" href={DOCUMENTATION_URL} target="_blank noreferrer"
 					>Learn how to improve site speed by optimizing images <External /></a

--- a/projects/plugins/boost/changelog/fix-proxy_image_guide_images
+++ b/projects/plugins/boost/changelog/fix-proxy_image_guide_images
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Boost: add a proxy to Image Guide so it can load remote images.


### PR DESCRIPTION
The Image Guide provides information about the images used on a web page but it cannot load remote images and show file size information about them.

This PR adds a proxy server and makes AJAX calls to it to fetch the remote image through the home server of the page.

Props to @thingalon for all his help with this.

Fixes #29896

## Proposed changes:
* It modifies MeasurableImage, adding a third parameter, a proxy callback, to the constructor.
* That callback is used to fetch remote images, returning only the size, which is handled in fetchFileWeight.
* Similarly, getMeasurableImages has a third parameter in the same way, passing it down to MeasurableImage.
* We needed to pass the ajax URL to prepareAdminAjaxRequest, as it would be used in the frontend.
* The proxy function is fetchWeightUsingProxy, which is used in the initialize() function when creating a list of MeasurableImage objects.
* Remove the notice that images on a different domain can't be loaded.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply PR
Embed an image from another domain in a test post.
View the post with Image Guide enabled and it will show the filesize of that image.

## Screenshots
![before](https://github.com/Automattic/jetpack/assets/5656673/d42776f3-2df2-4813-8a7b-27317f8b4cc3)
![after](https://github.com/Automattic/jetpack/assets/5656673/f560c0d2-9a2b-4ce3-9c05-9d263737f14a)
