### PR TITLE
[Boost] Fix UI on older versions of Safari

### DIFF
--- a/projects/js-packages/svelte-data-sync-client/changelog/fix-structuredClone-fallback
+++ b/projects/js-packages/svelte-data-sync-client/changelog/fix-structuredClone-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed support for older versions of Safari

--- a/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
+++ b/projects/js-packages/svelte-data-sync-client/src/SyncedStore.ts
@@ -35,6 +35,17 @@ export class SyncedStore< T > {
 		);
 	}
 
+	/**
+	 * Deep clone a JSON-compatible value. Uses structuredClone if available, otherwise uses JSON.parse.
+	 */
+	private clone( value: T ): T {
+		if ( typeof structuredClone === 'function' ) {
+			return structuredClone( value );
+		}
+
+		return JSON.parse( JSON.stringify( value ) );
+	}
+
 	private createStore( initialValue?: T ): SyncedWritable< T > {
 		const store = writable< T >( initialValue );
 
@@ -47,7 +58,7 @@ export class SyncedStore< T > {
 			// structuredClone may be necessary because using `set` in Svelte will mutate objects.
 			// By the time the value gets to SyncedStore methods it's already mutated,
 			// and so the previous value will be the same as the current value.
-			prevValue = isPrimitive ? value : structuredClone( value );
+			prevValue = isPrimitive ? value : this.clone( value );
 		} );
 
 		// `set` is a required method in the Writable interface.
@@ -123,7 +134,7 @@ export class SyncedStore< T > {
 			// structuredClone is necessary here,
 			// because the updateCallback can mutate the value,
 			// and that's going to fail the comparison in `abortableSynchronize`.
-			set( updateCallback( structuredClone( prevValue ) ) );
+			set( updateCallback( this.clone( prevValue ) ) );
 		};
 
 		return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes user complaints about white-screen of death on older versions of Safari. We relied on `structuredClone` which isn't always 100% available on older browsers.

## Proposed changes:
* Fall back to using json.serialize/parse when structuredClone isn't available.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use browserstack to test on older versions of safari.
* Make sure the boost dashboard loads and seems ok

