### PR TITLE
Sharing Buttons: Add a Nextdoor button

### DIFF
--- a/projects/plugins/jetpack/changelog/add-nextdoor-share-button
+++ b/projects/plugins/jetpack/changelog/add-nextdoor-share-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Share buttons: Add a Nextdoor sharing button

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
@@ -168,6 +168,9 @@ li.service.share-skype span:before {
 li.service.share-mastodon span:before {
 	content: '\f10a';
 }
+li.service.share-nextdoor span:before {
+	content: '\f10c';
+}
 
 /**
  * Preview section

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.js
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.js
@@ -166,6 +166,7 @@
 							! $( this ).hasClass( 'preview-press-this' ) &&
 							! $( this ).hasClass( 'preview-email' ) &&
 							! $( this ).hasClass( 'preview-mastodon' ) &&
+							! $( this ).hasClass( 'preview-nextdoor' ) &&
 							! $( this ).hasClass( 'preview-print' ) &&
 							! $( this ).hasClass( 'preview-telegram' ) &&
 							! $( this ).hasClass( 'preview-jetpack-whatsapp' ) &&

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -108,6 +108,7 @@ class Sharing_Service {
 			'jetpack-whatsapp' => 'Jetpack_Share_WhatsApp',
 			'skype'            => 'Share_Skype',
 			'mastodon'         => 'Share_Mastodon',
+			'nextdoor'         => 'Share_Nextdoor',
 		);
 
 		if ( is_multisite() && is_plugin_active( 'press-this/press-this-plugin.php' ) ) {

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -3198,3 +3198,76 @@ class Share_Mastodon extends Sharing_Source {
 		);
 	}
 }
+
+/**
+ * Nextdoor sharing service.
+ */
+class Share_Nextdoor extends Sharing_Source {
+	/**
+	 * Service short name.
+	 *
+	 * @var string
+	 */
+	public $shortname = 'nextdoor';
+
+	/**
+	 * Service icon font code.
+	 *
+	 * @var string
+	 */
+	public $icon = '\f10c';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int   $id       Sharing source ID.
+	 * @param array $settings Sharing settings.
+	 */
+	public function __construct( $id, array $settings ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
+		parent::__construct( $id, $settings );
+	}
+
+	/**
+	 * Service name.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Nextdoor', 'jetpack' );
+	}
+
+	/**
+	 * Get the markup of the sharing button.
+	 *
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return string
+	 */
+	public function get_display( $post ) {
+		return $this->get_link(
+			$this->get_process_request_url( $post->ID ),
+			_x( 'Nextdoor', 'share to', 'jetpack' ),
+			__( 'Click to share on Nextdoor', 'jetpack' ),
+			'share=nextdoor',
+			'sharing-nextdoor-' . $post->ID
+		);
+	}
+
+	/**
+	 * Process sharing request. Add actions that need to happen when sharing here.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @param array   $post_data Array of information about the post we're sharing.
+	 *
+	 * @return void
+	 */
+	public function process_request( $post, array $post_data ) {
+		// Record stats
+		parent::process_request( $post, $post_data );
+
+		$url  = 'https://nextdoor.com/sharekit/?source=jetpack&body=';
+		$url .= rawurlencode( $this->get_share_title( $post->ID ) . ' ' . $this->get_share_url( $post->ID ) );
+
+		parent::redirect_request( $url );
+	}
+}

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -3218,16 +3218,6 @@ class Share_Nextdoor extends Sharing_Source {
 	public $icon = '\f10c';
 
 	/**
-	 * Constructor.
-	 *
-	 * @param int   $id       Sharing source ID.
-	 * @param array $settings Sharing settings.
-	 */
-	public function __construct( $id, array $settings ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
-		parent::__construct( $id, $settings );
-	}
-
-	/**
 	 * Service name.
 	 *
 	 * @return string

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -375,6 +375,16 @@ body .sd-content ul li.share-custom.no-icon a span {
 	color: #fff !important;
 }
 
+.sd-social-icon .sd-content ul li.share-nextdoor a:before,
+.sd-social-text .sd-content ul li.share-nextdoor a:before,
+.sd-content ul li.share-nextdoor div.option.option-smart-off a:before,
+.sd-social-icon-text .sd-content li.share-nextdoor a:before,
+.sd-social-official .sd-content li.share-nextdoor a:before {
+	content: '\f10c';
+}
+.sd-social-official .sd-content li.share-nextdoor a:before {
+	color: #8ED500;
+}
 
 .sd-social-icon .sd-content ul li.share-deprecated a:before,
 .sd-social-icon-text .sd-content li.share-deprecated a:before,

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -385,6 +385,11 @@ body .sd-content ul li.share-custom.no-icon a span {
 .sd-social-official .sd-content li.share-nextdoor a:before {
 	color: #8ED500;
 }
+.sd-social-icon .sd-content ul li[class*='share-'].share-nextdoor a.sd-button {
+	background: #8ED500;
+	color: #fff !important;
+}
+
 
 .sd-social-icon .sd-content ul li.share-deprecated a:before,
 .sd-social-icon-text .sd-content li.share-deprecated a:before,


### PR DESCRIPTION
This adds a sharing button for Nextdoor. It's a simple link with the post title and URL.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1201611340747558-as-1203666305041653/f

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
* Check this PR out on a sandbox and sandbox the API
* On this branch on a dev site, go to `/wp-admin/admin.php?page=jetpack#/sharing`
* Enable Sharing Buttons, and click the link to configure the buttons
* Enable the Nextdoor button ( the logo won't show currently )
* Save changes and load a post on the dev site.
* The Nextdoor button should be displayed and link through to share the post on Nextdoor

<img width="440" alt="image" src="https://github.com/Automattic/jetpack/assets/96462/c63ef90f-1e01-4238-91c9-52874a1370df">
