### PR TITLE
CRM: Bump Jetpack CRM's major version to 6

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 5.9.0-alpha
+ * Version: 6.0.0-alpha
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/update-crm-3156-bump-major-version-to-6
+++ b/projects/plugins/crm/changelog/update-crm-3156-bump-major-version-to-6
@@ -1,3 +1,5 @@
 Significance: major
 Type: changed
 Comment: Bump major version to 6.0.0.
+
+CRM: Change version to 6.0.0

--- a/projects/plugins/crm/changelog/update-crm-3156-bump-major-version-to-6
+++ b/projects/plugins/crm/changelog/update-crm-3156-bump-major-version-to-6
@@ -1,0 +1,3 @@
+Significance: major
+Type: changed
+Comment: Bump major version to 6.0.0.

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -47,7 +47,7 @@
 		"platform": {
 			"php": "7.2"
 		},
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ5_9_0_alpha",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_0_0_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -24,7 +24,7 @@ final class ZeroBSCRM {
 	 *
 	 * @var string
 	 */
-	public $version = '5.8.0';
+	public $version = '6.0.0';
 
 	/**
 	 * WordPress version tested with.

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "5.9.0-alpha",
+	"version": "6.0.0-alpha",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",


### PR DESCRIPTION
## Proposed changes:
* This PR bumps Jetpack CRM's major version to 6.

### Other information:

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3156

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Check if the version was correctly changed to `6.0.0` in Jetpack CRM.
