### PR TITLE
Replace eslint-plugin-es with eslint-plugin-es-x

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3848,9 +3848,9 @@ importers:
       eslint-import-resolver-exports:
         specifier: 1.0.0-beta.5
         version: 1.0.0-beta.5(eslint-plugin-import@2.27.5)(eslint@8.39.0)
-      eslint-plugin-es:
-        specifier: 4.1.0
-        version: 4.1.0(eslint@8.39.0)
+      eslint-plugin-es-x:
+        specifier: 7.1.0
+        version: 7.1.0(eslint@8.39.0)
       eslint-plugin-import:
         specifier: 2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.59.0)(eslint@8.39.0)
@@ -14877,17 +14877,6 @@ packages:
       eslint: 8.39.0
     dev: true
 
-  /eslint-plugin-es@4.1.0(eslint@8.39.0):
-    resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
-    engines: {node: '>=8.10.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
-    dependencies:
-      eslint: 8.39.0
-      eslint-utils: 2.1.0
-      regexpp: 3.2.0
-    dev: true
-
   /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.0)(eslint@8.39.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
@@ -15137,18 +15126,6 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-    dev: true
-
-  /eslint-utils@2.1.0:
-    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
-    engines: {node: '>=6'}
-    dependencies:
-      eslint-visitor-keys: 1.3.0
-    dev: true
-
-  /eslint-visitor-keys@1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
     dev: true
 
   /eslint-visitor-keys@2.1.0:
@@ -21081,11 +21058,6 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.2.0
       functions-have-names: 1.2.3
-    dev: true
-
-  /regexpp@3.2.0:
-    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
-    engines: {node: '>=8'}
     dev: true
 
   /regexpu-core@5.3.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -454,9 +454,9 @@ importers:
       eslint:
         specifier: 8.39.0
         version: 8.39.0
-      eslint-plugin-es:
-        specifier: 4.1.0
-        version: 4.1.0(eslint@8.39.0)
+      eslint-plugin-es-x:
+        specifier: 7.1.0
+        version: 7.1.0(eslint@8.39.0)
       jest:
         specifier: 29.4.3
         version: 29.4.3
@@ -14864,6 +14864,17 @@ packages:
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /eslint-plugin-es-x@7.1.0(eslint@8.39.0):
+    resolution: {integrity: sha512-AhiaF31syh4CCQ+C5ccJA0VG6+kJK8+5mXKKE7Qs1xcPRg02CDPOj3mWlQxuWS/AYtg7kxrDNgW9YW3vc0Q+Mw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=8'
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.39.0)
+      '@eslint-community/regexpp': 4.5.1
+      eslint: 8.39.0
     dev: true
 
   /eslint-plugin-es@4.1.0(eslint@8.39.0):

--- a/projects/js-packages/eslint-config-target-es/README.md
+++ b/projects/js-packages/eslint-config-target-es/README.md
@@ -1,13 +1,13 @@
 # eslint-config-target-es
 
-ESLint shareable config to activate [eslint-plugin-es] checks based on [browserslist] browser targets and [MDN browser compatibility data].
+ESLint shareable config to activate [eslint-plugin-es-x] checks based on [browserslist] browser targets and [MDN browser compatibility data].
 
 ## Installation
 
 Generally you'll install this via your package manager, e.g.
 
 ```
-npm install --save-dev eslint eslint-plugin-es @automattic/eslint-config-target-es
+npm install --save-dev eslint eslint-plugin-es-x @automattic/eslint-config-target-es
 ```
 
 ## Usage
@@ -75,6 +75,6 @@ eslint-config-target-es is licensed under [GNU General Public License v2 (or lat
 
 --
 
-[eslint-plugin-es]: https://www.npmjs.com/package/eslint-plugin-es
+[eslint-plugin-es-x]: https://www.npmjs.com/package/eslint-plugin-es-x
 [browserslist]: https://www.npmjs.com/package/browserslist
 [MDN browser compatibility data]: https://www.npmjs.com/package/@mdn/browser-compat-data

--- a/projects/js-packages/eslint-config-target-es/changelog/update-replace-abandoned-eslint-plugin-es
+++ b/projects/js-packages/eslint-config-target-es/changelog/update-replace-abandoned-eslint-plugin-es
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+As `eslint-plugin-es` appears to be abandoned, change to using `eslint-plugin-es-x`.

--- a/projects/js-packages/eslint-config-target-es/package.json
+++ b/projects/js-packages/eslint-config-target-es/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/eslint-config-target-es",
-	"version": "1.0.7-alpha",
+	"version": "2.0.0-alpha",
 	"description": "ESLint sharable config to activate eslint-plugin-es checks based on browserslist targets.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/eslint-config-target-es/README.md#readme",
 	"bugs": {
@@ -25,12 +25,12 @@
 	"devDependencies": {
 		"@wordpress/browserslist-config": "5.18.0",
 		"eslint": "8.39.0",
-		"eslint-plugin-es": "4.1.0",
+		"eslint-plugin-es-x": "7.1.0",
 		"jest": "29.4.3"
 	},
 	"peerDependencies": {
 		"eslint": ">=4.19.1",
-		"eslint-plugin-es": "^4.1.0"
+		"eslint-plugin-es-x": "^7.1.0"
 	},
 	"engines": {
 		"node": "^18.13.0",

--- a/projects/js-packages/eslint-config-target-es/src/configs/base.js
+++ b/projects/js-packages/eslint-config-target-es/src/configs/base.js
@@ -1,6 +1,6 @@
 module.exports = {
 	env: {
-		es2021: true,
+		es2022: true,
 	},
-	plugins: [ 'es' ],
+	plugins: [ 'es-x' ],
 };

--- a/projects/js-packages/eslint-config-target-es/src/funcs.js
+++ b/projects/js-packages/eslint-config-target-es/src/funcs.js
@@ -1,7 +1,7 @@
 const mdn = require( '@mdn/browser-compat-data' );
 const browserslist = require( 'browserslist' );
 const debug = require( 'debug' );
-const { rules: esRules } = require( 'eslint-plugin-es' );
+const { rules: esRules } = require( 'eslint-plugin-es-x' );
 const semver = require( 'semver' );
 const browsersMap = require( './browsersMap.js' );
 const rulesMap = require( './rulesMap.js' );
@@ -122,7 +122,7 @@ function needsCheck( rule, browsers, options = {} ) {
 }
 
 /**
- * Get the es rule configurations.
+ * Get the es-x rule configurations.
  *
  * @param {object} options - Options.
  * @param {boolean|null} options.builtins - If true, only rules with "javascript.builtins" paths are checked. If false, such rules are not checked. If null/undefined, all may be checked.
@@ -133,7 +133,7 @@ function getRules( options = {} ) {
 	const browsers = getBrowsers( options );
 	const ret = {};
 	for ( const rule of Object.keys( esRules ) ) {
-		ret[ `es/${ rule }` ] = needsCheck( rule, browsers, options ) ? 2 : 0;
+		ret[ `es-x/${ rule }` ] = needsCheck( rule, browsers, options ) ? 2 : 0;
 	}
 	return ret;
 }

--- a/projects/js-packages/eslint-config-target-es/src/rulesMap.js
+++ b/projects/js-packages/eslint-config-target-es/src/rulesMap.js
@@ -1,7 +1,60 @@
-// Map of eslint-plugin-es rules to MDN compat-data paths.
+// Map of eslint-plugin-es-x rules to MDN compat-data paths.
 // Values are either a path, an array of paths, true to always enable the rule, or false to always disable it.
 module.exports = {
+	// ?
+	'no-atomics-waitasync': 'javascript.builtins.Atomics.waitAsync',
+	'no-string-prototype-iswellformed-towellformed': [
+		'javascript.builtins.String.isWellFormed',
+		'javascript.builtins.String.toWellFormed',
+	],
+
+	// ES2023
+	'no-array-prototype-findlast-findlastindex': [
+		'javascript.builtins.Array.findLast',
+		'javascript.builtins.Array.findLastIndex',
+	],
+	'no-array-prototype-toreversed': 'javascript.builtins.Array.toReversed',
+	'no-array-prototype-tosorted': 'javascript.builtins.Array.toSorted',
+	'no-array-prototype-tospliced': 'javascript.builtins.Array.toSpliced',
+	'no-array-prototype-with': 'javascript.builtins.Array.with',
+	'no-hashbang': 'javascript.grammar.hashbang_comments',
+	'no-intl-numberformat-prototype-formatrange': 'javascript.builtins.Intl.NumberFormat.formatRange',
+	'no-intl-numberformat-prototype-formatrangetoparts':
+		'javascript.builtins.Intl.NumberFormat.formatRangeToParts',
+	'no-intl-pluralrules-prototype-selectrange': 'javascript.builtins.Intl.PluralRules.selectRange',
+	'no-regexp-unicode-property-escapes-2023': false, // No support data in MDN separate from no-regexp-unicode-property-escapes. https://github.com/mdn/browser-compat-data/issues/19631
+
+	// ES2022
+	'no-arbitrary-module-namespace-names': false, // No support data. https://github.com/mdn/browser-compat-data/issues/18152
+	'no-array-string-prototype-at': [
+		'javascript.builtins.Array.at',
+		'javascript.builtins.String.at',
+		'javascript.builtins.TypedArray.at',
+	],
+	'no-class-fields': [
+		'javascript.classes.private_class_fields',
+		'javascript.classes.private_class_methods',
+		'javascript.classes.public_class_fields',
+		'javascript.classes.static_class_fields',
+	],
+	'no-class-static-block': 'javascript.classes.static_initialization_blocks',
+	'no-error-cause': [
+		'javascript.builtins.Error.Error.options_cause_parameter',
+		'javascript.builtins.Error.cause',
+	],
+	'no-intl-segmenter': 'javascript.builtins.Intl.Segmenter',
+	'no-intl-supportedvaluesof': 'javascript.builtins.Intl.supportedValuesOf',
+	'no-object-hasown': 'javascript.builtins.Object.hasOwn',
+	'no-private-in': 'javascript.classes.private_class_fields_in',
+	'no-regexp-d-flag': 'javascript.builtins.RegExp.hasIndices',
+	'no-regexp-unicode-property-escapes-2022': false, // No support data in MDN separate from no-regexp-unicode-property-escapes. https://github.com/mdn/browser-compat-data/issues/19631
+	'no-top-level-await': 'javascript.operators.await.top_level',
+
 	// ES2021
+	'no-intl-datetimeformat-prototype-formatrange':
+		'javascript.builtins.Intl.DateTimeFormat.formatRange',
+	'no-intl-displaynames': 'javascript.builtins.Intl.DisplayNames',
+	'no-intl-listformat': 'javascript.builtins.Intl.ListFormat',
 	'no-logical-assignment-operators': [
 		'javascript.operators.logical_and_assignment',
 		'javascript.operators.nullish_coalescing_assignment',
@@ -9,6 +62,8 @@ module.exports = {
 	],
 	'no-numeric-separators': 'javascript.grammar.numeric_separators',
 	'no-promise-any': [ 'javascript.builtins.AggregateError', 'javascript.builtins.Promise.any' ],
+	'no-regexp-unicode-property-escapes-2021': false, // No support data in MDN separate from no-regexp-unicode-property-escapes. https://github.com/mdn/browser-compat-data/issues/19631
+	'no-string-prototype-replaceall': 'javascript.builtins.String.replaceAll',
 	'no-weakrefs': [ 'javascript.builtins.WeakRef', 'javascript.builtins.FinalizationRegistry' ],
 
 	// ES2020
@@ -21,23 +76,40 @@ module.exports = {
 	'no-export-ns-from': 'javascript.statements.export.namespace',
 	'no-global-this': 'javascript.builtins.globalThis',
 	'no-import-meta': 'javascript.operators.import_meta',
+	'no-intl-locale': 'javascript.builtins.Intl.Locale',
+	'no-intl-relativetimeformat': 'javascript.builtins.Intl.RelativeTimeFormat',
 	'no-nullish-coalescing-operators': 'javascript.operators.nullish_coalescing',
 	'no-optional-chaining': 'javascript.operators.optional_chaining',
 	'no-promise-all-settled': 'javascript.builtins.Promise.allSettled',
+	'no-regexp-unicode-property-escapes-2020': false, // No support data in MDN separate from no-regexp-unicode-property-escapes. https://github.com/mdn/browser-compat-data/issues/19631
+	'no-string-prototype-matchall': 'javascript.builtins.String.matchAll',
 
 	// ES2019
+	'no-array-prototype-flat': [
+		'javascript.builtins.Array.flat',
+		'javascript.builtins.Array.flatMap',
+	],
 	'no-json-superset': 'javascript.builtins.JSON.json_superset',
 	'no-object-fromentries': 'javascript.builtins.Object.fromEntries',
 	'no-optional-catch-binding': 'javascript.statements.try_catch.optional_catch_binding',
-	'no-regexp-unicode-property-escapes-2019': false, // No support data in MDN separate from no-regexp-unicode-property-escapes?
+	'no-regexp-unicode-property-escapes-2019': false, // No support data in MDN separate from no-regexp-unicode-property-escapes. https://github.com/mdn/browser-compat-data/issues/19631
+	'no-string-prototype-trimstart-trimend': [
+		'javascript.builtins.String.trimEnd',
+		'javascript.builtins.String.trimStart',
+	],
+	'no-symbol-prototype-description': 'javascript.builtins.Symbol.description',
 
 	// ES2018
 	'no-async-iteration': [
 		'javascript.operators.async_generator_function',
 		'javascript.statements.async_generator_function',
 	],
+	'no-intl-numberformat-prototype-formattoparts':
+		'javascript.builtins.Intl.NumberFormat.formatToParts',
+	'no-intl-pluralrules': 'javascript.builtins.Intl.PluralRules',
 	'no-malformed-template-literals':
 		'javascript.grammar.template_literals.template_literal_revision',
+	'no-promise-prototype-finally': 'javascript.builtins.Promise.finally',
 	'no-regexp-lookbehind-assertions': 'javascript.regular_expressions.lookahead_assertion',
 	'no-regexp-named-capture-groups': 'javascript.regular_expressions.named_capturing_group',
 	'no-regexp-s-flag': 'javascript.builtins.RegExp.dotAll',
@@ -54,10 +126,16 @@ module.exports = {
 		'javascript.statements.async_function',
 	],
 	'no-atomics': 'javascript.builtins.Atomics',
+	'no-intl-datetimeformat-prototype-formattoparts':
+		'javascript.builtins.Intl.DateTimeFormat.formatRangeToParts',
 	'no-object-entries': 'javascript.builtins.Object.entries',
 	'no-object-getownpropertydescriptors': 'javascript.builtins.Object.getOwnPropertyDescriptors',
 	'no-object-values': 'javascript.builtins.Object.values',
 	'no-shared-array-buffer': 'javascript.builtins.SharedArrayBuffer',
+	'no-string-prototype-padstart-padend': [
+		'javascript.builtins.String.padEnd',
+		'javascript.builtins.String.padStart',
+	],
 	'no-trailing-function-commas': [
 		'javascript.grammar.trailing_commas.trailing_commas_in_functions',
 		'javascript.functions.arrow_functions.trailing_comma',
@@ -68,11 +146,20 @@ module.exports = {
 	],
 
 	// ES2016
+	'no-array-prototype-includes': 'javascript.builtins.Array.includes',
 	'no-exponential-operators': 'javascript.operators.exponentiation',
+	'no-intl-getcanonicallocales': 'javascript.builtins.Intl.getCanonicalLocales',
 
 	// ES2015
 	'no-array-from': 'javascript.builtins.Array.from',
 	'no-array-of': 'javascript.builtins.Array.of',
+	'no-array-prototype-copywithin': 'javascript.builtins.Array.copyWithin',
+	'no-array-prototype-entries': 'javascript.builtins.Array.entries',
+	'no-array-prototype-fill': 'javascript.builtins.Array.fill',
+	'no-array-prototype-find': 'javascript.builtins.Array.find',
+	'no-array-prototype-findindex': 'javascript.builtins.Array.findIndex',
+	'no-array-prototype-keys': 'javascript.builtins.Array.keys',
+	'no-array-prototype-values': 'javascript.builtins.Array.values',
 	'no-arrow-functions': 'javascript.functions.arrow_functions',
 	'no-binary-numeric-literals': 'javascript.grammar.binary_numeric_literals',
 	'no-block-scoped-functions': 'javascript.functions.block_level_functions',
@@ -134,6 +221,7 @@ module.exports = {
 	],
 	'no-proxy': 'javascript.builtins.Proxy',
 	'no-reflect': 'javascript.builtins.Reflect',
+	'no-regexp-prototype-flags': 'javascript.builtins.RegExp.flags',
 	'no-regexp-u-flag': 'javascript.builtins.RegExp.unicode',
 	'no-regexp-y-flag': 'javascript.builtins.RegExp.sticky',
 	'no-rest-parameters': 'javascript.functions.rest_parameters',
@@ -143,6 +231,12 @@ module.exports = {
 		'javascript.operators.spread.spread_in_function_calls',
 	],
 	'no-string-fromcodepoint': 'javascript.builtins.String.fromCodePoint',
+	'no-string-prototype-codepointat': 'javascript.builtins.String.codePointAt',
+	'no-string-prototype-endswith': 'javascript.builtins.String.endsWith',
+	'no-string-prototype-includes': 'javascript.builtins.String.includes',
+	'no-string-prototype-normalize': 'javascript.builtins.String.normalize',
+	'no-string-prototype-repeat': 'javascript.builtins.String.repeat',
+	'no-string-prototype-startswith': 'javascript.builtins.String.startsWith',
 	'no-string-raw': 'javascript.builtins.String.raw',
 	'no-subclassing-builtins': false, // No support data.
 	'no-symbol': 'javascript.builtins.Symbol',
@@ -169,9 +263,20 @@ module.exports = {
 	// ES5
 	'no-accessor-properties': 'javascript.operators.property_accessors',
 	'no-array-isarray': 'javascript.builtins.Array.isArray',
+	'no-array-prototype-every': 'javascript.builtins.Array.every',
+	'no-array-prototype-filter': 'javascript.builtins.Array.filter',
+	'no-array-prototype-foreach': 'javascript.builtins.Array.forEach',
+	'no-array-prototype-indexof': 'javascript.builtins.Array.indexOf',
+	'no-array-prototype-lastindexof': 'javascript.builtins.Array.lastIndexOf',
+	'no-array-prototype-map': 'javascript.builtins.Array.map',
+	'no-array-prototype-reduce': 'javascript.builtins.Array.reduce',
+	'no-array-prototype-reduceright': 'javascript.builtins.Array.reduceRight',
+	'no-array-prototype-some': 'javascript.builtins.Array.some',
 	'no-date-now': 'javascript.builtins.Date.now',
+	'no-function-prototype-bind': 'javascript.builtins.Function.bind',
 	'no-json': 'javascript.builtins.JSON',
 	'no-keyword-properties': false, // No support data.
+	'no-object-create': 'javascript.builtins.Object.create',
 	'no-object-defineproperties': 'javascript.builtins.Object.defineProperties',
 	'no-object-defineproperty': 'javascript.builtins.Object.defineProperty',
 	'no-object-freeze': 'javascript.builtins.Object.freeze',
@@ -184,8 +289,47 @@ module.exports = {
 	'no-object-keys': 'javascript.builtins.Object.keys',
 	'no-object-preventextensions': 'javascript.builtins.Object.preventExtensions',
 	'no-object-seal': 'javascript.builtins.Object.seal',
+	'no-string-prototype-trim': 'javascript.builtins.String.trim',
 	'no-trailing-commas': [
 		'javascript.grammar.trailing_commas',
 		'javascript.grammar.trailing_commas.trailing_commas_in_object_literals',
+	],
+
+	// Annex B
+	'no-date-prototype-getyear-setyear': [
+		'javascript.builtins.Date.getYear',
+		'javascript.builtins.Date.setYear',
+	],
+	'no-date-prototype-togmtstring': 'javascript.builtins.Date.toGMTString',
+	'no-escape-unescape': [ 'javascript.builtins.escape', 'javascript.builtins.unescape' ],
+	'no-function-declarations-in-if-statement-clauses-without-block': false, // No support data.
+	'no-initializers-in-for-in': false, // No support data.
+	'no-labelled-function-declarations': false, // No support data.
+	'no-regexp-prototype-compile': 'javascript.builtins.RegExp.compile',
+	'no-shadow-catch-param': false, // No support data.
+	'no-string-create-html-methods': [
+		'javascript.builtins.String.anchor',
+		'javascript.builtins.String.big',
+		'javascript.builtins.String.blink',
+		'javascript.builtins.String.bold',
+		'javascript.builtins.String.fixed',
+		'javascript.builtins.String.fontcolor',
+		'javascript.builtins.String.fontsize',
+		'javascript.builtins.String.italics',
+		'javascript.builtins.String.link',
+		'javascript.builtins.String.small',
+		'javascript.builtins.String.strike',
+		'javascript.builtins.String.sub',
+		'javascript.builtins.String.sup',
+	],
+	'no-string-prototype-substr': 'javascript.builtins.String.substr',
+	'no-string-prototype-trimleft-trimright': false, // No support data.
+
+	// Other legacy
+	'no-legacy-object-prototype-accessor-methods': [
+		'javascript.builtins.Object.defineGetter',
+		'javascript.builtins.Object.defineSetter',
+		'javascript.builtins.Object.lookupGetter',
+		'javascript.builtins.Object.lookupSetter',
 	],
 };

--- a/projects/js-packages/eslint-config-target-es/tests/configs.test.js
+++ b/projects/js-packages/eslint-config-target-es/tests/configs.test.js
@@ -37,9 +37,9 @@ function loadConfig( name ) {
 // The part of the config that doesn't vary.
 const template = {
 	env: {
-		es2021: true,
+		es2022: true,
 	},
-	plugins: [ 'es' ],
+	plugins: [ 'es-x' ],
 };
 
 // Configs and getRules options to test.

--- a/projects/js-packages/eslint-config-target-es/tests/funcs.test.js
+++ b/projects/js-packages/eslint-config-target-es/tests/funcs.test.js
@@ -17,60 +17,60 @@ describe( 'getRules', () => {
 		const rules = funcs.getRules( { query: 'ie 11' } );
 		expect( rules ).toMatchObject( {
 			// A small selection of rules to test against.
-			'es/no-array-from': 2,
-			'es/no-block-scoped-variables': 2,
-			'es/no-nullish-coalescing-operators': 2,
-			'es/no-promise-any': 2,
-			'es/no-regexp-unicode-property-escapes': 2,
-			'es/no-regexp-unicode-property-escapes-2019': 0,
-			'es/no-set': 0,
-			'es/no-symbol': 2,
-			'es/no-weak-map': 0,
+			'es-x/no-array-from': 2,
+			'es-x/no-block-scoped-variables': 2,
+			'es-x/no-nullish-coalescing-operators': 2,
+			'es-x/no-promise-any': 2,
+			'es-x/no-regexp-unicode-property-escapes': 2,
+			'es-x/no-regexp-unicode-property-escapes-2019': 0,
+			'es-x/no-set': 0,
+			'es-x/no-symbol': 2,
+			'es-x/no-weak-map': 0,
 		} );
 	} );
 
 	test( 'With FF 76', () => {
 		const rules = funcs.getRules( { query: 'ff 76' } );
 		expect( rules ).toMatchObject( {
-			'es/no-array-from': 0,
-			'es/no-block-scoped-variables': 0,
-			'es/no-nullish-coalescing-operators': 0,
-			'es/no-promise-any': 2,
-			'es/no-regexp-unicode-property-escapes': 2,
-			'es/no-regexp-unicode-property-escapes-2019': 0,
-			'es/no-set': 0,
-			'es/no-symbol': 0,
-			'es/no-weak-map': 0,
+			'es-x/no-array-from': 0,
+			'es-x/no-block-scoped-variables': 0,
+			'es-x/no-nullish-coalescing-operators': 0,
+			'es-x/no-promise-any': 2,
+			'es-x/no-regexp-unicode-property-escapes': 2,
+			'es-x/no-regexp-unicode-property-escapes-2019': 0,
+			'es-x/no-set': 0,
+			'es-x/no-symbol': 0,
+			'es-x/no-weak-map': 0,
 		} );
 	} );
 
 	test( 'With Chrome 79', () => {
 		const rules = funcs.getRules( { query: 'chrome 79' } );
 		expect( rules ).toMatchObject( {
-			'es/no-array-from': 0,
-			'es/no-block-scoped-variables': 0,
-			'es/no-nullish-coalescing-operators': 2,
-			'es/no-promise-any': 2,
-			'es/no-regexp-unicode-property-escapes': 0,
-			'es/no-regexp-unicode-property-escapes-2019': 0,
-			'es/no-set': 0,
-			'es/no-symbol': 0,
-			'es/no-weak-map': 0,
+			'es-x/no-array-from': 0,
+			'es-x/no-block-scoped-variables': 0,
+			'es-x/no-nullish-coalescing-operators': 2,
+			'es-x/no-promise-any': 2,
+			'es-x/no-regexp-unicode-property-escapes': 0,
+			'es-x/no-regexp-unicode-property-escapes-2019': 0,
+			'es-x/no-set': 0,
+			'es-x/no-symbol': 0,
+			'es-x/no-weak-map': 0,
 		} );
 	} );
 
 	test( 'With FF 76 and Chrome 79', () => {
 		const rules = funcs.getRules( { query: 'ff 76, chrome 79' } );
 		expect( rules ).toMatchObject( {
-			'es/no-array-from': 0,
-			'es/no-block-scoped-variables': 0,
-			'es/no-nullish-coalescing-operators': 2,
-			'es/no-promise-any': 2,
-			'es/no-regexp-unicode-property-escapes': 2,
-			'es/no-regexp-unicode-property-escapes-2019': 0,
-			'es/no-set': 0,
-			'es/no-symbol': 0,
-			'es/no-weak-map': 0,
+			'es-x/no-array-from': 0,
+			'es-x/no-block-scoped-variables': 0,
+			'es-x/no-nullish-coalescing-operators': 2,
+			'es-x/no-promise-any': 2,
+			'es-x/no-regexp-unicode-property-escapes': 2,
+			'es-x/no-regexp-unicode-property-escapes-2019': 0,
+			'es-x/no-set': 0,
+			'es-x/no-symbol': 0,
+			'es-x/no-weak-map': 0,
 		} );
 	} );
 
@@ -78,15 +78,15 @@ describe( 'getRules', () => {
 		const rules = funcs.getRules( { query: 'ie 11', builtins: true } );
 		expect( rules ).toMatchObject( {
 			// A small selection of rules to test against.
-			'es/no-array-from': 2,
-			'es/no-block-scoped-variables': 0,
-			'es/no-nullish-coalescing-operators': 0,
-			'es/no-promise-any': 2,
-			'es/no-regexp-unicode-property-escapes': 0,
-			'es/no-regexp-unicode-property-escapes-2019': 0,
-			'es/no-set': 0,
-			'es/no-symbol': 2,
-			'es/no-weak-map': 0,
+			'es-x/no-array-from': 2,
+			'es-x/no-block-scoped-variables': 0,
+			'es-x/no-nullish-coalescing-operators': 0,
+			'es-x/no-promise-any': 2,
+			'es-x/no-regexp-unicode-property-escapes': 0,
+			'es-x/no-regexp-unicode-property-escapes-2019': 0,
+			'es-x/no-set': 0,
+			'es-x/no-symbol': 2,
+			'es-x/no-weak-map': 0,
 		} );
 	} );
 
@@ -94,15 +94,15 @@ describe( 'getRules', () => {
 		const rules = funcs.getRules( { query: 'ie 11', builtins: false } );
 		expect( rules ).toMatchObject( {
 			// A small selection of rules to test against.
-			'es/no-array-from': 0,
-			'es/no-block-scoped-variables': 2,
-			'es/no-nullish-coalescing-operators': 2,
-			'es/no-promise-any': 0,
-			'es/no-regexp-unicode-property-escapes': 2,
-			'es/no-regexp-unicode-property-escapes-2019': 0,
-			'es/no-set': 0,
-			'es/no-symbol': 0,
-			'es/no-weak-map': 0,
+			'es-x/no-array-from': 0,
+			'es-x/no-block-scoped-variables': 2,
+			'es-x/no-nullish-coalescing-operators': 2,
+			'es-x/no-promise-any': 0,
+			'es-x/no-regexp-unicode-property-escapes': 2,
+			'es-x/no-regexp-unicode-property-escapes-2019': 0,
+			'es-x/no-set': 0,
+			'es-x/no-symbol': 0,
+			'es-x/no-weak-map': 0,
 		} );
 	} );
 } );

--- a/projects/js-packages/eslint-config-target-es/tests/rulesMap.test.js
+++ b/projects/js-packages/eslint-config-target-es/tests/rulesMap.test.js
@@ -1,5 +1,5 @@
 const mdn = require( '@mdn/browser-compat-data' );
-const { rules: esRules } = require( 'eslint-plugin-es' );
+const { rules: esRules } = require( 'eslint-plugin-es-x' );
 const rulesMap = require( '../src/rulesMap.js' );
 
 expect.extend( {

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -30,7 +30,7 @@
 		"eslint": "8.39.0",
 		"eslint-config-prettier": "8.8.0",
 		"eslint-import-resolver-exports": "1.0.0-beta.5",
-		"eslint-plugin-es": "4.1.0",
+		"eslint-plugin-es-x": "7.1.0",
 		"eslint-plugin-import": "2.27.5",
 		"eslint-plugin-inclusive-language": "2.2.0",
 		"eslint-plugin-jest": "27.2.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It appears that [eslint-plugin-es](https://www.npmjs.com/package/eslint-plugin-es) has been abandoned. A fork at [eslint-plugin-es-x](https://www.npmjs.com/package/eslint-plugin-es-x) is currently maintained, and has a bunch of updates. Let's use it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* If CI is happy, we should be good.
