### PR TITLE
e2e tests: always dismiss the sharing modal added by ETK

### DIFF
--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -72,6 +72,9 @@ configure_wp_env() {
 	$BASE_CMD wp option set permalink_structure ""
 	$BASE_CMD wp jetpack module deactivate sso
 
+	# Sharing modal added by the ETK plugin should be dismissed.
+	$BASE_CMD wp option update sharing_modal_dismissed 1
+
 	echo
 	$BASE_CMD wp plugin status
 	echo

--- a/tools/e2e-commons/env/prerequisites.js
+++ b/tools/e2e-commons/env/prerequisites.js
@@ -20,7 +20,6 @@ export function prerequisitesBuilder( page ) {
 		connected: undefined,
 		plan: undefined,
 		modules: { active: undefined, inactive: undefined },
-		sharingModalDismissed: undefined,
 	};
 
 	return {
@@ -60,10 +59,6 @@ export function prerequisitesBuilder( page ) {
 			state.clean = true;
 			return this;
 		},
-		withSharingModalDismissed() {
-			state.sharingModalDismissed = true;
-			return this;
-		},
 		async build() {
 			await buildPrerequisites( state, page );
 		},
@@ -79,7 +74,6 @@ async function buildPrerequisites( state, page ) {
 		plan: () => ensurePlan( state.plan, page ),
 		modules: () => ensureModulesState( state.modules ),
 		clean: () => ensureCleanState( state.clean ),
-		sharingModalDismissed: () => ensureSharingModalDismissed(),
 	};
 
 	logger.prerequisites( JSON.stringify( state, null, 2 ) );
@@ -158,11 +152,6 @@ async function ensureCleanState( shouldReset ) {
 		await execWpCommand( 'jetpack disconnect blog' );
 		await resetWordpressInstall();
 	}
-}
-
-async function ensureSharingModalDismissed() {
-	logger.prerequisites( 'Ensuring sharing modal added by the ETK plugin is dismissed' );
-	await execWpCommand( 'option update sharing_modal_dismissed 1' );
 }
 
 export async function ensurePlan( plan = undefined, page ) {

--- a/tools/e2e-commons/env/prerequisites.js
+++ b/tools/e2e-commons/env/prerequisites.js
@@ -20,6 +20,7 @@ export function prerequisitesBuilder( page ) {
 		connected: undefined,
 		plan: undefined,
 		modules: { active: undefined, inactive: undefined },
+		sharingModalDismissed: undefined,
 	};
 
 	return {
@@ -59,6 +60,10 @@ export function prerequisitesBuilder( page ) {
 			state.clean = true;
 			return this;
 		},
+		withSharingModalDismissed() {
+			state.sharingModalDismissed = true;
+			return this;
+		},
 		async build() {
 			await buildPrerequisites( state, page );
 		},
@@ -74,6 +79,7 @@ async function buildPrerequisites( state, page ) {
 		plan: () => ensurePlan( state.plan, page ),
 		modules: () => ensureModulesState( state.modules ),
 		clean: () => ensureCleanState( state.clean ),
+		sharingModalDismissed: () => ensureSharingModalDismissed(),
 	};
 
 	logger.prerequisites( JSON.stringify( state, null, 2 ) );
@@ -152,6 +158,11 @@ async function ensureCleanState( shouldReset ) {
 		await execWpCommand( 'jetpack disconnect blog' );
 		await resetWordpressInstall();
 	}
+}
+
+async function ensureSharingModalDismissed() {
+	logger.prerequisites( 'Ensuring sharing modal added by the ETK plugin is dismissed' );
+	await execWpCommand( 'option update sharing_modal_dismissed 1' );
 }
 
 export async function ensurePlan( plan = undefined, page ) {


### PR DESCRIPTION
## Proposed changes:

We do not need to test this modal in Jetpack, and we do not want it to interfer with the rest of the tests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1685976419147559-slack-C03QNBQKG73

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Check CI
