### PR TITLE
Stats Admin: Remove/notices from initial state

### DIFF
--- a/projects/packages/stats-admin/changelog/remove-notices-from-initial-state
+++ b/projects/packages/stats-admin/changelog/remove-notices-from-initial-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Stats: removed notices from initial state for better performance

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -76,14 +76,14 @@ class Odyssey_Config_Data {
 				'sites'       => array(
 					'items'    => array(
 						"$blog_id" => array(
-							'ID'            => $blog_id,
-							'URL'           => site_url(),
-							'jetpack'       => true,
-							'visible'       => true,
-							'capabilities'  => $empty_object,
-							'products'      => array(),
-							'plan'          => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
-							'options'       => array(
+							'ID'           => $blog_id,
+							'URL'          => site_url(),
+							'jetpack'      => true,
+							'visible'      => true,
+							'capabilities' => $empty_object,
+							'products'     => array(),
+							'plan'         => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
+							'options'      => array(
 								'wordads'               => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url'             => admin_url(),
 								'gmt_offset'            => $this->get_gmt_offset(),
@@ -94,8 +94,6 @@ class Odyssey_Config_Data {
 								'stats_admin_version'   => Main::VERSION,
 								'software_version'      => $wp_version,
 							),
-							// TODO remove this and use API so that we could reduce loading time.
-							'stats_notices' => ( new Notices() )->get_notices_to_show(),
 						),
 					),
 					'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),


### PR DESCRIPTION
Fixes #31263 

## Proposed changes:

The PR proposes to remove the unused `notices` key from Odyssey initial state which would optimize the page load time. The context behind this is [the notices was changed to call a remote API instead of a local request](https://github.com/Automattic/jetpack/pull/31261).

The PR should be merged after https://github.com/Automattic/wp-calypso/pull/78447 is shipped to Odyssey.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Open a new JN site
* Ensure New Stats notice shows and could be dismissed

![image](https://github.com/Automattic/jetpack/assets/1425433/17ba844c-c9ee-42e6-acc3-82068d525b5a)



