### PR TITLE
AI Assistant: Move caret to end of generated content when accepting

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-accept-caret
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-accept-caret
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Move caret to end of generated content when accepting

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -144,6 +144,10 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 
 		newContentBlocks.forEach( block => {
 			const element = document.querySelector( `.wp-block[data-block="${ block.clientId }"]` );
+			if ( ! element ) {
+				return;
+			}
+
 			if ( element.contentEditable === 'true' ) {
 				lastEditableElement = element;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31236

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When accepting a content, gets the last editable element and moves the caret to its end

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add an AI Assistant block
* Generate some content
* Accept it
* Check that the keyboard caret is moved to the end of the content

Before

https://github.com/Automattic/jetpack/assets/8486249/44f5fc29-1d94-46e5-8314-212b52220433

After

https://github.com/Automattic/jetpack/assets/8486249/f49376ee-eb3a-4d67-b041-5aaaf44b703d
