### PR TITLE
AI Assistant: Mark post as AI-assisted

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-mark-post-as-ai-assisted
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-mark-post-as-ai-assisted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Mark posts as AI-assisted when a AI Assistant completion is requested, using a post meta field called _jetpack_ai_calls.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -29,6 +29,29 @@ function register_block() {
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
+ * Registers a _jetpack_ai_calls meta option
+ * for all post types that will be used to count
+ * how many times the post got assisted by AI
+ */
+function register_jetpack_ai_post_meta() {
+	register_post_meta(
+		'', // for all post types
+		'_jetpack_ai_calls',
+		array(
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'integer',
+			'default'       => 0,
+			'description'   => __( 'How many times the content got assisted by AI', 'jetpack' ),
+			'auth_callback' => function () {
+				return true;
+			},
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_jetpack_ai_post_meta' );
+
+/**
  * Jetpack AI Assistant block registration/dependency declaration.
  *
  * @param array  $attr    Array containing the Jetpack AI Assistant block attributes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31235.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Register the `_jetpack_ai_calls` post meta field so we can expose and change it from Gutenberg
* Change the block to update the `_jetpack_ai_calls` post meta field when a completion is requested
* The name of the option is the same as the original one, from #28487

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* On the browser console, run:

```
wp.data.select('core/editor').getEditedPostAttribute('meta');
```

* It returns the list of post meta fields exposed on the rest API; notice the `_jetpack_ai_calls` field:

<img width="499" alt="Screen Shot 2023-06-09 at 19 10 25" src="https://github.com/Automattic/jetpack/assets/6760046/fe512e5f-7285-49ec-8dd7-49b31d5a38e9">

* Add an AI Assistant block and execute some prompt (for example: "a haiku on the winter winds")
* Run the `getEditedPostAttribute` command again
* Notice that now the `_jetpack_ai_calls` got incremented
* Save the post changes and reload the window
* Run the `getEditedPostAttribute` command again
* Notice that the value for the `_jetpack_ai_calls` post meta field got saved
* If you are running your test site locally, you can spot the post meta field on the `wp_postmeta` table for the given post ID
* If you are testing this for a Simple site, on your sandbox you can run the following commando to inspect the database value for the post meta fields

```
wp --url=YOUR_SITE_URL post meta list YOUR_POST_ID
```

* Test on Jetpack sites and on Simple sites

Note: I didn't test this on p2 comments, so we may need to check this as well and maybe work around the comment box limitations.