### PR TITLE
Launchpad: Update title text for `domain_claim` task when a domain is mapped but not registered

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-domain-claim-title
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-domain-claim-title
@@ -1,4 +1,4 @@
 Significance: minor
-Type: patch
+Type: changed
 
 Update the `domain_claim` task title when a domain is mapped.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-domain-claim-title
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-domain-claim-title
@@ -1,0 +1,4 @@
+Significance: minor
+Type: patch
+
+Update the `domain_claim` task title when a domain is mapped.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -30,9 +30,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_disabled_callback' => 'wpcom_is_design_step_enabled',
 		),
 		'domain_claim'                    => array(
-			'get_title'            => function () {
-				return __( 'Claim your free one-year domain', 'jetpack-mu-wpcom' );
-			},
+			'get_title'            => 'wpcom_get_domain_claim_title',
 			'is_complete_callback' => 'wpcom_is_domain_claim_completed',
 			'is_visible_callback'  => 'wpcom_domain_claim_is_visible_callback',
 		),
@@ -350,6 +348,34 @@ function wpcom_track_edit_site_task() {
  */
 function wpcom_is_design_step_enabled() {
 	return ! wpcom_can_update_design_selected_task();
+}
+
+/**
+ * Get the title for the `domain_claim` task.
+ *
+ * @return string The title for the `domain_claim` task.
+ */
+function wpcom_get_domain_claim_title() {
+	if ( function_exists( 'wpcom_get_site_purchases' ) ) {
+		$site_purchases = wpcom_get_site_purchases();
+
+		// Get site domain purchase product types.
+		$domain_purchase_types = array_map(
+			function ( $site_purchase ) {
+				if ( $site_purchase->product_type === 'domain_map' || $site_purchase->product_type === 'domain_reg' ) {
+					return $site_purchase->product_type;
+				}
+			},
+			$site_purchases
+		);
+
+		// If we've mapped a domain but there's no registration, change the task title.
+		if ( in_array( 'domain_map', $domain_purchase_types ) && ! in_array( 'domain_reg', $domain_purchase_types ) ) {
+			return __( 'Connect a domain', 'jetpack-mu-wpcom' );
+		}
+	}
+
+	return __( 'Claim your free one-year domain', 'jetpack-mu-wpcom' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -370,7 +370,7 @@ function wpcom_get_domain_claim_title() {
 		);
 
 		// If we've mapped a domain but there's no registration, change the task title.
-		if ( in_array( 'domain_map', $domain_purchase_types ) && ! in_array( 'domain_reg', $domain_purchase_types ) ) {
+		if ( in_array( 'domain_map', $domain_purchase_types, true ) && ! in_array( 'domain_reg', $domain_purchase_types, true ) ) {
 			return __( 'Connect a domain', 'jetpack-mu-wpcom' );
 		}
 	}


### PR DESCRIPTION

Fixes Automattic/wp-calypso#78270

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When a user has purchased a paid plan but not claimed their free domain, and if they map a domain that is not registered with us, change the task title to `Connect a domain`
* The task title should remain `Claim your free one-year domain` when the user registers a domain with us.

**Visuals**

Task list after user purchases paid plan:

<img width="703" alt="Screen Shot 2023-06-20 at 4 54 13 PM" src="https://github.com/Automattic/jetpack/assets/2124984/58f723f2-74b8-47e3-a145-a8837bced87c">

Task list after user maps a domain that is not registered with us:

<img width="728" alt="Screen Shot 2023-06-20 at 4 10 09 PM" src="https://github.com/Automattic/jetpack/assets/2124984/346c3001-a331-4ad8-83cf-682c25b5cf14">

Task list after user maps a domain that is registered with us:

<img width="715" alt="Screen Shot 2023-06-20 at 4 47 32 PM" src="https://github.com/Automattic/jetpack/assets/2124984/667a0a1b-71e8-45d1-bc6f-6a07d01da40a">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox `public-api.wordpress.com`
* Create a new site from `/start` with a non-eCommerce paid plan (Personal, Premium, Business) with the "Promote myself and business" intent
* Launch the site
* You should land in Customer Home and see the Keep Building task list as above
* Click on "Claim your free one-year domain"
* Purchase a new domain (don't forget to delete it within 24hours)
* Return to My Home and see the task has been marked completed, the title stays the same.
* Create a second new site following the steps above.
* Click on "Claim your free one-year domain"
* This time, scroll to the bottom of the screen and select the option to map a domain you already own.
* Map an existing domain.
* Go back to My Home and see you've completed the task and the title has changed to "Connect a domain"