### PR TITLE
Super Cache: Type check $posts to prevent warning in gzip output stream

### DIFF
--- a/projects/plugins/super-cache/changelog/2023-06-21-15-02-17-707403
+++ b/projects/plugins/super-cache/changelog/2023-06-21-15-02-17-707403
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Type check $posts to prevent warning

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -3370,7 +3370,7 @@ function wp_cache_post_id() {
 	if ( $comment_post_ID > 0 ) {
 		return $comment_post_ID;
 	}
-	if ( is_singular() && ! empty( $posts ) ) {
+	if ( is_singular() && ! empty( $posts ) && is_array($posts) ) {
 		return $posts[0]->ID;
 	}
 	if ( isset( $_GET['p'] ) && $_GET['p'] > 0 ) {

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -3370,7 +3370,7 @@ function wp_cache_post_id() {
 	if ( $comment_post_ID > 0 ) {
 		return $comment_post_ID;
 	}
-	if ( is_singular() && ! empty( $posts ) && is_array($posts) ) {
+	if ( is_singular() && ! empty( $posts ) && is_array( $posts ) ) {
 		return $posts[0]->ID;
 	}
 	if ( isset( $_GET['p'] ) && $_GET['p'] > 0 ) {


### PR DESCRIPTION
Fixes #31486

## Proposed changes:
* Type check $posts in wp_cache_post_id() to prevent a warning breaking the gzipped content in some browsers


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Install wordpress with supercache
* Create a page with slug "test"
* Add $posts = new WP_query(); to functions.php
* Delete all cached pages
* Visit page with slug "test" in safari