### PR TITLE
Launchpad: Add domain upsell task to keep building list

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-add-domain-upsell-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-add-domain-upsell-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds domain_upsell task to keep-building list and updates visibility rules for that same task.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -36,6 +36,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_domain_upsell_completed',
 			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
+			'is_visible_callback'  => 'wpcom_is_domain_upsell_visible',
 		),
 		'first_post_published'            => array(
 			'get_title'             => function () {
@@ -359,6 +360,29 @@ function wpcom_is_domain_upsell_completed( $task, $default ) {
 function wpcom_get_domain_upsell_badge_text() {
 	// Never run `wpcom_is_checklist_task_complete` within a is_complete_callback unless you are fond of infinite loops.
 	return wpcom_is_checklist_task_complete( 'domain_upsell' ) ? '' : __( 'Upgrade plan', 'jetpack-mu-wpcom' );
+}
+
+/**
+ * Determines whether or not domain upsell task should be visible.
+ *
+ * @return bool True if user is on a free plan with no custom domain name.
+ */
+function wpcom_is_domain_upsell_visible() {
+	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
+		return false;
+	}
+
+	// Check if the site has any domain purchases.
+	$site_purchases = wpcom_get_site_purchases();
+
+	$domain_purchases = array_filter(
+		$site_purchases,
+		function ( $site_purchase ) {
+			return in_array( $site_purchase->product_type, array( 'domain_map', 'domain_reg' ), true );
+		}
+	);
+
+	return ! empty( $domain_purchases );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -368,6 +368,14 @@ function wpcom_get_domain_upsell_badge_text() {
  * @return bool True if user is on a free plan with no custom domain name.
  */
 function wpcom_is_domain_upsell_visible() {
+	if ( ! class_exists( '\A8C\Billingdaddy\Container' ) ) {
+		return false;
+	}
+
+	if ( null !== \A8C\Billingdaddy\Container::get_purchases_api()->get_current_plan_for_site() ) {
+		return false; // Site is not on a free plan.
+	}
+
 	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 		return false;
 	}
@@ -382,7 +390,7 @@ function wpcom_is_domain_upsell_visible() {
 		}
 	);
 
-	return ! empty( $domain_purchases );
+	return empty( $domain_purchases );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -368,21 +368,22 @@ function wpcom_get_domain_upsell_badge_text() {
  * @return bool True if user is on a free plan with no custom domain name.
  */
 function wpcom_is_domain_upsell_visible() {
-	if ( ! class_exists( '\A8C\Billingdaddy\Container' ) ) {
-		return false;
-	}
-
-	if ( null !== \A8C\Billingdaddy\Container::get_purchases_api()->get_current_plan_for_site() ) {
-		return false; // Site is not on a free plan.
-	}
-
 	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 		return false;
 	}
 
-	// Check if the site has any domain purchases.
 	$site_purchases = wpcom_get_site_purchases();
 
+	$bundle_purchases = array_filter(
+		$site_purchases,
+		function ( $site_purchase ) {
+			return $site_purchase->product_type === 'bundle';
+		}
+	);
+
+	$is_free_plan = empty( $bundle_purchases );
+
+	// Check if the site has any domain purchases.
 	$domain_purchases = array_filter(
 		$site_purchases,
 		function ( $site_purchase ) {
@@ -390,7 +391,7 @@ function wpcom_is_domain_upsell_visible() {
 		}
 	);
 
-	return empty( $domain_purchases );
+	return $is_free_plan && empty( $domain_purchases );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -349,6 +349,23 @@ function wpcom_is_domain_upsell_completed( $task, $default ) {
 	if ( wpcom_site_has_feature( 'custom-domain' ) ) {
 		return true;
 	}
+
+	if ( function_exists( 'wpcom_get_site_purchases' ) ) {
+		$site_purchases = wpcom_get_site_purchases();
+
+		// Check if the site has any domain purchases.
+		$domain_purchases = array_filter(
+			$site_purchases,
+			function ( $site_purchase ) {
+				return in_array( $site_purchase->product_type, array( 'domain_map', 'domain_reg' ), true );
+			}
+		);
+
+		if ( ! empty( $domain_purchases ) ) {
+			return true;
+		}
+	}
+
 	return $default;
 }
 
@@ -365,7 +382,7 @@ function wpcom_get_domain_upsell_badge_text() {
 /**
  * Determines whether or not domain upsell task should be visible.
  *
- * @return bool True if user is on a free plan with no custom domain name.
+ * @return bool True if user is on a free plan.
  */
 function wpcom_is_domain_upsell_task_visible() {
 	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
@@ -381,19 +398,7 @@ function wpcom_is_domain_upsell_task_visible() {
 		}
 	);
 
-	if ( ! empty( $bundle_purchases ) ) {
-		return false;
-	}
-
-	// Check if the site has any domain purchases.
-	$domain_purchases = array_filter(
-		$site_purchases,
-		function ( $site_purchase ) {
-			return in_array( $site_purchase->product_type, array( 'domain_map', 'domain_reg' ), true );
-		}
-	);
-
-	return empty( $domain_purchases );
+	return empty( $bundle_purchases );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -36,7 +36,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_domain_upsell_completed',
 			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
-			'is_visible_callback'  => 'wpcom_is_domain_upsell_visible',
+			'is_visible_callback'  => 'wpcom_is_domain_upsell_task_visible',
 		),
 		'first_post_published'            => array(
 			'get_title'             => function () {
@@ -367,7 +367,7 @@ function wpcom_get_domain_upsell_badge_text() {
  *
  * @return bool True if user is on a free plan with no custom domain name.
  */
-function wpcom_is_domain_upsell_visible() {
+function wpcom_is_domain_upsell_task_visible() {
 	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 		return false;
 	}
@@ -381,7 +381,9 @@ function wpcom_is_domain_upsell_visible() {
 		}
 	);
 
-	$is_free_plan = empty( $bundle_purchases );
+	if ( ! empty( $bundle_purchases ) ) {
+		return false;
+	}
 
 	// Check if the site has any domain purchases.
 	$domain_purchases = array_filter(
@@ -391,7 +393,7 @@ function wpcom_is_domain_upsell_visible() {
 		}
 	);
 
-	return $is_free_plan && empty( $domain_purchases );
+	return empty( $domain_purchases );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -129,31 +129,14 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'keep-building'   => array(
-			'title'                  => 'Keep Building',
-			'task_ids'               => array(
+			'title'               => 'Keep Building',
+			'task_ids'            => array(
 				'site_title',
 				'design_edited',
 				'verify_email',
 				'domain_upsell',
 			),
-			'is_enabled_callback'    => 'wpcom_launchpad_is_keep_building_enabled',
-			'visible_tasks_callback' => function ( $task_list, $task_ids ) {
-				return array_filter(
-					$task_ids,
-					function ( $task_id ) {
-						if ( 'domain_upsell' === $task_id ) {
-							if ( ! class_exists( '\A8C\Billingdaddy\Container' ) ) {
-								return false;
-							}
-
-							$is_free_plan = null === \A8C\Billingdaddy\Container::get_purchases_api()->get_current_plan_for_site();
-							return $is_free_plan && ! wpcom_is_domain_upsell_completed( $task_id, false );
-						}
-
-						return true;
-					}
-				);
-			},
+			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -129,14 +129,31 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'keep-building'   => array(
-			'title'               => 'Keep Building',
-			'task_ids'            => array(
+			'title'                  => 'Keep Building',
+			'task_ids'               => array(
 				'site_title',
 				'design_edited',
 				'verify_email',
 				'domain_upsell',
 			),
-			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
+			'is_enabled_callback'    => 'wpcom_launchpad_is_keep_building_enabled',
+			'visible_tasks_callback' => function ( $task_list, $task_ids ) {
+				return array_filter(
+					$task_ids,
+					function ( $task_id ) {
+						if ( 'domain_upsell' === $task_id ) {
+							if ( ! class_exists( '\A8C\Billingdaddy\Container' ) ) {
+								return false;
+							}
+
+							$is_free_plan = null === \A8C\Billingdaddy\Container::get_purchases_api()->get_current_plan_for_site();
+							return $is_free_plan && ! wpcom_is_domain_upsell_completed( $task_id, false );
+						}
+
+						return true;
+					}
+				);
+			},
 		),
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -134,6 +134,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'site_title',
 				'design_edited',
 				'verify_email',
+				'domain_upsell',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes https://github.com/Automattic/wp-calypso/issues/77812

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds the `domain_upsell` task to the `keep-building` list. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox `public-api.wordpress.com`.
* Visit the dev console and select WP REST API, `wpcom/v2`.
* You'll need to get a free site and purchase a domain (make sure to cancel the subscription after testing)
* Make a GET request to the site with the domain you just created `/sites/[siteSlug]/launchpad?checklist_slug=keep-building`.
* Verify you see the `domain_upsell` task as completed.
* Make the same GET request but use a free site without any domain purchases.
* Verify you do see the `domain_upsell` task marked as incomplete.
* Make the same GET request but use a site with a plan.
* Verify you don't see `domain_upsell` task.
