### PR TITLE
Boost: Fix image guide position

### DIFF
--- a/projects/js-packages/image-guide/changelog/improve-image-url-validation
+++ b/projects/js-packages/image-guide/changelog/improve-image-url-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved image url validation for background image source.

--- a/projects/js-packages/image-guide/src/find-image-elements.ts
+++ b/projects/js-packages/image-guide/src/find-image-elements.ts
@@ -44,9 +44,13 @@ export function imageTagSource( node: HTMLImageElement ) {
  */
 export function backgroundImageSource( node: HTMLElement ) {
 	const src = getComputedStyle( node ).backgroundImage;
-	const url = src.match( /url\(.?(.*?).?\)/i );
-	if ( url && url[ 1 ] && imageLikeURL( url[ 1 ] ) ) {
-		return url[ 1 ];
+	const url = src.match( /url\(\s*(['"])(.*?)\1\s*\)/i );
+
+	// If background image is `url('')`, the computed value becomes the current page URL. So we need to check for that.
+	const currentUrlWithoutHash = window.location.href.split( '#' )[ 0 ];
+
+	if ( url && url[ 2 ] && url[ 2 ] !== currentUrlWithoutHash && imageLikeURL( url[ 2 ] ) ) {
+		return url[ 2 ];
 	}
 	return null;
 }

--- a/projects/plugins/boost/app/modules/image-guide/src/initialize.ts
+++ b/projects/plugins/boost/app/modules/image-guide/src/initialize.ts
@@ -67,6 +67,10 @@ function findContainer( image: MeasurableImage ): HTMLElement | undefined {
 		! ( image.node instanceof HTMLImageElement ) &&
 		[ 'static', 'relative' ].includes( getComputedStyle( node ).position )
 	) {
+		/* 
+		 Since we are only taking static and relative, let's convert it to relative 
+		 and mark it as a wrapper so that we can position the guide component properly.
+		*/
 		if ( ! node.classList.contains( 'jetpack-boost-guide' ) ) {
 			node.classList.add( 'jetpack-boost-guide', 'relative' );
 			node.dataset.jetpackBoostGuideId = ( ++wrapperID ).toString();

--- a/projects/plugins/boost/app/modules/image-guide/src/initialize.ts
+++ b/projects/plugins/boost/app/modules/image-guide/src/initialize.ts
@@ -108,6 +108,11 @@ function findContainer( image: MeasurableImage ): HTMLElement | undefined {
 			ancestor.style.position = 'relative';
 		}
 
+		if ( image.node instanceof HTMLImageElement ) {
+			// The guide element should be on the same y-axis level as the image.
+			wrapper.style.top = `${ image.node.offsetTop }px`;
+		}
+
 		ancestor.prepend( wrapper );
 		return wrapper;
 	}

--- a/projects/plugins/boost/app/modules/image-guide/src/initialize.ts
+++ b/projects/plugins/boost/app/modules/image-guide/src/initialize.ts
@@ -67,6 +67,10 @@ function findContainer( image: MeasurableImage ): HTMLElement | undefined {
 		! ( image.node instanceof HTMLImageElement ) &&
 		[ 'static', 'relative' ].includes( getComputedStyle( node ).position )
 	) {
+		if ( ! node.classList.contains( 'jetpack-boost-guide' ) ) {
+			node.classList.add( 'jetpack-boost-guide', 'relative' );
+			node.dataset.jetpackBoostGuideId = ( ++wrapperID ).toString();
+		}
 		return node;
 	}
 

--- a/projects/plugins/boost/app/modules/image-guide/src/ui/Main.svelte
+++ b/projects/plugins/boost/app/modules/image-guide/src/ui/Main.svelte
@@ -93,10 +93,6 @@
 			position: absolute;
 			top: 0;
 			left: 0;
-			right: 0;
-			bottom: 0;
-			width: 100%;
-			height: 100%;
 		}
 	}
 	:global( .jetpack-boost-guide.relative ) {

--- a/projects/plugins/boost/changelog/fix-image-guide-position
+++ b/projects/plugins/boost/changelog/fix-image-guide-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image Guide: Fixed some issues with image guide placement in UI.

--- a/projects/plugins/boost/changelog/improve-image-url-validation
+++ b/projects/plugins/boost/changelog/improve-image-url-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improved image url validation for background image source.

--- a/projects/plugins/boost/changelog/improve-image-url-validation
+++ b/projects/plugins/boost/changelog/improve-image-url-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved image url validation for background image source.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/jpop-issues#8348

## Proposed changes:
* Boost: Improved how image guide is attached 
* Image Guide: Improved background image source validation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Create a site with `newspaperex` theme, the image guide should place elements correctly
* Test to make sure image guide placement is correct in other themes and bunch of different image based blocks
* Create an element with `background-image: URL('')` and make sure image guide doesn't attach to it.

