### PR TITLE
Launchpad: Add options to jp sync

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-options-jp-sync
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-options-jp-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adding site_intent and launchpad_checklist_tasks_statuses to JP Sync.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -599,3 +599,27 @@ function wpcom_launchpad_keep_building_visible_tasks( $task_list ) {
 if ( class_exists( 'WPCOM_Launchpad' ) ) {
 	remove_action( 'plugins_loaded', array( WPCOM_Launchpad::get_instance(), 'init' ) );
 }
+
+/**
+ * Add launchpad options to Jetpack Sync.
+ *
+ * @param array $allowed_options The allowed options.
+ */
+function test_add_launchpad_options_to_jetpack_sync( $allowed_options ) {
+	// Bail if not on an Atomic site
+	if ( ! jetpack_is_atomic_site() ) {
+		return $allowed_options;
+	}
+
+	if ( ! is_array( $allowed_options ) ) {
+		return $allowed_options;
+	}
+
+	$launchpad_options = array(
+		'site_intent',
+		'launchpad_checklist_tasks_statuses',
+	);
+
+	return array_merge( $allowed_options, $launchpad_options );
+}
+add_filter( 'jetpack_sync_options_whitelist', 'test_add_launchpad_options_to_jetpack_sync', 10, 1 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -605,7 +605,7 @@ if ( class_exists( 'WPCOM_Launchpad' ) ) {
  *
  * @param array $allowed_options The allowed options.
  */
-function test_add_launchpad_options_to_jetpack_sync( $allowed_options ) {
+function add_launchpad_options_to_jetpack_sync( $allowed_options ) {
 	// Bail if not on an Atomic site
 	if ( ! jetpack_is_atomic_site() ) {
 		return $allowed_options;
@@ -622,4 +622,4 @@ function test_add_launchpad_options_to_jetpack_sync( $allowed_options ) {
 
 	return array_merge( $allowed_options, $launchpad_options );
 }
-add_filter( 'jetpack_sync_options_whitelist', 'test_add_launchpad_options_to_jetpack_sync', 10, 1 );
+add_filter( 'jetpack_sync_options_whitelist', 'add_launchpad_options_to_jetpack_sync', 10, 1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds options to Jetpack Sync that are required for Launchpad to function correctly. This options are: `site_intent` and `launchpad_checklist_tasks_statuses`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start by setting up a WoA dev blog
* Apply this PR on your WoA site. Not really sure what's the best way to do this, copying and pasting the code might be enough since it's a simple change.
* In one terminal window, open up an SSH session to your WPCOM sandbox
* In another terminal window, SSH to your test Atomic site - this should work using `ssh wpcomsubdomain.wordpress.com@sftp.wp.com`
* On your Atomic dev site, run the following commands to delete and then re-add the relevant options:
  - `wp option delete site_intent launchpad_checklist_tasks_statuses`
  - `wp option add site_intent 'build'`
  - `wp option add launchpad_checklist_tasks_statuses --format=json '{"test":true}'`
* Now go to the site in this comment and look for your site id: p1687789079246689/1687552631.470649-slack-C0Q664T29
* Filter for the `site_intent` and the `launchpad_checklist_tasks_statuses` options and you should see the correct values in the `shadow site` column
 - ![image](https://github.com/Automattic/jetpack/assets/375980/36af4677-db8e-42e6-ab9a-55bf27f3a31f)
 - ![image](https://github.com/Automattic/jetpack/assets/375980/4e51d42c-ee34-4729-b585-bffa216ca69c)

