### PR TITLE
Launchpad: Reuse completion method across all plugin codebase

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/refactor-reuse-completion-method
+++ b/projects/packages/jetpack-mu-wpcom/changelog/refactor-reuse-completion-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Reuse completion method to make it easier to add tracking and check for list completion.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -698,15 +698,7 @@ class Launchpad_Task_Lists {
 	 * @return bool True if successful, false if not.
 	 */
 	public function mark_task_complete( $task_id ) {
-		$task = $this->get_task( $task_id );
-		if ( empty( $task ) ) {
-			return false;
-		}
-
-		$key              = $this->get_task_key( $task );
-		$statuses         = get_option( 'launchpad_checklist_tasks_statuses', array() );
-		$statuses[ $key ] = true;
-		$result           = update_option( 'launchpad_checklist_tasks_statuses', $statuses );
+		$result = wpcom_mark_launchpad_task_complete( $task_id );
 
 		$this->maybe_disable_fullscreen_launchpad();
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -514,13 +514,14 @@ function wpcom_update_launchpad_task_status( $original_statuses ) {
 
 	$statuses = array();
 	foreach ( $original_statuses as $task_id => $value ) {
-		// Filter out non-existent tasks taking into account the id_map.
+		// Find out wether the task id sent is the actual task id or the id_map.
 		$actual_task_id = ( isset( $reverse_id_map[ $task_id ] ) ) ? $reverse_id_map[ $task_id ] : $task_id;
 		if ( ! isset( $task_definitions[ $actual_task_id ] ) ) {
+			// Bail if no task definition was found.
 			continue;
 		}
 
-		// Find the task id that should be used to store the status.
+		// If the task has an id_map, use that, otherwise use the actual task id as the key.
 		$task                        = $task_definitions[ $actual_task_id ];
 		$stored_task_id              = isset( $task['id_map'] ) ? $task['id_map'] : $actual_task_id;
 		$statuses[ $stored_task_id ] = $value;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -512,14 +512,18 @@ function wpcom_update_launchpad_task_status( $original_statuses ) {
 	$task_definitions = wpcom_launchpad_get_task_definitions();
 	$reverse_id_map   = wpcom_launchpad_get_reverse_id_mappings();
 
-	// Filter out non-existent tasks taking into account the id_map.
 	$statuses = array();
 	foreach ( $original_statuses as $task_id => $value ) {
+		// Filter out non-existent tasks taking into account the id_map.
 		$actual_task_id = ( isset( $reverse_id_map[ $task_id ] ) ) ? $reverse_id_map[ $task_id ] : $task_id;
 		if ( ! isset( $task_definitions[ $actual_task_id ] ) ) {
 			continue;
 		}
-		$statuses[ $task_id ] = $value;
+
+		// Find the task id that should be used to store the status.
+		$task                        = $task_definitions[ $actual_task_id ];
+		$stored_task_id              = isset( $task['id_map'] ) ? $task['id_map'] : $actual_task_id;
+		$statuses[ $stored_task_id ] = $value;
 	}
 
 	$old_values = (array) get_option( 'launchpad_checklist_tasks_statuses', array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -507,6 +507,10 @@ function wpcom_mark_launchpad_task_incomplete( $task_id ) {
  * @return bool[] Return the new values of the requested statuses with the requested task ID as the key. This will be an empty array if the option update fails, and any ignored status values will not be returned.
  */
 function wpcom_launchpad_update_task_status( $new_statuses ) {
+	if ( ! is_array( $new_statuses ) ) {
+		return array();
+	}
+
 	$task_definitions = wpcom_launchpad_get_task_definitions();
 	$reverse_id_map   = wpcom_launchpad_get_reverse_id_mappings();
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -524,7 +524,8 @@ function wpcom_launchpad_update_task_status( $new_statuses ) {
 				$resolved_task_id = $requested_task_id;
 			}
 		} elseif ( isset( $reverse_id_map[ $requested_task_id ] ) ) {
-			$resolved_task_id = $reverse_id_map[ $requested_task_id ];
+			// We have some tasks that are only an id_map, but not a standalone task ID.
+			$resolved_task_id = $requested_task_id;
 		} else {
 			continue;
 		}
@@ -542,7 +543,18 @@ function wpcom_launchpad_update_task_status( $new_statuses ) {
 		array_merge( $old_values, $statuses_to_update )
 	);
 
-	$update_result = update_option( 'launchpad_checklist_tasks_statuses', $new_values );
+	// Check for a no-op where we are not actually writing anything.
+	if ( $new_values === $old_values ) {
+		return $response_statuses;
+	}
+
+	if ( empty( $new_values ) ) {
+		// If the new value is empty, but we had values before, we need to delete the option.
+		$update_result = delete_option( 'launchpad_checklist_tasks_statuses' );
+	} else {
+		$update_result = update_option( 'launchpad_checklist_tasks_statuses', $new_values );
+	}
+
 	if ( ! $update_result ) {
 		return array();
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -480,22 +480,10 @@ function wpcom_mark_launchpad_task_complete( $task_ids ) {
 
 	$result = wpcom_update_launchpad_task_status( $values );
 
-<<<<<<< HEAD
 	// Record the completion event in Tracks.
-	wpcom_launchpad_track_completed_task( $key );
-=======
 	foreach ( $task_ids as $key => $value ) {
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			require_lib( 'tracks/client' );
-
-			tracks_record_event(
-				wp_get_current_user(),
-				'launchpad_mark_task_completed',
-				array( 'task_id' => $key )
-			);
-		}
+		wpcom_launchpad_track_completed_task( $key );
 	}
->>>>>>> c51e097aa6 (reuse completion method across all plugin codebase)
 
 	return $result;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -155,23 +155,20 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 		foreach ( $input as $key => $value ) {
 			switch ( $key ) {
 				case 'checklist_statuses':
-					$complete_values = array_filter(
-						$value,
-						function ( $item_value ) {
-							return $item_value;
-						}
-					);
+					$complete_values   = array();
+					$incomplete_values = array();
 
-					$incomplete_values = array_filter(
-						$value,
-						function ( $item_value ) {
-							return ! $item_value;
+					foreach ( $value as $task_id => $task_status ) {
+						if ( $task_status ) {
+							$complete_values[] = $task_id;
+						} else {
+							$incomplete_values[] = $task_id;
 						}
-					);
+					}
 
 					if (
-						wpcom_mark_launchpad_task_complete( array_keys( $complete_values ) ) ||
-						wpcom_mark_launchpad_task_incomplete( array_keys( $incomplete_values ) )
+						wpcom_mark_launchpad_task_complete( $complete_values ) ||
+						wpcom_mark_launchpad_task_incomplete( $incomplete_values )
 					) {
 						$updated[ $key ] = $value;
 					}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -155,22 +155,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 		foreach ( $input as $key => $value ) {
 			switch ( $key ) {
 				case 'checklist_statuses':
-					$complete_values   = array();
-					$incomplete_values = array();
-
-					foreach ( $value as $task_id => $task_status ) {
-						if ( $task_status ) {
-							$complete_values[] = $task_id;
-						} else {
-							$incomplete_values[] = $task_id;
-						}
-					}
-
-					$updated_complete_tasks   = wpcom_mark_launchpad_task_complete( $complete_values );
-					$updated_incomplete_tasks = wpcom_mark_launchpad_task_incomplete( $incomplete_values );
-					if ( $updated_complete_tasks || $updated_incomplete_tasks ) {
-						$updated[ $key ] = $value;
-					}
+					$updated = wpcom_launchpad_update_task_status( $value );
 
 					// This will check if we have completed all the tasks and disable Launchpad if so.
 					wpcom_launchpad_checklists()->maybe_disable_fullscreen_launchpad();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -155,7 +155,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 		foreach ( $input as $key => $value ) {
 			switch ( $key ) {
 				case 'checklist_statuses':
-					$updated = wpcom_launchpad_update_task_status( $value );
+					$updated[ $key ] = wpcom_launchpad_update_task_status( $value );
 
 					// This will check if we have completed all the tasks and disable Launchpad if so.
 					wpcom_launchpad_checklists()->maybe_disable_fullscreen_launchpad();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -166,10 +166,9 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 						}
 					}
 
-					if (
-						wpcom_mark_launchpad_task_complete( $complete_values ) ||
-						wpcom_mark_launchpad_task_incomplete( $incomplete_values )
-					) {
+					$updated_complete_tasks   = wpcom_mark_launchpad_task_complete( $complete_values );
+					$updated_incomplete_tasks = wpcom_mark_launchpad_task_incomplete( $incomplete_values );
+					if ( $updated_complete_tasks || $updated_incomplete_tasks ) {
 						$updated[ $key ] = $value;
 					}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Test class for Launchpad_Task_Lists.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Test class for Launchpad_Task_Lists.
+ *
+ * @coversDefaultClass Launchpad_Task_Lists
+ */
+class Launchpad_Task_Definitions_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_filter(
+			'wpcom_launchpad_extended_task_definitions',
+			function () {
+				return array(
+					'test_task1' => array(),
+					'test_task2' => array(),
+					'test_task3' => array(),
+				);
+			}
+		);
+	}
+
+	/**
+	 * Tests wether the wpcom_mark_launchpad_task_complete works correctly.
+	 */
+	public function test_wpcom_mark_launchpad_task_complete() {
+		wpcom_mark_launchpad_task_complete( 'test_task1' );
+		$options = get_option( 'launchpad_checklist_tasks_statuses' );
+		$this->assertTrue( isset( $options['test_task1'] ) );
+		$this->assertTrue( $options['test_task1'] );
+
+		wpcom_mark_launchpad_task_complete(
+			array(
+				'test_task2',
+				'test_task3',
+			)
+		);
+		$options = get_option( 'launchpad_checklist_tasks_statuses' );
+		$this->assertTrue( isset( $options['test_task2'] ) && $options['test_task2'] );
+		$this->assertTrue( isset( $options['test_task3'] ) && $options['test_task3'] );
+
+		$this->assertTrue( count( $options ) === 3 );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
@@ -21,9 +21,12 @@ class Launchpad_Task_Definitions_Test extends \WorDBless\BaseTestCase {
 			'wpcom_launchpad_extended_task_definitions',
 			function () {
 				return array(
-					'test_task1' => array(),
-					'test_task2' => array(),
-					'test_task3' => array(),
+					'test_task1'            => array(),
+					'test_task2'            => array(),
+					'test_task3'            => array(),
+					'test_task_with_id_map' => array(
+						'id_map' => 'test_task_id_map',
+					),
 				);
 			}
 		);
@@ -86,5 +89,16 @@ class Launchpad_Task_Definitions_Test extends \WorDBless\BaseTestCase {
 		$options = get_option( 'launchpad_checklist_tasks_statuses' );
 
 		$this->assertTrue( count( $options ) === 2 );
+	}
+
+	/**
+	 * Tests wether the correct task ID is stored in the 'launchpad_checklist_tasks_statuses' option.
+	 * When tasks have an 'id_map' property, the 'id_map' value should be used as the task ID.
+	 */
+	public function test_correct_task_id_is_stored() {
+		wpcom_mark_launchpad_task_complete( 'test_task_with_id_map' );
+		$options = get_option( 'launchpad_checklist_tasks_statuses' );
+		$this->assertFalse( isset( $options['test_task_with_id_map'] ) );
+		$this->assertTrue( isset( $options['test_task_id_map'] ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
@@ -24,6 +24,9 @@ class Launchpad_Task_Definitions_Test extends \WorDBless\BaseTestCase {
 					'test_task1'            => array(),
 					'test_task2'            => array(),
 					'test_task3'            => array(),
+					'test_task3_alias'      => array(
+						'id_map' => 'test_task3',
+					),
 					'test_task_with_id_map' => array(
 						'id_map' => 'test_task_id_map',
 					),
@@ -112,6 +115,55 @@ class Launchpad_Task_Definitions_Test extends \WorDBless\BaseTestCase {
 			$this->assertTrue( isset( $option_value[ $task_id ] ) );
 			$this->assertSame( $new_task_status, $option_value[ $task_id ] );
 		}
+	}
+
+	/**
+	 * Data provider for {@see test_wpcom_launchpad_update_task_status_id_map_handling()}.
+	 *
+	 * @return array[]
+	 */
+	public function provide_update_task_status_id_map_handling_test_cases() {
+		return array(
+			// First key is requested task ID, second key is the option we expect to update.
+			'Request for unmapped task ID updates that task ID'                         => array(
+				'test_task2',
+				'test_task2',
+			),
+			'Request for task ID with id_map for other task updates id_map'             => array(
+				'test_task3_alias',
+				'test_task3',
+			),
+			'Request for id_map where no task ID matches the id_map updates the id_map' => array(
+				'test_task_id_map',
+				'test_task_id_map',
+			),
+		);
+	}
+
+	/**
+	 * Tests {@see wpcom_launchpad_update_task_status()} to make sure we handle id_map
+	 * values correctly.
+	 *
+	 * @dataProvider provide_update_task_status_id_map_handling_test_cases()
+	 * @param string $requested_task_id The requested task ID or id_map.
+	 * @param string $expected_option_key The key we expect to be added to the underlying option.
+	 */
+	public function test_wpcom_launchpad_update_task_status_id_map_handling( $requested_task_id, $expected_option_key ) {
+		delete_option( 'launchpad_checklist_tasks_statuses' );
+
+		$update_request = array(
+			$requested_task_id => true,
+		);
+
+		$update_result = wpcom_launchpad_update_task_status( $update_request );
+
+		$this->assertSame( $update_request, $update_result );
+
+		$option_value = get_option( 'launchpad_checklist_tasks_statuses' );
+
+		$this->assertIsArray( $option_value );
+		$this->assertArrayHasKey( $expected_option_key, $option_value );
+		$this->assertTrue( $option_value[ $expected_option_key ] );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-definitions-test.php
@@ -50,4 +50,41 @@ class Launchpad_Task_Definitions_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertTrue( count( $options ) === 3 );
 	}
+
+	/**
+	 * Tests wether the wpcom_mark_launchpad_task_incomplete works correctly.
+	 */
+	public function test_wpcom_mark_launchpad_task_incomplete() {
+		wpcom_mark_launchpad_task_incomplete( 'test_task1' );
+		$options = get_option( 'launchpad_checklist_tasks_statuses' );
+		$this->assertTrue( isset( $options['test_task1'] ) && ! $options['test_task1'] );
+
+		wpcom_mark_launchpad_task_incomplete(
+			array(
+				'test_task2',
+				'test_task3',
+			)
+		);
+		$options = get_option( 'launchpad_checklist_tasks_statuses' );
+		$this->assertTrue( isset( $options['test_task2'] ) && ! $options['test_task2'] );
+		$this->assertTrue( isset( $options['test_task3'] ) && ! $options['test_task3'] );
+
+		$this->assertTrue( count( $options ) === 3 );
+	}
+
+	/**
+	 * Tests wether a correct amount of array elements get stored in the 'launchpad_checklist_tasks_statuses' option.
+	 */
+	public function test_correct_task_count() {
+		wpcom_mark_launchpad_task_complete(
+			array(
+				'test_task2',
+				'test_task3',
+			)
+		);
+
+		$options = get_option( 'launchpad_checklist_tasks_statuses' );
+
+		$this->assertTrue( count( $options ) === 2 );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
@@ -129,7 +129,38 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( array( 'updated' => array( 'checklist_statuses' => $values ) ), $result->get_data() );
-		$this->assertSame( $values, get_option( 'launchpad_checklist_tasks_statuses' ) );
+
+		// The API returns the requested true|false value, but we only store true values.
+		$option_value = get_option( 'launchpad_checklist_tasks_statuses' );
+		$this->assertIsArray( $option_value );
+		foreach ( $values as $task_id => $task_status ) {
+			if ( $task_status ) {
+				$this->assertTrue( isset( $option_value[ $task_id ] ), "Task ID $task_id has been stored" );
+				$this->assertTrue( $option_value[ $task_id ] );
+			} else {
+				$this->assertFalse( isset( $option_value[ $task_id ] ) );
+			}
+		}
+
+		// Mark all tasks as incomplete.
+		$values = array(
+			'domain_upsell_deferred' => false,
+			'site_launched'          => false,
+		);
+		$data   = array( 'checklist_statuses' => $values );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/launchpad' );
+		$request->set_header( 'content_type', 'application/json' );
+		$request->set_body( wp_json_encode( $data ) );
+
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( array( 'updated' => array( 'checklist_statuses' => $values ) ), $result->get_data() );
+
+		// Expect the option to have been deleted.
+		$option_value = get_option( 'launchpad_checklist_tasks_statuses' );
+		$this->assertFalse( $option_value );
 
 		// Invalid parameter.
 		$request->set_body( wp_json_encode( array( 'checklist_statuses' => array( 'wrong_key' => true ) ) ) );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
@@ -115,7 +115,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 
 		$values = array(
 			'domain_upsell_deferred' => true,
-			'site_launched'          => true,
+			'site_launched'          => false,
 		);
 		$data   = array( 'checklist_statuses' => $values );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The idea behind this PR is to centralise the task completion logic, including updates to the `'launchpad_checklist_tasks_statuses'` option and triggering any relevant Tracks events, while preserving the existing `wpcom_mark_launchpad_task_complete()` API. 
Right now we have multiple code paths updating the option and triggering events, which is prone to error and can cause confusion.

From an implementation perspective, there are a number of key changes:
* We're introducing a new `wpcom_launchpad_update_task_status()` function that accepts an array with task IDs as keys and booleans as values to represent the task completion status. The task IDs can be id_map values or the "raw" task ID - the function is responsible for identifying the right underlying option key to store.
  - This code is responsible for updating the `'launchpad_checklist_tasks_statuses'` option and calling `wpcom_launchpad_track_completed_task()`.
  - With the centralisation, we are also updating our storage mechanism to only store truthy values, and to enforce that newly stored values are `true`.
  - The function returns an array of successful task IDs as keys with their new values as array values. This includes ignoring unknown task IDs, returning an empty array for no successful operations, and returning the requested task ID as a key even when that task is mapped to a different underlying task slug in the option via an `id_map`
* We're introducing a new `wpcom_mark_launchpad_task_incomplete()` function to support marking a task as incomplete.
* The existing REST API to update the option has been refactored to call `wpcom_launchpad_update_task_status()` directly.
* The existing `wpcom_mark_launchpad_task_complete` function has been refactored to call `wpcom_launchpad_update_task_status()`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Run local tests

* Download this branch to your local environment, run `composer phpunit` in the plugin root and verify test passes.
 
### Test the actual API

* Checkout this branch on your sandbox.
* Sandbox `public-api`.
* Create a new site with the build intent.
* Publish your site using the Stepper Launchpad and verify it works as expected.
* After that go to your site home and complete some of the tasks in the build checklist and verify it works as expected.
