### PR TITLE
Launchpad: Add track when keep-building is complete

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-tracks-list-complete
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-tracks-list-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Fire off a track event when the keep-building list is complete.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -252,6 +252,14 @@ function wpcom_launchpad_track_completed_task( $task_id, $extra_props = array() 
 			$extra_props
 		)
 	);
+
+	if ( wpcom_default_launchpad_task_list_completed( 'keep-building' ) ) {
+		tracks_record_event(
+			wp_get_current_user(),
+			'wpcom_launchpad_mark_task_list_complete',
+			array( 'task_list' => 'keep-building' )
+		);
+	}
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -253,7 +253,7 @@ function wpcom_launchpad_track_completed_task( $task_id, $extra_props = array() 
 		)
 	);
 
-	if ( wpcom_default_launchpad_task_list_completed( 'keep-building' ) ) {
+	if ( wpcom_default_launchpad_task_list_completed( array( 'id' => 'keep-building' ) ) ) {
 		tracks_record_event(
 			wp_get_current_user(),
 			'wpcom_launchpad_mark_task_list_complete',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/77616

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This is the most hacky and straightforward way to add a track for the keep-building list completion event. Whenever a task is completed and an track event for that task is being fired of it checks for the `keep-building` list completion; and if it's complete it fires the `wpcom_launchpad_mark_task_list_complete` track event.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox `public-api.wordpress.com` and `stats.wp.com`
* Follow the instructions in the FG for logging server-side Tracks events by searching for: "Viewing tracks event details in real time". I added the following code to line 172 of `/wp-content/lib/tracks/client.php`: 

```
        if ( $event_name === 'wpcom_launchpad_mark_task_list_complete' ) {
		$details   = array();
		$details[] = '';
		$details[] = $event_name;
		foreach ( $event_obj as $prop => $value ) {
			if ( ! is_wp_error( $value ) ) {
				$details[] = $prop . ': ' . $value;
			}
		}

		$output = implode( "\n", $details );

		l( $output );
	}
```
* Create a new site from `/start` with the "Promote myself or business" intent.
* Sandbox your new site.
* Launch the site.
* You should see the new Launchpad task list on Customer Home.
* Complete all the tasks, you'll need to get a domain.
* You should see the Tracks event for that task logged to your sandbox's /tmp/php-errors file:

<img width="425" alt="image" src="https://github.com/Automattic/jetpack/assets/375980/18ccd343-f1fd-4e0d-bc23-dbae04ccf389">

