### PR TITLE
Fix send email preview endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php
@@ -23,7 +23,7 @@ trait WPCOM_REST_API_Proxy_Request_Trait {
 	public function proxy_request_to_wpcom_as_user( $request, $path = '' ) {
 		$blog_id = \Jetpack_Options::get_option( 'id' );
 		$path    = '/sites/' . rawurldecode( $blog_id ) . rawurldecode( $this->rest_base ) . ( $path ? '/' . rawurldecode( $path ) : '' );
-		$api_url = add_query_arg( $request->get_query_params(), $path );
+		$api_url = remove_query_arg( 'rest_route', add_query_arg( $request->get_query_params(), $path ) );
 
 		$request_options = array(
 			'headers' => array(

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php
@@ -21,8 +21,8 @@ trait WPCOM_REST_API_Proxy_Request_Trait {
 	 * @return mixed|WP_Error           Response from wpcom servers or an error.
 	 */
 	public function proxy_request_to_wpcom_as_user( $request, $path = '' ) {
-		$blog_id = \Jetpack_Options::get_option( 'id' );
-		$path    = '/sites/' . rawurldecode( $blog_id ) . rawurldecode( $this->rest_base ) . ( $path ? '/' . rawurldecode( $path ) : '' );
+		$blog_id      = \Jetpack_Options::get_option( 'id' );
+		$path         = '/sites/' . rawurldecode( $blog_id ) . rawurldecode( $this->rest_base ) . ( $path ? '/' . rawurldecode( $path ) : '' );
 		$query_params = $request->get_query_params();
 
 		/*

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php
@@ -23,7 +23,18 @@ trait WPCOM_REST_API_Proxy_Request_Trait {
 	public function proxy_request_to_wpcom_as_user( $request, $path = '' ) {
 		$blog_id = \Jetpack_Options::get_option( 'id' );
 		$path    = '/sites/' . rawurldecode( $blog_id ) . rawurldecode( $this->rest_base ) . ( $path ? '/' . rawurldecode( $path ) : '' );
-		$api_url = remove_query_arg( 'rest_route', add_query_arg( $request->get_query_params(), $path ) );
+		$query_params = $request->get_query_params();
+
+		/*
+		 * A rest_route parameter can be added when using plain permalinks.
+		 * It is not necessary to pass them to WordPress.com,
+		 * and may even cause issues with some endpoints.
+		 * Let's remove it.
+		 */
+		if ( isset( $query_params['rest_route'] ) ) {
+			unset( $query_params['rest_route'] );
+		}
+		$api_url = add_query_arg( $query_params, $path );
 
 		$request_options = array(
 			'headers' => array(

--- a/projects/plugins/jetpack/changelog/fix-send-email-preview-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-send-email-preview-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+Comment: fixes send preview email not working when using plain permalink
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/pull/31021#pullrequestreview-1491718360

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When a site uses "plain" permalinks the API endpoint path is passed via a `rest_route` query arg, in the `proxy_request_to_wpcom_as_user` this one was being passed to wpcom and wpcom was trying to use it to serve the endpoint. This removes the `rest_route` query arg when proxing api requests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:

* Set your site permalinks to "plain"
* Try the send an email preview feature using the newsletter prepublish panel.
* The request should succeed.

