### PR TITLE
 AI Assistant: remove shortcuts labels from block area

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-remove-shortcut-label
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-remove-shortcut-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: remove shortcuts labels from block area

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -15,7 +15,6 @@ import { useKeyboardShortcut } from '@wordpress/compose';
 import { forwardRef, useImperativeHandle, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { image, pencil, update, closeSmall, check } from '@wordpress/icons';
-import { isAppleOS } from '@wordpress/keycodes';
 /*
  * Internal dependencies
  */
@@ -118,13 +117,6 @@ const AIControl = forwardRef(
 			}
 		);
 
-		const promptButtonKeyboardTextEnter = __( 'Enter', 'jetpack' );
-		const promptButtonKeyboardTextEsc = __( 'Esc', 'jetpack' );
-
-		const promptButtonKeyboardText = ! isWaitingState
-			? promptButtonKeyboardTextEnter
-			: promptButtonKeyboardTextEsc;
-
 		return (
 			<>
 				{ ( siteRequireUpgrade || requireUpgrade ) && <UpgradePrompt /> }
@@ -222,11 +214,6 @@ const AIControl = forwardRef(
 									{ __( 'Stop', 'jetpack' ) }
 								</Button>
 							) }
-							{ ! isSm && (
-								<div className="jetpack-ai-assistant__prompt_button_keyboard">
-									{ promptButtonKeyboardText }
-								</div>
-							) }
 						</div>
 
 						<div className="jetpack-ai-assistant__prompt_button_wrapper">
@@ -253,11 +240,6 @@ const AIControl = forwardRef(
 										{ __( 'Accept', 'jetpack' ) }
 									</Button>
 								) ) }
-							{ ! isSm && contentIsLoaded && ! isWaitingState && (
-								<div className="jetpack-ai-assistant__prompt_button_keyboard">
-									{ isAppleOS() ? __( 'CMD+Enter', 'jetpack' ) : __( 'Ctrl+Enter', 'jetpack' ) }
-								</div>
-							) }
 						</div>
 					</div>
 				</div>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -144,16 +144,6 @@
 			cursor: not-allowed;
 		}
 	}
-
-	.jetpack-ai-assistant__prompt_button_keyboard {
-		opacity: 0.6;
-		font-size: 8px;
-		background: var( --wp--preset--color--cyan-bluish-gray );
-		color: var( --wp--preset--color--base );
-		padding: 2px 4px;
-		border-radius: 2px;
-		margin-right: 8px;
-	}
 }
 
 .jetpack-ai-assistant__accept {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: remove shortcuts labels from block area

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editore
* Confirm the shortcuts labels are not there anymore

**Before**
![image](https://github.com/Automattic/jetpack/assets/77539/8bb62eed-5d6c-4d07-b2f5-ff73b41cc3c0)

**After**
<img width="700" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/3766c9b1-f305-4b5a-8fb6-8fce49ded5e8">

