### PR TITLE
AI Assistant: Add different message for requests with moderation issues

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-moderation-message
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-moderation-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Add different message for requests with moderation issues

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -170,8 +170,7 @@ export class SuggestionsEventSource extends EventTarget {
 				if (
 					response.status >= 400 &&
 					response.status <= 500 &&
-					response.status !== 503 &&
-					response.status !== 429
+					! [ 422, 429 ].includes( response.status )
 				) {
 					self.processConnectionError( response );
 				}
@@ -190,6 +189,14 @@ export class SuggestionsEventSource extends EventTarget {
 				 */
 				if ( response.status === 429 ) {
 					self.dispatchEvent( new CustomEvent( 'error_quota_exceeded' ) );
+				}
+
+				/*
+				 * error code 422
+				 * request flagged by moderation system
+				 */
+				if ( response.status === 422 ) {
+					self.dispatchEvent( new CustomEvent( 'error_moderation' ) );
 				}
 
 				throw new Error();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -279,6 +279,21 @@ const useSuggestionsFromOpenAI = ( {
 			} );
 		} );
 
+		source?.current.addEventListener( 'error_moderation', () => {
+			source?.current.close();
+			setIsLoadingCompletion( false );
+			setWasCompletionJustRequested( false );
+			setShowRetry( false );
+			setError( {
+				code: 'error_moderation',
+				message: __(
+					'This request has been flagged by our moderation system. Please try to rephrase it and try again.',
+					'jetpack'
+				),
+				status: 'info',
+			} );
+		} );
+
 		source?.current.addEventListener( 'suggestion', e => {
 			setWasCompletionJustRequested( false );
 			debug( 'fullMessage', e.detail );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31122

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks for a `422` status and emit an `error_moderation` event

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add an AI Assistant block
* Make a normal request and check that it works
* Make a request with a bad word (ref: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Sonq%2Qjbeqf.cuc%3Se%3Q7pr2oqpp%2337-og)
* Check that a notice is shown with the following message: `This request has been flagged by our moderation system. Please try to rephrase it and try again.`

![2023-06-02_09-45-52](https://github.com/Automattic/jetpack/assets/8486249/8067c7a5-7b28-4fca-8506-39046afb4af7)
