### PR TITLE
Launchpad: Add drive traffic task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-drive-traffic-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-drive-traffic-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds drive_traffic task to keep-building list.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -215,6 +215,13 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 		),
+
+		'drive_traffic'                   => array(
+			'get_title'            => function () {
+				return __( 'Drive traffic to your site', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -136,6 +136,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'domain_claim',
 				'verify_email',
 				'domain_upsell',
+				'drive_traffic',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Moves forward https://github.com/Automattic/wp-calypso/issues/77809

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds a drive traffic task to the keep-building list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Apply this patch to your sandbox and sandbox `public-api.wordpress.com`.
* Visit the dev console and select WP REST API, `wpcom/v2`.
* Make a GET request to a site like this `/sites/[siteSlug]/launchpad?checklist_slug=keep-building`.
* Verify you see the `drive_traffic` task as uncompleted.


