### PR TITLE
AI Assistant: Set `postTitle` as empty string by default

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-title
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Set title as empty in create prompt

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -37,7 +37,7 @@ export const buildPromptTemplate = ( {
 	const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' ) || '';
 
 	const blogPostData = `Here's the content in the editor that serves as context to the user request:
-${ postTitle.length ? `- Current title: ${ postTitle }\n` : '' }${
+${ postTitle?.length ? `- Current title: ${ postTitle }\n` : '' }${
 		fullContent ? `- Current content: ${ fullContent }` : ''
 	}`;
 
@@ -57,7 +57,7 @@ ${ extraRules }- Format your responses in Markdown syntax, ready to be published
 
 	messages.push( { role: 'system', content: prompt } );
 
-	if ( postTitle.length || !! fullContent ) {
+	if ( postTitle?.length || !! fullContent ) {
 		messages.push( {
 			role: 'user',
 			content: blogPostData,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -64,7 +64,7 @@ ${ extraRules }- Format your responses in Markdown syntax, ready to be published
 		} );
 	}
 
-	if ( relevantContent != null && relevantContent.length ) {
+	if ( relevantContent != null && relevantContent?.length ) {
 		if ( isContentGenerated ) {
 			messages.push( {
 				role: 'assistant',
@@ -91,7 +91,7 @@ ${ extraRules }- Format your responses in Markdown syntax, ready to be published
 	}
 
 	messages.forEach( message => {
-		debug( `Role: ${ message.role }.\nMessage: ${ message.content }\n---` );
+		debug( `Role: ${ message?.role }.\nMessage: ${ message?.content }\n---` );
 	} );
 	return messages;
 };
@@ -107,7 +107,7 @@ export function buildPrompt( {
 	userPrompt,
 	isGeneratingTitle,
 } ) {
-	const isGenerated = options.contentType === 'generated';
+	const isGenerated = options?.contentType === 'generated';
 	const reference = {
 		content: isGeneratingTitle ? 'the title' : 'the content',
 		generated: isGeneratingTitle ? 'the title' : 'your last answer',

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/create-prompt.js
@@ -34,7 +34,7 @@ export const buildPromptTemplate = ( {
 
 	const messages = [];
 
-	const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' );
+	const postTitle = select( 'core/editor' ).getEditedPostAttribute( 'title' ) || '';
 
 	const blogPostData = `Here's the content in the editor that serves as context to the user request:
 ${ postTitle.length ? `- Current title: ${ postTitle }\n` : '' }${


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If selector returns `undefined` we set the `postTitle` to empty string to avoid exceptions.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add default `''` at `postTitle`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1685737717398149/1685713172.545309-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

N/A