### PR TITLE
Plans: update to remove Jetpack-the-plugin specificities

### DIFF
--- a/projects/packages/plans/changelog/update-current-plan
+++ b/projects/packages/plans/changelog/update-current-plan
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove Jetpack-the-plugin dependencies from Current Plan class.

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.3.1",
+	"version": "0.3.2-alpha",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -49,6 +49,8 @@ class Current_Plan {
 				'whatsapp-button',
 				'social-previews',
 				'videopress',
+				'videopress/video',
+				'v6-video-frame-poster',
 
 				'core/video',
 				'core/cover',

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -2,15 +2,13 @@
 /**
  * Handles fetching of the site's plan and products from WordPress.com and caching values locally.
  *
- * This file was copied and adapted from the Jetpack plugin on Mar 2022
- *
- * @package automattic/jetpack
+ * @package automattic/jetpack-plans
  */
 
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Connection\Client;
-use Jetpack_Options;
+use Automattic\Jetpack\Connection\Manager;
 
 /**
  * Provides methods methods for fetching the site's plan and products from WordPress.com.
@@ -213,9 +211,18 @@ class Current_Plan {
 	 * @return bool True if plan is updated, false if no update
 	 */
 	public static function refresh_from_wpcom() {
+		$site_id = Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return false;
+		}
+
 		// Make the API request.
 
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d', Jetpack_Options::get_option( 'id' ) ) . '?force=wpcom', '1.1' );
+		$response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d?force=wpcom', $site_id ),
+			'1.1'
+		);
+
 		return self::update_from_sites_response( $response );
 	}
 
@@ -319,7 +326,7 @@ class Current_Plan {
 	/**
 	 * Determine whether the active plan supports a particular feature
 	 *
-	 * @uses Jetpack_Plan::get()
+	 * @uses self::get()
 	 *
 	 * @access public
 	 * @static

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -251,16 +251,14 @@ class Current_Plan {
 
 		list( $plan['class'], $supports ) = self::get_class_and_features( $plan['product_slug'] );
 
-		// get available features if Jetpack is active.
-		if ( class_exists( 'Jetpack' ) ) {
-			foreach ( \Jetpack::get_available_modules() as $module_slug ) {
-				$module = \Jetpack::get_module( $module_slug );
-				if ( ! isset( $module ) || ! is_array( $module ) ) {
-					continue;
-				}
-				if ( in_array( 'free', $module['plan_classes'], true ) || in_array( $plan['class'], $module['plan_classes'], true ) ) {
-					$supports[] = $module_slug;
-				}
+		$modules = new Modules();
+		foreach ( $modules->get_available() as $module_slug ) {
+			$module = $modules->get( $module_slug );
+			if ( ! isset( $module ) || ! is_array( $module ) ) {
+				continue;
+			}
+			if ( in_array( 'free', $module['plan_classes'], true ) || in_array( $plan['class'], $module['plan_classes'], true ) ) {
+				$supports[] = $module_slug;
 			}
 		}
 


### PR DESCRIPTION
Fixes #30288

## Proposed changes:

This is another try at #23789.  This PR brings the `Current_Plan` up to date so it can completely replace `Jetpack_Plan` in the future.

- We add VideoPress blocks that were added in #29678
- We pull Modules data from package instead of using the Jetpack class. See #29736 for a previous discussion about this.
- We do not rely on `Jetpack_Options` directly

The `Current_Plan` isn't widely used yet, but these updates should help us make it usable in a follow-up PR. 
For reference, it is already used for Publicize, see #25347.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pdWQjU-4i-p2
* p9dueE-7pi-p2
* 1202726932197503-as-1202726932197515

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Right now, not much should change in the current behavior. A good way to test this PR would be to use the Social plugin:

1. Install the Social plugin, without purchasing a plan, and visit the Social menu page to see the prompt to upgrade.
2. Upgrade and see that the state is updated in the menu page.
