### PR TITLE
Launchpad: Add "Claim your free domain" task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-claim-domain-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-claim-domain-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new claim free domain task to Keep Building task list.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -571,7 +571,7 @@ function wpcom_domain_claim_is_visible_callback() {
 	}
 
 	// If we haven't completed the task, check to see if we have a bundle credit before showing it.
-	return bool /WPCOM_Store::has_bundle_credit();
+	return WPCOM_Store::has_bundle_credit();
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -554,11 +554,9 @@ add_action( 'update_option_blogname', 'wpcom_mark_site_title_complete', 10, 3 );
 /**
  * Determine `domain_claim` task visibility.
  *
- * @param array $task The task to check.
- *
  * @return bool True if we should show the task, false otherwise.
  */
-function wpcom_domain_claim_is_visible_callback( $task ) {
+function wpcom_domain_claim_is_visible_callback() {
 	if ( ! function_exists( 'wpcom_site_has_feature' ) ) {
 		return false;
 	}
@@ -569,10 +567,9 @@ function wpcom_domain_claim_is_visible_callback( $task ) {
 /**
  * Determines whether or not domain claim task is completed.
  *
- * @param array $task The Task object.
  * @return bool True if domain claim task is completed.
  */
-function wpcom_is_domain_claim_completed( $task ) {
+function wpcom_is_domain_claim_completed() {
 	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 		return false;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -29,6 +29,12 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => '__return_true',
 			'is_disabled_callback' => 'wpcom_is_design_step_enabled',
 		),
+		'domain_claim'                   => array( 
+			'get_title'            => function () {
+				return __( 'Claim your free one-year domain', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_domain_claim_is_complete_callback',
+		),
 		'domain_upsell'                   => array(
 			'id_map'               => 'domain_upsell_deferred',
 			'get_title'            => function () {
@@ -543,3 +549,16 @@ function wpcom_mark_site_title_complete( $old_value, $value ) {
 	}
 }
 add_action( 'update_option_blogname', 'wpcom_mark_site_title_complete', 10, 3 );
+
+/**
+ * Check to see if a site has a bundle credit for a free domain.
+ *
+ * @return bool True if the site has a bundle credit for a free domain, false otherwise.
+ */
+function wpcom_domain_claim_is_complete_callback() {
+	if ( ! class_exists( 'WPCOM_Store' ) ) {
+		return false;
+	};
+
+	return bool /WPCOM_Store::has_bundle_credit();
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -552,20 +552,17 @@ function wpcom_mark_site_title_complete( $old_value, $value ) {
 add_action( 'update_option_blogname', 'wpcom_mark_site_title_complete', 10, 3 );
 
 /**
- * Check to see if a site has a bundle credit for a free domain.
+ * Determine `domain_claim` task visibility.
  *
- * See if a site has a bundle credit active; if so they have not claimed their free domain.
- * Used with the `domain_claim` task to determine visibility.
- * 
  * @param array $task The task to check.
  *
- * @return bool True if the site has a bundle credit for a free domain, false otherwise.
+ * @return bool True if we should show the task, false otherwise.
  */
 function wpcom_domain_claim_is_visible_callback( $task ) {
 	// If we're not on WP.com, don't show this task.
 	if ( ! class_exists( 'WPCOM_Store' ) ) {
 		return false;
-	};
+	}
 
 	// If we've already completed the task, continue to show it.
 	if ( wpcom_is_domain_upsell_completed( $task, false ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -29,7 +29,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => '__return_true',
 			'is_disabled_callback' => 'wpcom_is_design_step_enabled',
 		),
-		'domain_claim'                   => array( 
+		'domain_claim'                    => array(
 			'get_title'            => function () {
 				return __( 'Claim your free one-year domain', 'jetpack-mu-wpcom' );
 			},
@@ -582,11 +582,11 @@ function wpcom_domain_claim_is_visible_callback() {
 function wpcom_domain_claim_task_listener() {
 	if ( ! class_exists( 'WPCOM_Domain' ) ) {
 		return;
-	};
+	}
 
 	// The the primary domain mapping record.
 	$mapping_record = get_primary_domain_mapping_record();
-	$wpcom_domain = new \WPCOM_Domain( $mapping_record->domain );
+	$wpcom_domain   = new \WPCOM_Domain( $mapping_record->domain );
 
 	// If the primary domain is not a WP.com TLD, they've mapped a domain; mark the task complete.
 	if ( ! $wpcom_domain->is_wpcom_tld() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -584,10 +584,11 @@ function wpcom_domain_claim_task_listener() {
 		return;
 	};
 
+	// The the primary domain mapping record.
 	$mapping_record = get_primary_domain_mapping_record();
 	$wpcom_domain = new \WPCOM_Domain( $mapping_record->domain );
 
-	// If the primary domain is not a WP.com TLD, mark the domain claim as complete.
+	// If the primary domain is not a WP.com TLD, they've mapped a domain; mark the task complete.
 	if ( ! $wpcom_domain->is_wpcom_tld() ) {
 		wpcom_mark_launchpad_task_complete( 'domain_claim' );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -33,7 +33,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Claim your free one-year domain', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_is_domain_upsell_completed',
 			'is_visible_callback'  => 'wpcom_domain_claim_is_visible_callback',
 		),
 		'domain_upsell'                   => array(
@@ -573,24 +573,3 @@ function wpcom_domain_claim_is_visible_callback() {
 	// If we haven't completed the task, check to see if we have a bundle credit before showing it.
 	return WPCOM_Store::has_bundle_credit();
 }
-
-/**
- * When the user maps a custom domain, mark `domain_credit` as done.
- *
- * @return void
- */
-function wpcom_domain_claim_task_listener() {
-	if ( ! class_exists( 'WPCOM_Domain' ) ) {
-		return;
-	}
-
-	// The the primary domain mapping record.
-	$mapping_record = get_primary_domain_mapping_record();
-	$wpcom_domain   = new \WPCOM_Domain( $mapping_record->domain );
-
-	// If the primary domain is not a WP.com TLD, they've mapped a domain; mark the task complete.
-	if ( ! $wpcom_domain->is_wpcom_tld() ) {
-		wpcom_mark_launchpad_task_complete( 'domain_claim' );
-	}
-}
-add_action( 'init', 'wpcom_domain_claim_task_listener', 11 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -556,17 +556,19 @@ add_action( 'update_option_blogname', 'wpcom_mark_site_title_complete', 10, 3 );
  *
  * See if a site has a bundle credit active; if so they have not claimed their free domain.
  * Used with the `domain_claim` task to determine visibility.
+ * 
+ * @param array $task The task to check.
  *
  * @return bool True if the site has a bundle credit for a free domain, false otherwise.
  */
-function wpcom_domain_claim_is_visible_callback() {
+function wpcom_domain_claim_is_visible_callback( $task ) {
 	// If we're not on WP.com, don't show this task.
 	if ( ! class_exists( 'WPCOM_Store' ) ) {
 		return false;
 	};
 
 	// If we've already completed the task, continue to show it.
-	if ( wpcom_is_task_option_completed( 'domain_claim' ) ) {
+	if ( wpcom_is_domain_upsell_completed( $task, false ) ) {
 		return true;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -133,6 +133,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids'            => array(
 				'site_title',
 				'design_edited',
+				'domain_claim',
 				'verify_email',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "f5e5d7135d0b0e5cd89a524d771f1ebe3c70f67b"
+                "reference": "7377c521b763e6bc065318a5a0194057e3236282"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.0.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "7377c521b763e6bc065318a5a0194057e3236282"
+                "reference": "f5e5d7135d0b0e5cd89a524d771f1ebe3c70f67b"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.0.x-dev"
+                    "dev-trunk": "3.1.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#77811

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the "Claim your free domain" task to the Keep Building task list.
* Only show the task if the user has a bundled domain credit, or if the task is already completed (ie. the user has a custom domain).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox the API
* Create a new site from `/start` and select a paid plan.
* Once your site has been created, go to the developer console and make a GET request  to the WP REST API `/wpcom/v2/sites/yourtestsite/launchpad?checklist_slug=keep-building`
* You should see a "Claim your free one year domain" task, status false:

<img width="957" alt="Screen Shot 2023-06-08 at 1 00 33 PM" src="https://github.com/Automattic/jetpack/assets/2124984/b0076ad0-acad-4345-96b5-4ebbee0ad8a5">

* Claim your free domain (don't forget to cancel it right after testing!) and check out
* Visit the developer console again; you should see the task, status is now true:

<img width="946" alt="Screen Shot 2023-06-13 at 12 21 38 PM" src="https://github.com/Automattic/jetpack/assets/2124984/198ff2b7-7232-4612-a7c4-27b9eb7a51ac">

* Create a second test site from `/start`, but on a Free plan.
* Visit the developer console again and check your new test site by making another GET request  to the WP REST API `/wpcom/v2/sites/yoursecondtestsite/launchpad?checklist_slug=keep-building`
* You should not see the claim your free domain task at all:

<img width="983" alt="Screen Shot 2023-06-08 at 3 35 10 PM" src="https://github.com/Automattic/jetpack/assets/2124984/c4e75d5e-c77f-4cb2-b6e6-39234ef3c9b2">
