### PR TITLE
 AI Assistant: Change delimiter and remove it from responses

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-delimiter-check
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-delimiter-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Change delimiter and remove it from responses

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -8,8 +8,8 @@ import debugFactory from 'debug';
 /**
  * Types
  */
+import { PromptItemProps, delimiter } from '../../lib/prompt';
 import { SuggestionsEventSource, askQuestion } from '../../lib/suggestions';
-import type { PromptItemProps } from '../../lib/prompt';
 
 const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
 
@@ -88,7 +88,10 @@ export default function useSuggestionsFromAI( {
 	 * @returns {void}
 	 */
 	const handleSuggestion = useCallback(
-		( event: CustomEvent ) => onSuggestion( event?.detail ),
+		( event: CustomEvent ) => {
+			// Remove the delimiter from the suggestion.
+			onSuggestion( event?.detail?.replaceAll( delimiter, '' ) );
+		},
 		[ onSuggestion ]
 	);
 
@@ -98,7 +101,13 @@ export default function useSuggestionsFromAI( {
 	 * @param {string} content - The content.
 	 * @returns {void}
 	 */
-	const handleDone = useCallback( ( event: CustomEvent ) => onDone( event?.detail ), [ onDone ] );
+	const handleDone = useCallback(
+		( event: CustomEvent ) => {
+			// Remove the delimiter from the suggestion.
+			onDone( event?.detail?.replaceAll( delimiter, '' ) );
+		},
+		[ onDone ]
+	);
 
 	/**
 	 * Request handler.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -89,8 +89,12 @@ export default function useSuggestionsFromAI( {
 	 */
 	const handleSuggestion = useCallback(
 		( event: CustomEvent ) => {
-			// Remove the delimiter from the suggestion.
-			onSuggestion( event?.detail?.replaceAll( delimiter, '' ) );
+			/*
+			 * Remove the delimiter string from the suggestion,
+			 * only at the beginning and end of the string.
+			 */
+			const delimiterRegEx = new RegExp( `^${ delimiter }|${ delimiter }$`, 'g' );
+			onSuggestion( event?.detail?.replace( delimiterRegEx, '' ) );
 		},
 		[ onSuggestion ]
 	);
@@ -104,10 +108,9 @@ export default function useSuggestionsFromAI( {
 	const handleDone = useCallback(
 		( event: CustomEvent ) => {
 			/*
-			 * Create a regex to remove the delimiter string from the suggestion,
+			 * Remove the delimiter string from the suggestion,
 			 * only at the beginning and end of the string.
 			 */
-
 			const delimiterRegEx = new RegExp( `^${ delimiter }|${ delimiter }$`, 'g' );
 			onDone( event?.detail?.replace( delimiterRegEx, '' ) );
 		},

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-ai/index.ts
@@ -103,8 +103,13 @@ export default function useSuggestionsFromAI( {
 	 */
 	const handleDone = useCallback(
 		( event: CustomEvent ) => {
-			// Remove the delimiter from the suggestion.
-			onDone( event?.detail?.replaceAll( delimiter, '' ) );
+			/*
+			 * Create a regex to remove the delimiter string from the suggestion,
+			 * only at the beginning and end of the string.
+			 */
+
+			const delimiterRegEx = new RegExp( `^${ delimiter }|${ delimiter }$`, 'g' );
+			onDone( event?.detail?.replace( delimiterRegEx, '' ) );
 		},
 		[ onDone ]
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -10,7 +10,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { DEFAULT_PROMPT_TONE } from '../../components/tone-dropdown-control';
-import { buildPromptForBlock } from '../../lib/prompt';
+import { buildPromptForBlock, delimiter } from '../../lib/prompt';
 import { askJetpack, askQuestion } from '../../lib/suggestions';
 import { getContentFromBlocks, getPartialContentToBlock } from '../../lib/utils/block-content';
 
@@ -202,7 +202,10 @@ const useSuggestionsFromOpenAI = ( {
 		}
 
 		source?.current?.addEventListener( 'done', e => {
-			const { detail: assistantResponse } = e;
+			const { detail } = e;
+
+			// Remove the delimiter from the suggestion.
+			const assistantResponse = detail.replaceAll( delimiter, '' );
 
 			// Populate the messages with the assistant response.
 			const lastAssistantPrompt = {
@@ -331,8 +334,9 @@ const useSuggestionsFromOpenAI = ( {
 
 		source?.current?.addEventListener( 'suggestion', e => {
 			setWasCompletionJustRequested( false );
-			debug( '(suggestion)', e.detail );
-			updateBlockAttributes( clientId, { content: e.detail } );
+			debug( '(suggestion)', e?.detail );
+			// Remove the delimiter from the suggestion and update the block.
+			updateBlockAttributes( clientId, { content: e?.detail?.replaceAll( delimiter, '' ) } );
 		} );
 		return source?.current;
 	};

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -134,7 +134,7 @@ const useSuggestionsFromOpenAI = ( {
 		} );
 
 		// Create a copy of the messages.
-		const updatedMessaages = [ ...attributes.messages ] ?? [];
+		const updatedMessages = [ ...attributes.messages ] ?? [];
 
 		let lastUserPrompt = {};
 
@@ -158,7 +158,7 @@ const useSuggestionsFromOpenAI = ( {
 			lastUserPrompt = prompt.pop();
 
 			// Populate prompt with the messages.
-			prompt = [ ...prompt, ...updatedMessaages ];
+			prompt = [ ...prompt, ...updatedMessages ];
 
 			// Restore the last user prompt.
 			prompt.push( lastUserPrompt );
@@ -212,7 +212,7 @@ const useSuggestionsFromOpenAI = ( {
 				role: 'assistant',
 				content: assistantResponse,
 			};
-			updatedMessaages.push( lastUserPrompt, lastAssistantPrompt );
+			updatedMessages.push( lastUserPrompt, lastAssistantPrompt );
 
 			debugPrompt( 'Add %o\n%s', `[${ lastUserPrompt.role }]`, lastUserPrompt.content );
 			debugPrompt( 'Add %o\n%s', `[${ lastAssistantPrompt.role }]`, lastAssistantPrompt.content );
@@ -221,15 +221,15 @@ const useSuggestionsFromOpenAI = ( {
 			 * Limit the messages to 20 items.
 			 * @todo: limit the prompt based on tokens.
 			 */
-			if ( updatedMessaages.length > 20 ) {
-				updatedMessaages.splice( 0, updatedMessaages.length - 20 );
+			if ( updatedMessages.length > 20 ) {
+				updatedMessages.splice( 0, updatedMessages.length - 20 );
 			}
 
 			stopSuggestion();
 
 			updateBlockAttributes( clientId, {
 				content: assistantResponse,
-				messages: updatedMessaages,
+				messages: updatedMessages,
 			} );
 			refreshFeatureData();
 		} );
@@ -255,9 +255,9 @@ const useSuggestionsFromOpenAI = ( {
 				 * Let's clean up the messages array and try again.
 				 * @todo: improve the process based on tokens / URL length.
 				 */
-				updatedMessaages.splice( 0, 8 );
+				updatedMessages.splice( 0, 8 );
 				updateBlockAttributes( clientId, {
-					messages: updatedMessaages,
+					messages: updatedMessages,
 				} );
 
 				/*
@@ -275,7 +275,7 @@ const useSuggestionsFromOpenAI = ( {
 					isGeneratingTitle: attributes.promptType === 'generateTitle',
 				} );
 
-				setLastPrompt( [ ...prompt, ...updatedMessaages, lastUserPrompt ] );
+				setLastPrompt( [ ...prompt, ...updatedMessages, lastUserPrompt ] );
 			}
 
 			source?.current?.close();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -44,7 +44,7 @@ export type PromptItemProps = {
 
 const debug = debugFactory( 'jetpack-ai-assistant:prompt' );
 
-export const delimiter = '####';
+export const delimiter = '````';
 
 /**
  * Helper function to get the initial system prompt.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/suggestions/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/suggestions/index.js
@@ -167,7 +167,7 @@ export class SuggestionsEventSource extends EventTarget {
 			 * - the doouble asterisks (bold markdown)
 			 */
 			const replacedMessage = this.fullMessage.replace( /__|(\*\*)/g, '' );
-			if ( replacedMessage === 'JETPACK_AI_ERROR' ) {
+			if ( replacedMessage.startsWith( 'JETPACK_AI_ERROR' ) ) {
 				// The unclear prompt marker was found, so we dispatch an error event
 				this.dispatchEvent( new CustomEvent( 'error_unclear_prompt' ) );
 			} else if ( 'JETPACK_AI_ERROR'.startsWith( replacedMessage ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #31515

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes the delimiter to ```` because `####` has meaning in Markdown
* Removes any delimiter from the response as it is streamed because sometimes the AI repeats them in the response
* Fixes the JETPACK_AI_ERROR check as sometimes more tokens are streamed together
* Fixes a typo

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add some text in Chinese
* In the extension, try to translate it to French. This is the most consistent way I could find to generate errors, as sometimes the AI asks for English text for some reason.
* Check that no JETPACK_AI_ERROR is printed and the responses do not have the delimiter in them

Before | After
-|-
![2023-06-22_16-34-03](https://github.com/Automattic/jetpack/assets/8486249/efb52ce7-d426-4308-9376-e023dd008c7d) | ![2023-06-22_16-36-44](https://github.com/Automattic/jetpack/assets/8486249/bc7b379c-7444-421b-88b7-5ecb76befcd9)
