### PR TITLE
Using design_completed instead of design_selected for design-first flow

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-using-design-completed-for-design-first-flow
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-using-design-completed-for-design-first-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Using design_completed instead of design_selected for design-first flow

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -22,7 +22,7 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
 			},
 		),
-		// Design completed checks for task completion while design_select will always return true
+		// design_completed checks for task completion while design_selected always returns true.
 		'design_completed'                => array(
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -22,6 +22,13 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
 			},
 		),
+		// Design completed checks for task completion while design_select will always return true
+		'design_completed'                => array(
+			'get_title'            => function () {
+				return __( 'Select a design', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
+		),
 		'design_selected'                 => array(
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -119,7 +119,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 		'design-first'    => array(
 			'title'               => 'Pick a Design',
 			'task_ids'            => array(
-				'design_selected',
+				'design_completed',
 				'setup_blog',
 				'domain_upsell',
 				'plan_completed',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to 2637-gh-Automattic/dotcom-forge

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Using `design_completed` instead of `design_selected` for the design-first flow

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1687441384881319-slack-CKZHG0QCR

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout your Calypso [to this branch](https://github.com/Automattic/wp-calypso/pull/78535) and follow that test instructions

## Does this pull request change what data or activity we track or use?

No