### PR TITLE
CRM: Resolves 3145 - fix company field typo

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3145-company_fields_typo
+++ b/projects/plugins/crm/changelog/fix-crm-3145-company_fields_typo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed typo introduced in #31030
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Companies.php
@@ -216,7 +216,7 @@
 								if ( $field_group === 'Second Address' ) {
 									$field_value[1] = str_replace( ' (' . $second_address_label . ')', '', $field_value[1] );
 								}
-								zeroBSCRM_html_editField( $zbsCompany, $field_key, $field_value, 'zbsc_' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+								zeroBSCRM_html_editField( $zbsCompany, $field_key, $field_value, 'zbsco_' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 							}
 						}
 					}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3145 - fix company field typo

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #31030 we updated edit page fields for the new Emerald style. In the field generation function call we introduced a typo which made it so new companies could not be created: `zbsco_` → `zbsc_`

This PR fixes said typo.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to the new company page: `/wp-admin/admin.php?page=zbs-add-edit&action=edit&zbstype=company`
2. Add a name and click "Save Company".

In `trunk`, one gets an error.

In the `fix/crm/3145-company_fields_typo` branch, the new company is properly created.