### PR TITLE
Launchpad: Add customize domain task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/78198-update-claim-domain-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/78198-update-claim-domain-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Launchpad task for domain customization

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -135,7 +135,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'design_edited',
 				'domain_claim',
 				'verify_email',
-				'domain_upsell',
+				'domain_customize',
 				'drive_traffic',
 			),
 			'is_enabled_callback'    => 'wpcom_launchpad_is_keep_building_enabled',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #78198

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the "Keep Building" Launchpad task list, this adds a new `domain_customize` which replaces the `domain_upsell` task.

The task is shown to:

* Free plan users without a custom domain (marked incomplete).
* Paid plain users with a custom domain (marked complete).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test setup
* Apply the Calypso PR [78545](https://github.com/Automattic/wp-calypso/pull/78545) (or use the calypso.live link there).
* Apply this patch to Jetpack on your sandbox and sandbox the public api.

### Free plan
* Once you're running Calypso with the above PR, go to `/start` and create a new site with the Free plan. Do not purchase a domain.
* Make sure you select the "Promote myself or business" goal
![image](https://github.com/Automattic/jetpack/assets/917632/a4df5373-2f45-47fa-a7a0-effa4fe3f771)
* Launch the site.
* Upon returning to `/home`, you should see a task list like the following which includes the "Customize your domain" task which is marked incomplete.
![image](https://github.com/Automattic/jetpack/assets/917632/2a66be40-b617-4205-a35c-0571e47ab486)
* Click on the "Customize your domain" task and go through the process of purchasing a domain.
* Once the domain purchase is complete, the "Customize your domain" task should be gone from the list.

### Paid plan
* Once you're running Calypso with the above PR, go to `/start`.
* Pick a custom domain for the site and any paid plan (Personal or Professional is easiest).
* After checking out, make sure you select the "Promote myself or business" goal
![image](https://github.com/Automattic/jetpack/assets/917632/a4df5373-2f45-47fa-a7a0-effa4fe3f771)
* Launch the site.
* Upon returning to `/home`, you should see a task list like the following which includes the "Customize your domain" task _which is marked as complete_.
![image](https://github.com/Automattic/jetpack/assets/917632/642028dd-6063-4489-bc30-e7a6103700ca)
* Click on the "Customize your domain" task and go through the process of purchasing a domain.
* Once the domain purchase is complete, the "Customize your domain" task should be gone from the list.

### Test cleanup
* Make sure to delete the two domains you purchased within 24h of testing!

