### PR TITLE
AI Assistant: collect, store and send prompt history

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-store-prompts-in-block-attr
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-store-prompts-in-block-attr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: collect, store and send prompt history

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
@@ -2,7 +2,13 @@ export default {
 	content: {
 		type: 'string',
 	},
+
 	promptType: {
 		type: 'string',
+	},
+
+	promptHistory: {
+		type: 'array',
+		default: [],
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
@@ -7,7 +7,7 @@ export default {
 		type: 'string',
 	},
 
-	promptHistory: {
+	messages: {
 		type: 'array',
 		default: [],
 	},

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -194,7 +194,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	};
 
 	const handleTryAgain = () => {
-		setAttributes( { content: undefined, promptType: undefined, promptHistory: [] } );
+		setAttributes( { content: undefined, promptType: undefined, messages: [] } );
 	};
 
 	const handleGetSuggestion = ( ...args ) => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -194,7 +194,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	};
 
 	const handleTryAgain = () => {
-		setAttributes( { content: undefined, promptType: undefined } );
+		setAttributes( { content: undefined, promptType: undefined, promptHistory: [] } );
 	};
 
 	const handleGetSuggestion = ( ...args ) => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -195,6 +195,14 @@ const useSuggestionsFromOpenAI = ( {
 				content: assistantResponse,
 			} );
 
+			/*
+			 * Limit the prompt history to 20 items.
+			 * @todo: limit the prompt based on tokens.
+			 */
+			if ( updatedPromptHistory.length > 20 ) {
+				updatedPromptHistory.splice( 0, updatedPromptHistory.length - 20 );
+			}
+
 			stopSuggestion();
 
 			updateBlockAttributes( clientId, {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -15,6 +15,7 @@ import { askJetpack, askQuestion } from '../../lib/suggestions';
 import { getContentFromBlocks, getPartialContentToBlock } from '../../lib/utils/block-content';
 
 const debug = debugFactory( 'jetpack-ai-assistant:event' );
+const debugPromt = debugFactory( 'jetpack-ai-assistant:prompt' );
 
 const useSuggestionsFromOpenAI = ( {
 	attributes,
@@ -165,6 +166,7 @@ const useSuggestionsFromOpenAI = ( {
 		try {
 			setIsLoadingCompletion( true );
 			setWasCompletionJustRequested( true );
+			debugPromt( 'sent %o:', prompt );
 			source.current = await askQuestion( prompt, { postId, requireUpgrade } );
 		} catch ( err ) {
 			if ( err.message ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -224,7 +224,19 @@ const useSuggestionsFromOpenAI = ( {
 			onUnclearPrompt?.();
 		} );
 
-		source?.current?.addEventListener( 'error_network', () => {
+		source?.current?.addEventListener( 'error_network', ( { detail: error } ) => {
+			const { name: errorName, message: errorMessage } = error;
+			if ( errorName === 'TypeError' && errorMessage === 'Failed to fetch' ) {
+				/*
+				 * This is a network error.
+				 * Probably: "414 Request-URI Too Large".
+				 * Let's clean up the prompt history and try again.
+				 */
+				updateBlockAttributes( clientId, {
+					promptHistory: updatedPromptHistory.splice( 0, updatedPromptHistory.length - 8 ),
+				} );
+			}
+
 			source?.current?.close();
 			setIsLoadingCompletion( false );
 			setWasCompletionJustRequested( false );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -15,7 +15,7 @@ import { askJetpack, askQuestion } from '../../lib/suggestions';
 import { getContentFromBlocks, getPartialContentToBlock } from '../../lib/utils/block-content';
 
 const debug = debugFactory( 'jetpack-ai-assistant:event' );
-const debugPromt = debugFactory( 'jetpack-ai-assistant:prompt' );
+const debugPrompt = debugFactory( 'jetpack-ai-assistant:prompt' );
 
 const useSuggestionsFromOpenAI = ( {
 	attributes,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -137,7 +137,7 @@ const useSuggestionsFromOpenAI = ( {
 		} );
 
 		// Create a copy of the prompt history.
-		const updatedPromptHistory = [ ...attributes.promptHistory ] ?? [];
+		let updatedPromptHistory = [ ...attributes.promptHistory ] ?? [];
 
 		/*
 		 * Pop the last item from the prompt history,
@@ -200,7 +200,7 @@ const useSuggestionsFromOpenAI = ( {
 			 * @todo: limit the prompt based on tokens.
 			 */
 			if ( updatedPromptHistory.length > 20 ) {
-				updatedPromptHistory.splice( 0, updatedPromptHistory.length - 20 );
+				updatedPromptHistory = updatedPromptHistory.splice( 0, updatedPromptHistory.length - 20 );
 			}
 
 			stopSuggestion();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -122,8 +122,8 @@ const useSuggestionsFromOpenAI = ( {
 			post_id: postId,
 		} );
 
-		// Create a copy of the prompt history.
-		const updatedPromptHistory = [ ...attributes.promptHistory ] ?? [];
+		// Create a copy of the messages.
+		const updatedMessaages = [ ...attributes.messages ] ?? [];
 
 		let lastUserPrompt = {};
 
@@ -141,13 +141,13 @@ const useSuggestionsFromOpenAI = ( {
 			} );
 
 			/*
-			 * Pop the last item from the prompt history,
+			 * Pop the last item from the messages array,
 			 * which is the fresh `user` request by convention.
 			 */
 			lastUserPrompt = prompt.pop();
 
-			// Populate prompt with the prompt history.
-			prompt = [ ...prompt, ...updatedPromptHistory ];
+			// Populate prompt with the messages.
+			prompt = [ ...prompt, ...updatedMessaages ];
 
 			// Restore the last user prompt.
 			prompt.push( lastUserPrompt );
@@ -193,29 +193,29 @@ const useSuggestionsFromOpenAI = ( {
 		source?.current?.addEventListener( 'done', e => {
 			const { detail: assistantResponse } = e;
 
-			// Populate the prompt history with the assistant response.
+			// Populate the messages with the assistant response.
 			const lastAssistantPrompt = {
 				role: 'assistant',
 				content: assistantResponse,
 			};
-			updatedPromptHistory.push( lastUserPrompt, lastAssistantPrompt );
+			updatedMessaages.push( lastUserPrompt, lastAssistantPrompt );
 
 			debugPromt( 'Add %o\n%s', `[${ lastUserPrompt.role }]`, lastUserPrompt.content );
 			debugPromt( 'Add %o\n%s', `[${ lastAssistantPrompt.role }]`, lastAssistantPrompt.content );
 
 			/*
-			 * Limit the prompt history to 20 items.
+			 * Limit the messages to 20 items.
 			 * @todo: limit the prompt based on tokens.
 			 */
-			if ( updatedPromptHistory.length > 20 ) {
-				updatedPromptHistory.splice( 0, updatedPromptHistory.length - 20 );
+			if ( updatedMessaages.length > 20 ) {
+				updatedMessaages.splice( 0, updatedMessaages.length - 20 );
 			}
 
 			stopSuggestion();
 
 			updateBlockAttributes( clientId, {
 				content: assistantResponse,
-				promptHistory: updatedPromptHistory,
+				messages: updatedMessaages,
 			} );
 			refreshFeatureData();
 		} );
@@ -238,17 +238,17 @@ const useSuggestionsFromOpenAI = ( {
 				/*
 				 * This is a network error.
 				 * Probably: "414 Request-URI Too Large".
-				 * Let's clean up the prompt history and try again.
+				 * Let's clean up the messages array and try again.
 				 * @todo: improve the process based on tokens / URL length.
 				 */
-				updatedPromptHistory.splice( 0, 8 );
+				updatedMessaages.splice( 0, 8 );
 				updateBlockAttributes( clientId, {
-					promptHistory: updatedPromptHistory,
+					messages: updatedMessaages,
 				} );
 
 				/*
-				 * Update the last prompt with the new prompt history.
-				 * @todo: Iterate over Prompt libraru to address properly the prompt history.
+				 * Update the last prompt with the new messages.
+				 * @todo: Iterate over Prompt libraru to address properly the messages.
 				 */
 				prompt = buildPromptForBlock( {
 					generatedContent: content,
@@ -261,7 +261,7 @@ const useSuggestionsFromOpenAI = ( {
 					isGeneratingTitle: attributes.promptType === 'generateTitle',
 				} );
 
-				setLastPrompt( [ ...prompt, ...updatedPromptHistory, lastUserPrompt ] );
+				setLastPrompt( [ ...prompt, ...updatedMessaages, lastUserPrompt ] );
 			}
 
 			source?.current?.close();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -168,7 +168,7 @@ const useSuggestionsFromOpenAI = ( {
 			setWasCompletionJustRequested( true );
 			// debug all prompt items, one by one
 			prompt.forEach( ( { role, content: promptContent }, i ) =>
-				debugPromt( '(%s/%s) %o\n%s', i + 1, prompt.length, `[${ role }]`, promptContent )
+				debugPrompt( '(%s/%s) %o\n%s', i + 1, prompt.length, `[${ role }]`, promptContent )
 			);
 
 			source.current = await askQuestion( prompt, { postId, requireUpgrade } );
@@ -200,8 +200,8 @@ const useSuggestionsFromOpenAI = ( {
 			};
 			updatedMessaages.push( lastUserPrompt, lastAssistantPrompt );
 
-			debugPromt( 'Add %o\n%s', `[${ lastUserPrompt.role }]`, lastUserPrompt.content );
-			debugPromt( 'Add %o\n%s', `[${ lastAssistantPrompt.role }]`, lastAssistantPrompt.content );
+			debugPrompt( 'Add %o\n%s', `[${ lastUserPrompt.role }]`, lastUserPrompt.content );
+			debugPrompt( 'Add %o\n%s', `[${ lastAssistantPrompt.role }]`, lastAssistantPrompt.content );
 
 			/*
 			 * Limit the messages to 20 items.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -14,7 +14,7 @@ import { buildPromptForBlock } from '../../lib/prompt';
 import { askJetpack, askQuestion } from '../../lib/suggestions';
 import { getContentFromBlocks, getPartialContentToBlock } from '../../lib/utils/block-content';
 
-const debug = debugFactory( 'jetpack-ai-assistant:event:fullMessage' );
+const debug = debugFactory( 'jetpack-ai-assistant:event' );
 
 const useSuggestionsFromOpenAI = ( {
 	attributes,
@@ -165,7 +165,6 @@ const useSuggestionsFromOpenAI = ( {
 		try {
 			setIsLoadingCompletion( true );
 			setWasCompletionJustRequested( true );
-
 			source.current = await askQuestion( prompt, { postId, requireUpgrade } );
 		} catch ( err ) {
 			if ( err.message ) {
@@ -272,7 +271,7 @@ const useSuggestionsFromOpenAI = ( {
 
 		source?.current?.addEventListener( 'suggestion', e => {
 			setWasCompletionJustRequested( false );
-			debug( 'fullMessage', e.detail );
+			debug( '(suggestion)', e.detail );
 			updateBlockAttributes( clientId, { content: e.detail } );
 		} );
 		return source?.current;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -137,7 +137,7 @@ const useSuggestionsFromOpenAI = ( {
 		} );
 
 		// Create a copy of the prompt history.
-		let updatedPromptHistory = [ ...attributes.promptHistory ] ?? [];
+		const updatedPromptHistory = [ ...attributes.promptHistory ] ?? [];
 
 		/*
 		 * Pop the last item from the prompt history,
@@ -199,9 +199,9 @@ const useSuggestionsFromOpenAI = ( {
 			 * Limit the prompt history to 20 items.
 			 * @todo: limit the prompt based on tokens.
 			 */
-			if ( updatedPromptHistory.length > 20 ) {
-				updatedPromptHistory = updatedPromptHistory.splice( 0, updatedPromptHistory.length - 20 );
-			}
+			// if ( updatedPromptHistory.length > 20 ) {
+			// 	updatedPromptHistory = updatedPromptHistory.splice( 0, updatedPromptHistory.length - 20 );
+			// }
 
 			stopSuggestion();
 
@@ -232,9 +232,9 @@ const useSuggestionsFromOpenAI = ( {
 				 * Probably: "414 Request-URI Too Large".
 				 * Let's clean up the prompt history and try again.
 				 */
-				updateBlockAttributes( clientId, {
-					promptHistory: updatedPromptHistory.splice( 0, updatedPromptHistory.length - 8 ),
-				} );
+				// updateBlockAttributes( clientId, {
+				// 	promptHistory: updatedPromptHistory.splice( 0, updatedPromptHistory.length - 8 ),
+				// } );
 			}
 
 			source?.current?.close();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -153,12 +153,7 @@ export const buildPromptTemplate = ( {
 	}
 
 	if ( relevantContent != null && relevantContent?.length ) {
-		if ( isContentGenerated ) {
-			messages.push( {
-				role: 'assistant',
-				content: relevantContent,
-			} );
-		} else {
+		if ( ! isContentGenerated ) {
 			messages.push( {
 				role: 'system',
 				content: `The specific relevant content for this request, if necessary: ${ relevantContent }`,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -86,14 +86,14 @@ ${ extraRules }- Format your responses in Markdown syntax, ready to be published
  * @param {string} options.content - The content of the post.
  * @returns {PromptItemProps} The blog post data prompt.
  */
-export function getBlogPostDataPrompt( { content }: { content: string } ): PromptItemProps {
+export function getBlogPostDataUserPrompt( { content }: { content: string } ): PromptItemProps {
 	const postTitle = select( editorStore ).getEditedPostAttribute( 'title' );
 
 	if ( ! postTitle?.length && ! content?.length ) {
 		return null;
 	}
 
-	const blogPostData = `Here's the content in the editor that serves as context to the user request:
+	const blogPostData = `I'm working on a blog post. Here's the data I have so far:
 ${ postTitle?.length ? `- Current title: ${ postTitle }\n` : '' }${
 		content ? `- Current content: ${ content }` : ''
 	}`;
@@ -147,7 +147,7 @@ export const buildPromptTemplate = ( {
 	const messages = [ getInitialSystemPrompt( { rules } ) ];
 
 	// Add blog post data prompt.
-	const postDataPrompt = getBlogPostDataPrompt( { content: fullContent } );
+	const postDataPrompt = getBlogPostDataUserPrompt( { content: fullContent } );
 	if ( postDataPrompt ) {
 		messages.push( postDataPrompt );
 	}
@@ -166,17 +166,16 @@ export const buildPromptTemplate = ( {
 		}
 	}
 
-	messages.push( {
+	const lastUserRequest: PromptItemProps = {
 		role: 'user',
 		content: request,
-	} );
+	};
 
 	if ( isGeneratingTitle ) {
-		messages.push( {
-			role: 'user',
-			content: 'Only output a title, do not generate body content.',
-		} );
+		lastUserRequest.content += ' Only output a title, do not generate body content.';
 	}
+
+	messages.push( lastUserRequest );
 
 	messages.forEach( message => {
 		debug( `Role: ${ message?.role }.\nMessage: ${ message?.content }\n---` );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -56,7 +56,7 @@ const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
  * @returns {PromptItemProps} The initial system prompt.
  */
 export function getInitialSystemPrompt( {
-	context = 'You are an AI assistant, your task is to generate and modify content based on user requests. This functionality is integrated into the Jetpack product developed by Automattic. Users interact with you through a Gutenberg block, you are inside the Wordpress editor',
+	context = 'Impersonate a ghostwriter to help me write in the WordPress editor, your task is to generate and modify content based on user requests. This functionality is integrated into the Jetpack product developed by Automattic. Users interact with you through a Gutenberg block, you are inside the Wordpress editor',
 	rules,
 }: {
 	context?: string;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -56,7 +56,7 @@ const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
  * @returns {PromptItemProps} The initial system prompt.
  */
 export function getInitialSystemPrompt( {
-	context = 'Impersonate a ghostwriter to help me write in the WordPress editor, your task is to generate and modify content based on user requests. This functionality is integrated into the Jetpack product developed by Automattic. Users interact with you through a Gutenberg block, you are inside the Wordpress editor',
+	context = 'You are an AI assistant, your task is to generate and modify content based on user requests. This functionality is integrated into the Jetpack product developed by Automattic. Users interact with you through a Gutenberg block, you are inside the Wordpress editor',
 	rules,
 }: {
 	context?: string;
@@ -93,7 +93,7 @@ export function getBlogPostDataUserPrompt( { content }: { content: string } ): P
 		return null;
 	}
 
-	const blogPostData = `I'm working on a blog post. Here's the data I have so far:
+	const blogPostData = `Here's the content in the editor that serves as context to the user request:
 ${ postTitle?.length ? `- Current title: ${ postTitle }\n` : '' }${
 		content ? `- Current content: ${ content }` : ''
 	}`;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/suggestions/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/suggestions/index.js
@@ -217,6 +217,6 @@ export class SuggestionsEventSource extends EventTarget {
 		debug( e );
 
 		// Dispatch a generic network error event
-		this.dispatchEvent( new CustomEvent( 'error_network' ) );
+		this.dispatchEvent( new CustomEvent( 'error_network', { detail: e } ) );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR aims to collect, store, and pass the prompt history to the AI endpoint.

* Register a new promptHistory attribute
* Combine the prompt generated by the library with the history
* Send the history when hitting the endpoint 
* Limit the number of prompt items to 20 (hardcoded for now)
* It tries to catch [422](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) which happens when the URL is too long. If so, it removes items from the history to be able to retry the request

### Follow-up issues

* Compute the prompt size depending on tokens and URL length
* Keep iterating over the Prompt list. The API is still tough to use.


Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: collect, store and send prompt history

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create an AI Assistant block instance
* Start to generate content.
* Use the de console to see the prompt data

<img width="750" alt="Screenshot 2023-06-16 at 13 36 34" src="https://github.com/Automattic/jetpack/assets/77539/3317a5d0-4357-4cbb-bbb8-4a32d49fbb41">

* Keep iterating over the same block instance. You can check the block attribute:
<img width="499" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/d6bfd30e-de3a-4e5d-a28f-4aad138abfdf">

* Finally, confirm the block works as expected.
* Check block generation options.
