### PR TITLE
tools: Update output for `check-intra-monorepo-deps.sh -R`

### DIFF
--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -312,10 +312,10 @@ if $RELEASEBRANCH && [[ "${#SKIPPED[@]}" -gt 0 && "$EXIT" == "0" ]]; then
 	jetpackGreen <<-EOF
 		Due to use of \`-R\`, dependencies may not be fully updated. If you're doing a
 		package release from a release branch, next steps are:
-		 1. Commit the changes and push to the release branch. Note the
-		    "Check plugin monorepo dep versions" test will fail.
-		 2. Use the build artifact to do the package releases for any not auto-tagged.
-		 3. Update the release plugin's deps by running
+		 1. Commit the changes. Do not push yet.
+		 2. Create a prerelease branch with this commit. Wait for CI to run, and verify
+		    the new package versions are on Packagist.
+		 3. Back on this release branch, update the release plugin's deps by running
 		      tools/check-intra-monorepo-deps.sh -aU ${SKIPPED[*]}
 		    then commit and push.
 	EOF


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When cherry-picking package changes to a relase branch, one of the early steps is to run `changelogger-release.sh -R`, which calls `check-intra-monorepo-deps.sh -R`, which prints a reminder that the dependencies are being incompletly updated and what the next steps are.

We're updating those steps now, so the reminder also needs updating.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
To match changes to PCYsg-zR1-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the new message make sense?