### PR TITLE
AI Assistant: iterate over custom hook to request suggestions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-print-when-suggestion-event
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-print-when-suggestion-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: iterate over custom hook to request suggestions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -51,7 +51,7 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ setAttributes ]
 		);
 
-		useSuggestionsFromAI( { content, prompt, onSuggestion: setContent } );
+		useSuggestionsFromAI( { prompt, onSuggestion: setContent } );
 
 		const requestSuggestion = useCallback(
 			(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -51,7 +51,7 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ setAttributes ]
 		);
 
-		useSuggestionsFromAI( { content, prompt, onDone: setContent } );
+		useSuggestionsFromAI( { content, prompt, onSuggestion: setContent } );
 
 		const requestSuggestion = useCallback(
 			(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -143,7 +143,9 @@ export default function useSuggestionsFromAI( {
 				return;
 			}
 
+			// Close the connection.
 			source.current.close();
+
 			// Clean up the event listeners.
 			source?.current?.removeEventListener( 'suggestion', handleSuggestion );
 			source?.current?.removeEventListener( 'done', handleDone );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -12,11 +12,6 @@ import type { PromptItemProps } from '../../lib/prompt';
 
 type UseSuggestionsFromAIOptions = {
 	/*
-	 * The content to get suggestions for.
-	 */
-	content: string;
-
-	/*
 	 * Request prompt.
 	 */
 	prompt: Array< PromptItemProps >;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -105,7 +105,7 @@ export default function useSuggestionsFromAI( {
 			}
 
 			if ( onDone ) {
-				source?.current?.addEventListener( 'suggestion', ( event: CustomEvent ) => {
+				source?.current?.addEventListener( 'done', ( event: CustomEvent ) => {
 					onDone( event?.detail );
 				} );
 			}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -83,8 +83,6 @@ export default function useSuggestionsFromAI( {
 	// Store the event source in a ref, so we can handle it if needed.
 	const source = useRef< SuggestionsEventSource | undefined >( undefined );
 
-	const readyToRequest = postId && prompt?.length;
-
 	/**
 	 * onSuggestion function handler.
 	 *
@@ -132,7 +130,8 @@ export default function useSuggestionsFromAI( {
 
 	// Request suggestions automatically when ready.
 	useEffect( () => {
-		if ( ! readyToRequest ) {
+		// Check if there is a prompt to request.
+		if ( ! prompt?.length ) {
 			return;
 		}
 
@@ -154,11 +153,11 @@ export default function useSuggestionsFromAI( {
 			source?.current?.removeEventListener( 'suggestion', handleSuggestion );
 			source?.current?.removeEventListener( 'done', handleDone );
 		};
-	}, [ autoRequest, handleDone, handleSuggestion, readyToRequest, request ] );
+	}, [ autoRequest, handleDone, handleSuggestion, prompt, request ] );
 
 	return {
 		// Expose the request handler.
-		request: readyToRequest ? request : undefined,
+		request,
 
 		// Expose the EventHandlerSource
 		source: source.current,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR:

* Fixes a minor issue when setting the block content
* Better handling on subscribing event source events

Fixes https://github.com/Automattic/jetpack/issues/31379

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: iterate over custom hook to request suggestions

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a paragraph/heading block
* Generate the content. Use `Extend` since you'll need time to do the next step
* Remove the block
* Confirm the client stops requesting.

You can compare the behavior with the AI Assistant block. It keeps requesting even when it's removed from the editor.

* Test the rest of the options. Confirm it keeps working as expected.

