### PR TITLE
Boost: Fix class namespace

### DIFF
--- a/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Entry.php
+++ b/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Entry.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Image_Size_Analysis\Data_Sync;
 
-use Automattic\Jetpack\Boost_Speed_Score\Lib\Boost_API;
+use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Lazy_Entry;

--- a/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Summary.php
+++ b/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Summary.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Image_Size_Analysis\Data_Sync;
 
-use Automattic\Jetpack\Boost_Speed_Score\Lib\Boost_API;
+use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Lazy_Entry;
 

--- a/projects/plugins/boost/app/rest-api/endpoints/Image_Analysis_Start.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/Image_Analysis_Start.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\REST_API\Endpoints;
 
-use Automattic\Jetpack\Boost_Speed_Score\Lib\Boost_API;
+use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Endpoint;
 use Automattic\Jetpack_Boost\REST_API\Permissions\Current_User_Admin;

--- a/projects/plugins/boost/changelog/fix-boost-class-namespace
+++ b/projects/plugins/boost/changelog/fix-boost-class-namespace
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed fatal error due to wrong class reference
+
+


### PR DESCRIPTION
## Proposed changes:
* Fix wrong class reference causing a fatal error. Related to creation of boost-core package

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1686821473348879-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Define `JETPACK_BOOST_IMAGE_SIZE_ANALYSIS` to true
* Upgrade to premium
* Attempt to run an image analysis