### PR TITLE
AI Extension: reorganize prompt items for AI extension

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-re-organize-prompt-items
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-re-organize-prompt-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: reorganize prompt items for the AI extension

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -76,17 +76,18 @@ export const withAIAssistant = createHigherOrderComponent(
 			( assistantContent: string ) => {
 				setStoredPrompt( prevPrompt => {
 					const messages: Array< PromptItemProps > = [
-						...prevPrompt.messages.splice( -3 ), // Preserv only the last 3 items
+						/*
+						 * Do not store `system` role items,
+						 * and preserve the last 3 ones.
+						 */
+						...prevPrompt.messages.filter( _ => _.role !== 'system' ).slice( -3 ),
 						{
 							role: 'assistant',
 							content: assistantContent, // + 1 `assistant` role item
 						},
 					];
 
-					return {
-						...prevPrompt,
-						messages,
-					};
+					return { ...prevPrompt, messages };
 				} );
 			},
 			[ setStoredPrompt ]
@@ -111,15 +112,13 @@ export const withAIAssistant = createHigherOrderComponent(
 				clientIdsRef.current = clientIds;
 
 				setStoredPrompt( prevPrompt => {
-					const freshPrompt = {
-						...prevPrompt,
-						messages: getPrompt( promptType, {
-							...options,
-							content,
-							prevMessages: prevPrompt.messages,
-						} ),
-					};
+					const messages = getPrompt( promptType, {
+						...options,
+						content,
+						prevMessages: prevPrompt.messages,
+					} );
 
+					const freshPrompt = { ...prevPrompt, messages };
 					// Request the suggestion from the AI.
 					request( freshPrompt.messages );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -80,7 +80,7 @@ export const withAIAssistant = createHigherOrderComponent(
 						 * Do not store `system` role items,
 						 * and preserve the last 3 ones.
 						 */
-						...prevPrompt.messages.filter( _ => _.role !== 'system' ).slice( -3 ),
+						...prevPrompt.messages.filter( message => message.role !== 'system' ).slice( -3 ),
 						{
 							role: 'assistant',
 							content: assistantContent, // + 1 `assistant` role item

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -72,21 +72,11 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ removeBlocks, updateBlockAttributes ]
 		);
 
-		const addAssistantMessage = useCallback(
+		const updateStoredPrompt = useCallback(
 			( assistantContent: string ) => {
 				setStoredPrompt( prevPrompt => {
-					/*
-					 * Add the assistant messages to the prompt.
-					 * - Preserve the first item of the array (`system` role )
-					 * - Keep the last 4 messages.
-					 */
-
-					// Pick the first item of the array.
-					const firstItem = prevPrompt.messages.shift();
-
 					const messages: Array< PromptItemProps > = [
-						firstItem, // first item (`system` by default)
-						...prevPrompt.messages.splice( -3 ), // last 3 items
+						...prevPrompt.messages.splice( -3 ), // Preserv only the last 3 items
 						{
 							role: 'assistant',
 							content: assistantContent, // + 1 `assistant` role item
@@ -105,7 +95,7 @@ export const withAIAssistant = createHigherOrderComponent(
 		const { request } = useSuggestionsFromAI( {
 			prompt: storedPrompt.messages,
 			onSuggestion: setContent,
-			onDone: addAssistantMessage,
+			onDone: updateStoredPrompt,
 			autoRequest: false,
 		} );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -403,48 +403,44 @@ export function getPrompt(
 		'You are an advanced polyglot ghostwriter.' +
 		'Your task is to help the user create and modify content based on their requests.';
 
-	/*
-	 * Create the initial prompt only if there are no previous messages.
-	 * Otherwise, let's use the previous messages as the initial prompt.
-	 */
-	let prompt: Array< PromptItemProps > = ! prevMessages?.length
-		? [
-				{
-					role: 'system',
-					content: `${ context }
+	const systemPrompt: PromptItemProps = {
+		role: 'system',
+		content: `${ context }
 Writing rules:
 - Execute the request without any acknowledgment or explanation to the user.
 - Avoid sensitive or controversial topics and ensure your responses are grammatically correct and coherent.
 - If you cannot generate a meaningful response to a user’s request, reply with “__JETPACK_AI_ERROR__“. This term should only be used in this context, it is used to generate user facing errors.
 `,
-				},
-		  ]
-		: prevMessages;
+	};
 
+	// Prompt starts with the previous messages, if any.
+	const prompt: Array< PromptItemProps > = prevMessages;
+
+	// Then, add the `system` prompt to clarify the context.
+	prompt.push( systemPrompt );
+
+	// Finally, add the current `user` request.
 	switch ( type ) {
 		case PROMPT_TYPE_CORRECT_SPELLING:
-			prompt = [ ...prompt, ...getCorrectSpellingPrompt( options ) ];
-			break;
+			return [ ...prompt, ...getCorrectSpellingPrompt( options ) ];
 
 		case PROMPT_TYPE_SIMPLIFY:
-			prompt = [ ...prompt, ...getSimplifyPrompt( options ) ];
-			break;
+			return [ ...prompt, ...getSimplifyPrompt( options ) ];
 
 		case PROMPT_TYPE_SUMMARIZE:
-			prompt = [ ...prompt, ...getSummarizePrompt( options ) ];
-			break;
+			return [ ...prompt, ...getSummarizePrompt( options ) ];
 
 		case PROMPT_TYPE_MAKE_LONGER:
-			prompt = [ ...prompt, ...getExpandPrompt( options ) ];
-			break;
+			return [ ...prompt, ...getExpandPrompt( options ) ];
 
 		case PROMPT_TYPE_CHANGE_LANGUAGE:
-			prompt = [ ...prompt, ...getTranslatePrompt( options ) ];
-			break;
+			return [ ...prompt, ...getTranslatePrompt( options ) ];
 
 		case PROMPT_TYPE_CHANGE_TONE:
-			prompt = [ ...prompt, ...getTonePrompt( options ) ];
-			break;
+			return [ ...prompt, ...getTonePrompt( options ) ];
+
+		default:
+			throw new Error( `Unknown prompt type: ${ type }` );
 	}
 
 	return prompt;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR changes the order of the prompt items to send a clearer message when requesting content. Basically, it moves the `system` role message just before to the last `user` role message. Currently, the `system` message is the first one in the prompt.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: reorganize prompt items for the AI extension

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add some content
* Change the content by using the AI Extension tool
* Confirm now you see the `system` role message just before to the last `user` role message:

before | after
------|-----
<img width="854" alt="Screenshot 2023-06-22 at 13 36 43" src="https://github.com/Automattic/jetpack/assets/77539/798da280-99bb-43f4-a007-adb9af807850"> | <img width="851" alt="Screenshot 2023-06-22 at 13 33 55" src="https://github.com/Automattic/jetpack/assets/77539/8f12389e-03ca-4e16-a599-2f1184864aa8">

* Confirm that it seems to follow the rules in a better way. For instance, it preserves the content language among the user requests