### PR TITLE
AI Assistant: add and use QuickEditsDropdown component

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-quick-edits-dropdown
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-quick-edits-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: add and use QuickEditsDropdown component

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quick-edits-dropdown/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quick-edits-dropdown/index.tsx
@@ -1,0 +1,110 @@
+/*
+ * External dependencies
+ */
+import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { pencil } from '@wordpress/icons';
+import React from 'react';
+
+export const QUICK_EDITS_KEY_MAKE_LONGER = 'make-longer' as const;
+const QUICK_EDITS_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;
+
+export const QUICK_EDITS_KEY_MAKE_SHORTER = 'make-shorter' as const;
+const QUICK_EDITS_SUGGESTION_MAKE_SHORTER = 'makeShorter' as const;
+
+export const QUICK_EDITS_KEY_SUMMARIZE = 'summarize' as const;
+const QUICK_EDITS_SUGGESTION_SUMMARIZE = 'summarize' as const;
+
+const QUICK_EDITS_KEY_LIST = [
+	QUICK_EDITS_KEY_SUMMARIZE,
+	QUICK_EDITS_KEY_MAKE_LONGER,
+	QUICK_EDITS_KEY_MAKE_SHORTER,
+] as const;
+
+const QUICK_EDITS_SUGGESTION_LIST = [
+	QUICK_EDITS_SUGGESTION_SUMMARIZE,
+	QUICK_EDITS_SUGGESTION_MAKE_LONGER,
+	QUICK_EDITS_SUGGESTION_MAKE_SHORTER,
+] as const;
+
+type QuickEditsKeyProp = ( typeof QUICK_EDITS_KEY_LIST )[ number ];
+type QuickEditsSuggestionProp = ( typeof QUICK_EDITS_SUGGESTION_LIST )[ number ];
+
+const quickActionsList = [
+	{
+		name: __( 'Summarize', 'jetpack' ),
+		key: QUICK_EDITS_KEY_SUMMARIZE,
+		aiSuggestion: QUICK_EDITS_SUGGESTION_SUMMARIZE,
+	},
+	{
+		name: __( 'Make longer', 'jetpack' ),
+		key: QUICK_EDITS_KEY_MAKE_LONGER,
+		aiSuggestion: QUICK_EDITS_SUGGESTION_MAKE_LONGER,
+	},
+	{
+		name: __( 'Make shorter', 'jetpack' ),
+		key: QUICK_EDITS_KEY_MAKE_SHORTER,
+		aiSuggestion: QUICK_EDITS_SUGGESTION_MAKE_SHORTER,
+	},
+];
+
+type QuickEditsDropdownProps = {
+	/*
+	 * Can be used to externally control the value of the control. Optional.
+	 */
+	key?: QuickEditsKeyProp;
+
+	/*
+	 * The label to use for the dropdown. Optional.
+	 */
+	label: string;
+
+	/*
+	 * A list of quick edits to exclude from the dropdown.
+	 */
+	exclude: QuickEditsKeyProp[];
+
+	onChange: ( item: QuickEditsSuggestionProp, options: { contentType: string } ) => void;
+};
+
+export default function QuickEditsDropdown( {
+	key,
+	label,
+	exclude,
+	onChange,
+}: QuickEditsDropdownProps ) {
+	return (
+		<ToolbarDropdownMenu
+			icon={ pencil }
+			label={ label || __( 'Quick edits', 'jetpack' ) }
+			popoverProps={ {
+				variant: 'toolbar',
+			} }
+		>
+			{ () => {
+				// Exclude quick edits from the list.
+				const quickActionsListFiltered = quickActionsList.filter(
+					quickAction => ! exclude.includes( quickAction.key )
+				);
+
+				return (
+					<MenuGroup label={ __( 'Quick edits', 'jetpack' ) }>
+						{ quickActionsListFiltered.map( quickAction => {
+							return (
+								<MenuItem
+									key={ `key-${ quickAction.key }` }
+									onClick={ () =>
+										onChange( quickAction.aiSuggestion, { contentType: 'generated' } )
+									}
+									isSelected={ key === quickAction.key }
+								>
+									{ quickAction.name }
+								</MenuItem>
+							);
+						} ) }
+					</MenuGroup>
+				);
+			} }
+		</ToolbarDropdownMenu>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
@@ -2,14 +2,15 @@
  * External dependencies
  */
 import { BlockControls } from '@wordpress/block-editor';
-import { ToolbarButton, ToolbarDropdownMenu, ToolbarGroup } from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { image, pencil, update, check } from '@wordpress/icons';
+import { image, update, check } from '@wordpress/icons';
 /*
  * Internal dependencies
  */
 import I18nDropdownControl from '../i18n-dropdown-control';
 import PromptTemplatesControl from '../prompt-templates-control';
+import QuickEditsDropdown from '../quick-edits-dropdown';
 import ToneDropdownControl from '../tone-dropdown-control';
 
 // Consider to enable when we have image support
@@ -30,25 +31,6 @@ const ToolbarControls = ( {
 	recordEvent,
 	isGeneratingTitle,
 } ) => {
-	const dropdownControls = [
-		// Interactive controls
-		{
-			title: __( 'Make longer', 'jetpack' ),
-			onClick: () => getSuggestionFromOpenAI( 'makeLonger', { contentType: 'generated' } ),
-		},
-		{
-			title: __( 'Make shorter', 'jetpack' ),
-			onClick: () => getSuggestionFromOpenAI( 'makeShorter', { contentType: 'generated' } ),
-		},
-	];
-
-	if ( ! isGeneratingTitle ) {
-		dropdownControls.unshift( {
-			title: __( 'Summarize', 'jetpack' ),
-			onClick: () => getSuggestionFromOpenAI( 'summarize', { contentType: 'generated' } ),
-		} );
-	}
-
 	return (
 		<>
 			{ contentIsLoaded && (
@@ -69,10 +51,10 @@ const ToolbarControls = ( {
 						disabled={ contentIsLoaded }
 					/>
 
-					<ToolbarDropdownMenu
-						icon={ pencil }
-						label={ __( 'Improve', 'jetpack' ) }
-						controls={ dropdownControls }
+					<QuickEditsDropdown
+						onChange={ getSuggestionFromOpenAI }
+						label={ __( 'Improvements', 'jetpack' ) }
+						exclude={ isGeneratingTitle ? [ 'summarize' ] : [] }
 					/>
 				</BlockControls>
 			) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds and uses the QuickEditsDropdown component.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: add and use QuickEditsDropdown component

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create and use the AI Assistant block
* Confirm the Quick Edits dropdown works as expected
  * `Make longer`, `Make shorter`,  `Summarize`
  * Confirm when it's editing the post title, the `Summarize` option is not listed

<img width="678" alt="Screenshot 2023-06-12 at 19 13 21" src="https://github.com/Automattic/jetpack/assets/77539/1926b6f0-2677-477a-90a2-f1c944086c1c">
