### PR TITLE
Launchpad: Add site title task to Keep Building checklist.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-site-title-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-site-title-task
@@ -1,4 +1,4 @@
 Significance: minor
-Type: 
+Type: added
 
 Add a site title task to the Keep Building task list.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-site-title-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-site-title-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: 
+
+Add a site title task to the Keep Building task list.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -205,7 +205,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Give your site a name', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_site_title_is_complete_callback',
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
 		),
 	);
 
@@ -524,24 +524,14 @@ function wpcom_track_video_uploaded_task( $post_id ) {
 }
 
 /**
- * Mark the site_title task as complete if the site title is not empty and not "Site Title".
- * 
- * @return void
+ * Mark the site_title task as complete if the site title is not empty and not the default.
  */
 function wpcom_launchpad_mark_site_title_complete() {
 	$site_title = get_option( 'blogname' );
 
-	if ( ! empty( $site_title ) && __( 'Site Title', 'jetpack-mu-wpcom' ) !== $site_title ) {
+	// "Site Title" is the default title we give to sites during signup; check both EN and translated variations.
+	if ( ! empty( $site_title ) && 'Site Title' !== $site_title && __( 'Site Title', 'jetpack-mu-wpcom' ) !== $site_title ) {
 		wpcom_mark_launchpad_task_complete( 'site_title' );
 	}
 }
-add_action( 'init', 'wpcom_launchpad_site_title_complete_callback', 11 );
-
-/**
- * Update Launchpad's site_title task.
- * 
- * @return bool True if the site title was updated, false otherwise.
- */
-function wpcom_launchpad_site_title_is_complete_callback() {
-	return wpcom_launchpad_mark_site_title_complete();
-}
+add_action( 'init', 'wpcom_launchpad_mark_site_title_complete', 11 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -531,9 +531,9 @@ function wpcom_track_video_uploaded_task( $post_id ) {
  *
  * @return void
  */
-function wpcom_launchpad_mark_site_title_complete( $old_value, $value ) {
+function wpcom_mark_site_title_complete( $old_value, $value ) {
 	if ( $value !== $old_value ) {
 		wpcom_mark_launchpad_task_complete( 'site_title' );
 	}
 }
-add_action( 'update_option_blogname', 'wpcom_launchpad_mark_site_title_complete', 10, 3 );
+add_action( 'update_option_blogname', 'wpcom_mark_site_title_complete', 10, 3 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -525,13 +525,15 @@ function wpcom_track_video_uploaded_task( $post_id ) {
 
 /**
  * Mark the site_title task as complete if the site title is not empty and not the default.
+ *
+ * @param string $old_value The old value of the site title.
+ * @param string $value The new value of the site title.
+ *
+ * @return void
  */
-function wpcom_launchpad_mark_site_title_complete() {
-	$site_title = get_option( 'blogname' );
-
-	// "Site Title" is the default title we give to sites during signup; check both EN and translated variations.
-	if ( ! empty( $site_title ) && 'Site Title' !== $site_title && __( 'Site Title', 'jetpack-mu-wpcom' ) !== $site_title ) {
+function wpcom_launchpad_mark_site_title_complete( $old_value, $value ) {
+	if ( $value !== $old_value ) {
 		wpcom_mark_launchpad_task_complete( 'site_title' );
 	}
 }
-add_action( 'init', 'wpcom_launchpad_mark_site_title_complete', 11 );
+add_action( 'update_option_blogname', 'wpcom_launchpad_mark_site_title_complete', 10, 3 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -201,7 +201,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Keep Building tasks.
-		'site_title'					  => array(
+		'site_title'                      => array(
 			'get_title'            => function () {
 				return __( 'Give your site a name', 'jetpack-mu-wpcom' );
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -200,7 +200,13 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_disabled_callback' => '__return_true',
 		),
 
-		// @todo Add Keep Building tasks.
+		// Keep Building tasks.
+		'site_title'					  => array(
+			'get_title'            => function () {
+				return __( 'Give your site a name', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_site_title_is_complete_callback',
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );
@@ -515,4 +521,27 @@ function wpcom_track_video_uploaded_task( $post_id ) {
 		return;
 	}
 	wpcom_mark_launchpad_task_complete( 'videopress_upload' );
+}
+
+/**
+ * Mark the site_title task as complete if the site title is not empty and not "Site Title".
+ * 
+ * @return void
+ */
+function wpcom_launchpad_mark_site_title_complete() {
+	$site_title = get_option( 'blogname' );
+
+	if ( ! empty( $site_title ) && __( 'Site Title', 'jetpack-mu-wpcom' ) !== $site_title ) {
+		wpcom_mark_launchpad_task_complete( 'site_title' );
+	}
+}
+add_action( 'init', 'wpcom_launchpad_site_title_complete_callback', 11 );
+
+/**
+ * Update Launchpad's site_title task.
+ * 
+ * @return bool True if the site title was updated, false otherwise.
+ */
+function wpcom_launchpad_site_title_is_complete_callback() {
+	return wpcom_launchpad_mark_site_title_complete();
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -131,9 +131,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		'keep-building'   => array(
 			'title'               => 'Keep Building',
 			'task_ids'            => array(
+				'site_title',
 				'design_edited',
 				'verify_email',
-				// @todo Add more tasks here!
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#77290

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a `site_title` task to the Keep Building task list.
* Add function hooked into `update_option_blogname` to check the site title field for changes and mark the task complete if the title has changed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox the API.
* Create a new site from `/start`
* Sandbox the new test site
* Visit the developer console and GET from the WP REST API `wpcom/v2/sites/yourtestsiteslug/launchpad?checklist_slug=keep-building`
* You should see a new `site_title` task in the list, `completed` should be `false`:

<img width="973" alt="Screen Shot 2023-06-07 at 12 44 48 PM" src="https://github.com/Automattic/jetpack/assets/2124984/c2a2f186-f13b-424e-983e-62371c5c5e66">

* Visit `/settings/general/yourtestsiteslug` and update the site title.
* Go back to the developer console and make the same GET request.
* The `site_title` task should now have `completed` as `true` and the `site_title` key in the `checklist_statuses` should be set to `true`:

<img width="966" alt="Screen Shot 2023-06-07 at 1 02 38 PM" src="https://github.com/Automattic/jetpack/assets/2124984/af61aa3b-b056-42ea-98bf-1a2231a97208">


