### PR TITLE
AI Extension: disable the AI toolbar button when the block doesn't have content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-disable-when-no-content
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-disable-when-no-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: disable the AI toolbar button when the block doesn't have content

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -108,6 +108,11 @@ type AiAssistantControlComponentProps = {
 	 */
 	requestingState?: RequestingStateProp;
 
+	/*
+	 * Whether the dropdown is disabled.
+	 */
+	disabled?: boolean;
+
 	onChange: ( item: PromptTypeProp, options?: AiAssistantDropdownOnChangeOptionsArgProps ) => void;
 };
 
@@ -117,6 +122,7 @@ export default function AiAssistantDropdown( {
 	exclude = [],
 	requestingState,
 	onChange,
+	disabled,
 }: AiAssistantControlComponentProps ) {
 	const quickActionsListFiltered = quickActionsList.filter(
 		quickAction => ! exclude.includes( quickAction.key )
@@ -139,6 +145,7 @@ export default function AiAssistantDropdown( {
 						aria-expanded={ isOpen }
 						label={ label || __( 'AI Assistant', 'jetpack' ) }
 						icon={ aiAssistant }
+						disabled={ disabled }
 					/>
 				);
 			} }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -16,7 +16,10 @@ import AiAssistantDropdown, {
 } from '../../components/ai-assistant-controls';
 import useSuggestionsFromAI, { SuggestionError } from '../../hooks/use-suggestions-from-ai';
 import { getPrompt } from '../../lib/prompt';
-import { getTextContentFromSelectedBlocks } from '../../lib/utils/block-content';
+import {
+	getRawTextFromHTML,
+	getTextContentFromSelectedBlocks,
+} from '../../lib/utils/block-content';
 /*
  * Types
  */
@@ -112,10 +115,10 @@ export const withAIAssistant = createHigherOrderComponent(
 			autoRequest: false,
 		} );
 
+		const { content, clientIds } = getTextContentFromSelectedBlocks();
+
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				const { content, clientIds } = getTextContentFromSelectedBlocks();
-
 				/*
 				 * Store the selected clientIds when the user requests a suggestion.
 				 * The client Ids will be used to update the content of the block,
@@ -138,15 +141,21 @@ export const withAIAssistant = createHigherOrderComponent(
 					return freshPrompt;
 				} );
 			},
-			[ request ]
+			[ clientIds, content, request ]
 		);
+
+		const rawContent = getRawTextFromHTML( props.attributes.content );
 
 		return (
 			<>
 				<BlockEdit { ...props } />
 
 				<BlockControls group="block">
-					<AiAssistantDropdown onChange={ requestSuggestion } requestingState={ requestingState } />
+					<AiAssistantDropdown
+						onChange={ requestSuggestion }
+						requestingState={ requestingState }
+						disabled={ ! rawContent?.length }
+					/>
 				</BlockControls>
 			</>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -16,7 +16,7 @@ import AiAssistantDropdown, {
 } from '../../components/ai-assistant-controls';
 import useSuggestionsFromAI, { SuggestionError } from '../../hooks/use-suggestions-from-ai';
 import { getPrompt } from '../../lib/prompt';
-import { getTextContentFromBlocks } from '../../lib/utils/block-content';
+import { getTextContentFromSelectedBlocks } from '../../lib/utils/block-content';
 /*
  * Types
  */
@@ -114,7 +114,7 @@ export const withAIAssistant = createHigherOrderComponent(
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				const { content, clientIds } = getTextContentFromBlocks();
+				const { content, clientIds } = getTextContentFromSelectedBlocks();
 
 				/*
 				 * Store the selected clientIds when the user requests a suggestion.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
@@ -84,8 +84,8 @@ export function getTextContentFromSelectedBlocks(): GetTextContentFromBlocksProp
 		count: blocks.length,
 		clientIds,
 		content: blocks
-			.map( block => getBlockTextContent( block.clientId ) )
-			.join( HTML_JOIN_CHARACTERS ),
+			? blocks.map( block => getBlockTextContent( block.clientId ) ).join( HTML_JOIN_CHARACTERS )
+			: '',
 	};
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
@@ -122,3 +122,19 @@ export function getBlockTextContent( clientId: string ): string {
 
 	return getBlockContent( block );
 }
+
+/**
+ * Extract raw text from HTML content
+ *
+ * @param {string} htmlString - The HTML content.
+ * @returns {string}            The raw text.
+ */
+export function getRawTextFromHTML( htmlString: string ): string {
+	if ( ! htmlString?.length ) {
+		return '';
+	}
+
+	const tempDomContainer = document.createElement( 'div' );
+	tempDomContainer.innerHTML = htmlString;
+	return tempDomContainer.textContent || tempDomContainer.innerText || '';
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
@@ -62,7 +62,8 @@ type GetTextContentFromBlocksProps = {
  *
  * @returns {GetTextContentFromBlocksProps} The text content.
  */
-export function getTextContentFromBlocks(): GetTextContentFromBlocksProps {
+
+export function getTextContentFromSelectedBlocks(): GetTextContentFromBlocksProps {
 	const clientIds = select( 'core/block-editor' ).getSelectedBlockClientIds();
 	const defaultContent = {
 		count: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/31553

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: disable the AI toolbar button when the block doesn't have content

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a heading block instance
* Confirm you see the AI Assistant button in the toolbar **disabled** 
* Once the block has content, the button gets enabled

<img width="497" alt="Screenshot 2023-06-23 at 16 48 07" src="https://github.com/Automattic/jetpack/assets/77539/5221b51f-58ae-48f8-bfae-187850af430e">
