### PR TITLE
CRM: Resolves 3138 - hide resources and support pages on white label installs

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3138-hide_resources_page_on_white_label
+++ b/projects/plugins/crm/changelog/fix-crm-3138-hide_resources_page_on_white_label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+White label: JPCRM support and resources pages no longer show

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -553,7 +553,9 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 
 			$popout_menu = array(
 				'col1' => array(),
+				##WLREMOVE
 				'col2' => array(),
+				##/WLREMOVE
 				'col3' => array(),
 			);
 
@@ -609,36 +611,33 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 						echo $link; }
 					?>
 					</div>
-				</div><?php } ?>
+				</div>
+				<?php
+			}
+			##WLREMOVE
+			// no need for support column if white label
+			?>
 				<div class="column">
 					<h4 class="ui header"><?php esc_html_e( 'Support', 'zero-bs-crm' ); ?></h4>
 					<div class="ui link list">
-					
-				<?php ##WLREMOVE ?>
-					<a href="<?php echo esc_url( $zbs->urls['docs'] ); ?>" class="item" target="_blank"><i class="file text outline icon"></i> <?php esc_html_e( 'Knowledge base', 'zero-bs-crm' ); ?></a>
-				<?php ##/WLREMOVE ?>
-					
-					<a href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['support'] ) ); ?>" class="item"><i class="icon user md"></i> <?php esc_html_e( 'Support', 'zero-bs-crm' ); ?></a>
-
-					<?php ##WLREMOVE ?>
-					<a href="<?php echo esc_url( $zbs->urls['twitter'] ); ?>" class="item" target="_blank"><i class="icon twitter"></i> <?php esc_html_e( '@jetpackcrm', 'zero-bs-crm' ); ?></a>
-					<?php ##/WLREMOVE ?>
-
-					<a class="item" href="<?php echo esc_url( $zbs->urls['rateuswporg'] ); ?>"><i class="star icon" aria-hidden="true"></i> <?php esc_html_e( 'Leave a review', 'zero-bs-crm' ); ?></a>
-					
-					<?php
-					// welcome tour and crm resources page for admins :)
-					if ( zeroBSCRM_isZBSAdminOrAdmin() ) {
-						##WLREMOVE
-						?>
-						<a id="zbs-tour-top-menu-dash" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['dash'] ) ); ?>&zbs-welcome-tour=1" class="item"><i class="icon magic"></i> <?php esc_html_e( 'Welcome Tour', 'zero-bs-crm' ); ?></a>
-						<a id="crm-resources-top-menu-dash" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['crmresources'] ) ); ?>" class="item"><i class="icon building"></i> <?php esc_html_e( 'Resources', 'zero-bs-crm' ); ?></a>
+						<a href="<?php echo esc_url( $zbs->urls['docs'] ); ?>" class="item" target="_blank"><i class="file text outline icon"></i> <?php esc_html_e( 'Knowledge base', 'zero-bs-crm' ); ?></a>
+						<a href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['support'] ) ); ?>" class="item"><i class="icon user md"></i> <?php esc_html_e( 'Support', 'zero-bs-crm' ); ?></a>
+						<a href="<?php echo esc_url( $zbs->urls['twitter'] ); ?>" class="item" target="_blank"><i class="icon twitter"></i> <?php esc_html_e( '@jetpackcrm', 'zero-bs-crm' ); ?></a>
+						<a class="item" href="<?php echo esc_url( $zbs->urls['rateuswporg'] ); ?>"><i class="star icon" aria-hidden="true"></i> <?php esc_html_e( 'Leave a review', 'zero-bs-crm' ); ?></a>
 						<?php
-						##/WLREMOVE
-					}
-					?>
+						// welcome tour and crm resources page for admins :)
+						if ( zeroBSCRM_isZBSAdminOrAdmin() ) {
+							?>
+							<a id="zbs-tour-top-menu-dash" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['dash'] ) ); ?>&zbs-welcome-tour=1" class="item"><i class="icon magic"></i> <?php esc_html_e( 'Welcome Tour', 'zero-bs-crm' ); ?></a>
+							<a id="crm-resources-top-menu-dash" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['crmresources'] ) ); ?>" class="item"><i class="icon building"></i> <?php esc_html_e( 'Resources', 'zero-bs-crm' ); ?></a>
+							<?php
+						}
+						?>
 					</div>
 				</div>
+				<?php
+				##/WLREMOVE
+				?>
 				<div class="column">
 					<h4 class="ui header"><?php echo esc_html( $currentUser->display_name ); ?></h4>
 					<div class="ui link list">

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.WP.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.WP.php
@@ -65,8 +65,9 @@ function zeroBSCRM_menu_buildMenu() {
 	$use_calendar     = zeroBSCRM_getSetting( 'feat_calendar' ) == 1;
 
 	// Check if it has license to show the Support menu
-	$license     = zeroBSCRM_getSetting( 'license_key' );
-	$has_license = is_array( $license ) && ! empty( $license['key'] );
+	$license      = zeroBSCRM_getSetting( 'license_key' );
+	$has_license  = is_array( $license ) && ! empty( $license['key'] );
+	$support_menu = $has_license ? 'jpcrm' : 'hidden';
 
 	// this is the "first build" function, so begin with this :)
 	$menu = array(
@@ -293,8 +294,6 @@ function zeroBSCRM_menu_buildMenu() {
 			'stylefuncs' => array( 'zeroBSCRM_global_admin_styles', 'jpcrm_crm_resources_page_styles_scripts' ),
 		);
 
-		$support_menu = $has_license ? 'jpcrm' : 'hidden';
-
 		$menu[ $support_menu ]['subitems']['support'] = array(
 			'title'      => '<span>' . __( 'Support', 'zero-bs-crm' ) . '</span>',
 			'url'        => $zbs->slugs['support'],
@@ -396,8 +395,9 @@ function zeroBSCRM_menu_buildMenu() {
 			'stylefuncs' => array( 'zeroBSCRM_global_admin_styles', 'zeroBSCRM_settingspage_admin_styles' ),
 		);
 
-		// Feedback (sub)
-		$menu['jpcrm']['subitems']['feedback'] = array(
+		##WLREMOVE
+		// Resources (sub)
+		$menu['jpcrm']['subitems']['crmresources'] = array(
 			'title'      => '<span style="color: #64ca43;">' . __( 'Resources', 'zero-bs-crm' ) . '</span>',
 			'url'        => $zbs->slugs['crmresources'],
 			'perms'      => 'admin_zerobs_manage_options',
@@ -406,6 +406,17 @@ function zeroBSCRM_menu_buildMenu() {
 			'callback'   => 'zeroBSCRM_pages_crmresources',
 			'stylefuncs' => array( 'zeroBSCRM_global_admin_styles', 'jpcrm_crm_resources_page_styles_scripts' ),
 		);
+
+		$menu[ $support_menu ]['subitems']['support'] = array(
+			'title'      => '<span>' . __( 'Support', 'zero-bs-crm' ) . '</span>',
+			'url'        => $zbs->slugs['support'],
+			'perms'      => 'admin_zerobs_manage_options',
+			'order'      => 102,
+			'wpposition' => 102,
+			'callback'   => 'jpcrm_pages_support',
+			'stylefuncs' => array( 'zeroBSCRM_global_admin_styles', 'jpcrm_support_page_styles_scripts' ),
+		);
+		##/WLREMOVE
 		/**
 		 * End Jetpack CRM submenu items
 		 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3138 - hide resources and support pages on white label installs

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
On white label, we were sometimes showing pages we shouldn't. For example, we see Resources:

![image](https://github.com/Automattic/jetpack/assets/32492176/2cb4f3cb-e31c-45dd-ae22-8aceb55bf741)

And we see Support and Review:
![image](https://github.com/Automattic/jetpack/assets/32492176/52b69595-d3fe-4431-bd63-0ce19dcff026)

Likewise, on a regular install we don't see support if using Full/CRM Only menu mode:
![image](https://github.com/Automattic/jetpack/assets/32492176/905f8a31-b40f-4df1-920b-644dfbbb8430)

This PR removes Resources and the middle column of the profile menu from white label installs, and adds support to regular installs when using Full/CRM Only menu mode.

**Note:** beware of Automattic/zero-bs-crm#3137 if using an older white label install to test the "before" state.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a built copy of this PR to your local `app`'s `/rebrandr/_build/core-versions/` and `/rebrandr/_build/templates/`. You can download that from here: https://betadownload.jetpack.me/data/zero-bs-crm/fix_crm_3138-hide_resources_page_on_white_label/zero-bs-crm-dev.zip
2. Run `app` and go to `/rebrandr-app` to set up a template and build the white-label CRM.
3. Download the CRM bundle zip.
4. Upload the downloaded CRM zip (which is nested in a parent zip) to a test site.
5. Ensure the menus are as described.