### PR TITLE
Update/remove customizer menu for block themes on jetpack sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-customizer-menu-for-block-themes-on-jetpack-sites
+++ b/projects/plugins/jetpack/changelog/update-remove-customizer-menu-for-block-themes-on-jetpack-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+The Customize menu is removed on self hosted sites that are using a block based theme.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
+use Jetpack_Custom_CSS;
+
 require_once __DIR__ . '/class-admin-menu.php';
 
 /**
@@ -183,7 +185,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		$position = 0;
 		global $submenu;
 		foreach ( $submenu['jetpack'] as $submenu_item ) {
-			$position ++;
+			++$position;
 			if ( __( 'Backup', 'jetpack' ) === $submenu_item[3] ) {
 				break;
 			}
@@ -203,6 +205,13 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 
 		add_menu_page( esc_attr__( 'Appearance', 'jetpack' ), __( 'Appearance', 'jetpack' ), 'switch_themes', $themes_url, null, 'dashicons-admin-appearance', 60 );
 		add_submenu_page( $themes_url, esc_attr__( 'Themes', 'jetpack' ), __( 'Themes', 'jetpack' ), 'switch_themes', 'https://wordpress.com/themes/' . $this->domain );
+
+		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+			if ( class_exists( 'Jetpack_Custom_CSS' ) && empty( Jetpack_Custom_CSS::get_css() ) ) {
+				return $customize_url;
+			}
+		}
+
 		add_submenu_page( $themes_url, esc_attr__( 'Customize', 'jetpack' ), __( 'Customize', 'jetpack' ), 'customize', $customize_url );
 
 		return $customize_url;
@@ -287,7 +296,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		end( $menu );
 		$position = key( $menu );
 
-		$this->add_admin_menu_separator( ++ $position );
+		$this->add_admin_menu_separator( ++$position );
 		add_menu_page( __( 'WP Admin', 'jetpack' ), __( 'WP Admin', 'jetpack' ), 'read', 'index.php', null, 'dashicons-wordpress-alt', $position );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed the customizer submenu on self-hosted sites when using a block-based theme.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

