### PR TITLE
CRM: Resolves 3134 - show invoice assignee link

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3134-show_invoice_assignee_link
+++ b/projects/plugins/crm/changelog/fix-crm-3134-show_invoice_assignee_link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Invoices: show assigned contact/company link

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -200,6 +200,9 @@ function zbscrm_JS_draw_invoice_html() {
 		// hide this to show msg properly, also
 		jQuery( '#zbs_loader, #zbs_invoice' ).hide();
 	}
+
+	zeroBSCRMJS_showContactLinkIf(jQuery( '#zbs_invoice_contact' ).val());
+	zeroBSCRMJS_showCompanyLinkIf(jQuery( '#zbs_invoice_company' ).val());
 }
 
 //draws the status line (and links that are present (download PDF, preview, send))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3134 - show invoice assignee link

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When assigning a contact or company to an object, it is supposed to show a link to said assignee in the learn menu. This works for all objects after selecting an assignee, but when loading an invoice that is assigned, it doesn't show the link unless one reassigns the contact.

This PR resolves that by running the proper functions after drawing the invoice page. This is what the link looks like ("View contact" or "View company"):

![image](https://github.com/Automattic/jetpack/assets/32492176/2664c2c0-b636-49b7-863c-5a236a19852d)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a contact.
2. Create a company.
3. Create an invoice assigned to the contact. Refresh.
4. Create an invoice assigned to the company. Refresh.

In `trunk`, the "View X" link won't show after refresh (or upon initial pageload).

In the `fix/crm/3134-show_invoice_assignee_link` branch, the "View X" link will show when it's supposed to.