### PR TITLE
Boost: build on yalc push

### DIFF
--- a/projects/plugins/boost/changelog/update-build-boost-on-yalc
+++ b/projects/plugins/boost/changelog/update-build-boost-on-yalc
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Build boost on yalc push to ease critical-css-gen development
+
+

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -69,7 +69,7 @@
 		"test-e2e:stop": "pnpm --prefix tests/e2e run tunnel:down && pnpm --prefix tests/e2e run env:down",
 		"test-e2e:decrypt-config": "pnpm --prefix tests/e2e run config:decrypt",
 		"postinstall": "pnpm run postyalc.jetpack-boost-critical-css-gen",
-		"postyalc.jetpack-boost-critical-css-gen": "symlink='./node_modules/jetpack-boost-critical-css-gen'; new_target='../.yalc/jetpack-boost-critical-css-gen'; [ -d ./.yalc ] && rm -f \"$symlink\" && ln -s \"$new_target\" \"$symlink\" || echo 'Proceeding without yalc'"
+		"postyalc.jetpack-boost-critical-css-gen": "symlink='./node_modules/jetpack-boost-critical-css-gen'; new_target='../.yalc/jetpack-boost-critical-css-gen'; [ -d ./.yalc ] && rm -f \"$symlink\" && ln -s \"$new_target\" \"$symlink\" && pnpm run build-development || echo 'Proceeding without yalc'"
 	},
 	"private": true,
 	"repository": {


### PR DESCRIPTION
## Proposed changes:
* When there is a new push(i.e. from Automattic/jetpack-boost-critical-css-gen), build boost on development mode

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Setup jetpack-boost-ciritcal-css-gen to use with yalc and boost see: pc9hqz-1NI-p2
* Do a yalc push from the library
* Make sure boost rebuilds with the changes in library