### PR TITLE
Publicize | Simplify i18n strings

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-simplify-publicize-translations
+++ b/projects/js-packages/publicize-components/changelog/fix-simplify-publicize-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Simplified i18n strings

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -195,7 +195,7 @@ export default function PublicizeForm( {
 												: {} ),
 										} ) }
 										target="_blank"
-										rel="noreferrer"
+										rel="noopener noreferrer"
 										onClick={ autosaveAndRedirect }
 									>
 										{ __( 'More about Jetpack Social.', 'jetpack' ) }

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -181,26 +181,20 @@ export default function PublicizeForm( {
 										}
 									) }
 									<br />
-									{ createInterpolateElement(
-										/* translators: %d is the number of shares remaining, moreLink is the link to find out more information about the plan */
-										__( '<moreLink>More about Jetpack Social</moreLink>.', 'jetpack' ),
-										{
-											moreLink: (
-												<a
-													className={ styles[ 'more-link' ] }
-													href={ getRedirectUrl( 'jetpack-social-block-editor-more-info', {
-														site: getSiteFragment(),
-														...( adminUrl
-															? { query: 'redirect_to=' + encodeURIComponent( adminUrl ) }
-															: {} ),
-													} ) }
-													target="_blank"
-													rel="noreferrer"
-													onClick={ autosaveAndRedirect }
-												/>
-											),
-										}
-									) }
+									<a
+										className={ styles[ 'more-link' ] }
+										href={ getRedirectUrl( 'jetpack-social-block-editor-more-info', {
+											site: getSiteFragment(),
+											...( adminUrl
+												? { query: 'redirect_to=' + encodeURIComponent( adminUrl ) }
+												: {} ),
+										} ) }
+										target="_blank"
+										rel="noreferrer"
+										onClick={ autosaveAndRedirect }
+									>
+										{ __( 'More about Jetpack Social.', 'jetpack' ) }
+									</a>
 								</Fragment>
 							</Notice>
 						</PanelRow>

--- a/projects/packages/publicize/changelog/fix-simplify-publicize-translations
+++ b/projects/packages/publicize/changelog/fix-simplify-publicize-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Simplified i18n strings

--- a/projects/packages/publicize/src/class-share-limits.php
+++ b/projects/packages/publicize/src/class-share-limits.php
@@ -113,7 +113,7 @@ class Share_Limits {
 			)
 		);
 		$more_link = sprintf(
-			'<a href="%1$s" target="_blank">%2$s</a>',
+			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
 			Redirect::get_url(
 				'jetpack-social-basic-plan-block-editor',
 				array(

--- a/projects/packages/publicize/src/class-share-limits.php
+++ b/projects/packages/publicize/src/class-share-limits.php
@@ -113,14 +113,14 @@ class Share_Limits {
 			)
 		);
 		$more_link = sprintf(
-			/* translators: %s: link to find out more about the plan, and potentially upgrade. */
-			__( '<a href="%s" target="_blank">More about Jetpack Social</a>', 'jetpack-publicize-pkg' ),
+			'<a href="%1$s" target="_blank">%2$s</a>',
 			Redirect::get_url(
 				'jetpack-social-basic-plan-block-editor',
 				array(
 					'query' => 'redirect_to=' . rawurlencode( $current_url ),
 				)
-			)
+			),
+			__( 'More about Jetpack Social', 'jetpack-publicize-pkg' )
 		);
 
 		$kses_allowed_tags = array(


### PR DESCRIPTION
Completes 1204479765123387-as-1204741887007073/f

## Proposed changes:

* Improve and simplify i18n strings to make them re-usable
* Remove the unnecessary use of `createInterpolateElement` in client-side code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/27617#discussion_r1214418510

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* On a site pointing to your sandbox with no Jetpack Social plan, create a new post
* Open Jetpack plugin sidebar
* Confirm that under "Share this post" section, the "More about Jetpack Social" link for shares limit works as before