### PR TITLE
Launchpad: Support task list filtering of visible task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-is-visible-callback
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-is-visible-callback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support task list filtering of visible task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -197,9 +197,12 @@ class Launchpad_Task_Lists {
 			return $tasks_for_task_list;
 		}
 
+		// Filter the task list's task ids to only include visible tasks if a callback is provided.
+		$task_ids = $this->load_value_from_callback( $task_list, 'visible_tasks_callback', $task_list['task_ids'] );
+
 		// Takes a registered task list, looks at its associated task ids,
 		// and returns a collection of associated tasks.
-		foreach ( $task_list['task_ids'] as $task_id ) {
+		foreach ( $task_ids as $task_id ) {
 			$task_definition = $this->get_task( $task_id );
 
 			// if task can't be found don't add anything
@@ -373,6 +376,11 @@ class Launchpad_Task_Lists {
 
 		if ( ! isset( $task_list['task_ids'] ) ) {
 			_doing_it_wrong( 'validate_task_list', 'The Launchpad task list being registered requires a "task_ids" attribute', '6.1' );
+			return false;
+		}
+
+		if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
+			_doing_it_wrong( 'validate_task_list', 'The visible_tasks_callback attribute must be callable', '6.1' );
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -22,4 +22,49 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 		$this->assertIsArray( $result );
 		$this->assertEmpty( $result );
 	}
+
+	/**
+	 * Filter out tasks with the task list callback.
+	 *
+	 * @covers ::build
+	 */
+	public function test_task_list_is_visible_callback() {
+		wpcom_register_launchpad_task(
+			array(
+				'id'    => 'task_0',
+				'title' => 'task_0',
+			)
+		);
+
+		wpcom_register_launchpad_task(
+			array(
+				'id'    => 'task_1',
+				'title' => 'task_1',
+			)
+		);
+
+		wpcom_register_launchpad_task_list(
+			array(
+				'id'                     => 'test-task-list',
+				'title'                  => 'test-task-list',
+				'task_ids'               => array(
+					'task_0',
+					'task_1',
+				),
+				'visible_tasks_callback' => function ( $task_list, $task_ids ) {
+					return array_filter(
+						$task_ids,
+						function ( $task_id ) {
+							return 'task_1' === $task_id;
+						}
+					);
+				},
+			)
+		);
+
+		$result = Launchpad_Task_Lists::get_instance()->build( 'test-task-list' );
+
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'task_1', $result[0]['id'] );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -73,9 +73,9 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertCount( 1, $result );
 		$this->assertEquals( 'task_1', $result[0]['id'] );
- 	}
+	}
 
-  /**
+	/**
 	 * Data provider for {@see test_task_list_is_completed()}.
 	 */
 	public function provider_test_task_list_is_completed() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Currently, we can filter tasks by the task definition, but it would be hard to filter tasks in different task lists. We add support for filtering tasks on the task list level to allow us to manage the tasks for experiments or different contexts.

Closes https://github.com/Automattic/wp-calypso/issues/77297

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new callback to allow filtering tasks on the task list level.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The callback is not being used yet. I added some unit tests to cover it:
```
cd projects/packages/jetpack-mu-wpcom; ./vendor/bin/phpunit --filter=La
unchpad_Task_Lists_Test; cd -
```
* Make sure that this change doesn't break the current behavior.
  * Sandbox the public-api
  * Apply these changes to your sandbox: https://github.com/Automattic/jetpack/pull/31186#issuecomment-1576416273
  * Create a new free site, and go through the Launchpad.
