### PR TITLE
Launchpad: Move Keep Building visibility check to Jetpack

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-keep-building-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-keep-building-filter
@@ -1,0 +1,4 @@
+Significance: minor 
+Type: added
+
+Add filter for the Keep Building checklist visibility

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -614,8 +614,8 @@ if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
 		$intent  = get_option( 'site_intent', false );
 		$blog_id = get_current_blog_id();
 
-		if ( 'build' !== $intent || $blog_id < 220443356 ) {
-			return false;
+		if ( 'build' === $intent && $blog_id > 220443356 ) {
+			return true;
 		}
 
 		return $is_enabled;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -138,7 +138,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'domain_upsell',
 				'drive_traffic',
 			),
-			'is_enabled_callback'    => 'wpcom_launchpad_is_keep_building_enabled',
+			'is_enabled_callback'    => 'wpcom_is_launchpad_keep_building_enabled',
 			'visible_tasks_callback' => 'wpcom_launchpad_keep_building_visible_tasks',
 		),
 	);
@@ -557,18 +557,6 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
 }
 
 /**
- * Checks if the Keep building task list is enabled.
- *
- * This function uses the `is_launchpad_keep_building_enabled` filter to allow for overriding the
- * default value.
- *
- * @return bool True if the task list is enabled, false otherwise.
- */
-function wpcom_launchpad_is_keep_building_enabled() {
-	return apply_filters( 'is_launchpad_keep_building_enabled', false );
-}
-
-/**
  * Filter task visibility for the Keep building task list.
  *
  * @param array $task_list The task array.
@@ -606,10 +594,9 @@ if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
 	 * We wrap it in a `function_exists` check for now because this function originated on WP.com
 	 * and is being moved to Jetpack to enable the task list on Atomic sites.
 	 *
-	 * @param bool $is_enabled The current state of the "Keep building" task list.
 	 * @return bool Whether the "Keep building" task list is enabled.
 	 */
-	function wpcom_is_launchpad_keep_building_enabled( $is_enabled ) {
+	function wpcom_is_launchpad_keep_building_enabled() {
 		$intent = get_option( 'site_intent', false );
 
 		if ( 'build' !== $intent ) {
@@ -624,8 +611,6 @@ if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
 		 */
 		return $blog_id > 220443356;
 	}
-
-	add_filter( 'is_launchpad_keep_building_enabled', 'wpcom_is_launchpad_keep_building_enabled' );
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -610,18 +610,13 @@ if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
 	 */
 	function wpcom_is_launchpad_keep_building_enabled( $is_enabled ) {
 		$intent = get_option( 'site_intent', false );
+		$blog_id = get_current_blog_id();
 
-		if ( 'build' !== $intent ) {
+		if ( 'build' !== $intent || $blog_id < 220443356) {
 			return false;
 		}
 
-		$blog_id = get_current_blog_id();
-
-		/**
-		 * All blogs created after blog ID `220443356`
-		 * should show the "Keep building" task list.
-		 */
-		return $blog_id > 220443356;
+		return $is_enabled;
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -138,7 +138,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'domain_upsell',
 				'drive_traffic',
 			),
-			'is_enabled_callback'    => 'wpcom_is_launchpad_keep_building_enabled',
+			'is_enabled_callback'    => 'wpcom_launchpad_is_keep_building_enabled',
 			'visible_tasks_callback' => 'wpcom_launchpad_keep_building_visible_tasks',
 		),
 	);
@@ -557,6 +557,18 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
 }
 
 /**
+ * Checks if the Keep building task list is enabled.
+ *
+ * This function uses the `is_launchpad_keep_building_enabled` filter to allow for overriding the
+ * default value.
+ *
+ * @return bool True if the task list is enabled, false otherwise.
+ */
+function wpcom_launchpad_is_keep_building_enabled() {
+	return apply_filters( 'is_launchpad_keep_building_enabled', false );
+}
+
+/**
  * Filter task visibility for the Keep building task list.
  *
  * @param array $task_list The task array.
@@ -596,7 +608,7 @@ if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
 	 *
 	 * @return bool Whether the "Keep building" task list is enabled.
 	 */
-	function wpcom_is_launchpad_keep_building_enabled() {
+	function wpcom_is_launchpad_keep_building_enabled( $is_enabled ) {
 		$intent = get_option( 'site_intent', false );
 
 		if ( 'build' !== $intent ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -614,7 +614,7 @@ if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
 		$intent = get_option( 'site_intent', false );
 		$blog_id = get_current_blog_id();
 
-		if ( 'build' !== $intent || $blog_id < 220443356) {
+		if ( 'build' !== $intent || $blog_id < 220443356 ) {
 			return false;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -595,6 +595,39 @@ function wpcom_launchpad_keep_building_visible_tasks( $task_list ) {
 	);
 }
 
+/**
+ * Determines if the Launchpad "Keep building" task list is enabled.
+ *
+ * This filter allows customization of the Launchpad "Keep building" task list.
+ * By default, the "Keep building" task list should be enabled for sites with the Build intent,
+ * new sites only.
+ *
+ * We wrap it in a `function_exists` check for now because this function originated on WP.com
+ * and is being moved to Jetpack to enable the task list on Atomic sites.
+ *
+ * @param bool $is_enabled The current state of the "Keep building" task list.
+ * @return bool Whether the "Keep building" task list is enabled.
+ */
+if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
+	function wpcom_is_launchpad_keep_building_enabled( $is_enabled ) {
+		$intent = get_option( 'site_intent', false );
+
+		if ( 'build' !== $intent ) {
+			return false;
+		}
+
+		$blog_id = get_current_blog_id();
+
+		/**
+		 * All blogs created after blog ID `220443356`
+		 * should show the "Keep building" task list.
+		 */
+		return $blog_id > 220443356;
+	}
+
+	add_filter( 'is_launchpad_keep_building_enabled', 'wpcom_is_launchpad_keep_building_enabled' );
+}
+
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.
 if ( class_exists( 'WPCOM_Launchpad' ) ) {
 	remove_action( 'plugins_loaded', array( WPCOM_Launchpad::get_instance(), 'init' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -607,11 +607,11 @@ if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
 	 * and is being moved to Jetpack to enable the task list on Atomic sites.
 	 *
 	 * @param bool $is_enabled Whether the "Keep building" task list is enabled.
-	 * 
+	 *
 	 * @return bool Whether the "Keep building" task list is enabled.
 	 */
 	function wpcom_is_launchpad_keep_building_enabled( $is_enabled ) {
-		$intent = get_option( 'site_intent', false );
+		$intent  = get_option( 'site_intent', false );
 		$blog_id = get_current_blog_id();
 
 		if ( 'build' !== $intent || $blog_id < 220443356 ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -595,20 +595,20 @@ function wpcom_launchpad_keep_building_visible_tasks( $task_list ) {
 	);
 }
 
-/**
- * Determines if the Launchpad "Keep building" task list is enabled.
- *
- * This filter allows customization of the Launchpad "Keep building" task list.
- * By default, the "Keep building" task list should be enabled for sites with the Build intent,
- * new sites only.
- *
- * We wrap it in a `function_exists` check for now because this function originated on WP.com
- * and is being moved to Jetpack to enable the task list on Atomic sites.
- *
- * @param bool $is_enabled The current state of the "Keep building" task list.
- * @return bool Whether the "Keep building" task list is enabled.
- */
 if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
+	/**
+	 * Determines if the Launchpad "Keep building" task list is enabled.
+	 *
+	 * This filter allows customization of the Launchpad "Keep building" task list.
+	 * By default, the "Keep building" task list should be enabled for sites with the Build intent,
+	 * new sites only.
+	 *
+	 * We wrap it in a `function_exists` check for now because this function originated on WP.com
+	 * and is being moved to Jetpack to enable the task list on Atomic sites.
+	 *
+	 * @param bool $is_enabled The current state of the "Keep building" task list.
+	 * @return bool Whether the "Keep building" task list is enabled.
+	 */
 	function wpcom_is_launchpad_keep_building_enabled( $is_enabled ) {
 		$intent = get_option( 'site_intent', false );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -606,6 +606,8 @@ if ( ! function_exists( 'wpcom_is_launchpad_keep_building_enabled' ) ) {
 	 * We wrap it in a `function_exists` check for now because this function originated on WP.com
 	 * and is being moved to Jetpack to enable the task list on Atomic sites.
 	 *
+	 * @param bool $is_enabled Whether the "Keep building" task list is enabled.
+	 * 
 	 * @return bool Whether the "Keep building" task list is enabled.
 	 */
 	function wpcom_is_launchpad_keep_building_enabled( $is_enabled ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#78401

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Copy the `wpcom_is_launchpad_keep_building_enabled` filter function to jetpack-mu-wpcom, wrapped in a function_exists check so we don't cause fatals. :) We'll remove the function from WP.com as part of cleanup.
* This effectively enables the Keep Building task list for Atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox
* Create a new site from `/start`, selecting the "Promote myself or business" intent.
* Launch your site
* You should see the Keep Building task list in Customer Home
* Double-check that there are no PHP errors on your sandbox

* Mark your new test site as a WoA developer site and transfer it to Atomic
* Add and activate [the Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/)
* Go to the Beta plugin management page and go to WordPress.com Features -> Manage
* Search for this branch and activate it on your WoA dev site
* Ensure there are no PHP errors on your test site
* You should still see the Keep Building checklist in Customer Home

