### PR TITLE
Tock Block: avoid PHP warning when restaurant name isn't set yet

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tock-warning
+++ b/projects/plugins/jetpack/changelog/fix-tock-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tock Block: avoid PHP warning when restaurant name isn't set.

--- a/projects/plugins/jetpack/extensions/blocks/tock/tock.php
+++ b/projects/plugins/jetpack/extensions/blocks/tock/tock.php
@@ -40,7 +40,7 @@ function render_block( $attr ) {
 			return;
 		}
 
-		$content .= Jetpack_Gutenberg::notice(
+		return Jetpack_Gutenberg::notice(
 			__( 'The block will not be shown to your site visitors until a Tock business name is set.', 'jetpack' ),
 			'warning',
 			Blocks::classes( FEATURE_NAME, $attr )


### PR DESCRIPTION
## Proposed changes:

If you create the block but do not fill in a restaurant name, you'll get a PHP warning when viewing the post:

```
PHP Warning:  Undefined array key "url" in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/extensions/blocks/tock/tock.php on line 60
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Enable Beta blocks on your site.
* Go to Posts > Add New
* Add a Tock block
* Do not enter a restaurant name.
* Publish your post.
* Visit the post on the frontend. If you've added other blocks, they should be displayed with no issues. You should only see a warning instead of the Tock block, when logged in as an admin.
