### PR TITLE
Jetpack: Remove use of `react-redux/lib/alternate-renderers`

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-no-longer-needed-react-redux-alternate-renderers
+++ b/projects/plugins/jetpack/changelog/remove-no-longer-needed-react-redux-alternate-renderers
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Adjust build to remove no-longer-needed use of `react-redux/lib/alternate-renderers`. Should be no change to the plugin itself.
+
+

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -168,13 +168,6 @@ module.exports = [
 			...sharedWebpackConfig.output,
 			libraryTarget: 'commonjs2',
 		},
-		resolve: {
-			...sharedWebpackConfig.resolve,
-			alias: {
-				...sharedWebpackConfig.resolve.alias,
-				'react-redux': require.resolve( 'react-redux/lib/alternate-renderers' ),
-			},
-		},
 		plugins: [
 			...jetpackWebpackConfig.StandardPlugins( {
 				DependencyExtractionPlugin: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We added this in #24306 because the static-site-generator build was hanging without it. But it seems that something when we updated to React 18 made it no longer necessary, so let's remove it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/24306#issuecomment-1601174582

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the build not hang?
* Might not hurt to check that the build artifact doesn't have unexpected changes either.
