### PR TITLE
AI Assistant: build prompt from AI Assistant toolbar menu

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-feature-build-prompt
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-feature-build-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: build prompt from AI Assistant toolbar menu

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -82,6 +82,8 @@ type AiAssistantDropdownOnChangeOptionsArgProps = {
 	tone?: ToneProp;
 };
 
+export type AiAssistantSuggestionProp = QuickEditsSuggestionProp | 'changeTone';
+
 type AiAssistantControlComponentProps = {
 	/*
 	 * Can be used to externally control the value of the control. Optional.
@@ -99,7 +101,7 @@ type AiAssistantControlComponentProps = {
 	exclude?: QuickEditsKeyProp[];
 
 	onChange: (
-		item: QuickEditsSuggestionProp,
+		item: AiAssistantSuggestionProp,
 		options?: AiAssistantDropdownOnChangeOptionsArgProps
 	) => void;
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -77,7 +77,7 @@ const quickActionsList = [
 	},
 ];
 
-type AiAssistantDropdownOnChangeOptionsArgProps = {
+export type AiAssistantDropdownOnChangeOptionsArgProps = {
 	contentType: 'generated' | string;
 	tone?: ToneProp;
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -3,12 +3,17 @@
  */
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useCallback } from '@wordpress/element';
 import React from 'react';
 /**
  * Internal dependencies
  */
-import AiAssistantDropdown from '../../components/ai-assistant-controls';
+import AiAssistantDropdown, {
+	AiAssistantDropdownOnChangeOptionsArgProps,
+	AiAssistantSuggestionProp,
+} from '../../components/ai-assistant-controls';
 import AiAssistantPanel from '../../components/ai-assistant-panel';
+import { buildPrompt } from '../../lib/prompt';
 
 /*
  * Extend the withAIAssistant function of the block
@@ -16,6 +21,22 @@ import AiAssistantPanel from '../../components/ai-assistant-panel';
  */
 export const withAIAssistant = createHigherOrderComponent(
 	BlockEdit => props => {
+		const content = props?.attributes?.content;
+		const requestSuggestion = useCallback(
+			(
+				suggestion: AiAssistantSuggestionProp,
+				options: AiAssistantDropdownOnChangeOptionsArgProps
+			) => {
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				const prompt = buildPrompt( {
+					type: suggestion,
+					generatedContent: content,
+					options,
+				} );
+			},
+			[ content ]
+		);
+
 		return (
 			<>
 				<BlockEdit { ...props } />
@@ -25,12 +46,7 @@ export const withAIAssistant = createHigherOrderComponent(
 				</InspectorControls>
 
 				<BlockControls group="block">
-					<AiAssistantDropdown
-						onChange={ ( suggestion, options ) => {
-							console.log( { suggestion } ); // eslint-disable-line no-console
-							console.log( { options } ); // eslint-disable-line no-console
-						} }
-					/>
+					<AiAssistantDropdown onChange={ requestSuggestion } />
 				</BlockControls>
 			</>
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR builds the prompt when using the AI Assistant dropdown menu from the block toolbar. It improves the types in the prompt library.
I'd like to point out that generating prompt is going to be addressed in a follow-up.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: build prompt from AI Assistant toolbar menu

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a paragraph/heading block
* Use the AI Assistant dropdone menu
* Select an option form there
* Confirm it generates the prompt by taking a look at the dev console

```
localStorage.setItem( 'debug', 'jetpack-*' )
```

For the `Expand` option, for instance:

<img width="463" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/6a8a5e7f-d7e2-4e32-98d7-966c54ec54bb">

<img width="731" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/8d2a4321-98fc-4c83-ab64-58fcbbb3a1c1">

