### PR TITLE
Launchpad: Remove filter for wpcom_launchpad_is_keep_building_enabled

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-keep-building-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-keep-building-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove use of the is_launchpad_keep_building_enabled feature.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -559,13 +559,17 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
 /**
  * Checks if the Keep building task list is enabled.
  *
- * This function uses the `is_launchpad_keep_building_enabled` filter to allow for overriding the
- * default value.
- *
  * @return bool True if the task list is enabled, false otherwise.
  */
 function wpcom_launchpad_is_keep_building_enabled() {
-	return apply_filters( 'is_launchpad_keep_building_enabled', false );
+	$intent  = get_option( 'site_intent', false );
+	$blog_id = get_current_blog_id();
+
+	if ( 'build' === $intent && $blog_id > 220443356 ) {
+		return true;
+	}
+
+	return false;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/wp-calypso#78401

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Since we've launched, we no longer need to filter who gets to see the Keep Building task list, so just check for the necessary site parameters and pass that to the callback directly.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox
* Create a new site from `/start`, selecting the "Promote myself or business" intent.
* Launch your site
* You should see the Keep Building task list in Customer Home.