### PR TITLE
CRM: Resolves 3114 and 3115 - listview settings bugs

### DIFF
--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -45,7 +45,7 @@ function jpcrm_render_company_view_page( $id = -1 ) {
 			}
 
 			// Get screen options for user
-			$screenOpts = $zbs->userScreenOptions();
+			$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 			// Retrieve company
 			$company = $zbs->DAL->companies->getCompany( $id, $args );

--- a/projects/plugins/crm/changelog/fix-crm-3114-screenopt_save_issues
+++ b/projects/plugins/crm/changelog/fix-crm-3114-screenopt_save_issues
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+Listview: per-page settings no longer reset
+Listview: PHP notice no longer shows when saving settings

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5640,7 +5640,7 @@ function zeroBSCRM_AJAX_saveScreenOptions() {
 		// Formerly this used FILTER_SANITIZE_STRING, which is now deprecated as it was fairly broken. This is basically equivalent.
 		// @todo Replace this with something more correct.
 		foreach ( $screenOpts as $k => $v ) {
-			if ( isset( $screenOptionsFilters[$k]['filter'] ) && $screenOptionsFilters[$k]['filter'] === FILTER_UNSAFE_RAW ) {
+			if ( isset( $screenOptionsFilters[ $k ]['filter'] ) && $screenOptionsFilters[ $k ]['filter'] === FILTER_UNSAFE_RAW && $v !== null ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				foreach ( $v as $k2 => $v2 ) {
 					$screenOpts[$k][$k2] = strtr(
 						strip_tags( $v2 ),

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -2687,7 +2687,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 		if ( isset( $listViewParams['pagekey'] ) && ! empty( $listViewParams['pagekey'] ) ) {
 
 			// has a key, get screen opts
-			$screenOpts = $zbs->userScreenOptions( $listViewParams['pagekey'] );
+			$screenOpts = $zbs->global_screen_options( $listViewParams['pagekey'] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			if ( is_array( $screenOpts ) ) {
 
 				if ( isset( $screenOpts['perpage'] ) ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5662,7 +5662,7 @@ function zeroBSCRM_AJAX_saveScreenOptions() {
 	if ( ! empty( $pageKey ) ) {
 
 		// } Brutally update
-		$zbs->DAL->updateUserSetting( $zbs->user(), 'screenopts_' . $pageKey, $screenOpts );
+		$zbs->DAL->updateSetting( 'screenopts_' . $pageKey, $screenOpts ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		zeroBSCRM_sendJSONSuccess( array( 'fini' => 1 ) );
 		exit();

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -2734,22 +2734,36 @@ final class ZeroBSCRM {
 
 		if ( $currentUserID > 0 && ! empty( $pageKeyCheck ) ) {
 
-			/*
-			Array
-			(
-				[tabs_1] => zerobs-customer-logs,zerobs-customer-edit
-				[zerobs-customer-files] => self
-			)
-			*/
-
 			// retrieve via dal
-			// print_r($this->DAL->userSetting($currentUserID,'screenopts_'.$currentPageKey,false));
 
 			return $this->DAL->userSetting( $currentUserID, 'screenopts_' . $pageKeyCheck, false );
 
 		}
 
 		return array();
+	}
+
+	/**
+	 * Get global screen option settings
+	 *
+	 * @param string $page_key Page key.
+	 */
+	public function global_screen_options( $page_key = false ) {
+
+		if ( empty( $page_key ) ) {
+			$page_key = apply_filters( 'zbs_pagekey', $this->pageKey ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+
+		if ( empty( $page_key ) ) {
+			return array();
+		}
+
+		$screen_options = $this->DAL->getSetting( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			array(
+				'key' => 'screenopts_' . $page_key,
+			)
+		);
+		return $screen_options;
 	}
 
 	/**

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -204,6 +204,14 @@ class zeroBSCRM_list{
 			}
 		}
 
+		$screen_opts = $zbs->global_screen_options();
+
+		if ( ! empty( $screen_opts['perpage'] ) && $screen_opts['perpage'] > 0 ) {
+			$per_page = (int) $screen_opts['perpage'];
+		} else {
+			$per_page = 20;
+		}
+
         #} Refresh 2
         ?>
 
@@ -331,41 +339,28 @@ class zeroBSCRM_list{
                 <div class="ui divider"></div>
                 <?php } // if admin/can manage columns ?>
 
-                <div id="zbs-list-options-base-wrap" class="ui grid">
+								<div id="zbs-list-options-base-wrap" class="ui grid">
 
-                    <?php 
-                        # here we add stuff which is saved by screenOptions, even tho it's in its own dom elements, not sceen options area 
-											$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+									<div class="two column clearing centered row">
+										<div class="column" style="max-width:364px;">
+											<div class="ui labeled input">
+												<div class="ui label"><i class="table icon"></i>  <?php esc_html_e( 'Records per page:', 'zero-bs-crm' ); ?></div>
+												<input type="text" style="width:70px;" class="intOnly" id="zbs-screenoptions-records-per-page" value="<?php echo esc_attr( $per_page ); ?>" />
+											</div>
+										</div>
+									</div>
 
-                        // debug echo '<pre>'; print_r($screenOpts); echo '</pre>'; 
+									<div class="ui divider" style="margin-bottom:0;margin-top:0;"></div>
 
-                        // default
-                        $perPage = 20; 
-                        if (isset($screenOpts) && is_array($screenOpts) && isset($screenOpts['perpage']) && !empty($screenOpts['perpage']) && $screenOpts['perpage'] > 0) $perPage = (int)$screenOpts['perpage'];
-                    ?>
-                    <div class="two column clearing centered row">
+									<div class="two column clearing centered row">
+										<div class="column" style="max-width:364px;">
+											<button id="zbs-columnmanager-bottomsave" type="button" class="ui button black positive">
+												<i class="check square icon"></i> <?php esc_html_e( 'Save Options and Close', 'zero-bs-crm' ); ?>
+											</button>
+										</div>
+									</div>
 
-                        <div class="column" style="max-width:364px;">
-                            <div class="ui labeled input">
-										<div class="ui label"><i class="table icon"></i>  <?php esc_html_e( 'Records per page:', 'zero-bs-crm' ); ?></div>
-                                <input type="text" style="width:70px;" class="intOnly" id="zbs-screenoptions-records-per-page" value="<?php echo esc_attr( $perPage ); ?>" />
-                            </div>
-                        </div>
-
-                    </div>
-
-
-                <div class="ui divider" style="margin-bottom:0;margin-top:0;"></div>
-
-                    <div class="two column clearing centered row">
-
-                        <div class="column" style="max-width:364px;">
-									<button id="zbs-columnmanager-bottomsave" type="button" class="ui button black positive"><i class="check square icon"></i> <?php esc_html_e( 'Save Options and Close', 'zero-bs-crm' ); ?></button>
-                        </div>
-
-                    </div>
-
-                </div>
+								</div>
 
 
             </div>
@@ -456,17 +451,6 @@ class zeroBSCRM_list{
 
 		            $inlineEditStr[ $colKey ] = (int) $inline;
 	            }
-            }
-
-            #} Check for screen options (perpage)
-            $per_page = 20;
-					$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-            if ( is_array( $screenOpts ) ) {
-
-	            if ( isset( $screenOpts['perpage'] ) ) $per_page = (int)$screenOpts['perpage'];
-	            // catch
-	            if ( $per_page < 1 ) $per_page = 20;
-
             }
 
             // build options objects

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -335,7 +335,7 @@ class zeroBSCRM_list{
 
                     <?php 
                         # here we add stuff which is saved by screenOptions, even tho it's in its own dom elements, not sceen options area 
-                        $screenOpts = $zbs->userScreenOptions();
+											$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
                         // debug echo '<pre>'; print_r($screenOpts); echo '</pre>'; 
 
@@ -460,7 +460,7 @@ class zeroBSCRM_list{
 
             #} Check for screen options (perpage)
             $per_page = 20;
-            $screenOpts = $zbs->userScreenOptions();
+					$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
             if ( is_array( $screenOpts ) ) {
 
 	            if ( isset( $screenOpts['perpage'] ) ) $per_page = (int)$screenOpts['perpage'];

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBox.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBox.php
@@ -437,8 +437,7 @@ function zeroBSCRM_do_meta_boxes( $screen, $context, $object ) {
 
         //echo 'Screen: '.$zbs->pageKey.' # '.$context;
         // use ours
-        $screenOpts = $zbs->userScreenOptions(); // false = not set, array if set (can be either GLOBAL FORCED by admin, or user specific)
-        // not needed here: $screenOptionsList = array(); if (is_array($screenOpts) && isset($screenOpts['mb_'.$context]) && is_array($screenOpts['mb_'.$context])) $screenOptionsList = $screenOpts['mb_'.$context];
+				$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
         $hidden = array(); if (is_array($screenOpts) && isset($screenOpts['mb_hidden']) && is_array($screenOpts['mb_hidden'])) $hidden = $screenOpts['mb_hidden'];
         $minimised = array(); if (is_array($screenOpts) && isset($screenOpts['mb_mini']) && is_array($screenOpts['mb_mini'])) $minimised = $screenOpts['mb_mini'];
 
@@ -502,10 +501,11 @@ function zeroBSCRM_do_meta_boxes( $screen, $context, $object ) {
 
 function zeroBSCRM_applyScreenOptions($screenOpts = false,$page = '', $context = ''){
 
-    global $zbs;
+	global $zbs;
 
-    // if not passed, load users :) 
-    if (!is_array($screenOpts)) $screenOpts = $zbs->userScreenOptions();
+	if ( ! is_array( $screenOpts ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	}
     $screenOptionsList = array(); if (is_array($screenOpts) && isset($screenOpts['mb_'.$context]) && is_array($screenOpts['mb_'.$context])) $screenOptionsList = $screenOpts['mb_'.$context];
     // not needed here: $hidden = array(); if (is_array($screenOpts) && isset($screenOpts['mb_hidden']) && is_array($screenOpts['mb_hidden'])) $hidden = $screenOpts['mb_hidden'];
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.ScreenOptions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.ScreenOptions.php
@@ -24,7 +24,7 @@ function zeroBSCRM_screenOptionsPanel(){
 	global $zbs;
 
 	$screenOptionsHTML = ''; $options = array(); $rights = true; // this is 'okay for everyone' - current_user_can('administrator')?
-    $screenOpts = $zbs->userScreenOptions();
+	$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	switch ($zbs->pageKey){
 
@@ -221,7 +221,7 @@ function zeroBS_outputScreenOptions(){
 
 	global $zbs;
 
-	$screenOpts = $zbs->userScreenOptions();
+	$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	?><script type="text/javascript">var zbsPageKey = '<?php echo esc_html( $zbs->pageKey ); ?>';var zbsScreenOptions = <?php echo json_encode($screenOpts); ?>;</script><?php
 

--- a/projects/plugins/crm/includes/wh.config.lib.php
+++ b/projects/plugins/crm/includes/wh.config.lib.php
@@ -65,33 +65,11 @@
 		#} Checks through defaults + existing and adds defaults where unset
 		function validateAndUpdate(){
 
-			global $zbs;
-
-			// DAL1 save:
-			if (!$zbs->isDAL2()){
-				
-				$defaultsAdded = 0;
-				foreach ($this->settingsDefault as $key => $val){ 
-					if (!isset($this->settings[$key])) {
-						$this->settings[$key] = $val;
-						$defaultsAdded++;
-					}
-				}
-				
-				if ($defaultsAdded > 0) $this->saveToDB();
-
-			} else {
-
-				// DAL 2
-				
 				foreach ($this->settingsDefault as $key => $val){ 
 					if (!isset($this->settings[$key])) {
 						$this->update($key,$val);
 					}
 				}
-				
-
-			}
 
 		}
 		
@@ -159,22 +137,8 @@
 			if (empty($key) === true) return false;
 
 			global $zbs;
-			
-			// if $freshFromDB, reload from db
-			if (!$freshFromDB && $zbs->isDAL2()){
-
-				// normal way
-				if (isset($this->settings[$key]))
-					return $this->settings[$key];
-				else
-					return false;
-
-			} else {
-
 				// db-loading way (ONLY WORKS DB2!)
 				return $zbs->DAL->getSetting(array('key' => $key,'fullDetails' => false));	
-			}
-			
 		}
 		
 		#} Add/Update *brutally
@@ -184,22 +148,9 @@
 
 			global $zbs;
 
-			// DAL1 save:
-			if (!$zbs->isDAL2()){
-
-				#} Don't even check existence as I guess it doesn't matter?
-				$this->settings[$key] = $val;	
-				
-				#} Save down
-				$this->saveToDB();
-
-			} else {
-
 				#} Don't even check existence as I guess it doesn't matter?
 				$this->settings[$key] = $val;	
 				$zbs->DAL->updateSetting($key, $val);	
-				
-			}
 			
 		}		
 		
@@ -353,27 +304,6 @@
 
 			global $zbs;
 
-			// DAL1 load:
-			if (!$zbs->isDAL2()){
-			
-				#} Load the register
-				$this->settingsDMZRegister = get_option($this->settingsDMZKey);
-
-				#} Load anything logged in register
-				if (is_array($this->settingsDMZRegister) && count($this->settingsDMZRegister) > 0) { foreach ($this->settingsDMZRegister as $regEntry){
-
-						#} Load it
-						$this->settingsDMZ[$regEntry] = get_option($this->settingsDMZKey.'_'.$regEntry);
-
-					}
-				}
-				return $this->settingsDMZ;
-
-			} else {
-
-				// DAL 2 load :)
-				global $zbs;
-			
 				#} Load the register
 				$this->settingsDMZRegister = $zbs->DAL->setting($this->settingsDMZKey,array());
 
@@ -391,10 +321,6 @@
 					}
 				}
 				return $this->settingsDMZ;
-
-
-			}
-			
 		}
 
 		#} / DMZ Fields
@@ -405,29 +331,6 @@
 		function saveToDB(){
 
 			global $zbs;
-
-			// DAL1 save:
-			if (!$zbs->isDAL2()){
-		
-				$u = array();
-				$u[] = update_option($this->settingsKey, $this->settings);				
-
-				#} Also any DMZ's!
-
-					#} save register
-					update_option($this->settingsDMZKey,$this->settingsDMZRegister);
-					if (isset($this->settingsDMZRegister) && is_array($this->settingsDMZRegister)) foreach ($this->settingsDMZRegister as $dmzKey){ # => $dmzVal
-
-						$u[] = update_option($this->settingsDMZKey.'_'.$dmzKey, $this->settingsDMZ[$dmzKey]);	
-
-					}
-
-				return $u;
-
-			} else {
-
-				// DAL 2 save :)
-				global $zbs;
 		
 				// DAL2 saves individually :)
 				$u = array();
@@ -449,7 +352,6 @@
 					}
 
 				return $u;
-			}
 			
 		}
 		
@@ -458,22 +360,9 @@
 
 			global $zbs;
 
-			// DAL1 load:
-			if (!$zbs->isDAL2()){
-				
-				$this->settings = get_option($this->settingsKey);
-				return $this->settings;
-
-			} else {
-
-				// DAL2 load:
-				// for now, load everything
-				global $zbs; 
 				$this->settings = $zbs->DAL->getSettings(array('autoloadOnly' => true,'fullDetails' => false));				
 				return $this->settings;
 
-			}
-			
 		}		
 		
 		#} Uninstall func - effectively creates a bk then removes its main setting
@@ -487,20 +376,11 @@
 			
 			#} Blank it out
 			$this->settings = NULL;
-			
-			#} Return the delete
-			if (!$zbs->isDAL2()){
-
-				// DAL 1
-				return delete_option($this->settingsKey);
-
-			} else {
 
 				// DAL2 
 				// leave for now
 				return true;
-			}
-			
+
 		}
 		
 		#} Backup existing settings obj (ripped from sgv2.0)
@@ -684,5 +564,3 @@ function zeroBS_temp_ext_legacy_notice(){
 		define('ZBSLEGACYSET',1);
 	}
 }	
-	
-?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3114 and Automattic/zero-bs-crm#3115 - listview settings bugs

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR addresses two issues:

1. PHP errors when saving page settings (e.g. listview settings or contact edit metabox settings)
2. listview settings resets

For the first item, there was a `for` loop that was trying to cycle through key values on `null` in some instances. Adding a non-null condition fixed this.

The second issue was far more complex. Essentially anytime a module (e.g. WooSync or MailPoet) loads its settings, it does a brute force resave of all loaded settings, including "screen options" (per-page view settings). While it's a bit overkill, it generally works fine.

However, screen options were implemented to save in a per-user fashion, and the brute force save has no concept of setting ownership, so when resaving, the setting owner is changed to `-1` (no owner), and then the page can't find its screen options anymore.

Given that:

* Per-user settings were never fully implemented through the system,
* It hasn't ever worked,
* A change is unlikely to impact many installs, and
* A core fix wouldn't suffice, as extensions also implement the same brute force update...

I just went ahead and made screen option settings global until a future date when we might consider per-user settings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to a listview: `/wp-admin/admin.php?page=manage-customers`
2. Change per-page settings.
3. Go to the WooSync Hub: `/wp-admin/admin.php?page=woo-sync-hub`
4. Go back to the listview and look at its settings.

In `trunk`, one gets PHP errors after step 2, and per-page settings are reset to default (20).

In the `fix/crm/3114-screenopt_save_issues` branch, there are no errors after step 2 and the per-page settings are not affected by modules/extensions.