### PR TITLE
AI Assistant: Add Expand option to the extended blocks toolbar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-add-make-longer-option
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-add-make-longer-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Add Expand option into AI Assistant dropdown menu.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -8,7 +8,7 @@ import {
 	CustomSelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { post, termDescription } from '@wordpress/icons';
+import { post, postContent, termDescription } from '@wordpress/icons';
 import React from 'react';
 /**
  * Internal dependencies
@@ -25,11 +25,20 @@ const QUICK_EDIT_SUGGESTION_CORRECT_SPELLING = 'correctSpelling' as const;
 const QUICK_EDIT_KEY_SIMPLIFY = 'simplify' as const;
 const QUICK_EDIT_SUGGESTION_SIMPLIFY = 'simplify' as const;
 
-const QUICK_EDIT_KEY_LIST = [ QUICK_EDIT_KEY_CORRECT_SPELLING, QUICK_EDIT_KEY_SIMPLIFY ] as const;
+// Quick edits option: "Make longer"
+const QUICK_EDIT_KEY_MAKE_LONGER = 'make-longer' as const;
+const QUICK_EDIT_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;
+
+const QUICK_EDIT_KEY_LIST = [
+	QUICK_EDIT_KEY_CORRECT_SPELLING,
+	QUICK_EDIT_KEY_SIMPLIFY,
+	QUICK_EDIT_KEY_MAKE_LONGER,
+] as const;
 
 const QUICK_EDIT_SUGGESTION_LIST = [
 	QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
 	QUICK_EDIT_SUGGESTION_SIMPLIFY,
+	QUICK_EDIT_SUGGESTION_MAKE_LONGER,
 ] as const;
 
 type QuickEditsKeyProp = ( typeof QUICK_EDIT_KEY_LIST )[ number ];
@@ -47,6 +56,12 @@ const quickActionsList = [
 		key: QUICK_EDIT_KEY_SIMPLIFY,
 		aiSuggestion: QUICK_EDIT_SUGGESTION_SIMPLIFY,
 		icon: post,
+	},
+	{
+		name: __( 'Expand', 'jetpack' ),
+		key: QUICK_EDIT_KEY_MAKE_LONGER,
+		aiSuggestion: QUICK_EDIT_SUGGESTION_MAKE_LONGER,
+		icon: postContent,
 	},
 ];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31326

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include the "Expand" option on the toolbar, triggering the action "makeLonger"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open your browser development console
* Type something on a paragraph block (tip: you can use the AI Assistant to generate a paragraph for you)
* Click on the AI Assistant extension toolbar option:

<img width="600" alt="Screen Shot 2023-06-13 at 16 09 23" src="https://github.com/Automattic/jetpack/assets/6760046/ed4be836-5450-4ca1-bb7a-a09576fb1fd8">

* Confirm that you see the "Expand" option there, with the correct icon from the design reference (see #31326 issue)

<img width="430" alt="Screen Shot 2023-06-13 at 16 15 31" src="https://github.com/Automattic/jetpack/assets/6760046/c939934e-82de-4e2c-95a6-946792b7c2e3">

* Click on the "Expand" option
* Confirm that you see the following logs on the console:

<img width="296" alt="Screen Shot 2023-06-13 at 16 11 36" src="https://github.com/Automattic/jetpack/assets/6760046/d0a68460-880b-43f4-8d84-5309a7cd7099">

* The option is not connected to the content generation piece (#31362 will start this work), it's just triggering the right suggestion type, to be handled after