### PR TITLE
Beta: fix PHP 8.1 deprecation warning for array manipulation

### DIFF
--- a/projects/plugins/beta/changelog/fix-deprecation-warning-beta
+++ b/projects/plugins/beta/changelog/fix-deprecation-warning-beta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid deprecation warning in PHP 8.1 when viewing Beta settings screen.

--- a/projects/plugins/beta/src/admin/plugin-manage.template.php
+++ b/projects/plugins/beta/src/admin/plugin-manage.template.php
@@ -194,9 +194,10 @@ if ( is_plugin_active( $plugin->plugin_file() ) ) {
 		</div>
 		<div id="section-pr">
 			<?php
-			end( $manifest->pr );
-			$last = key( $manifest->pr );
-			foreach ( $manifest->pr as $k => $pr ) {
+			$pr_list = (array) $manifest->pr;
+			end( $pr_list );
+			$last = key( $pr_list );
+			foreach ( $pr_list as $k => $pr ) {
 				$branch = $plugin->source_info( 'pr', $pr->branch );
 				if ( $branch && ! is_wp_error( $branch ) ) {
 					// Add spaces around the branch name for historical reasons.


### PR DESCRIPTION
## Proposed changes:

This should avoid warnings like this one on sites with PHP 8.1+:

```
PHP Deprecated:  key(): Calling key() on an object is deprecated
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* Primary issue: #23695

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On a site running PHP 8.1+, visit the Jetpack Beta admin pages.
* Ensure that you can still search for branches and switch to a new branch.
