### PR TITLE
Stats Admin: Add modules toggling API

### DIFF
--- a/projects/packages/stats-admin/changelog/add-stats-admin-modules-api
+++ b/projects/packages/stats-admin/changelog/add-stats-admin-modules-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats Admin: added modules toggling API support

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -50,7 +50,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.8.x-dev"
+			"dev-trunk": "0.9.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.8.0",
+	"version": "0.9.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.8.0';
+	const VERSION = '0.9.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -624,7 +624,7 @@ class REST_Controller {
 				'/sites/%d/jetpack-stats-dashboard/modules?%s',
 				Jetpack_Options::get_option( 'id' ),
 				$this->filter_and_build_query_string(
-					$req->get_params()
+					$req->get_query_params()
 				)
 			),
 			'v2',

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -607,7 +607,7 @@ class REST_Controller {
 				'method'  => 'POST',
 				'headers' => array( 'Content-Type' => 'application/json' ),
 			),
-			null,
+			$req->get_body(),
 			'wpcom'
 		);
 	}

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -598,13 +598,14 @@ class REST_Controller {
 				'/sites/%d/jetpack-stats-dashboard/modules?%s',
 				Jetpack_Options::get_option( 'id' ),
 				$this->filter_and_build_query_string(
-					$req->get_params()
+					$req->get_query_params()
 				)
 			),
 			'v2',
 			array(
 				'timeout' => 5,
 				'method'  => 'POST',
+				'headers' => array( 'Content-Type' => 'application/json' ),
 			),
 			null,
 			'wpcom'

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -20,6 +20,7 @@ use WP_REST_Server;
  * It bascially forwards the requests to the WordPress.com REST API.
  */
 class REST_Controller {
+	const JETPACK_STATS_DASHBOARD_MODULES_CACHE_KEY = 'jetpack_stats_dashboard_modules_cache_key';
 	/**
 	 * Namespace for the REST API.
 	 *
@@ -221,6 +222,26 @@ class REST_Controller {
 						'description' => 'Domain of the referrer',
 					),
 				),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/jetpack-stats-dashboard/modules', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_dashboard_modules' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
+
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/jetpack-stats-dashboard/modules', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_dashboard_modules' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
 	}
@@ -564,6 +585,59 @@ class REST_Controller {
 	}
 
 	/**
+	 * Toggle modules on dashboard.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function update_dashboard_modules( $req ) {
+		// Clear dashboard modules cache.
+		delete_transient( static::JETPACK_STATS_DASHBOARD_MODULES_CACHE_KEY );
+		return $this->request_as_blog_cached(
+			sprintf(
+				'/sites/%d/jetpack-stats-dashboard/modules?%s',
+				Jetpack_Options::get_option( 'id' ),
+				$this->filter_and_build_query_string(
+					$req->get_params()
+				)
+			),
+			'v2',
+			array(
+				'timeout' => 5,
+				'method'  => 'POST',
+			),
+			null,
+			'wpcom'
+		);
+	}
+
+	/**
+	 * Get modules on dashboard.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_dashboard_modules( $req ) {
+		return $this->request_as_blog_cached(
+			sprintf(
+				'/sites/%d/jetpack-stats-dashboard/modules?%s',
+				Jetpack_Options::get_option( 'id' ),
+				$this->filter_and_build_query_string(
+					$req->get_params()
+				)
+			),
+			'v2',
+			array(
+				'timeout' => 5,
+			),
+			null,
+			'wpcom',
+			true,
+			static::JETPACK_STATS_DASHBOARD_MODULES_CACHE_KEY
+		);
+	}
+
+	/**
 	 * Query the WordPress.com REST API using the blog token
 	 *
 	 * @param String $path The API endpoint relative path.
@@ -572,14 +646,15 @@ class REST_Controller {
 	 * @param String $body Request body.
 	 * @param String $base_api_path (optional) the API base path override, defaults to 'rest'.
 	 * @param bool   $use_cache (optional) default to true.
+	 * @param string $cache_key (optional) default to null meaning the function auto generates cache key.
 	 * @return array|WP_Error $response Data.
 	 */
-	protected function request_as_blog_cached( $path, $version = '1.1', $args = array(), $body = null, $base_api_path = 'rest', $use_cache = true ) {
+	protected function request_as_blog_cached( $path, $version = '1.1', $args = array(), $body = null, $base_api_path = 'rest', $use_cache = true, $cache_key = null ) {
 		// Only allow caching GET requests.
 		$use_cache = $use_cache && ! ( isset( $args['method'] ) && strtoupper( $args['method'] ) !== 'GET' );
 
 		// Arrays are serialized without considering the order of objects, but it's okay atm.
-		$cache_key = 'STATS_REST_RESP_' . md5( implode( '|', array( $path, $version, wp_json_encode( $args ), wp_json_encode( $body ), $base_api_path ) ) );
+		$cache_key = $cache_key !== null ? $cache_key : 'STATS_REST_RESP_' . md5( implode( '|', array( $path, $version, wp_json_encode( $args ), wp_json_encode( $body ), $base_api_path ) ) );
 
 		if ( $use_cache ) {
 			$response_body_content = get_transient( $cache_key );

--- a/projects/plugins/jetpack/changelog/add-stats-admin-modules-api
+++ b/projects/plugins/jetpack/changelog/add-stats-admin-modules-api
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2432,7 +2432,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "cc191277c2f3d7980556703070eb3e5e7d6c0ad3"
+                "reference": "d3d32e75b06be725801594b9501c17d2ced45373"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2454,7 +2454,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
Partially Fixes #31228 

## Proposed changes:

The PR proposes to add API to get modules status on Stats Dashboard, and API to toggle module status. The APIs are forwarded to WPCOM.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Please test with Calypso branch ~`update/stats_page_modules_apply_API`~ `trunk` since the branch is merged.
* Build Odyssey `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Open `/wp-admin/admin.php?page=stats&flags=stats/module-settings`
* Toggle modules on Traffic page
* Refresh page
* Ensure module status is persisted

<img width="890" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/70730753-4d13-4b13-a010-c659b09e0bbe">


