### PR TITLE
 AI Assistant: Add a specific delimiter for content in the prompts

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-delimiter
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-delimiter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Add a specific delimiter for content in the prompts

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -86,11 +86,6 @@ type PromptOptionsProps = {
 	content: string;
 
 	/*
-	 * The delimited content.
-	 */
-	delimitedContent: string;
-
-	/*
 	 * The language to translate to. Optional.
 	 */
 	language?: string;
@@ -111,76 +106,92 @@ type PromptOptionsProps = {
 	prevMessages?: Array< PromptItemProps >;
 };
 
+function getDelimitedContent( content: string ): string {
+	return `${ delimiter }${ content.replaceAll( delimiter, '' ) }${ delimiter }`;
+}
+
 function getCorrectSpellingPrompt( {
-	delimitedContent,
+	content,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Repeat the text delimited with ${ delimiter }, without the delimiter, correcting any spelling and grammar mistakes directly in the text without providing feedback about the corrections, keeping the language of the text: ${ delimitedContent }`,
+			content: `Repeat the text delimited with ${ delimiter }, without the delimiter, correcting any spelling and grammar mistakes directly in the text without providing feedback about the corrections, keeping the language of the text: ${ getDelimitedContent(
+				content
+			) }`,
 		},
 	];
 }
 
 function getSimplifyPrompt( {
-	delimitedContent,
+	content,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Simplify the text delimited with ${ delimiter }, using words and phrases that are easier to understand and keeping the language of the text: ${ delimitedContent }`,
+			content: `Simplify the text delimited with ${ delimiter }, using words and phrases that are easier to understand and keeping the language of the text: ${ getDelimitedContent(
+				content
+			) }`,
 		},
 	];
 }
 
 function getSummarizePrompt( {
-	delimitedContent,
+	content,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Summarize the text delimited with ${ delimiter }, keeping the language of the text: ${ delimitedContent }`,
+			content: `Summarize the text delimited with ${ delimiter }, keeping the language of the text: ${ getDelimitedContent(
+				content
+			) }`,
 		},
 	];
 }
 
 function getExpandPrompt( {
-	delimitedContent,
+	content,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Expand the text delimited with ${ delimiter } to about double its size, keeping the language of the text: ${ delimitedContent }`,
+			content: `Expand the text delimited with ${ delimiter } to about double its size, keeping the language of the text: ${ getDelimitedContent(
+				content
+			) }`,
 		},
 	];
 }
 
 function getTranslatePrompt( {
-	delimitedContent,
+	content,
 	language,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Translate the text delimited with ${ delimiter } to ${ language }, preserving the same core meaning and tone: ${ delimitedContent }`,
+			content: `Translate the text delimited with ${ delimiter } to ${ language }, preserving the same core meaning and tone: ${ getDelimitedContent(
+				content
+			) }`,
 		},
 	];
 }
 
 function getTonePrompt( {
-	delimitedContent,
+	content,
 	tone,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Rewrite the text delimited with ${ delimiter }, with a ${ tone } tone, keeping the language of the text: ${ delimitedContent }`,
+			content: `Rewrite the text delimited with ${ delimiter }, with a ${ tone } tone, keeping the language of the text: ${ getDelimitedContent(
+				content
+			) }`,
 		},
 	];
 }
@@ -429,11 +440,6 @@ Writing rules:
 				},
 		  ]
 		: prevMessages;
-
-	options.delimitedContent = `${ delimiter }${ options.content?.replaceAll(
-		delimiter,
-		''
-	) }${ delimiter }`;
 
 	switch ( type ) {
 		case PROMPT_TYPE_CORRECT_SPELLING:

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -44,6 +44,8 @@ export type PromptItemProps = {
 
 const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
 
+export const delimiter = '####';
+
 /**
  * Helper function to get the initial system prompt.
  * It defines the `context` value in case it isn't provided.
@@ -84,6 +86,11 @@ type PromptOptionsProps = {
 	content: string;
 
 	/*
+	 * The delimited content.
+	 */
+	delimitedContent: string;
+
+	/*
 	 * The language to translate to. Optional.
 	 */
 	language?: string;
@@ -105,75 +112,75 @@ type PromptOptionsProps = {
 };
 
 function getCorrectSpellingPrompt( {
-	content,
+	delimitedContent,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Repeat the following text, correcting any spelling and grammar mistakes directly in the text without providing feedback about the corrections, keeping the language of the text: \n\n${ content }`,
+			content: `Repeat the text delimited with ${ delimiter }, without the delimiter, correcting any spelling and grammar mistakes directly in the text without providing feedback about the corrections, keeping the language of the text: ${ delimitedContent }`,
 		},
 	];
 }
 
 function getSimplifyPrompt( {
-	content,
+	delimitedContent,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Simplify the following text, using words and phrases that are easier to understand and keeping the language of the text:\n\n${ content }`,
+			content: `Simplify the text delimited with ${ delimiter }, using words and phrases that are easier to understand and keeping the language of the text: ${ delimitedContent }`,
 		},
 	];
 }
 
 function getSummarizePrompt( {
-	content,
+	delimitedContent,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Summarize the following text, keeping the language of the text:\n\n${ content }`,
+			content: `Summarize the text delimited with ${ delimiter }, keeping the language of the text: ${ delimitedContent }`,
 		},
 	];
 }
 
 function getExpandPrompt( {
-	content,
+	delimitedContent,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Expand the following text to about double its size, keeping the language of the text:\n\n${ content }`,
+			content: `Expand the text delimited with ${ delimiter } to about double its size, keeping the language of the text: ${ delimitedContent }`,
 		},
 	];
 }
 
 function getTranslatePrompt( {
-	content,
+	delimitedContent,
 	language,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Translate the following text to ${ language }, preserving the same core meaning and tone:\n\n${ content }`,
+			content: `Translate the text delimited with ${ delimiter } to ${ language }, preserving the same core meaning and tone: ${ delimitedContent }`,
 		},
 	];
 }
 
 function getTonePrompt( {
-	content,
+	delimitedContent,
 	tone,
 	role = 'user',
 }: PromptOptionsProps ): Array< PromptItemProps > {
 	return [
 		{
 			role,
-			content: `Rewrite the following text with a ${ tone } tone, keeping the language of the text:\n\n${ content }`,
+			content: `Rewrite the text delimited with ${ delimiter }, with a ${ tone } tone, keeping the language of the text: ${ delimitedContent }`,
 		},
 	];
 }
@@ -218,10 +225,12 @@ export const buildPromptTemplate = ( {
 	const messages = [ getInitialSystemPrompt( { rules } ) ];
 
 	if ( relevantContent != null && relevantContent?.length ) {
+		const sanitizedContent = relevantContent.replaceAll( delimiter, '' );
+
 		if ( ! isContentGenerated ) {
 			messages.push( {
-				role: 'system',
-				content: `The specific relevant content for this request, if necessary: ${ relevantContent }`,
+				role: 'user',
+				content: `The specific relevant content for this request, if necessary, delimited with ${ delimiter } characters: ${ delimiter }${ sanitizedContent }${ delimiter }`,
 			} );
 		}
 	}
@@ -420,6 +429,11 @@ Writing rules:
 				},
 		  ]
 		: prevMessages;
+
+	options.delimitedContent = `${ delimiter }${ options.content?.replaceAll(
+		delimiter,
+		''
+	) }${ delimiter }`;
 
 	switch ( type ) {
 		case PROMPT_TYPE_CORRECT_SPELLING:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Following a tip from the DeepLearning.ai course, this PR adds a clear delimiter for the content to be acted upon. This should reduce the occasions where parts of the prompt are repeated or its structure leaks, like this:
![2023-06-22_13-10-11](https://github.com/Automattic/jetpack/assets/8486249/d57901b2-2e0c-41ff-8a49-eb1f2f57f50f)

* It also replaces the `system` message with the content to a `user` message, to fix this problem:
![2023-06-22_13-09-19](https://github.com/Automattic/jetpack/assets/8486249/05600cd3-0630-4870-b315-27f5ed6e1b73)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the AI Assistant block many times. The responses should not contain phrases like "The specific relevant content for this request"

![2023-06-22_13-54-11](https://github.com/Automattic/jetpack/assets/8486249/11e45c97-7fae-419b-b725-c12388895031)
