### PR TITLE
CRM: API include tags in the contact endpoints responses

### DIFF
--- a/projects/plugins/crm/api/customer_search.php
+++ b/projects/plugins/crm/api/customer_search.php
@@ -48,6 +48,7 @@ if ( isset( $_GET['email'] ) ) {
 			'email'            => $email,
 			'withInvoices'     => true,
 			'withTransactions' => true,
+			'withTags'         => true,
 		)
 	);
 

--- a/projects/plugins/crm/api/customers.php
+++ b/projects/plugins/crm/api/customers.php
@@ -26,6 +26,8 @@ if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
 // Ultimately this should be switched to GET, but the docs have it as POST, so best to wait for a rewrite
 // Also seems to mostly be a duplicate of customer_search, other than not being able to search by email...
 
+// phpcs:disabled WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
 global $zbs;
 
 $json_params     = file_get_contents( 'php://input' );
@@ -65,6 +67,11 @@ if ( isset( $customer_params['company'] ) ) {
 	$companyID = (int) $customer_params['company'];
 }
 
+$withTags = -1;
+if ( isset( $customer_params['tags'] ) ) {
+	$withTags = true;
+}
+
 // #FORMIKENOTES -
 // These should be Bools - see https://stackoverflow.com/questions/7336861/how-to-convert-string-to-boolean-php
 // ... this forces them from string of "true" or "false" into a bool
@@ -81,6 +88,7 @@ $args = array(
 	'withQuotes'       => $withQuotes,
 	'withInvoices'     => $withInvoices,
 	'withTransactions' => $withTransactions,
+	'withTags'         => $withTags,
 	'page'             => $page,
 	'perPage'          => $perPage,
 	'ignoreowner'      => zeroBSCRM_DAL2_ignoreOwnership( ZBS_TYPE_CONTACT ),
@@ -89,5 +97,7 @@ $args = array(
 $customers = $zbs->DAL->contacts->getContacts( $args );
 
 wp_send_json( $customers );
+
+// phpcs:enabled WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 

--- a/projects/plugins/crm/api/customers.php
+++ b/projects/plugins/crm/api/customers.php
@@ -67,7 +67,7 @@ if ( isset( $customer_params['company'] ) ) {
 	$companyID = (int) $customer_params['company'];
 }
 
-$withTags = -1;
+$withTags = false;
 if ( isset( $customer_params['tags'] ) ) {
 	$withTags = true;
 }

--- a/projects/plugins/crm/api/customers.php
+++ b/projects/plugins/crm/api/customers.php
@@ -69,7 +69,7 @@ if ( isset( $customer_params['company'] ) ) {
 
 $withTags = false;
 if ( isset( $customer_params['tags'] ) ) {
-	$withTags = true;
+	$withTags = (bool) $customer_params['tags'];
 }
 
 // #FORMIKENOTES -

--- a/projects/plugins/crm/changelog/api-include-contact-tags
+++ b/projects/plugins/crm/changelog/api-include-contact-tags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+API contacts endpoints to retrive contacts does not have tags

--- a/projects/plugins/crm/changelog/api-include-contact-tags
+++ b/projects/plugins/crm/changelog/api-include-contact-tags
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-API contacts endpoints to retrive contacts does not have tags
+API contact endpoints: Now it retrieves contacts with tags


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3154

## Proposed changes:
This PR adds the field `withTags` to allow the API contacts endpoint to retrieve contacts including tags:

- `/zbs_api/customers/`
- `/zbs_api/customer_search/`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:

- Use an application to make API queries
- Get/copy your JPCRM API keys from your installation: `api_key` and `api_secret`
- Make these queries:

GET `/zbs_api/customer_search?api_key=you_api_key&api_secret=your_api_secret&email=contact_email&tags=1`
- **In trunk,** you won't get the tags in the JSON response
- **In this branch,** you will get the contact tags.

POST `/zbs_api/customers?api_key=you_api_key&api_secret=your_api_secret` and in the body request, put this JSON content:

```
{
	"tags": true,
	"perpage": 3
}
```

- **In trunk,** you won't get the tags in the JSON response
- **In this branch,** you will get the contact tags.


