### PR TITLE
Jetpack: backport 12.3-a.1 release

### DIFF
--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.15.6 - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## 0.15.5 - 2023-05-02
 ### Changed
 - Updated package dependencies. [#30375]

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.15.6-alpha",
+	"version": "0.15.6",
 	"description": "Jetpack Api Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2023-06-06
+### Changed
+- Update connection module to have an RNA option that updates the design [#31201]
+- Updated package dependencies. [#31129]
+
 ## [0.5.1] - 2023-05-29
 ### Added
 - Added the jp-highlight colour for use with the social previews [#31023]
@@ -180,6 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.0]: https://github.com/Automattic/jetpack-base-styles/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/Automattic/jetpack-base-styles/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/Automattic/jetpack-base-styles/compare/0.4.4...0.5.0
 [0.4.4]: https://github.com/Automattic/jetpack-base-styles/compare/0.4.3...0.4.4

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/changelog/update-backup-connection-cta-modules-design
+++ b/projects/js-packages/base-styles/changelog/update-backup-connection-cta-modules-design
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update connection module to have an RNA option that updates the design

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.0-alpha",
+	"version": "0.6.0",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2023-06-06
+### Added
+- Add tests [#31084]
+
+### Changed
+- Updated package dependencies. [#31129]
+
 ## 0.1.0 - 2023-05-29
 ### Added
 - Create package for the boost score bar API [#30781]
+
+[0.1.1]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.0...v0.1.1

--- a/projects/js-packages/boost-score-api/changelog/add-tests-to-boost-score-api-package
+++ b/projects/js-packages/boost-score-api/changelog/add-tests-to-boost-score-api-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add tests

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.1-alpha",
+	"version": "0.1.1",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.37.0 - 2023-06-06
+### Changed
+- Update connection module to have an RNA option that updates the design [#31201]
+- Updated package dependencies. [#31129]
+- Update pricing table tooltip to allow its position to be configurable from pricing table. [#31107]
+
 ## 0.36.0 - 2023-05-29
 ### Added
 - Added the Instagram social icon [#30803]

--- a/projects/js-packages/components/changelog/make-pricing-table-tooltip-placement-configurable
+++ b/projects/js-packages/components/changelog/make-pricing-table-tooltip-placement-configurable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update pricing table tooltip to allow its position to be configurable from pricing table.

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/update-backup-connection-cta-modules-design
+++ b/projects/js-packages/components/changelog/update-backup-connection-cta-modules-design
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update connection module to have an RNA option that updates the design

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.37.0-alpha",
+	"version": "0.37.0",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## 0.28.0 - 2023-06-06
+### Changed
+- Update connection module to have an RNA option that updates the design [#31201]
+- Updated package dependencies. [#31129]
+
 ## 0.27.1 - 2023-05-29
 ### Added
 - Add logo prop to `ConnectScreen` and `ConnectScreenVisual` so we could use produucts logos similar to `ConnectScreenRequiredPlan` component. [#30886]

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/changelog/update-backup-connection-cta-modules-design
+++ b/projects/js-packages/connection/changelog/update-backup-connection-cta-modules-design
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update connection module to have an RNA option that updates the design

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.28.0-alpha",
+	"version": "0.28.0",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.32] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [2.0.31] - 2023-05-02
 ### Changed
 - Updated package dependencies. [#30375]
@@ -152,6 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.32]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.31...v2.0.32
 [2.0.31]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.30...v2.0.31
 [2.0.30]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.29...v2.0.30
 [2.0.29]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.28...v2.0.29

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.32-alpha",
+	"version": "2.0.32",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.40 - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## 0.10.39 - 2023-05-02
 ### Changed
 - Updated package dependencies.

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.40-alpha",
+	"version": "0.10.40",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.2 - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## 0.10.1 - 2023-05-02
 ### Changed
 - Updated package dependencies.

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.10.2-alpha",
+	"version": "0.10.2",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.48 - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## 0.2.47 - 2023-05-02
 ### Changed
 - Updated package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.48-alpha",
+	"version": "0.2.48",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.1] - 2023-06-06
+### Changed
+- Updated package dependencies.
+
+### Fixed
+- Jetpack Social: Hide the image requirement notice when the site is out of shares [#31184]
+- Simplified i18n strings [#31185]
+- Social: Fixed the connection state to ensure that new connections are disabled by default when there are no shares left. [#31168]
+
 ## [0.26.0] - 2023-05-29
 ### Added
 - Added account_name field to the connections post field. [#30937]
@@ -312,6 +321,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.26.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.23.0...v0.24.0

--- a/projects/js-packages/publicize-components/changelog/fix-simplify-publicize-translations
+++ b/projects/js-packages/publicize-components/changelog/fix-simplify-publicize-translations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Simplified i18n strings

--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-state
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social: Fixed the connection state to ensure that new connections are disabled by default when there are no shares left.

--- a/projects/js-packages/publicize-components/changelog/fix-social-remove-img-req-when-out-of-shares
+++ b/projects/js-packages/publicize-components/changelog/fix-social-remove-img-req-when-out-of-shares
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack Social: Hide the image requirement notice when the site is out of shares

--- a/projects/js-packages/publicize-components/changelog/renovate-automattic-social-previews-2.x
+++ b/projects/js-packages/publicize-components/changelog/renovate-automattic-social-previews-2.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.26.1-alpha",
+	"version": "0.26.1",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.5] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [0.10.4] - 2023-05-02
 ### Changed
 - Updated package dependencies.
@@ -201,6 +205,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.10.5]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.4...0.10.5
 [0.10.4]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.3...0.10.4
 [0.10.3]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.2...0.10.3
 [0.10.2]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.1...0.10.2

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.10.5-alpha",
+	"version": "0.10.5",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.1 - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## 1.5.0 - 2023-05-02
 ### Added
 - Webpack's `.resolve.conditionNames` may now be set from `.npmrc` or the corresponding environment variable. [#30313]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.5.1-alpha",
+	"version": "1.5.1",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/action-bar/CHANGELOG.md
+++ b/projects/packages/action-bar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.19] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [0.1.18] - 2023-05-02
 ### Changed
 - Updated package dependencies.
@@ -81,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds the Action Bar package and Jetpack plugin module for follows, likes, and comments. Just a scaffold to build on, for now. [#25447]
 
+[0.1.19]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.17...v0.1.18
 [0.1.17]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.16...v0.1.17
 [0.1.16]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.15...v0.1.16

--- a/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/action-bar/package.json
+++ b/projects/packages/action-bar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-action-bar",
-	"version": "0.1.19-alpha",
+	"version": "0.1.19",
 	"description": "An easy way for visitors to follow, like, and comment on your WordPress site.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/action-bar/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.4] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [1.18.3] - 2023-05-15
 ### Changed
 - Internal updates.
@@ -329,6 +333,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[1.18.4]: https://github.com/Automattic/jetpack-assets/compare/v1.18.3...v1.18.4
 [1.18.3]: https://github.com/Automattic/jetpack-assets/compare/v1.18.2...v1.18.3
 [1.18.2]: https://github.com/Automattic/jetpack-assets/compare/v1.18.1...v1.18.2
 [1.18.1]: https://github.com/Automattic/jetpack-assets/compare/v1.18.0...v1.18.1

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.0] - 2023-06-06
+### Changed
+- Update connection module to have an RNA option that updates the design [#31201]
+- Updated package dependencies. [#31129]
+
 ## [1.13.0] - 2023-05-29
 ### Added
 - Add connection screen for secondary admins [#30862]
@@ -419,6 +424,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[1.14.0]: https://github.com/Automattic/jetpack-backup/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/Automattic/jetpack-backup/compare/v1.12.17...v1.13.0
 [1.12.17]: https://github.com/Automattic/jetpack-backup/compare/v1.12.16...v1.12.17
 [1.12.16]: https://github.com/Automattic/jetpack-backup/compare/v1.12.15...v1.12.16

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/changelog/update-backup-connection-cta-modules-design
+++ b/projects/packages/backup/changelog/update-backup-connection-cta-modules-design
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update connection module to have an RNA option that updates the design

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.14.0-alpha';
+	const PACKAGE_VERSION = '1.14.0';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.14] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [0.5.13] - 2023-05-22
 ### Changed
 - Internal updates.
@@ -126,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.5.14]: https://github.com/automattic/jetpack-blaze/compare/v0.5.13...v0.5.14
 [0.5.13]: https://github.com/automattic/jetpack-blaze/compare/v0.5.12...v0.5.13
 [0.5.12]: https://github.com/automattic/jetpack-blaze/compare/v0.5.11...v0.5.12
 [0.5.11]: https://github.com/automattic/jetpack-blaze/compare/v0.5.10...v0.5.11

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.5.14-alpha",
+	"version": "0.5.14",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Sync\Settings as Sync_Settings;
  */
 class Blaze {
 
-	const PACKAGE_VERSION = '0.5.14-alpha';
+	const PACKAGE_VERSION = '0.5.14';
 
 	/**
 	 * Script handle for the JS file we enqueue in the post editor.

--- a/projects/packages/boost-core/CHANGELOG.md
+++ b/projects/packages/boost-core/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2023-06-06
+### Added
+- Introduce new package. [#31163]

--- a/projects/packages/boost-core/changelog/add-package-boost-core
+++ b/projects/packages/boost-core/changelog/add-package-boost-core
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Introduce new package.

--- a/projects/packages/boost-core/package.json
+++ b/projects/packages/boost-core/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-boost-core",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "Core functionality for boost and relevant packages to depend on",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/boost-core/#readme",
 	"bugs": {

--- a/projects/packages/boost-speed-score/CHANGELOG.md
+++ b/projects/packages/boost-speed-score/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-06-06
+### Changed
+- Moved boost core classes to boost-core package [#31163]
+- Updated package dependencies. [#31163]
+
 ## 0.1.0 - 2023-05-29
 ### Added
 - Add a new package for Boost Speed Score [#30914]
 - Add a new argument to `Speed_Score` to identify where the request was made from (e.g. 'boost-plugin', 'jetpack-dashboard', etc). [#31012]
+
+[0.2.0]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.1.0...v0.2.0

--- a/projects/packages/boost-speed-score/changelog/add-package-boost-core
+++ b/projects/packages/boost-speed-score/changelog/add-package-boost-core
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Moved boost core classes to boost-core package

--- a/projects/packages/boost-speed-score/changelog/add-package-boost-core#2
+++ b/projects/packages/boost-speed-score/changelog/add-package-boost-core#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.2.0-alpha';
+	const PACKAGE_VERSION = '0.2.0';
 
 	/**
 	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.2] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [1.52.1] - 2023-05-29
 ### Added
 - Include the user's email in data returned from WordPress.com Connected User data query [#30990]
@@ -817,6 +821,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[1.52.2]: https://github.com/Automattic/jetpack-connection/compare/v1.52.1...v1.52.2
 [1.52.1]: https://github.com/Automattic/jetpack-connection/compare/v1.52.0...v1.52.1
 [1.52.0]: https://github.com/Automattic/jetpack-connection/compare/v1.51.10...v1.52.0
 [1.51.10]: https://github.com/Automattic/jetpack-connection/compare/v1.51.9...v1.51.10

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.52.2-alpha';
+	const PACKAGE_VERSION = '1.52.2';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.3] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
+### Fixed
+- Editor view: remove duplicated Add Contact Form button. [#31158]
+
 ## [0.19.2] - 2023-05-30
 ### Changed
 - Jetpack Forms: added basic email template [#31026]
@@ -259,6 +266,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.19.3]: https://github.com/automattic/jetpack-forms/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/automattic/jetpack-forms/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/automattic/jetpack-forms/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/automattic/jetpack-forms/compare/v0.18.0...v0.19.0

--- a/projects/packages/forms/changelog/fix-double-contact-form-button
+++ b/projects/packages/forms/changelog/fix-double-contact-form-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Editor view: remove duplicated Add Contact Form button.

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.19.3-alpha",
+	"version": "0.19.3",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.19.3-alpha';
+	const PACKAGE_VERSION = '0.19.3';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.48] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [0.8.47] - 2023-05-15
 ### Changed
 - Internal updates.
@@ -364,6 +368,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.8.48]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.47...v0.8.48
 [0.8.47]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.46...v0.8.47
 [0.8.46]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.45...v0.8.46
 [0.8.45]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.44...v0.8.45

--- a/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.8.48-alpha",
+	"version": "0.8.48",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -28,7 +28,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.8.48-alpha';
+	const PACKAGE_VERSION = '0.8.48';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2023-06-06
+### Fixed
+- Photon: fix potential bug where two "?" characters might be added to a url [#30865]
+
 ## [0.2.2] - 2023-05-15
 ### Added
 - Add compatibility layer for the ActivityPub plugin [#30298]
@@ -27,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.2.3]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.1.0...v0.2.0

--- a/projects/packages/image-cdn/changelog/fix-photon_url_filter_and_args
+++ b/projects/packages/image-cdn/changelog/fix-photon_url_filter_and_args
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Photon: fix potential bug where two "?" characters might be added to a url

--- a/projects/packages/image-cdn/package.json
+++ b/projects/packages/image-cdn/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-image-cdn",
-	"version": "0.2.3-alpha",
+	"version": "0.2.3",
 	"description": "Serve images through Jetpack's powerful CDN",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/image-cdn/#readme",
 	"bugs": {

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Assets;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.2.3-alpha';
+	const PACKAGE_VERSION = '0.2.3';
 
 	/**
 	 * Singleton.

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
@@ -54,7 +54,7 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 	/**
 	 * @author donncha
 	 * @covers ::Image_CDN_Core::cdn_url
-	 * @since $$next-version$$
+	 * @since 0.2.3
 	 */
 	public function test_photon_url_with_query_parameters() {
 		$args = array(

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2023-06-06
+### Added
+- Add a new is_enabled logic to the launchpad endpoint to determine whether the task list is enabled for a site. [#30913]
+- Add `is_enabled_callback` to all existing task lists with a callback function that checks launchpad_screen. [#31092]
+- Apply filter to the Keep building task list [#31113]
+- Register a "Keep Building" task list. [#30954]
+- Remove unused API endpoint launchpad/checklist [#30882]
+
+### Changed
+- Launchpad: use callbacks for task titles to pick up the user locale [#30915]
+
 ## [2.3.0] - 2023-05-29
 ### Added
 - Launchpad: Add design-first Launchpad checklist API definition [#30871]
@@ -155,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[2.4.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v2.2.1...v2.3.0
 [2.2.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v2.1.0...v2.2.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-apply-filter-for-keep-building-task-list
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-apply-filter-for-keep-building-task-list
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Apply filter to the Keep building task list

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-is-enabled-callback
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-is-enabled-callback
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a new is_enabled logic to the launchpad endpoint to determine whether the task list is enabled for a site.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-task-list
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-task-list
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Register a "Keep Building" task list.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-translation-for-launchpad-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-translation-for-launchpad-tasks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Launchpad: use callbacks for task titles to pick up the user locale

--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-launchpad-checklist-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-launchpad-checklist-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Remove unused API endpoint launchpad/checklist

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-task-list-is-enabled
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-task-list-is-enabled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add `is_enabled_callback` to all existing task lists with a callback function that checks launchpad_screen.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "2.4.x-dev"
+			"dev-trunk": "2.5.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "2.4.0-alpha",
+	"version": "2.4.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "2.4.0",
+	"version": "2.5.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '2.4.0-alpha';
+	const PACKAGE_VERSION = '2.4.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '2.4.0';
+	const PACKAGE_VERSION = '2.5.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.9] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [2.3.8] - 2023-05-08
 ### Added
 - JITM: Add jetpack-videopress to JITM refetch on hashchange list [#30465]
@@ -581,6 +585,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[2.3.9]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.8...v2.3.9
 [2.3.8]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.7...v2.3.8
 [2.3.7]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.6...v2.3.7
 [2.3.6]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.5...v2.3.6

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.3.9-alpha';
+	const PACKAGE_VERSION = '2.3.9';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/lazy-images/CHANGELOG.md
+++ b/projects/packages/lazy-images/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.39] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [2.1.38] - 2023-05-11
+
 - Updated package dependencies
 
 ## [2.1.37] - 2023-05-02
@@ -319,6 +324,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy Images: Move into a package
 
+[2.1.39]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.38...v2.1.39
 [2.1.38]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.37...v2.1.38
 [2.1.37]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.36...v2.1.37
 [2.1.36]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.35...v2.1.36

--- a/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.2] - 2023-06-06
+### Changed
+- Filter out revoked licenses from the license activation options. [#31088]
+- Updated package dependencies. [#31129]
+
 ## [2.14.1] - 2023-05-29
 ### Added
 - My Jetpack: Add new Jetpack AI card [#30904]
@@ -892,6 +897,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[2.14.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.14.1...2.14.2
 [2.14.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.14.0...2.14.1
 [2.14.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.13.0...2.14.0
 [2.13.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/2.12.2...2.13.0

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-add-license-filtering
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-add-license-filtering
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Filter out revoked licenses from the license activation options.

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "2.14.2-alpha",
+	"version": "2.14.2",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '2.14.2-alpha';
+	const PACKAGE_VERSION = '2.14.2';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.1] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
+### Fixed
+- Simplified i18n strings [#31185]
+
 ## [0.30.0] - 2023-05-29
 ### Added
 - Added account_name field to the publicize connections object. [#30937]
@@ -327,6 +334,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.30.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.27.0...v0.28.0

--- a/projects/packages/publicize/changelog/fix-simplify-publicize-translations
+++ b/projects/packages/publicize/changelog/fix-simplify-publicize-translations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Simplified i18n strings

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.30.1-alpha",
+	"version": "0.30.1",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.2] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [0.37.1] - 2023-05-22
 ### Changed
 - PHP Compatibility: fix dynamic property deprecation notices [#30786]
@@ -752,6 +756,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.37.2]: https://github.com/Automattic/jetpack-search/compare/v0.37.1...v0.37.2
 [0.37.1]: https://github.com/Automattic/jetpack-search/compare/v0.37.0...v0.37.1
 [0.37.0]: https://github.com/Automattic/jetpack-search/compare/v0.36.3...v0.37.0
 [0.36.3]: https://github.com/Automattic/jetpack-search/compare/v0.36.2...v0.36.3

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.37.2-alpha",
+	"version": "0.37.2",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.37.2-alpha';
+	const VERSION = '0.37.2';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.5] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
+### Fixed
+- Fixes VideoPress ajax calls on wp.com [#30947]
+
 ## [0.14.4] - 2023-05-22
 ### Added
 - RNMobile: Disable VideoPress settings if video does not belong to the site [#30759]
@@ -1025,6 +1032,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.14.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.14.4...v0.14.5
 [0.14.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.14.1...v0.14.2

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/update-videopress-ajax-wpcom-support
+++ b/projects/packages/videopress/changelog/update-videopress-ajax-wpcom-support
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixes VideoPress ajax calls on wp.com

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.14.5-alpha",
+	"version": "0.14.5",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.14.5-alpha';
+	const PACKAGE_VERSION = '0.14.5';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.43] - 2023-06-06
+### Changed
+- Updated package dependencies. [#31129]
+
 ## [0.2.42] - 2023-05-02
 ### Changed
 - Updated package dependencies.
@@ -205,6 +209,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.2.43]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.42...v0.2.43
 [0.2.42]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.41...v0.2.42
 [0.2.41]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.40...v0.2.41
 [0.2.40]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.39...v0.2.40

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.43-alpha",
+	"version": "0.2.43",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.43-alpha';
+	const VERSION = '0.2.43';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.3-a.1 - 2023-06-06
+### Enhancements
+- AI Assistant: improve the process of getting post content. [#31211]
+- AI Assistant: replace tone button icon for clarity. [#31152]
+- Stats: display the links to a post's stats in the Posts list as soon as the user has access to stats. [#31025]
+
+### Bug fixes
+- Newsletters: verify the access level should be gated before checking subscriptions. [#30807]
+- Newsletters: show paid subscriber reach numbers in the past tense when the post has been already been published. [#30883]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Added comments to the LaunchpadSaveModal code for future reference. [#31149]
+- Remove Anchor.fm extension. [#31117]
+- RNA: update connection module to have an RNA option that updates the design [#31201]
+- Updated package dependencies.
+- WPcom: add send email preview endpoint. [#31028]
+
 ## [12.2] - 2023-06-06
 ### Major Enhancements
 - New AI Assistant block: harness AI power directly from your editor.
@@ -8174,13 +8191,13 @@ Other bugfixes and enhancements at https://github.com/Automattic/jetpack/commits
 
 - Initial release
 
+[11.6]: https://wp.me/p1moTy-PLI
 [12.2]: https://wp.me/p1moTy-Tzw
 [12.1]: https://wp.me/p1moTy-TA2
 [12.0]: https://wp.me/p1moTy-RGw
 [11.9]: https://wp.me/p1moTy-RdX
 [11.8]: https://wp.me/p1moTy-QEM
 [11.7]: https://wp.me/p1moTy-Q9t
-[11.6]: https://wp.me/p1moTy-PLI
 [11.5]: https://wp.me/p1moTy-Ppq
 [11.4]: https://wp.me/p1moTy-O5I
 [11.3]: https://wp.me/p1moTy-M5i

--- a/projects/plugins/jetpack/changelog/add-package-boost-core
+++ b/projects/plugins/jetpack/changelog/add-package-boost-core
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-preview-email-endpoint
+++ b/projects/plugins/jetpack/changelog/add-preview-email-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add send email preview endpoint

--- a/projects/plugins/jetpack/changelog/anchor-remove-extension
+++ b/projects/plugins/jetpack/changelog/anchor-remove-extension
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Removes Anchor.fm extension.

--- a/projects/plugins/jetpack/changelog/fix-improve-user-can-view-check
+++ b/projects/plugins/jetpack/changelog/fix-improve-user-can-view-check
@@ -1,4 +1,0 @@
-Significance: minor
-Type: bugfix
-
-Verify the access level should be gated before checking subscriptions

--- a/projects/plugins/jetpack/changelog/fix-make-notice-reflect-subscribers-reached
+++ b/projects/plugins/jetpack/changelog/fix-make-notice-reflect-subscribers-reached
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Show Paid Newsletter subscriber reach numbers in the past tense when the post has been already been published

--- a/projects/plugins/jetpack/changelog/fix-server-rendering-ai-assistant
+++ b/projects/plugins/jetpack/changelog/fix-server-rendering-ai-assistant
@@ -1,5 +1,0 @@
-Significance: patch
-Type: compat
-Comment: enables no-post-editor build for ai-assistant-block
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 12.3-a.0
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 12.3-a.2
+
+

--- a/projects/plugins/jetpack/changelog/renovate-automattic-social-previews-2.x
+++ b/projects/plugins/jetpack/changelog/renovate-automattic-social-previews-2.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-getting-blocks-content
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-getting-blocks-content
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: improve the process of getting post content

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-update-tone-icon
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-update-tone-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: replace tone icon

--- a/projects/plugins/jetpack/changelog/update-backup-connection-cta-modules-design
+++ b/projects/plugins/jetpack/changelog/update-backup-connection-cta-modules-design
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Update connection module to have an RNA option that updates the design

--- a/projects/plugins/jetpack/changelog/update-boost-independent-concat-service
+++ b/projects/plugins/jetpack/changelog/update-boost-independent-concat-service
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Added Page-Optimize-compatible PHP endpoint for loading concatenated files without loading wp

--- a/projects/plugins/jetpack/changelog/update-comments-on-launchpad-modal
+++ b/projects/plugins/jetpack/changelog/update-comments-on-launchpad-modal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Added comments to the LaunchpadSaveModal code for future reference.

--- a/projects/plugins/jetpack/changelog/update-newsletter-panel-link
+++ b/projects/plugins/jetpack/changelog/update-newsletter-panel-link
@@ -1,5 +1,0 @@
-Significance: patch
-Type: bugfix
-Comment: Tiny change, won't affect anyone.
-
-

--- a/projects/plugins/jetpack/changelog/update-readme-instagram
+++ b/projects/plugins/jetpack/changelog/update-readme-instagram
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Readme: update pending Meta approval.
-
-

--- a/projects/plugins/jetpack/changelog/update-stats-posts-column-access
+++ b/projects/plugins/jetpack/changelog/update-stats-posts-column-access
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Stats: display the links to a post's stats in the Posts list as soon as  the user has access to stats.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_3_a_0",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_3_a_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_3_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_3_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.3-a.0
+ * Version: 12.3-a.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.1' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.3-a.0' );
+define( 'JETPACK__VERSION', '12.3-a.1' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.3-a.1
+ * Version: 12.3-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.1' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.3-a.1' );
+define( 'JETPACK__VERSION', '12.3-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.3.0-a.1",
+	"version": "12.3.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.3.0-a.0",
+	"version": "12.3.0-a.1",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,86 +293,15 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 12.2 - 2023-06-06
-#### Major Enhancements
-- New AI Assistant block: harness AI power directly from your editor.
-- Donations, Paid Content and Payment Buttons blocks are now available with all Jetpack plans. A commission is charged for free plans.
-- Social: automatically share your new posts to Mastodon.
-
+### 12.3-a.1 - 2023-06-06
 #### Enhancements
-- Author Recommendations: Connected block with backend and added `remove_user_blogs` option.
-- Blocks: Rename "Premium Content" block to "Paid Content" block.
-- Contact Form: Improve spam filtering.
-- Dashboard: Add Jetpack Boost module.
-- Forms: Improve styling of response emails.
-- Forms: Introduce Multiple Choice and Single Choice style variations.
-- Forms: Update pattern modal default view to Grid.
-- Image CDN: Replace Photon implementation with the image-cdn package.
-- Maps: Add Mapkit maps.
-- Modules list: Update to current styles. Visual refresh, if you will.
-- My Plan: Display the correct plan for Jetpack Security and Backup 2-year plans.
-- My Plan: Hide the "My Plan" on My Plan page if user has a paid product and a free plan.
-- My Plan: Properly display plans with no expiration date.
-- Newsletters: Add misconfiguration warning functionality and improve design.
-- Newsletters: Add newsletter access level to the post edit page.
-- Newsletters: Add Post Publish Panel.
-- Newsletters: Enable on self-hosted environments.
-- Newsletters: Refactor and update Paid Newsletter user experience.
-- Publicize: Changed the way we skip a post from being publicized.
-- Reading Settings: Add a toggle for showing post views in the WordPress.com Reader.
-- Recommendations: Change CTA on backup recommendation card to inform about first year discount.
-- Related Posts: Add "Display author" toggle to block.
-- Related Posts: Add per-block header support.
-- Related Posts: Reorganize sidebar into layout and metadata.
-- Related Posts: Update labels for consistency with core.
-- Social: Add a notice to let users know Instagram is available.
-- Social: Use `connection_id` as the uninque identifier of the editor elements on the sidebar.
-- Social Previews: Add Instagram preview.
-- Social Previews: Add Mastodon post preview.
-- Starter: Add post-purchase flow to recommendations.
-- Subscriptions: Make free subscribers confirm email before viewing content.
-- Theme Tools: Remove jQuery dependency from responsive-videos script.
-- WordPress.com: Adds a 'Staging' badge to the wp-admin nav menu when the site is a WordPress.com staging site.
-
-#### Improved compatibility
-- ActivityPub: Allow disabling Jetpack's Image CDN in requests made for the ActivityPub plugin.
-- Bit.ly: Avoid errors when using non-official Bit.ly plugins alongside Jetpack.
-- Earn: Add "Read me" links to Stripe connection banners in blocks.
-- Filters: `jetpack_set_available_blocks` and `jetpack_set_available_plugins`, deprecated since Jetpack 7.0, have been removed.
-- Full-Site Editing: Use modern `wp_is_block_theme` instead of `gutenberg_is_fse_theme`.
-- General: PHP 8 compatibility updates.
-- Internationalization: Add necessary context to the word "Trash" in the Contact Form interface.
-- Security: Ensure blocks are always fully displayed on your site, even when using a caching plugin.
-- Sharing / Likes / Related Posts: Do not display them in JSON requests available when using the ActivityPub plugin.
-- Social: Flag unsupported connections in the editor UI.
-- WooCommerce: Avoid fatal errors when other plugins make changes to WooCommerce Products or Orders.
+- AI Assistant: improve the process of getting post content.
+- AI Assistant: replace tone button icon for clarity.
+- Stats: display the links to a post's stats in the Posts list as soon as the user has access to stats.
 
 #### Bug fixes
-- API: Add a `WP_User` check in `get_author` method.
-- API: Fix race condition bug in the Plugin update endpoint.
-- API: Use default values in settings API, when set.
-- At-a-Glance: Fix styling for Stats banner.
-- Carousel: Stop auto-scrolling to top when advancing slides.
-- Dashboard: Use the correct file path for all images in the "My Plan" screen.
-- Donations Block: Ensure the tab colors are correct in all themes.
-- Donations Block: Fix crash on currency change.
-- Donations Block: Make the "Connect" link the primary color.
-- Forms: Fix Forms hash generation.
-- Identity Crisis: Fix Jetpack Dashboard for broken connection.
-- Maps: Fix zoom being reset when changing map marker color.
-- Newsletters: Return early when possible to prevent spamming the database.
-- Related Posts: Fix context for use in block editor.
-- Security: WordPress.com REST API: Ensure that files uploaded via the API are properly validated.
-- SEO Tools: Suggest a specific SEO description maximum length.
-- Settings: Add loading indicator when fetching rewind state.
-- Settings: Fixed the site preview in SEO settings.
-- Social: Add username to publicize connection test results.
-- Subscriptions: Change the "Add payments" text to "Set up a paid plan".
-- Subscriptions: Fix display of number of paid subscribers.
-- Subscriptions: Do not remove bulk-editing checkboxes from the posts list.
-- Users: Display "Super Admin" badge in edit user form.
-- VideoPress: Add tracks to attributes definition.
-- WAF: Fix IP allow list updates.
+- Newsletters: verify the access level should be gated before checking subscriptions.
+- Newsletters: show paid subscriber reach numbers in the past tense when the post has been already been published.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 - 2023-06-06
+### Changed
+- Updated jetpack-mu-wpcom [#30915]
+
 ## 1.2.6 - 2023-05-29
 
 ## 1.2.5 - 2023-05-22

--- a/projects/plugins/mu-wpcom-plugin/changelog/init-release-cycle
+++ b/projects/plugins/mu-wpcom-plugin/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 1.3.1-alpha
+
+

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-dependency
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-dependency
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated jetpack-mu-wpcom

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_3_0"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_3_1_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_3_0_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_3_0"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "de856cd8874c1685dc35b66d80abe1052c3e77a0"
+                "reference": "21fbbe80d811d0595b1a51477938748debf791b6"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "2.4.x-dev"
+                    "dev-trunk": "2.5.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.3.0-alpha
+ * Version: 1.3.0
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.3.0
+ * Version: 1.3.1-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.3.0-alpha",
+	"version": "1.3.0",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.3.0",
+	"version": "1.3.1-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:

Jetpack: backport 12.3-a.1 release

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread.
