### PR TITLE
Docker: Change MariaDB version to LTS

### DIFF
--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   ## We map a local directory (data/mysql) so we can have the mysql data locally
   ## and reuse it if we need to remove containers and images for rebuilding from scratch.
   db:
-    image: mariadb:latest
+    image: mariadb:lts
     volumes:
       - ./data/${COMPOSE_PROJECT_NAME}_mysql:/var/lib/mysql
       - ./logs/${COMPOSE_PROJECT_NAME}/mysql:/var/log/mysql


### PR DESCRIPTION
## Proposed changes:
I ran into an issue where running `jetpack docker up` failed to start MariaDB, because the `mysqld` binary was not available in the container image.

It seems like MariaDB decided to sunset the mysql/mysqld commands in favor of mariadbd/mariadb commands, but [didn't update the Docker image](https://github.com/MariaDB/mariadb-docker/issues/512) to reflect this.

This PR updates the version used from `latest` to `lts`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1686562119649609-slack-C0299DMPG

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Checkout this branch
2. Run `jetpack docker up`