### PR TITLE
AI Extension: do not populate the prompt with previous messages for now

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-do-not-populate-prompt-with-prev-messages
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-do-not-populate-prompt-with-prev-messages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: do not populate the prompt with previous messages for now

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -72,40 +72,42 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ removeBlocks, updateBlockAttributes ]
 		);
 
-		const addAssistantMessage = useCallback(
-			( assistantContent: string ) => {
-				setStoredPrompt( prevPrompt => {
-					/*
-					 * Add the assistant messages to the prompt.
-					 * - Preserve the first item of the array (`system` role )
-					 * - Keep the last 4 messages.
-					 */
+		// This commented function is used to add the assistant messages to the prompt.
+		// It's not used for now.
+		// const addAssistantMessage = useCallback(
+		// 	( assistantContent: string ) => {
+		// 		setStoredPrompt( prevPrompt => {
+		// 			/*
+		// 			 * Add the assistant messages to the prompt.
+		// 			 * - Preserve the first item of the array (`system` role )
+		// 			 * - Keep the last 4 messages.
+		// 			 */
 
-					// Pick the first item of the array.
-					const firstItem = prevPrompt.messages.shift();
+		// 			// Pick the first item of the array.
+		// 			const firstItem = prevPrompt.messages.shift();
 
-					const messages: Array< PromptItemProps > = [
-						firstItem, // first item (`system` by default)
-						...prevPrompt.messages.splice( -3 ), // last 3 items
-						{
-							role: 'assistant',
-							content: assistantContent, // + 1 `assistant` role item
-						},
-					];
+		// 			const messages: Array< PromptItemProps > = [
+		// 				firstItem, // first item (`system` by default)
+		// 				// ...prevPrompt.messages.splice( -3 ), // last 3 items
+		// 				{
+		// 					role: 'assistant',
+		// 					content: assistantContent, // + 1 `assistant` role item
+		// 				},
+		// 			];
 
-					return {
-						...prevPrompt,
-						messages,
-					};
-				} );
-			},
-			[ setStoredPrompt ]
-		);
+		// 			return {
+		// 				...prevPrompt,
+		// 				messages,
+		// 			};
+		// 		} );
+		// 	},
+		// 	[ setStoredPrompt ]
+		// );
 
 		const { request } = useSuggestionsFromAI( {
 			prompt: storedPrompt.messages,
 			onSuggestion: setContent,
-			onDone: addAssistantMessage,
+			// onDone: addAssistantMessage,
 			autoRequest: false,
 		} );
 
@@ -120,22 +122,14 @@ export const withAIAssistant = createHigherOrderComponent(
 				 */
 				clientIdsRef.current = clientIds;
 
-				setStoredPrompt( prevPrompt => {
-					const freshPrompt = {
-						...prevPrompt,
-						messages: getPrompt( promptType, {
-							...options,
-							content,
-							prevMessages: prevPrompt.messages,
-						} ),
-					};
-
-					// Request the suggestion from the AI.
-					request( freshPrompt.messages );
-
-					// Update the stored prompt locally.
-					return freshPrompt;
+				const messages = getPrompt( promptType, {
+					...options,
+					content,
 				} );
+
+				setStoredPrompt( { messages } );
+
+				request( messages );
 			},
 			[ request ]
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: do not populate the prompt with previous messages for now

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add content in a paragraph block in English lang
* Translate to another language
* Continue changing the content by using the AI Assistant tools

### Before (trunk)

Initial content (English) | Translated to Spanish | Changed the tone (response in English 🍎 )
-----|------|-----
<img width="692" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/f2984cda-860e-4af3-895e-0a6fd66bf0f6">|<img width="699" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/a69e5b9a-6a2e-4679-a746-894c2d5a12b3">| <img width="685" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/31a09246-259b-4f78-bb31-9b7005d0bcbd">

 

### After
Initial content (English) | Translated to Spanish | Changed the tone (preserves the Spanish 🍏 )
-----|------|-----
<img width="681" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/a0c8baf5-add9-4a67-8a1c-c479dbf0a3d5">|<img width="693" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/22c2a05f-8a05-4783-aa2d-56c38696a837">|<img width="731" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/9bfb932e-98da-4c07-9e3b-d3ca65399f22">
