### PR TITLE
Stats: Add stats card to my jetpack

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -35,10 +35,10 @@ const ProductCardsSection = () => {
 				<SearchCard admin={ true } />
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<StatsCard admin={ true } />
+				<VideopressCard admin={ true } />
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<VideopressCard admin={ true } />
+				<StatsCard admin={ true } />
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
 				<CrmCard admin={ true } />

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -16,6 +16,10 @@ import VideopressCard from './videopress-card';
  *
  * @returns {object} ProductCardsSection React component.
  */
+
+// flag for enabling stats card. Logic is in 02-stats.php mu-plugin
+const { jetpackStats = false } = window.myJetpackInitialState?.myJetpackFlags ?? {};
+
 const ProductCardsSection = () => {
 	return (
 		<Container fluid horizontalSpacing={ 0 } horizontalGap={ 3 }>
@@ -37,9 +41,11 @@ const ProductCardsSection = () => {
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
 				<VideopressCard admin={ true } />
 			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<StatsCard admin={ true } />
-			</Col>
+			{ jetpackStats && (
+				<Col sm={ 4 } md={ 4 } lg={ 4 }>
+					<StatsCard admin={ true } />
+				</Col>
+			) }
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
 				<CrmCard admin={ true } />
 			</Col>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -17,7 +17,7 @@ import VideopressCard from './videopress-card';
  * @returns {object} ProductCardsSection React component.
  */
 
-// flag for enabling stats card. Logic is in 02-stats.php mu-plugin
+// flag for enabling stats card.
 const { jetpackStats = false } = window.myJetpackInitialState?.myJetpackFlags ?? {};
 
 const ProductCardsSection = () => {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -8,6 +8,7 @@ import CrmCard from './crm-card';
 import ScanAndProtectCard from './scan-protect-card';
 import SearchCard from './search-card';
 import SocialCard from './social-card';
+import StatsCard from './stats-card';
 import VideopressCard from './videopress-card';
 
 /**
@@ -32,6 +33,9 @@ const ProductCardsSection = () => {
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
 				<SearchCard admin={ true } />
+			</Col>
+			<Col sm={ 4 } md={ 4 } lg={ 4 }>
+				<StatsCard admin={ true } />
 			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
 				<VideopressCard admin={ true } />

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/stats-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/stats-card.jsx
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ProductCard from '../connected-product-card';
+
+const StatsCard = ( { admin } ) => {
+	return <ProductCard admin={ admin } slug="stats" showMenu />;
+};
+
+StatsCard.propTypes = {
+	admin: PropTypes.bool.isRequired,
+};
+
+export default StatsCard;

--- a/projects/packages/my-jetpack/changelog/add-stats-card-to-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-stats-card-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: add stats card to my jetpack

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -199,6 +199,7 @@ class Initializer {
 	public static function get_my_jetpack_flags() {
 		$flags = array(
 			'videoPressStats' => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
+			'jetpackStats'    => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_STATS_ENABLED' ),
 		);
 
 		return $flags;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related #31343

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR is the first iteration to add a stats card behind a feature flag to the my-jetpack screen. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run it locally
* Open `My Jetpack` page.
* Check the product cards being shown. Jetpack Stats should *not* display
* Either open `tools/docker/wordpress/wp-config.php`, or create a temporary mu-pluhin in `tools/docker/mu-plugins` and define `JETPACK_MY_JETPACK_STATS_ENABLED` as true.
* Reload the page and rerun the console.
* You should see now a Jetpack Stats product card visible. NOTE the button text, functionality, and active/inactive status is not yet expected to work correctly. 

![image](https://github.com/Automattic/jetpack/assets/30754158/67ae8b7f-db66-4d29-8c15-cdbd3d21dde6)


