### PR TITLE
ci: Fix checkout logic in pr-is-up-to-date workflow

### DIFF
--- a/.github/workflows/pr-is-up-to-date.yml
+++ b/.github/workflows/pr-is-up-to-date.yml
@@ -14,12 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5  # 2021-03-23: The run on push to the tag might take a minute or two.
     steps:
-      - name: Checkout trunk
+
+      # We basically have two workflows in one here, one for pushes to trunk and one for PRs and pushes to tags.
+      # The reason we don't separate them into two is because GitHub's UI would then always be showing a skipped job
+      # in the PR check list, which is kind of annoying.
+
+      # First, the "PR or tag" job.
+
+      - name: Checkout trunk for tag push or PR
         uses: actions/checkout@v3
+        if: github.event_name != 'push' || github.ref != 'refs/heads/trunk'
         with:
           ref: trunk
-          # The "Check whether the tag needs updating for trunk commit" needs the previous commit for diffing.
-          fetch-depth: 2
           token: ${{ secrets.API_TOKEN_GITHUB }}
 
       # On a PR, we need to fetch (but not check out) the actual PR too.
@@ -61,6 +67,16 @@ jobs:
           paths: ${{ steps.determine.outputs.push-paths }}
           token: ${{ secrets.API_TOKEN_GITHUB }}
           status: PR is up to date
+
+      # Second, the "push to trunk" job.
+
+      - name: Checkout push to trunk
+        uses: actions/checkout@v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'
+        with:
+          # The "Check whether the tag needs updating for trunk commit" needs the previous commit for diffing.
+          fetch-depth: 2
+          token: ${{ secrets.API_TOKEN_GITHUB }}
 
       - name: Wait for prior instances of the workflow to finish
         if: github.event_name == 'push' && github.ref == 'refs/heads/trunk'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We need to check out trunk for pushes to tags and to PRs.

But for pushes to trunk, we need to check out the actual commit rather than whatever is currently trunk to avoid skipping commits.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that it worked for this PR, and in particular that the "checkout" step checked out trunk.
* Merge to trunk, then check that it worked for that too and that the "checkout" step used a SHA rather than "trunk".
