### PR TITLE
Jetpack plugin: add srcset to related posts thumbs

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-srcset-to-related-posts
+++ b/projects/plugins/jetpack/changelog/update-add-srcset-to-related-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Related posts: added srcset to thumbnails

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1501,9 +1501,8 @@ EOT;
 			);
 
 			if ( is_array( $post_image ) ) {
-				$img_url    = $post_image['src'];
-				$src_width  = $post_image['src_width'];
-				$src_height = $post_image['src_height'];
+				$img_url   = $post_image['src'];
+				$src_width = $post_image['src_width'];
 			} elseif ( class_exists( 'Jetpack_Media_Summary' ) ) {
 				$media = Jetpack_Media_Summary::get( $post_id );
 
@@ -1539,8 +1538,8 @@ EOT;
 
 					$srcset_url      = Jetpack_PostImages::fit_image_url(
 						$img_url,
-						$thumbnail_size['width'] * $multiplier,
-						$thumbnail_size['height'] * $multiplier
+						$srcset_width,
+						$srcset_height
 					);
 					$srcset_values[] = "{$srcset_url} {$multiplier}x";
 				}

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1530,7 +1530,7 @@ EOT;
 				$multipliers   = array( 1, 2, 3, 4 );
 				$srcset_values = array();
 				foreach ( $multipliers as $multiplier ) {
-					// Forcefully cast to int, in case we ever aff decimal multipliers.
+					// Forcefully cast to int, in case we ever add decimal multipliers.
 					$srcset_width  = (int) $thumbnail_size['width'] * $multiplier;
 					$srcset_height = (int) $thumbnail_size['height'] * $multiplier;
 					if ( ! isset( $src_width ) || $srcset_width > $src_width ) {

--- a/projects/plugins/jetpack/modules/related-posts/related-posts.js
+++ b/projects/plugins/jetpack/modules/related-posts/related-posts.js
@@ -171,6 +171,8 @@
 						post.img.width +
 						'" height="' +
 						post.img.height +
+						( post.img.srcset ? '" srcset="' + post.img.srcset : '' ) +
+						( post.img.sizes ? '" sizes="' + post.img.sizes : '' ) +
 						'" alt="' +
 						post.img.alt_text +
 						'" />' +


### PR DESCRIPTION
Fixes #13106

## Proposed changes:

In an effort to move away from the `devicepx` script towards native functionality, this PR adds a `srcset` to related posts thumbnails (from the Jetpack module feature, not the block). The browser will automatically pick the most appropriate image from the options in the `srcset`, depending on the screen pixel ratio and the current zoom value.

* Add a `srcset` attribute to related post thumbnail API responses (`sizes` is not needed, since we're using pixel ratio multipliers instead of widths)
* Add the ability for the related posts script to set `srcset` (and `sizes`) if present in the API response

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- Enable the "Related Posts" feature for your test blog (`Settings -> Traffic -> Show related content after posts`).
- Enable related posts thumbnails (`Show a thumbnail image where available` in the same place).
- Open a post that has related posts with thumbnails.
- Verify that the thumbnails include a `srcset` with different pixel ratios (up to 4x, if the source image is large enough).
- Optionally, validate that the variants that get fetched on page load change as you change zoom values and/or try different pixel ratio screens.

