### PR TITLE
Contact Form: remove duplicated Add Contact Form button

### DIFF
--- a/projects/packages/forms/changelog/fix-double-contact-form-button
+++ b/projects/packages/forms/changelog/fix-double-contact-form-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Editor view: remove duplicated Add Contact Form button.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contact_Form_Admin class.
+ * Admin class.
  *
  * @package automattic/jetpack-forms
  */
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Redirect;
 
 /**
- * Class Grunion_Admin
+ * Class Admin
  *
  * Singleton for Grunion admin area support.
  */

--- a/projects/packages/forms/src/contact-form/class-editor-view.php
+++ b/projects/packages/forms/src/contact-form/class-editor-view.php
@@ -32,7 +32,7 @@ class Editor_View {
 	 * Admin header.
 	 */
 	public static function admin_head() {
-		remove_action( 'media_buttons', 'grunion_media_button', 999 );
+		remove_action( 'media_buttons', array( Admin::init(), 'grunion_media_button' ), 999 );
 		add_action( 'media_buttons', array( __CLASS__, 'grunion_media_button' ), 999 );
 	}
 


### PR DESCRIPTION
Fixes #31151

## Proposed changes:

This was introduced by mistake when moving the contact form code from the module to its own package; we forgot to change the reference to the code that removes the legacy button.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site where Jetpack is installed and connected, and where the contact form module is active.
* Go to Plugins > Add New, install and activate the WooCommerce plugin.
* Go to Products > Add New
* Notice the single "Add Contact Form" button.
* Now go back to Plugins > Add New, install and activate the Classic editor plugin.
* Go to Pages > Add New
* You should see the same, single "Add contact form" button there as well.
