### PR TITLE
AI Extension: extend the block when the edit post store is undefined (P2)

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-handle-hidden-in-p2
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-handle-hidden-in-p2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Extension: extend the block when the edit post store is undefined (P2)

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -67,9 +67,13 @@ export function isPossibleToExtendBlock(): boolean {
 		return false;
 	}
 
-	// Do not extend if the AI Assistant block is hidden
-	const { getHiddenBlockTypes } = select( editPostStore );
-	const hiddenBlocks = getHiddenBlockTypes();
+	/*
+	 * Do not extend if the AI Assistant block is hidden
+	 * ToDo: the `editPostStore` is undefined for P2 sites.
+	 * Let's find a way to check if the block is hidden.
+	 */
+	const { getHiddenBlockTypes } = select( editPostStore ) || {};
+	const hiddenBlocks = getHiddenBlockTypes?.() || []; // It will extend the block if the function is undefined.
 	if ( hiddenBlocks.includes( blockName ) ) {
 		return false;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -3,7 +3,6 @@
  */
 import { getBlockType } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { store as editPostStore } from '@wordpress/edit-post';
 import { addFilter } from '@wordpress/hooks';
 /*
  * Internal dependencies
@@ -72,7 +71,7 @@ export function isPossibleToExtendBlock(): boolean {
 	 * ToDo: the `editPostStore` is undefined for P2 sites.
 	 * Let's find a way to check if the block is hidden.
 	 */
-	const { getHiddenBlockTypes } = select( editPostStore ) || {};
+	const { getHiddenBlockTypes } = select( 'core/edit-post' ) || {};
 	const hiddenBlocks = getHiddenBlockTypes?.() || []; // It will extend the block if the function is undefined.
 	if ( hiddenBlocks.includes( blockName ) ) {
 		return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The edit post store is not defined in P2 sites. We can't rely on it to check if there are hidden blocks. This PR checks if the store and the function to detect hidden blocks are defined. If so, it relies on it. Otherwise, the app won't check the hidden blocks. Follow-up PR to handle this for P2 sites is coming on.
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: extend the block when the edit post store is undefined (P2)

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a Simple site
* Confirm the AI Extension depends on the AI block availability
* Confirm the extension is visible for P2 sites

