### PR TITLE
Boost: Fix image analysis report not rendering

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/zod-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/zod-types.ts
@@ -25,9 +25,9 @@ export const ImageData = z.object( {
 	} ),
 	page: z.object( {
 		id: z.number(),
-		url: z.string().url().nullable(),
+		url: z.string().url(),
 		title: z.string(),
-		edit_url: z.string().url().nullable(),
+		edit_url: z.string().url().nullable().default( null ),
 	} ),
 	device_type: z.enum( [ 'phone', 'desktop' ] ),
 	instructions: z.string(),

--- a/projects/plugins/boost/changelog/fix-boost-image-analysis-not-rendering
+++ b/projects/plugins/boost/changelog/fix-boost-image-analysis-not-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix not loading report items if one of them was missing the edit_url property.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31434

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow Image Size Analysis report items to not have an `edit_url`, which was causing the whole list of items to not render. Websites without front pages don't have an edit_url for their front-page.
* This needs expanding, as it just solves the problem with a missing property. Ideally, we would skip an invalid item from the batch of items for the page, and show the rest. I've opened an additional issue for that - https://github.com/Automattic/jetpack/issues/31436

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**You need to have the Image Size Analysis feature enabled**

* Don't set a front-page for your website - leave it to `Your latest posts`;
* Make sure you have a large image on the front-page (you can add a featured image to the first post);
* Generate a report;

### Test that it breaks
* Open the Homepage tab of the report UI;
* It should show 10 placeholder images.

### Test that it works
* Apply the patch;
* The UI should properly show the front page as having an issue.