### PR TITLE
CRM: Resolves 3091 - clean up user roles

### DIFF
--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -18,7 +18,8 @@ if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
 	====================================================== */
 
 // permissions check
-if ( ! zeroBSCRM_permsCustomers() ) {
+global $current_user;
+if ( ! $current_user || ! $current_user->has_cap( 'zbs_dash' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'zero-bs-crm' ) );
 }
 

--- a/projects/plugins/crm/changelog/fix-crm-3091-clean_up_user_roles
+++ b/projects/plugins/crm/changelog/fix-crm-3091-clean_up_user_roles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+User roles: further restricted capabilities on some roles

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -175,7 +175,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 			$toolsMenu = array();
 
 			// calendar
-			if ( zeroBSCRM_getSetting( 'feat_calendar' ) > 0 ) {
+			if ( zeroBSCRM_permsEvents() && zeroBSCRM_getSetting( 'feat_calendar' ) > 0 ) {
 				$toolsMenu[] = '<a href="' . zeroBSCRM_getAdminURL( $zbs->slugs['manage-events'] ) . '" class="item"><i class="icon calendar outline"></i> ' . __( 'Task Scheduler', 'zero-bs-crm' ) . '</a>';
 			}
 			// forms

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -462,7 +462,10 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 			</div>
 			<?php } ?>
 
-			<?php if ( zeroBSCRM_permsViewTransactions() && zeroBSCRM_getSetting( 'feat_transactions' ) > 0 ) { ?>
+			<?php
+			if ( zeroBSCRM_permsViewTransactions() && zeroBSCRM_getSetting( 'feat_transactions' ) > 0 ) {
+				$transactions_menu = array();
+				?>
 			<div class="ui simple dropdown item select<?php zeroBS_menu_active_type( 'transaction' ); ?>" id="zbs-transactions-topmenu" style="z-index:5">
 				<span class="text"><?php esc_html_e( 'Transactions', 'zero-bs-crm' ); ?></span>
 				<i class="dropdown icon"></i>
@@ -473,12 +476,12 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 					}
 					?>
 					<a class="item" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['managetransactions'] ) ); ?>"><i class="icon list"></i> <?php esc_html_e( 'View all', 'zero-bs-crm' ); ?></a>
-					<a class="item" href="<?php echo jpcrm_esc_link( 'tags', -1, 'zerobs_transaction', false, 'zerobscrm_transactiontag' ); ?>"><i class="icon tags"></i> <?php esc_html_e( 'Tags', 'zero-bs-crm' ); ?></a>
-
 					<?php
 					if ( zeroBSCRM_permsTransactions() ) {
+						?>
+						<a class="item" href="<?php echo jpcrm_esc_link( 'tags', -1, 'zerobs_transaction', false, 'zerobscrm_transactiontag' ); ?>"><i class="icon tags"></i> <?php esc_html_e( 'Tags', 'zero-bs-crm' ); ?></a>
+						<?php
 						// If CSV Pro is installed and active it will add an Import menu item to the zbs-transactions-menu filter - we'll then add that here
-						$transactions_menu = array();
 						$transactions_menu = apply_filters( 'zbs-transactions-menu', $transactions_menu ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 						$import_menu_item  = preg_grep( '/\bpage\=zerobscrm\-csvimporter\-app\b/i', $transactions_menu );
 						if ( count( $import_menu_item ) > 0 ) {

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.WP.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.WP.php
@@ -675,7 +675,7 @@ function zeroBSCRM_menu_buildMenu() {
 				'ico'        => 'dashicons-calendar-alt',
 				'title'      => __( 'Task Scheduler', 'zero-bs-crm' ),
 				'url'        => $zbs->slugs['manage-events'],
-				'perms'      => 'admin_zerobs_events',
+				'perms'      => 'admin_zerobs_view_events',
 				'order'      => 50,
 				'wpposition' => 50,
 				'subitems'   => array(),
@@ -690,7 +690,7 @@ function zeroBSCRM_menu_buildMenu() {
 			$menu['calendar']['subitems']['list'] = array(
 				'title'      => __( 'Task List', 'zero-bs-crm' ),
 				'url'        => $zbs->slugs['manage-events-list'],
-				'perms'      => 'admin_zerobs_customers',
+				'perms'      => 'admin_zerobs_view_events',
 				'order'      => 1,
 				'wpposition' => 1,
 				'callback'   => 'zeroBSCRM_render_eventslist_page',
@@ -701,7 +701,7 @@ function zeroBSCRM_menu_buildMenu() {
 			$menu['calendar']['subitems']['tags'] = array(
 				'title'      => __( 'Task Tags', 'zero-bs-crm' ),
 				'url'        => 'admin.php?page=' . $zbs->slugs['tagmanager'] . '&tagtype=event',
-				'perms'      => 'admin_zerobs_customers',
+				'perms'      => 'admin_zerobs_view_events',
 				'order'      => 2,
 				'wpposition' => 2,
 				'callback'   => '',
@@ -950,7 +950,7 @@ function zeroBSCRM_menu_buildMenu() {
 	$menu['hidden']['subitems']['eventlist'] = array(
 		'title'      => __( 'Task List', 'zero-bs-crm' ),
 		'url'        => $zbs->slugs['manage-events-list'],
-		'perms'      => 'admin_zerobs_customers',
+		'perms'      => 'admin_zerobs_view_events',
 		'order'      => 1,
 		'wpposition' => 3,
 		'callback'   => 'zeroBSCRM_render_eventslist_page',
@@ -961,7 +961,7 @@ function zeroBSCRM_menu_buildMenu() {
 	$menu['hidden']['subitems']['eventtags'] = array(
 		'title'      => __( 'Task Tags', 'zero-bs-crm' ),
 		'url'        => 'admin.php?page=' . $zbs->slugs['tagmanager'] . '&tagtype=event',
-		'perms'      => 'admin_zerobs_customers',
+		'perms'      => 'admin_zerobs_view_events',
 		'order'      => 3,
 		'wpposition' => 3,
 		'callback'   => '',

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Page.Controller.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Page.Controller.php
@@ -94,7 +94,9 @@ function zeroBSCRM_pages_admin_addedit_page( $type = 'contact', $action = 'new',
 			if ( zeroBSCRM_permsObjType( $obj_type_id ) ) {
 				zeroBSCRM_pages_admin_addedit_page_generic( $id, $action );
 			} else {
+				echo '<div style="margin-left: 20px">';
 				echo esc_html( sprintf( __( 'You do not have permission to edit this %s.', 'zero-bs-crm' ), $zbs->DAL->typeStr( $obj_type_id ) ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.WP.I18n.MissingTranslatorsComment
+				echo '</div>';
 			}
 			break;
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Page.Controller.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Page.Controller.php
@@ -66,51 +66,36 @@ function zeroBSCRM_pages_admin_addedit() {
 // } This is a slow general move to new UI (and new DB) and moving away from the custom post add / edit links
 function zeroBSCRM_pages_admin_addedit_page( $type = 'contact', $action = 'new', $id = -1 ) {
 
-	// } learn script (for this page)
+	global $zbs;
+	$obj_type_id = $zbs->DAL->objTypeID( $type ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-	?>
+	switch ( $obj_type_id ) {
 
-	<script type="text/javascript">
-
-		jQuery(function($){
-
-			jQuery('.learn')
-			.popup({
-				inline: false,
-				on:'click',
-				lastResort: 'bottom right',
-			});
-
-		});
-	</script>
-
-
-
-
-	<?php
-	switch ( $type ) {
-
-		case 'contact':
+		case ZBS_TYPE_CONTACT:
 			// pass them this way..
 			zeroBSCRM_pages_admin_addedit_page_contact( $id, $action );
 			break;
 
-		case 'company':
+		case ZBS_TYPE_COMPANY:
 			zeroBSCRM_pages_admin_addedit_page_company( $id, $action );
 			break;
 
-		case 'segment':
+		case ZBS_TYPE_SEGMENT:
 			zeroBSCRM_pages_admin_addedit_page_segment( $id, $action );
 			break;
 
 		// DAL3.0 + the rest can be fired via zeroBSCRM_pages_admin_addedit_page_generic
-		case 'quote':
-		case 'invoice':
-		case 'transaction':
-		case 'event':
-		case 'form':
-		case 'quotetemplate':
-			zeroBSCRM_pages_admin_addedit_page_generic( $id, $action );
+		case ZBS_TYPE_QUOTE:
+		case ZBS_TYPE_INVOICE:
+		case ZBS_TYPE_TRANSACTION:
+		case ZBS_TYPE_EVENT:
+		case ZBS_TYPE_FORM:
+		case ZBS_TYPE_QUOTETEMPLATE:
+			if ( zeroBSCRM_permsObjType( $obj_type_id ) ) {
+				zeroBSCRM_pages_admin_addedit_page_generic( $id, $action );
+			} else {
+				echo esc_html( sprintf( __( 'You do not have permission to edit this %s.', 'zero-bs-crm' ), $zbs->DAL->typeStr( $obj_type_id ) ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.WP.I18n.MissingTranslatorsComment
+			}
 			break;
 
 	}

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -22,7 +22,6 @@
    ====================================================== */
 
 global $zeroBSCRM_migrations; $zeroBSCRM_migrations = array(
-	'240', // Refresh user roles
 	'288', // build client portal page (moved to shortcodes) if using
 	'2963', // 2.96.3 - installs page templates
 	'29999', // Flush permalinks 
@@ -37,6 +36,7 @@ global $zeroBSCRM_migrations; $zeroBSCRM_migrations = array(
 	'551', // 5.5.1 Deletes orphaned aka rows linked to contacts since deleted
 	'560', // 5.6.0 Moves old folder structure (zbscrm-store) to new (jpcrm-storage)
 	'task_offset_fix', // removes task timezone offsets from database
+	'refresh_user_roles', // Refresh user roles
 	);
 
 global $zeroBSCRM_migrations_requirements; $zeroBSCRM_migrations_requirements = array(
@@ -283,31 +283,6 @@ function zeroBSCRM_adminNotices_majorMigrationError(){
 /* ======================================================
 	MIGRATIONS
    ====================================================== */
-
-	/*
-	* Migration 2.4 - Refresh user roles
-	*/
-	function zeroBSCRM_migration_240(){
-
-		#} Glob
-		global $zbs, $zeroBSCRM_Conf_Setup; #req
-
-		#} This function migrates users from before ver 2.4
-
-		  #} re-add/remove any roles :)
-
-			    // roles
-				zeroBSCRM_clearUserRoles();
-
-				// roles + 
-				zeroBSCRM_addUserRoles();
-
-	    	zeroBSCRM_migrations_markComplete('240',array('updated'=>1));
-			
-
-
-	}
-
 
 	/*
 	* Migration 2.88 - build client portal page (moved to shortcodes) if using
@@ -1148,6 +1123,19 @@ function zeroBSCRM_migration_task_offset_fix() { // phpcs:ignore WordPress.Namin
 	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	zeroBSCRM_migrations_markComplete( 'task_offset_fix', array( 'updated' => 1 ) );
+}
+
+/**
+ * Refresh user roles after tightening restrictions
+ */
+function zeroBSCRM_migration_refresh_user_roles() {
+	// remove roles
+	zeroBSCRM_clearUserRoles();
+
+	// add roles anew
+	zeroBSCRM_addUserRoles();
+
+	zeroBSCRM_migrations_markComplete( 'refresh_user_roles', array( 'updated' => 1 ) );
 }
 
 /* ======================================================

--- a/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
@@ -376,6 +376,7 @@ function zeroBSCRM_addUserRoles() { // phpcs:ignore WordPress.NamingConventions.
 	// CRM object edit capabilities
 	$role->add_cap( 'admin_zerobs_customers' );
 	$role->add_cap( 'admin_zerobs_customers_tags' );
+	$role->add_cap( 'admin_zerobs_events' );
 
 	// needed for notifications
 	$role->add_cap( 'admin_zerobs_notifications' );

--- a/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
@@ -9,483 +9,382 @@
  * Date: 01/11/16
  */
 
-/* ======================================================
-  Breaking Checks ( stops direct access )
-   ====================================================== */
-    if ( ! defined( 'ZEROBSCRM_PATH' ) ) exit;
-/* ======================================================
-  / Breaking Checks
-   ====================================================== */
-
-
-
-/* ======================================================
-  Add Roles
-   ====================================================== */
-
-   // for changes to be enacted, need to remove them before adding them!
-   function zeroBSCRM_clearUserRoles(){
-
-   		remove_role('zerobs_admin');
-   		remove_role('zerobs_customermgr');
-   		remove_role('zerobs_quotemgr');
-   		remove_role('zerobs_invoicemgr');
-   		remove_role('zerobs_transactionmgr');
-   		remove_role('zerobs_customer');
-   		remove_role('zerobs_mailmgr');
-
-   }
-
-	#} Build User Roles
-	function zeroBSCRM_addUserRoles(){
-
-			#} ZBS Admin
-			// Add a custom user role
-			#https://managewp.com/create-custom-user-roles-wordpress
-			$result = add_role(
-				'zerobs_admin',
-				__( 'Jetpack CRM Admin (Full CRM Permissions)', 'zero-bs-crm' ),
-
-				array(
-
-				'read' => true, // true allows this capability
-				'edit_posts' => false, // Allows user to edit their own posts
-				'edit_pages' => false, // Allows user to edit pages
-				'edit_others_posts' => false, // Allows user to edit others posts not just their own
-				'create_posts' => false, // Allows user to create new posts
-				'manage_categories' => false, // Allows user to manage post categories
-				'publish_posts' => false, // Allows the user to publish, otherwise posts stays in draft mode
-
-				)
-
-			);
-
-		    // gets the author role
-		    $role = get_role( 'zerobs_admin' );
-
-		    // This only works, because it accesses the class instance.
-		    // would allow the author to edit others' posts for current theme only
-
-		    #} W Note... can't we add all these above in add_role?
-		    $role->add_cap( 'read' );
-		    $role->remove_cap( 'edit_posts' );
-		   	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
-		    $role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
-		    $role->add_cap( 'admin_zerobs_customers' );
-		    $role->add_cap( 'admin_zerobs_customers_tags' );
-		    $role->add_cap( 'admin_zerobs_quotes' );
-		    $role->add_cap( 'admin_zerobs_events' );
-		    $role->add_cap( 'admin_zerobs_invoices' );
-		    $role->add_cap( 'admin_zerobs_transactions' );
-		    $role->add_cap( 'admin_zerobs_forms' );
-		    // NOTE. Adding this adds a random "Post categories / not posts" to menu
-		    // will have to remove programattically :(
-		    	$role->add_cap( 'manage_categories' );
-		    $role->add_cap( 'manage_sales_dash' ); #mike added
-		    $role->add_cap( 'admin_zerobs_mailcampaigns' );
-		    $role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
-
-		    // added 2.4 - for settings
-		    $role->add_cap( 'admin_zerobs_manage_options' );
-		    // ... and view versions (cannot edit)
-		    $role->add_cap( 'admin_zerobs_view_customers' );
-		    $role->add_cap( 'admin_zerobs_view_quotes' );
-		    $role->add_cap( 'admin_zerobs_view_invoices' );
-		    $role->add_cap( 'admin_zerobs_view_events' );
-		   	$role->add_cap( 'admin_zerobs_view_transactions' );
-
-		   	// logs
-		    $role->add_cap( 'admin_zerobs_logs_addedit' );
-		    $role->add_cap( 'admin_zerobs_logs_delete' );
-
-		    // emails
-		    $role->add_cap( 'admin_zerobs_sendemails_contacts' );
-
-		    unset($role);
-
-
-
-
-		    #=====================================================
-		    #=====================================================
-
-		    #} ALL ADMINS TOO :)
-
-		    // gets the author role
-		    $role = get_role( 'administrator' );
-
-		    // this is for users who've removed 'administrator' role type
-		    // WH temp catch anyhow, for Nimitz.
-		    if ($role !== null){
-
-			    // Caps
-			    $role->add_cap( 'admin_zerobs_customers' );
-			    $role->add_cap( 'admin_zerobs_customers_tags' );
-			    $role->add_cap( 'admin_zerobs_quotes' );
-			    $role->add_cap( 'admin_zerobs_invoices' );
-			    $role->add_cap( 'admin_zerobs_events' );
-			   	$role->add_cap( 'admin_zerobs_transactions' );
-			    $role->add_cap( 'manage_sales_dash' );
-			    $role->add_cap( 'admin_zerobs_mailcampaigns' );
-			    $role->add_cap( 'admin_zerobs_forms' );
-			    $role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
-			    // NOPE. this shouldn't be here, _usr is to group our users $role->add_cap( 'admin_zerobs_usr' );
-
-			    // added 2.4 - for settings
-			    $role->add_cap( 'admin_zerobs_manage_options' );
-			    // ... and view versions (cannot edit)
-			    $role->add_cap( 'admin_zerobs_view_customers' );
-			    $role->add_cap( 'admin_zerobs_view_quotes' );
-			    $role->add_cap( 'admin_zerobs_view_invoices' );
-			    $role->add_cap( 'admin_zerobs_view_events' );
-			   	$role->add_cap( 'admin_zerobs_view_transactions' );
-			   	// needed for notifications
-			   	$role->add_cap( 'admin_zerobs_notifications' );
-
-			   	// logs
-			    $role->add_cap( 'admin_zerobs_logs_addedit' );
-			    $role->add_cap( 'admin_zerobs_logs_delete' );
-
-				//all users
-	            $role->add_cap('admin_zerobs_usr');
-
-			    // emails
-			    $role->add_cap( 'admin_zerobs_sendemails_contacts' );
-
-			    unset($role);
-
-			}
-
-
-
-		    #=====================================================
-		    #=====================================================
-
-		    #} Jetpack Customer Manager
-			$result = add_role(
-				'zerobs_customermgr',
-				__( 'Jetpack CRM Contact Manager', 'zero-bs-crm' ),
-
-				array(
-
-				'read' => true, // true allows this capability
-				'edit_posts' => false, // Allows user to edit their own posts
-				'edit_pages' => false, // Allows user to edit pages
-				'edit_others_posts' => false, // Allows user to edit others posts not just their own
-				'create_posts' => false, // Allows user to create new posts
-				'manage_categories' => false, // Allows user to manage post categories
-				'publish_posts' => false, // Allows the user to publish, otherwise posts stays in draft mode
-
-				)
-
-			);
-
-		    // gets the author role
-		    $role = get_role( 'zerobs_customermgr' );
-
-		    // caps
-		    $role->add_cap( 'read' );
-		    $role->remove_cap( 'edit_posts' );
-		   	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
-		    $role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
-		    $role->add_cap( 'admin_zerobs_customers' );
-		    $role->add_cap( 'admin_zerobs_customers_tags' );
-		    $role->add_cap( 'manage_categories' );
-		    $role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
-			$role->add_cap( 'admin_zerobs_events' );
-
-		    // ... and view versions (cannot edit)
-		    $role->add_cap( 'admin_zerobs_view_customers' );
-		    $role->add_cap( 'admin_zerobs_view_quotes' );
-		    $role->add_cap( 'admin_zerobs_view_invoices' );
-		    $role->add_cap( 'admin_zerobs_view_events' );
-		   	$role->add_cap( 'admin_zerobs_view_transactions' );
-		   	
-		   	// ADDING these until we have singular views for all
-		    $role->add_cap( 'admin_zerobs_quotes' );
-		    $role->add_cap( 'admin_zerobs_events' );
-		    $role->add_cap( 'admin_zerobs_invoices' );
-		    $role->add_cap( 'admin_zerobs_transactions' );
-		   	// needed for notifications
-		   	$role->add_cap( 'admin_zerobs_notifications' );
-
-		   	// logs
-		    $role->add_cap( 'admin_zerobs_logs_addedit' );
-		    //$role->add_cap( 'admin_zerobs_logs_delete' );
-            
-		    // emails
-		    $role->add_cap( 'admin_zerobs_sendemails_contacts' );
-
-		    unset($role);
-
-
-
-
-		    #=====================================================
-		    #=====================================================
-
-
-
-		    #} ZBS Quote Manager
-			$result = add_role(
-				'zerobs_quotemgr',
-				__( 'Jetpack CRM Quote Manager', 'zero-bs-crm' ),
-
-				array(
-
-				'read' => true, // true allows this capability
-				'edit_posts' => false, // Allows user to edit their own posts
-				'edit_pages' => false, // Allows user to edit pages
-				'edit_others_posts' => false, // Allows user to edit others posts not just their own
-				'create_posts' => false, // Allows user to create new posts
-				'manage_categories' => false, // Allows user to manage post categories
-				'publish_posts' => false, // Allows the user to publish, otherwise posts stays in draft mode
-
-				)
-
-			);
-
-		    // gets the author role
-		    $role = get_role( 'zerobs_quotemgr' );
-
-		    // caps
-		    $role->add_cap( 'read' );
-		    $role->remove_cap( 'edit_posts' );
-		   	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
-		    $role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
-		    $role->add_cap( 'admin_zerobs_quotes' );
-		    $role->add_cap( 'manage_categories' );
-		    $role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
-		    // ... and view versions (cannot edit)
-		    $role->add_cap( 'admin_zerobs_view_customers' );
-		    $role->add_cap( 'admin_zerobs_view_quotes' );
-		    $role->add_cap( 'admin_zerobs_view_events' );
-
-		   	// ADDING these until we have singular views for all
-		    $role->add_cap( 'admin_zerobs_customers' );
-		    $role->add_cap( 'admin_zerobs_events' );
-		   	// needed for notifications
-		   	$role->add_cap( 'admin_zerobs_notifications' );
-
-		   	// logs
-		    $role->add_cap( 'admin_zerobs_logs_addedit' );
-		    //$role->add_cap( 'admin_zerobs_logs_delete' );
-
-		    unset($role);
-
-
-
-
-		    #=====================================================
-		    #=====================================================
-
-		    #} ZBS Invoice Manager
-			$result = add_role(
-				'zerobs_invoicemgr',
-				__( 'Jetpack CRM Invoice Manager', 'zero-bs-crm' ),
-
-				array(
-
-				'read' => true, // true allows this capability
-				'edit_posts' => false, // Allows user to edit their own posts
-				'edit_pages' => false, // Allows user to edit pages
-				'edit_others_posts' => false, // Allows user to edit others posts not just their own
-				'create_posts' => false, // Allows user to create new posts
-				'manage_categories' => false, // Allows user to manage post categories
-				'publish_posts' => false, // Allows the user to publish, otherwise posts stays in draft mode
-
-				)
-
-			);
-
-		    // gets the author role
-		    $role = get_role( 'zerobs_invoicemgr' );
-
-		    // caps
-		    $role->add_cap( 'read' );
-		    $role->remove_cap( 'edit_posts' );
-		   	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
-		    $role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
-		    $role->add_cap( 'admin_zerobs_invoices' );
-		    $role->add_cap( 'manage_categories' );
-		    $role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
-		    // ... and view versions (cannot edit)
-		    $role->add_cap( 'admin_zerobs_view_customers' );
-		    $role->add_cap( 'admin_zerobs_view_events' );
-		    $role->add_cap( 'admin_zerobs_view_invoices' );
-
-		   	// ADDING these until we have singular views for all
-		    $role->add_cap( 'admin_zerobs_customers' );
-		    $role->add_cap( 'admin_zerobs_events' );
-		   	// needed for notifications
-		   	$role->add_cap( 'admin_zerobs_notifications' );
-
-		   	// logs
-		    $role->add_cap( 'admin_zerobs_logs_addedit' );
-		    //$role->add_cap( 'admin_zerobs_logs_delete' );
-
-		    unset($role);
-
-
-
-
-		    #=====================================================
-		    #=====================================================
-
-		    #} ZBS Transaction Manager
-			$result = add_role(
-				'zerobs_transactionmgr',
-				__( 'Jetpack CRM Transaction Manager', 'zero-bs-crm' ),
-
-				array(
-
-				'read' => false, // true allows this capability
-				'edit_posts' => false, // Allows user to edit their own posts
-				'edit_pages' => false, // Allows user to edit pages
-				'edit_others_posts' => false, // Allows user to edit others posts not just their own
-				'create_posts' => false, // Allows user to create new posts
-				'manage_categories' => false, // Allows user to manage post categories
-				'publish_posts' => false, // Allows the user to publish, otherwise posts stays in draft mode
-
-				)
-
-			);
-
-		    // gets the author role
-		    $role = get_role( 'zerobs_transactionmgr' );
-
-		    // caps
-		    $role->add_cap( 'read' );
-		    $role->remove_cap( 'edit_posts' );
-		   	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
-		    $role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
-		    $role->add_cap( 'admin_zerobs_transactions' );
-		    $role->add_cap( 'manage_categories' );
-		    $role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
-		    // ... and view versions (cannot edit)
-		    $role->add_cap( 'admin_zerobs_view_customers' );
-		    $role->add_cap( 'admin_zerobs_view_events' );
-		   	$role->add_cap( 'admin_zerobs_view_transactions' );
-
-		   	// ADDING these until we have singular views for all
-		    $role->add_cap( 'admin_zerobs_customers' );
-		    $role->add_cap( 'admin_zerobs_events' );
-		   	// needed for notifications
-		   	$role->add_cap( 'admin_zerobs_notifications' );
-
-		   	// logs
-		    $role->add_cap( 'admin_zerobs_logs_addedit' );
-		    //$role->add_cap( 'admin_zerobs_logs_delete' );
-
-		    unset($role);
-
-
-
-
-		    #=====================================================
-		    #=====================================================
-
-
-		    #} Jetpack Customer
-			$result = add_role(
-				'zerobs_customer',
-				__( 'Jetpack CRM Contact', 'zero-bs-crm' ),
-
-				array(
-
-					'read' => true, // true allows this capability
-					'edit_posts' => false, // Allows user to edit their own posts
-					'edit_pages' => false, // Allows user to edit pages
-					'edit_others_posts' => false, // Allows user to edit others posts not just their own
-					'create_posts' => false, // Allows user to create new posts
-					'manage_categories' => false, // Allows user to manage post categories
-					'publish_posts' => false, // Allows the user to publish, otherwise posts stays in draft mode
-
-				)
-
-			);
-
-
-		    #=====================================================
-		    #=====================================================
-
-		    #} ZBS Mail Manager - Manages campaigns, customers / companies
-			$result = add_role(
-				'zerobs_mailmgr',
-				__( 'Jetpack CRM Mail Manager', 'zero-bs-crm' ),
-
-				array(
-
-				'read' => false, // true allows this capability
-				'edit_posts' => false, // Allows user to edit their own posts
-				'edit_pages' => false, // Allows user to edit pages
-				'edit_others_posts' => false, // Allows user to edit others posts not just their own
-				'create_posts' => false, // Allows user to create new posts
-				'manage_categories' => false, // Allows user to manage post categories
-				'publish_posts' => false, // Allows the user to publish, otherwise posts stays in draft mode
-
-				)
-
-			);
-
-		    // gets the author role
-		    $role = get_role( 'zerobs_mailmgr' );
-
-		    // caps
-		    $role->add_cap( 'read' );
-		    $role->remove_cap( 'edit_posts' );
-		   	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
-		    $role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
-		    $role->add_cap( 'admin_zerobs_mailcampaigns' );
-		    $role->add_cap( 'admin_zerobs_customers' );
-		    $role->add_cap( 'admin_zerobs_customers_tags' );
-		    $role->add_cap( 'manage_categories' );
-		    $role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
-
-		    // ... and view versions (cannot edit)
-		    $role->add_cap( 'admin_zerobs_view_customers' );
-		    $role->add_cap( 'admin_zerobs_view_quotes' );
-		    $role->add_cap( 'admin_zerobs_view_invoices' );
-		    $role->add_cap( 'admin_zerobs_view_events' );
-		   	$role->add_cap( 'admin_zerobs_view_transactions' );
-
-		   	// ADDING these until we have singular views for all
-		    $role->add_cap( 'admin_zerobs_quotes' );
-		    $role->add_cap( 'admin_zerobs_events' );
-		    $role->add_cap( 'admin_zerobs_invoices' );
-		    $role->add_cap( 'admin_zerobs_transactions' );
-		   	// needed for notifications
-		   	$role->add_cap( 'admin_zerobs_notifications' );
-            
-		    // emails
-		    $role->add_cap( 'admin_zerobs_sendemails_contacts' );
-
-		    unset($role);
-
-
-
-
-		    #=====================================================
-		    #=====================================================
-
-
+if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
+	exit;
+}
+
+/**
+ * Remove user roles
+ */
+function zeroBSCRM_clearUserRoles() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+	remove_role( 'zerobs_admin' );
+	remove_role( 'zerobs_customermgr' );
+	remove_role( 'zerobs_quotemgr' );
+	remove_role( 'zerobs_invoicemgr' );
+	remove_role( 'zerobs_transactionmgr' );
+	remove_role( 'zerobs_customer' );
+	remove_role( 'zerobs_mailmgr' );
+}
+
+/**
+ * Build User Roles
+ */
+function zeroBSCRM_addUserRoles() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+
+	// Jetpack CRM Admin
+	add_role(
+		'zerobs_admin',
+		__( 'Jetpack CRM Admin (Full CRM Permissions)', 'zero-bs-crm' ),
+		array(
+			'read'              => true,  // true allows this capability
+			'edit_posts'        => false, // Allows user to edit their own posts
+			'edit_pages'        => false, // Allows user to edit pages
+			'edit_others_posts' => false, // Allows user to edit others posts not just their own
+			'create_posts'      => false, // Allows user to create new posts
+			'manage_categories' => false, // Allows user to manage post categories
+			'publish_posts'     => false, // Allows the user to publish, otherwise posts stays in draft mode
+		)
+	);
+
+	// gets the role from WP
+	$role = get_role( 'zerobs_admin' );
+
+	$role->add_cap( 'read' );
+	$role->remove_cap( 'edit_posts' );
+	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
+	$role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
+	// NOTE. Adding this adds a random "Post categories / not posts" to menu
+	// will have to remove programattically :(
+	$role->add_cap( 'manage_categories' );
+	$role->add_cap( 'manage_sales_dash' ); #mike added
+	$role->add_cap( 'admin_zerobs_mailcampaigns' );
+	$role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
+
+	// give permission to edit settings
+	$role->add_cap( 'admin_zerobs_manage_options' );
+
+	// CRM object view capabilities
+	$role->add_cap( 'admin_zerobs_view_customers' );
+	$role->add_cap( 'admin_zerobs_view_quotes' );
+	$role->add_cap( 'admin_zerobs_view_invoices' );
+	$role->add_cap( 'admin_zerobs_view_events' );
+	$role->add_cap( 'admin_zerobs_view_transactions' );
+
+	// CRM object edit capabilities
+	$role->add_cap( 'admin_zerobs_customers' );
+	$role->add_cap( 'admin_zerobs_customers_tags' );
+	$role->add_cap( 'admin_zerobs_quotes' );
+	$role->add_cap( 'admin_zerobs_events' );
+	$role->add_cap( 'admin_zerobs_invoices' );
+	$role->add_cap( 'admin_zerobs_transactions' );
+	$role->add_cap( 'admin_zerobs_forms' );
+
+	// logs
+	$role->add_cap( 'admin_zerobs_logs_addedit' );
+	$role->add_cap( 'admin_zerobs_logs_delete' );
+
+	// emails
+	$role->add_cap( 'admin_zerobs_sendemails_contacts' );
+
+	// paranoia
+	unset( $role );
+
+	// give WP admins extra capabilities
+	$role = get_role( 'administrator' );
+
+	// this is for users who've removed 'administrator' role type
+	// WH temp catch anyhow, for Nimitz.
+	if ( $role !== null ) {
+
+		// Caps
+		$role->add_cap( 'manage_sales_dash' );
+		$role->add_cap( 'admin_zerobs_mailcampaigns' );
+		$role->add_cap( 'admin_zerobs_forms' );
+		$role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
+
+		// give permission to edit settings
+		$role->add_cap( 'admin_zerobs_manage_options' );
+
+		// CRM object view capabilities
+		$role->add_cap( 'admin_zerobs_view_customers' );
+		$role->add_cap( 'admin_zerobs_view_quotes' );
+		$role->add_cap( 'admin_zerobs_view_invoices' );
+		$role->add_cap( 'admin_zerobs_view_events' );
+		$role->add_cap( 'admin_zerobs_view_transactions' );
+
+		// CRM object edit capabilities
+		$role->add_cap( 'admin_zerobs_customers' );
+		$role->add_cap( 'admin_zerobs_customers_tags' );
+		$role->add_cap( 'admin_zerobs_quotes' );
+		$role->add_cap( 'admin_zerobs_invoices' );
+		$role->add_cap( 'admin_zerobs_events' );
+		$role->add_cap( 'admin_zerobs_transactions' );
+
+		// needed for notifications
+		$role->add_cap( 'admin_zerobs_notifications' );
+
+		// logs
+		$role->add_cap( 'admin_zerobs_logs_addedit' );
+		$role->add_cap( 'admin_zerobs_logs_delete' );
+
+		// all users
+		$role->add_cap( 'admin_zerobs_usr' );
+
+		// emails
+		$role->add_cap( 'admin_zerobs_sendemails_contacts' );
+
+		// paranoia
+		unset( $role );
 
 	}
 
-	#function zeroBSCRM_RemoveUserRoles(){
+	// CRM Contact Manager
+	add_role(
+		'zerobs_customermgr',
+		__( 'Jetpack CRM Contact Manager', 'zero-bs-crm' ),
+		array(
+			'read'              => true,  // true allows this capability
+			'edit_posts'        => false, // Allows user to edit their own posts
+			'edit_pages'        => false, // Allows user to edit pages
+			'edit_others_posts' => false, // Allows user to edit others posts not just their own
+			'create_posts'      => false, // Allows user to create new posts
+			'manage_categories' => false, // Allows user to manage post categories
+			'publish_posts'     => false, // Allows the user to publish, otherwise posts stays in draft mode
+		)
+	);
 
-	/*
-		    // gets the author role
-		    $role = get_role( 'zerobs_user' );
+	// gets the role from WP
+	$role = get_role( 'zerobs_customermgr' );
 
-		    // This only works, because it accesses the class instance.
-		    // would allow the author to edit others' posts for current theme only
-		    $role->remove_cap( 'admin_zerobs_customers' );
-		    $role->remove_cap( 'admin_zerobs_quotes' );
-		    $role->remove_cap( 'admin_zerobs_invoices' );
+	// caps
+	$role->add_cap( 'read' );
+	$role->remove_cap( 'edit_posts' );
+	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
+	$role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
+	$role->add_cap( 'manage_categories' );
+	$role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
 
-	*/
+	// CRM object view capabilities
+	$role->add_cap( 'admin_zerobs_view_customers' );
+	$role->add_cap( 'admin_zerobs_view_quotes' );
+	$role->add_cap( 'admin_zerobs_view_invoices' );
+	$role->add_cap( 'admin_zerobs_view_events' );
+	$role->add_cap( 'admin_zerobs_view_transactions' );
 
+	// CRM object edit capabilities
+	$role->add_cap( 'admin_zerobs_customers' );
+	$role->add_cap( 'admin_zerobs_customers_tags' );
+	$role->add_cap( 'admin_zerobs_quotes' );
+	$role->add_cap( 'admin_zerobs_events' );
+	$role->add_cap( 'admin_zerobs_invoices' );
+	$role->add_cap( 'admin_zerobs_transactions' );
+
+	// needed for notifications
+	$role->add_cap( 'admin_zerobs_notifications' );
+
+	// logs
+	$role->add_cap( 'admin_zerobs_logs_addedit' );
+
+	// emails
+	$role->add_cap( 'admin_zerobs_sendemails_contacts' );
+
+	unset( $role );
+
+	// CRM Quote Manager
+	add_role(
+		'zerobs_quotemgr',
+		__( 'Jetpack CRM Quote Manager', 'zero-bs-crm' ),
+		array(
+			'read'              => true,  // true allows this capability
+			'edit_posts'        => false, // Allows user to edit their own posts
+			'edit_pages'        => false, // Allows user to edit pages
+			'edit_others_posts' => false, // Allows user to edit others posts not just their own
+			'create_posts'      => false, // Allows user to create new posts
+			'manage_categories' => false, // Allows user to manage post categories
+			'publish_posts'     => false, // Allows the user to publish, otherwise posts stays in draft mode
+		)
+	);
+
+	// gets the role from WP
+	$role = get_role( 'zerobs_quotemgr' );
+
+	// caps
+	$role->add_cap( 'read' );
+	$role->remove_cap( 'edit_posts' );
+	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
+	$role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
+	$role->add_cap( 'manage_categories' );
+	$role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
+
+	// CRM object view capabilities
+	$role->add_cap( 'admin_zerobs_view_customers' );
+	$role->add_cap( 'admin_zerobs_view_quotes' );
+
+	// CRM object edit capabilities
+	$role->add_cap( 'admin_zerobs_customers' );
+	$role->add_cap( 'admin_zerobs_quotes' );
+
+	// needed for notifications
+	$role->add_cap( 'admin_zerobs_notifications' );
+
+	// logs
+	$role->add_cap( 'admin_zerobs_logs_addedit' );
+
+	// paranoia
+	unset( $role );
+
+	// CRM Invoice Manager
+	add_role(
+		'zerobs_invoicemgr',
+		__( 'Jetpack CRM Invoice Manager', 'zero-bs-crm' ),
+		array(
+			'read'              => true,  // true allows this capability
+			'edit_posts'        => false, // Allows user to edit their own posts
+			'edit_pages'        => false, // Allows user to edit pages
+			'edit_others_posts' => false, // Allows user to edit others posts not just their own
+			'create_posts'      => false, // Allows user to create new posts
+			'manage_categories' => false, // Allows user to manage post categories
+			'publish_posts'     => false, // Allows the user to publish, otherwise posts stays in draft mode
+		)
+	);
+
+	// gets the role from WP
+	$role = get_role( 'zerobs_invoicemgr' );
+
+	// caps
+	$role->add_cap( 'read' );
+	$role->remove_cap( 'edit_posts' );
+	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
+	$role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
+	$role->add_cap( 'manage_categories' );
+	$role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
+
+	// CRM object view capabilities
+	$role->add_cap( 'admin_zerobs_view_customers' );
+	$role->add_cap( 'admin_zerobs_view_invoices' );
+	$role->add_cap( 'admin_zerobs_view_transactions' );
+
+	// CRM object edit capabilities
+	$role->add_cap( 'admin_zerobs_customers' );
+	$role->add_cap( 'admin_zerobs_invoices' );
+	$role->add_cap( 'admin_zerobs_transactions' );
+
+	// needed for notifications
+	$role->add_cap( 'admin_zerobs_notifications' );
+
+	// logs
+	$role->add_cap( 'admin_zerobs_logs_addedit' );
+
+	// paranoia
+	unset( $role );
+
+	// CRM Transaction Manager
+	add_role(
+		'zerobs_transactionmgr',
+		__( 'Jetpack CRM Transaction Manager', 'zero-bs-crm' ),
+		array(
+			'read'              => false, // true allows this capability
+			'edit_posts'        => false, // Allows user to edit their own posts
+			'edit_pages'        => false, // Allows user to edit pages
+			'edit_others_posts' => false, // Allows user to edit others posts not just their own
+			'create_posts'      => false, // Allows user to create new posts
+			'manage_categories' => false, // Allows user to manage post categories
+			'publish_posts'     => false, // Allows the user to publish, otherwise posts stays in draft mode
+		)
+	);
+
+	// gets the role from WP
+	$role = get_role( 'zerobs_transactionmgr' );
+
+	// caps
+	$role->add_cap( 'read' );
+	$role->remove_cap( 'edit_posts' );
+	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
+	$role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
+	$role->add_cap( 'manage_categories' );
+	$role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
+
+	// CRM object view capabilities
+	$role->add_cap( 'admin_zerobs_view_customers' );
+	$role->add_cap( 'admin_zerobs_view_transactions' );
+
+	// CRM object edit capabilities
+	$role->add_cap( 'admin_zerobs_customers' );
+	$role->add_cap( 'admin_zerobs_transactions' );
+
+	// needed for notifications
+	$role->add_cap( 'admin_zerobs_notifications' );
+
+	// logs
+	$role->add_cap( 'admin_zerobs_logs_addedit' );
+
+	// paranoia
+	unset( $role );
+
+	// CRM Customer
+	add_role(
+		'zerobs_customer',
+		__( 'Jetpack CRM Contact', 'zero-bs-crm' ),
+		array(
+			'read'              => true,  // true allows this capability
+			'edit_posts'        => false, // Allows user to edit their own posts
+			'edit_pages'        => false, // Allows user to edit pages
+			'edit_others_posts' => false, // Allows user to edit others posts not just their own
+			'create_posts'      => false, // Allows user to create new posts
+			'manage_categories' => false, // Allows user to manage post categories
+			'publish_posts'     => false, // Allows the user to publish, otherwise posts stays in draft mode
+		)
+	);
+
+	// paranoia
+	unset( $role );
+
+	// CRM Mail Manager - Manages campaigns, customers / companies
+	add_role(
+		'zerobs_mailmgr',
+		__( 'Jetpack CRM Mail Manager', 'zero-bs-crm' ),
+		array(
+			'read'              => false, // true allows this capability
+			'edit_posts'        => false, // Allows user to edit their own posts
+			'edit_pages'        => false, // Allows user to edit pages
+			'edit_others_posts' => false, // Allows user to edit others posts not just their own
+			'create_posts'      => false, // Allows user to create new posts
+			'manage_categories' => false, // Allows user to manage post categories
+			'publish_posts'     => false, // Allows the user to publish, otherwise posts stays in draft mode
+		)
+	);
+
+	// gets the role from WP
+	$role = get_role( 'zerobs_mailmgr' );
+
+	// caps
+	$role->add_cap( 'read' );
+	$role->remove_cap( 'edit_posts' );
+	$role->add_cap( 'upload_files' ); // added 21/5/18 to ensure can upload media
+	$role->add_cap( 'admin_zerobs_usr' ); #} For all zerobs users :)
+	$role->add_cap( 'admin_zerobs_mailcampaigns' );
+	$role->add_cap( 'manage_categories' );
+	$role->add_cap( 'zbs_dash' ); # WH added 1.2 - has rights to view ZBS Dash
+
+	// CRM object view capabilities
+	$role->add_cap( 'admin_zerobs_view_customers' );
+	$role->add_cap( 'admin_zerobs_view_quotes' );
+	$role->add_cap( 'admin_zerobs_view_invoices' );
+	$role->add_cap( 'admin_zerobs_view_events' );
+	$role->add_cap( 'admin_zerobs_view_transactions' );
+
+	// CRM object edit capabilities
+	$role->add_cap( 'admin_zerobs_customers' );
+	$role->add_cap( 'admin_zerobs_customers_tags' );
+
+	// needed for notifications
+	$role->add_cap( 'admin_zerobs_notifications' );
+
+	// emails
+	$role->add_cap( 'admin_zerobs_sendemails_contacts' );
+
+	unset( $role );
+}
 
 /* ======================================================
   / Add + Remove Roles

--- a/projects/plugins/crm/includes/jpcrm-learn-menu-legacy-functions.php
+++ b/projects/plugins/crm/includes/jpcrm-learn-menu-legacy-functions.php
@@ -170,7 +170,10 @@ function jpcrm_tasklistview_learn_menu( $learn_menu ) {
 	$learn_menu['right_buttons'] = get_jpcrm_table_options_button();
 
 	$learn_menu['right_buttons'] .= ' <a href="' . jpcrm_esc_link( $zbs->slugs['manage-events'] ) . '" class="jpcrm-button white-bg font-14px">' . __( 'View Calendar', 'zero-bs-crm' ) . '</a>';
-	$learn_menu['right_buttons'] .= ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_event', false ) . '" class="jpcrm-button font-14px">' . __( 'Add new task', 'zero-bs-crm' ) . '</a>';
+
+	if ( zeroBSCRM_permsEvents() ) {
+		$learn_menu['right_buttons'] .= ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_event', false ) . '" class="jpcrm-button font-14px">' . __( 'Add new task', 'zero-bs-crm' ) . '</a>';
+	}
 
 	return $learn_menu;
 }
@@ -392,7 +395,10 @@ EOF;
 
 	$learn_menu['right_buttons']  = $task_users_html;
 	$learn_menu['right_buttons'] .= ' <a href="' . jpcrm_esc_link( $zbs->slugs['manage-events-list'] ) . '" class="jpcrm-button white-bg font-14px">' . __( 'List view', 'zero-bs-crm' ) . '</a>';
-	$learn_menu['right_buttons'] .= ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_event', false ) . '" class="jpcrm-button font-14px">' . __( 'Add new event', 'zero-bs-crm' ) . '</a>';
+
+	if ( zeroBSCRM_permsEvents() ) {
+		$learn_menu['right_buttons'] .= ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_event', false ) . '" class="jpcrm-button font-14px">' . __( 'Add new task', 'zero-bs-crm' ) . '</a>';
+	}
 
 	return $learn_menu;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3091 - clean up user roles

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the linked issue, a user cited our docs stating that the Mail Manager should not be able to edit quotes or invoices:

https://kb.jetpackcrm.com/knowledge-base/setting-up-your-team/

Looking at the roles, I confirmed that confirmed that we were lax in most of our permissions; most roles could view and edit most objects. I cleaned up the code and tried to standardise the role definitions as follows:

* CRM Admin: full access to everything
* WP Admin: full access to everything
* Contact Manager: view and edit all objects, but not settings
* Quote Manager: view and edit contacts and quotes
* Invoice Manager: view and edit contacts, invoices, and transactions (as transactions are directly linked to invoices)
* Transaction Manager: view and edit contacts and transactions
* CRM Customer: custom role with no special capabilities (used for Client Portal)
* Mail Manager: view all objects (in listview), and edit contacts and tasks

Note that all team member roles can edit contacts, as that permission is deeply engrained in the system checks that are not directly related to contacts.

Prior to this PR, anyone could add a new object (even if they could edit it). This adds a basic check to prevent that (it's not pretty at this stage, but no one should run into it accidentally).

I also restricted display of the Dashboard and Task Scheduler according to their proper permissions.

Finally, I co-opted an old migration so that the roles would be properly refreshed (deleted and added) in WordPress.

I have not updated the KB to reflect the above, but we'll need to do so if this gets merged.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Essentially make a user and switch its role (I used a private browser) to make sure things are properly restricted per my outline above.