### PR TITLE
Launchpad: Add task to keep-building task-list

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-verify-email-keep-building
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-verify-email-keep-building
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: Add verify email task to keep-building task list

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -132,6 +132,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'title'               => 'Keep Building',
 			'task_ids'            => array(
 				'design_edited',
+				'verify_email',
 				// @todo Add more tasks here!
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes https://github.com/Automattic/wp-calypso/issues/77808

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds the `verify_email` task to the `keep-building` task list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO

## Testing instructions:
* You will either need a new account with an unverified email or you can override the `is_visible_callback` to always return true; to do this 
  * Open the file ` wp-content/mu-plugins/jetpack-mu-wpcom-plugin/moon/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php` on your sandbox
  * replace the `is_visible_callback` value on the `verify_email` task with: `'__return_true',`
* Apply this patch to your sandbox and sandbox `public-api.wordpress.com`.
* Visit the dev console and select WP REST API, `wpcom/v2`.
* Make a GET request to `/sites/[siteSlug]/launchpad?checklist_slug=keep-building`.
* Verify you get the `verify_email` task:
<img width="907" alt="image" src="https://github.com/Automattic/jetpack/assets/375980/4270e451-27ff-476b-aa63-0b91c05ba986">

