### PR TITLE
My Jetpack: show number of free requests in AI Assistant card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -283,17 +283,13 @@ const ProductCard = props => {
 					/>
 				) }
 			</div>
-			{
-				// If is not active, no reason to use children
-				// Since we want user to take action if isn't active
-				isActive && children ? (
-					children
-				) : (
-					<Text variant="body-small" className={ styles.description }>
-						{ description }
-					</Text>
-				)
-			}
+			{ children ? (
+				children
+			) : (
+				<Text variant="body-small" className={ styles.description }>
+					{ description }
+				</Text>
+			) }
 			<div className={ styles.actions }>
 				<ActionButton
 					{ ...props }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -1,9 +1,61 @@
+/**
+ * External dependencies
+ */
+import { Text } from '@automattic/jetpack-components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
+/**
+ * Internal dependencies
+ */
+import { useProduct } from '../../hooks/use-product';
 import ProductCard from '../connected-product-card';
+import { PRODUCT_STATUSES } from '../product-card/action-buton';
+import productCardStyles from '../product-card/style.module.scss';
 
 const AiCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="jetpack-ai" />;
+	const { detail = {} } = useProduct( 'jetpack-ai' );
+	const aiAssistantFeature = detail?.[ 'ai-assistant-feature' ];
+	const { status, isPluginActive } = detail;
+
+	const requestsLimit = aiAssistantFeature?.[ 'requests-limit' ] || 20;
+	const requestsCount = 3;
+	const requestsLeft = Math.max( 0, requestsLimit - requestsCount );
+	const limitReached = aiAssistantFeature?.limit_reached;
+
+	let statsMessage = null;
+
+	if ( ! isPluginActive ) {
+		return <ProductCard admin={ admin } slug="jetpack-ai" />;
+	}
+
+	if ( status === PRODUCT_STATUSES.NEEDS_PURCHASE ) {
+		statsMessage = createInterpolateElement(
+			__( 'You have <stats /> free requests left.', 'jetpack-my-jetpack' ),
+			{
+				stats: (
+					<strong
+						className={ `jetpack-ai-assistant__stats${
+							limitReached ? ' was-limit-achieved' : ''
+						}` }
+					>
+						{ requestsLeft }
+					</strong>
+				),
+			}
+		);
+	} else {
+		statsMessage = __( 'You have unlimited requests.', 'jetpack-my-jetpack' );
+	}
+
+	return (
+		<ProductCard admin={ admin } slug="jetpack-ai">
+			<Text variant="body-small" className={ productCardStyles.description }>
+				{ statsMessage }
+			</Text>
+		</ProductCard>
+	);
 };
 
 AiCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -20,7 +20,7 @@ const AiCard = ( { admin } ) => {
 	const { status, isPluginActive } = detail;
 
 	const requestsLimit = aiAssistantFeature?.[ 'requests-limit' ] || 20;
-	const requestsCount = 3;
+	const requestsCount = aiAssistantFeature?.[ 'requests-count' ] || 0;
 	const requestsLeft = Math.max( 0, requestsLimit - requestsCount );
 	const limitReached = aiAssistantFeature?.limit_reached;
 

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-get-feature-data-async
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-get-feature-data-async
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: show number of requests in the AI Assistant product card


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


Fixes #
Part of https://github.com/Automattic/jetpack/issues/31036

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: show number of free requests in AI Assistant card

### Other information:

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack dashboard
* Check the AI Product card states

Plugin  inactive - No plan   | Plugin  active - No plan | Plugin active - Paid plan | Plugin  inactive - Paid plan
--------------------|-------------------------|---------------|----------
<img width="273" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/6b8a71d9-0794-4652-b841-eef84d2660f6"> | <img width="276" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/57e6f91a-3ee0-4050-a45a-1625b09b4f26"> | <img width="266" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/cb8adb05-9235-4e54-9438-94fe4d071515"> | <img width="267" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/b47d2d9d-217b-47fb-92f3-1d2e434e8b51">

The card behaves dynamically when the plugin is active and the site supports the feature. Something that we can keep polishing in the following tasks.

https://github.com/Automattic/jetpack/assets/77539/6571ffb7-b424-4e60-9e9a-500ab792a787