### PR TITLE
AI Assistant: add transform from core to AI Assistant block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-add-transform-to
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-add-transform-to
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: add transform from core to AI Assistant block

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -11,7 +11,7 @@ import { AI_Assistant_Initial_State } from '../../hooks/use-ai-feature';
 import { isUserConnected } from '../../lib/connection';
 
 /*
- * Types and Contstants
+ * Types and Constants
  */
 export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -10,12 +10,15 @@ import { blockName } from '../..';
 import { AI_Assistant_Initial_State } from '../../hooks/use-ai-feature';
 import { isUserConnected } from '../../lib/connection';
 
+/*
+ * Types and Contstants
+ */
 export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
 
-/*
- * List of blocks that can be extended.
- */
-export const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading' ];
+// List of blocks that can be extended.
+export const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading' ] as const;
+
+type ExtendedBlock = ( typeof EXTENDED_BLOCKS )[ number ];
 
 type BlockSettingsProps = {
 	supports: {
@@ -69,10 +72,13 @@ export function isPossibleToExtendBlock(): boolean {
  * Add jetpack/ai support to the extended blocks.
  *
  * @param {BlockSettingsProps} settings - Block settings.
- * @param {string} name                 - Block name.
+ * @param {ExtendedBlock} name          - Block name.
  * @returns {BlockSettingsProps}          Block settings.
  */
-function addJetpackAISupport( settings: BlockSettingsProps, name: string ): BlockSettingsProps {
+function addJetpackAISupport(
+	settings: BlockSettingsProps,
+	name: ExtendedBlock
+): BlockSettingsProps {
 	if ( ! isPossibleToExtendBlock() ) {
 		return settings;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/index.js
@@ -12,6 +12,7 @@ import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
 import edit from './edit';
 import Icon from './icons/ai-assistant';
+import transforms from './transforms';
 /**
  * Supports and extensions
  */
@@ -79,7 +80,7 @@ export const settings = {
 	edit,
 	save: () => null,
 	attributes,
-	transforms: {},
+	transforms,
 	example: {
 		attributes: {
 			content: __( "I'm afraid I can't do that, Dave.", 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -22,7 +22,7 @@ const transformFromCore = {
 	transform: ( { content } ) => {
 		const messages: Array< PromptItemProps > = [
 			{
-				role: 'user',
+				role: 'assistant',
 				content,
 			},
 		];

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -25,6 +25,6 @@ const transformFromCore = {
 	},
 };
 
-const from = [ transformFromCoreEmbed ];
+const from = [ transformFromCore ];
 
 export default { from };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -6,11 +6,12 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { blockName } from '..';
-import { EXTENDED_BLOCKS } from '../extensions/ai-assistant';
+import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assistant';
 
 const transformFromCoreEmbed = {
 	type: 'block',
 	blocks: EXTENDED_BLOCKS,
+	isMatch: () => isPossibleToExtendBlock(),
 	transform: ( { content } ) => {
 		return createBlock( blockName, { content } );
 	},

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -7,13 +7,21 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { blockName } from '..';
 import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assistant';
+import { PromptItemProps } from '../lib/prompt';
 
 const transformFromCoreEmbed = {
 	type: 'block',
 	blocks: EXTENDED_BLOCKS,
 	isMatch: () => isPossibleToExtendBlock(),
 	transform: ( { content } ) => {
-		return createBlock( blockName, { content } );
+		const messages: Array< PromptItemProps > = [
+			{
+				role: 'user',
+				content,
+			},
+		];
+
+		return createBlock( blockName, { content, messages } );
 	},
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -2,12 +2,18 @@
  * External dependencies
  */
 import { createBlock } from '@wordpress/blocks';
+import TurndownService from 'turndown';
 /**
  * Internal dependencies
  */
 import { blockName } from '..';
 import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assistant';
+/**
+ * Types
+ */
 import { PromptItemProps } from '../lib/prompt';
+
+const turndownService = new TurndownService();
 
 const transformFromCore = {
 	type: 'block',
@@ -21,7 +27,7 @@ const transformFromCore = {
 			},
 		];
 
-		return createBlock( blockName, { content, messages } );
+		return createBlock( blockName, { content: turndownService.turndown( content ), messages } );
 	},
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -9,7 +9,7 @@ import { blockName } from '..';
 import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assistant';
 import { PromptItemProps } from '../lib/prompt';
 
-const transformFromCoreEmbed = {
+const transformFromCore = {
 	type: 'block',
 	blocks: EXTENDED_BLOCKS,
 	isMatch: () => isPossibleToExtendBlock(),

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+/**
+ * Internal dependencies
+ */
+import { blockName } from '..';
+import { EXTENDED_BLOCKS } from '../extensions/ai-assistant';
+
+const transformFromCoreEmbed = {
+	type: 'block',
+	blocks: EXTENDED_BLOCKS,
+	transform: ( { content } ) => {
+		return createBlock( blockName, { content } );
+	},
+};
+
+const from = [ transformFromCoreEmbed ];
+
+export default { from };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR allows transforming from the current extended blocks (paragraph and heading) to the AI Assistant block.

Fixes https://github.com/Automattic/jetpack/issues/31319

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: add transform from core to AI Assistant block

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a paragraph/heading block
* Confirm both block-type instances allow transforming to the AI Assistant block by clicking on the transform button ONLY when it's doable:
  * The AI Assistant block is registered
  * Beta Extension is enabled
  * Jetpack site is connected
  * Site doesn't require an upgrade

<img width="701" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/1bbeba15-deeb-4f88-aa7d-1f21245e1c21">
* Tramsfomr the block
* Edit the content by using the new AI Assistant block as usual 

https://github.com/Automattic/jetpack/assets/77539/30afa7d3-5670-4268-ac34-c7baec3d1e03

