### PR TITLE
Tock Block: Hardcode the HTML code for PHP rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tock-block-render
+++ b/projects/plugins/jetpack/changelog/fix-tock-block-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Tock block: Fix the embed rendering on WordPress.com

--- a/projects/plugins/jetpack/extensions/blocks/tock/tock.php
+++ b/projects/plugins/jetpack/extensions/blocks/tock/tock.php
@@ -31,10 +31,10 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 /**
  * Render the widget and associated JS
  *
- * @param array  $attr    The block attributes.
- * @param string $content The saved content of the block, which is the placeholder div.
+ * @param array $attr    The block attributes.
  */
-function render_block( $attr, $content ) {
+function render_block( $attr ) {
+	$content = '<div id="Tock_widget_container" data-tock-display-mode="Button" data-tock-color-mode="Blue" data-tock-locale="en-us" data-tock-timezone="America/New_York"></div>';
 	if ( empty( $attr['url'] ) ) {
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			return;


### PR DESCRIPTION
On WPCOM we strip data attributes to prevent XSS vulnerabilities from unsanitized user data being injected in to the HTML.

For the Tock block to function properly it needs these attrbutes, so we can hardcode the HTML for the embed in the PHP render_block function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Insert a Tock block in a post on a WordPress.com simple site
* Publish and view the post. Notice that the button isn't styled correctly
* Check out this PR and sandbox the site
* Reload the post and check that it fixes the issue

#### Before
<img width="486" alt="image" src="https://github.com/Automattic/jetpack/assets/96462/822985aa-cccc-4c4a-a374-09af45e41d75">

#### After
<img width="486" alt="image" src="https://github.com/Automattic/jetpack/assets/96462/50508fee-45ad-491f-ba24-f89819155e8f">


