### PR TITLE
AI Extension: improve block transform process for Heading core block type

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-improve-heading-transform
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-improve-heading-transform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: improve block transform process for Heading core block type

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -19,7 +19,7 @@ export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
 // List of blocks that can be extended.
 export const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading', 'core/list-item' ] as const;
 
-type ExtendedBlock = ( typeof EXTENDED_BLOCKS )[ number ];
+export type ExtendedBlockProp = ( typeof EXTENDED_BLOCKS )[ number ];
 
 type BlockSettingsProps = {
 	supports: {
@@ -84,12 +84,12 @@ export function isPossibleToExtendBlock(): boolean {
  * Add jetpack/ai support to the extended blocks.
  *
  * @param {BlockSettingsProps} settings - Block settings.
- * @param {ExtendedBlock} name          - Block name.
+ * @param {ExtendedBlockProp} name          - Block name.
  * @returns {BlockSettingsProps}          Block settings.
  */
 function addJetpackAISupport(
 	settings: BlockSettingsProps,
-	name: ExtendedBlock
+	name: ExtendedBlockProp
 ): BlockSettingsProps {
 	// Only extend the blocks in the list.
 	if ( ! EXTENDED_BLOCKS.includes( name ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -21,10 +21,10 @@ import {
 	getRawTextFromHTML,
 	getTextContentFromSelectedBlocks,
 } from '../../lib/utils/block-content';
+import { transfromToAIAssistantBlock } from '../../transforms';
 /*
  * Types
  */
-import { transfromToAIAssistantBlock } from '../../transforms';
 import type { PromptItemProps, PromptTypeProp } from '../../lib/prompt';
 
 type StoredPromptProps = {
@@ -158,7 +158,7 @@ export const withAIAssistant = createHigherOrderComponent(
 		);
 
 		const replaceWithAiAssistantBlock = useCallback( () => {
-			replaceBlock( props.clientId, transfromToAIAssistantBlock( { content, blockType } ) );
+			replaceBlock( props.clientId, transfromToAIAssistantBlock( { content }, blockType ) );
 		}, [ blockType, content, props.clientId, replaceBlock ] );
 
 		const rawContent = getRawTextFromHTML( props.attributes.content );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -13,17 +13,24 @@ import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assis
  */
 import { PromptItemProps } from '../lib/prompt';
 
-const turndownService = new TurndownService( { emDelimiter: '_' } );
+const turndownService = new TurndownService( { emDelimiter: '_', headingStyle: 'atx' } );
 
 const from = [];
 
-export function transfromToAIAssistantBlock( { content, blockType } ) {
+export function transfromToAIAssistantBlock( attrs ) {
+	const { blockType, content } = attrs;
 	// Create a temporary block to get the HTML content.
 	const temporaryBlock = createBlock( blockType, { content } );
-	const htmlContent = getBlockContent( temporaryBlock );
+	let htmlContent = getBlockContent( temporaryBlock );
+
+	// core/heading custom transform handling.
+	if ( blockType === 'core/heading' && attrs?.level ) {
+		// Replace the HTML tags with the block level.
+		htmlContent = htmlContent.replace( /<(\/?)h\d([^>]*)>/g, `<$1h${ attrs.level }$2>` );
+	}
 
 	// Convert the content to markdown.
-	content = turndownService.turndown( htmlContent );
+	const aiAssistantBlockcontent = turndownService.turndown( htmlContent );
 
 	// Create a pair of user/assistant messages.
 	const messages: Array< PromptItemProps > = [
@@ -37,7 +44,7 @@ export function transfromToAIAssistantBlock( { content, blockType } ) {
 		},
 	];
 
-	return createBlock( blockName, { content, messages } );
+	return createBlock( blockName, { content: aiAssistantBlockcontent, messages } );
 }
 
 /*
@@ -48,7 +55,7 @@ for ( const blockType of EXTENDED_BLOCKS ) {
 		type: 'block',
 		blocks: [ blockType ],
 		isMatch: () => isPossibleToExtendBlock(),
-		transform: ( { content } ) => transfromToAIAssistantBlock( { content, blockType } ),
+		transform: attrs => transfromToAIAssistantBlock( { ...attrs, blockType } ),
 	} );
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -7,7 +7,11 @@ import TurndownService from 'turndown';
  * Internal dependencies
  */
 import { blockName } from '..';
-import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assistant';
+import {
+	EXTENDED_BLOCKS,
+	ExtendedBlockProp,
+	isPossibleToExtendBlock,
+} from '../extensions/ai-assistant';
 /**
  * Types
  */
@@ -17,8 +21,15 @@ const turndownService = new TurndownService( { emDelimiter: '_', headingStyle: '
 
 const from = [];
 
-export function transfromToAIAssistantBlock( attrs ) {
-	const { blockType, content } = attrs;
+/**
+ * Return an AI Assistant block instance from a given block type.
+ *
+ * @param {object} attrs                - Block attributes.
+ * @param {ExtendedBlockProp} blockType - Block type.
+ * @returns {object}                      AI Assistant block instance.
+ */
+export function transfromToAIAssistantBlock( attrs, blockType: ExtendedBlockProp ) {
+	const { content } = attrs;
 	// Create a temporary block to get the HTML content.
 	const temporaryBlock = createBlock( blockType, { content } );
 	let htmlContent = getBlockContent( temporaryBlock );
@@ -55,7 +66,7 @@ for ( const blockType of EXTENDED_BLOCKS ) {
 		type: 'block',
 		blocks: [ blockType ],
 		isMatch: () => isPossibleToExtendBlock(),
-		transform: attrs => transfromToAIAssistantBlock( { ...attrs, blockType } ),
+		transform: attrs => transfromToAIAssistantBlock( attrs, blockType ),
 	} );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR improves the process of block transformation from Heading blocks (`core/heading`) to AI Assistant blocks: 

* Get the heading level from block attribute
* Update the `transfromToAIAssistantBlock()` API function to decouple block type from block attributes.

Fixes https://github.com/Automattic/jetpack/issues/31570

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: improve block transform process for Heading core block type

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create Heading block instances using different levels
* Confirm the block transform to AI Assistant block respecting the level

H3 instance | before | after
-------|-------|-------
<img width="577" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/2b9403df-9797-4636-9863-231d95dd8bc4"> | <img width="625" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/b50da30e-cbec-4096-8859-dac7ef658dce"> | <img width="625" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/e10719c7-b44c-4b57-b248-38d819f0ef9e">



