### PR TITLE
AI Extension: dispatch action to update extended block attributes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-update-attrs-dispatching-action
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-update-attrs-dispatching-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: dispatch action to update extended block attributes

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import React from 'react';
 /**
@@ -21,8 +23,10 @@ import { PromptItemProps, PromptTypeProp, buildPromptForExtensions } from '../..
  */
 export const withAIAssistant = createHigherOrderComponent(
 	BlockEdit => props => {
-		const { setAttributes } = props;
+		const { clientId } = props;
 		const [ prompt, setPrompt ] = useState< Array< PromptItemProps > >( [] );
+
+		const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 		/*
 		 * Pick the content from the block attribute from now.
@@ -45,9 +49,9 @@ export const withAIAssistant = createHigherOrderComponent(
 				 * It doesn't scale for other blocks.
 				 * @todo: find a better way to update the content.
 				 */
-				setAttributes( { content: newContent } );
+				updateBlockAttributes( clientId, { content: newContent } );
 			},
-			[ setAttributes ]
+			[ clientId, updateBlockAttributes ]
 		);
 
 		useSuggestionsFromAI( { prompt, onSuggestion: setContent } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The PR replaces the way to update the block attributes of the extended blocks. Instead of using the setAttributes() function, it dispatches the updateBlockAttributes() function that relies on the given clientId to identify the block to update.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: dispatch action to update extended block attributes

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a paragraph/heading block
* Edit the content by using any AI Assistant option 
* Confirm the block updates its content as expected

