### PR TITLE
Jetpack Social | Fix state when adding a new connection

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-state
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed the connection state to ensure that new connections are disabled by default when there are no shares left.

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -10,7 +10,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { Button, PanelRow, Disabled, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState, Fragment, createInterpolateElement, useCallback } from '@wordpress/element';
+import { Fragment, createInterpolateElement, useCallback } from '@wordpress/element';
 import { _n, sprintf, __ } from '@wordpress/i18n';
 import useAttachedMedia from '../../hooks/use-attached-media';
 import useDismissNotice from '../../hooks/use-dismiss-notice';
@@ -67,13 +67,15 @@ export default function PublicizeForm( {
 	const hasInstagramConnection = connections.some(
 		connection => connection.service_name === 'instagram-business'
 	);
-	const [ shouldShowInstagramNotice, setShouldShowInstagramNotice ] = useState(
-		! hasInstagramConnection && isInstagramConnectionSupported
-	);
+
+	const shouldShowInstagramNotice =
+		! hasInstagramConnection &&
+		isInstagramConnectionSupported &&
+		! dismissedNotices.includes( 'instagram' );
+
 	const onDismissInstagramNotice = useCallback( () => {
 		dismissNotice( 'instagram' );
-		setShouldShowInstagramNotice( false );
-	}, [ dismissNotice, setShouldShowInstagramNotice ] );
+	}, [ dismissNotice ] );
 	const shouldDisableMediaPicker =
 		isSocialImageGeneratorAvailable && isSocialImageGeneratorEnabledForPost;
 	const Wrapper = isPublicizeDisabledBySitePlan ? Disabled : Fragment;
@@ -255,7 +257,7 @@ export default function PublicizeForm( {
 			) }
 			{ ! isPublicizeDisabledBySitePlan && (
 				<Fragment>
-					{ ! dismissedNotices.includes( 'instagram' ) && shouldShowInstagramNotice && (
+					{ shouldShowInstagramNotice && (
 						<Notice
 							onDismiss={ onDismissInstagramNotice }
 							type={ 'highlight' }

--- a/projects/js-packages/publicize-components/src/store/effects.js
+++ b/projects/js-packages/publicize-components/src/store/effects.js
@@ -13,9 +13,9 @@ import { SUPPORTED_CONTAINER_BLOCKS } from '../components/twitter';
  */
 export async function refreshConnectionTestResults() {
 	try {
+		const jetpackSocialData = getJetpackData()?.social || {};
 		const connectionRefreshPath =
-			getJetpackData()?.social?.connectionRefreshPath ??
-			'/wpcom/v2/publicize/connection-test-results';
+			jetpackSocialData.connectionRefreshPath ?? '/wpcom/v2/publicize/connection-test-results';
 		const results = await apiFetch( { path: connectionRefreshPath } );
 
 		// Combine current connections with new connections.
@@ -24,7 +24,7 @@ export async function refreshConnectionTestResults() {
 		const connections = [];
 		const defaults = {
 			done: false,
-			enabled: true,
+			enabled: Boolean( jetpackSocialData.sharesData?.shares_remaining ),
 			toggleable: true,
 		};
 

--- a/projects/plugins/social/changelog/fix-social-connection-state
+++ b/projects/plugins/social/changelog/fix-social-connection-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed the connection state to ensure that new connections are disabled by default when there are no shares left.

--- a/projects/plugins/social/src/js/components/instagram-notice/index.jsx
+++ b/projects/plugins/social/src/js/components/instagram-notice/index.jsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/jetpack-components';
 import { useDismissNotice } from '@automattic/jetpack-publicize-components';
 import { useSelect } from '@wordpress/data';
-import { useState, useCallback } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { STORE_ID } from '../../store';
 import styles from './styles.module.scss';
@@ -22,7 +22,7 @@ const paidPlanNoticeText = __(
 
 const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
 	const { dismissedNotices, dismissNotice } = useDismissNotice();
-	const [ showNotice, setShowNotice ] = useState( ! dismissedNotices.includes( 'instagram' ) );
+	const showNotice = ! dismissedNotices.includes( 'instagram' );
 
 	const { connectionsAdminUrl, isInstagramConnectionSupported, isEnhancedPublishingEnabled } =
 		useSelect( select => {
@@ -36,8 +36,7 @@ const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
 
 	const handleDismiss = useCallback( () => {
 		dismissNotice( 'instagram' );
-		setShowNotice( false );
-	}, [ dismissNotice, setShowNotice ] );
+	}, [ dismissNotice ] );
 
 	if ( ! showNotice || ! isInstagramConnectionSupported ) {
 		return null;


### PR DESCRIPTION
Fixes 1203820938137329-as-1204692223892765/f

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable a connection by default if no shares left.
* Imrove `useDismissNotice` hook to create a local re-usable state of dismissed notices
* Ensure that Instagram notice is displayed only if there is no IG account connected.
* Update Social admin page notice to get rid of local `useState` in favour of `dismissedNotices` from `useDismissNotice`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### To test "Disable a connection by default if no shares left."

* Point `public-api.wordpress.com` to your sandbox
* In your sandbox, update `PUBLICIZE_MONTHLY_LIMIT` to `0` in `publicize/publicize-wpcom.php`
* On a site pointing to your sandbox with no Jetpack Social plan, create a new post
* Open Jetpack plugin sidebar
* Confirm that under "Share this post" section, you see the notice `You have 0 shares remaining in the next 30 days`
* Click on "Connect an account" link to add a new connection in a new tab
* Add another social media account
* Goto the post edit page again and wait for the social media accounts list to refresh
* Confirm that the newly added account is _disabled_ by default
* Now set `PUBLICIZE_MONTHLY_LIMIT` back to `30`
* Reload the post edit page
* Add another social media account as above
* Goto the post edit page again and wait for the social media accounts list to refresh
* Confirm that the newly added account is _enabled_ by default

### To test "Ensure that Instagram notice is displayed only if there is no IG account connected."

* Add Jetpack Social Advance plan to your site
* Ensure that you have D111103-code applied to your sandbox 
* Add Instagram blog sticker to the site as mentioned in D111103-code
* Run `jetpack docker wp option delete jetpack_social_dismissed_notices` to delete the dismiss notice option to ensure that Instagram notice appears
* Create a new post
* Open Jetpack plugin sidebar
* Confirm that under "Share this post" section, you see the notice `You can now share directly to your Instagram account!`
* Add an Instagram connection to the site.
* Goto the post edit page again and wait for the social media accounts list to refresh
* Confirm that the above notice is hidden
* Disconnect the Instagram account
* Goto the post edit page again and wait for the social media accounts list to refresh
* Confirm that the notice appears again
* Click on the dismiss icon for the notice
* Confirm that the notice is hidden
* Reload the page to verify that the notice is no longer visible
* Run `jetpack docker wp option get jetpack_social_dismissed_notices` and verify that `'instagram'` is added to the dismissed notices option
* Run `jetpack docker wp option delete jetpack_social_dismissed_notices` again 
* Goto Jetpack Social admin page - `/wp-admin/admin.php?page=jetpack-social`
* Confirm that you see the "Instagram is now available in Jetpack Social" notice
* Click on its dismiss icon
* Confirm that the notice is hidden
* Reload the page
* Confirm that the notice is hidden

| Before adding a new connection | Before adding a new connection |
|--------|--------|
| <img width="284" alt="Screenshot 2023-06-02 at 6 56 06 PM" src="https://github.com/Automattic/jetpack/assets/18226415/28828ca3-5872-4b15-a4df-b2a6f4749a19"> | <img width="285" alt="Screenshot 2023-06-02 at 6 57 05 PM" src="https://github.com/Automattic/jetpack/assets/18226415/ce714890-b76f-4af6-9780-a3c07a9d1538"> | 