### PR TITLE
AI Extension: improve block transform process

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-fix-transform-from-heading-block
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-fix-transform-from-heading-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: improve block transform process

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockContent } from '@wordpress/blocks';
 import TurndownService from 'turndown';
 /**
  * Internal dependencies
@@ -13,24 +13,41 @@ import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assis
  */
 import { PromptItemProps } from '../lib/prompt';
 
-const turndownService = new TurndownService();
+const turndownService = new TurndownService( { emDelimiter: '_' } );
 
-const transformFromCore = {
-	type: 'block',
-	blocks: EXTENDED_BLOCKS,
-	isMatch: () => isPossibleToExtendBlock(),
-	transform: ( { content } ) => {
-		const messages: Array< PromptItemProps > = [
-			{
-				role: 'assistant',
-				content,
-			},
-		];
+const from = [];
 
-		return createBlock( blockName, { content: turndownService.turndown( content ), messages } );
-	},
-};
+/*
+ * Create individual transform handler for each block type.
+ */
+for ( const blockType of EXTENDED_BLOCKS ) {
+	from.push( {
+		type: 'block',
+		blocks: [ blockType ],
+		isMatch: () => isPossibleToExtendBlock(),
+		transform: ( { content } ) => {
+			// Create a temporary block to get the HTML content.
+			const temporaryBlock = createBlock( blockType, { content } );
+			const htmlContent = getBlockContent( temporaryBlock );
 
-const from = [ transformFromCore ];
+			// Convert the content to markdown.
+			content = turndownService.turndown( htmlContent );
+
+			// Create anr user/assistant message.
+			const messages: Array< PromptItemProps > = [
+				{
+					role: 'user',
+					content: 'Tell me with some content for this block, please.',
+				},
+				{
+					role: 'assistant',
+					content,
+				},
+			];
+
+			return createBlock( blockName, { content, messages } );
+		},
+	} );
+}
 
 export default { from };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -37,7 +37,7 @@ for ( const blockType of EXTENDED_BLOCKS ) {
 			const messages: Array< PromptItemProps > = [
 				{
 					role: 'user',
-					content: 'Tell me with some content for this block, please.',
+					content: 'Tell me some content for this block, please.',
 				},
 				{
 					role: 'assistant',

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -33,7 +33,7 @@ for ( const blockType of EXTENDED_BLOCKS ) {
 			// Convert the content to markdown.
 			content = turndownService.turndown( htmlContent );
 
-			// Create anr user/assistant message.
+			// Create a pair of user/assistant messages.
 			const messages: Array< PromptItemProps > = [
 				{
 					role: 'user',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR transforms the process from the paragraph and heading blocks to the AI Assistant one. The key change is how it gets the HTML code from the block instance.

* It creates a temporary block
* Get its HTML content by using the `getBlockContent()` function
* Finally, transform to Markdown to serve the AI Assistant block.

Also, it populates the initial messages with a `user`/`assistant` pair to pave the prompt history. 

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: improve block transform process

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a heading block
* Transform to AI Asisstant

Heading (H2) | before | after
------|------|------
<img width="611" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/f466cacc-e044-4284-bac1-25491d56a8c5"> | <img width="597" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/830b706c-d08c-488c-953f-86b204a104de"> | <img width="589" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/86547dfe-6240-47bf-b143-08016086ed15">


