### PR TITLE
Boost: Fix CSS regen notice not showing on Atomic

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
@@ -31,6 +31,6 @@ const allowedSuggestions = [
 export type RegenReason = ( typeof allowedSuggestions )[ number ];
 
 export const suggestRegenerateDS = jetpack_boost_ds.createAsyncStore(
-	'critical_css_suggest_regenerate',
+	'critical_css_regen',
 	z.enum( allowedSuggestions ).nullable()
 );

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -200,7 +200,7 @@ class Jetpack_Boost {
 			Regenerate_Admin_Notice::enable();
 		}
 
-		jetpack_boost_ds_set( 'critical_css_suggest_regenerate', $change_type );
+		jetpack_boost_ds_set( 'critical_css_regen', $change_type );
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/Boost_Health.php
+++ b/projects/plugins/boost/app/lib/Boost_Health.php
@@ -60,7 +60,7 @@ class Boost_Health {
 			return false;
 		}
 
-		$suggest_regenerate = jetpack_boost_ds_get( 'critical_css_suggest_regenerate' );
+		$suggest_regenerate = jetpack_boost_ds_get( 'critical_css_regen' );
 
 		return in_array( $suggest_regenerate, Environment_Change_Detector::get_available_env_change_statuses(), true );
 	}

--- a/projects/plugins/boost/changelog/fix-boost-css-regen-notice-name
+++ b/projects/plugins/boost/changelog/fix-boost-css-regen-notice-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update CSS regen notice data sync option name, to allow it to work on Atomic.

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -137,7 +137,7 @@ $critical_css_suggest_regenerate_schema = Schema::enum(
  * Register Data Sync Stores
  */
 jetpack_boost_register_option( 'critical_css_state', $critical_css_state_schema );
-jetpack_boost_register_option( 'critical_css_suggest_regenerate', $critical_css_suggest_regenerate_schema );
+jetpack_boost_register_option( 'critical_css_regen', $critical_css_suggest_regenerate_schema );
 
 $modules_state_schema = Schema::as_array(
 	Schema::as_assoc_array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31539

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reduce the name of the CSS regen notice data sync store, to fix the notice not showing on Atomic.
   * Old name in DB: `jetpack_boost_ds_critical_css_suggest_regenerate`
   * New name in DB: `jetpack_boost_ds_critical_css_regen`
* This also fixes the CSS regen entry not showing in the Site Health panel on Atomic.

**Note:** I couldn't figure out why reducing the name fixed the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Deploy Boost on Atomic and set it up;
* Wait for Critical CSS to finish generating;
* Make sure there's no notice showing under the generation UI;
* Add a page or a post or change the theme;
* Now go back to the Boost UI - there should be a notice, prompting you to regenerate;
* If you check the SIte Health panel, it should also show an entry, saying CSS is outdated.

<img width="824" alt="CleanShot 2023-06-23 at 14 17 08@2x" src="https://github.com/Automattic/jetpack/assets/11799079/999a278d-2e3c-4ada-8b97-0c79be495484">