### PR TITLE
Masterbar: avoid php warning with PHP 8.2

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-php82-dynamic-properties-masterbar
+++ b/projects/plugins/jetpack/changelog/fix-php82-dynamic-properties-masterbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+WordPress.com Toolbar: avoid PHP warnings with PHP 8.2.

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -84,6 +84,12 @@ class Masterbar {
 	 */
 	private $primary_site_slug;
 	/**
+	 * Site URL displayed in the UI.
+	 *
+	 * @var string
+	 */
+	private $primary_site_url;
+	/**
 	 * Whether the text direction is RTL (based on connected WordPress.com user's interface settings).
 	 *
 	 * @var boolean


### PR DESCRIPTION

## Proposed changes:

- Follow-up to #30786 and #31296

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- Primary issue: 27927

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On a site running PHP 8.2, go to Jetpack > Settings > Writing and enable the WordPress.com toolbar (masterbar module).
* Check your logs; you should not see any warnings.
