### PR TITLE
AI Assistant: avoid to send the same AI request

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-do-not-allow-send-the-same-request
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-do-not-allow-send-the-same-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: avoid to send the same AI request


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR disables the `Send` button when the user prompt has been used before. The idea is avoiding to send the same request twice.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: avoid to send the same AI request

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a new AI Assistant block instance
* Type a user prompt
* Send it
* Once the generated text is done:
  * Confirm the `Send` button is disabled
  * Confirm the button enables/disables depending on the current prompt is the same as the sent one

https://github.com/Automattic/jetpack/assets/77539/34c6dd0e-d03c-4f96-89c1-b82a32f99679
