### PR TITLE
Fix: Redirecting from setup page to dashboard

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -504,7 +504,6 @@ class Main extends React.Component {
 			case '/connect-user':
 			case '/connect-user-setup':
 			case '/woo-setup':
-			case '/setup':
 				pageComponent = (
 					<AtAGlance
 						siteRawUrl={ this.props.siteRawUrl }
@@ -512,6 +511,12 @@ class Main extends React.Component {
 						rewindStatus={ this.props.rewindStatus }
 					/>
 				);
+				break;
+			case '/setup':
+				if ( this.props.isSiteConnected ) {
+					this.props.history.replace( '/dashboard' );
+					pageComponent = this.getAtAGlance();
+				}
 				break;
 			case '/my-plan':
 				pageComponent = (

--- a/projects/plugins/jetpack/changelog/fix-connection-back-setup
+++ b/projects/plugins/jetpack/changelog/fix-connection-back-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Connection: redirecting users who click back button before approving connection to Jetpack Dashboard


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If user tries to connect Jetpack but clicks browser back button before approving the user 
connection, they will get redirected to the Jetpack dashboard but the header will be 
missing and the URL will still show /setup page.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adding redirection from /setup to /dashboard for sites with site connection regardless of 
the user connection.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1191179647901802-as-1204540829524155/f

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to dashboard and click Set up Jetpack
* Before approving the user connection click browser back button
* You should go back to the dashboard but the Jetpack logo will be missing and URL should 
end with /setup
* Disconnect Jetpack
* Load this PR and try same steps again
* Dashboard should look OK and URL should show /dashboard instead of /setup