### PR TITLE
Fix jetpack iframe wpcom path for proper staticizing url generation

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
+++ b/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
@@ -39,7 +39,7 @@ class Jetpack_Iframe_Embed {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			wp_enqueue_script(
 				'jetpack-iframe-embed',
-				WPMU_PLUGIN_URL . '/jetpack-iframe-embed/jetpack-iframe-embed.js',
+				'/wp-content/mu-plugins/jetpack-iframe-embed/jetpack-iframe-embed.js',
 				array( 'jquery' ),
 				$ver,
 				false

--- a/projects/plugins/jetpack/changelog/update-fix-jetpack-iframe-wpcom-path-for-proper-staticizing-url-generation
+++ b/projects/plugins/jetpack/changelog/update-fix-jetpack-iframe-wpcom-path-for-proper-staticizing-url-generation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes output of staticized script path on wordpress.com


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR updates the path that is used for enqueueing the `jetpack-iframe-embed.js` script when run on wordpress.com to match pattern used by other scripts (see fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Seyg.cuc%3Se%3Q7410s8nn%2319-og `rlt.php`). This script was being enqueued with `http` even though the page was requested on `https`. It was the only script that behaved this way.

Alternatively, the path could just be hardcoded with `https://s0.wp.com` like `videopress-iframe-api.js` does in https://github.com/Automattic/jetpack/blob/dfc7588bcc0f034b7aa53e87c9777c956f3988c3/projects/packages/videopress/src/class-initializer.php#L398

| before | after |
| -- | -- |
| <img width="1515" alt="image" src="https://github.com/Automattic/jetpack/assets/4081020/7b5d022b-dcc2-4160-8859-783d05b1409c"> | <img width="1633" alt="image" src="https://github.com/Automattic/jetpack/assets/4081020/72997ecd-390b-4be4-bd06-2c243ccc3e2f"> |


Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* updates the path that is used for enqueueing the `jetpack-iframe-embed.js` script when run on wordpress.com

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pMz3w-hKd-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to a wpcom sandbox
* Skip the `WPCOM_SANDBOXED` early return in `wp-content/mu-plugins/optimizations.php` by adding `false &&` to the condition (or just comment out the code)
* sandbox `jgcactivateissue06132023.wordpress.com`
* visit the following url `https://jgcactivateissue06132023.wordpress.com/?iframe=true&theme_preview=true&hide_banners=true&preview=true&do_preview_no_interactions=false&concat_js=no`
* view page source
* search for `jetpack-iframe-embed-js`
* the url for the script should be `https://s0.wp.com` not `http`
* remove the patch
* refresh the page source, you will see the script has the wrong protocol now (original issue)