### PR TITLE
Instant Search: Add a style-able class to the wrapper divs for the filter options

### DIFF
--- a/projects/packages/search/src/instant-search/components/search-filter.jsx
+++ b/projects/packages/search/src/instant-search/components/search-filter.jsx
@@ -69,7 +69,7 @@ class SearchFilter extends Component {
 	renderDate = ( { key_as_string: key, doc_count: count } ) => {
 		const { locale = 'en-US' } = this.props;
 		return (
-			<div>
+			<div className={ `jetpack-instant-search__search-filter__dates-${ key }` }>
 				<input
 					checked={ this.isChecked( key ) }
 					disabled={ ! this.isChecked( key ) && count === 0 }
@@ -96,7 +96,7 @@ class SearchFilter extends Component {
 	renderPostType = ( { key, doc_count: count } ) => {
 		const name = key in this.props.postTypes ? this.props.postTypes[ key ].singular_name : key;
 		return (
-			<div>
+			<div className={ `jetpack-instant-search__search-filter__post-types-${ key }` }>
 				<input
 					checked={ this.isChecked( key ) }
 					disabled={ ! this.isChecked( key ) && count === 0 }
@@ -120,7 +120,7 @@ class SearchFilter extends Component {
 		const [ slug, name ] = key && key.split( /\/(.+)/ );
 
 		return (
-			<div>
+			<div className={ `jetpack-instant-search__search-filter__authors-${ slug }` }>
 				<input
 					checked={ this.isChecked( slug ) }
 					disabled={ ! this.isChecked( slug ) && count === 0 }
@@ -147,7 +147,7 @@ class SearchFilter extends Component {
 		const name = this.props.blogIdFilteringLabels?.[ key ] || strKey;
 
 		return (
-			<div>
+			<div className={ `jetpack-instant-search__search-filter__blog-ids-${ strKey }` }>
 				<input
 					checked={ this.isChecked( strKey ) }
 					disabled={ ! this.isChecked( strKey ) && count === 0 }
@@ -172,7 +172,7 @@ class SearchFilter extends Component {
 		const [ slug, name ] = key && key.split( /\/(.+)/ );
 
 		return (
-			<div>
+			<div className={ `jetpack-instant-search__search-filter__taxonomies-${ slug }` }>
 				<input
 					checked={ this.isChecked( slug ) }
 					disabled={ ! this.isChecked( slug ) && count === 0 }


### PR DESCRIPTION
This can allow sites to hide filters if desired, or to make them bold, or change the color of a specific category or post type that they wish to emphasize or the like.

I didn't add anything to line 198 as I wasn't quite certain how that was used or what "groups" it renders, so I didn't want to tempt fate and mess with it, but a similar logic could likely extend to add a differentiating class there based on `group.value`

There's nothing visible that this should change or be testable, apart from some classes rendering in the markup for sites to be able to style based off of.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add classes to the individual divs of each filter on Instant Search.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Discussed the impetus for this in Slack with @robfelty, threw this together as a proof of concept of what I was hoping for.
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
Nope
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the inspector to ensure that the generated markup includes classes on the wrapper divs in the sidebar for Filtering the search results.

