### PR TITLE
AI Extension: populate the prompt with previous messages

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-preserve-prompt-content-among-requests
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-preserve-prompt-content-among-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: populate the prompt with previous messages

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -125,7 +125,7 @@ export default function AiAssistantDropdown( {
 							iconPosition="left"
 							key={ `key-${ quickAction.key }` }
 							onClick={ () => {
-								onChange( quickAction.aiSuggestion, { contentType: 'generated' } );
+								onChange( quickAction.aiSuggestion );
 								closeDropdown();
 							} }
 							isSelected={ key === quickAction.key }
@@ -136,14 +136,14 @@ export default function AiAssistantDropdown( {
 
 					<ToneDropdownMenu
 						onChange={ tone => {
-							onChange( PROMPT_TYPE_CHANGE_TONE, { tone, contentType: 'generated' } );
+							onChange( PROMPT_TYPE_CHANGE_TONE, { tone } );
 							closeDropdown();
 						} }
 					/>
 
 					<I18nMenuDropdown
 						onChange={ language => {
-							onChange( PROMPT_TYPE_CHANGE_LANGUAGE, { language, contentType: 'generated' } );
+							onChange( PROMPT_TYPE_CHANGE_LANGUAGE, { language } );
 							closeDropdown();
 						} }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -68,12 +68,15 @@ export const withAIAssistant = createHigherOrderComponent(
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				setStoredPrompt( {
-					messages: getPrompt( promptType, {
-						...options,
-						content,
-					} ),
-				} );
+				setStoredPrompt( prevMessages => ( {
+					messages: [
+						...prevMessages.messages,
+						...getPrompt( promptType, {
+							...options,
+							content,
+						} ),
+					],
+				} ) );
 			},
 			[ content ]
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -15,7 +15,15 @@ import AiAssistantDropdown, {
 } from '../../components/ai-assistant-controls';
 import AiAssistantPanel from '../../components/ai-assistant-panel';
 import useSuggestionsFromAI from '../../hooks/use-suggestions-from-ai';
-import { PromptItemProps, PromptTypeProp, getPrompt } from '../../lib/prompt';
+import { getPrompt } from '../../lib/prompt';
+/*
+ * Types
+ */
+import type { PromptItemProps, PromptTypeProp } from '../../lib/prompt';
+
+type StoredPromptProps = {
+	messages: Array< PromptItemProps >;
+};
 
 /*
  * Extend the withAIAssistant function of the block
@@ -24,7 +32,9 @@ import { PromptItemProps, PromptTypeProp, getPrompt } from '../../lib/prompt';
 export const withAIAssistant = createHigherOrderComponent(
 	BlockEdit => props => {
 		const { clientId } = props;
-		const [ storedPrompt, setStoredPrompt ] = useState< Array< PromptItemProps > >( [] );
+		const [ storedPrompt, setStoredPrompt ] = useState< StoredPromptProps >( {
+			messages: [],
+		} );
 
 		const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
@@ -54,16 +64,16 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ clientId, updateBlockAttributes ]
 		);
 
-		useSuggestionsFromAI( { prompt: storedPrompt, onSuggestion: setContent } );
+		useSuggestionsFromAI( { prompt: storedPrompt.messages, onSuggestion: setContent } );
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				setStoredPrompt(
-					getPrompt( promptType, {
+				setStoredPrompt( {
+					messages: getPrompt( promptType, {
 						...options,
 						content,
-					} )
-				);
+					} ),
+				} );
 			},
 			[ content ]
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -68,15 +68,16 @@ export const withAIAssistant = createHigherOrderComponent(
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				setStoredPrompt( prevMessages => ( {
-					messages: [
-						...prevMessages.messages,
-						...getPrompt( promptType, {
+				setStoredPrompt( prevPrompt => {
+					return {
+						...prevPrompt,
+						messages: getPrompt( promptType, {
 							...options,
 							content,
+							prevMessages: prevPrompt.messages,
 						} ),
-					],
-				} ) );
+					};
+				} );
 			},
 			[ content ]
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -64,7 +64,29 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ clientId, updateBlockAttributes ]
 		);
 
-		useSuggestionsFromAI( { prompt: storedPrompt.messages, onSuggestion: setContent } );
+		const addAssistantMessage = useCallback(
+			( assistantContent: string ) => {
+				setStoredPrompt( prevPrompt => {
+					return {
+						...prevPrompt,
+						messages: [
+							...prevPrompt.messages,
+							{
+								role: 'assistant',
+								content: assistantContent,
+							},
+						],
+					};
+				} );
+			},
+			[ setStoredPrompt ]
+		);
+
+		useSuggestionsFromAI( {
+			prompt: storedPrompt.messages,
+			onSuggestion: setContent,
+			onDone: addAssistantMessage,
+		} );
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -138,7 +138,9 @@ export default function useSuggestionsFromAI( {
 		}
 
 		// Trigger the request.
-		request();
+		if ( autoRequest ) {
+			request();
+		}
 
 		// Close the connection when unmounting.
 		return () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -4,11 +4,14 @@
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
+import debugFactory from 'debug';
 /**
  * Types
  */
 import { SuggestionsEventSource, askQuestion } from '../../lib/suggestions';
 import type { PromptItemProps } from '../../lib/prompt';
+
+const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
 
 type UseSuggestionsFromAIOptions = {
 	/*
@@ -103,6 +106,10 @@ export default function useSuggestionsFromAI( {
 	 * @returns {Promise<void>} The promise.
 	 */
 	const request = useCallback( async () => {
+		prompt.forEach( ( { role, content: promptContent }, i ) =>
+			debug( '(%s/%s) %o\n%s', i + 1, prompt.length, `[${ role }]`, promptContent )
+		);
+
 		try {
 			source.current = await askQuestion( prompt, {
 				postId,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -376,6 +376,8 @@ export function getPrompt(
 	type: PromptTypeProp,
 	options: PromptOptionsProps
 ): Array< PromptItemProps > {
+	debug( 'Addressing prompt type: %o %o', type, options );
+
 	const context =
 		'You are an excellent polyglot ghostwriter. ' +
 		'Your task is to help the user to create and modify content based on their requests.';

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -78,10 +78,29 @@ ${ extraRules }- Format your responses in Markdown syntax, ready to be published
 }
 
 type PromptOptionsProps = {
+	/*
+	 * The content to add to the prompt.
+	 */
 	content: string;
+
+	/*
+	 * The language to translate to. Optional.
+	 */
 	language?: string;
+
+	/*
+	 * The tone to use. Optional.
+	 */
 	tone?: ToneProp;
+
+	/*
+	 * The role of the prompt. Optional.
+	 */
 	role?: PromptItemProps[ 'role' ];
+
+	/*
+	 * The previous messages of the same prompt. Optional.
+	 */
 	prevMessages?: Array< PromptItemProps >;
 };
 
@@ -384,6 +403,10 @@ export function getPrompt(
 		'You are an excellent polyglot ghostwriter. ' +
 		'Your task is to help the user to create and modify content based on their requests.';
 
+	/*
+	 * Create the initial prompt only if there are no previous messages.
+	 * Otherwise, let's use the previous messages as the initial prompt.
+	 */
 	let prompt: Array< PromptItemProps > = ! prevMessages?.length
 		? [
 				{

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -82,6 +82,7 @@ type PromptOptionsProps = {
 	language?: string;
 	tone?: ToneProp;
 	role?: PromptItemProps[ 'role' ];
+	prevMessages?: Array< PromptItemProps >;
 };
 
 function getCorrectSpellingPrompt( {
@@ -377,14 +378,17 @@ export function getPrompt(
 	options: PromptOptionsProps
 ): Array< PromptItemProps > {
 	debug( 'Addressing prompt type: %o %o', type, options );
+	const { prevMessages } = options;
 
 	const context =
 		'You are an excellent polyglot ghostwriter. ' +
 		'Your task is to help the user to create and modify content based on their requests.';
 
-	const initialSystemPrompt: PromptItemProps = {
-		role: 'system',
-		content: `${ context }
+	let prompt: Array< PromptItemProps > = ! prevMessages?.length
+		? [
+				{
+					role: 'system',
+					content: `${ context }
 Writing rules:
 - When it isn't clarified, the content should be written in the same language as the original content.
 - Format your responses in Markdown syntax.
@@ -392,32 +396,33 @@ Writing rules:
 - Avoid sensitive or controversial topics and ensure your responses are grammatically correct and coherent.
 - If you cannot generate a meaningful response to a user’s request, reply with “__JETPACK_AI_ERROR__“. This term should only be used in this context, it is used to generate user facing errors.
 `,
-	};
+				},
+		  ]
+		: prevMessages;
 
-	const prompt: Array< PromptItemProps > = [ initialSystemPrompt ];
 	switch ( type ) {
 		case PROMPT_TYPE_CORRECT_SPELLING:
-			prompt.push( ...getCorrectSpellingPrompt( options ) );
+			prompt = [ ...prompt, ...getCorrectSpellingPrompt( options ) ];
 			break;
 
 		case PROMPT_TYPE_SIMPLIFY:
-			prompt.push( ...getSimplifyPrompt( options ) );
+			prompt = [ ...prompt, ...getSimplifyPrompt( options ) ];
 			break;
 
 		case PROMPT_TYPE_SUMMARIZE:
-			prompt.push( ...getSummarizePrompt( options ) );
+			prompt = [ ...prompt, ...getSummarizePrompt( options ) ];
 			break;
 
 		case PROMPT_TYPE_MAKE_LONGER:
-			prompt.push( ...getExpandPrompt( options ) );
+			prompt = [ ...prompt, ...getExpandPrompt( options ) ];
 			break;
 
 		case PROMPT_TYPE_CHANGE_LANGUAGE:
-			prompt.push( ...getTranslatePrompt( options ) );
+			prompt = [ ...prompt, ...getTranslatePrompt( options ) ];
 			break;
 
 		case PROMPT_TYPE_CHANGE_TONE:
-			prompt.push( ...getTonePrompt( options ) );
+			prompt = [ ...prompt, ...getTonePrompt( options ) ];
 			break;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -421,9 +421,5 @@ Writing rules:
 			break;
 	}
 
-	prompt.forEach( ( { role, content: promptContent }, i ) =>
-		debug( '(%s/%s) %o\n%s', i + 1, prompt.length, `[${ role }]`, promptContent )
-	);
-
 	return prompt;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR populates the prompt with the last messages when the user generates changes by using the AI Extensions. For this:

* It slightly changes the hook `useSuggestionsFromAI()` API:
  The `request()` method accepts a prompt argument
* The `getPrompt()` accepts `prevMessages` options to populate the fresh prompt.
* `withAIAssistant()` collects and stores the previous messages in a local state.
  Data is not persistent. We don't want to touche the core blocks extending the attributes.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create some content by using a paragraph/heading block
* Start to edit its content by using the AI Extension
* Take a look at the logs
* Confirm the prompt collects previous messages

<img width="618" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/b59065d8-1714-4b3b-8a3d-96194753516e">

<img width="821" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/fd1b6e69-1cb5-4dbb-8162-c91e6c19eaf5">


