### PR TITLE
Post Build Action: Update MariaDB version

### DIFF
--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -189,7 +189,7 @@ jobs:
     timeout-minutes: 15  # 2022-08-26: Successful runs seem to take about 6 minutes, but give some extra time for the downloads.
     services:
       db:
-        image: mariadb:latest
+        image: mariadb:lts
         env:
           MARIADB_ROOT_PASSWORD: wordpress
         ports:


### PR DESCRIPTION
Similar to #31315 we need to change the version in the post-build action to stop the 'Test plugin upgrades' check from failing.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the MariaDB version to LTS

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Check that the Test plugin upgrade check now passes?

