### PR TITLE
Email Preview add tracks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-email-preview-tracks
+++ b/projects/plugins/jetpack/changelog/update-email-preview-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add tracks to email preview feature

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -1,4 +1,5 @@
 import { useBreakpointMatch } from '@automattic/jetpack-components';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
@@ -23,8 +24,13 @@ export default function EmailPreview( { isModalOpen, closeModal } ) {
 	const [ errorMessage, setErrorMessage ] = useState( false );
 	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId() );
 	const [ isSmall ] = useBreakpointMatch( 'sm' );
+	const { tracks } = useAnalytics();
 
 	const sendEmailPreview = () => {
+		tracks.recordEvent( 'jetpack_send_email_preview', {
+			post_id: postId,
+		} );
+
 		setEmailSending( true );
 		apiFetch( {
 			path: '/wpcom/v2/send-email-preview/',

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -308,6 +308,7 @@ export default function SubscribePanels() {
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const [ postMeta = [], setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const { tracks } = useAnalytics();
 
 	// Set the accessLevel to "everybody" when one is not defined
 	let accessLevel =
@@ -371,7 +372,10 @@ export default function SubscribePanels() {
 				paidSubscribers={ paidSubscribers }
 				isModuleActive={ isModuleActive }
 				showMisconfigurationWarning={ showMisconfigurationWarning }
-				showPreviewModal={ () => setIsModalOpen( true ) }
+				showPreviewModal={ () => {
+					tracks.recordEvent( 'jetpack_send_email_preview_prepublish_preview_button' );
+					setIsModalOpen( true );
+				} }
 			/>
 			<NewsletterPostPublishSettingsPanel
 				accessLevel={ accessLevel }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds tracking events in order to measure adoption of this new feature.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p2-peKye1-6z

## Does this pull request change what data or activity we track or use?
* Adds a track event for when users open the Modal to send preview emails and another track event for when they click on the send button.

## Testing instructions:

* Create a new Draft.
* In the PrePublish Panel click on Preview in the Newsletter Panel.
* Click "Send" in the modal.
* Make sure the events are recoded.

