### PR TITLE
CRM: Skip CS linter for JPCRM. PHP 7.2 code is used and required

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -171,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '5.6', '7.0', '7.4', '8.0', '8.1', '8.2' ]
+        php-versions: [ '5.6', '7.0', '7.2', '7.4', '8.0', '8.1', '8.2' ]
         experimental: [ false ]
 
     steps:

--- a/tools/parallel-lint.sh
+++ b/tools/parallel-lint.sh
@@ -27,7 +27,7 @@ if $ALL; then
 	if php -r 'exit( PHP_VERSION_ID < 70000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php7 )
 	fi
-	if php -r 'exit( PHP_VERSION_ID < 70200 ? 0 : 1 )'; then
+	if php -r 'exit( PHP_VERSION_ID < 70200 ? 0 : 1 );'; then
 		# Plugin requires PHP 7.2 or later.
 		SKIPS+=( -o -path ./projects/plugins/crm )
 	fi

--- a/tools/parallel-lint.sh
+++ b/tools/parallel-lint.sh
@@ -27,6 +27,10 @@ if $ALL; then
 	if php -r 'exit( PHP_VERSION_ID < 70000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php7 )
 	fi
+	if php -r 'exit( PHP_VERSION_ID < 70200 ? 0 : 1 )'; then
+      # Plugin requires PHP 7.2 or later.
+      SKIPS+=( -o -path ./projects/plugins/crm )
+  fi
 	if php -r 'exit( PHP_VERSION_ID < 80000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php8 )
 	fi

--- a/tools/parallel-lint.sh
+++ b/tools/parallel-lint.sh
@@ -28,9 +28,9 @@ if $ALL; then
 		SKIPS+=( -o -name php7 )
 	fi
 	if php -r 'exit( PHP_VERSION_ID < 70200 ? 0 : 1 )'; then
-      # Plugin requires PHP 7.2 or later.
-      SKIPS+=( -o -path ./projects/plugins/crm )
-  fi
+		# Plugin requires PHP 7.2 or later.
+		SKIPS+=( -o -path ./projects/plugins/crm )
+	fi
 	if php -r 'exit( PHP_VERSION_ID < 80000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php8 )
 	fi


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3149

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR adds an exception for Jetpack CRM for skipping the linter for PHP <7.2 code. In Jetpack CRM we have code that requires PHP 7.2, which is the minimal version for the plugin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

CBG1CP4EN-slack-T024FN1V2

## Does this pull request to change what data or activity we track or use?
N/A

## Testing instructions:
- Check the condition added to the script
- Once it's merged, it should skip the linter check for PHP versions below 7.2

