### PR TITLE
Jetpack: Fix newsletter editor sidebar panel in WP 6.1

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-panel-with-react-17
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-panel-with-react-17
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletters: Fix sidebar panel in WordPress 6.1.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -56,7 +56,7 @@ function NewsletterEditorSettingsPanel( {
 	showMisconfigurationWarning,
 } ) {
 	if ( ! isModuleActive ) {
-		return;
+		return null;
 	}
 
 	return (
@@ -185,7 +185,7 @@ function NewsletterPostPublishSettingsPanel( {
 	showMisconfigurationWarning,
 } ) {
 	if ( ! isModuleActive ) {
-		return;
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #30958 added some code to return early from the sidebar panels when the subscriptions module is disabled. Unfortunately it did this in a way that only works with React 18, and WordPress 6.1 (which we still support) comes with React 17.

Fixing this for React 17 is simple enough, we just have to return `null` instead of `undefined` in the early return.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1686754280648659-slack-CDD9LQRSN
p1686759008790089-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a testing site with Jetpack trunk, WordPress 6.1.3, and without the Gutenberg plugin. Open the post editor and verify the presence of red error bars complaining about "The "jetpack-subscriptions" plugin has encountered an error and cannot be rendered".
* Update Jetpack to this PR. Verify the red error bars are no longer present.