### PR TITLE
Social | Hide the image requirement notice when the site is out of shares

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-remove-img-req-when-out-of-shares
+++ b/projects/js-packages/publicize-components/changelog/fix-social-remove-img-req-when-out-of-shares
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Social: Hide the image requirement notice when the site is out of shares

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -148,6 +148,11 @@ export default function PublicizeForm( {
 		</>
 	);
 
+	const showNoMediaMessage =
+		! postHasValidImage &&
+		numberOfSharesRemaining !== 0 &&
+		connections.some( ( { service_name } ) => isConnectionNeedMedia( service_name ) );
+
 	return (
 		<Wrapper>
 			{ hasConnections && (
@@ -243,16 +248,15 @@ export default function PublicizeForm( {
 							) }
 						</ul>
 					</PanelRow>
-					{ connections.some( ( { service_name } ) => isConnectionNeedMedia( service_name ) ) &&
-						! postHasValidImage && (
-							<Notice type={ 'warning' }>
-								{ __( 'You need a valid image in your post to share to Instagram.', 'jetpack' ) }
-								<br />
-								<ExternalLink href={ getRedirectUrl( 'jetpack-social-media-support-information' ) }>
-									{ __( 'Learn more', 'jetpack' ) }
-								</ExternalLink>
-							</Notice>
-						) }
+					{ showNoMediaMessage && (
+						<Notice type={ 'warning' }>
+							{ __( 'You need a valid image in your post to share to Instagram.', 'jetpack' ) }
+							<br />
+							<ExternalLink href={ getRedirectUrl( 'jetpack-social-media-support-information' ) }>
+								{ __( 'Learn more', 'jetpack' ) }
+							</ExternalLink>
+						</Notice>
+					) }
 				</>
 			) }
 			{ ! isPublicizeDisabledBySitePlan && (
@@ -262,12 +266,20 @@ export default function PublicizeForm( {
 							onDismiss={ onDismissInstagramNotice }
 							type={ 'highlight' }
 							actions={ [
-								<Button key="connect" href={ connectionsAdminUrl } variant="primary">
+								<Button
+									key="connect"
+									href={ connectionsAdminUrl }
+									target="_blank"
+									rel="noreferrer noopener"
+									variant="primary"
+								>
 									{ __( 'Connect now', 'jetpack' ) }
 								</Button>,
 								<Button
 									key="learn-more"
 									href={ getRedirectUrl( 'jetpack-social-connecting-to-social-networks' ) }
+									target="_blank"
+									rel="noreferrer noopener"
 								>
 									{ __( 'Learn more', 'jetpack' ) }
 								</Button>,


### PR DESCRIPTION
Completes 1203820938137329-as-1204692223892751/f

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide the image requirement notice when the site is out of shares
* Change the "Connect NOW" button in Instagram notice to open in new tab

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
1203820938137329-as-1204692223892751/f

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* On a site pointing to your sandbox with no Jetpack Social plan, connect an Instagram account
* Create a new post without a featured image
* Open Jetpack plugin sidebar
* Confirm that under "Share this post" section, you see the notice `You need a valid image in your post to share to Instagram.`
* Add a featured image to the post
* Confirm that the above notice is gone
* Remove the featured image
* Save the post as draft
* Point `public-api.wordpress.com` to your sandbox
* In your sandbox, update `PUBLICIZE_MONTHLY_LIMIT` to `0` in `publicize/publicize-wpcom.php`
* Reload the post edit page
* Open Jetpack sidebar again
* Confirm that under "Share this post" section, you see the notice `You have 0 shares remaining in the next 30 days`
* Confirm that you no longer see the notice `You need a valid image in your post to share to Instagram.`

<img width="292" alt="Screenshot 2023-06-05 at 10 00 38 AM" src="https://github.com/Automattic/jetpack/assets/18226415/8d295517-349a-4fd0-a6dd-2fd16f1c6e6a">

