### PR TITLE
Launchpad: Add backend tracks event for task completion

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-tracks-function
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-tracks-function
@@ -1,4 +1,4 @@
 Significance: minor
-Type: patch
+Type: added
 
 Add a function to fire off a Tracks event when a task is completed and update existing mark task complete functions to use it.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-tracks-function
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-tracks-function
@@ -1,0 +1,4 @@
+Significance: minor
+Type: patch
+
+Add a function to fire off a Tracks event when a task is completed and update existing mark task complete functions to use it.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -230,6 +230,26 @@ function wpcom_launchpad_get_task_definitions() {
 }
 
 /**
+ * Record completion event in Tracks if we're running on WP.com.
+ *
+ * @param string $task_id The task ID.
+ * @return void
+ */
+function wpcom_launchpad_track_completed_task( $task_id ) {
+	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+		return;
+	}
+
+	require_lib( 'tracks/client' );
+
+	tracks_record_event(
+		wp_get_current_user(),
+		'wpcom_launchpad_mark_task_complete',
+		array( 'task_id' => $task_id )
+	);
+}
+
+/**
  * Mark a task as complete.
  *
  * @param string $task_id The task ID.
@@ -254,29 +274,9 @@ function wpcom_mark_launchpad_task_complete( $task_id ) {
 	$result           = update_option( 'launchpad_checklist_tasks_statuses', $statuses );
 
 	// Record the completion event in Tracks.
-	wpcom_track_task_is_complete( $key );
+	wpcom_launchpad_track_completed_task( $key );
 
 	return $result;
-}
-
-/**
- * Record completion event in Tracks if we're running on WP.com.
- *
- * @param string $task_id The task ID.
- * @return void
- */
-function wpcom_track_task_is_complete( $task_id ) {
-	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-		return;
-	}
-
-	require_lib( 'tracks/client' );
-
-	tracks_record_event(
-		wp_get_current_user(),
-		'wpcom_launchpad_mark_task_complete',
-		array( 'task_id' => $task_id )
-	);
 }
 
 /**
@@ -342,6 +342,7 @@ add_action( 'init', 'wpcom_launchpad_init_task_definitions', 11 );
  * @return bool True if successful, false if not.
  */
 function wpcom_mark_launchpad_task_complete_if_active( $task_id ) {
+	wpcom_launchpad_track_completed_task( $task_id );
 	return wpcom_launchpad_checklists()->mark_task_complete_if_active( $task_id );
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -347,8 +347,12 @@ add_action( 'init', 'wpcom_launchpad_init_task_definitions', 11 );
  * @return bool True if successful, false if not.
  */
 function wpcom_mark_launchpad_task_complete_if_active( $task_id ) {
-	wpcom_launchpad_track_completed_task( $task_id );
-	return wpcom_launchpad_checklists()->mark_task_complete_if_active( $task_id );
+	if ( wpcom_launchpad_checklists()->mark_task_complete_if_active( $task_id ) ) {
+		wpcom_launchpad_track_completed_task( $task_id );
+		return true;
+	}
+
+	return false;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -247,7 +247,10 @@ function wpcom_launchpad_track_completed_task( $task_id, $extra_props = array() 
 	tracks_record_event(
 		wp_get_current_user(),
 		'wpcom_launchpad_mark_task_complete',
-		array( 'task_id' => $task_id, ...$extra_props )
+		array_merge(
+			array( 'task_id' => $task_id ),
+			$extra_props
+		)
 	);
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -253,18 +253,30 @@ function wpcom_mark_launchpad_task_complete( $task_id ) {
 	$statuses[ $key ] = true;
 	$result           = update_option( 'launchpad_checklist_tasks_statuses', $statuses );
 
-	// Record the completion event in Tracks if we're running on WP.com.
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		require_lib( 'tracks/client' );
-
-		tracks_record_event(
-			wp_get_current_user(),
-			'launchpad_mark_task_completed',
-			array( 'task_id' => $key )
-		);
-	}
+	// Record the completion event in Tracks.
+	wpcom_track_task_is_complete( $key );
 
 	return $result;
+}
+
+/**
+ * Record completion event in Tracks if we're running on WP.com.
+ *
+ * @param string $task_id The task ID.
+ * @return void
+ */
+function wpcom_track_task_is_complete( $task_id ) {
+	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+		return;
+	}
+
+	require_lib( 'tracks/client' );
+
+	tracks_record_event(
+		wp_get_current_user(),
+		'wpcom_launchpad_mark_task_complete',
+		array( 'task_id' => $task_id )
+	);
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -651,3 +651,28 @@ function wpcom_is_domain_claim_completed() {
 
 	return ! empty( $domain_purchases );
 }
+
+/**
+ * Mark `domain_claim`, `domain_upsell`, and `domain_upsell_deferred` tasks complete
+ * when a domain product is activated.
+ *
+ * @param int    $blog_id The blog ID.
+ * @param int    $user_id The user ID.
+ * @param string $product_id The product ID.
+ *
+ * @return void
+ */
+function wpcom_mark_domain_tasks_complete( $blog_id, $user_id, $product_id ) {
+	if ( ! class_exists( 'domains' ) ) {
+		return;
+	}
+
+	if ( ! domains::is_domain_product( $product_id ) ) {
+		return;
+	}
+
+	wpcom_mark_launchpad_task_complete( 'domain_claim' );
+	wpcom_mark_launchpad_task_complete( 'domain_upsell' );
+	wpcom_mark_launchpad_task_complete( 'domain_upsell_deferred' );
+}
+add_action( 'activate_product', 'wpcom_mark_domain_tasks_complete', 10, 6 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -233,9 +233,11 @@ function wpcom_launchpad_get_task_definitions() {
  * Record completion event in Tracks if we're running on WP.com.
  *
  * @param string $task_id The task ID.
+ * @param array  $extra_props Optional extra arguments to pass to the Tracks event.
+ *
  * @return void
  */
-function wpcom_launchpad_track_completed_task( $task_id ) {
+function wpcom_launchpad_track_completed_task( $task_id, $extra_props = array() ) {
 	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
 		return;
 	}
@@ -245,7 +247,7 @@ function wpcom_launchpad_track_completed_task( $task_id ) {
 	tracks_record_event(
 		wp_get_current_user(),
 		'wpcom_launchpad_mark_task_complete',
-		array( 'task_id' => $task_id )
+		array( 'task_id' => $task_id, ...$extra_props )
 	);
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -141,11 +141,12 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 				case 'checklist_statuses':
 					$launchpad_checklist_tasks_statuses_option = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );
 					$launchpad_checklist_tasks_statuses_option = array_merge( $launchpad_checklist_tasks_statuses_option, $value );
-
 					if ( update_option( 'launchpad_checklist_tasks_statuses', $launchpad_checklist_tasks_statuses_option ) ) {
-						// If we're marking a task as complete, the value should be `true`, so fire the Tracks event.
-						if ( $value === true ) {
-							wpcom_launchpad_track_completed_task( $key );
+						foreach ( $value as $key => $val ) {
+							if ( $val ) {
+								// If we're marking a task as complete, the value should be truthy, so fire the Tracks event.
+								wpcom_launchpad_track_completed_task( $key );
+							}
 						}
 						$updated[ $key ] = $value;
 					}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -143,7 +143,10 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					$launchpad_checklist_tasks_statuses_option = array_merge( $launchpad_checklist_tasks_statuses_option, $value );
 
 					if ( update_option( 'launchpad_checklist_tasks_statuses', $launchpad_checklist_tasks_statuses_option ) ) {
-						wpcom_launchpad_track_completed_task( $key );
+						// If we're marking a task as complete, the value should be `true`, so fire the Tracks event.
+						if ( $value === true ) {
+							wpcom_launchpad_track_completed_task( $key );
+						}
 						$updated[ $key ] = $value;
 					}
 					// This will check if we have completed all the tasks and disable Launchpad if so.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -143,6 +143,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					$launchpad_checklist_tasks_statuses_option = array_merge( $launchpad_checklist_tasks_statuses_option, $value );
 
 					if ( update_option( 'launchpad_checklist_tasks_statuses', $launchpad_checklist_tasks_statuses_option ) ) {
+						wpcom_launchpad_track_completed_task( $key );
 						$updated[ $key ] = $value;
 					}
 					// This will check if we have completed all the tasks and disable Launchpad if so.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -141,13 +141,15 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 				case 'checklist_statuses':
 					$launchpad_checklist_tasks_statuses_option = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );
 					$launchpad_checklist_tasks_statuses_option = array_merge( $launchpad_checklist_tasks_statuses_option, $value );
-					if ( update_option( 'launchpad_checklist_tasks_statuses', $launchpad_checklist_tasks_statuses_option ) ) {
-						foreach ( $value as $key => $val ) {
-							if ( $val ) {
-								// If we're marking a task as complete, the value should be truthy, so fire the Tracks event.
-								wpcom_launchpad_track_completed_task( $key );
-							}
+
+					foreach ( $value as $task => $task_value ) {
+						if ( $task_value ) {
+							// If we're marking a task as complete, the value should be truthy, so fire the Tracks event.
+							wpcom_launchpad_track_completed_task( $task );
 						}
+					}
+
+					if ( update_option( 'launchpad_checklist_tasks_statuses', $launchpad_checklist_tasks_statuses_option ) ) {
 						$updated[ $key ] = $value;
 					}
 					// This will check if we have completed all the tasks and disable Launchpad if so.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#78202, related to Automattic/wp-calypso#77616

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a function that records a Tracks event, `wpcom_launchpad_mark_task_complete` for marking a task complete if we're on WP.com.
* Includes the following properties: `task_id`: the task ID being completed and `extra_props`, anything else we want to log about this task ID's completion.
* Call this function whenever we mark a task complete, either via the backend or the API.
* Add a function to mark the `domain_*` tasks as complete when a domain product is activated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox `public-api.wordpress.com` and `stats.wp.com`
* Follow the instructions in the FG for logging server-side Tracks events by searching for: "Viewing tracks event details in real time". I added the following code to line 172 of `/wp-content/lib/tracks/client.php`: 

```
        if ( $event_name === 'wpcom_launchpad_mark_task_complete' ) {
		$details   = array();
		$details[] = '';
		$details[] = $event_name;
		foreach ( $event_obj as $prop => $value ) {
			if ( ! is_wp_error( $value ) ) {
				$details[] = $prop . ': ' . $value;
			}
		}

		$output = implode( "\n", $details );

		l( $output );
	}
```
* Create a new site from `/start` with the "Promote myself or business" intent.
* Sandbox your new site.
* Launch the site.
* You should see the new Launchpad task list on Customer Home.
* Complete a task, like editing the site title, or editing the site design.
* You should see the Tracks event for that task logged to your sandbox's /tmp/php-errors file:

<img width="419" alt="Screen Shot 2023-06-19 at 5 00 22 PM" src="https://github.com/Automattic/jetpack/assets/2124984/2a2f953f-2d29-431d-ac0e-fc3a00433089">
