### PR TITLE
ci: Checkout package trees for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,31 @@ jobs:
             const data = await checkTestReminderComment( github, context, core );
             return data;
 
+      # We need the tree (but not the blob) for packages that will have -alpha version numbers so the timestamp appending works right.
+      - name: Deepen tree for packages
+        env:
+          CHANGED: ${{ steps.changed.outputs.projects }}
+        run: |
+          mapfile -t PROJECTS < <(jq -r 'to_entries[] | select( .value ) | .key' <<<"$CHANGED")
+          if [[ ${#PROJECTS[@]} -gt 0 ]]; then
+            depth=$( git rev-list --count --first-parent HEAD )
+            [[ "$depth" -lt 1000 ]] && depth=1000
+            BASE=$PWD
+            for SLUG in $(pnpm jetpack dependencies list --add-dependencies --extra="build" --ignore-root "${PROJECTS[@]}"); do
+              [[ "$SLUG" == packages/* ]] || continue
+              cd "$BASE/projects/$SLUG/"
+              CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
+              [[ -d "$CHANGES_DIR" && -n "$(ls -- "$CHANGES_DIR")" ]] || continue
+              while git log --format=%D -1 . | grep -E -q '(^|, )grafted(,|$)'; do
+                depth=$((depth * 2))
+                echo "::group::Deepen to $depth"
+                echo "/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin HEAD"
+                /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin HEAD
+                echo "::endgroup::"
+              done
+            done
+          fi
+
       - name: Build changed projects
         id: build
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,16 +74,18 @@ jobs:
             depth=$( git rev-list --count --first-parent HEAD )
             [[ "$depth" -lt 1000 ]] && depth=1000
             BASE=$PWD
+            REF=$(git rev-parse HEAD)
             for SLUG in $(pnpm jetpack dependencies list --add-dependencies --extra="build" --ignore-root "${PROJECTS[@]}"); do
               [[ "$SLUG" == packages/* ]] || continue
               cd "$BASE/projects/$SLUG/"
               CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
               [[ -d "$CHANGES_DIR" && -n "$(ls -- "$CHANGES_DIR")" ]] || continue
-              while git log --format=%D -1 . | grep -E -q '(^|, )grafted(,|$)'; do
+              echo "Checking depth for $SLUG"
+              while git log --format='%h, %D,' -1 . | grep ', grafted,'; do
                 depth=$((depth * 2))
                 echo "::group::Deepen to $depth"
-                echo "/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin HEAD"
-                /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin HEAD
+                echo "/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin $REF"
+                /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin "$REF"
                 echo "::endgroup::"
               done
             done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #31220 we added logic to the build to append a timestamp to package alpha versions, derived from the last git commit to the package.

But in CI we use a shallow checkout, so the "last git commit" is the grafted commit. To get the correct timestamp we need to deepen the checkout until `git log -1` returns a non-grafted commit for each package that has any change entries.

On the plus side, we can use `--filter=blob:none` to fetch only the directory tree metadata and not all the file contents.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the build artifact for this PR. Assuming no later PRs have been merged touching packages/connection, the version recorded in the Jetpack plugin's `vendor/composer/jetpack_autoload_classmap.php` for `Automattic\\Jetpack\\Connection\\Client` should be "1.53.0.0-alpha1686840636" (based on when dfc7588bcc0f034b7aa53e87c9777c956f3988c3 was committed).