### PR TITLE
Jetpack plugin: fix warnings in related posts

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-undefined-array-key-warnings
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-undefined-array-key-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Small fix to a recent enhancement.
+
+

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1501,8 +1501,10 @@ EOT;
 			);
 
 			if ( is_array( $post_image ) ) {
-				$img_url   = $post_image['src'];
-				$src_width = $post_image['src_width'];
+				$img_url = $post_image['src'];
+				if ( ! empty( $post_image['src_width'] ) ) {
+					$src_width = $post_image['src_width'];
+				}
 			} elseif ( class_exists( 'Jetpack_Media_Summary' ) ) {
 				$media = Jetpack_Media_Summary::get( $post_id );
 
@@ -1517,12 +1519,24 @@ EOT;
 				} else {
 					$image_params['alt_text'] = '';
 				}
-				$image_params['width']  = $thumbnail_size['width'];
-				$image_params['height'] = $thumbnail_size['height'];
-				$image_params['src']    = Jetpack_PostImages::fit_image_url(
+
+				$thumbnail_width  = 0;
+				$thumbnail_height = 0;
+
+				if ( ! empty( $thumbnail_size['width'] ) ) {
+					$thumbnail_width       = $thumbnail_size['width'];
+					$image_params['width'] = $thumbnail_width;
+				}
+
+				if ( ! empty( $thumbnail_size['height'] ) ) {
+					$thumbnail_height       = $thumbnail_size['height'];
+					$image_params['height'] = $thumbnail_height;
+				}
+
+				$image_params['src'] = Jetpack_PostImages::fit_image_url(
 					$img_url,
-					$thumbnail_size['width'],
-					$thumbnail_size['height']
+					$thumbnail_width,
+					$thumbnail_height
 				);
 
 				// Add a srcset to handle zoomed views and high-density screens.
@@ -1530,9 +1544,9 @@ EOT;
 				$srcset_values = array();
 				foreach ( $multipliers as $multiplier ) {
 					// Forcefully cast to int, in case we ever add decimal multipliers.
-					$srcset_width  = (int) $thumbnail_size['width'] * $multiplier;
-					$srcset_height = (int) $thumbnail_size['height'] * $multiplier;
-					if ( ! isset( $src_width ) || $srcset_width > $src_width ) {
+					$srcset_width  = (int) ( $thumbnail_width * $multiplier );
+					$srcset_height = (int) ( $thumbnail_height * $multiplier );
+					if ( empty( $src_width ) || $srcset_width > $src_width ) {
 						break;
 					}
 

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1546,7 +1546,7 @@ EOT;
 					// Forcefully cast to int, in case we ever add decimal multipliers.
 					$srcset_width  = (int) ( $thumbnail_width * $multiplier );
 					$srcset_height = (int) ( $thumbnail_height * $multiplier );
-					if ( empty( $src_width ) || $srcset_width > $src_width ) {
+					if ( empty( $src_width ) || $srcset_width < 1 || $srcset_width > $src_width ) {
 						break;
 					}
 


### PR DESCRIPTION
This PR fixes some warnings in the Related Posts feature, following the work in #31432.

Fixes the issue raised in https://github.com/Automattic/jetpack/pull/31432#issuecomment-1599254960 .

## Proposed changes:
* Add some checks to prevent the undefined array key warning for `src_width` in related posts
* Add further checks to prevent other undefined array key warnings in the same module

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
I'm not entirely sure how to reproduce the conditions that lead to the warning; for that to happen, there needs to exist a `Jetpack_PostImages` image that has a defined URL, but no defined `src_width`. I'm not entirely sure how to accomplish that. @samiff : Do you happen to know how?

Assuming you're able to reproduce the above, you can test by following the same instructions as in #31432, pasted below:
>- Enable the "Related Posts" feature for your test blog (`Settings -> Traffic -> Show related content after posts`).
>- Enable related posts thumbnails (`Show a thumbnail image where available` in the same place).
>- Open a post that has related posts with thumbnails.
>- Verify that the thumbnails include a `srcset` with different pixel ratios (up to 4x, if the source image is large enough).
>- Optionally, validate that the variants that get fetched on page load change as you change zoom values and/or try different pixel ratio screens.
