### PR TITLE
AI Assistant: block query requests when required upgrade

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-block-requests-when-limit-achieved
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-block-requests-when-limit-achieved
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: block query requests when required upgrade

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-control.js
@@ -23,7 +23,6 @@ import ConnectPrompt from './components/connect-prompt';
 import I18nDropdownControl from './components/i18n-dropdown-control';
 import PromptTemplatesControl from './components/prompt-templates-control';
 import ToneDropdownControl from './components/tone-dropdown-control';
-import useAIFeature from './hooks/use-ai-feature';
 import AIAssistantIcon from './icons/ai-assistant';
 import origamiPlane from './icons/origami-plane';
 import { isUserConnected } from './lib/connection';
@@ -63,7 +62,6 @@ const AIControl = forwardRef(
 		const [ isSm ] = useBreakpointMatch( 'sm' );
 
 		const connected = isUserConnected();
-		const { requireUpgrade: siteRequireUpgrade } = useAIFeature();
 
 		const textPlaceholder = __( 'Ask Jetpack AI', 'jetpack' );
 
@@ -119,7 +117,7 @@ const AIControl = forwardRef(
 
 		return (
 			<>
-				{ ( siteRequireUpgrade || requireUpgrade ) && <UpgradePrompt /> }
+				{ requireUpgrade && <UpgradePrompt /> }
 				{ ! connected && <ConnectPrompt /> }
 				{ ! isWaitingState && connected && (
 					<ToolbarControls
@@ -182,9 +180,7 @@ const AIControl = forwardRef(
 						} }
 						placeholder={ placeholder }
 						className="jetpack-ai-assistant__input"
-						disabled={
-							isWaitingState || loadingImages || ! connected || siteRequireUpgrade || requireUpgrade
-						}
+						disabled={ isWaitingState || loadingImages || ! connected || requireUpgrade }
 						ref={ promptUserInputRef }
 					/>
 
@@ -195,9 +191,7 @@ const AIControl = forwardRef(
 									className="jetpack-ai-assistant__prompt_button"
 									onClick={ () => handleGetSuggestion( 'userPrompt' ) }
 									isSmall={ true }
-									disabled={
-										! userPrompt?.length || ! connected || siteRequireUpgrade || requireUpgrade
-									}
+									disabled={ ! userPrompt?.length || ! connected || requireUpgrade }
 									label={ __( 'Send request', 'jetpack' ) }
 								>
 									<Icon icon={ origamiPlane } />

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -88,6 +88,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		tracks,
 		userPrompt,
 		refreshFeatureData,
+		requireUpgrade,
 	} );
 
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -16,6 +16,7 @@ import { useEffect, useRef } from 'react';
  * Internal dependencies
  */
 import AIControl from './ai-control';
+import useAIFeature from './hooks/use-ai-feature';
 import ImageWithSelect from './image-with-select';
 import { getImagesFromOpenAI } from './lib';
 import useSuggestionsFromOpenAI from './use-suggestions-from-openai';
@@ -91,6 +92,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			setErrorDismissed( false );
 		}
 	}, [ errorData ] );
+
+	const { requireUpgrade } = useAIFeature();
 
 	const saveImage = async image => {
 		if ( loadingImages ) {
@@ -244,10 +247,11 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				wholeContent={ wholeContent }
 				promptType={ attributes.promptType }
 				onChange={ () => setErrorDismissed( true ) }
-				requireUpgrade={ errorData?.code === 'error_quota_exceeded' }
+				requireUpgrade={ errorData?.code === 'error_quota_exceeded' || requireUpgrade }
 				recordEvent={ tracks.recordEvent }
 				isGeneratingTitle={ attributes.promptType === 'generateTitle' }
 			/>
+
 			{ ! loadingImages && resultImages.length > 0 && (
 				<Flex direction="column" style={ { width: '100%' } }>
 					<FlexBlock

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -64,6 +64,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		}, 100 );
 	};
 
+	const { requireUpgrade, refresh: refreshFeatureData } = useAIFeature();
+
 	const {
 		isLoadingCategories,
 		isLoadingCompletion,
@@ -85,6 +87,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		setError,
 		tracks,
 		userPrompt,
+		refreshFeatureData,
 	} );
 
 	useEffect( () => {
@@ -92,8 +95,6 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			setErrorDismissed( false );
 		}
 	}, [ errorData ] );
-
-	const { requireUpgrade } = useAIFeature();
 
 	const saveImage = async image => {
 		if ( loadingImages ) {
@@ -274,6 +275,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 					</Flex>
 				</Flex>
 			) }
+
 			{ ! loadingImages && imageModal && (
 				<Modal onRequestClose={ () => setImageModal( null ) }>
 					<ImageWithSelect

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -35,12 +35,22 @@ export async function askJetpack( question ) {
 /**
  * Leaving this here to make it easier to debug the streaming API calls for now
  *
- * @param {string} question           - The query to send to the API
- * @param {object} options            - Options
- * @param {number} options.postId     - The post where this completion is being requested, if available
- * @param {boolean} options.fromCache - Get a cached response. False by default.
+ * @param {string} question                   - The query to send to the API
+ * @param {object} options                    - Options
+ * @param {number} options.postId             - The post where this completion is being requested, if available
+ * @param {boolean} options.fromCache         - Get a cached response. False by default.
+ * @param {boolean} options.requireUpgrade    - If the site requires an upgrade to use the feature
+ * @returns {Promise<SuggestionsEventSource>} The event source
  */
-export async function askQuestion( question, { postId = null, fromCache = false } ) {
+export async function askQuestion(
+	question,
+	{ postId = null, fromCache = false, requireUpgrade }
+) {
+	if ( requireUpgrade ) {
+		// Return an empty event source
+		return new SuggestionsEventSource( '' );
+	}
+
 	const { token } = await requestToken();
 
 	const url = new URL( 'https://public-api.wordpress.com/wpcom/v2/jetpack-ai-query' );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/get-suggestion-with-stream.js
@@ -35,11 +35,12 @@ export async function askJetpack( question ) {
 /**
  * Leaving this here to make it easier to debug the streaming API calls for now
  *
- * @param {string} question   - The query to send to the API
- * @param {number} postId     - The post where this completion is being requested, if available
- * @param {boolean} fromCache - Get a cached response. False by default.
+ * @param {string} question           - The query to send to the API
+ * @param {object} options            - Options
+ * @param {number} options.postId     - The post where this completion is being requested, if available
+ * @param {boolean} options.fromCache - Get a cached response. False by default.
  */
-export async function askQuestion( question, postId = null, fromCache = false ) {
+export async function askQuestion( question, { postId = null, fromCache = false } ) {
 	const { token } = await requestToken();
 
 	const url = new URL( 'https://public-api.wordpress.com/wpcom/v2/jetpack-ai-query' );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/Readme.md
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/Readme.md
@@ -4,7 +4,7 @@ React custom hook that provides valuable data about AI requests for the site.
 
 ```es6
 function UpgradePlan() {
-	const { hasFeature, count } = useAIFeature();
+	const { hasFeature, count, refresh } = useAIFeature();
 	if ( ! hasFeature ) {
 		return null;
 	}
@@ -13,6 +13,7 @@ function UpgradePlan() {
 		<div>
 			{ `You have made ${ count } requests so far.` }
 			<Button>Upgrade</Button>
+			<Button onClick={ refresh}>Refresh Data!</Button>
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -27,9 +27,8 @@ type AIFeatureProps = {
 const NUM_FREE_REQUESTS_LIMIT = 20;
 
 export const AI_Assistant_Initial_State = {
-	hasFeature: window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'has-feature' ] || true,
-	isOverLimit:
-		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-over-limit' ] || false,
+	hasFeature: !! window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'has-feature' ],
+	isOverLimit: !! window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-over-limit' ],
 	requestsCount:
 		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'requests-count' ] || 0,
 	requestsLimit:

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -68,5 +68,8 @@ export default function useAIFeature() {
 		getAIFeatures().then( setData );
 	}, [] );
 
-	return data;
+	return {
+		...data,
+		refresh: () => getAIFeatures().then( setData ),
+	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -26,18 +26,16 @@ type AIFeatureProps = {
 
 const NUM_FREE_REQUESTS_LIMIT = 20;
 
+const aiAssistantFeature = window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ];
+
 export const AI_Assistant_Initial_State = {
-	hasFeature: !! window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'has-feature' ],
-	isOverLimit: !! window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-over-limit' ],
-	requestsCount:
-		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'requests-count' ] || 0,
-	requestsLimit:
-		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'requests-limit' ] ||
-		NUM_FREE_REQUESTS_LIMIT,
-	requireUpgrade:
-		window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'site-require-upgrade' ] || false,
-	errorMessage: window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'error-message' ] || '',
-	errorCode: window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'error-code' ],
+	hasFeature: !! aiAssistantFeature?.[ 'has-feature' ],
+	isOverLimit: !! aiAssistantFeature?.[ 'is-over-limit' ],
+	requestsCount: aiAssistantFeature?.[ 'requests-count' ] || 0,
+	requestsLimit: aiAssistantFeature?.[ 'requests-limit' ] || NUM_FREE_REQUESTS_LIMIT,
+	requireUpgrade: !! aiAssistantFeature?.[ 'site-require-upgrade' ],
+	errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
+	errorCode: aiAssistantFeature?.[ 'error-code' ],
 };
 
 export async function getAIFeatures(): Promise< AIFeatureProps > {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -69,6 +69,7 @@ const useSuggestionsFromOpenAI = ( {
 	onSuggestionDone,
 	onUnclearPrompt,
 	onModeration,
+	refreshFeatureData,
 } ) => {
 	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
 	const [ isLoadingCompletion, setIsLoadingCompletion ] = useState( false );
@@ -211,6 +212,7 @@ const useSuggestionsFromOpenAI = ( {
 		source?.current?.addEventListener( 'done', e => {
 			stopSuggestion();
 			updateBlockAttributes( clientId, { content: e.detail } );
+			refreshFeatureData();
 		} );
 
 		source?.current?.addEventListener( 'error_unclear_prompt', () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -190,7 +190,7 @@ const useSuggestionsFromOpenAI = ( {
 		try {
 			setIsLoadingCompletion( true );
 			setWasCompletionJustRequested( true );
-			source.current = await askQuestion( prompt, postId );
+			source.current = await askQuestion( prompt, { postId } );
 		} catch ( err ) {
 			if ( err.message ) {
 				setError( { message: err.message, code: err?.code || 'unknown', status: 'error' } );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/use-suggestions-from-openai.js
@@ -70,6 +70,7 @@ const useSuggestionsFromOpenAI = ( {
 	onUnclearPrompt,
 	onModeration,
 	refreshFeatureData,
+	requireUpgrade,
 } ) => {
 	const [ isLoadingCategories, setIsLoadingCategories ] = useState( false );
 	const [ isLoadingCompletion, setIsLoadingCompletion ] = useState( false );
@@ -190,7 +191,7 @@ const useSuggestionsFromOpenAI = ( {
 		try {
 			setIsLoadingCompletion( true );
 			setWasCompletionJustRequested( true );
-			source.current = await askQuestion( prompt, { postId } );
+			source.current = await askQuestion( prompt, { postId, requireUpgrade } );
 		} catch ( err ) {
 			if ( err.message ) {
 				setError( { message: err.message, code: err?.code || 'unknown', status: 'error' } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR checks if the site requires an upgrade before hitting the query endpoint.
This PR makes evident that we need a better data handling, probably by using Redux or useContext() React hook.

Fixes https://github.com/Automattic/jetpack/issues/31198

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: block query requests when required upgrade

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create an AI Assistant block instance
* Perform a query request
* Confirm it works as expected
* Test with a site that requires an upgrade
* When you see the upgrade banner, request a new query, for instance, by using Tone or Translate.
* Confirm the query request never takes off
* Confirm you see the error

<img width="564" alt="Screenshot 2023-06-08 at 16 40 27" src="https://github.com/Automattic/jetpack/assets/77539/7d6de9b7-b351-444a-8c4c-1b00f84417ef">
<img width="693" alt="Screenshot 2023-06-08 at 16 40 02" src="https://github.com/Automattic/jetpack/assets/77539/b100053b-652d-4d83-a6d6-25824ab1e010">


