### PR TITLE
Fix "Memberships: fatal Jetpack_Memberships not found" on WoA

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fix-jetpack-membership-error
+++ b/projects/plugins/jetpack/changelog/fix-fix-jetpack-membership-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Require "Jetpack_Memberships" before using class

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-offline-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-offline-subscription-service.php
@@ -53,6 +53,7 @@ class WPCOM_Offline_Subscription_Service extends WPCOM_Online_Subscription_Servi
 			return true;
 		}
 
+		require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 		$valid_plan_ids     = \Jetpack_Memberships::get_all_plans_id_jetpack_recurring_payments();
 		$is_blog_subscriber = true; // it is a subscriber as this is used in async when lopping through subscribers...
 		$allowed            = $this->user_can_view_content( $valid_plan_ids, $access_level, $is_blog_subscriber, $post_id );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -804,6 +804,8 @@ function get_locked_content_placeholder_text( $newsletter_access_level ) {
 	$access_level = __( 'subscribers', 'jetpack' );
 
 	// Only display this text when Stripe is connected and the post is marked for paid subscribers
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+
 	if (
 		$newsletter_access_level === 'paid_subscribers'
 		&& ! empty( Jetpack_Memberships::get_connected_account_id() )

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -12,7 +12,6 @@ use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Sub
 use Automattic\Jetpack\Status;
 use Jetpack;
 use Jetpack_Gutenberg;
-use Jetpack_Memberships;
 use Jetpack_Subscriptions_Widget;
 
 require_once __DIR__ . '/constants.php';
@@ -489,7 +488,8 @@ function get_post_access_level_for_current_post() {
 		return Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
 	}
 
-	return Jetpack_Memberships::get_post_access_level();
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+	return \Jetpack_Memberships::get_post_access_level();
 }
 
 /**
@@ -749,11 +749,11 @@ function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
 function maybe_get_locked_content( $the_content ) {
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 
-	if ( Jetpack_Memberships::user_can_view_post() ) {
+	if ( \Jetpack_Memberships::user_can_view_post() ) {
 		return $the_content;
 	}
 
-	$post_access_level = Jetpack_Memberships::get_post_access_level();
+	$post_access_level = \Jetpack_Memberships::get_post_access_level();
 	return get_locked_content_placeholder_text( $post_access_level );
 }
 
@@ -771,7 +771,7 @@ function maybe_close_comments( $default_comments_open, $post_id ) {
 	}
 
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
-	return Jetpack_Memberships::user_can_view_post();
+	return \Jetpack_Memberships::user_can_view_post();
 }
 
 /**
@@ -787,7 +787,7 @@ function maybe_gate_existing_comments( $comment ) {
 	}
 
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
-	if ( Jetpack_Memberships::user_can_view_post() ) {
+	if ( \Jetpack_Memberships::user_can_view_post() ) {
 		return $comment;
 	}
 	return '';
@@ -808,7 +808,7 @@ function get_locked_content_placeholder_text( $newsletter_access_level ) {
 
 	if (
 		$newsletter_access_level === 'paid_subscribers'
-		&& ! empty( Jetpack_Memberships::get_connected_account_id() )
+		&& ! empty( \Jetpack_Memberships::get_connected_account_id() )
 	) {
 		$access_level = __( 'paid subscribers', 'jetpack' );
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -347,7 +347,9 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$submit_button_wrapper_styles = isset( $instance['submit_button_wrapper_styles'] ) ? $instance['submit_button_wrapper_styles'] : '';
 		$email_field_classes          = isset( $instance['email_field_classes'] ) ? $instance['email_field_classes'] : '';
 		$email_field_styles           = isset( $instance['email_field_styles'] ) ? $instance['email_field_styles'] : '';
-		$post_access_level            = \Jetpack_Memberships::get_post_access_level();
+
+		require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+		$post_access_level = Jetpack_Memberships::get_post_access_level();
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {
 			global $current_blog;

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -349,7 +349,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$email_field_styles           = isset( $instance['email_field_styles'] ) ? $instance['email_field_styles'] : '';
 
 		require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
-		$post_access_level = Jetpack_Memberships::get_post_access_level();
+		$post_access_level = \Jetpack_Memberships::get_post_access_level();
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {
 			global $current_blog;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/31258

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fix "Memberships: fatal Jetpack_Memberships not found" on WoA

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

WPCOM. Sanity Checks: 

1. Mark a post as a subscriber-only the subscribe
2. Add the Subscribe block to a post then subscribe

WoA: Unable to reproduce the error.

