### PR TITLE
AI Feature: fix generating prompt when requesting suggestion

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-feature-fix-building-prompt
+++ b/projects/plugins/jetpack/changelog/update-ai-feature-fix-building-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Feature: fix generating prompt when requesting suggestion

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -15,11 +15,11 @@ import React from 'react';
  */
 import AIAssistantIcon from '../../icons/ai-assistant';
 import {
-	QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
-	QUICK_EDIT_SUGGESTION_MAKE_LONGER,
-	QUICK_EDIT_SUGGESTION_SIMPLIFY,
-	QUICK_EDIT_SUGGESTION_SUMMARIZE,
-	QuickEditsSuggestionProp,
+	PROMPT_TYPE_CORRECT_SPELLING,
+	PROMPT_TYPE_MAKE_LONGER,
+	PROMPT_TYPE_SIMPLIFY,
+	PROMPT_TYPE_SUMMARIZE,
+	PromptTypeProp,
 } from '../../lib/prompt';
 import { ToneDropdownMenu, ToneProp } from '../tone-dropdown-control';
 import './style.scss';
@@ -49,25 +49,25 @@ const quickActionsList = [
 	{
 		name: __( 'Correct spelling and grammar', 'jetpack' ),
 		key: QUICK_EDIT_KEY_CORRECT_SPELLING,
-		aiSuggestion: QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
+		aiSuggestion: PROMPT_TYPE_CORRECT_SPELLING,
 		icon: termDescription,
 	},
 	{
 		name: __( 'Simplify', 'jetpack' ),
 		key: QUICK_EDIT_KEY_SIMPLIFY,
-		aiSuggestion: QUICK_EDIT_SUGGESTION_SIMPLIFY,
+		aiSuggestion: PROMPT_TYPE_SIMPLIFY,
 		icon: post,
 	},
 	{
 		name: __( 'Summarize', 'jetpack' ),
 		key: QUICK_EDIT_KEY_SUMMARIZE,
-		aiSuggestion: QUICK_EDIT_SUGGESTION_SUMMARIZE,
+		aiSuggestion: PROMPT_TYPE_SUMMARIZE,
 		icon: postExcerpt,
 	},
 	{
 		name: __( 'Expand', 'jetpack' ),
 		key: QUICK_EDIT_KEY_MAKE_LONGER,
-		aiSuggestion: QUICK_EDIT_SUGGESTION_MAKE_LONGER,
+		aiSuggestion: PROMPT_TYPE_MAKE_LONGER,
 		icon: postContent,
 	},
 ];
@@ -77,7 +77,7 @@ export type AiAssistantDropdownOnChangeOptionsArgProps = {
 	tone?: ToneProp;
 };
 
-export type AiAssistantSuggestionProp = QuickEditsSuggestionProp | 'changeTone';
+export type AiAssistantSuggestionProp = PromptTypeProp | 'changeTone';
 
 type AiAssistantControlComponentProps = {
 	/*

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -15,6 +15,7 @@ import React from 'react';
  */
 import AIAssistantIcon from '../../icons/ai-assistant';
 import {
+	PROMPT_TYPE_CHANGE_TONE,
 	PROMPT_TYPE_CORRECT_SPELLING,
 	PROMPT_TYPE_MAKE_LONGER,
 	PROMPT_TYPE_SIMPLIFY,
@@ -77,8 +78,6 @@ export type AiAssistantDropdownOnChangeOptionsArgProps = {
 	tone?: ToneProp;
 };
 
-export type AiAssistantSuggestionProp = PromptTypeProp | 'changeTone';
-
 type AiAssistantControlComponentProps = {
 	/*
 	 * Can be used to externally control the value of the control. Optional.
@@ -95,10 +94,7 @@ type AiAssistantControlComponentProps = {
 	 */
 	exclude?: QuickEditsKeyProp[];
 
-	onChange: (
-		item: AiAssistantSuggestionProp,
-		options?: AiAssistantDropdownOnChangeOptionsArgProps
-	) => void;
+	onChange: ( item: PromptTypeProp, options?: AiAssistantDropdownOnChangeOptionsArgProps ) => void;
 };
 
 export default function AiAssistantDropdown( {
@@ -138,7 +134,7 @@ export default function AiAssistantDropdown( {
 
 					<ToneDropdownMenu
 						onChange={ tone => {
-							onChange( 'changeTone', { tone, contentType: 'generated' } );
+							onChange( PROMPT_TYPE_CHANGE_TONE, { tone, contentType: 'generated' } );
 							closeDropdown();
 						} }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -14,24 +14,26 @@ import React from 'react';
  * Internal dependencies
  */
 import AIAssistantIcon from '../../icons/ai-assistant';
-import './style.scss';
+import {
+	QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
+	QUICK_EDIT_SUGGESTION_MAKE_LONGER,
+	QUICK_EDIT_SUGGESTION_SIMPLIFY,
+	QUICK_EDIT_SUGGESTION_SUMMARIZE,
+} from '../../lib/prompt';
 import { ToneDropdownMenu, ToneProp } from '../tone-dropdown-control';
+import './style.scss';
 
 // Quick edits option: "Correct spelling and grammar"
 const QUICK_EDIT_KEY_CORRECT_SPELLING = 'correct-spelling' as const;
-const QUICK_EDIT_SUGGESTION_CORRECT_SPELLING = 'correctSpelling' as const;
 
 // Quick edits option: "Simplify"
 const QUICK_EDIT_KEY_SIMPLIFY = 'simplify' as const;
-const QUICK_EDIT_SUGGESTION_SIMPLIFY = 'simplify' as const;
 
 // Quick edits option: "Summarize"
 const QUICK_EDIT_KEY_SUMMARIZE = 'summarize' as const;
-const QUICK_EDIT_SUGGESTION_SUMMARIZE = 'summarize' as const;
 
 // Quick edits option: "Make longer"
 const QUICK_EDIT_KEY_MAKE_LONGER = 'make-longer' as const;
-const QUICK_EDIT_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;
 
 const QUICK_EDIT_KEY_LIST = [
 	QUICK_EDIT_KEY_CORRECT_SPELLING,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -19,6 +19,7 @@ import {
 	QUICK_EDIT_SUGGESTION_MAKE_LONGER,
 	QUICK_EDIT_SUGGESTION_SIMPLIFY,
 	QUICK_EDIT_SUGGESTION_SUMMARIZE,
+	QuickEditsSuggestionProp,
 } from '../../lib/prompt';
 import { ToneDropdownMenu, ToneProp } from '../tone-dropdown-control';
 import './style.scss';
@@ -42,15 +43,7 @@ const QUICK_EDIT_KEY_LIST = [
 	QUICK_EDIT_KEY_MAKE_LONGER,
 ] as const;
 
-const QUICK_EDIT_SUGGESTION_LIST = [
-	QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
-	QUICK_EDIT_SUGGESTION_SIMPLIFY,
-	QUICK_EDIT_SUGGESTION_SUMMARIZE,
-	QUICK_EDIT_SUGGESTION_MAKE_LONGER,
-] as const;
-
 type QuickEditsKeyProp = ( typeof QUICK_EDIT_KEY_LIST )[ number ];
-type QuickEditsSuggestionProp = ( typeof QUICK_EDIT_SUGGESTION_LIST )[ number ] | 'changeTone';
 
 const quickActionsList = [
 	{

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/toolbar-controls/index.js
@@ -8,6 +8,7 @@ import { image, update, check } from '@wordpress/icons';
 /*
  * Internal dependencies
  */
+import { PROMPT_TYPE_CHANGE_TONE } from '../../lib/prompt';
 import I18nDropdownControl from '../i18n-dropdown-control';
 import ImproveToolbarDropdownMenu from '../improve-dropdown-control';
 import PromptTemplatesControl from '../prompt-templates-control';
@@ -38,7 +39,7 @@ const ToolbarControls = ( {
 					<ToneToolbarDropdownMenu
 						value="neutral"
 						onChange={ tone =>
-							getSuggestionFromOpenAI( 'changeTone', { tone, contentType: 'generated' } )
+							getSuggestionFromOpenAI( PROMPT_TYPE_CHANGE_TONE, { tone, contentType: 'generated' } )
 						}
 						disabled={ contentIsLoaded }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -10,11 +10,10 @@ import React from 'react';
  */
 import AiAssistantDropdown, {
 	AiAssistantDropdownOnChangeOptionsArgProps,
-	AiAssistantSuggestionProp,
 } from '../../components/ai-assistant-controls';
 import AiAssistantPanel from '../../components/ai-assistant-panel';
 import useSuggestionsFromAI from '../../hooks/use-suggestions-from-ai';
-import { PromptItemProps, buildPrompt } from '../../lib/prompt';
+import { PromptItemProps, PromptTypeProp, buildPrompt } from '../../lib/prompt';
 
 /*
  * Extend the withAIAssistant function of the block
@@ -54,10 +53,7 @@ export const withAIAssistant = createHigherOrderComponent(
 		useSuggestionsFromAI( { content, prompt, onDone: setContent } );
 
 		const requestSuggestion = useCallback(
-			(
-				suggestion: AiAssistantSuggestionProp,
-				options: AiAssistantDropdownOnChangeOptionsArgProps
-			) => {
+			( suggestion: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				setPrompt(
 					buildPrompt( {
 						type: suggestion,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -53,7 +53,7 @@ export const withAIAssistant = createHigherOrderComponent(
 		useSuggestionsFromAI( { content, prompt, onDone: setContent } );
 
 		const requestSuggestion = useCallback(
-			( promptTupe: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
+			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				setPrompt(
 					getPrompt( promptType, {
 						...options,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -13,7 +13,7 @@ import AiAssistantDropdown, {
 } from '../../components/ai-assistant-controls';
 import AiAssistantPanel from '../../components/ai-assistant-panel';
 import useSuggestionsFromAI from '../../hooks/use-suggestions-from-ai';
-import { PromptItemProps, PromptTypeProp, buildPrompt } from '../../lib/prompt';
+import { PromptItemProps, PromptTypeProp, getPrompt } from '../../lib/prompt';
 
 /*
  * Extend the withAIAssistant function of the block
@@ -55,10 +55,9 @@ export const withAIAssistant = createHigherOrderComponent(
 		const requestSuggestion = useCallback(
 			( suggestion: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				setPrompt(
-					buildPrompt( {
-						type: suggestion,
-						generatedContent: content,
-						options,
+					getPrompt( suggestion, {
+						...options,
+						content,
 					} )
 				);
 			},

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -55,7 +55,7 @@ export const withAIAssistant = createHigherOrderComponent(
 		const requestSuggestion = useCallback(
 			( promptTupe: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				setPrompt(
-					getPrompt( promptTupe, {
+					getPrompt( promptType, {
 						...options,
 						content,
 					} )

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -53,9 +53,9 @@ export const withAIAssistant = createHigherOrderComponent(
 		useSuggestionsFromAI( { content, prompt, onDone: setContent } );
 
 		const requestSuggestion = useCallback(
-			( suggestion: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
+			( promptTupe: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				setPrompt(
-					getPrompt( suggestion, {
+					getPrompt( promptTupe, {
 						...options,
 						content,
 					} )

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -355,6 +355,7 @@ export function getPrompt(
 		generatedContent: options.content,
 		postContentAbove: options.content,
 		options: {
+			...options,
 			contentType: 'generated', // Set `generated` to ensure providing the generated content :-/
 		},
 	} );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -3,19 +3,35 @@
  */
 import { select } from '@wordpress/data';
 import debugFactory from 'debug';
+/**
+ * Internal dependencies
+ */
 import { ToneProp } from '../../components/tone-dropdown-control';
-
-const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
-
+/**
+ * Types & consts
+ */
 export const QUICK_EDIT_SUGGESTION_CORRECT_SPELLING = 'correctSpelling' as const;
 export const QUICK_EDIT_SUGGESTION_SIMPLIFY = 'simplify' as const;
 export const QUICK_EDIT_SUGGESTION_SUMMARIZE = 'summarize' as const;
 export const QUICK_EDIT_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;
 
+export const QUICK_EDIT_SUGGESTION_LIST = [
+	QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
+	QUICK_EDIT_SUGGESTION_SIMPLIFY,
+	QUICK_EDIT_SUGGESTION_SUMMARIZE,
+	QUICK_EDIT_SUGGESTION_MAKE_LONGER,
+] as const;
+
+export type QuickEditsSuggestionProp =
+	| ( typeof QUICK_EDIT_SUGGESTION_LIST )[ number ]
+	| 'changeTone';
+
 export type PromptItemProps = {
 	role: 'system' | 'user' | 'assistant';
 	content: string;
 };
+
+const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
 
 /*
  * Builds a prompt template based on context, rules and content

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -340,7 +340,7 @@ type GetPromptOptionsProps = {
 };
 
 /**
- * Retunr a prompt based on the type and options
+ * Returns a prompt based on the type and options
  *
  * @param {PromptTypeProp} type           - The type of prompt.
  * @param {GetPromptOptionsProps} options - The prompt options.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -7,6 +7,11 @@ import { ToneProp } from '../../components/tone-dropdown-control';
 
 const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
 
+export const QUICK_EDIT_SUGGESTION_CORRECT_SPELLING = 'correctSpelling' as const;
+export const QUICK_EDIT_SUGGESTION_SIMPLIFY = 'simplify' as const;
+export const QUICK_EDIT_SUGGESTION_SUMMARIZE = 'summarize' as const;
+export const QUICK_EDIT_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;
+
 export type PromptItemProps = {
 	role: 'system' | 'user' | 'assistant';
 	content: string;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -10,21 +10,19 @@ import { ToneProp } from '../../components/tone-dropdown-control';
 /**
  * Types & consts
  */
-export const QUICK_EDIT_SUGGESTION_CORRECT_SPELLING = 'correctSpelling' as const;
-export const QUICK_EDIT_SUGGESTION_SIMPLIFY = 'simplify' as const;
-export const QUICK_EDIT_SUGGESTION_SUMMARIZE = 'summarize' as const;
-export const QUICK_EDIT_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;
+export const PROMPT_TYPE_CORRECT_SPELLING = 'correctSpelling' as const;
+export const PROMPT_TYPE_SIMPLIFY = 'simplify' as const;
+export const PROMPT_TYPE_SUMMARIZE = 'summarize' as const;
+export const PROMPT_TYPE_MAKE_LONGER = 'makeLonger' as const;
 
-export const QUICK_EDIT_SUGGESTION_LIST = [
-	QUICK_EDIT_SUGGESTION_CORRECT_SPELLING,
-	QUICK_EDIT_SUGGESTION_SIMPLIFY,
-	QUICK_EDIT_SUGGESTION_SUMMARIZE,
-	QUICK_EDIT_SUGGESTION_MAKE_LONGER,
+export const PROMPT_TYPE_LIST = [
+	PROMPT_TYPE_CORRECT_SPELLING,
+	PROMPT_TYPE_SIMPLIFY,
+	PROMPT_TYPE_SUMMARIZE,
+	PROMPT_TYPE_MAKE_LONGER,
 ] as const;
 
-export type QuickEditsSuggestionProp =
-	| ( typeof QUICK_EDIT_SUGGESTION_LIST )[ number ]
-	| 'changeTone';
+export type PromptTypeProp = ( typeof PROMPT_TYPE_LIST )[ number ] | 'changeTone';
 
 export type PromptItemProps = {
 	role: 'system' | 'user' | 'assistant';

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -134,7 +134,7 @@ type BuildPromptOptions = {
 	userPrompt?: string;
 	isGeneratingTitle?: boolean;
 	options: {
-		contentType?: string;
+		contentType?: 'generated' | string;
 		tone?: ToneProp;
 		language?: string;
 	};
@@ -333,4 +333,29 @@ export function buildPrompt( {
 	}
 
 	return prompt;
+}
+
+type GetPromptOptionsProps = {
+	content: string;
+};
+
+/**
+ * Retunr a prompt based on the type and options
+ *
+ * @param {PromptTypeProp} type           - The type of prompt.
+ * @param {GetPromptOptionsProps} options - The prompt options.
+ * @returns {Array< PromptItemProps >}      The prompt.
+ */
+export function getPrompt(
+	type: PromptTypeProp,
+	options: GetPromptOptionsProps
+): Array< PromptItemProps > {
+	return buildPrompt( {
+		type,
+		generatedContent: options.content,
+		postContentAbove: options.content,
+		options: {
+			contentType: 'generated', // Set `generated` to ensure providing the generated content :-/
+		},
+	} );
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -269,7 +269,7 @@ export function buildPrompt( {
 		/*
 		 * Change the tone of the content.
 		 */
-		case 'changeTone':
+		case PROMPT_TYPE_CHANGE_TONE:
 			prompt = buildPromptTemplate( {
 				request: `Rewrite ${ isGenerated ? reference.generated : reference.content } with a ${
 					options.tone

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -14,6 +14,7 @@ export const PROMPT_TYPE_CORRECT_SPELLING = 'correctSpelling' as const;
 export const PROMPT_TYPE_SIMPLIFY = 'simplify' as const;
 export const PROMPT_TYPE_SUMMARIZE = 'summarize' as const;
 export const PROMPT_TYPE_MAKE_LONGER = 'makeLonger' as const;
+export const PROMPT_TYPE_CHANGE_TONE = 'changeTone' as const;
 
 export const PROMPT_TYPE_LIST = [
 	PROMPT_TYPE_CORRECT_SPELLING,
@@ -22,7 +23,7 @@ export const PROMPT_TYPE_LIST = [
 	PROMPT_TYPE_MAKE_LONGER,
 ] as const;
 
-export type PromptTypeProp = ( typeof PROMPT_TYPE_LIST )[ number ] | 'changeTone';
+export type PromptTypeProp = ( typeof PROMPT_TYPE_LIST )[ number ] | typeof PROMPT_TYPE_CHANGE_TONE;
 
 export type PromptItemProps = {
 	role: 'system' | 'user' | 'assistant';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The current `buildPrompt()` doesn't scale very well with the AI Feature requirements. It expects some parameters that may not make sense when trying to build the prompt. This is why I've created a getPrompt() helper that is a wrapper of `buildPrompt()`.
It isn't a flawless implementation but makes the implementation clearer. Also, it opens the door to continue iterating over it.
Almost all changes are part of consts and types reorganization.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Feature: fix generating prompt when requesting suggestion

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create paragraph/heading block
* Change the content by using the AI Assistant dropdown
* Check the prompt
* Confirm the generated code is expected 
* Don't forget to test the AI Assistant block. It should work as expected too.

