### PR TITLE
AI Assistant: Add stats panel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-introduce-simple-stats-panel
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-introduce-simple-stats-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Add stats panel

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -22,7 +22,6 @@ import ConnectPrompt from './components/connect-prompt';
 import I18nDropdownControl from './components/i18n-dropdown-control';
 import PromptTemplatesControl from './components/prompt-templates-control';
 import ToneDropdownControl from './components/tone-dropdown-control';
-import useAIFeature from './hooks/use-ai-feature';
 import AIAssistantIcon from './icons/ai-assistant';
 import origamiPlane from './icons/origami-plane';
 import { isUserConnected } from './lib/connection';
@@ -67,7 +66,6 @@ const AIControl = forwardRef(
 		};
 
 		const connected = isUserConnected();
-		const { requireUpgrade: siteRequireUpgrade } = useAIFeature();
 
 		const textPlaceholder = __( 'Ask Jetpack AI', 'jetpack' );
 
@@ -97,7 +95,7 @@ const AIControl = forwardRef(
 
 		return (
 			<>
-				{ ( siteRequireUpgrade || requireUpgrade ) && <UpgradePrompt /> }
+				{ requireUpgrade && <UpgradePrompt /> }
 				{ ! connected && <ConnectPrompt /> }
 				{ ! isWaitingState && connected && (
 					<ToolbarControls
@@ -161,9 +159,7 @@ const AIControl = forwardRef(
 						onKeyPress={ handleInputEnter }
 						placeholder={ placeholder }
 						className="jetpack-ai-assistant__input"
-						disabled={
-							isWaitingState || loadingImages || ! connected || siteRequireUpgrade || requireUpgrade
-						}
+						disabled={ isWaitingState || loadingImages || ! connected || requireUpgrade }
 						ref={ promptUserInputRef }
 					/>
 
@@ -173,9 +169,7 @@ const AIControl = forwardRef(
 								className="jetpack-ai-assistant__prompt_button"
 								onClick={ () => handleGetSuggestion( 'userPrompt' ) }
 								isSmall={ true }
-								disabled={
-									! userPrompt?.length || ! connected || siteRequireUpgrade || requireUpgrade
-								}
+								disabled={ ! userPrompt?.length || ! connected || requireUpgrade }
 								label={ __( 'Send request', 'jetpack' ) }
 							>
 								<Icon icon={ origamiPlane } />

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { PanelBody, PanelRow } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Types
+ */
+import { AIFeatureProps } from '../../hooks/use-ai-feature';
+/**
+ * Styles
+ */
+import './style.scss';
+
+export default function BasicStatsPanel( { requestsCount, requireUpgrade }: AIFeatureProps ) {
+	let statsMessage = createInterpolateElement(
+		__( 'You have <stats /> free requests left.', 'jetpack' ),
+		{
+			stats: <strong>{ requestsCount }</strong>,
+		}
+	);
+
+	if ( ! requireUpgrade ) {
+		statsMessage = createInterpolateElement(
+			__( 'You did <stats /> requests so far!', 'jetpack' ),
+			{
+				stats: (
+					<strong className="jetpack-ai-assistant__stats has-unlimited-requests">
+						{ requestsCount }
+					</strong>
+				),
+			}
+		);
+	}
+
+	return (
+		<PanelBody title={ __( 'Basic Stats', 'jetpack' ) } initialOpen={ true }>
+			<PanelRow>
+				<div className="jetpack-ai-assistant__simple-stats">{ statsMessage }</div>
+			</PanelRow>
+		</PanelBody>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { PanelBody, PanelRow } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { PanelBody, PanelRow, Button } from '@wordpress/components';
+import { createInterpolateElement, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Types
@@ -14,10 +14,12 @@ import { AIFeatureProps } from '../../hooks/use-ai-feature';
 import './style.scss';
 
 export default function BasicStatsPanel( { requestsCount, requireUpgrade }: AIFeatureProps ) {
+	const [ isRedirecting, setIsRedirecting ] = useState( false );
+
 	let statsMessage = createInterpolateElement(
 		__( 'You have <stats /> free requests left.', 'jetpack' ),
 		{
-			stats: <strong>{ requestsCount }</strong>,
+			stats: <strong className="jetpack-ai-assistant__stats">{ requestsCount }</strong>,
 		}
 	);
 
@@ -34,11 +36,26 @@ export default function BasicStatsPanel( { requestsCount, requireUpgrade }: AIFe
 		);
 	}
 
+	const checkoutUrl = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/add-jetpack-ai`;
+
 	return (
 		<PanelBody title={ __( 'Basic Stats', 'jetpack' ) } initialOpen={ true }>
 			<PanelRow>
 				<div className="jetpack-ai-assistant__simple-stats">{ statsMessage }</div>
 			</PanelRow>
+			{ requireUpgrade && (
+				<PanelRow>
+					<Button
+						href={ checkoutUrl }
+						onClick={ () => setIsRedirecting( true ) }
+						target="_top"
+						className="jetpack-ai-assistant__upgrade-button"
+						isBusy={ isRedirecting }
+					>
+						{ __( 'Upgrade', 'jetpack' ) }
+					</Button>
+				</PanelRow>
+			) }
 		</PanelBody>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
@@ -39,7 +39,7 @@ export default function BasicStatsPanel( { requestsCount, requireUpgrade }: AIFe
 	const checkoutUrl = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/add-jetpack-ai`;
 
 	return (
-		<PanelBody title={ __( 'Basic Stats', 'jetpack' ) } initialOpen={ true }>
+		<PanelBody title={ __( 'Stats', 'jetpack' ) } initialOpen={ true }>
 			<PanelRow>
 				<div className="jetpack-ai-assistant__simple-stats">{ statsMessage }</div>
 			</PanelRow>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
@@ -43,6 +43,7 @@ export default function BasicStatsPanel( { requestsCount, requireUpgrade }: AIFe
 			<PanelRow>
 				<div className="jetpack-ai-assistant__simple-stats">{ statsMessage }</div>
 			</PanelRow>
+
 			{ requireUpgrade && (
 				<PanelRow>
 					<Button

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
@@ -20,11 +20,18 @@ export default function BasicStatsPanel( {
 }: AIFeatureProps ) {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 	const requestsLeft = Math.max( 0, requestsLimit - requestsCount );
+	const limitReached = requestsLeft === 0;
 
 	let statsMessage = createInterpolateElement(
 		__( 'You have <stats /> free requests left. Upgrade to get unlimited requests.', 'jetpack' ),
 		{
-			stats: <strong className="jetpack-ai-assistant__stats">{ requestsLeft }</strong>,
+			stats: (
+				<strong
+					className={ `jetpack-ai-assistant__stats${ limitReached ? ' was-limit-achieved' : '' }` }
+				>
+					{ requestsLeft }
+				</strong>
+			),
 		}
 	);
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
@@ -17,7 +17,7 @@ export default function BasicStatsPanel( { requestsCount, requireUpgrade }: AIFe
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 
 	let statsMessage = createInterpolateElement(
-		__( 'You have <stats /> free requests left.', 'jetpack' ),
+		__( 'You have <stats /> free requests left. Upgrade to get unlimited requests.', 'jetpack' ),
 		{
 			stats: <strong className="jetpack-ai-assistant__stats">{ requestsCount }</strong>,
 		}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
@@ -14,8 +14,8 @@ import { AIFeatureProps } from '../../hooks/use-ai-feature';
 import './style.scss';
 
 export default function BasicStatsPanel( {
+	hasFeature,
 	requestsCount,
-	requireUpgrade,
 	requestsLimit = 20,
 }: AIFeatureProps ) {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
@@ -35,7 +35,7 @@ export default function BasicStatsPanel( {
 		}
 	);
 
-	if ( ! requireUpgrade ) {
+	if ( hasFeature ) {
 		statsMessage = createInterpolateElement(
 			__( 'You did <stats /> requests so far!', 'jetpack' ),
 			{
@@ -56,7 +56,7 @@ export default function BasicStatsPanel( {
 				<div className="jetpack-ai-assistant__simple-stats">{ statsMessage }</div>
 			</PanelRow>
 
-			{ requireUpgrade && (
+			{ ! hasFeature && (
 				<PanelRow>
 					<Button
 						href={ checkoutUrl }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/index.tsx
@@ -13,13 +13,18 @@ import { AIFeatureProps } from '../../hooks/use-ai-feature';
  */
 import './style.scss';
 
-export default function BasicStatsPanel( { requestsCount, requireUpgrade }: AIFeatureProps ) {
+export default function BasicStatsPanel( {
+	requestsCount,
+	requireUpgrade,
+	requestsLimit = 20,
+}: AIFeatureProps ) {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
+	const requestsLeft = Math.max( 0, requestsLimit - requestsCount );
 
 	let statsMessage = createInterpolateElement(
 		__( 'You have <stats /> free requests left. Upgrade to get unlimited requests.', 'jetpack' ),
 		{
-			stats: <strong className="jetpack-ai-assistant__stats">{ requestsCount }</strong>,
+			stats: <strong className="jetpack-ai-assistant__stats">{ requestsLeft }</strong>,
 		}
 	);
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/style.scss
@@ -5,6 +5,10 @@
 	&.has-unlimited-requests {
 		color: var( --jp-green-40 );
 	}
+
+	&.was-limit-achieved {
+		color: var( --jp-red );
+	}
 }
 
 // Tweak the button style to match the other buttons in the UI

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/style.scss
@@ -1,0 +1,7 @@
+@import '@automattic/jetpack-base-styles/style';
+
+.jetpack-ai-assistant__stats {
+	&.has-unlimited-requests {
+		color: var( --jp-green-40 );
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/simple-stats-panel/style.scss
@@ -1,7 +1,25 @@
 @import '@automattic/jetpack-base-styles/style';
 
 .jetpack-ai-assistant__stats {
+	color: var( --jp-orange-20 );
 	&.has-unlimited-requests {
 		color: var( --jp-green-40 );
+	}
+}
+
+// Tweak the button style to match the other buttons in the UI
+.jetpack-ai-assistant__upgrade-button {
+	background-color: var( --jp-black );
+	color: var( --jp-white );
+
+	&.components-button:not(:disabled,[aria-disabled=true]):active,
+	&:focus,
+	&:active,
+	&:hover {
+		color: var( --jp-gray );
+	}
+
+	&.is-busy {
+		color: var( --jp-gray-80 );
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -59,7 +59,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		}, 100 );
 	};
 
-	const { requireUpgrade, requestsCount, requestsLimit, increaseRequestsCount } = useAIFeature();
+	const { requireUpgrade, requestsCount, requestsLimit, hasFeature, increaseRequestsCount } =
+		useAIFeature();
 
 	const {
 		isLoadingCategories,
@@ -233,8 +234,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			<InspectorControls>
 				<BasicStatsPanel
 					requestsCount={ requestsCount }
-					requireUpgrade={ requireUpgrade }
 					requestsLimit={ requestsLimit }
+					hasFeature={ hasFeature }
 				/>
 			</InspectorControls>
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -59,6 +59,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		}, 100 );
 	};
 
+	const { requireUpgrade, requestsCount, refresh: refreshFeatureData } = useAIFeature();
+
 	const {
 		isLoadingCategories,
 		isLoadingCompletion,
@@ -80,6 +82,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		setError,
 		tracks,
 		userPrompt,
+		refreshFeatureData,
 	} );
 
 	useEffect( () => {
@@ -87,8 +90,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			setErrorDismissed( false );
 		}
 	}, [ errorData ] );
-
-	const { requireUpgrade, requestsCount } = useAIFeature();
 
 	const saveImage = async image => {
 		if ( loadingImages ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -59,7 +59,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		}, 100 );
 	};
 
-	const { requireUpgrade, requestsCount, increaseRequestsCount } = useAIFeature();
+	const { requireUpgrade, requestsCount, requestsLimit, increaseRequestsCount } = useAIFeature();
 
 	const {
 		isLoadingCategories,
@@ -231,7 +231,11 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			/>
 
 			<InspectorControls>
-				<BasicStatsPanel requestsCount={ requestsCount } requireUpgrade={ requireUpgrade } />
+				<BasicStatsPanel
+					requestsCount={ requestsCount }
+					requireUpgrade={ requireUpgrade }
+					requestsLimit={ requestsLimit }
+				/>
 			</InspectorControls>
 
 			{ ! loadingImages && resultImages.length > 0 && (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	store as blockEditorStore,
+	InspectorControls,
+} from '@wordpress/block-editor';
 import { rawHandler, createBlock } from '@wordpress/blocks';
 import { Flex, FlexBlock, Modal, Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -15,6 +19,8 @@ import { useEffect, useRef } from 'react';
  * Internal dependencies
  */
 import AIControl from './ai-control';
+import BasicStatsPanel from './components/simple-stats-panel';
+import useAIFeature from './hooks/use-ai-feature';
 import ImageWithSelect from './image-with-select';
 import { getImagesFromOpenAI } from './lib';
 import useSuggestionsFromOpenAI from './use-suggestions-from-openai';
@@ -81,6 +87,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			setErrorDismissed( false );
 		}
 	}, [ errorData ] );
+
+	const { requireUpgrade, requestsCount } = useAIFeature();
 
 	const saveImage = async image => {
 		if ( loadingImages ) {
@@ -216,10 +224,15 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				wholeContent={ wholeContent }
 				promptType={ attributes.promptType }
 				onChange={ () => setErrorDismissed( true ) }
-				requireUpgrade={ errorData?.code === 'error_quota_exceeded' }
+				requireUpgrade={ errorData?.code === 'error_quota_exceeded' || requireUpgrade }
 				recordEvent={ tracks.recordEvent }
 				isGeneratingTitle={ attributes.promptType === 'generateTitle' }
 			/>
+
+			<InspectorControls>
+				<BasicStatsPanel requestsCount={ requestsCount } requireUpgrade={ requireUpgrade } />
+			</InspectorControls>
+
 			{ ! loadingImages && resultImages.length > 0 && (
 				<Flex direction="column" style={ { width: '100%' } }>
 					<FlexBlock

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -59,7 +59,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		}, 100 );
 	};
 
-	const { requireUpgrade, requestsCount, refresh: refreshFeatureData } = useAIFeature();
+	const { requireUpgrade, requestsCount, increaseRequestsCount } = useAIFeature();
 
 	const {
 		isLoadingCategories,
@@ -82,7 +82,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		setError,
 		tracks,
 		userPrompt,
-		refreshFeatureData,
+		increaseRequestsCount,
 	} );
 
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/Readme.md
@@ -4,7 +4,7 @@ React custom hook that provides valuable data about AI requests for the site.
 
 ```es6
 function UpgradePlan() {
-	const { hasFeature, count } = useAIFeature();
+	const { hasFeature, count, refresh } = useAIFeature();
 	if ( ! hasFeature ) {
 		return null;
 	}
@@ -13,6 +13,7 @@ function UpgradePlan() {
 		<div>
 			{ `You have made ${ count } requests so far.` }
 			<Button>Upgrade</Button>
+			<Button onClick={ refresh}>Refresh Data!</Button>
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -71,5 +71,12 @@ export default function useAIFeature() {
 	return {
 		...data,
 		refresh: () => getAIFeatures().then( setData ),
+		increaseRequestsCount: () => {
+			setData( prevData => ( {
+				...prevData,
+				requestsCount: prevData.requestsCount + 1,
+			} ) );
+			getAIFeatures().then( setData );
+		},
 	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -26,18 +26,16 @@ export type AIFeatureProps = {
 
 const NUM_FREE_REQUESTS_LIMIT = 20;
 
+const aiAssistantFeature = window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ];
+
 export const AI_Assistant_Initial_State = {
-	hasFeature: !! window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'has-feature' ],
-	isOverLimit: !! window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-over-limit' ],
-	requestsCount:
-		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'requests-count' ] || 0,
-	requestsLimit:
-		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'requests-limit' ] ||
-		NUM_FREE_REQUESTS_LIMIT,
-	requireUpgrade:
-		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'site-require-upgrade' ] || false,
-	errorMessage: window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'error-message' ] || '',
-	errorCode: window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'error-code' ],
+	hasFeature: !! aiAssistantFeature?.[ 'has-feature' ],
+	isOverLimit: !! aiAssistantFeature?.[ 'is-over-limit' ],
+	requestsCount: aiAssistantFeature?.[ 'requests-count' ] || 0,
+	requestsLimit: aiAssistantFeature?.[ 'requests-limit' ] || NUM_FREE_REQUESTS_LIMIT,
+	requireUpgrade: !! aiAssistantFeature?.[ 'site-require-upgrade' ],
+	errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
+	errorCode: aiAssistantFeature?.[ 'error-code' ],
 };
 
 export async function getAIFeatures(): Promise< AIFeatureProps > {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -27,9 +27,8 @@ export type AIFeatureProps = {
 const NUM_FREE_REQUESTS_LIMIT = 20;
 
 export const AI_Assistant_Initial_State = {
-	hasFeature: window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'has-feature' ] || true,
-	isOverLimit:
-		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-over-limit' ] || false,
+	hasFeature: !! window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'has-feature' ],
+	isOverLimit: !! window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-over-limit' ],
 	requestsCount:
 		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'requests-count' ] || 0,
 	requestsLimit:

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -68,5 +68,8 @@ export default function useAIFeature() {
 		getAIFeatures().then( setData );
 	}, [] );
 
-	return data;
+	return {
+		...data,
+		refresh: () => getAIFeatures().then( setData ),
+	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -14,7 +14,7 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'error-code': string;
 };
 
-type AIFeatureProps = {
+export type AIFeatureProps = {
 	hasFeature: boolean;
 	isOverLimit: boolean;
 	requestsCount: number;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -69,7 +69,7 @@ const useSuggestionsFromOpenAI = ( {
 	onSuggestionDone,
 	onUnclearPrompt,
 	onModeration,
-	refreshFeatureData,
+	increaseRequestsCount,
 } ) => {
 	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
 	const [ isLoadingCompletion, setIsLoadingCompletion ] = useState( false );
@@ -212,7 +212,7 @@ const useSuggestionsFromOpenAI = ( {
 		source?.current?.addEventListener( 'done', e => {
 			stopSuggestion();
 			updateBlockAttributes( clientId, { content: e.detail } );
-			refreshFeatureData();
+			increaseRequestsCount();
 		} );
 
 		source?.current?.addEventListener( 'error_unclear_prompt', () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -69,6 +69,7 @@ const useSuggestionsFromOpenAI = ( {
 	onSuggestionDone,
 	onUnclearPrompt,
 	onModeration,
+	refreshFeatureData,
 } ) => {
 	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
 	const [ isLoadingCompletion, setIsLoadingCompletion ] = useState( false );
@@ -211,6 +212,7 @@ const useSuggestionsFromOpenAI = ( {
 		source?.current?.addEventListener( 'done', e => {
 			stopSuggestion();
 			updateBlockAttributes( clientId, { content: e.detail } );
+			refreshFeatureData();
 		} );
 
 		source?.current?.addEventListener( 'error_unclear_prompt', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a simple Stats panel to the block sidebar. 
When the site requires an upgrade, the panel will show an Upgrade button that leads the user to AI Assistant interstitial page. 

### Approach

It exposes two methods in the useAIFeature() hook that allows refreshing the feature data. 
The `increaseRequestsCount()` will work optimistically, increasing the counter right after the method is called, but then will perform an async request to keep the data in sync with the server side.

Disclaimer: this approach won't scale. We should change to another data approach, like useContent() or create a new store.

Fixes https://github.com/Automattic/jetpack/issues/31225

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: Add stats panel

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You may like to test with a fresh JN site
* Go to the block editor
* Create a new AI Assistant block instance
* Open the block sidebar
* Confirm you see the Stats panel there
* Confirm the message changes depending on the requests you do and if the site supports or doesn't support the AI Assistant feature
* Confirm the Upgrade button leads to the checkout page

Free requests | No requests available | Feature available
-------|-------|-------
<img width="283" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/acb45ef6-6f8b-4582-96ac-27bef77614e0">| <img width="284" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/b4819488-d333-4ad1-b01e-31ed53a30f00"> | <img width="288" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/2315ec27-745e-4c44-b3c5-39518b786ffd">


https://github.com/Automattic/jetpack/assets/77539/c0fa8446-d8b3-4584-88e5-5c1138facb2b

