### PR TITLE
Device Detection: Prevent checking the platform when the user agent is not set

### DIFF
--- a/projects/packages/device-detection/changelog/patch-1
+++ b/projects/packages/device-detection/changelog/patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Catch PHP notice if User Agent is not available

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -230,6 +230,10 @@ class User_Agent_Info {
 				return $this->platform;
 		}
 
+		if ( empty( $this->useragent ) ) {
+			return false;
+		}
+
 		if ( strpos( $this->useragent, 'windows phone' ) !== false ) {
 				$this->platform = self::PLATFORM_WINDOWS;
 		} elseif ( strpos( $this->useragent, 'windows ce' ) !== false ) {

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -223,7 +223,7 @@ class User_Agent_Info {
 	 * Note that this function returns the platform name, not the UA name/type. You should use a different function
 	 * if you need to test the UA capabilites.
 	 *
-	 * @return string Name of the platform, false otherwise.
+	 * @return string|bool Name of the platform, false otherwise.
 	 */
 	public function get_platform() {
 		if ( isset( $this->platform ) ) {


### PR DESCRIPTION
Prevent checking the platform when the user agent is not set. 

Fixes an PHP 8.1 error when `strpos()` is used and argument 1 is null:

```
PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /Users/srtfisher/broadway/www/client/wp-content/mu-plugins/jetpack-12.0/jetpack_vendor/automattic/jetpack-device-detection/src/class-user-agent-info.php on line 235
```

Primarily came up during unit testing when the user agent is not set.

## Proposed changes:
* Prevents the platform from being checked when the user agent is not set. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

n/a

