### PR TITLE
[Boost] Fix image guide proxy

### DIFF
--- a/projects/js-packages/image-guide/changelog/fix-image-guide-proxy
+++ b/projects/js-packages/image-guide/changelog/fix-image-guide-proxy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check response.url, not response.ok to verify a response worked

--- a/projects/js-packages/image-guide/src/MeasurableImage.ts
+++ b/projects/js-packages/image-guide/src/MeasurableImage.ts
@@ -94,7 +94,7 @@ export class MeasurableImage {
 	 */
 	private async fetchFileWeight( url: string ) {
 		const response = await this.fetch( url );
-		if ( ! response.url ) {
+		if ( ! response.ok ) {
 			// eslint-disable-next-line no-console
 			console.log( `Can't get image size for ${ url } likely due to a CORS error.` );
 			return -1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The image guide was using `response.url` to check if a given Response worked, which isn't correct. This PR updates it to use `response.ok` which should verify the response is valid (aka 200 response).

The image guide proxy work in https://github.com/Automattic/jetpack/pull/31145 generates a manufactured response without a `url` set, causing it to always fail.

## Proposed changes:
* Use `response.ok` to check that the response received by the image guide is ok

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Use the image guide to check the size of an image on an external URL
* Verify it works with this patch, doesn't without it.

