### PR TITLE
CRM: Adding several new PHPCompatibility rules to support Automations code additions

### DIFF
--- a/projects/plugins/crm/.phpcs.dir.phpcompatibility.xml
+++ b/projects/plugins/crm/.phpcs.dir.phpcompatibility.xml
@@ -26,4 +26,10 @@
 	<rule ref="PHPCompatibility.Interfaces.NewInterfaces.throwableFound">
 		<severity>0</severity>
 	</rule>
+	<rule ref="PHPCompatibility.FunctionDeclarations.NewNullableTypes.returnTypeFound">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PHPCompatibility.Operators.NewOperators.t_coalesceFound">
+		<severity>0</severity>
+	</rule>
 </ruleset>

--- a/projects/plugins/crm/.phpcs.dir.phpcompatibility.xml
+++ b/projects/plugins/crm/.phpcs.dir.phpcompatibility.xml
@@ -29,6 +29,9 @@
 	<rule ref="PHPCompatibility.FunctionDeclarations.NewNullableTypes.returnTypeFound">
 		<severity>0</severity>
 	</rule>
+	<rule ref="PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.InvalidTypeHintFound">
+		<severity>0</severity>
+	</rule>
 	<rule ref="PHPCompatibility.Operators.NewOperators.t_coalesceFound">
 		<severity>0</severity>
 	</rule>

--- a/projects/plugins/crm/.phpcs.dir.xml
+++ b/projects/plugins/crm/.phpcs.dir.xml
@@ -57,6 +57,18 @@
 	<rule ref="PHPCompatibility.Interfaces.NewInterfaces.throwableFound">
 		<severity>0</severity>
 	</rule>
+	<rule ref="PHPCompatibility.FunctionDeclarations.NewNullableTypes.returnTypeFound">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.InvalidTypeHintFound">
+		<severity>0</severity>
+	</rule>
+	<rule ref="PHPCompatibility.Operators.NewOperators.t_coalesceFound">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Generic.Commenting.DocComment.MissingShort">
+		<severity>0</severity>
+	</rule>
 
 	<!-- Custom JPCRM escape function -->
 	<rule ref="WordPress.Security.EscapeOutput">

--- a/projects/plugins/crm/changelog/add-crm-phpcompatibility-rules-automation
+++ b/projects/plugins/crm/changelog/add-crm-phpcompatibility-rules-automation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+PHPCompatibility: Adding additional rules based on new PHP added in the Automations project.


### PR DESCRIPTION

## Proposed changes:

* In the main Automations branch - https://github.com/Automattic/jetpack/pull/30366 - several new usages of PHP operators / declarations / comments have been used. This was resulting in some failed PHPCompabitility linting checks for PHP 5.6 and 7. As [Jetpack CRM supports PHP 7.2 onwards,](https://kb.jetpackcrm.com/knowledge-base/php-version-jetpack-crm/) this PR adds a few rulesets to make sure the specific monorepo checks against older PHP versions are not included here.

More information on the rules added:

* `PHPCompatibility.Operators.NewOperators.t_coalesceFound` is in place as we use the t_coalesce operator (null coalescing operator) throughout, eg. `$this->next_step_true = $step_data['next_step_true'] ?? null;`
* `PHPCompatibility.FunctionDeclarations.NewNullableTypes.returnTypeFound` (
[reference](https://github.com/PHPCompatibility/PHPCompatibility/blob/develop/PHPCompatibility/Sniffs/FunctionDeclarations/NewNullableTypesSniff.php)) refers to a new feature available from PHP 7.1 - https://www.php.net/manual/en/migration71.new-features.php - refers to type declarations that can now be marked as nullable.
* `Generic.Commenting.DocComment.MissingShort` refers to short descriptions in doc blocks (eg. 	`/** @var array|null Next step data if it does not meet the condition */`)
* `PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.InvalidTypeHintFound` refers to default values for parameters with a class type hint that are not null (in our example a bool: `public static function instance( bool $force = false ): Automation_Logger {`)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read.
* Once this PR is merged, checks in the main Automations branch should then pass (Linting / PHP lint (5.6) and Linting / PHP lint (7.0) ): https://github.com/Automattic/jetpack/pull/30366

