### PR TITLE
AI Assistant: extend blocks toolbar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-quick-edits-controls
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-quick-edits-controls
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI Assistant: extened blocks toolbar
+AI Assistant: extend blocks toolbar

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-quick-edits-controls
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-quick-edits-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: extened blocks toolbar

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -110,10 +110,15 @@ export default function AiAssistantDropdown( {
 				variant: 'toolbar',
 			} }
 		>
-			{ () => (
-				<>
-					<QuickEditsMenuGroup key={ key } exclude={ exclude } onChange={ onChange } />
-				</>
+			{ ( { onClose: closeDropdown } ) => (
+				<QuickEditsMenuGroup
+					key={ key }
+					exclude={ exclude }
+					onChange={ args => {
+						closeDropdown();
+						onChange( args );
+					} }
+				/>
 			) }
 		</ToolbarDropdownMenu>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -15,12 +15,20 @@ import React from 'react';
 import AIAssistantIcon from '../../icons/ai-assistant';
 import './style.scss';
 
-export const QUICK_EDIT_KEY_SUMMARIZE = 'correct-spelling' as const;
-const QUICK_EDIT_SUGGESTION_SUMMARIZE = 'correctSpelling' as const;
+// Quick edits option: "Correct spelling and grammar"
+const QUICK_EDIT_KEY_CORRECT_SPELLING = 'correct-spelling' as const;
+const QUICK_EDIT_SUGGESTION_CORRECT_SPELLING = 'correctSpelling' as const;
 
-const QUICK_EDIT_KEY_LIST = [ QUICK_EDIT_KEY_SUMMARIZE ] as const;
+// Quick edits option: "Simplify"
+const QUICK_EDIT_KEY_SIMPLIFY = 'simplify' as const;
+const QUICK_EDIT_SUGGESTION_SIMPLIFY = 'simplify' as const;
 
-const QUICK_EDIT_SUGGESTION_LIST = [ QUICK_EDIT_SUGGESTION_SUMMARIZE ] as const;
+const QUICK_EDIT_KEY_LIST = [ QUICK_EDIT_KEY_CORRECT_SPELLING, QUICK_EDIT_KEY_SIMPLIFY ] as const;
+
+const QUICK_EDIT_SUGGESTION_LIST = [
+	QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
+	QUICK_EDIT_SUGGESTION_SIMPLIFY,
+] as const;
 
 type QuickEditsKeyProp = ( typeof QUICK_EDIT_KEY_LIST )[ number ];
 type QuickEditsSuggestionProp = ( typeof QUICK_EDIT_SUGGESTION_LIST )[ number ];
@@ -28,8 +36,13 @@ type QuickEditsSuggestionProp = ( typeof QUICK_EDIT_SUGGESTION_LIST )[ number ];
 const quickActionsList = [
 	{
 		name: __( 'Correct spelling and grammar', 'jetpack' ),
-		key: QUICK_EDIT_KEY_SUMMARIZE,
-		aiSuggestion: QUICK_EDIT_SUGGESTION_SUMMARIZE,
+		key: QUICK_EDIT_KEY_CORRECT_SPELLING,
+		aiSuggestion: QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
+	},
+	{
+		name: __( 'Simplify', 'jetpack' ),
+		key: QUICK_EDIT_KEY_SIMPLIFY,
+		aiSuggestion: QUICK_EDIT_SUGGESTION_SIMPLIFY,
 	},
 ];
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -8,8 +8,12 @@ import {
 	CustomSelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { pencil } from '@wordpress/icons';
 import React from 'react';
+/**
+ * Internal dependencies
+ */
+import AIAssistantIcon from '../../icons/ai-assistant';
+import './style.scss';
 
 export const QUICK_EDIT_KEY_SUMMARIZE = 'correct-spelling' as const;
 const QUICK_EDIT_SUGGESTION_SUMMARIZE = 'correctSpelling' as const;
@@ -29,7 +33,7 @@ const quickActionsList = [
 	},
 ];
 
-type QuickEditsDropdownProps = {
+type AiAssistantControlComponentProps = {
 	/*
 	 * Can be used to externally control the value of the control. Optional.
 	 */
@@ -48,44 +52,51 @@ type QuickEditsDropdownProps = {
 	onChange: ( item: QuickEditsSuggestionProp, options?: { contentType: string } ) => void;
 };
 
-export default function QuickEditsDropdown( {
+const QuickEditsMenuGroup = ( {
+	key,
+	exclude,
+	label,
+	onChange,
+}: AiAssistantControlComponentProps ) => {
+	// Exclude quick edits from the list.
+	const quickActionsListFiltered = quickActionsList.filter(
+		quickAction => ! exclude.includes( quickAction.key )
+	);
+
+	return (
+		<MenuGroup label={ label }>
+			{ quickActionsListFiltered.map( quickAction => (
+				<MenuItem
+					key={ `key-${ quickAction.key }` }
+					onClick={ () => onChange( quickAction.aiSuggestion, { contentType: 'generated' } ) }
+					isSelected={ key === quickAction.key }
+				>
+					<div className="jetpack-ai-assistant__menu-item">{ quickAction.name }</div>
+				</MenuItem>
+			) ) }
+		</MenuGroup>
+	);
+};
+
+export default function AiAssistantDropdown( {
 	key,
 	label,
 	exclude = [],
 	onChange,
-}: QuickEditsDropdownProps ) {
+}: AiAssistantControlComponentProps ) {
 	return (
 		<ToolbarDropdownMenu
-			icon={ pencil }
-			label={ label || __( 'Quick edits', 'jetpack' ) }
+			icon={ AIAssistantIcon }
+			label={ label || __( 'AI Assistant', 'jetpack' ) }
 			popoverProps={ {
 				variant: 'toolbar',
 			} }
 		>
-			{ () => {
-				// Exclude quick edits from the list.
-				const quickActionsListFiltered = quickActionsList.filter(
-					quickAction => ! exclude.includes( quickAction.key )
-				);
-
-				return (
-					<MenuGroup>
-						{ quickActionsListFiltered.map( quickAction => {
-							return (
-								<MenuItem
-									key={ `key-${ quickAction.key }` }
-									onClick={ () =>
-										onChange( quickAction.aiSuggestion, { contentType: 'generated' } )
-									}
-									isSelected={ key === quickAction.key }
-								>
-									{ quickAction.name }
-								</MenuItem>
-							);
-						} ) }
-					</MenuGroup>
-				);
-			} }
+			{ () => (
+				<>
+					<QuickEditsMenuGroup key={ key } exclude={ exclude } onChange={ onChange } />
+				</>
+			) }
 		</ToolbarDropdownMenu>
 	);
 }
@@ -95,7 +106,7 @@ export function QuickEditsSelectControl( {
 	label,
 	exclude = [],
 	onChange,
-}: QuickEditsDropdownProps ) {
+}: AiAssistantControlComponentProps ) {
 	// Initial value. If not found, use empty.
 	const value = quickActionsList.find( quickAction => quickAction.key === key ) || '';
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -8,6 +8,7 @@ import {
 	CustomSelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { post, termDescription } from '@wordpress/icons';
 import React from 'react';
 /**
  * Internal dependencies
@@ -38,11 +39,13 @@ const quickActionsList = [
 		name: __( 'Correct spelling and grammar', 'jetpack' ),
 		key: QUICK_EDIT_KEY_CORRECT_SPELLING,
 		aiSuggestion: QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
+		icon: termDescription,
 	},
 	{
 		name: __( 'Simplify', 'jetpack' ),
 		key: QUICK_EDIT_KEY_SIMPLIFY,
 		aiSuggestion: QUICK_EDIT_SUGGESTION_SIMPLIFY,
+		icon: post,
 	},
 ];
 
@@ -80,6 +83,8 @@ const QuickEditsMenuGroup = ( {
 		<MenuGroup label={ label }>
 			{ quickActionsListFiltered.map( quickAction => (
 				<MenuItem
+					icon={ quickAction?.icon }
+					iconPosition="left"
 					key={ `key-${ quickAction.key }` }
 					onClick={ () => onChange( quickAction.aiSuggestion, { contentType: 'generated' } ) }
 					isSelected={ key === quickAction.key }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/style.scss
@@ -1,0 +1,3 @@
+.jetpack-ai-assistant__menu-item {
+	flex-grow: 2;
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quick-edits-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quick-edits-controls/index.tsx
@@ -1,7 +1,12 @@
 /*
  * External dependencies
  */
-import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components';
+import {
+	MenuItem,
+	MenuGroup,
+	ToolbarDropdownMenu,
+	CustomSelectControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
 import React from 'react';
@@ -33,14 +38,14 @@ type QuickEditsDropdownProps = {
 	/*
 	 * The label to use for the dropdown. Optional.
 	 */
-	label: string;
+	label?: string;
 
 	/*
 	 * A list of quick edits to exclude from the dropdown.
 	 */
-	exclude: QuickEditsKeyProp[];
+	exclude?: QuickEditsKeyProp[];
 
-	onChange: ( item: QuickEditsSuggestionProp, options: { contentType: string } ) => void;
+	onChange: ( item: QuickEditsSuggestionProp, options?: { contentType: string } ) => void;
 };
 
 export default function QuickEditsDropdown( {
@@ -82,5 +87,29 @@ export default function QuickEditsDropdown( {
 				);
 			} }
 		</ToolbarDropdownMenu>
+	);
+}
+
+export function QuickEditsSelectControl( {
+	key,
+	label,
+	exclude = [],
+	onChange,
+}: QuickEditsDropdownProps ) {
+	// Initial value. If not found, use empty.
+	const value = quickActionsList.find( quickAction => quickAction.key === key ) || '';
+
+	// Exclude when required.
+	const quickActionsListFiltered = exclude.length
+		? quickActionsList.filter( quickAction => ! exclude.includes( quickAction.key ) )
+		: quickActionsList;
+
+	return (
+		<CustomSelectControl
+			label={ label }
+			value={ value }
+			options={ quickActionsListFiltered }
+			onChange={ ( { selectedItem } ) => onChange( selectedItem ) }
+		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quick-edits-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quick-edits-controls/index.tsx
@@ -1,0 +1,86 @@
+/*
+ * External dependencies
+ */
+import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { pencil } from '@wordpress/icons';
+import React from 'react';
+
+export const QUICK_EDIT_KEY_SUMMARIZE = 'correct-spelling' as const;
+const QUICK_EDIT_SUGGESTION_SUMMARIZE = 'correctSpelling' as const;
+
+const QUICK_EDIT_KEY_LIST = [ QUICK_EDIT_KEY_SUMMARIZE ] as const;
+
+const QUICK_EDIT_SUGGESTION_LIST = [ QUICK_EDIT_SUGGESTION_SUMMARIZE ] as const;
+
+type QuickEditsKeyProp = ( typeof QUICK_EDIT_KEY_LIST )[ number ];
+type QuickEditsSuggestionProp = ( typeof QUICK_EDIT_SUGGESTION_LIST )[ number ];
+
+const quickActionsList = [
+	{
+		name: __( 'Correct spelling and grammar', 'jetpack' ),
+		key: QUICK_EDIT_KEY_SUMMARIZE,
+		aiSuggestion: QUICK_EDIT_SUGGESTION_SUMMARIZE,
+	},
+];
+
+type QuickEditsDropdownProps = {
+	/*
+	 * Can be used to externally control the value of the control. Optional.
+	 */
+	key?: QuickEditsKeyProp;
+
+	/*
+	 * The label to use for the dropdown. Optional.
+	 */
+	label: string;
+
+	/*
+	 * A list of quick edits to exclude from the dropdown.
+	 */
+	exclude: QuickEditsKeyProp[];
+
+	onChange: ( item: QuickEditsSuggestionProp, options: { contentType: string } ) => void;
+};
+
+export default function QuickEditsDropdown( {
+	key,
+	label,
+	exclude = [],
+	onChange,
+}: QuickEditsDropdownProps ) {
+	return (
+		<ToolbarDropdownMenu
+			icon={ pencil }
+			label={ label || __( 'Quick edits', 'jetpack' ) }
+			popoverProps={ {
+				variant: 'toolbar',
+			} }
+		>
+			{ () => {
+				// Exclude quick edits from the list.
+				const quickActionsListFiltered = quickActionsList.filter(
+					quickAction => ! exclude.includes( quickAction.key )
+				);
+
+				return (
+					<MenuGroup>
+						{ quickActionsListFiltered.map( quickAction => {
+							return (
+								<MenuItem
+									key={ `key-${ quickAction.key }` }
+									onClick={ () =>
+										onChange( quickAction.aiSuggestion, { contentType: 'generated' } )
+									}
+									isSelected={ key === quickAction.key }
+								>
+									{ quickAction.name }
+								</MenuItem>
+							);
+						} ) }
+					</MenuGroup>
+				);
+			} }
+		</ToolbarDropdownMenu>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -94,4 +94,4 @@ function addJetpackAISupport( settings: BlockSettingsProps, name: string ): Bloc
 }
 
 // Extend BlockType.
-addFilter( 'blocks.registerBlockType', 'jetpack/ai-assistant-support', addJetpackAISupport );
+addFilter( 'blocks.registerBlockType', 'jetpack/ai-assistant-support', addJetpackAISupport, 100 );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import React from 'react';
 /**
  * Internal dependencies
  */
+import AiAssistantDropdown from '../../components/ai-assistant-controls';
 import AiAssistantPanel from '../../components/ai-assistant-panel';
 
 /*
@@ -22,6 +23,14 @@ export const withAIAssistant = createHigherOrderComponent(
 				<InspectorControls>
 					<AiAssistantPanel />
 				</InspectorControls>
+
+				<BlockControls group="block">
+					<AiAssistantDropdown
+						onChange={ item => {
+							console.log( { item } ); // eslint-disable-line no-console
+						} }
+					/>
+				</BlockControls>
 			</>
 		);
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/31324
Fixes https://github.com/Automattic/jetpack/issues/31323
Fixes https://github.com/Automattic/jetpack/issues/31321

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: extend blocks toolbar

### Other information:

- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a paragraph and heading block
* Select the block
* Confirm you see the AI Assistant dropdown in the block toolbar 

Heading (h4) | Paragraph
-------|-------|
<img width="629" alt="Screenshot 2023-06-13 at 11 28 11" src="https://github.com/Automattic/jetpack/assets/77539/2a76e4de-bdc2-47a5-92fc-b2b3ccd535b4"> | <img width="687" alt="Screenshot 2023-06-13 at 11 28 35" src="https://github.com/Automattic/jetpack/assets/77539/040e17ce-5863-492b-a8a9-cd897855f1bf">

* Confirm it shows a log line in the dev console when clicking on the items

<img width="220" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/c19a21c7-6944-4810-bf29-6f894369adec">



