### PR TITLE
AI Assistant: Add Summarize option to the AI Assistant dropdown menu for extended blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-summarize-option
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-summarize-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Add Summarize option to the AI Assistant dropdown menu

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -8,7 +8,7 @@ import {
 	CustomSelectControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { post, postContent, termDescription } from '@wordpress/icons';
+import { post, postContent, postExcerpt, termDescription } from '@wordpress/icons';
 import React from 'react';
 /**
  * Internal dependencies
@@ -25,6 +25,10 @@ const QUICK_EDIT_SUGGESTION_CORRECT_SPELLING = 'correctSpelling' as const;
 const QUICK_EDIT_KEY_SIMPLIFY = 'simplify' as const;
 const QUICK_EDIT_SUGGESTION_SIMPLIFY = 'simplify' as const;
 
+// Quick edits option: "Summarize"
+const QUICK_EDIT_KEY_SUMMARIZE = 'summarize' as const;
+const QUICK_EDIT_SUGGESTION_SUMMARIZE = 'summarize' as const;
+
 // Quick edits option: "Make longer"
 const QUICK_EDIT_KEY_MAKE_LONGER = 'make-longer' as const;
 const QUICK_EDIT_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;
@@ -32,12 +36,14 @@ const QUICK_EDIT_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;
 const QUICK_EDIT_KEY_LIST = [
 	QUICK_EDIT_KEY_CORRECT_SPELLING,
 	QUICK_EDIT_KEY_SIMPLIFY,
+	QUICK_EDIT_KEY_SUMMARIZE,
 	QUICK_EDIT_KEY_MAKE_LONGER,
 ] as const;
 
 const QUICK_EDIT_SUGGESTION_LIST = [
 	QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
 	QUICK_EDIT_SUGGESTION_SIMPLIFY,
+	QUICK_EDIT_SUGGESTION_SUMMARIZE,
 	QUICK_EDIT_SUGGESTION_MAKE_LONGER,
 ] as const;
 
@@ -56,6 +62,12 @@ const quickActionsList = [
 		key: QUICK_EDIT_KEY_SIMPLIFY,
 		aiSuggestion: QUICK_EDIT_SUGGESTION_SIMPLIFY,
 		icon: post,
+	},
+	{
+		name: __( 'Summarize', 'jetpack' ),
+		key: QUICK_EDIT_KEY_SUMMARIZE,
+		aiSuggestion: QUICK_EDIT_SUGGESTION_SUMMARIZE,
+		icon: postExcerpt,
 	},
 	{
 		name: __( 'Expand', 'jetpack' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31325

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Includes the Summarize action to extended blocks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add a paragraph block and a Heading block with some text in them
* Click on the AI Assistant extension icon
* Check that the Summarize option is displayed

It should not work yet, only log the action in the console

![2023-06-13_16-42-21](https://github.com/Automattic/jetpack/assets/8486249/25e0eb7f-0cc4-4851-824c-7d7e8100a38a)
![2023-06-13_16-42-32](https://github.com/Automattic/jetpack/assets/8486249/7931bcc9-32cd-49b3-856f-c0fcb7fb5a79)