### PR TITLE
Stats Admin: Add subscribers endpoints

### DIFF
--- a/projects/packages/stats-admin/changelog/add-add-subscribers-endpoints
+++ b/projects/packages/stats-admin/changelog/add-add-subscribers-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats Admin: add subscribers endpoints

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -51,7 +51,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.10.x-dev"
+			"dev-trunk": "0.11.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.10.0",
+	"version": "0.11.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.10.0';
+	const VERSION = '0.11.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -130,6 +130,17 @@ class REST_Controller {
 			)
 		);
 
+		// List posts.
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/subscribers/counts', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_site_subscribers_counts' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
+
 		// WordAds Earnings.
 		register_rest_route(
 			static::$namespace,
@@ -387,6 +398,21 @@ class REST_Controller {
 			case 'highlights':
 				return $this->wpcom_stats->get_highlights( $req->get_params() );
 
+			case 'subscribers':
+				return WPCOM_Client::request_as_blog_cached(
+					sprintf(
+						'/sites/%d/stats/subscribers?%s',
+						Jetpack_Options::get_option( 'id' ),
+						$this->filter_and_build_query_string(
+							$req->get_query_params()
+						)
+					),
+					'v1.1',
+					array( 'timeout' => 5 ),
+					'rest',
+					false
+				);
+
 			default:
 				return $this->get_forbidden_error();
 		}
@@ -521,6 +547,29 @@ class REST_Controller {
 		}
 
 		return $response_body;
+	}
+
+	/**
+	 * Get site subscribers counts.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 *
+	 * @return array
+	 */
+	public function get_site_subscribers_counts( $req ) {
+		return WPCOM_Client::request_as_blog_cached(
+			sprintf(
+				'/sites/%d/subscribers/counts?%s',
+				Jetpack_Options::get_option( 'id' ),
+				$this->filter_and_build_query_string(
+					$req->get_query_params()
+				)
+			),
+			'v2',
+			array( 'timeout' => 5 ),
+			null,
+			'wpcom'
+		);
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -408,9 +408,7 @@ class REST_Controller {
 						)
 					),
 					'v1.1',
-					array( 'timeout' => 5 ),
-					'rest',
-					false
+					array( 'timeout' => 5 )
 				);
 
 			default:
@@ -827,6 +825,9 @@ class REST_Controller {
 	 * @return string The filtered and built query string.
 	 */
 	protected function filter_and_build_query_string( $params, $keys_to_unset = array() ) {
+		if ( ! is_array( $params ) ) {
+			return '';
+		}
 		if ( isset( $params['rest_route'] ) ) {
 			unset( $params['rest_route'] );
 		}

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -130,7 +130,7 @@ class REST_Controller {
 			)
 		);
 
-		// List posts.
+		// Subscribers counts.
 		register_rest_route(
 			static::$namespace,
 			sprintf( '/sites/%d/subscribers/counts', Jetpack_Options::get_option( 'id' ) ),
@@ -825,9 +825,6 @@ class REST_Controller {
 	 * @return string The filtered and built query string.
 	 */
 	protected function filter_and_build_query_string( $params, $keys_to_unset = array() ) {
-		if ( ! is_array( $params ) ) {
-			return '';
-		}
 		if ( isset( $params['rest_route'] ) ) {
 			unset( $params['rest_route'] );
 		}

--- a/projects/packages/stats-admin/tests/php/test-rest-controller.php
+++ b/projects/packages/stats-admin/tests/php/test-rest-controller.php
@@ -34,9 +34,11 @@ class Test_REST_Controller extends Stats_Test_Case {
 		'/jetpack/v4/stats-app/sites/999/stats/publicize',
 		'/jetpack/v4/stats-app/sites/999/stats/comments',
 		'/jetpack/v4/stats-app/sites/999/stats/comment-followers',
+		'/jetpack/v4/stats-app/sites/999/stats/subscribers',
 		'/jetpack/v4/stats-app/sites/999/stats/post/1',
 		'/jetpack/v4/stats-app/sites/999/stats/video/1',
 		'/jetpack/v4/stats-app/sites/999/site-has-never-published-post',
+		'/jetpack/v4/stats-app/sites/999/subscribers/counts',
 	);
 
 	const SUPPORTED_POST_ROUTES = array(

--- a/projects/plugins/jetpack/changelog/add-add-subscribers-endpoints
+++ b/projects/plugins/jetpack/changelog/add-add-subscribers-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+dependency update

--- a/projects/plugins/jetpack/changelog/add-add-subscribers-endpoints#2
+++ b/projects/plugins/jetpack/changelog/add-add-subscribers-endpoints#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2389,7 +2389,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "faac780f3f5a28b267eef563ee7d9adeebad4a8f"
+                "reference": "857b8f2a389c1daa46ad3e98755b1aea8778bcf7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2412,7 +2412,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
+                    "dev-trunk": "0.11.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/78082#issuecomment-1590359383

## Proposed changes:

* Adds `/sites/%d/subscribers/counts` endpoint
* Adds `/sites/%d/stats/subscribers` endpoint (the WPCOM is currently a mock, but we want to support it from Jetpack before it actually works)

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

- Apply `D113855-code` to your sandbox
- Sandbox your Jetpack `define( 'JETPACK__SANDBOX_DOMAIN', 'xxx.yoursanbox.domain' );`
- Follow test instructions in https://github.com/Automattic/wp-calypso/pull/78355

