### PR TITLE
Stats Admin: use WPCOM notice API

### DIFF
--- a/projects/packages/stats-admin/changelog/update-stats-admin-use-wpcom-notice-api
+++ b/projects/packages/stats-admin/changelog/update-stats-admin-use-wpcom-notice-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats Admin: use WPCOM notices API

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -32,7 +32,7 @@ class Notices {
 	 * @param int   $postponed_for Postponed for how many seconds.
 	 * @return bool
 	 */
-	public function update_notice_status( $id, $status, $postponed_for = 0 ) {
+	public function update_notice( $id, $status, $postponed_for = 0 ) {
 		delete_transient( self::STATS_DASHBOARD_NOTICES_CACHE_KEY );
 		return WPCOM_Client::request_as_blog(
 			sprintf(

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -16,7 +16,7 @@ use Jetpack_Options;
  * @package Automattic\Jetpack\Stats_Admin
  */
 class Notices {
-	const STATS_DASHBOARD_NOTICES_CACHE_KEY = 'stats_dashboard_notices_cache_key';
+	const STATS_DASHBOARD_NOTICES_CACHE_KEY = 'jetpack_stats_dashboard_notices_cache_key';
 	const OPT_OUT_NEW_STATS_NOTICE_ID       = 'opt_out_new_stats';
 	const NEW_STATS_FEEDBACK_NOTICE_ID      = 'new_stats_feedback';
 	const OPT_IN_NEW_STATS_NOTICE_ID        = 'opt_in_new_stats';

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -47,7 +47,11 @@ class Notices {
 					'Content-Type' => 'application/json',
 				),
 			),
-			compact( $id, $status, $postponed_for ),
+			array(
+				'id'            => $id,
+				'status'        => $status,
+				'postponed_for' => $postponed_for,
+			),
 			'wpcom'
 		);
 	}

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Stats\Options as Stats_Options;
+use Jetpack_Options;
 
 /**
  * The Notices class handles the notices for the Stats Admin dashboard.
@@ -27,82 +28,58 @@ class Notices {
 	const POSTPONE_OPT_IN_NOTICE_DAYS = 30;
 
 	/**
-	 * Update the notice status.
-	 *
-	 * @param mixed $id ID of the notice.
-	 * @param mixed $status Status of the notice.
-	 * @param int   $postponed_for Postponed for how many seconds.
-	 * @return bool
-	 */
-	public function update_notice( $id, $status, $postponed_for = 0 ) {
-		$notices        = Stats_Options::get_option( 'notices' );
-		$notices[ $id ] = array(
-			'status'       => $status,
-			'id'           => $id,
-			'dismissed_at' => time(),
-		);
-		// Set the next show time if the notice is postponed.
-		if ( $status === self::NOTICE_STATUS_POSTPONED ) {
-			$notices[ $id ]['next_show_at'] = time() + ( $postponed_for > 0 ? $postponed_for : self::POSTPONE_FEEDBACK_DAYS * DAY_IN_SECONDS );
-		}
-		return Stats_Options::set_option( 'notices', $notices );
-	}
-
-	/**
 	 * Return an array of notices IDs as keys and their value to flag whther to show them.
 	 *
 	 * @return array
 	 */
 	public function get_notices_to_show() {
+		$notices_wpcom = $this->get_notices_from_wpcom();
+
 		$new_stats_enabled        = Stats_Options::get_option( 'enable_odyssey_stats' );
-		$stats_views              = $this->get_new_stats_views();
+		$stats_views              = intval( Stats_Options::get_option( 'views' ) );
 		$odyssey_stats_changed_at = intval( Stats_Options::get_option( 'odyssey_stats_changed_at' ) );
 
-		return array(
-			// Show Opt-in notice 30 days after the new stats being disabled.
-			self::OPT_IN_NEW_STATS_NOTICE_ID   => ! $new_stats_enabled
-				&& $odyssey_stats_changed_at < time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
-				&& ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
+		return array_merge(
+			$notices_wpcom,
+			array(
+				// Show Opt-in notice 30 days after the new stats being disabled.
+				self::OPT_IN_NEW_STATS_NOTICE_ID   => ! $new_stats_enabled
+					&& $odyssey_stats_changed_at < time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
+					&& ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
 
-			// Show feedback notice after 3 views of the new stats.
-			self::NEW_STATS_FEEDBACK_NOTICE_ID => $new_stats_enabled
-				&& $stats_views >= self::VIEWS_TO_SHOW_FEEDBACK
-				&& ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ),
+				// Show feedback notice after 3 views of the new stats.
+				self::NEW_STATS_FEEDBACK_NOTICE_ID => $new_stats_enabled
+					&& $stats_views >= self::VIEWS_TO_SHOW_FEEDBACK
+					&& ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ),
 
-			// Show opt-out notice before 3 views of the new stats, where 3 is included.
-			self::OPT_OUT_NEW_STATS_NOTICE_ID  => $new_stats_enabled
-				&& $stats_views < self::VIEWS_TO_SHOW_FEEDBACK
-				&& ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ),
+				// Show opt-out notice before 3 views of the new stats, where 3 is included.
+				self::OPT_OUT_NEW_STATS_NOTICE_ID  => $new_stats_enabled
+					&& $stats_views < self::VIEWS_TO_SHOW_FEEDBACK
+					&& ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ),
+			)
 		);
 	}
 
 	/**
-	 * Returns the array of hidden notices.
-	 *
-	 * @return array Array of hidden notices.
+	 * Get the array of hidden notices from WPCOM.
 	 */
-	public function get_hidden_notices() {
-		$notices = Stats_Options::get_option( 'notices' );
-
-		$hidden_notices = array_filter(
-			$notices,
-			function ( $notice ) {
-				if ( ! isset( $notice['status'] ) ) {
-					return false;
-				}
-				switch ( $notice['status'] ) {
-					case self::NOTICE_STATUS_DISMISSED:
-						return true;
-					case self::NOTICE_STATUS_POSTPONED:
-						return empty( $notice['next_show_at'] ) || $notice['next_show_at'] > time();
-					default:
-						return false;
-				}
-			},
-			ARRAY_FILTER_USE_BOTH
+	public function get_notices_from_wpcom() {
+		$notices_wpcom = WPCOM_Client::request_as_blog_cached(
+			sprintf(
+				'/sites/%d/jetpack-stats-dashboard/notices',
+				Jetpack_Options::get_option( 'id' )
+			),
+			'v2',
+			array(
+				'timeout' => 5,
+			),
+			null,
+			'wpcom'
 		);
-
-		return $hidden_notices;
+		if ( is_wp_error( $notices_wpcom ) ) {
+			return array();
+		}
+		return $notices_wpcom;
 	}
 
 	/**
@@ -112,13 +89,6 @@ class Notices {
 	 * @return bool
 	 */
 	public function is_notice_hidden( $id ) {
-		return array_key_exists( $id, $this->get_hidden_notices() );
-	}
-
-	/**
-	 * Returns the number of views of the new stats dashboard.
-	 */
-	public function get_new_stats_views() {
-		return Stats_Options::get_option( 'views' );
+		return array_key_exists( $id, $this->get_notices_from_wpcom() );
 	}
 }

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -47,10 +47,12 @@ class Notices {
 					'Content-Type' => 'application/json',
 				),
 			),
-			array(
-				'id'            => $id,
-				'status'        => $status,
-				'postponed_for' => $postponed_for,
+			wp_json_encode(
+				array(
+					'id'            => $id,
+					'status'        => $status,
+					'postponed_for' => $postponed_for,
+				)
 			),
 			'wpcom'
 		);

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -25,6 +25,34 @@ class Notices {
 	const POSTPONE_OPT_IN_NOTICE_DAYS = 30;
 
 	/**
+	 * Update notice status.
+	 *
+	 * @param mixed $id ID of the notice.
+	 * @param mixed $status Status of the notice.
+	 * @param int   $postponed_for Postponed for how many seconds.
+	 * @return bool
+	 */
+	public function update_notice_status( $id, $status, $postponed_for = 0 ) {
+		delete_transient( self::STATS_DASHBOARD_NOTICES_CACHE_KEY );
+		return WPCOM_Client::request_as_blog(
+			sprintf(
+				'/sites/%d/jetpack-stats-dashboard/notices',
+				Jetpack_Options::get_option( 'id' )
+			),
+			'v2',
+			array(
+				'timeout' => 5,
+				'method'  => 'POST',
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+			),
+			compact( $id, $status, $postponed_for ),
+			'wpcom'
+		);
+	}
+
+	/**
 	 * Return an array of notices IDs as keys and their value to flag whther to show them.
 	 *
 	 * @return array

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -16,15 +16,12 @@ use Jetpack_Options;
  * @package Automattic\Jetpack\Stats_Admin
  */
 class Notices {
-	const OPT_OUT_NEW_STATS_NOTICE_ID  = 'opt_out_new_stats';
-	const NEW_STATS_FEEDBACK_NOTICE_ID = 'new_stats_feedback';
-	const OPT_IN_NEW_STATS_NOTICE_ID   = 'opt_in_new_stats';
-
-	const NOTICE_STATUS_DISMISSED = 'dismissed';
-	const NOTICE_STATUS_POSTPONED = 'postponed';
+	const STATS_DASHBOARD_NOTICES_CACHE_KEY = 'stats_dashboard_notices_cache_key';
+	const OPT_OUT_NEW_STATS_NOTICE_ID       = 'opt_out_new_stats';
+	const NEW_STATS_FEEDBACK_NOTICE_ID      = 'new_stats_feedback';
+	const OPT_IN_NEW_STATS_NOTICE_ID        = 'opt_in_new_stats';
 
 	const VIEWS_TO_SHOW_FEEDBACK      = 3;
-	const POSTPONE_FEEDBACK_DAYS      = 30;
 	const POSTPONE_OPT_IN_NOTICE_DAYS = 30;
 
 	/**
@@ -74,8 +71,11 @@ class Notices {
 				'timeout' => 5,
 			),
 			null,
-			'wpcom'
+			'wpcom',
+			true,
+			static::STATS_DASHBOARD_NOTICES_CACHE_KEY
 		);
+
 		if ( is_wp_error( $notices_wpcom ) ) {
 			return array();
 		}
@@ -89,6 +89,7 @@ class Notices {
 	 * @return bool
 	 */
 	public function is_notice_hidden( $id ) {
-		return array_key_exists( $id, $this->get_notices_from_wpcom() );
+		$notices_wpcom = $this->get_notices_from_wpcom();
+		return array_key_exists( $id, $notices_wpcom ) && $notices_wpcom[ $id ] === false;
 	}
 }

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -93,6 +93,7 @@ class Odyssey_Config_Data {
 								'stats_admin_version'   => Main::VERSION,
 								'software_version'      => $wp_version,
 							),
+							// TODO remove this and use API so that we could reduce loading time.
 							'stats_notices' => ( new Notices() )->get_notices_to_show(),
 						),
 					),

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -8,7 +8,6 @@
 
 namespace Automattic\Jetpack\Stats_Admin;
 
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
 use Jetpack_Options;
@@ -163,20 +162,11 @@ class REST_Controller {
 						'required'    => true,
 						'type'        => 'string',
 						'description' => 'ID of the notice',
-						'enum'        => array(
-							Notices::OPT_IN_NEW_STATS_NOTICE_ID,
-							Notices::OPT_OUT_NEW_STATS_NOTICE_ID,
-							Notices::NEW_STATS_FEEDBACK_NOTICE_ID,
-						),
 					),
 					'status'        => array(
 						'required'    => true,
 						'type'        => 'string',
 						'description' => 'Status of the notice',
-						'enum'        => array(
-							Notices::NOTICE_STATUS_DISMISSED,
-							Notices::NOTICE_STATUS_POSTPONED,
-						),
 					),
 					'postponed_for' => array(
 						'type'        => 'number',
@@ -452,7 +442,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function site_has_never_published_post( $req ) {
-		return $this->request_as_blog_cached(
+		return WPCOM_Client::request_as_blog_cached(
 			sprintf(
 				'/sites/%d/site-has-never-published-post?%s',
 				Jetpack_Options::get_option( 'id' ),
@@ -474,7 +464,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function get_wordads_earnings( $req ) {
-		return $this->request_as_blog_cached(
+		return WPCOM_Client::request_as_blog_cached(
 			sprintf(
 				'/sites/%d/wordads/earnings?%s',
 				Jetpack_Options::get_option( 'id' ),
@@ -494,7 +484,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function get_wordads_stats( $req ) {
-		return $this->request_as_blog_cached(
+		return WPCOM_Client::request_as_blog_cached(
 			sprintf(
 				'/sites/%d/wordads/stats?%s',
 				Jetpack_Options::get_option( 'id' ),
@@ -514,7 +504,25 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function update_notice_status( $req ) {
-		return ( new Notices() )->update_notice( $req->get_param( 'id' ), $req->get_param( 'status' ), $req->get_param( 'postponed_for' ) );
+		return WPCOM_Client::request_as_blog(
+			sprintf(
+				'/sites/%d/jetpack-stats-dashboard/notices?%s',
+				Jetpack_Options::get_option( 'id' ),
+				$this->filter_and_build_query_string(
+					$req->get_query_params()
+				)
+			),
+			'v2',
+			array(
+				'timeout' => 5,
+				'method'  => 'POST',
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+			),
+			$req->get_body(),
+			'wpcom'
+		);
 	}
 
 	/**
@@ -524,12 +532,12 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function mark_referrer_spam( $req ) {
-		return $this->request_as_blog_cached(
+		return WPCOM_Client::request_as_blog(
 			sprintf(
 				'/sites/%d/stats/referrers/spam/new?%s',
 				Jetpack_Options::get_option( 'id' ),
 				$this->filter_and_build_query_string(
-					$req->get_params()
+					$req->get_query_params()
 				)
 			),
 			'v1.1',
@@ -547,12 +555,12 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function unmark_referrer_spam( $req ) {
-		return $this->request_as_blog_cached(
+		return WPCOM_Client::request_as_blog(
 			sprintf(
 				'/sites/%d/stats/referrers/spam/delete?%s',
 				Jetpack_Options::get_option( 'id' ),
 				$this->filter_and_build_query_string(
-					$req->get_params()
+					$req->get_query_params()
 				)
 			),
 			'v1.1',
@@ -561,59 +569,6 @@ class REST_Controller {
 				'method'  => 'POST',
 			)
 		);
-	}
-
-	/**
-	 * Query the WordPress.com REST API using the blog token
-	 *
-	 * @param String $path The API endpoint relative path.
-	 * @param String $version The API version.
-	 * @param array  $args Request arguments.
-	 * @param String $body Request body.
-	 * @param String $base_api_path (optional) the API base path override, defaults to 'rest'.
-	 * @param bool   $use_cache (optional) default to true.
-	 * @return array|WP_Error $response Data.
-	 */
-	protected function request_as_blog_cached( $path, $version = '1.1', $args = array(), $body = null, $base_api_path = 'rest', $use_cache = true ) {
-		// Only allow caching GET requests.
-		$use_cache = $use_cache && ! ( isset( $args['method'] ) && strtoupper( $args['method'] ) !== 'GET' );
-
-		// Arrays are serialized without considering the order of objects, but it's okay atm.
-		$cache_key = 'STATS_REST_RESP_' . md5( implode( '|', array( $path, $version, wp_json_encode( $args ), wp_json_encode( $body ), $base_api_path ) ) );
-
-		if ( $use_cache ) {
-			$response_body_content = get_transient( $cache_key );
-			if ( false !== $response_body_content ) {
-				return json_decode( $response_body_content, true );
-			}
-		}
-
-		$response = Client::wpcom_json_api_request_as_blog(
-			$path,
-			$version,
-			$args,
-			$body,
-			$base_api_path
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$response_code         = wp_remote_retrieve_response_code( $response );
-		$response_body_content = wp_remote_retrieve_body( $response );
-		$response_body         = json_decode( $response_body_content, true );
-
-		$error = $this->get_wp_error( $response_body, (int) $response_code );
-		if ( is_wp_error( $error ) ) {
-			return $error;
-		}
-
-		if ( $use_cache ) {
-			// Cache the successful JSON response for 5 minutes.
-			set_transient( $cache_key, $response_body_content, 5 * MINUTE_IN_SECONDS );
-		}
-		return $response_body;
 	}
 
 	/**
@@ -647,34 +602,5 @@ class REST_Controller {
 			}
 		}
 		return http_build_query( $params );
-	}
-
-	/**
-	 * Build error object from remote response body and status code.
-	 *
-	 * @param array $response_body Remote response body.
-	 * @param int   $response_code Http response code.
-	 * @return WP_Error
-	 */
-	protected function get_wp_error( $response_body, $response_code = 200 ) {
-		$error_code = null;
-		foreach ( array( 'code', 'error' ) as $error_code_key ) {
-			if ( isset( $response_body[ $error_code_key ] ) ) {
-				$error_code = $response_body[ $error_code_key ];
-				break;
-			}
-		}
-
-		// Sometimes the response code could be 200 but the response body still contains an error.
-		if ( $error_code !== null || $response_code !== 200 ) {
-			return new WP_Error(
-				$error_code,
-				isset( $response_body['message'] ) ? $response_body['message'] : 'unknown remote error',
-				array( 'status' => $response_code )
-			);
-		}
-
-		// No error.
-		return null;
 	}
 }

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -149,7 +149,7 @@ class REST_Controller {
 			)
 		);
 
-		// Stats notices.
+		// Update Stats notices.
 		register_rest_route(
 			static::$namespace,
 			'/stats/notices',
@@ -175,6 +175,17 @@ class REST_Controller {
 						'minimum'     => 0,
 					),
 				),
+			)
+		);
+
+		// Get Stats notices.
+		register_rest_route(
+			static::$namespace,
+			'/stats/notices',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_notice_status' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
 
@@ -504,26 +515,16 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function update_notice_status( $req ) {
-		delete_transient( Notices::STATS_DASHBOARD_NOTICES_CACHE_KEY );
-		return WPCOM_Client::request_as_blog(
-			sprintf(
-				'/sites/%d/jetpack-stats-dashboard/notices?%s',
-				Jetpack_Options::get_option( 'id' ),
-				$this->filter_and_build_query_string(
-					$req->get_query_params()
-				)
-			),
-			'v2',
-			array(
-				'timeout' => 5,
-				'method'  => 'POST',
-				'headers' => array(
-					'Content-Type' => 'application/json',
-				),
-			),
-			$req->get_body(),
-			'wpcom'
-		);
+		return ( new Notices() )->update_notice_status( $req->get_param( 'id' ), $req->get_param( 'status' ), $req->get_param( 'postponed_for' ) );
+	}
+
+	/**
+	 * Get stats notices.
+	 *
+	 * @return array
+	 */
+	public function get_notice_status() {
+		return ( new Notices() )->get_notices_to_show();
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -149,7 +149,8 @@ class REST_Controller {
 			)
 		);
 
-		// Update Stats notices.
+		// Legacy: Update Stats notices.
+		// TODO: remove this in the next release.
 		register_rest_route(
 			static::$namespace,
 			'/stats/notices',
@@ -178,10 +179,39 @@ class REST_Controller {
 			)
 		);
 
+		// Update Stats notices.
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/jetpack-stats-dashboard/notices', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'update_notice_status' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+				'args'                => array(
+					'id'            => array(
+						'required'    => true,
+						'type'        => 'string',
+						'description' => 'ID of the notice',
+					),
+					'status'        => array(
+						'required'    => true,
+						'type'        => 'string',
+						'description' => 'Status of the notice',
+					),
+					'postponed_for' => array(
+						'type'        => 'number',
+						'default'     => null,
+						'description' => 'Postponed for (in seconds)',
+						'minimum'     => 0,
+					),
+				),
+			)
+		);
+
 		// Get Stats notices.
 		register_rest_route(
 			static::$namespace,
-			'/stats/notices',
+			sprintf( '/sites/%d/jetpack-stats-dashboard/notices', Jetpack_Options::get_option( 'id' ) ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_notice_status' ),

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -515,7 +515,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function update_notice_status( $req ) {
-		return ( new Notices() )->update_notice_status( $req->get_param( 'id' ), $req->get_param( 'status' ), $req->get_param( 'postponed_for' ) );
+		return ( new Notices() )->update_notice( $req->get_param( 'id' ), $req->get_param( 'status' ), $req->get_param( 'postponed_for' ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -504,6 +504,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function update_notice_status( $req ) {
+		delete_transient( Notices::STATS_DASHBOARD_NOTICES_CACHE_KEY );
 		return WPCOM_Client::request_as_blog(
 			sprintf(
 				'/sites/%d/jetpack-stats-dashboard/notices?%s',

--- a/projects/packages/stats-admin/src/class-wpcom-client.php
+++ b/projects/packages/stats-admin/src/class-wpcom-client.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * A class that wraps `Automattic\Jetpack\Connection\Client` and handles cache and errors.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Connection\Client;
+use WP_Error;
+
+/**
+ * A class that wraps `Automattic\Jetpack\Connection\Client` and handles cache and errors.
+ *
+ * @package Automattic\Jetpack\Stats_Admin
+ */
+class WPCOM_Client {
+	/**
+	 * Query the WordPress.com REST API using the blog token cached.
+	 *
+	 * @param String $path The API endpoint relative path.
+	 * @param String $version The API version.
+	 * @param array  $args Request arguments.
+	 * @param String $body Request body.
+	 * @param String $base_api_path (optional) the API base path override, defaults to 'rest'.
+	 * @param bool   $use_cache (optional) default to true.
+	 * @param string $cache_key (optional) default to null meaning the function auto generates cache key.
+	 * @return array|WP_Error $response Data.
+	 */
+	public static function request_as_blog_cached( $path, $version = '1.1', $args = array(), $body = null, $base_api_path = 'rest', $use_cache = true, $cache_key = null ) {
+		// Only allow caching GET requests.
+		$use_cache = $use_cache && ! ( isset( $args['method'] ) && strtoupper( $args['method'] ) !== 'GET' );
+
+		// Arrays are serialized without considering the order of objects, but it's okay atm.
+		$cache_key = $cache_key !== null ? $cache_key : 'STATS_REST_RESP_' . md5( implode( '|', array( $path, $version, wp_json_encode( $args ), wp_json_encode( $body ), $base_api_path ) ) );
+
+		if ( $use_cache ) {
+			$response_body_content = get_transient( $cache_key );
+			if ( false !== $response_body_content ) {
+				return json_decode( $response_body_content, true );
+			}
+		}
+
+		$response_body = static::request_as_blog( $path, $version, $args, $body, $base_api_path );
+
+		if ( is_wp_error( $response_body ) ) {
+			return $response_body;
+		}
+
+		if ( $use_cache ) {
+			// Cache the successful JSON response for 5 minutes.
+			set_transient( $cache_key, wp_json_encode( $response_body ), 5 * MINUTE_IN_SECONDS );
+		}
+
+		return $response_body;
+	}
+
+	/**
+	 * Query the WordPress.com REST API using the blog token
+	 *
+	 * @param String $path The API endpoint relative path.
+	 * @param String $version The API version.
+	 * @param array  $args Request arguments.
+	 * @param String $body Request body.
+	 * @param String $base_api_path (optional) the API base path override, defaults to 'rest'.
+	 * @return array|WP_Error $response Data.
+	 */
+	public static function request_as_blog( $path, $version = '1.1', $args = array(), $body = null, $base_api_path = 'rest' ) {
+		$response = Client::wpcom_json_api_request_as_blog(
+			$path,
+			$version,
+			$args,
+			$body,
+			$base_api_path
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_code         = wp_remote_retrieve_response_code( $response );
+		$response_body_content = wp_remote_retrieve_body( $response );
+		$response_body         = json_decode( $response_body_content, true );
+
+		$error = static::get_wp_error( $response_body, (int) $response_code );
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+
+		return $response_body;
+	}
+
+	/**
+	 * Build error object from remote response body and status code.
+	 *
+	 * @param array $response_body Remote response body.
+	 * @param int   $response_code Http response code.
+	 * @return WP_Error
+	 */
+	protected static function get_wp_error( $response_body, $response_code = 200 ) {
+		$error_code = null;
+		foreach ( array( 'code', 'error' ) as $error_code_key ) {
+			if ( isset( $response_body[ $error_code_key ] ) ) {
+				$error_code = $response_body[ $error_code_key ];
+				break;
+			}
+		}
+
+		// Sometimes the response code could be 200 but the response body still contains an error.
+		if ( $error_code !== null || $response_code !== 200 ) {
+			return new WP_Error(
+				$error_code,
+				isset( $response_body['message'] ) ? $response_body['message'] : 'unknown remote error',
+				array( 'status' => $response_code )
+			);
+		}
+
+		// No error.
+		return null;
+	}
+}

--- a/projects/packages/stats-admin/tests/php/class-test-case.php
+++ b/projects/packages/stats-admin/tests/php/class-test-case.php
@@ -121,6 +121,16 @@ class Test_Case extends TestCase {
 			);
 		}
 
+		if ( strpos( $url, '/jetpack-stats-dashboard/notices' ) !== false ) {
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'ok',
+				),
+				'body'     => '{"opt_in_new_stats":true,"opt_out_new_stats":true,"new_stats_feedback":true,"traffic_page_settings":false}',
+			);
+		}
+
 		if ( strpos( $url, '/sites/999/' ) !== false ) {
 			return array(
 				'response' => array(

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -254,7 +254,7 @@ class Test_REST_Controller extends Stats_Test_Case {
 	 * Test filter_and_build_query_string.
 	 */
 	public function test_get_wp_error() {
-		$get_wp_error = new \ReflectionMethod( $this->rest_controller, 'get_wp_error' );
+		$get_wp_error = new \ReflectionMethod( WPCOM_Client::class, 'get_wp_error' );
 		$get_wp_error->setAccessible( true );
 
 		$error = $get_wp_error->invoke(

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -180,7 +180,7 @@ class Test_REST_Controller extends Stats_Test_Case {
 	 */
 	public function test_stats_notices_succeed() {
 		wp_set_current_user( $this->admin_id );
-		$request = new WP_REST_Request( 'POST', '/jetpack/v4/stats-app/stats/notices' );
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/stats-app/sites/999/jetpack-stats-dashboard/notices' );
 		$request->set_body_params(
 			array(
 				'id'     => 'new_stats_feedback',
@@ -197,7 +197,7 @@ class Test_REST_Controller extends Stats_Test_Case {
 	 * Test '/jetpack/v4/stats-app/stats/notices' failed
 	 */
 	public function test_stats_notices_illegal_params() {
-		$request = new WP_REST_Request( 'POST', '/jetpack/v4/stats-app/stats/notices' );
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/stats-app/sites/999/jetpack-stats-dashboard/notices' );
 		$request->set_body_params(
 			array(
 				'id' => 'new_stats_feedback',

--- a/projects/packages/stats-admin/tests/php/test-stats-notices.php
+++ b/projects/packages/stats-admin/tests/php/test-stats-notices.php
@@ -39,13 +39,8 @@ class Test_Notices extends Stats_Test_Case {
 
 		Stats_Options::set_option( 'views', 2 );
 		$this->assertTrue( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
-	}
 
-	/**
-	 * Test opt out new stats notice dismissed.
-	 */
-	public function test_opt_out_new_stats_notice_dismissed() {
-		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
+		Stats_Options::set_option( 'views', 3 );
 		$this->assertFalse( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
 	}
 
@@ -58,45 +53,6 @@ class Test_Notices extends Stats_Test_Case {
 	}
 
 	/**
-	 * Test new stats feedback notice dismissed.
-	 */
-	public function test_new_stats_feedback_notice_dismissed() {
-		self::$notices->update_notice( 'new_stats_feedback', 'dismissed' );
-		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
-		$this->assertFalse( self::$notices->get_notices_to_show()['new_stats_feedback'] );
-		$this->assertFalse( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
-	}
-
-	/**
-	 * Test new stats feedback notice dismissed.
-	 */
-	public function test_new_stats_feedback_notice_postponed() {
-		self::$notices->update_notice( 'new_stats_feedback', 'postponed', 10000 );
-		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
-		$stored_notices = Stats_Options::get_option( 'notices' );
-
-		$this->assertGreaterThanOrEqual( time(), $stored_notices['new_stats_feedback']['next_show_at'] );
-		$this->assertFalse( self::$notices->get_notices_to_show()['new_stats_feedback'] );
-		$this->assertFalse( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
-	}
-
-	/**
-	 * Test new stats feedback notice postponed and show again.
-	 */
-	public function test_new_stats_feedback_notice_postponed_show_again() {
-		self::$notices->update_notice( 'new_stats_feedback', 'postponed', 10000 );
-		self::$notices->update_notice( 'opt_out_new_stats', 'dismissed' );
-		Stats_Options::set_option( 'views', 3 );
-
-		$stored_notices                                       = Stats_Options::get_option( 'notices' );
-		$stored_notices['new_stats_feedback']['next_show_at'] = time() - 1;
-		Stats_Options::set_option( 'notices', $stored_notices );
-
-		$this->assertTrue( self::$notices->get_notices_to_show()['new_stats_feedback'] );
-		$this->assertFalse( self::$notices->get_notices_to_show()['opt_out_new_stats'] );
-	}
-
-	/**
 	 * Test opt in new stats notice show.
 	 */
 	public function test_opt_in_new_stats_notice_show() {
@@ -106,40 +62,9 @@ class Test_Notices extends Stats_Test_Case {
 	}
 
 	/**
-	 * Test get views.
+	 * Test opt in new stats notice show.
 	 */
-	public function test_get_new_stats_views() {
-		Stats_Options::set_option( 'views', 3 );
-		$this->assertEquals( 3, self::$notices->get_new_stats_views() );
+	public function test_traffic_page_settings_hidden() {
+		$this->assertFalse( self::$notices->get_notices_to_show()['traffic_page_settings'] );
 	}
-
-	/**
-	 * Test is notice hidden.
-	 */
-	public function test_is_notice_hidden() {
-		$this->assertFalse( self::$notices->is_notice_hidden( 'opt_in_new_stats' ) );
-		self::$notices->update_notice( 'opt_in_new_stats', 'dismissed' );
-		$this->assertTrue( self::$notices->is_notice_hidden( 'opt_in_new_stats' ) );
-		self::$notices->update_notice( 'opt_in_new_stats', 'postponed' );
-		$this->assertTrue( self::$notices->is_notice_hidden( 'opt_in_new_stats' ) );
-	}
-
-	/**
-	 * Test get hidden notices.
-	 */
-	public function test_get_hidden_notices() {
-		$this->assertEmpty( self::$notices->get_hidden_notices( 'opt_in_new_stats' ) );
-		self::$notices->update_notice( 'opt_in_new_stats', 'dismissed' );
-		self::$notices->update_notice( 'new_stats_feedback', 'postponed' );
-
-		$this->assertArrayHasKey( 'opt_in_new_stats', self::$notices->get_hidden_notices() );
-		$this->assertArrayHasKey( 'new_stats_feedback', self::$notices->get_hidden_notices() );
-
-		$stored_notices                                       = Stats_Options::get_option( 'notices' );
-		$stored_notices['new_stats_feedback']['next_show_at'] = time() - 1;
-		Stats_Options::set_option( 'notices', $stored_notices );
-
-		$this->assertArrayNotHasKey( 'new_stats_feedback', self::$notices->get_hidden_notices() );
-	}
-
 }


### PR DESCRIPTION
Partially Fixes #31228

## Proposed changes:

We moved notices visibility functionalities to WPCOM in `D112871-code` to support both Calypso and Odyssey Stats, so we need to update how notices are dealt with in the Stats Admin package.

* Extracted WPCOM API access to class `WPCOM_Client` to share the functionality
* Changed to use WPCOM notices API instead of local options
* Added notices list API which proxies to WPCOM
* Updated unit tests to adapt the changes

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Build with latest Calypso trunk: `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Delete option `stats_options` from the site
* Open `wp-admin/admin.php?page=stats&flags=stats/highlights-settings`
* Ensure Highlights tooltip is shown
* Dismiss it and refresh
* Ensure the notice doesn't come up again
* Ensure Opt out notice is shown
* Dismiss it and refresh
* Ensure the notice doesn't come up again

<img width="883" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/3b7334e5-4576-4654-9808-3e0a5fac9620">


