### PR TITLE
AI Assistant: Separate prompt text from relevant content for extensions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-separate-prompt-text-from-content
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-separate-prompt-text-from-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Separate prompt text from relevant content for extensions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -13,7 +13,7 @@ import AiAssistantDropdown, {
 } from '../../components/ai-assistant-controls';
 import AiAssistantPanel from '../../components/ai-assistant-panel';
 import useSuggestionsFromAI from '../../hooks/use-suggestions-from-ai';
-import { PromptItemProps, PromptTypeProp, getPrompt } from '../../lib/prompt';
+import { PromptItemProps, PromptTypeProp, buildPromptForExtensions } from '../../lib/prompt';
 
 /*
  * Extend the withAIAssistant function of the block
@@ -55,8 +55,9 @@ export const withAIAssistant = createHigherOrderComponent(
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				setPrompt(
-					getPrompt( promptType, {
+					buildPromptForExtensions( promptType, {
 						...options,
+						contentType: 'original', // Extended block content is not interactive.
 						content,
 					} )
 				);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -12,7 +12,7 @@ import TurndownService from 'turndown';
  * Internal dependencies
  */
 import { DEFAULT_PROMPT_TONE } from '../../components/tone-dropdown-control';
-import { buildPrompt } from '../../lib/prompt';
+import { buildPromptForBlock } from '../../lib/prompt';
 import { askJetpack, askQuestion } from '../../lib/suggestions';
 
 const debug = debugFactory( 'jetpack-ai-assistant' );
@@ -162,13 +162,12 @@ const useSuggestionsFromOpenAI = ( {
 
 		if ( ! options.retryRequest ) {
 			// If there is a content already, let's iterate over it.
-			prompt = buildPrompt( {
+			prompt = buildPromptForBlock( {
 				generatedContent: content,
 				allPostContent: getContentFromBlocks(),
 				postContentAbove: getPartialContentToBlock( clientId ),
 				currentPostTitle,
 				options,
-				prompt,
 				userPrompt,
 				type,
 				isGeneratingTitle: attributes.promptType === 'generateTitle',

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -10,24 +10,33 @@ import { ToneProp } from '../../components/tone-dropdown-control';
 /**
  * Types & consts
  */
-export const PROMPT_TYPE_CORRECT_SPELLING = 'correctSpelling' as const;
+export const PROMPT_TYPE_SUMMARY_BY_TITLE = 'titleSummary' as const;
+export const PROMPT_TYPE_CONTINUE = 'continue' as const;
 export const PROMPT_TYPE_SIMPLIFY = 'simplify' as const;
-export const PROMPT_TYPE_SUMMARIZE = 'summarize' as const;
+export const PROMPT_TYPE_CORRECT_SPELLING = 'correctSpelling' as const;
+export const PROMPT_TYPE_GENERATE_TITLE = 'generateTitle' as const;
 export const PROMPT_TYPE_MAKE_LONGER = 'makeLonger' as const;
+export const PROMPT_TYPE_MAKE_SHORTER = 'makeShorter' as const;
 export const PROMPT_TYPE_CHANGE_TONE = 'changeTone' as const;
+export const PROMPT_TYPE_SUMMARIZE = 'summarize' as const;
 export const PROMPT_TYPE_CHANGE_LANGUAGE = 'changeLanguage' as const;
+export const PROMPT_TYPE_USER_PROMPT = 'userPrompt' as const;
 
 export const PROMPT_TYPE_LIST = [
-	PROMPT_TYPE_CORRECT_SPELLING,
+	PROMPT_TYPE_SUMMARY_BY_TITLE,
+	PROMPT_TYPE_CONTINUE,
 	PROMPT_TYPE_SIMPLIFY,
-	PROMPT_TYPE_SUMMARIZE,
+	PROMPT_TYPE_CORRECT_SPELLING,
+	PROMPT_TYPE_GENERATE_TITLE,
 	PROMPT_TYPE_MAKE_LONGER,
+	PROMPT_TYPE_MAKE_SHORTER,
+	PROMPT_TYPE_CHANGE_TONE,
+	PROMPT_TYPE_SUMMARIZE,
+	PROMPT_TYPE_CHANGE_LANGUAGE,
+	PROMPT_TYPE_USER_PROMPT,
 ] as const;
 
-export type PromptTypeProp =
-	| ( typeof PROMPT_TYPE_LIST )[ number ]
-	| typeof PROMPT_TYPE_CHANGE_TONE
-	| typeof PROMPT_TYPE_CHANGE_LANGUAGE;
+export type PromptTypeProp = ( typeof PROMPT_TYPE_LIST )[ number ];
 
 export type PromptItemProps = {
 	role: 'system' | 'user' | 'assistant';
@@ -153,8 +162,7 @@ type BuildPromptOptions = {
 	allPostContent?: string;
 	postContentAbove?: string;
 	currentPostTitle?: string;
-	prompt?: Array< PromptItemProps >;
-	type: string;
+	type: PromptTypeProp;
 	userPrompt?: string;
 	isGeneratingTitle?: boolean;
 	options: {
@@ -164,203 +172,132 @@ type BuildPromptOptions = {
 	};
 };
 
-/**
- * Builds a prompt based on the type of prompt.
- *
- * @param {BuildPromptOptions} options - The prompt options.
- * @returns {Array< PromptItemProps >} The prompt.
- * @throws {Error} If the type is not recognized.
- */
-export function buildPrompt( {
-	generatedContent,
-	allPostContent,
-	postContentAbove,
-	currentPostTitle,
-	options,
-	prompt,
-	type,
-	userPrompt,
-	isGeneratingTitle,
-}: BuildPromptOptions ): Array< PromptItemProps > {
+export function promptTextFor(
+	type: PromptTypeProp,
+	isGeneratingTitle = false,
+	options: GetPromptOptionsProps
+): { request: string; rules?: string[] } {
 	const isGenerated = options?.contentType === 'generated';
-	const reference = {
-		content: isGeneratingTitle ? 'the title' : 'the content',
-		generated: isGeneratingTitle ? 'the title' : 'your last answer',
-	};
+	let subject = 'the title';
+	if ( ! isGeneratingTitle ) {
+		subject = isGenerated ? 'your last answer' : 'the content';
+	}
 
 	switch ( type ) {
-		/*
-		 * Non-interactive types
-		 */
-
-		/*
-		 * Generate content from title.
-		 */
-		case 'titleSummary':
-			prompt = buildPromptTemplate( {
-				request: 'Write a short piece for a blog post based on the content.',
-				fullContent: allPostContent,
-				relevantContent: currentPostTitle,
-			} );
-			break;
-
-		/*
-		 * Continue generating from the content.
-		 */
-		case 'continue':
-			prompt = buildPromptTemplate( {
-				request: 'Continue writing from the content.',
-				rules: [ 'Only output the continuation of the content, without repeating it' ],
-				fullContent: allPostContent,
-				relevantContent: postContentAbove,
-			} );
-			break;
-
-		/*
-		 * Simplify the content.
-		 */
-		case 'simplify':
-			prompt = buildPromptTemplate( {
-				request: 'Simplify the content.',
+		case PROMPT_TYPE_SUMMARY_BY_TITLE:
+			return { request: `Write a short piece for a blog post based on ${ subject }.` };
+		case PROMPT_TYPE_CONTINUE:
+			return {
+				request: `Continue writing from ${ subject }.`,
+				rules: isGenerated
+					? []
+					: [ 'Only output the continuation of the content, without repeating it' ],
+			};
+		case PROMPT_TYPE_SIMPLIFY:
+			return {
+				request: `Simplify ${ subject }.`,
 				rules: [
 					'Use words and phrases that are easier to understand for non-technical people',
 					'Output in the same language of the content',
 					'Use as much of the original language as possible',
 				],
-				fullContent: allPostContent,
-				relevantContent: postContentAbove,
-			} );
-			break;
-
-		/**
-		 * Correct grammar and spelling
-		 */
-		case 'correctSpelling':
-			prompt = buildPromptTemplate( {
-				request:
-					'Repeat the content, correcting any spelling and grammar mistakes, and do not add new content.',
-				fullContent: allPostContent,
-				relevantContent: postContentAbove,
-			} );
-			break;
-
-		/*
-		 * Generate a title for this blog post, based on the content.
-		 */
-		case 'generateTitle':
-			prompt = buildPromptTemplate( {
+			};
+		case PROMPT_TYPE_CORRECT_SPELLING:
+			return {
+				request: `Repeat ${ subject }, correcting any spelling and grammar mistakes, and do not add new content.`,
+			};
+		case PROMPT_TYPE_GENERATE_TITLE:
+			return {
 				request: 'Generate a new title for this blog post and only output the title.',
 				rules: [ 'Only output the raw title, without any prefix or quotes' ],
-				fullContent: allPostContent,
-				relevantContent: allPostContent,
-			} );
-			break;
-
-		/*
-		 * Interactive only types
-		 */
-
-		/*
-		 * Make the content longer.
-		 */
-		case 'makeLonger':
-			prompt = buildPromptTemplate( {
-				request: `Make ${ reference.generated } longer.`,
-				fullContent: allPostContent,
-				relevantContent: generatedContent,
-				isContentGenerated: true,
-				isGeneratingTitle,
-			} );
-			break;
-
-		/*
-		 * Make the content shorter.
-		 */
-		case 'makeShorter':
-			prompt = buildPromptTemplate( {
-				request: `Make ${ reference.generated } shorter.`,
-				fullContent: allPostContent,
-				relevantContent: generatedContent,
-				isContentGenerated: true,
-				isGeneratingTitle,
-			} );
-			break;
-
-		/*
-		 * Types that can be interactive or non-interactive
-		 */
-
-		/*
-		 * Change the tone of the content.
-		 */
+			};
+		case PROMPT_TYPE_MAKE_LONGER:
+			return { request: `Make ${ subject } longer.` };
+		case PROMPT_TYPE_MAKE_SHORTER:
+			return { request: `Make ${ subject } shorter.` };
 		case PROMPT_TYPE_CHANGE_TONE:
-			prompt = buildPromptTemplate( {
-				request: `Rewrite ${ isGenerated ? reference.generated : reference.content } with a ${
-					options.tone
-				} tone.`,
-				fullContent: allPostContent,
-				relevantContent: isGenerated ? generatedContent : allPostContent,
-				isContentGenerated: isGenerated,
-				isGeneratingTitle,
-			} );
-			break;
-
-		/*
-		 * Summarize the content.
-		 */
-		case 'summarize':
-			prompt = buildPromptTemplate( {
-				request: `Summarize ${ isGenerated ? reference.generated : reference.content }.`,
-				fullContent: allPostContent,
-				relevantContent: isGenerated ? generatedContent : allPostContent,
-				isContentGenerated: isGenerated,
-			} );
-			break;
-
-		/**
-		 * Change the language, based on options.language
-		 */
-		case 'changeLanguage':
-			prompt = buildPromptTemplate( {
-				request: `Translate ${
-					isGenerated ? reference.generated : reference.content
-				} to the following language: ${ options.language }.`,
-				fullContent: allPostContent,
-				relevantContent: isGenerated ? generatedContent : allPostContent,
-				isContentGenerated: isGenerated,
-				isGeneratingTitle,
-			} );
-			break;
-
-		/**
-		 * Open ended prompt from user
-		 */
-		case 'userPrompt':
-			prompt = buildPromptTemplate( {
-				request: userPrompt,
-				fullContent: allPostContent,
-				relevantContent: generatedContent || allPostContent,
-				isContentGenerated: !! generatedContent?.length,
-				isGeneratingTitle,
-			} );
-			break;
-
+			return { request: `Rewrite ${ subject } with a ${ options.tone } tone.` };
+		case PROMPT_TYPE_SUMMARIZE:
+			return { request: `Summarize ${ subject }.` };
+		case PROMPT_TYPE_CHANGE_LANGUAGE:
+			return {
+				request: `Translate ${ subject } to the following language: ${ options.language }.`,
+			};
 		default:
-			prompt = buildPromptTemplate( {
-				request: userPrompt,
-				fullContent: allPostContent,
-				relevantContent: generatedContent,
-				isContentGenerated: true,
-				isGeneratingTitle,
-			} );
-			break;
+			return null;
+	}
+}
+
+/**
+ * Builds a prompt based on the type of prompt.
+ * Meant for use by the block, not the extensions.
+ *
+ * @param {BuildPromptOptions} options - The prompt options.
+ * @returns {Array< PromptItemProps >} The prompt.
+ * @throws {Error} If the type is not recognized.
+ */
+export function buildPromptForBlock( {
+	generatedContent,
+	allPostContent,
+	postContentAbove,
+	currentPostTitle,
+	options,
+	type,
+	userPrompt,
+	isGeneratingTitle,
+}: BuildPromptOptions ): Array< PromptItemProps > {
+	const isContentGenerated = options?.contentType === 'generated';
+	const promptText = promptTextFor( type, isGeneratingTitle, options );
+
+	if ( type !== PROMPT_TYPE_USER_PROMPT ) {
+		let relevantContent;
+
+		switch ( type ) {
+			case PROMPT_TYPE_SUMMARY_BY_TITLE:
+				relevantContent = currentPostTitle;
+				break;
+			case PROMPT_TYPE_CONTINUE:
+			case PROMPT_TYPE_SIMPLIFY:
+			case PROMPT_TYPE_CORRECT_SPELLING:
+				relevantContent = postContentAbove;
+				break;
+			case PROMPT_TYPE_GENERATE_TITLE:
+				relevantContent = allPostContent;
+				break;
+			case PROMPT_TYPE_MAKE_LONGER:
+			case PROMPT_TYPE_MAKE_SHORTER:
+				relevantContent = generatedContent;
+				break;
+			case PROMPT_TYPE_CHANGE_TONE:
+			case PROMPT_TYPE_SUMMARIZE:
+			case PROMPT_TYPE_CHANGE_LANGUAGE:
+				relevantContent = isContentGenerated ? generatedContent : allPostContent;
+				break;
+		}
+
+		return buildPromptTemplate( {
+			...promptText,
+			fullContent: allPostContent,
+			relevantContent,
+			isContentGenerated,
+			isGeneratingTitle,
+		} );
 	}
 
-	return prompt;
+	return buildPromptTemplate( {
+		request: userPrompt,
+		fullContent: allPostContent,
+		relevantContent: generatedContent || allPostContent,
+		isContentGenerated: !! generatedContent?.length,
+		isGeneratingTitle,
+	} );
 }
 
 type GetPromptOptionsProps = {
-	content: string;
+	content?: string;
+	contentType?: 'generated' | string;
+	tone?: ToneProp;
+	language?: string;
 };
 
 /**
@@ -370,17 +307,16 @@ type GetPromptOptionsProps = {
  * @param {GetPromptOptionsProps} options - The prompt options.
  * @returns {Array< PromptItemProps >}      The prompt.
  */
-export function getPrompt(
+export function buildPromptForExtensions(
 	type: PromptTypeProp,
 	options: GetPromptOptionsProps
 ): Array< PromptItemProps > {
-	return buildPrompt( {
-		type,
-		generatedContent: options.content,
-		postContentAbove: options.content,
-		options: {
-			...options,
-			contentType: 'generated', // Set `generated` to ensure providing the generated content :-/
-		},
+	const promptText = promptTextFor( type, false, options );
+
+	return buildPromptTemplate( {
+		...promptText,
+		fullContent: options.content,
+		relevantContent: options.content,
+		isContentGenerated: false,
 	} );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR separates the prompt text and rules from what content should be relevant. This makes it possible to reuse the same prompts in the block and the extensions with different relevant contents.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add an AI Assistant block
* Check all the options, they should work as normal (check the results and the logs)
* Add a new paragraph or heading
* Try the options in the extended block
* They should use the correct content (the block content) and work as intended
