### PR TITLE
AI Feature: update block content once AI response is ready

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-plug-ai-feature-with-data-layer
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-plug-ai-feature-with-data-layer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Feature: update block content once AI response is ready

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -3,7 +3,7 @@
  */
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import React from 'react';
 /**
  * Internal dependencies
@@ -13,7 +13,8 @@ import AiAssistantDropdown, {
 	AiAssistantSuggestionProp,
 } from '../../components/ai-assistant-controls';
 import AiAssistantPanel from '../../components/ai-assistant-panel';
-import { buildPrompt } from '../../lib/prompt';
+import useSuggestionsFromAI from '../../hooks/use-ai-suggestions-from-ai';
+import { PromptItemProps, buildPrompt } from '../../lib/prompt';
 
 /*
  * Extend the withAIAssistant function of the block
@@ -21,18 +22,49 @@ import { buildPrompt } from '../../lib/prompt';
  */
 export const withAIAssistant = createHigherOrderComponent(
 	BlockEdit => props => {
-		const content = props?.attributes?.content;
+		const { setAttributes } = props;
+		const [ prompt, setPrompt ] = useState< Array< PromptItemProps > >( [] );
+
+		/*
+		 * Pick the content from the block attribute from now.
+		 * @todo: it doesn't scale well, we need to find a better way to get the content.
+		 */
+		const content: string = props?.attributes?.content;
+
+		/**
+		 * Set the content of the block.
+		 *
+		 * @param {string} newContent - The new content of the block.
+		 * @returns {void}
+		 */
+		const setContent = useCallback(
+			( newContent: string ) => {
+				/*
+				 * Update the content of the block
+				 * by calling the setAttributes function,
+				 * updating the `content` attribute.
+				 * It doesn't scale for other blocks.
+				 * @todo: find a better way to update the content.
+				 */
+				setAttributes( { content: newContent } );
+			},
+			[ setAttributes ]
+		);
+
+		useSuggestionsFromAI( { content, prompt, onDone: setContent } );
+
 		const requestSuggestion = useCallback(
 			(
 				suggestion: AiAssistantSuggestionProp,
 				options: AiAssistantDropdownOnChangeOptionsArgProps
 			) => {
-				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				const prompt = buildPrompt( {
-					type: suggestion,
-					generatedContent: content,
-					options,
-				} );
+				setPrompt(
+					buildPrompt( {
+						type: suggestion,
+						generatedContent: content,
+						options,
+					} )
+				);
 			},
 			[ content ]
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -13,7 +13,7 @@ import AiAssistantDropdown, {
 	AiAssistantSuggestionProp,
 } from '../../components/ai-assistant-controls';
 import AiAssistantPanel from '../../components/ai-assistant-panel';
-import useSuggestionsFromAI from '../../hooks/use-ai-suggestions-from-ai';
+import useSuggestionsFromAI from '../../hooks/use-suggestions-from-ai';
 import { PromptItemProps, buildPrompt } from '../../lib/prompt';
 
 /*

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-suggestions-from-ai/index.ts
@@ -124,7 +124,7 @@ export default function useSuggestionsFromAI( {
 		// Trigger the request.
 		request();
 
-		// Close the conenction when unmounting.
+		// Close the connection when unmounting.
 		return () => {
 			if ( ! autoRequest ) {
 				return;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-suggestions-from-ai/index.ts
@@ -1,0 +1,152 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
+/**
+ * Types
+ */
+import { SuggestionsEventSource, askQuestion } from '../../lib/suggestions';
+import type { PromptItemProps } from '../../lib/prompt';
+
+type useSuggestionsFromAIOptions = {
+	/*
+	 * The content to get suggestions for.
+	 */
+	content: string;
+
+	/*
+	 * Request prompt.
+	 */
+	prompt: Array< PromptItemProps >;
+
+	/*
+	 * Whether to request suggestions automatically.
+	 */
+	autoRequest?: boolean;
+
+	/*
+	 * onSuggestion callback.
+	 */
+	onSuggestion?: ( suggestion: string ) => void;
+
+	/*
+	 * onDone callback.
+	 */
+	onDone?: ( content: string ) => void;
+};
+
+type useSuggestionsFromAIProps = {
+	/*
+	 * The post ID.
+	 */
+	postId: number;
+
+	/*
+	 * The post title.
+	 */
+	postTitle: string;
+
+	/*
+	 * The event source.
+	 */
+	source: SuggestionsEventSource | undefined;
+
+	/*
+	 * The request handler.
+	 */
+	request: () => Promise< void >;
+};
+
+/**
+ * React custom hook to get suggestions from AI,
+ * by hitting the query endpoint.
+ *
+ * @param {useSuggestionsFromAIOptions} options - The options for the hook.
+ * @returns {useSuggestionsFromAIProps}           The props for the hook.
+ */
+export default function useSuggestionsFromAI( {
+	prompt,
+	autoRequest = true,
+	onSuggestion,
+	onDone,
+}: useSuggestionsFromAIOptions ): useSuggestionsFromAIProps {
+	// Collect data
+	const { postId, postTitle } = useSelect( select => {
+		return {
+			postId: select( editorStore ).getCurrentPostId(),
+			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
+		};
+	}, [] );
+
+	// Store the event source in a ref, so we can handle it if needed.
+	const source = useRef< SuggestionsEventSource | undefined >( undefined );
+
+	const readyToRequest = postId && prompt?.length;
+
+	/**
+	 * Request handler.
+	 *
+	 * @returns {Promise<void>} The promise.
+	 */
+	const request = useCallback( async () => {
+		try {
+			source.current = await askQuestion( prompt, {
+				postId,
+				requireUpgrade: false, // It shouldn't be part of the askQuestion API.
+				fromCache: false,
+			} );
+
+			if ( onSuggestion ) {
+				source?.current?.addEventListener( 'suggestion', ( event: CustomEvent ) => {
+					onSuggestion( event?.detail );
+				} );
+			}
+
+			if ( onDone ) {
+				source?.current?.addEventListener( 'suggestion', ( event: CustomEvent ) => {
+					onDone( event?.detail );
+				} );
+			}
+		} catch ( e ) {
+			// eslint-disable-next-line no-console
+			console.error( e );
+		}
+	}, [ prompt, postId, onSuggestion, onDone ] );
+
+	// Request suggestions automatically when ready.
+	useEffect( () => {
+		if ( ! readyToRequest ) {
+			return;
+		}
+
+		// Trigger the request.
+		request();
+
+		// Close the conenction when unmounting.
+		return () => {
+			if ( ! autoRequest ) {
+				return;
+			}
+
+			if ( ! source?.current ) {
+				return;
+			}
+
+			source.current.close();
+		};
+	}, [ autoRequest, readyToRequest, request ] );
+
+	return {
+		// Expose the request handler.
+		request: readyToRequest ? request : undefined,
+
+		// Expose the EventHandlerSource
+		source: source.current,
+
+		// Export additional props doesn't hurt.
+		postId,
+		postTitle,
+	};
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-suggestions-from-ai/index.ts
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { SuggestionsEventSource, askQuestion } from '../../lib/suggestions';
 import type { PromptItemProps } from '../../lib/prompt';
 
-type useSuggestionsFromAIOptions = {
+type UseSuggestionsFromAIOptions = {
 	/*
 	 * The content to get suggestions for.
 	 */

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -63,7 +63,7 @@ type useSuggestionsFromAIProps = {
  * React custom hook to get suggestions from AI,
  * by hitting the query endpoint.
  *
- * @param {useSuggestionsFromAIOptions} options - The options for the hook.
+ * @param {UseSuggestionsFromAIOptions} options - The options for the hook.
  * @returns {useSuggestionsFromAIProps}           The props for the hook.
  */
 export default function useSuggestionsFromAI( {
@@ -71,7 +71,7 @@ export default function useSuggestionsFromAI( {
 	autoRequest = true,
 	onSuggestion,
 	onDone,
-}: useSuggestionsFromAIOptions ): useSuggestionsFromAIProps {
+}: UseSuggestionsFromAIOptions ): useSuggestionsFromAIProps {
 	// Collect data
 	const { postId, postTitle } = useSelect( select => {
 		return {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -7,7 +7,7 @@ import { ToneProp } from '../../components/tone-dropdown-control';
 
 const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
 
-type PromptItemProps = {
+export type PromptItemProps = {
 	role: 'system' | 'user' | 'assistant';
 	content: string;
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/suggestions/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/suggestions/index.js
@@ -38,7 +38,7 @@ export async function askJetpack( question ) {
 /**
  * Leaving this here to make it easier to debug the streaming API calls for now
  *
- * @param {string} question                   - The query to send to the API
+ * @param {string|Array} question             - The query to send to the API
  * @param {object} options                    - Options
  * @param {number} options.postId             - The post where this completion is being requested, if available
  * @param {boolean} options.fromCache         - Get a cached response. False by default.
@@ -50,7 +50,10 @@ export async function askQuestion(
 	{ postId = null, fromCache = false, requireUpgrade }
 ) {
 	if ( requireUpgrade ) {
-		// Return an empty event source
+		/*
+		 * Return an empty event source
+		 * @todo: ideally, business part shouln't be here
+		 */
 		return new SuggestionsEventSource( '' );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the part that allows requesting and updating the block text content by hitting the AI endpoint.

https://github.com/Automattic/jetpack/assets/77539/4d29c63b-28f4-41e0-8835-015a80fd7745

### Significant changes

* **It introduces the new `useSuggestionsFromAI()` custom hook.** 
  Using the current `useSuggestionsFromOpenAI()` hook gets tough. For instance, it updates the block content by setting the block attributes.
That makes the ability to handle other blocks tricky to scale. Ideally, from my PoV, the hook should take over the data layer, meaning that it should accept the request data (prompt, for instance) and return only the generated suggestion.
Everything else should be handled out of the hook.

* It plugs the `AiAssistantDropdown` dropdown (UI) with the data layer via the mentioned hook
* Multiple selection edition is impleemnted
* Edit selected is not implemented.

### Disclaimer

* This implementation relies on the `done` event to update the block content. We do want to see the `suggestion` event instead, but it will be addressed in a follow-up.
* Error handling is not implemented
* Checking the product feature availability is not implanted.

Fixes https://github.com/Automattic/jetpack/issues/31362

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Feature: update block content once AI response is ready

### Other information:


- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Select a paraphrase/heading block
* Change the content by using the AI Assistant dropdown
* Wait...
* Confirm the content is updated 

