### PR TITLE
CRM: Port back 6.0.0 release changelog, readme and package updates

### DIFF
--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.15.7 - 2023-06-21
+### Changed
+- Updated package dependencies. [#31468]
+
 ## 0.15.6 - 2023-06-06
 ### Changed
 - Updated package dependencies. [#31129]

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.15.7-alpha",
+	"version": "0.15.7",
 	"description": "Jetpack Api Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2023-06-21
+### Changed
+- Updated package dependencies. [#31468]
+
 ## [0.6.0] - 2023-06-06
 ### Changed
 - Update connection module to have an RNA option that updates the design [#31201]
@@ -185,6 +189,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.1]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/Automattic/jetpack-base-styles/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/Automattic/jetpack-base-styles/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/Automattic/jetpack-base-styles/compare/0.4.4...0.5.0

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.1-alpha",
+	"version": "0.6.1",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.38.1 - 2023-06-21
+### Changed
+- Updated package dependencies. [#31468]
+
 ## 0.38.0 - 2023-06-15
 ### Added
 - Add testimonial component and use it on the backup connect screen [#31221]

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.38.1-alpha",
+	"version": "0.38.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## 0.29.1 - 2023-06-21
+### Changed
+- Updated package dependencies. [#31468]
+
 ## 0.29.0 - 2023-06-15
 ### Changed
 - Connection: always display connection button on connection screen. [#31196]

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.29.1-alpha",
+	"version": "0.29.1",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.33] - 2023-06-21
+### Changed
+- Updated package dependencies. [#31468]
+
 ## [2.0.32] - 2023-06-06
 ### Changed
 - Updated package dependencies. [#31129]
@@ -156,6 +160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.33]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.32...v2.0.33
 [2.0.32]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.31...v2.0.32
 [2.0.31]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.30...v2.0.31
 [2.0.30]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.29...v2.0.30

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.33-alpha",
+	"version": "2.0.33",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.6] - 2023-06-21
+### Changed
+- Updated package dependencies. [#31468]
+
 ## [0.10.5] - 2023-06-06
 ### Changed
 - Updated package dependencies. [#31129]
@@ -205,6 +209,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.10.6]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.5...0.10.6
 [0.10.5]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.4...0.10.5
 [0.10.4]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.3...0.10.4
 [0.10.3]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.2...0.10.3

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.10.6-alpha",
+	"version": "0.10.6",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.2 - 2023-06-21
+### Changed
+- Updated package dependencies. [#31468]
+
 ## 1.5.1 - 2023-06-06
 ### Changed
 - Updated package dependencies. [#31129]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.5.2-alpha",
+	"version": "1.5.2",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.5] - 2023-06-21
+### Changed
+- Updated package dependencies. [#31468]
+
 ## [1.18.4] - 2023-06-06
 ### Changed
 - Updated package dependencies. [#31129]
@@ -333,6 +337,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[1.18.5]: https://github.com/Automattic/jetpack-assets/compare/v1.18.4...v1.18.5
 [1.18.4]: https://github.com/Automattic/jetpack-assets/compare/v1.18.3...v1.18.4
 [1.18.3]: https://github.com/Automattic/jetpack-assets/compare/v1.18.2...v1.18.3
 [1.18.2]: https://github.com/Automattic/jetpack-assets/compare/v1.18.1...v1.18.2

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -5,6 +5,29 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2023-06-21
+### Added
+- CRM: Revamped CRM User Interface - Merge the sleek aesthetics of Jetpack’s style, bringing a new level of sophistication and seamless navigation to your CRM experience [#30916]
+- API: Now it retrieves contacts with tags [#31418]
+- Contacts: Allow unsubscribe flag to be removed [#31029]
+
+### Changed
+- User roles: Further restricted capabilities on some roles [#31174]
+- Contacts: Use sha256 instead of md5 for gravatar images [#31288]
+
+### Fixed
+- Client Portal: Fix a fatal error initializing endpoints and shortcodes [#30678]
+- CRM: Fix new lines display in quote templates [#30974]
+- CRM: Fix whitelabel bug with full menu layout [#31126]
+- CRM: Page layout now has a max width of 1551px [#30961]
+- CRM: Welcome tour now goes through all steps [#31178]
+- Extensions: Catch PHP notice if offline [#31032]
+- Invoices: Show assigned contact/company link [#31153]
+- Listview: Per-page settings no longer reset
+- Listview: PHP notice no longer shows when saving settings [#31154]
+- Quotes: Fix sort by status [#31087]
+- White label: JPCRM support and resources pages no longer show [#31155]
+
 ## [5.8.0] - 2023-05-18
 ### Added
 - Composer: Added jetpack-forms as a required dependency to fix a Jetpack form compat issue [#30749]
@@ -165,6 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved: Added a migration to remove outdated AKA lines
 
 [5.5.4-a.1]: https://github.com/Automattic/jetpack-crm/compare/v5.5.3...v5.5.4-a.1
+[6.0.0]: https://github.com/Automattic/jetpack-crm/compare/5.8.0...6.0.0
 [5.8.0]: https://github.com/Automattic/jetpack-crm/compare/5.7.0...5.8.0
 [5.7.0]: https://github.com/Automattic/jetpack-crm/compare/v5.6.0...v5.7.0
 [5.6.0]: https://github.com/Automattic/jetpack-crm/compare/v5.5.4-a.1...v5.6.0

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 6.0.0-alpha
+ * Version: 6.0.0
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/add-composer-dev-keywords
+++ b/projects/plugins/crm/changelog/add-composer-dev-keywords
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/changelog/add-crm-phpcompatibility-rules-automation
+++ b/projects/plugins/crm/changelog/add-crm-phpcompatibility-rules-automation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-PHPCompatibility: Adding additional rules based on new PHP added in the Automations project.

--- a/projects/plugins/crm/changelog/api-include-contact-tags
+++ b/projects/plugins/crm/changelog/api-include-contact-tags
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-API contact endpoints: Now it retrieves contacts with tags

--- a/projects/plugins/crm/changelog/fix-crm-1907-welcome_tour_fixes
+++ b/projects/plugins/crm/changelog/fix-crm-1907-welcome_tour_fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Welcome tour now goes through all steps

--- a/projects/plugins/crm/changelog/fix-crm-2985-email_manager_placeholder_position_fix
+++ b/projects/plugins/crm/changelog/fix-crm-2985-email_manager_placeholder_position_fix
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Move the email manager placeholders upward
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3003-client-portal-fatal-error-loading-endpoints
+++ b/projects/plugins/crm/changelog/fix-crm-3003-client-portal-fatal-error-loading-endpoints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Client Portal: Fix a fatal error initializing endpoints and shortcodes.

--- a/projects/plugins/crm/changelog/fix-crm-3091-clean_up_user_roles
+++ b/projects/plugins/crm/changelog/fix-crm-3091-clean_up_user_roles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-User roles: further restricted capabilities on some roles

--- a/projects/plugins/crm/changelog/fix-crm-3104-emerald_listviews
+++ b/projects/plugins/crm/changelog/fix-crm-3104-emerald_listviews
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Listviews: implement Emerald style

--- a/projects/plugins/crm/changelog/fix-crm-3105-redesign-colors-buttons-to-emerald
+++ b/projects/plugins/crm/changelog/fix-crm-3105-redesign-colors-buttons-to-emerald
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-CRM: buttons and colors to Emerald style

--- a/projects/plugins/crm/changelog/fix-crm-3106-emerald_learn_menu
+++ b/projects/plugins/crm/changelog/fix-crm-3106-emerald_learn_menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Learn menu: implement Emerald style

--- a/projects/plugins/crm/changelog/fix-crm-3107-emerald_top_menu
+++ b/projects/plugins/crm/changelog/fix-crm-3107-emerald_top_menu
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Top menu: implement Emerald style

--- a/projects/plugins/crm/changelog/fix-crm-3114-screenopt_save_issues
+++ b/projects/plugins/crm/changelog/fix-crm-3114-screenopt_save_issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-
-Listview: per-page settings no longer reset
-Listview: PHP notice no longer shows when saving settings

--- a/projects/plugins/crm/changelog/fix-crm-3117-emerald_dashboard
+++ b/projects/plugins/crm/changelog/fix-crm-3117-emerald_dashboard
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Dashboard: implement Emerald style

--- a/projects/plugins/crm/changelog/fix-crm-3118-remove_inbox
+++ b/projects/plugins/crm/changelog/fix-crm-3118-remove_inbox
@@ -1,3 +1,0 @@
-Significance: patch
-Type: removed
-Comment: removed non-implemented CRM Inbox references

--- a/projects/plugins/crm/changelog/fix-crm-3119-handle_wp_update_pages
+++ b/projects/plugins/crm/changelog/fix-crm-3119-handle_wp_update_pages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update tests to handle WP database updates
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3120-change-CRM-page-layout-to-emerald
+++ b/projects/plugins/crm/changelog/fix-crm-3120-change-CRM-page-layout-to-emerald
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-CRM: page layout now has a max width of 1551px

--- a/projects/plugins/crm/changelog/fix-crm-3121-allow_unsubscribe_flag_removal
+++ b/projects/plugins/crm/changelog/fix-crm-3121-allow_unsubscribe_flag_removal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Contacts: allow unsubscribe flag to be removed

--- a/projects/plugins/crm/changelog/fix-crm-3122-php_notices_in_listview
+++ b/projects/plugins/crm/changelog/fix-crm-3122-php_notices_in_listview
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Catch PHP notices when using an invalid filter name.
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3124-change-crm-edit-pages-to-emerald
+++ b/projects/plugins/crm/changelog/fix-crm-3124-change-crm-edit-pages-to-emerald
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-CRM: edit pages changed to match Jetpack Emerald style

--- a/projects/plugins/crm/changelog/fix-crm-3129-php_errors
+++ b/projects/plugins/crm/changelog/fix-crm-3129-php_errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Extensions: catch PHP notice if offline

--- a/projects/plugins/crm/changelog/fix-crm-3130-centralise_browser_autocomplete_disable
+++ b/projects/plugins/crm/changelog/fix-crm-3130-centralise_browser_autocomplete_disable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Use jpcrm_disable_browser_autocomplete() throughout
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3131-emerald_totals_table
+++ b/projects/plugins/crm/changelog/fix-crm-3131-emerald_totals_table
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Listview: use Emerald style on totals table

--- a/projects/plugins/crm/changelog/fix-crm-3132-crm-emerald-polish
+++ b/projects/plugins/crm/changelog/fix-crm-3132-crm-emerald-polish
@@ -1,3 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Polish the CRM after changes from project Emerald

--- a/projects/plugins/crm/changelog/fix-crm-3133-quote_sort_by_status
+++ b/projects/plugins/crm/changelog/fix-crm-3133-quote_sort_by_status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Quotes: sort by status now works

--- a/projects/plugins/crm/changelog/fix-crm-3134-show_invoice_assignee_link
+++ b/projects/plugins/crm/changelog/fix-crm-3134-show_invoice_assignee_link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Invoices: show assigned contact/company link

--- a/projects/plugins/crm/changelog/fix-crm-3137-whitelabel-error-not-allowed
+++ b/projects/plugins/crm/changelog/fix-crm-3137-whitelabel-error-not-allowed
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: fix whitelabel bug with full menu layout

--- a/projects/plugins/crm/changelog/fix-crm-3138-hide_resources_page_on_white_label
+++ b/projects/plugins/crm/changelog/fix-crm-3138-hide_resources_page_on_white_label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-White label: JPCRM support and resources pages no longer show

--- a/projects/plugins/crm/changelog/fix-crm-3143-additional_emerald_polish
+++ b/projects/plugins/crm/changelog/fix-crm-3143-additional_emerald_polish
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Additional Emerald polish
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3145-company_fields_typo
+++ b/projects/plugins/crm/changelog/fix-crm-3145-company_fields_typo
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed typo introduced in #31030
-
-

--- a/projects/plugins/crm/changelog/fix-crm-quote-template-new-line
+++ b/projects/plugins/crm/changelog/fix-crm-quote-template-new-line
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-CRM: Fix new lines display in quote templates

--- a/projects/plugins/crm/changelog/fix-crm-temporarily-disabling-tests-in-trunk
+++ b/projects/plugins/crm/changelog/fix-crm-temporarily-disabling-tests-in-trunk
@@ -1,3 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Temporarily disable tests in trunk

--- a/projects/plugins/crm/changelog/fix-forms-hash-generation
+++ b/projects/plugins/crm/changelog/fix-forms-hash-generation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/changelog/fix-forms-hash-generation#2
+++ b/projects/plugins/crm/changelog/fix-forms-hash-generation#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/crm/changelog/init-release-cycle
+++ b/projects/plugins/crm/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Init 5.8.1-alpha
-
-

--- a/projects/plugins/crm/changelog/remove-crm-jetpack-forms-dependency
+++ b/projects/plugins/crm/changelog/remove-crm-jetpack-forms-dependency
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Composer: Removed jetpack-forms as a required dependency as the Jetpack form compat issue is now fixed
-
-

--- a/projects/plugins/crm/changelog/remove-twitter-api
+++ b/projects/plugins/crm/changelog/remove-twitter-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Minor changes around upcoming functionality change in Twitter.

--- a/projects/plugins/crm/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/crm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/crm/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/update-crm-3156-bump-major-version-to-6
+++ b/projects/plugins/crm/changelog/update-crm-3156-bump-major-version-to-6
@@ -1,5 +1,0 @@
-Significance: major
-Type: changed
-Comment: Bump major version to 6.0.0.
-
-CRM: Change version to 6.0.0

--- a/projects/plugins/crm/changelog/update-crm-change-wording-to-jetpack-team
+++ b/projects/plugins/crm/changelog/update-crm-change-wording-to-jetpack-team
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Simply renaming refences from Woody/Mike to Jetpack which doesn't change anything for end users
-
-

--- a/projects/plugins/crm/changelog/update-crm-gravatar-hash
+++ b/projects/plugins/crm/changelog/update-crm-gravatar-hash
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Use sha256 instead of md5 for gravatar images

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -47,7 +47,7 @@
 		"platform": {
 			"php": "7.2"
 		},
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_0_0_alpha",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_0_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "6.0.0-alpha",
+	"version": "6.0.0",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -389,39 +389,26 @@ We offer a full, no-hassle refund within 14 days. You can read more about that, 
 
 
 == Changelog ==
-### 5.8.0 - 2023-05-18
+### 6.0.0 - 2023-06-21
 #### Added
-- Composer: Added jetpack-forms as a required dependency to fix a Jetpack form compat issue
-- Segments: Adding a doesnotcontain condition for email segments, for better compatibility with Advanced Segments
+- CRM: Revamped CRM User Interface - Merge the sleek aesthetics of Jetpack’s style, bringing a new level of sophistication and seamless navigation to your CRM experience
+- API: Now it retrieves contacts with tags
+- Contacts: Allow unsubscribe flag to be removed
 
 #### Changed
-- Code cleanup: Cleaning up WP Editor helper functions and wp_editor usage
-- General: Update link references to releases in changelog
-- Navigation: Changed Learn More button and Learn More link to be consistent with Jetpack styles
-- PDF generator: Objects in filenames are translated
-- WooSync: Improved status mapping logic
+- User roles: Further restricted capabilities on some roles
+- Contacts: Use sha256 instead of md5 for gravatar images
 
 #### Fixed
-- Companies: Fix company name prefill so add links - transaction, invoice and tasks - prefill company name
-- Contact / Company: Fix date styling for transactions, invoices and quotes
-- Contact / Company: Profile summary total value and invoice count now removes deleted invoices
-- Custom fields: Use native date pickers
-- Quotes: Use native date pickers
-- Export: Contact segments now export company info
-- Logs: Facebook, Twitter, Feedback, and Other Contact log types now update last contacted timestamp
-- Settings: Eliminate orphaned references to custom fields within field sorting settings when removing custom fields
-- Segments: Make sure total count is updated on tag changes
-- Tasks: Start and end times now show correctly throughout the CRM
-- Tasks: New migration to remove timezone offset from database
-- Tasks: Removed reliance on strftime for better PHP 8.1 compatibility
-- Tasks: Switch to native browser date and time inputs
-- Tasks: Catch moment.js notice due to using fallback date format
-- Tasks: Fix ##TASK-BODY## placeholder
-- Tooling: Allowing minification of JS files in development
-- Transactions: Always show current status in editor
-- WooSync: Fix the fee amount from a WooCommerce order is not added to the invoice
-- WooSync: Fix shipping tax and discount amounts from Woocommerce orders are not calculated in invoices
-- WooSync: Fix the subtotal amount from WooCommerce orders is not calculated in invoices
-- WooSync: Fix PHP Warning
-- Invoices: On invoice update the shipping tax selected is removed resulting on incorrect total amount
+- Client Portal: Fix a fatal error initializing endpoints and shortcodes
+- CRM: Fix new lines display in quote templates
+- CRM: Fix whitelabel bug with full menu layout
+- CRM: Page layout now has a max width of 1551px
+- CRM: Welcome tour now goes through all steps
+- Extensions: Catch PHP notice if offline
+- Invoices: Show assigned contact/company link
+- Listview: Per-page settings no longer reset
+- Listview: PHP notice no longer shows when saving settings
+- Quotes: Fix sort by status
+- White label: JPCRM support and resources pages no longer show
 


### PR DESCRIPTION
## Proposed changes:

* This PR ports the changelog, readme and package updates for the CRM 6.0.0 release back to trunk

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read - check that versions are as expected.

