### PR TITLE
Fix an issue where Jetpack_Memberships::user_can_view_post would cache the wrong value

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-bug-with-loop
+++ b/projects/plugins/jetpack/changelog/fix-bug-with-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix an issue where Jetpack_Memberships::user_can_view_post would cachethe wrong value

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -467,8 +467,14 @@ class Jetpack_Memberships {
 	 * @return bool Whether the post can be viewed
 	 */
 	public static function user_can_view_post() {
-		$user_id   = get_current_user_id();
-		$post_id   = get_the_ID() || 0;
+		$user_id = get_current_user_id();
+		$post_id = get_the_ID();
+
+		if ( empty( $post_id ) ) {
+			// We are not viewing a post.
+			$post_id = 0;
+		}
+
 		$cache_key = sprintf( '%d_%d', $user_id, $post_id );
 
 		if ( isset( self::$user_can_view_post_cache[ $cache_key ] ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31237 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*In this PR: https://github.com/Automattic/jetpack/commit/ba6a8391edb84d72637cb6a9fd9033b0093a2f4f
Notice:

```
$post_id = get_the_ID() || 0;
```

$post_id is always FALSE (because of the JS notation), therefore caching the value with the wrong key. So subsequent calls would return the wrong data.

With theis fix, all non-post call will return get_post_access_level, which return true in the end.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is tricky to test, but the fix should make sense on its own.

