### PR TITLE
AI Extension: improve prompt when using the AI Assistant in extended blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extensions-iterate-over-prompts
+++ b/projects/plugins/jetpack/changelog/update-ai-extensions-iterate-over-prompts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: improve prompt when using the AI Assistant in extended blocks

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -76,7 +76,6 @@ const quickActionsList = [
 ];
 
 export type AiAssistantDropdownOnChangeOptionsArgProps = {
-	contentType: 'generated' | string;
 	tone?: ToneProp;
 	language?: string;
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -24,7 +24,7 @@ import { PromptItemProps, PromptTypeProp, getPrompt } from '../../lib/prompt';
 export const withAIAssistant = createHigherOrderComponent(
 	BlockEdit => props => {
 		const { clientId } = props;
-		const [ storedPrompt, storePromptInLocalState ] = useState< Array< PromptItemProps > >( [] );
+		const [ storedPrompt, setStoredPrompt ] = useState< Array< PromptItemProps > >( [] );
 
 		const { updateBlockAttributes } = useDispatch( blockEditorStore );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -58,7 +58,7 @@ export const withAIAssistant = createHigherOrderComponent(
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				storePromptInLocalState(
+				setStoredPrompt(
 					getPrompt( promptType, {
 						...options,
 						content,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -15,7 +15,7 @@ import AiAssistantDropdown, {
 } from '../../components/ai-assistant-controls';
 import AiAssistantPanel from '../../components/ai-assistant-panel';
 import useSuggestionsFromAI from '../../hooks/use-suggestions-from-ai';
-import { PromptItemProps, PromptTypeProp, buildPromptForExtensions } from '../../lib/prompt';
+import { PromptItemProps, PromptTypeProp, getPrompt } from '../../lib/prompt';
 
 /*
  * Extend the withAIAssistant function of the block
@@ -24,7 +24,7 @@ import { PromptItemProps, PromptTypeProp, buildPromptForExtensions } from '../..
 export const withAIAssistant = createHigherOrderComponent(
 	BlockEdit => props => {
 		const { clientId } = props;
-		const [ prompt, setPrompt ] = useState< Array< PromptItemProps > >( [] );
+		const [ storedPrompt, storePromptInLocalState ] = useState< Array< PromptItemProps > >( [] );
 
 		const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
@@ -54,14 +54,13 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ clientId, updateBlockAttributes ]
 		);
 
-		useSuggestionsFromAI( { prompt, onSuggestion: setContent } );
+		useSuggestionsFromAI( { prompt: storedPrompt, onSuggestion: setContent } );
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				setPrompt(
-					buildPromptForExtensions( promptType, {
+				storePromptInLocalState(
+					getPrompt( promptType, {
 						...options,
-						contentType: 'original', // Extended block content is not interactive.
 						content,
 					} )
 				);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -107,6 +107,7 @@ ${ postTitle?.length ? `- Current title: ${ postTitle }\n` : '' }${
 type PromptOptionsProps = {
 	content: string;
 	language: string;
+	tone?: ToneProp;
 	role?: PromptItemProps[ 'role' ];
 };
 
@@ -118,6 +119,16 @@ function getTranslatePrompt( {
 	return {
 		role,
 		content: `Translate the following text to ${ language }:
+
+${ content }
+`,
+	};
+}
+
+function getTonePrompt( { content, tone, role = 'user' }: PromptOptionsProps ): PromptItemProps {
+	return {
+		role,
+		content: `Rewrite the following text with a ${ tone } tone:
 
 ${ content }
 `,
@@ -354,24 +365,23 @@ export function getPrompt(
 	options: PromptOptionsProps
 ): Array< PromptItemProps > {
 	const initialSystemPrompt = getInitialSystemPrompt( {} );
-	const promptText = promptTextFor( type, false, options );
 
 	let prompt: Array< PromptItemProps > = [];
 	switch ( type ) {
 		case PROMPT_TYPE_CHANGE_LANGUAGE:
 			prompt = [ initialSystemPrompt, getTranslatePrompt( options ) ];
+			break;
+
+		case PROMPT_TYPE_CHANGE_TONE:
+			prompt = [ initialSystemPrompt, getTonePrompt( options ) ];
+			break;
 	}
+
+	prompt[ prompt.length - 1 ].content += '\nDo not add any feedback to the user.';
 
 	prompt.forEach( ( { role, content: promptContent }, i ) =>
 		debug( '(%s/%s) %o\n%s', i + 1, prompt.length, `[${ role }]`, promptContent )
 	);
 
 	return prompt;
-
-	return buildPromptTemplate( {
-		...promptText,
-		fullContent: options.content,
-		relevantContent: options.content,
-		isContentGenerated: false,
-	} );
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -154,7 +154,7 @@ function getExpandPrompt( {
 	return [
 		{
 			role,
-			content: `Expand the following text to about double its size approximately. Write the content in the same language as the original content:\n\n${ content }`,
+			content: `Expand the following text to about double its size. Write the content in the same language as the original content:\n\n${ content }`,
 		},
 	];
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -416,7 +416,7 @@ export function getPrompt(
 ): Array< PromptItemProps > {
 	const context =
 		'You are an excellent polyglot ghostwriter. ' +
-		'Your task is to help to the user to create and modify content based on their requests.';
+		'Your task is to help the user to create and modify content based on their requests.';
 
 	const initialSystemPrompt: PromptItemProps = {
 		role: 'system',

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -400,8 +400,6 @@ export function getPrompt(
 			break;
 	}
 
-	prompt[ prompt.length - 1 ].content += '\nDo not add any feedback to the user.';
-
 	prompt.forEach( ( { role, content: promptContent }, i ) =>
 		debug( '(%s/%s) %o\n%s', i + 1, prompt.length, `[${ role }]`, promptContent )
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -79,6 +79,29 @@ ${ extraRules }- Format your responses in Markdown syntax, ready to be published
 	return { role: 'system', content: prompt };
 }
 
+export function getInitialSystemPrompt35( {
+	context = 'You are an AI assistant, your task is to generate and modify content based on user requests. This functionality is integrated into the Jetpack product developed by Automattic. Please remember to provide only the direct translation without any introductory or explanatory sentences',
+	rules,
+}: {
+	context?: string;
+	rules?: Array< string >;
+} ): PromptItemProps {
+	// Rules
+	let extraRules = '';
+	if ( rules?.length ) {
+		extraRules = rules.map( rule => `- ${ rule }.` ).join( '\n' ) + '\n';
+	}
+	const prompt = `${ context }.
+Strictly follow these rules:
+
+${ extraRules }- Format your responses in Markdown syntax, ready to be published.
+- Avoid sensitive or controversial topics and ensure your responses are grammatically correct and coherent.
+- If you cannot generate a meaningful response to a user’s request, reply with “__JETPACK_AI_ERROR__“. This term should only be used in this context, it is used to generate user facing errors.
+`;
+
+	return { role: 'system', content: prompt };
+}
+
 /**
  * Helper function to get the blog post data prompt.
  *
@@ -364,7 +387,7 @@ export function getPrompt(
 	type: PromptTypeProp,
 	options: PromptOptionsProps
 ): Array< PromptItemProps > {
-	const initialSystemPrompt = getInitialSystemPrompt( {} );
+	const initialSystemPrompt = getInitialSystemPrompt35( {} );
 
 	let prompt: Array< PromptItemProps > = [];
 	switch ( type ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR polishes the process that builds the prompt only for the AI Extension. It doesn't change the prompt for the AI Assistant block. For this:

* Add a few basic helpers functions to build prompt items
* Tries to preserve the language and tone when it's desired.
* Renames (again) some helper prompt functions

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: improve prompt when using the AI Assistant in extended blocks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a paragraph/heading block instance 
* Change, again and again, the content of the block. The app will try to preserve the language, for instance
  1. Create content in English (English)
  2. Translate to another language (Spanish)
  3. Change the tone (Spanish)
  4. Summarize (Spanish)
The trace mentioned above doesn't work properly in trunk. The implementation suggested by this PR improves the process. 


https://github.com/Automattic/jetpack/assets/77539/4a8664ce-97cb-48bd-a363-21e2fdc5b6e5

