### PR TITLE
[Subscription] Fix for WoA error

### DIFF
--- a/projects/plugins/jetpack/changelog/add-fix-for-wao-error
+++ b/projects/plugins/jetpack/changelog/add-fix-for-wao-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix potential bug in subscription widget on WoA

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -347,7 +347,9 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$submit_button_wrapper_styles = isset( $instance['submit_button_wrapper_styles'] ) ? $instance['submit_button_wrapper_styles'] : '';
 		$email_field_classes          = isset( $instance['email_field_classes'] ) ? $instance['email_field_classes'] : '';
 		$email_field_styles           = isset( $instance['email_field_styles'] ) ? $instance['email_field_styles'] : '';
-		$post_access_level            = \Jetpack_Memberships::get_post_access_level();
+
+		require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+		$post_access_level = \Jetpack_Memberships::get_post_access_level();
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {
 			global $current_blog;

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -349,8 +349,8 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$email_field_styles           = isset( $instance['email_field_styles'] ) ? $instance['email_field_styles'] : '';
 
 		// We need to include those in case Jetpack blocks are disabled
-		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$post_access_level = \Jetpack_Memberships::get_post_access_level();
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -349,8 +349,8 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$email_field_styles           = isset( $instance['email_field_styles'] ) ? $instance['email_field_styles'] : '';
 
 		// We need to include those in case Jetpack blocks are disabled
-		require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+		require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 		$post_access_level = \Jetpack_Memberships::get_post_access_level();
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -348,7 +348,9 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$email_field_classes          = isset( $instance['email_field_classes'] ) ? $instance['email_field_classes'] : '';
 		$email_field_styles           = isset( $instance['email_field_styles'] ) ? $instance['email_field_styles'] : '';
 
+		// We need to include those in case Jetpack blocks are disabled
 		require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$post_access_level = \Jetpack_Memberships::get_post_access_level();
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31258 
Lighter version of #31259 as a hotfix for WPCOM
See p1686162943989619-slack-C01U2KGS2PQ for context
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Require Jetpack Membership and Subscription services in Subscription widget form

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Atomic

* Spin up a new Atomic site
* Change the theme to `Wilson` (Any non-block theme with sidebar)
* Add plugin `widget classic`
* In "Appearence > Widgets" add the `(Jepack) Subscription widget` to the sidebar
<img width="400" alt="Screenshot 2023-06-08 at 15 11 08" src="https://github.com/Automattic/jetpack/assets/790558/e138ac53-deea-4b00-8266-048199cbb396">

* **Enable**: Admin-> Settings → Discussion → Subscriptions
<img width="200" alt="Screenshot 2023-06-08 at 15 21 59" src="https://github.com/Automattic/jetpack/assets/790558/6b099321-db75-46e6-92b6-c5ec03e83702">


* Create a new post with a subscribe block, publish
* Make sure it displays well
* **Disable** Gutenberg by SSHing and adding this filter:
```
HOST:~/htdocs/wp-content/mu-plugins$ more index.php 
<?php
//silence is golden

add_filter( 'jetpack_gutenberg', '__return_false' );
```

* Reloading the post should not display the block or the widget in the sidebar (if you have debug enabled you should see the error in the logs)
<img width="400" alt="Screenshot 2023-06-08 at 15 15 28" src="https://github.com/Automattic/jetpack/assets/790558/292ef9b1-06bf-4907-bf4b-6ff4d04059ca">

* Load this branch by pulling this branch locally, building and rsync'ing into it
* Reload the post

You should now see in the widget 🥳
<img width="400" alt="Screenshot 2023-06-08 at 15 24 38" src="https://github.com/Automattic/jetpack/assets/790558/7d9fbbec-ec97-4e68-8da5-c91c6ada8302">


### Self-hosted / Jurassic Ninja

* Spin up a new site from trunk: https://jurassic.ninja/create/?jetpack-beta&branches.jetpack=master
* Set up Jetpack
* Change the theme to `Wilson` (Any non-block theme with sidebar)
* Add plugin `widget classic`
* In "Appearence > Widgets" add the `(Jepack) Subscription widget` to the sidebar
<img width="400" alt="Screenshot 2023-06-08 at 15 11 08" src="https://github.com/Automattic/jetpack/assets/790558/e138ac53-deea-4b00-8266-048199cbb396">

* **Enable**: Jetpack → Settings → Discussion → Subscriptions
<img width="200" alt="Screenshot 2023-06-08 at 15 13 55" src="https://github.com/Automattic/jetpack/assets/790558/1bd95207-1498-44b2-bc31-eb54b3f88a63">

* Create a new post with a subscribe block, publish
* Make sure it displays well
* **Disable** Jetpack → Settings → Writing → Composing->Jetpack blocs
<img width="400" alt="Screenshot 2023-06-08 at 15 14 22" src="https://github.com/Automattic/jetpack/assets/790558/a648a323-eca1-4185-ac2d-8dc1dd5b3df5">

* Reloading the post should not display the block or the widget in the sidebar (if you have debug enabled you should see the error in the logs)
<img width="400" alt="Screenshot 2023-06-08 at 15 15 28" src="https://github.com/Automattic/jetpack/assets/790558/292ef9b1-06bf-4907-bf4b-6ff4d04059ca">

* Go to jetpack beta and load this branch
<img width="200" alt="Screenshot 2023-06-08 at 15 16 56" src="https://github.com/Automattic/jetpack/assets/790558/0c2e19cd-e964-4399-873d-e246ca28937c">

<img width="200" alt="Screenshot 2023-06-08 at 15 17 18" src="https://github.com/Automattic/jetpack/assets/790558/a1cefea7-ff18-4f49-a27e-0c47fa23dc52">


* Reload the post

You should now see in the widget 🥳