### PR TITLE
Stats: add stats flag to my-jetpack

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-flag-for-stats-card
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-flag-for-stats-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+stats: adds flag for stats to my jetpack

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -199,6 +199,7 @@ class Initializer {
 	public static function get_my_jetpack_flags() {
 		$flags = array(
 			'videoPressStats' => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
+			'jetpackStats'    => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_STATS_ENABLED' ),
 		);
 
 		return $flags;


### PR DESCRIPTION
Related to #30241

## Proposed changes:
* Defines a second flag, `jetpackStats` to be used in the `myJetpackFlags` field in the initial state.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run it locally
* Open `My Jetpack` page.
* Run in console `window.myJetpackInitialState.myJetpackFlags`.
* You should see `jetpackStats` as `false`.
* Open `tools/docker/wordpress/wp-config.php` and define `JETPACK_MY_JETPACK_STATS_ENABLED`
* Reload the page and rerun the console.
* You should see `jetpackStats` as `true`.

