### PR TITLE
AI Assistant: add tone into AI Assistant dropdown menu

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-change-tone-option
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-change-tone-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: add tone into AI Assistant dropdown menu

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -15,6 +15,7 @@ import React from 'react';
  */
 import AIAssistantIcon from '../../icons/ai-assistant';
 import './style.scss';
+import { ToneDropdownControl, ToneProp } from '../tone-dropdown-control';
 
 // Quick edits option: "Correct spelling and grammar"
 const QUICK_EDIT_KEY_CORRECT_SPELLING = 'correct-spelling' as const;
@@ -32,7 +33,7 @@ const QUICK_EDIT_SUGGESTION_LIST = [
 ] as const;
 
 type QuickEditsKeyProp = ( typeof QUICK_EDIT_KEY_LIST )[ number ];
-type QuickEditsSuggestionProp = ( typeof QUICK_EDIT_SUGGESTION_LIST )[ number ];
+type QuickEditsSuggestionProp = ( typeof QUICK_EDIT_SUGGESTION_LIST )[ number ] | 'changeTone';
 
 const quickActionsList = [
 	{
@@ -49,11 +50,16 @@ const quickActionsList = [
 	},
 ];
 
+type AiAssistantDropdownOnChangeOptionsArgProps = {
+	contentType: 'generated' | string;
+	tone?: ToneProp;
+};
+
 type AiAssistantControlComponentProps = {
 	/*
 	 * Can be used to externally control the value of the control. Optional.
 	 */
-	key?: QuickEditsKeyProp;
+	key?: QuickEditsKeyProp | string;
 
 	/*
 	 * The label to use for the dropdown. Optional.
@@ -65,35 +71,10 @@ type AiAssistantControlComponentProps = {
 	 */
 	exclude?: QuickEditsKeyProp[];
 
-	onChange: ( item: QuickEditsSuggestionProp, options?: { contentType: string } ) => void;
-};
-
-const QuickEditsMenuGroup = ( {
-	key,
-	exclude,
-	label,
-	onChange,
-}: AiAssistantControlComponentProps ) => {
-	// Exclude quick edits from the list.
-	const quickActionsListFiltered = quickActionsList.filter(
-		quickAction => ! exclude.includes( quickAction.key )
-	);
-
-	return (
-		<MenuGroup label={ label }>
-			{ quickActionsListFiltered.map( quickAction => (
-				<MenuItem
-					icon={ quickAction?.icon }
-					iconPosition="left"
-					key={ `key-${ quickAction.key }` }
-					onClick={ () => onChange( quickAction.aiSuggestion, { contentType: 'generated' } ) }
-					isSelected={ key === quickAction.key }
-				>
-					<div className="jetpack-ai-assistant__menu-item">{ quickAction.name }</div>
-				</MenuItem>
-			) ) }
-		</MenuGroup>
-	);
+	onChange: (
+		item: QuickEditsSuggestionProp,
+		options?: AiAssistantDropdownOnChangeOptionsArgProps
+	) => void;
 };
 
 export default function AiAssistantDropdown( {
@@ -102,6 +83,10 @@ export default function AiAssistantDropdown( {
 	exclude = [],
 	onChange,
 }: AiAssistantControlComponentProps ) {
+	const quickActionsListFiltered = quickActionsList.filter(
+		quickAction => ! exclude.includes( quickAction.key )
+	);
+
 	return (
 		<ToolbarDropdownMenu
 			icon={ AIAssistantIcon }
@@ -111,14 +96,29 @@ export default function AiAssistantDropdown( {
 			} }
 		>
 			{ ( { onClose: closeDropdown } ) => (
-				<QuickEditsMenuGroup
-					key={ key }
-					exclude={ exclude }
-					onChange={ args => {
-						closeDropdown();
-						onChange( args );
-					} }
-				/>
+				<MenuGroup label={ label }>
+					{ quickActionsListFiltered.map( quickAction => (
+						<MenuItem
+							icon={ quickAction?.icon }
+							iconPosition="left"
+							key={ `key-${ quickAction.key }` }
+							onClick={ () => {
+								onChange( quickAction.aiSuggestion, { contentType: 'generated' } );
+								closeDropdown();
+							} }
+							isSelected={ key === quickAction.key }
+						>
+							<div className="jetpack-ai-assistant__menu-item">{ quickAction.name }</div>
+						</MenuItem>
+					) ) }
+
+					<ToneDropdownControl
+						onChange={ tone => {
+							onChange( 'changeTone', { tone, contentType: 'generated' } );
+							closeDropdown();
+						} }
+					/>
+				</MenuGroup>
 			) }
 		</ToolbarDropdownMenu>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -15,7 +15,7 @@ import React from 'react';
  */
 import AIAssistantIcon from '../../icons/ai-assistant';
 import './style.scss';
-import { ToneDropdownControl, ToneProp } from '../tone-dropdown-control';
+import { ToneDropdownMenu, ToneProp } from '../tone-dropdown-control';
 
 // Quick edits option: "Correct spelling and grammar"
 const QUICK_EDIT_KEY_CORRECT_SPELLING = 'correct-spelling' as const;
@@ -112,7 +112,7 @@ export default function AiAssistantDropdown( {
 						</MenuItem>
 					) ) }
 
-					<ToneDropdownControl
+					<ToneDropdownMenu
 						onChange={ tone => {
 							onChange( 'changeTone', { tone, contentType: 'generated' } );
 							closeDropdown();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -128,7 +128,7 @@ export const PROMPT_TONES_MAP = {
 export type ToneProp = ( typeof PROMPT_TONES_LIST )[ number ];
 
 type ToneDropdownMenuControlProps = {
-	value: ToneProp;
+	value?: ToneProp;
 	onChange: ( value: ToneProp ) => void;
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -129,7 +129,7 @@ export type ToneProp = ( typeof PROMPT_TONES_LIST )[ number ];
 
 type ToneDropdownMenuControlProps = {
 	value: ToneProp;
-	onChange: ( value: string ) => void;
+	onChange: ( value: ToneProp ) => void;
 };
 
 const ToneMenuGroup = ( { value, onChange }: ToneDropdownMenuControlProps ) => (

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -9,12 +9,13 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { chevronDown } from '@wordpress/icons';
+import { chevronRight } from '@wordpress/icons';
 import React from 'react';
 /**
  * Internal dependencies
  */
 import speakToneIcon from '../../icons/speak-tone';
+import './style.scss';
 
 const PROMPT_TONES_LIST = [
 	'formal',
@@ -155,14 +156,17 @@ export function ToneDropdownControl( {
 		<DropdownMenu
 			icon={ speakToneIcon }
 			label={ __( 'Change tone', 'jetpack' ) }
+			className="ai-assistant__tone-dropdown"
 			popoverProps={ {
 				variant: 'toolbar',
 			} }
 			toggleProps={ {
 				children: (
 					<>
-						<div>{ __( 'Change tone', 'jetpack' ) }</div>
-						<Icon icon={ chevronDown } />
+						<div className="ai-assistant__tone-dropdown__toggle-label">
+							{ __( 'Change tone', 'jetpack' ) }
+						</div>
+						<Icon icon={ chevronRight } />
 					</>
 				),
 			} }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -1,8 +1,15 @@
 /*
  * External dependencies
  */
-import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components';
+import {
+	MenuItem,
+	MenuGroup,
+	ToolbarDropdownMenu,
+	DropdownMenu,
+	Icon,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { chevronDown } from '@wordpress/icons';
 import React from 'react';
 /**
  * Internal dependencies
@@ -139,6 +146,31 @@ const ToneMenuGroup = ( { value, onChange }: ToneDropdownMenuControlProps ) => (
 		} ) }
 	</MenuGroup>
 );
+
+export function ToneDropdownControl( {
+	value = DEFAULT_PROMPT_TONE,
+	onChange,
+}: ToneDropdownMenuControlProps ) {
+	return (
+		<DropdownMenu
+			icon={ speakToneIcon }
+			label={ __( 'Change tone', 'jetpack' ) }
+			popoverProps={ {
+				variant: 'toolbar',
+			} }
+			toggleProps={ {
+				children: (
+					<>
+						<div>{ __( 'Change tone', 'jetpack' ) }</div>
+						<Icon icon={ chevronDown } />
+					</>
+				),
+			} }
+		>
+			{ () => <ToneMenuGroup value={ value } onChange={ onChange } /> }
+		</DropdownMenu>
+	);
+}
 
 export default function ToneDropdownMenuControl( {
 	value = DEFAULT_PROMPT_TONE,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -127,12 +127,12 @@ export const PROMPT_TONES_MAP = {
 
 export type ToneProp = ( typeof PROMPT_TONES_LIST )[ number ];
 
-type ToneDropdownMenuControlProps = {
+type ToneToolbarDropdownMenuProps = {
 	value?: ToneProp;
 	onChange: ( value: ToneProp ) => void;
 };
 
-const ToneMenuGroup = ( { value, onChange }: ToneDropdownMenuControlProps ) => (
+const ToneMenuGroup = ( { value, onChange }: ToneToolbarDropdownMenuProps ) => (
 	<MenuGroup label={ __( 'Select tone', 'jetpack' ) }>
 		{ PROMPT_TONES_LIST.map( tone => {
 			return (
@@ -148,10 +148,10 @@ const ToneMenuGroup = ( { value, onChange }: ToneDropdownMenuControlProps ) => (
 	</MenuGroup>
 );
 
-export function ToneDropdownControl( {
+export function ToneDropdownMenu( {
 	value = DEFAULT_PROMPT_TONE,
 	onChange,
-}: ToneDropdownMenuControlProps ) {
+}: ToneToolbarDropdownMenuProps ) {
 	return (
 		<DropdownMenu
 			icon={ speakToneIcon }
@@ -176,10 +176,10 @@ export function ToneDropdownControl( {
 	);
 }
 
-export default function ToneDropdownMenuControl( {
+export default function ToneToolbarDropdownMenu( {
 	value = DEFAULT_PROMPT_TONE,
 	onChange,
-}: ToneDropdownMenuControlProps ) {
+}: ToneToolbarDropdownMenuProps ) {
 	return (
 		<ToolbarDropdownMenu
 			icon={ speakToneIcon }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -119,15 +119,15 @@ export const PROMPT_TONES_MAP = {
 
 export type ToneProp = ( typeof PROMPT_TONES_LIST )[ number ];
 
-type ToneDropdownControlProps = {
+type ToneDropdownMenuControlProps = {
 	value: ToneProp;
 	onChange: ( value: string ) => void;
 };
 
-export default function ToneDropdownControl( {
+export default function ToneDropdownMenuControl( {
 	value = DEFAULT_PROMPT_TONE,
 	onChange,
-}: ToneDropdownControlProps ) {
+}: ToneDropdownMenuControlProps ) {
 	return (
 		<ToolbarDropdownMenu
 			icon={ speakToneIcon }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -124,6 +124,22 @@ type ToneDropdownMenuControlProps = {
 	onChange: ( value: string ) => void;
 };
 
+const ToneMenuGroup = ( { value, onChange }: ToneDropdownMenuControlProps ) => (
+	<MenuGroup label={ __( 'Select tone', 'jetpack' ) }>
+		{ PROMPT_TONES_LIST.map( tone => {
+			return (
+				<MenuItem
+					key={ `key-${ tone }` }
+					onClick={ () => onChange( tone ) }
+					isSelected={ value === tone }
+				>
+					{ `${ PROMPT_TONES_MAP[ tone ].emoji } ${ PROMPT_TONES_MAP[ tone ].label }` }
+				</MenuItem>
+			);
+		} ) }
+	</MenuGroup>
+);
+
 export default function ToneDropdownMenuControl( {
 	value = DEFAULT_PROMPT_TONE,
 	onChange,
@@ -136,23 +152,7 @@ export default function ToneDropdownMenuControl( {
 				variant: 'toolbar',
 			} }
 		>
-			{ () => {
-				return (
-					<MenuGroup label={ __( 'Select tone', 'jetpack' ) }>
-						{ PROMPT_TONES_LIST.map( tone => {
-							return (
-								<MenuItem
-									key={ `key-${ tone }` }
-									onClick={ () => onChange( tone ) }
-									isSelected={ value === tone }
-								>
-									{ `${ PROMPT_TONES_MAP[ tone ].emoji } ${ PROMPT_TONES_MAP[ tone ].label }` }
-								</MenuItem>
-							);
-						} ) }
-					</MenuGroup>
-				);
-			} }
+			{ () => <ToneMenuGroup value={ value } onChange={ onChange } /> }
 		</ToolbarDropdownMenu>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/style.scss
@@ -1,0 +1,14 @@
+.ai-assistant__tone-dropdown {
+	width: 100%;
+	.components-dropdown-menu__toggle {
+		display: flex;
+		gap: 8px;
+		width: 100%;
+	}
+}
+
+.ai-assistant__tone-dropdown__toggle-label {
+	flex-grow: 2;
+	width: 100;
+	text-align: left;
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
@@ -10,7 +10,7 @@ import { image, pencil, update, check } from '@wordpress/icons';
  */
 import I18nDropdownControl from '../i18n-dropdown-control';
 import PromptTemplatesControl from '../prompt-templates-control';
-import ToneDropdownMenuControl from '../tone-dropdown-control';
+import ToneToolbarDropdownMenu from '../tone-dropdown-control';
 
 // Consider to enable when we have image support
 const isImageGenerationEnabled = false;
@@ -53,7 +53,7 @@ const ToolbarControls = ( {
 		<>
 			{ contentIsLoaded && (
 				<BlockControls group="block">
-					<ToneDropdownMenuControl
+					<ToneToolbarDropdownMenu
 						value="neutral"
 						onChange={ tone =>
 							getSuggestionFromOpenAI( 'changeTone', { tone, contentType: 'generated' } )
@@ -110,7 +110,7 @@ const ToolbarControls = ( {
 
 					{ ! showRetry && ! contentIsLoaded && !! wholeContent?.length && (
 						<BlockControls group="block">
-							<ToneDropdownMenuControl
+							<ToneToolbarDropdownMenu
 								value="neutral"
 								onChange={ tone => getSuggestionFromOpenAI( 'changeTone', { tone } ) }
 							/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
@@ -10,7 +10,7 @@ import { image, pencil, update, check } from '@wordpress/icons';
  */
 import I18nDropdownControl from '../i18n-dropdown-control';
 import PromptTemplatesControl from '../prompt-templates-control';
-import ToneDropdownControl from '../tone-dropdown-control';
+import ToneDropdownMenuControl from '../tone-dropdown-control';
 
 // Consider to enable when we have image support
 const isImageGenerationEnabled = false;
@@ -53,7 +53,7 @@ const ToolbarControls = ( {
 		<>
 			{ contentIsLoaded && (
 				<BlockControls group="block">
-					<ToneDropdownControl
+					<ToneDropdownMenuControl
 						value="neutral"
 						onChange={ tone =>
 							getSuggestionFromOpenAI( 'changeTone', { tone, contentType: 'generated' } )
@@ -110,7 +110,7 @@ const ToolbarControls = ( {
 
 					{ ! showRetry && ! contentIsLoaded && !! wholeContent?.length && (
 						<BlockControls group="block">
-							<ToneDropdownControl
+							<ToneDropdownMenuControl
 								value="neutral"
 								onChange={ tone => getSuggestionFromOpenAI( 'changeTone', { tone } ) }
 							/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -26,8 +26,9 @@ export const withAIAssistant = createHigherOrderComponent(
 
 				<BlockControls group="block">
 					<AiAssistantDropdown
-						onChange={ item => {
-							console.log( { item } ); // eslint-disable-line no-console
+						onChange={ ( suggestion, options ) => {
+							console.log( { suggestion } ); // eslint-disable-line no-console
+							console.log( { options } ); // eslint-disable-line no-console
 						} }
 					/>
 				</BlockControls>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the Tone dropdown into the AI Assistant dropdown menu:

<img width="300" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/767cb32a-23a8-4872-9798-ea9e213e9b5c">


For this, I've had to:

* Extract, rename, and expose tone controls:
  * <ToneToolbarDropdownMenu /> to be used straight in the block toolbar
  * <ToneToolbarDropdown /> to be used in other contexts

Fixes https://github.com/Automattic/jetpack/issues/31328

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: add tone into AI Assistant dropdown menu

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create an AI Assistant block
* Confirm the `Tone` dropdown works as expected
  * Select the tone
  * Check the prompt
  * Check the generated content

<img width="442" alt="Screenshot 2023-06-13 at 13 53 34" src="https://github.com/Automattic/jetpack/assets/77539/294eb6c6-efb5-4a8f-8aa2-b322be4a862b">

* Create a paragraph/heading block
* Confirm you see the Tone dropdown as part of the AI Assistant dropdown menu
* Confirm you can select an option by clicking on the tone items
* Take a look at the dev console.

<img width="480" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/86788d16-2f48-4790-92c3-8dc158f3fec0">

<img width="248" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/95695761-7019-4b12-9bba-88b9147f32c5">

* Confirm it's possible to navigate the options by using the `TAB` key
