### PR TITLE
[Boost] Upgrade Critical CSS gen lib

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2516,8 +2516,8 @@ importers:
         specifier: 5.3.0
         version: 5.3.0
       jetpack-boost-critical-css-gen:
-        specifier: github:automattic/jetpack-boost-critical-css-gen#release-0.0.7
-        version: github.com/automattic/jetpack-boost-critical-css-gen/d46421f455e3f7ff025a4e7f4b9d01443dfdc8aa
+        specifier: github:automattic/jetpack-boost-critical-css-gen#release-0.0.9
+        version: github.com/automattic/jetpack-boost-critical-css-gen/7b1368f6fc4551745ac7681de73c3a4c6049dce6
       prettier:
         specifier: 2.8.6
         version: 2.8.6
@@ -23823,10 +23823,10 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
 
-  github.com/automattic/jetpack-boost-critical-css-gen/d46421f455e3f7ff025a4e7f4b9d01443dfdc8aa:
-    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/d46421f455e3f7ff025a4e7f4b9d01443dfdc8aa}
+  github.com/automattic/jetpack-boost-critical-css-gen/7b1368f6fc4551745ac7681de73c3a4c6049dce6:
+    resolution: {tarball: https://codeload.github.com/automattic/jetpack-boost-critical-css-gen/tar.gz/7b1368f6fc4551745ac7681de73c3a4c6049dce6}
     name: jetpack-boost-critical-css-gen
-    version: 0.0.6
+    version: 0.0.9
     prepare: true
     requiresBuild: true
     dependencies:

--- a/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
@@ -132,6 +132,7 @@ async function generateForKeys(
 					properties: keepProperty,
 				},
 				successRatio: success_ratio,
+				maxPages: 10,
 			} );
 
 			const updateResult = await saveCriticalCssChunk( key, css, passthrough );

--- a/projects/plugins/boost/changelog/boost-upgrade-boost-critical-css-gen
+++ b/projects/plugins/boost/changelog/boost-upgrade-boost-critical-css-gen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: On sites with fewer than 10 pages/posts, ensure that pages and posts are not skipped during Critical CSS generation

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -13,7 +13,7 @@
 		"@wordpress/components": "25.1.0",
 		"@wordpress/element": "5.12.0",
 		"history": "5.3.0",
-		"jetpack-boost-critical-css-gen": "github:automattic/jetpack-boost-critical-css-gen#release-0.0.7",
+		"jetpack-boost-critical-css-gen": "github:automattic/jetpack-boost-critical-css-gen#release-0.0.9",
 		"prettier": "2.8.6",
 		"svelte-navigator": "3.2.2",
 		"zod": "3.20.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/boost-cloud/issues/268

We had a bug in our Critical CSS generator where some pages / posts would be skipped on sites with < 10 pages or posts. This bug was fixed in the generator, this PR brings the latest version of the generator into Boost.

## Proposed changes:
* Upgrade to Critical CSS generator 0.0.9

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Run local / free Critical CSS generation on a test site with < 10 pages
* Ensure that all pages get included in the generation process (watch the network tab. Each should appear twice)
* Run it on a site with > 10 pages
* Ensure that 10 pages are included in the process.

