### PR TITLE
Launchpad: Hide design_edited task from task list if completed for post-launch sites.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-design-edited-step
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-design-edited-step
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Update visibility for design_edited task for post-launch sites.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "3.1.x-dev"
+			"dev-trunk": "3.2.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "3.1.0",
+	"version": "3.2.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '3.1.0';
+	const PACKAGE_VERSION = '3.2.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -571,11 +571,17 @@ function wpcom_launchpad_is_keep_building_enabled() {
 /**
  * Filter task visibility for the Keep building task list.
  *
- * @param array $task_ids The array of task IDs from the `task_ids` key.
+ * @param array $task The task array.
  *
  * @return array The filtered array of task IDs.
  */
-function wpcom_launchpad_keep_building_visible_tasks( $task_ids ) {
+function wpcom_launchpad_keep_building_visible_tasks( $task ) {
+	$task_ids = $task['task_ids'];
+
+	if ( ! $task_ids ) {
+		return array();
+	}
+
 	return array_filter(
 		$task_ids,
 		function ( $task_id ) {
@@ -585,7 +591,6 @@ function wpcom_launchpad_keep_building_visible_tasks( $task_ids ) {
 				return ! isset( $task_statuses[ $task_id ] ) || ! $task_statuses[ $task_id ] ? $task_id : null;
 			}
 
-			// All other tasks.
 			return $task_id;
 		}
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -571,16 +571,18 @@ function wpcom_launchpad_is_keep_building_enabled() {
 /**
  * Filter task visibility for the Keep building task list.
  *
+ * @param array $task_ids The array of task IDs from the `task_ids` key.
+ *
  * @return array The filtered array of task IDs.
  */
 function wpcom_launchpad_keep_building_visible_tasks( $task_ids ) {
-	$task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
 	return array_filter(
 		$task_ids,
 		function ( $task_id ) {
-			// Only show design_edited/site_edited if it hasn't been marked as completed.
+			$task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
+			// Only show design_edited/site_edited if it hasn't been marked as complete.
 			if ( 'design_edited' === $task_id || 'site_edited' === $task_id ) {
-				return ! isset( $task_statuses[$task_id] ) || ! $task_statuses[$task_id] ? $task_id : null;
+				return ! isset( $task_statuses[ $task_id ] ) || ! $task_statuses[ $task_id ] ? $task_id : null;
 			}
 
 			// All other tasks.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -587,7 +587,7 @@ function wpcom_launchpad_keep_building_visible_tasks( $task_list ) {
 		function ( $task_id ) {
 			// Only show design_edited/site_edited if it hasn't been marked as complete.
 			if ( in_array( $task_id, array( 'design_edited', 'site_edited' ), true ) ) {
-				return ! is_array( wpcom_is_checklist_task_complete( $task_id ) );
+				return ! wpcom_is_checklist_task_complete( $task_id );
 			}
 
 			return true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -586,7 +586,7 @@ function wpcom_launchpad_keep_building_visible_tasks( $task_list ) {
 		$task_ids,
 		function ( $task_id ) {
 			// Only show design_edited/site_edited if it hasn't been marked as complete.
-			if ( in_array( $task_id, [ 'design_edited', 'site_edited' ], true ) ) {
+			if ( in_array( $task_id, array( 'design_edited', 'site_edited' ), true ) ) {
 				return ! is_array( wpcom_is_checklist_task_complete( $task_id ) );
 			}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -129,8 +129,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'keep-building'   => array(
-			'title'               => 'Keep Building',
-			'task_ids'            => array(
+			'title'                  => 'Keep Building',
+			'task_ids'               => array(
 				'site_title',
 				'design_edited',
 				'domain_claim',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -138,7 +138,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'domain_upsell',
 				'drive_traffic',
 			),
-			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
+			'is_enabled_callback'    => 'wpcom_launchpad_is_keep_building_enabled',
+			'visible_tasks_callback' => 'wpcom_launchpad_keep_building_visible_tasks',
 		),
 	);
 
@@ -565,6 +566,27 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
  */
 function wpcom_launchpad_is_keep_building_enabled() {
 	return apply_filters( 'is_launchpad_keep_building_enabled', false );
+}
+
+/**
+ * Filter task visibility for the Keep building task list.
+ *
+ * @return array The filtered array of task IDs.
+ */
+function wpcom_launchpad_keep_building_visible_tasks( $task_ids ) {
+	$task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
+	return array_filter(
+		$task_ids,
+		function ( $task_id ) {
+			// Only show design_edited/site_edited if it hasn't been marked as completed.
+			if ( 'design_edited' === $task_id || 'site_edited' === $task_id ) {
+				return ! isset( $task_statuses[$task_id] ) || ! $task_statuses[$task_id] ? $task_id : null;
+			}
+
+			// All other tasks.
+			return $task_id;
+		}
+	);
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -571,7 +571,7 @@ function wpcom_launchpad_is_keep_building_enabled() {
 /**
  * Filter task visibility for the Keep building task list.
  *
- * @param array $task The task array.
+ * @param array $task_list The task array.
  *
  * @return array The filtered array of task IDs.
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -588,7 +588,7 @@ function wpcom_launchpad_keep_building_visible_tasks( $task ) {
 			$task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
 			// Only show design_edited/site_edited if it hasn't been marked as complete.
 			if ( 'design_edited' === $task_id || 'site_edited' === $task_id ) {
-				return ! isset( $task_statuses[ $task_id ] ) || ! $task_statuses[ $task_id ] ? $task_id : null;
+				return is_array( wpcom_is_checklist_task_complete( 'design_edited' ) ) || is_array( wpcom_is_checklist_task_complete( 'site_edited' ) ) ? false : $task_id;
 			}
 
 			return $task_id;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -586,11 +586,11 @@ function wpcom_launchpad_keep_building_visible_tasks( $task ) {
 		$task_ids,
 		function ( $task_id ) {
 			// Only show design_edited/site_edited if it hasn't been marked as complete.
-			if ( 'design_edited' === $task_id || 'site_edited' === $task_id ) {
-				return is_array( wpcom_is_checklist_task_complete( 'design_edited' ) ) || is_array( wpcom_is_checklist_task_complete( 'site_edited' ) ) ? false : $task_id;
+			if ( in_array( $task_id, [ 'design_edited', 'site_edited' ], true ) ) {
+				return ! is_array( wpcom_is_checklist_task_complete($task_id) );
 			}
 
-			return $task_id;
+			return true;
 		}
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -585,7 +585,6 @@ function wpcom_launchpad_keep_building_visible_tasks( $task ) {
 	return array_filter(
 		$task_ids,
 		function ( $task_id ) {
-			$task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
 			// Only show design_edited/site_edited if it hasn't been marked as complete.
 			if ( 'design_edited' === $task_id || 'site_edited' === $task_id ) {
 				return is_array( wpcom_is_checklist_task_complete( 'design_edited' ) ) || is_array( wpcom_is_checklist_task_complete( 'site_edited' ) ) ? false : $task_id;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -575,8 +575,8 @@ function wpcom_launchpad_is_keep_building_enabled() {
  *
  * @return array The filtered array of task IDs.
  */
-function wpcom_launchpad_keep_building_visible_tasks( $task ) {
-	$task_ids = $task['task_ids'];
+function wpcom_launchpad_keep_building_visible_tasks( $task_list ) {
+	$task_ids = $task_list['task_ids'];
 
 	if ( ! $task_ids ) {
 		return array();
@@ -587,7 +587,7 @@ function wpcom_launchpad_keep_building_visible_tasks( $task ) {
 		function ( $task_id ) {
 			// Only show design_edited/site_edited if it hasn't been marked as complete.
 			if ( in_array( $task_id, [ 'design_edited', 'site_edited' ], true ) ) {
-				return ! is_array( wpcom_is_checklist_task_complete($task_id) );
+				return ! is_array( wpcom_is_checklist_task_complete( $task_id ) );
 			}
 
 			return true;

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-lock-file
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-lock-file
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Updates package version.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_5_1_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_0_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "f5e5d7135d0b0e5cd89a524d771f1ebe3c70f67b"
+                "reference": "7377c521b763e6bc065318a5a0194057e3236282"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.0.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "f5e5d7135d0b0e5cd89a524d771f1ebe3c70f67b"
+                "reference": "edda45b5df870bfcaab26fe4c4c803a2936d8fb9"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "7377c521b763e6bc065318a5a0194057e3236282"
+                "reference": "f5e5d7135d0b0e5cd89a524d771f1ebe3c70f67b"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.0.x-dev"
+                    "dev-trunk": "3.1.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.5.1-alpha
+ * Version: 1.6.0-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.5.1-alpha",
+	"version": "1.6.0-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
Fixes Automattic/wp-calypso#77292

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Using the filter introduced in #31186, this filters task visibility for the Keep Building list to only show `design_edited`/`site_edited` if it isn't completed.
* This keeps the task visible on the Stepper Launchpad regardless of completion status, but hides it from Keep Building's task list if completed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out this patch to your sandbox and sandbox the API
* Create a new site from`/start` selecting "Promote myself or business" as a goal -- this will put you into the Build flow with the `build` site intent.
* When you get to Launchpad in Stepper, confirm that the "Edit site design" task is incomplete.
* Launch your site without completing the "Edit site design" task.
* Go to the developer console and GET from the WP REST API `wpcom/v2/sites/siteSlug/launchpad`
* You should see the following list of tasks:

<img width="880" alt="Screen Shot 2023-06-08 at 11 50 02 AM" src="https://github.com/Automattic/jetpack/assets/2124984/00838ff5-7b08-4b32-b9ad-cf06b6b3c1bd">

* GET from the WP REST API `wpcom/v2/sites/siteSlug/launchpad?checklist_slug=keep-building`
* You should see the following tasks:

<img width="961" alt="Screen Shot 2023-06-08 at 12 01 42 PM" src="https://github.com/Automattic/jetpack/assets/2124984/9f3dadb2-7436-4a03-a720-8e963669b269">

* Complete the Edit site design task in Stepper (click on it, go to the site editor, then navigate back to Launchpad in Stepper).
* Go back to the developer console and GET from the WP REST API `wpcom/v2/sites/siteSlug2/launchpad`
* You should see the same task list, with the `design_edited` task marked as complete:

<img width="842" alt="Screen Shot 2023-06-08 at 12 09 46 PM" src="https://github.com/Automattic/jetpack/assets/2124984/39e97ee3-0247-410a-96f7-bccc6ed89099">

* GET from the WP REST API `wpcom/v2/sites/siteSlug/launchpad?checklist_slug=keep-building`
* You should see the Keep Building task list no longer has the `design_edited` task:

<img width="962" alt="Screen Shot 2023-06-08 at 12 19 41 PM" src="https://github.com/Automattic/jetpack/assets/2124984/65b3992f-39e4-420f-80c0-ed4fcba143fe">
