### PR TITLE
Launchpad: Improve launchpad status check

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-improve-launchpad-status-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-improve-launchpad-status-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Improved the launchpad task status check

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -22,4 +22,35 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 		$this->assertIsArray( $result );
 		$this->assertEmpty( $result );
 	}
+
+	/**
+	 * Test completing a task and verifying that it's marked as complete.
+	 *
+	 * @covers ::mark_task_complete ::is_task_complete
+	 */
+	public function test_mark_task_complete() {
+		$task_to_complete = 'task_0';
+		$task_incomplete  = 'task_1';
+		wpcom_register_launchpad_task(
+			array(
+				'id'    => $task_to_complete,
+				'title' => $task_to_complete,
+			)
+		);
+		wpcom_register_launchpad_task(
+			array(
+				'id'    => $task_incomplete,
+				'title' => $task_incomplete,
+			)
+		);
+
+		$task_lists = Launchpad_Task_Lists::get_instance();
+		$task_lists->mark_task_complete( $task_to_complete );
+
+		$this->assertTrue( $task_lists->is_task_id_complete( $task_to_complete ) );
+		$this->assertTrue( $task_lists->get_task_status( $task_to_complete ) );
+		$this->assertEquals( array( $task_to_complete => true ), $task_lists->get_task_statuses() );
+		$this->assertFalse( $task_lists->is_task_id_complete( $task_incomplete ) );
+		$this->assertFalse( $task_lists->get_task_status( false ) );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/77331

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Cache the task list statuses in the `Launchpad_Task_Lists` class to avoid invoking the `get_option` function multiple times.
* Adds the `update_task_statuses` filter when updating the tasks. This filter can help us exclude deleted tasks from the task status list.


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

paYKcK-322-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the unit tests with the following command:
```bash
cd projects/packages/jetpack-mu-wpcom; ./vendor/bin/phpunit --filter=Launchpad_Task_Lists_Test; cd -
```
* Sandbox the public-api
* Apply these changes: https://github.com/Automattic/jetpack/pull/31166#issuecomment-1573740044
* Create a new free site and go through the Launchpad.
* Make sure that the tasks are correctly marked as completed.
