### PR TITLE
IDC: fix connection screen for broken connection

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -74,7 +74,7 @@ abstract class Jetpack_Admin_Page {
 		$this->jetpack = $jetpack;
 
 		self::$block_page_rendering_for_idc = (
-			Identity_Crisis::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' )
+			Jetpack::is_connection_ready() && Identity_Crisis::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' )
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-idc-missing-blog-token
+++ b/projects/plugins/jetpack/changelog/fix-idc-missing-blog-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+IDC: fix Jetpack Dashboard for broken connection.


### PR DESCRIPTION
Solving an edge case for missing connection screen when the site is technically in IDC, but actually disconnected.

When Jetpack site falls into IDC (`jetpack_sync_error_idc` option is set), we do not display Jetpack Dashboard and show the IDC screen instead.

However, if Jetpack connection is broken to a point where we consider the site no longer connected (e.g. blog token is missing), but the `jetpack_sync_error_idc` option hasn't been cleared, we do the following:
- do not show the connection screen because there should be the IDC screen (`jetpack_sync_error_idc` option is present)
- do not show the IDC screen because we don't consider the site connected (blog token is missing)

The option `jetpack_sync_error_idc` is irrelevant if we force the user to reconnect, as it'll be cleared during connection process anyway.

**Note:** this PR does not fix the WoA problem that can be reproduced the same way, as it's complicated by WoA-specific setup.
See details in the linked PR.

## Proposed changes:
* Do not hide Jetpack Dashboard (including connection screen) if site is not connected, no matter if there's IDC or not.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack
2. Use "IDC Simulator" to force IDC (fill `jetpack_sync_error_idc` option with values)
3. Use "Broken Token" to remove the blog token
4. Go to "Jetpack -> Jetpack" and confirm that connection screen shows up.
5. Go through the connection flow, confirm it