### PR TITLE
AI Extension: do not extend block sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-do-not-extend-sidebar-for-now
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-do-not-extend-sidebar-for-now
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AU Extension: do not extend block sidebar

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { InspectorControls, BlockControls } from '@wordpress/block-editor';
+import { BlockControls } from '@wordpress/block-editor';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
@@ -13,7 +13,6 @@ import React from 'react';
 import AiAssistantDropdown, {
 	AiAssistantDropdownOnChangeOptionsArgProps,
 } from '../../components/ai-assistant-controls';
-import AiAssistantPanel from '../../components/ai-assistant-panel';
 import useSuggestionsFromAI from '../../hooks/use-suggestions-from-ai';
 import { PromptItemProps, PromptTypeProp, getPrompt } from '../../lib/prompt';
 
@@ -71,10 +70,6 @@ export const withAIAssistant = createHigherOrderComponent(
 		return (
 			<>
 				<BlockEdit { ...props } />
-
-				<InspectorControls>
-					<AiAssistantPanel />
-				</InspectorControls>
 
 				<BlockControls group="block">
 					<AiAssistantDropdown onChange={ requestSuggestion } />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: do not extend block sidebar

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Select a paragraph/heading block
* Confirm the sidebar is not extended anymore

before | after
-------|------
<img width="896" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/9f2d5658-b78b-41b6-a2ff-e45ab74f9c44"> | <img width="890" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/8fc6e847-92fd-40a6-bcf2-597512ee9ceb">


