### PR TITLE
Launchpad: Adjust Logstash ref to fix fatal on WoA sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-fatal-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-fatal-launchpad
@@ -1,0 +1,4 @@
+Significance: major
+Type: fixed
+
+Fix fatal error for WoA sites due to absence of Logstash on that infrastructure.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "2.5.x-dev"
+			"dev-trunk": "3.0.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "2.5.0-alpha",
+	"version": "3.0.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '2.5.0-alpha';
+	const PACKAGE_VERSION = '3.0.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -256,6 +256,8 @@ function wpcom_mark_launchpad_task_complete( $task_id ) {
  * Initialize the Launchpad task listener callbacks.
  *
  * @param array $task_definitions The tasks to initialize.
+ *
+ * @return mixed void or WP_Error.
  */
 function wpcom_launchpad_init_listeners( $task_definitions ) {
 	foreach ( $task_definitions as $task_id => $task_definition ) {
@@ -265,7 +267,25 @@ function wpcom_launchpad_init_listeners( $task_definitions ) {
 			try {
 				call_user_func( $task_definition['add_listener_callback'], $task_data ); // Current callbacks expect the built, registered task for the second parameter, which won't work in this case.
 			} catch ( Exception $e ) {
-				// @todo: We can't use logstash on WoA sites, so figure out where/how to log this.
+				if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+					require_once WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+
+					$data = array(
+						'blog_id'     => get_current_blog_id(),
+						'task_id'     => $task_id,
+						'site_intent' => get_option( 'site_intent' ),
+					);
+
+					log2logstash(
+						array(
+							'feature' => 'launchpad',
+							'message' => 'Launchpad failed to add listener callback.',
+							'extra'   => wp_json_encode( $data ),
+						)
+					);
+				}
+
+				return new WP_Error( 'launchpad_add_listener_callback_failed', $e->getMessage() );
 			}
 		}
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -258,8 +258,6 @@ function wpcom_mark_launchpad_task_complete( $task_id ) {
  * @param array $task_definitions The tasks to initialize.
  */
 function wpcom_launchpad_init_listeners( $task_definitions ) {
-	require_once WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
-
 	foreach ( $task_definitions as $task_id => $task_definition ) {
 		if ( isset( $task_definition['add_listener_callback'] ) && is_callable( $task_definition['add_listener_callback'] ) ) {
 			$task_data = array_merge( $task_definition, array( 'id' => $task_id ) );
@@ -267,19 +265,7 @@ function wpcom_launchpad_init_listeners( $task_definitions ) {
 			try {
 				call_user_func( $task_definition['add_listener_callback'], $task_data ); // Current callbacks expect the built, registered task for the second parameter, which won't work in this case.
 			} catch ( Exception $e ) {
-				$data = array(
-					'blog_id'     => get_current_blog_id(),
-					'task_id'     => $task_id,
-					'site_intent' => get_option( 'site_intent' ),
-				);
-
-				log2logstash(
-					array(
-						'feature' => 'launchpad',
-						'message' => 'Launchpad failed to add listener callback.',
-						'extra'   => wp_json_encode( $data ),
-					)
-				);
+				// @todo: We can't use logstash on WoA sites, so figure out where/how to log this.
 			}
 		}
 	}

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-woa-fatal-launchpad
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-woa-fatal-launchpad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_3_1_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_4_0_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "21fbbe80d811d0595b1a51477938748debf791b6"
+                "reference": "7377c521b763e6bc065318a5a0194057e3236282"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "2.5.x-dev"
+                    "dev-trunk": "3.0.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.3.1-alpha
+ * Version: 1.4.0-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.3.1-alpha",
+	"version": "1.4.0-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31283

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Wrap references to Logstash in an `IS_WPCOM` check to prevent fatal errors on WoA sites, and return WP_Error if task initialization fails for any site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a WoA developer site if you don't have one already
* Use the Jetpack Beta Tester plugin to apply this patch to your WoA site
* Alternatively, apply this patch to the site via SSH/rsync or SFTP; you may need to check out this patch locally and overwrite the entire contents of the `/launchpad` directory, not just this patched file. You'll find the files in `/wpcomsh/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/`
* `tail -F /tmp/php-errors` on the WoA site
* Ensure you no longer see fatal errors like the following:

<img width="1156" alt="Screen Shot 2023-06-08 at 4 01 21 PM" src="https://github.com/Automattic/jetpack/assets/2124984/999fad18-3e62-45ee-9b34-30f4b334b314">


