### PR TITLE
Blaze: introduce Blaze module

### DIFF
--- a/projects/packages/blaze/README.md
+++ b/projects/packages/blaze/README.md
@@ -11,32 +11,11 @@ Use composer to add the package to your project:
 composer add automattic/jetpack-blaze
 ```
 
-### Initializing the features
-
-#### Using the Config Package
-
-The JITMs can be enabled using the Config package:
-
-```
-use Automattic/Jetpack/Blaze;
-
-add_action( 'plugins_loaded', 'configure_blaze', 1 );
-
-function configure_blaze() {
-    $config = new Config();
-    $config->ensure( 'blaze' );
-}
-```
-
-#### Hook it
-Or can initialize it on the `admin_init` hook:
-
-```php
-add_action( 'admin_init', array( '\Automattic\Jetpack\Blaze', 'configure' ) );
-```
+### Initializing the feature
 
 #### Direct invocation
-Or directly invoke with a method call: 
+You can directly invoke the feature with a method call: 
+
 ```php
 use Automattic\Jetpack\Blaze;
 Blaze::init();

--- a/projects/packages/blaze/changelog/update-blaze-module
+++ b/projects/packages/blaze/changelog/update-blaze-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze can now be loaded as a module, instead of relying on the Config package.

--- a/projects/packages/config/changelog/update-blaze-module
+++ b/projects/packages/config/changelog/update-blaze-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blaze can now be loaded as a module, instead of relying on the Config package.

--- a/projects/packages/config/src/class-config.php
+++ b/projects/packages/config/src/class-config.php
@@ -12,7 +12,6 @@ namespace Automattic\Jetpack;
  * contain the package classes shown below. The consumer plugin
  * must require the corresponding packages to use these features.
  */
-use Automattic\Jetpack\Blaze as Blaze;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Connection\Plugin;
 use Automattic\Jetpack\Import\Main as Import_Main;
@@ -56,7 +55,6 @@ class Config {
 		'videopress'      => false,
 		'stats'           => false,
 		'stats_admin'     => false,
-		'blaze'           => false,
 		'yoast_promo'     => false,
 		'import'          => false,
 	);
@@ -161,10 +159,6 @@ class Config {
 		}
 		if ( $this->config['stats_admin'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\Stats_Admin\Main' ) && $this->ensure_feature( 'stats_admin' );
-		}
-
-		if ( $this->config['blaze'] ) {
-			$this->ensure_class( 'Automattic\Jetpack\Blaze' ) && $this->ensure_feature( 'blaze' );
 		}
 
 		if ( $this->config['yoast_promo'] ) {
@@ -357,14 +351,6 @@ class Config {
 		if ( ! empty( $options ) ) {
 			VideoPress_Pkg_Initializer::update_init_options( $options );
 		}
-		return true;
-	}
-
-	/**
-	 * Enables Blaze.
-	 */
-	protected function enable_blaze() {
-		Blaze::init();
 		return true;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -661,6 +661,16 @@ export function isOdysseyStatsEnabled( state ) {
 }
 
 /**
+ * Returns if the wp-admin Blaze dashboard is enabled.
+ *
+ * @param {object} state - Global state tree.
+ * @returns {boolean} True if the Blaze dashboard is enabled.
+ */
+export function isBlazeDashboardEnabled( state ) {
+	return !! state.jetpack.initialState.isBlazeDashboardEnabled;
+}
+
+/**
  * Returns true if Jetpack's Pre-connection helpers are enabled.
  *
  * @param {object} state - Global state tree.

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -661,7 +661,17 @@ export function isOdysseyStatsEnabled( state ) {
 }
 
 /**
- * Returns if the wp-admin Blaze dashboard is enabled.
+ * Returns true if Blaze can be used on the site.
+ *
+ * @param {object} state - Global state tree.
+ * @returns {boolean} True if Blaze is available on the site.
+ */
+export function shouldInitializeBlaze( state ) {
+	return !! state.jetpack.initialState.shouldInitializeBlaze;
+}
+
+/**
+ * Returns true if the wp-admin Blaze dashboard is enabled.
  *
  * @param {object} state - Global state tree.
  * @returns {boolean} True if the Blaze dashboard is enabled.

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -1,0 +1,59 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { __, _x } from '@wordpress/i18n';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import { ModuleToggle } from 'components/module-toggle';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import React from 'react';
+import { connect } from 'react-redux';
+import { getModule } from 'state/modules';
+
+/**
+ * Blaze settings component.
+ *
+ * @param {object} props - Component props.
+ * @returns {React.Component} Blaze settings component.
+ */
+function Blaze( props ) {
+	const {
+		blazeActive,
+		blazeModule: { description },
+		isSavingAnyOption,
+		toggleModuleNow,
+	} = props;
+
+	return (
+		<SettingsCard
+			{ ...props }
+			header={ _x( 'Blaze', 'Settings header', 'jetpack' ) }
+			module="blaze"
+			hideButton
+		>
+			<SettingsGroup
+				module={ { module: 'blaze' } }
+				support={ {
+					text: description,
+					link: getRedirectUrl( 'jetpack-support-blaze' ),
+				} }
+			>
+				<ModuleToggle
+					slug="blaze"
+					activated={ blazeActive }
+					toggling={ isSavingAnyOption( 'blaze' ) }
+					toggleModule={ toggleModuleNow }
+				>
+					{ __( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' ) }
+				</ModuleToggle>
+			</SettingsGroup>
+		</SettingsCard>
+	);
+}
+
+export default withModuleSettingsFormHelpers(
+	connect( ( state, ownProps ) => {
+		return {
+			blazeActive: ownProps.getOptionValue( 'blaze' ),
+			blazeModule: getModule( state, 'blaze' ),
+		};
+	} )( Blaze )
+);

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -1,7 +1,8 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
 import Card from 'components/card';
 import ConnectUserBar from 'components/connect-user-bar';
+import { FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
@@ -12,7 +13,7 @@ import { connect } from 'react-redux';
 import { getModule } from 'state/modules';
 
 const trackDashboardClick = () => {
-	analytics.tracks.recordJetpackClick( 'view-blaze-dashboard' );
+	analytics.tracks.recordJetpackClick( 'blaze-dashboard' );
 };
 
 /**
@@ -24,11 +25,14 @@ const trackDashboardClick = () => {
 function Blaze( props ) {
 	const {
 		blazeActive,
+		blazeDashboardEnabled,
 		blazeModule: { description },
+		getSettingCurrentValue,
 		hasConnectedOwner,
 		isOfflineMode,
 		isSavingAnyOption,
 		isUnavailableInOfflineMode,
+		updateOptions,
 		toggleModuleNow,
 	} = props;
 
@@ -44,6 +48,16 @@ function Blaze( props ) {
 				{ __( 'Manage your campaigns and view your earnings in the Blaze dashboard', 'jetpack' ) }
 			</Card>
 		);
+	};
+
+	/**
+	 * Update the option that enables or disables the Blaze dashboard.
+	 *
+	 * @returns {*} the updated value
+	 */
+	const toggleBlazeDashboard = () => {
+		const updateValue = ! getSettingCurrentValue( 'jetpack_blaze_dashboard_enable' );
+		return updateOptions( { jetpack_blaze_dashboard_enable: updateValue } );
 	};
 
 	return (
@@ -71,6 +85,22 @@ function Blaze( props ) {
 				>
 					{ __( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' ) }
 				</ModuleToggle>
+				<FormFieldset className="jp-blaze-dashboard-toggle">
+					<ToggleControl
+						checked={ !! blazeDashboardEnabled }
+						disabled={
+							! blazeActive || unavailableInOfflineMode || isSavingAnyOption( [ 'blaze' ] )
+						}
+						toggling={ isSavingAnyOption( [ 'jetpack_blaze_dashboard_enable' ] ) }
+						onChange={ toggleBlazeDashboard() }
+						label={
+							<>
+								{ __( 'Manage your Blaze campaigns straight from your dashboard', 'jetpack' ) }
+								<span className="jp-blaze-dashboard-badge">{ __( 'New', 'jetpack' ) }</span>
+							</>
+						}
+					/>
+				</FormFieldset>
 			</SettingsGroup>
 			{ blazeActive && hasConnectedOwner && ! isOfflineMode && blazeCard() }
 			{ ! hasConnectedOwner && ! isOfflineMode && (
@@ -88,6 +118,7 @@ export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
 			blazeActive: ownProps.getOptionValue( 'blaze' ),
+			blazeDashboardEnabled: ownProps.getOptionValue( 'jetpack_blaze_dashboard_enable' ),
 			blazeModule: getModule( state, 'blaze' ),
 		};
 	} )( Blaze )

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -1,6 +1,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
 import Card from 'components/card';
+import ConnectUserBar from 'components/connect-user-bar';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
@@ -24,9 +25,14 @@ function Blaze( props ) {
 	const {
 		blazeActive,
 		blazeModule: { description },
+		hasConnectedOwner,
+		isOfflineMode,
 		isSavingAnyOption,
+		isUnavailableInOfflineMode,
 		toggleModuleNow,
 	} = props;
+
+	const unavailableInOfflineMode = isUnavailableInOfflineMode( 'blaze' );
 
 	const blazeCard = () => {
 		return (
@@ -49,6 +55,8 @@ function Blaze( props ) {
 		>
 			<SettingsGroup
 				module={ { module: 'blaze' } }
+				disableInOfflineMode
+				disableInSiteConnectionMode
 				support={ {
 					text: description,
 					link: getRedirectUrl( 'jetpack-support-blaze' ),
@@ -57,13 +65,21 @@ function Blaze( props ) {
 				<ModuleToggle
 					slug="blaze"
 					activated={ blazeActive }
+					disabled={ unavailableInOfflineMode || ! hasConnectedOwner }
 					toggling={ isSavingAnyOption( 'blaze' ) }
 					toggleModule={ toggleModuleNow }
 				>
 					{ __( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' ) }
 				</ModuleToggle>
 			</SettingsGroup>
-			{ blazeActive && blazeCard() }
+			{ blazeActive && hasConnectedOwner && ! isOfflineMode && blazeCard() }
+			{ ! hasConnectedOwner && ! isOfflineMode && (
+				<ConnectUserBar
+					feature="blaze"
+					featureLabel={ __( 'Blaze', 'jetpack' ) }
+					text={ __( 'Connect to set up campaigns and promote your content.', 'jetpack' ) }
+				/>
+			) }
 		</SettingsCard>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -1,8 +1,7 @@
-import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
 import Card from 'components/card';
 import ConnectUserBar from 'components/connect-user-bar';
-import { FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
@@ -25,14 +24,11 @@ const trackDashboardClick = () => {
 function Blaze( props ) {
 	const {
 		blazeActive,
-		blazeDashboardEnabled,
 		blazeModule: { description },
-		getSettingCurrentValue,
 		hasConnectedOwner,
 		isOfflineMode,
 		isSavingAnyOption,
 		isUnavailableInOfflineMode,
-		updateOptions,
 		toggleModuleNow,
 	} = props;
 
@@ -48,16 +44,6 @@ function Blaze( props ) {
 				{ __( 'Manage your campaigns and view your earnings in the Blaze dashboard', 'jetpack' ) }
 			</Card>
 		);
-	};
-
-	/**
-	 * Update the option that enables or disables the Blaze dashboard.
-	 *
-	 * @returns {*} the updated value
-	 */
-	const toggleBlazeDashboard = () => {
-		const updateValue = ! getSettingCurrentValue( 'jetpack_blaze_dashboard_enable' );
-		return updateOptions( { jetpack_blaze_dashboard_enable: updateValue } );
 	};
 
 	return (
@@ -85,22 +71,6 @@ function Blaze( props ) {
 				>
 					{ __( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' ) }
 				</ModuleToggle>
-				<FormFieldset className="jp-blaze-dashboard-toggle">
-					<ToggleControl
-						checked={ !! blazeDashboardEnabled }
-						disabled={
-							! blazeActive || unavailableInOfflineMode || isSavingAnyOption( [ 'blaze' ] )
-						}
-						toggling={ isSavingAnyOption( [ 'jetpack_blaze_dashboard_enable' ] ) }
-						onChange={ toggleBlazeDashboard() }
-						label={
-							<>
-								{ __( 'Manage your Blaze campaigns straight from your dashboard', 'jetpack' ) }
-								<span className="jp-blaze-dashboard-badge">{ __( 'New', 'jetpack' ) }</span>
-							</>
-						}
-					/>
-				</FormFieldset>
 			</SettingsGroup>
 			{ blazeActive && hasConnectedOwner && ! isOfflineMode && blazeCard() }
 			{ ! hasConnectedOwner && ! isOfflineMode && (
@@ -118,7 +88,6 @@ export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
 			blazeActive: ownProps.getOptionValue( 'blaze' ),
-			blazeDashboardEnabled: ownProps.getOptionValue( 'jetpack_blaze_dashboard_enable' ),
 			blazeModule: getModule( state, 'blaze' ),
 		};
 	} )( Blaze )

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -9,7 +9,11 @@ import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
 import React from 'react';
 import { connect } from 'react-redux';
-import { isBlazeDashboardEnabled, shouldInitializeBlaze } from 'state/initial-state';
+import {
+	isBlazeDashboardEnabled,
+	isWoASite as getIsWoASite,
+	shouldInitializeBlaze,
+} from 'state/initial-state';
 import { getModule } from 'state/modules';
 
 const trackDashboardClick = () => {
@@ -32,9 +36,14 @@ function Blaze( props ) {
 		isOfflineMode,
 		isSavingAnyOption,
 		isUnavailableInOfflineMode,
+		isWoASite,
 		siteAdminUrl,
 		toggleModuleNow,
 	} = props;
+
+	if ( isWoASite ) {
+		return null;
+	}
 
 	const unavailableInOfflineMode = isUnavailableInOfflineMode( 'blaze' );
 
@@ -115,6 +124,7 @@ export default withModuleSettingsFormHelpers(
 			blazeDashboardEnabled: isBlazeDashboardEnabled( state ),
 			blazeModule: getModule( state, 'blaze' ),
 			blazeAvailable: shouldInitializeBlaze( state ),
+			isWoASite: getIsWoASite( state ),
 		};
 	} )( Blaze )
 );

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -9,6 +9,7 @@ import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
 import React from 'react';
 import { connect } from 'react-redux';
+import { isBlazeDashboardEnabled } from 'state/initial-state';
 import { getModule } from 'state/modules';
 
 const trackDashboardClick = () => {
@@ -25,10 +26,12 @@ function Blaze( props ) {
 	const {
 		blazeActive,
 		blazeModule: { description },
+		blazeDashboardEnabled,
 		hasConnectedOwner,
 		isOfflineMode,
 		isSavingAnyOption,
 		isUnavailableInOfflineMode,
+		siteAdminUrl,
 		toggleModuleNow,
 	} = props;
 
@@ -37,9 +40,15 @@ function Blaze( props ) {
 	const blazeCard = () => {
 		return (
 			<Card
-				className="blaze-card"
-				href="tools.php?page=advertising"
+				compact
+				className="jp-settings-card__configure-link"
+				href={
+					blazeDashboardEnabled
+						? siteAdminUrl + 'tools.php?page=advertising'
+						: getRedirectUrl( 'jetpack-blaze' )
+				}
 				onClick={ trackDashboardClick }
+				{ ...( ! blazeDashboardEnabled ? { target: '_blank', rel: 'noopener noreferrer' } : {} ) }
 			>
 				{ __( 'Manage your campaigns and view your earnings in the Blaze dashboard', 'jetpack' ) }
 			</Card>
@@ -88,6 +97,7 @@ export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
 			blazeActive: ownProps.getOptionValue( 'blaze' ),
+			blazeDashboardEnabled: isBlazeDashboardEnabled( state ),
 			blazeModule: getModule( state, 'blaze' ),
 		};
 	} )( Blaze )

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -1,12 +1,18 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
+import Card from 'components/card';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import analytics from 'lib/analytics';
 import React from 'react';
 import { connect } from 'react-redux';
 import { getModule } from 'state/modules';
+
+const trackDashboardClick = () => {
+	analytics.tracks.recordJetpackClick( 'view-blaze-dashboard' );
+};
 
 /**
  * Blaze settings component.
@@ -21,6 +27,18 @@ function Blaze( props ) {
 		isSavingAnyOption,
 		toggleModuleNow,
 	} = props;
+
+	const blazeCard = () => {
+		return (
+			<Card
+				className="blaze-card"
+				href="tools.php?page=advertising"
+				onClick={ trackDashboardClick }
+			>
+				{ __( 'Manage your campaigns and view your earnings in the Blaze dashboard', 'jetpack' ) }
+			</Card>
+		);
+	};
 
 	return (
 		<SettingsCard
@@ -45,6 +63,7 @@ function Blaze( props ) {
 					{ __( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' ) }
 				</ModuleToggle>
 			</SettingsGroup>
+			{ blazeActive && blazeCard() }
 		</SettingsCard>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/traffic/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/index.jsx
@@ -14,6 +14,7 @@ import { getModule, getModuleOverride } from 'state/modules';
 import { isModuleFound } from 'state/search';
 import { getSettings } from 'state/settings';
 import { Ads } from './ads';
+import Blaze from './blaze';
 import { GoogleAnalytics } from './google-analytics';
 import { RelatedPosts } from './related-posts';
 import SEO from './seo';
@@ -44,7 +45,8 @@ export class Traffic extends React.Component {
 			foundRelated = this.props.isModuleFound( 'related-posts' ),
 			foundVerification = this.props.isModuleFound( 'verification-tools' ),
 			foundSitemaps = this.props.isModuleFound( 'sitemaps' ),
-			foundAnalytics = this.props.isModuleFound( 'google-analytics' );
+			foundAnalytics = this.props.isModuleFound( 'google-analytics' ),
+			foundBlaze = this.props.isModuleFound( 'blaze' );
 
 		if ( ! this.props.searchTerm && ! this.props.active ) {
 			return null;
@@ -58,7 +60,8 @@ export class Traffic extends React.Component {
 			! foundRelated &&
 			! foundVerification &&
 			! foundSitemaps &&
-			! foundAnalytics
+			! foundAnalytics &&
+			! foundBlaze
 		) {
 			return null;
 		}
@@ -116,6 +119,7 @@ export class Traffic extends React.Component {
 						} ) }
 					/>
 				) }
+				{ foundBlaze && <Blaze { ...commonProps } /> }
 				{ foundShortlinks && <Shortlinks { ...commonProps } /> }
 				{ foundSitemaps && <Sitemaps { ...commonProps } /> }
 				{ foundVerification && <VerificationServices { ...commonProps } /> }

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -263,18 +263,15 @@ $twitter-pofile-image-padding: 17px;
 	}
 }
 
-.jp-stats-odyssey-toggle,
-.jp-blaze-dashboard-toggle {
+.jp-stats-odyssey-toggle {
 	margin-bottom: 20px;
 }
 
-.jp-stats-odyssey-toggle > .components-base-control,
-.jp-blaze-dashboard-toggle > .components-base-control {
+.jp-stats-odyssey-toggle > .components-base-control {
 	margin-bottom: 0;
 }
 
-.jp-stats-odyssey-badge,
-.jp-blaze-dashboard-badge {
+.jp-stats-odyssey-badge {
 	color: #008710;
 	background-color: #D0E6B8;
 	border-radius: 3px;

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -253,7 +253,7 @@ $twitter-pofile-image-padding: 17px;
 		a.dops-notice__action {
 			white-space: initial;
 		}
-	
+
 		a.dops-notice__action .gridicon {
 			display: none;
 		}
@@ -263,15 +263,18 @@ $twitter-pofile-image-padding: 17px;
 	}
 }
 
-.jp-stats-odyssey-toggle {
+.jp-stats-odyssey-toggle,
+.jp-blaze-dashboard-toggle {
 	margin-bottom: 20px;
 }
 
-.jp-stats-odyssey-toggle > .components-base-control {
+.jp-stats-odyssey-toggle > .components-base-control,
+.jp-blaze-dashboard-toggle > .components-base-control {
 	margin-bottom: 0;
 }
 
-.jp-stats-odyssey-badge {
+.jp-stats-odyssey-badge,
+.jp-blaze-dashboard-badge {
 	color: #008710;
 	background-color: #D0E6B8;
 	border-radius: 3px;

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -232,6 +232,7 @@ class Jetpack_Redux_State_Helper {
 			'isWooCommerceActive'         => in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ), true ),
 			'useMyJetpackLicensingUI'     => My_Jetpack_Initializer::is_licensing_ui_enabled(),
 			'isOdysseyStatsEnabled'       => Stats_Options::get_option( 'enable_odyssey_stats' ),
+			'shouldInitializeBlaze'       => Blaze::should_initialize(),
 			'isBlazeDashboardEnabled'     => Blaze::is_dashboard_enabled(),
 		);
 	}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -6,6 +6,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score_History;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
@@ -231,6 +232,7 @@ class Jetpack_Redux_State_Helper {
 			'isWooCommerceActive'         => in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', Jetpack::get_active_plugins() ), true ),
 			'useMyJetpackLicensingUI'     => My_Jetpack_Initializer::is_licensing_ui_enabled(),
 			'isOdysseyStatsEnabled'       => Stats_Options::get_option( 'enable_odyssey_stats' ),
+			'isBlazeDashboardEnabled'     => Blaze::is_dashboard_enabled(),
 		);
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2220,6 +2220,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function get_updateable_data_list( $selector = '' ) {
 
 		$options = array(
+			// Blaze.
+			'jetpack_blaze_dashboard_enable'       => array(
+				'description'       => esc_html__( 'Enable a dashboard to manage your Blaze campaigns.', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => false,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'blaze',
+			),
+
 			// Blocks.
 			'jetpack_blocks_disabled'              => array(
 				'description'       => esc_html__( 'Jetpack Blocks disabled.', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2220,15 +2220,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function get_updateable_data_list( $selector = '' ) {
 
 		$options = array(
-			// Blaze.
-			'jetpack_blaze_dashboard_enable'       => array(
-				'description'       => esc_html__( 'Enable a dashboard to manage your Blaze campaigns.', 'jetpack' ),
-				'type'              => 'boolean',
-				'default'           => false,
-				'validate_callback' => __CLASS__ . '::validate_boolean',
-				'jp_group'          => 'blaze',
-			),
-
 			// Blocks.
 			'jetpack_blocks_disabled'              => array(
 				'description'       => esc_html__( 'Jetpack Blocks disabled.', 'jetpack' ),

--- a/projects/plugins/jetpack/changelog/update-blaze-module
+++ b/projects/plugins/jetpack/changelog/update-blaze-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blaze: introduce module, instead of automatically initializing the feature.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -846,7 +846,6 @@ class Jetpack {
 
 		foreach (
 			array(
-				'blaze',
 				'jitm',
 				'sync',
 				'waf',

--- a/projects/plugins/jetpack/modules/blaze.php
+++ b/projects/plugins/jetpack/modules/blaze.php
@@ -7,7 +7,7 @@
  * First Introduced: 12.3
  * Requires Connection: Yes
  * Auto Activate: Yes
- * Module Tags: Traffic
+ * Module Tags: Traffic, Social
  * Additional Search Queries: advertising, ads
  *
  * @package automattic/jetpack

--- a/projects/plugins/jetpack/modules/blaze.php
+++ b/projects/plugins/jetpack/modules/blaze.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Module Name: Blaze
+ * Module Description: Attract high-quality traffic to your site using Blaze.
+ * Sort Order: 22
+ * Recommendation Order: 12
+ * First Introduced: 12.3
+ * Requires Connection: Yes
+ * Auto Activate: Yes
+ * Module Tags: Traffic
+ * Additional Search Queries: advertising, ads
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Blaze;
+
+Blaze::init();

--- a/projects/plugins/jetpack/modules/blaze.php
+++ b/projects/plugins/jetpack/modules/blaze.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Blaze
- * Module Description: Attract high-quality traffic to your site using Blaze.
+ * Module Description: Grow your audience by promoting your content across Tumblr and WordPress.com.
  * Sort Order: 22
  * Recommendation Order: 12
  * First Introduced: 12.3

--- a/projects/plugins/jetpack/modules/module-info.php
+++ b/projects/plugins/jetpack/modules/module-info.php
@@ -924,3 +924,19 @@ function jetpack_more_info_waf() {
 	esc_html_e( 'The Jetpack Firewall is a web application firewall designed to protect your WordPress site from malicious requests.', 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_waf', 'jetpack_more_info_waf' );
+
+/**
+ * Blaze support link.
+ */
+function jetpack_blaze_more_link() {
+	echo esc_url( Redirect::get_url( 'jetpack-support-blaze' ) );
+}
+add_action( 'jetpack_learn_more_button_blaze', 'jetpack_blaze_more_link' );
+
+/**
+ * Blaze description.
+ */
+function jetpack_more_info_blaze() {
+	esc_html_e( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' );
+}
+add_action( 'jetpack_module_more_info_blaze', 'jetpack_more_info_blaze' );

--- a/projects/plugins/jetpack/modules/module-info.php
+++ b/projects/plugins/jetpack/modules/module-info.php
@@ -937,6 +937,6 @@ add_action( 'jetpack_learn_more_button_blaze', 'jetpack_blaze_more_link' );
  * Blaze description.
  */
 function jetpack_more_info_blaze() {
-	esc_html_e( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' );
+	esc_html_e( 'Grow your audience by promoting your content across Tumblr and WordPress.com.', 'jetpack' );
 }
 add_action( 'jetpack_module_more_info_blaze', 'jetpack_more_info_blaze' );


### PR DESCRIPTION
Fixes #29294

> **Warning**
> This depends on #30103 and #31485 being merged.

## Proposed changes:

Instead of loading Blaze automatically and only providing a code snippet to disable it, let's make it a module (automatically enabled upon connection to WordPress.com) that can be disabled via the modules as well as the Settings page.

This will be especially important once #30103 will be merged and the new dashboard will be enabled, since the Blaze feature  will then have its own menu in the dashboard, and will thus become more prominent in WordPress dashboards.

Since the feature becomes a module, we do not need to include it in the Config package anymore. It will be initialized when the module is activated.

> **Note**
> The new module will be automatically activated when new sites connect to WordPress.com or when sites are updated to the next version of Jetpack. However, on your test site using the Beta plugin or on your local development site, the module will not be automatically updated. You'll consequently have the feature disabled when you start testing.

### UI Changes

This PR introduces UI changes in 2 different interfaces:

- The old modules page at `wp-admin/admin.php?page=jetpack_modules`, where you'll see a new "Blaze" item.
- A new card in Jetpack > Settings > Traffic

### Screenshots

Here are some screenshots of the different use-cases you may find in Jetpack > Settings > Traffic:

**Offline mode**
<img width="1110" alt="Screenshot 2023-06-21 at 12 43 35" src="https://github.com/Automattic/jetpack/assets/426388/17d759be-4506-41c1-92ed-c1da0ff3cef1">

**Feature disabled on the site**

 for example via `add_filter( 'jetpack_blaze_enabled', '__return_false' );`

<img width="1099" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/cf2e3d57-9600-474d-b6cc-b8c9defe6a1b">

**Inactive**

<img width="1112" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/5c225d23-4f4c-411b-8cee-9c0be82a02de">

**Active with the new Dashboard enabled**

via `add_filter( 'jetpack_blaze_dashboard_enable', '__return_true' );`

<img width="1113" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/78185b04-62b8-4c57-ad82-26175212a249">

**Active with the new Dashboard not active yet**

This should be the default, does not require any filter:

<img width="1121" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/9d6bb187-ef51-44ec-853e-7526483ae2b5">

**Site connected, but user not connected**
<img width="1101" alt="Screenshot 2023-06-21 at 12 44 52" src="https://github.com/Automattic/jetpack/assets/426388/d2d27c18-d84d-4d6f-a1f3-74311307acce">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related PRs:

* https://github.com/Automattic/wp-calypso/pull/78637
* 1416-gh-Automattic/wpcomsh

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Here are some basic tests:

* Go to Jetpack > Settings > Traffic.
* Enable the Blaze feature.
* Go to Posts > All Posts, and notice the Blaze CTA links when hovering the published posts.
* Go to Jetpack > Settings > Modules
* Check that when clicking on Blaze you're redirected to the Blaze support docs.
* Disable the module.
* Go back to Posts > All Posts: the links should be gone.

For more advanced tests, I would recommend playing with the filters I mentioned above.