### PR TITLE
AI Assistant: Request WPCOM JWT endpoint as user, not blog

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -775,7 +775,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function get_openai_jwt() {
 		$blog_id = \Jetpack_Options::get_option( 'id' );
 
-		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
+		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
 			"/sites/$blog_id/jetpack-openai-query/jwt",
 			'2',
 			array(

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-request-wpcom-jwt-endpoint-as-user
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-request-wpcom-jwt-endpoint-as-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+AI Assistant: Request completion JWT token as the user, not the blog.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-request-wpcom-jwt-endpoint-as-user
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-request-wpcom-jwt-endpoint-as-user
@@ -1,4 +1,4 @@
 Significance: patch
-Type: update
+Type: enhancement
 
 AI Assistant: Request completion JWT token as the user, not the blog.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #30738. Test with D113109-code.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack sites handle the JWT token request on `jetpack/v4/jetpack-ai-jwt` and forward it to `wpcom/v2` `/sites/$site/jetpack-openai-query/jwt`, so we can stablish the right chain of authentication
* Before this change, the request is being performed as the `blog`, so no user info is sent on the request
* After this change, the same user that requested the Jetpack endpoint is forwarded to the WPCOM request, using `wpcom_json_api_request_as_user`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D113109-code to your sandbox
* Make sure your test site points to the sandbox when requesting the `public-api` (case you test using a JN site; locally everything is set, as long as you are sandboxing the `public-api` on your machine)
* Go to the block editor, open your browser console on the network tab and add an "AI Assistant" block
* Inspect the response from the `/jetpack-ai-jwt` request; you will find a token in the response
* Copy the token, go to https://jwt.io/#debugger-io and paste the token on the debugger
* Notice the `user_id` property
   * before this change, it would be set to `0` since the request is performed as the blog
   * after this change, it should be set with the user ID of the WPCOM account connected on your test Jetpack site (run v1.1 `/me` request to discover your account ID), since now the request is performed as the user
* The block should work normally