### PR TITLE
AI Extension: Do not extend core blocks when AI Assistant block is hidden

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-only-extend-when-ai-assistant-is-visible
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-only-extend-when-ai-assistant-is-visible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: Do not extend core blocks when the user decided to hide the AI Assistant block.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { getBlockType } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 import { addFilter } from '@wordpress/hooks';
 /*
  * Internal dependencies
@@ -62,6 +64,13 @@ export function isPossibleToExtendBlock(): boolean {
 
 	// Do not extend if there is an error getting the feature.
 	if ( AI_Assistant_Initial_State.errorCode ) {
+		return false;
+	}
+
+	// Do not extend if the AI Assistant block is hidden
+	const { getHiddenBlockTypes } = select( editPostStore );
+	const hiddenBlocks = getHiddenBlockTypes();
+	if ( hiddenBlocks.includes( blockName ) ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -79,12 +79,12 @@ function addJetpackAISupport(
 	settings: BlockSettingsProps,
 	name: ExtendedBlock
 ): BlockSettingsProps {
-	if ( ! isPossibleToExtendBlock() ) {
+	// Only extend the blocks in the list.
+	if ( ! EXTENDED_BLOCKS.includes( name ) ) {
 		return settings;
 	}
 
-	// Only extend the blocks in the list.
-	if ( ! EXTENDED_BLOCKS.includes( name ) ) {
+	if ( ! isPossibleToExtendBlock() ) {
 		return settings;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31554.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refactor the extensibility logic to only verify extensibility when the target block is of interest (is on `EXTENDED_BLOCKS` list)
* Add check for AI Assistant visibility to decide if we should extend core blocks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add a paragraph of content
* Confirm that the AI Extension is showed on the paragraph block:

<img width="667" alt="Screen Shot 2023-06-23 at 16 44 39" src="https://github.com/Automattic/jetpack/assets/6760046/5b316137-3857-4fd4-9f80-63bfcf26f718">

* Open the editor preferences by clicking on the `three-dots menu > Preferences`:

<img width="312" alt="Screen Shot 2023-06-23 at 16 46 23" src="https://github.com/Automattic/jetpack/assets/6760046/29e948d7-26d1-4cc1-b6c0-dc666c97364f">

* Hide the AI Assistant block by clicking `Blocks` and unchecking the AI Assistant block:

<img width="774" alt="Screen Shot 2023-06-23 at 16 47 03" src="https://github.com/Automattic/jetpack/assets/6760046/7f0ebfe0-bde3-4d00-b293-a6795761ee6f">

* Close the `Preferences` window and reload the editor
* Go to the paragraph block that you checked before and confirm that the AI Extension icon is gone:

<img width="658" alt="Screen Shot 2023-06-23 at 16 48 52" src="https://github.com/Automattic/jetpack/assets/6760046/67c4ad64-ce14-45f1-8df8-809bf3bee592">

* Change the AI Assistant block back to visible again, refresh the editor and check that now the AI Extension icon is back:

<img width="674" alt="Screen Shot 2023-06-23 at 16 49 23" src="https://github.com/Automattic/jetpack/assets/6760046/9ead1f31-312d-4fd6-a0f0-594fb9b35541">

* Test on Jetpack and Simple sites