### PR TITLE
Launchpad: Add function to see if the keep building task list is complete

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-keep-building-completion
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-keep-building-completion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a completion check callback to the keep-building task list.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -140,6 +140,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback'    => 'wpcom_launchpad_is_keep_building_enabled',
 			'visible_tasks_callback' => 'wpcom_launchpad_keep_building_visible_tasks',
+			'is_completed_callback'  => 'wpcom_launchpad_keep_building_is_completed',
 		),
 	);
 
@@ -593,6 +594,19 @@ function wpcom_launchpad_keep_building_visible_tasks( $task_list ) {
 			return true;
 		}
 	);
+}
+
+/**
+ * Check to see if the Keep building task list is completed.
+ *
+ * @param array $task_list The task list array.
+ *
+ * @return bool True if the task list is completed, false otherwise.
+ */
+function wpcom_launchpad_keep_building_is_completed( $task_list ) {
+	$task_list_id = array_key_first( $task_list );
+	// The task list is complete if we have no active tasks.
+	return ! wpcom_launchpad_checklists()->has_active_tasks( $task_list_id );
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* TBD

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* TBD

