### PR TITLE
AI Assistant: Fix empty content on P2

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-p2-content
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-p2-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Fix empty content on P2

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { getBlockContent } from '@wordpress/blocks';
 import { serialize } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
@@ -64,7 +63,7 @@ type GetTextContentFromBlocksProps = {
  * @returns {GetTextContentFromBlocksProps} The text content.
  */
 export function getTextContentFromBlocks(): GetTextContentFromBlocksProps {
-	const clientIds = select( blockEditorStore ).getSelectedBlockClientIds();
+	const clientIds = select( 'core/block-editor' ).getSelectedBlockClientIds();
 	const defaultContent = {
 		count: 0,
 		clientIds: [],
@@ -75,7 +74,7 @@ export function getTextContentFromBlocks(): GetTextContentFromBlocksProps {
 		return defaultContent;
 	}
 
-	const blocks = select( blockEditorStore ).getBlocksByClientId( clientIds );
+	const blocks = select( 'core/block-editor' ).getBlocksByClientId( clientIds );
 	if ( ! blocks?.length ) {
 		return defaultContent;
 	}
@@ -104,7 +103,7 @@ export function getBlockTextContent( clientId: string ): string {
 		return '';
 	}
 
-	const editor = select( blockEditorStore );
+	const editor = select( 'core/block-editor' );
 	const block = editor.getBlock( clientId );
 
 	/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31555
Depends on #31563

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes the `'core/block-editor'` constant to a string. It seems that P2 does not load correctly using the import

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test locally
* build and `rsync` the changes to your sandbox
* Sandbox a P2 site
* In a post or comment, use the extension
* Check that the content is sent
