### PR TITLE
AI Extension: add ask to assistant menu option

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-add-ask-ai-assistant
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-add-ask-ai-assistant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: add ask to assistant menu option

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -46,6 +46,9 @@ const QUICK_EDIT_KEY_SUMMARIZE = 'summarize' as const;
 // Quick edits option: "Make longer"
 const QUICK_EDIT_KEY_MAKE_LONGER = 'make-longer' as const;
 
+// Ask AI Assistant option
+export const KEY_ASK_AI_ASSISTANT = 'ask-ai-assistant' as const;
+
 const QUICK_EDIT_KEY_LIST = [
 	QUICK_EDIT_KEY_CORRECT_SPELLING,
 	QUICK_EDIT_KEY_SIMPLIFY,
@@ -53,7 +56,7 @@ const QUICK_EDIT_KEY_LIST = [
 	QUICK_EDIT_KEY_MAKE_LONGER,
 ] as const;
 
-type QuickEditsKeyProp = ( typeof QUICK_EDIT_KEY_LIST )[ number ];
+type AiAssistantKeyProp = ( typeof QUICK_EDIT_KEY_LIST )[ number ] | typeof KEY_ASK_AI_ASSISTANT;
 
 const quickActionsList = [
 	{
@@ -91,7 +94,7 @@ type AiAssistantControlComponentProps = {
 	/*
 	 * Can be used to externally control the value of the control. Optional.
 	 */
-	key?: QuickEditsKeyProp | string;
+	key?: AiAssistantKeyProp | string;
 
 	/*
 	 * The label to use for the dropdown. Optional.
@@ -101,7 +104,7 @@ type AiAssistantControlComponentProps = {
 	/*
 	 * A list of quick edits to exclude from the dropdown.
 	 */
-	exclude?: QuickEditsKeyProp[];
+	exclude?: AiAssistantKeyProp[];
 
 	/*
 	 * Whether the dropdown is requesting suggestions from AI.
@@ -154,17 +157,19 @@ export default function AiAssistantDropdown( {
 			} }
 			renderContent={ ( { onClose: closeDropdown } ) => (
 				<MenuGroup label={ label }>
-					<MenuItem
-						icon={ aiAssistant }
-						iconPosition="left"
-						key="key-ai-assistant"
-						onClick={ onReplace }
-						isSelected={ key === 'key-ai-assistant' }
-					>
-						<div className="jetpack-ai-assistant__menu-item">
-							{ __( 'Ask AI Assistant', 'jetpack' ) }
-						</div>
-					</MenuItem>
+					{ ! exclude.includes( KEY_ASK_AI_ASSISTANT ) && (
+						<MenuItem
+							icon={ aiAssistant }
+							iconPosition="left"
+							key="key-ai-assistant"
+							onClick={ onReplace }
+							isSelected={ key === 'key-ai-assistant' }
+						>
+							<div className="jetpack-ai-assistant__menu-item">
+								{ __( 'Ask AI Assistant', 'jetpack' ) }
+							</div>
+						</MenuItem>
+					) }
 
 					{ quickActionsListFiltered.map( quickAction => (
 						<MenuItem

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -114,6 +114,8 @@ type AiAssistantControlComponentProps = {
 	disabled?: boolean;
 
 	onChange: ( item: PromptTypeProp, options?: AiAssistantDropdownOnChangeOptionsArgProps ) => void;
+
+	onReplace: () => void;
 };
 
 export default function AiAssistantDropdown( {
@@ -121,8 +123,9 @@ export default function AiAssistantDropdown( {
 	label,
 	exclude = [],
 	requestingState,
-	onChange,
 	disabled,
+	onChange,
+	onReplace,
 }: AiAssistantControlComponentProps ) {
 	const quickActionsListFiltered = quickActionsList.filter(
 		quickAction => ! exclude.includes( quickAction.key )
@@ -151,6 +154,18 @@ export default function AiAssistantDropdown( {
 			} }
 			renderContent={ ( { onClose: closeDropdown } ) => (
 				<MenuGroup label={ label }>
+					<MenuItem
+						icon={ aiAssistant }
+						iconPosition="left"
+						key="key-ai-assistant"
+						onClick={ onReplace }
+						isSelected={ key === 'key-ai-assistant' }
+					>
+						<div className="jetpack-ai-assistant__menu-item">
+							{ __( 'Ask AI Assistant', 'jetpack' ) }
+						</div>
+					</MenuItem>
+
 					{ quickActionsListFiltered.map( quickAction => (
 						<MenuItem
 							icon={ quickAction?.icon }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -3,6 +3,7 @@
  */
 import { BlockControls } from '@wordpress/block-editor';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState, useRef } from '@wordpress/element';
@@ -43,6 +44,7 @@ export const withAIAssistant = createHigherOrderComponent(
 
 		const { updateBlockAttributes, removeBlocks } = useDispatch( blockEditorStore );
 		const { createNotice } = useDispatch( noticesStore );
+		const { replaceBlock } = useDispatch( blockEditorStore );
 
 		const showSuggestionError = useCallback(
 			( suggestionError: SuggestionError ) => {
@@ -144,6 +146,18 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ clientIds, content, request ]
 		);
 
+		const replaceWithAiAssistantBlock = useCallback( () => {
+			// Create a new AI Assistant block instance.
+			const aiAssistantBlock = createBlock( 'jetpack/ai-assistant', {
+				content,
+			} );
+
+			/*
+			 * Replace the current block with a new AI Assistant block instance.
+			 */
+			replaceBlock( props.clientId, aiAssistantBlock );
+		}, [ content, replaceBlock, props.clientId ] );
+
 		const rawContent = getRawTextFromHTML( props.attributes.content );
 
 		return (
@@ -152,9 +166,10 @@ export const withAIAssistant = createHigherOrderComponent(
 
 				<BlockControls group="block">
 					<AiAssistantDropdown
-						onChange={ requestSuggestion }
 						requestingState={ requestingState }
 						disabled={ ! rawContent?.length }
+						onChange={ requestSuggestion }
+						onReplace={ replaceWithAiAssistantBlock }
 					/>
 				</BlockControls>
 			</>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -45,9 +45,8 @@ export const withAIAssistant = createHigherOrderComponent(
 
 		const { name: blockType } = props;
 
-		const { updateBlockAttributes, removeBlocks } = useDispatch( blockEditorStore );
+		const { updateBlockAttributes, removeBlocks, replaceBlock } = useDispatch( blockEditorStore );
 		const { createNotice } = useDispatch( noticesStore );
-		const { replaceBlock } = useDispatch( blockEditorStore );
 
 		/*
 		 * Set exclude dropdown options.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -13,6 +13,7 @@ import React from 'react';
  */
 import AiAssistantDropdown, {
 	AiAssistantDropdownOnChangeOptionsArgProps,
+	KEY_ASK_AI_ASSISTANT,
 } from '../../components/ai-assistant-controls';
 import useSuggestionsFromAI, { SuggestionError } from '../../hooks/use-suggestions-from-ai';
 import { getPrompt } from '../../lib/prompt';
@@ -47,6 +48,15 @@ export const withAIAssistant = createHigherOrderComponent(
 		const { updateBlockAttributes, removeBlocks } = useDispatch( blockEditorStore );
 		const { createNotice } = useDispatch( noticesStore );
 		const { replaceBlock } = useDispatch( blockEditorStore );
+
+		/*
+		 * Set exclude dropdown options.
+		 * - Exclude "Ask AI Assistant" for core/list-item block.
+		 */
+		const exclude = [];
+		if ( blockType === 'core/list-item' ) {
+			exclude.push( KEY_ASK_AI_ASSISTANT );
+		}
 
 		const showSuggestionError = useCallback(
 			( suggestionError: SuggestionError ) => {
@@ -164,6 +174,7 @@ export const withAIAssistant = createHigherOrderComponent(
 						disabled={ ! rawContent?.length }
 						onChange={ requestSuggestion }
 						onReplace={ replaceWithAiAssistantBlock }
+						exclude={ exclude }
 					/>
 				</BlockControls>
 			</>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -3,7 +3,6 @@
  */
 import { BlockControls } from '@wordpress/block-editor';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState, useRef } from '@wordpress/element';
@@ -24,6 +23,7 @@ import {
 /*
  * Types
  */
+import { transfromToAIAssistantBlock } from '../../transforms';
 import type { PromptItemProps, PromptTypeProp } from '../../lib/prompt';
 
 type StoredPromptProps = {
@@ -41,6 +41,8 @@ export const withAIAssistant = createHigherOrderComponent(
 		} );
 
 		const clientIdsRef = useRef< Array< string > >();
+
+		const { name: blockType } = props;
 
 		const { updateBlockAttributes, removeBlocks } = useDispatch( blockEditorStore );
 		const { createNotice } = useDispatch( noticesStore );
@@ -147,16 +149,8 @@ export const withAIAssistant = createHigherOrderComponent(
 		);
 
 		const replaceWithAiAssistantBlock = useCallback( () => {
-			// Create a new AI Assistant block instance.
-			const aiAssistantBlock = createBlock( 'jetpack/ai-assistant', {
-				content,
-			} );
-
-			/*
-			 * Replace the current block with a new AI Assistant block instance.
-			 */
-			replaceBlock( props.clientId, aiAssistantBlock );
-		}, [ content, replaceBlock, props.clientId ] );
+			replaceBlock( props.clientId, transfromToAIAssistantBlock( { content, blockType } ) );
+		}, [ blockType, content, props.clientId, replaceBlock ] );
 
 		const rawContent = getRawTextFromHTML( props.attributes.content );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -17,6 +17,29 @@ const turndownService = new TurndownService( { emDelimiter: '_' } );
 
 const from = [];
 
+export function transfromToAIAssistantBlock( { content, blockType } ) {
+	// Create a temporary block to get the HTML content.
+	const temporaryBlock = createBlock( blockType, { content } );
+	const htmlContent = getBlockContent( temporaryBlock );
+
+	// Convert the content to markdown.
+	content = turndownService.turndown( htmlContent );
+
+	// Create a pair of user/assistant messages.
+	const messages: Array< PromptItemProps > = [
+		{
+			role: 'user',
+			content: 'Tell me some content for this block, please.',
+		},
+		{
+			role: 'assistant',
+			content,
+		},
+	];
+
+	return createBlock( blockName, { content, messages } );
+}
+
 /*
  * Create individual transform handler for each block type.
  */
@@ -25,28 +48,7 @@ for ( const blockType of EXTENDED_BLOCKS ) {
 		type: 'block',
 		blocks: [ blockType ],
 		isMatch: () => isPossibleToExtendBlock(),
-		transform: ( { content } ) => {
-			// Create a temporary block to get the HTML content.
-			const temporaryBlock = createBlock( blockType, { content } );
-			const htmlContent = getBlockContent( temporaryBlock );
-
-			// Convert the content to markdown.
-			content = turndownService.turndown( htmlContent );
-
-			// Create a pair of user/assistant messages.
-			const messages: Array< PromptItemProps > = [
-				{
-					role: 'user',
-					content: 'Tell me some content for this block, please.',
-				},
-				{
-					role: 'assistant',
-					content,
-				},
-			];
-
-			return createBlock( blockName, { content, messages } );
-		},
+		transform: ( { content } ) => transfromToAIAssistantBlock( { content, blockType } ),
 	} );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the `Ask AI Assistant` option to the Paragraph and Heading block instance. It is a shorthand to transform to the AI Assistant block.
The list item block doesn't support the block transform. This is why we've removed the notion for this block type.

Fixes https://github.com/Automattic/jetpack/issues/31564

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: add ask to assistant menu option

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Paragraph or Heading block
* Confirm there is a new "Ask AI Assistant" option
* Confirm it transforms the block to an AI Assistant block instance

<img width="473" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/86f435da-a7bc-40b7-91d1-84253da29905">

* Create a list blocks composition
* Confirm the `Ask AI Assistant` option is not available for this block

<img width="574" alt="Screenshot 2023-06-26 at 08 19 46" src="https://github.com/Automattic/jetpack/assets/77539/f3bec96d-46aa-4068-8bef-1862e7ade2ff">



