### PR TITLE
Launchpad: Add new page task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/77295-update-add-new-page-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/77295-update-add-new-page-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad task for adding a new page

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -234,7 +234,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add a new page', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_add_new_page_completed',
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
 		),
 
 		'domain_customize'                => array(
@@ -677,15 +677,6 @@ function wpcom_is_domain_claim_completed() {
 	);
 
 	return ! empty( $domain_purchases );
-}
-
-/**
- * Check if the add_new_page task is complete.
- *
- * @return bool True if add_new_page task is completed.
- */
-function wpcom_is_add_new_page_completed() {
-	return wpcom_is_task_option_completed( 'add_new_page' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -687,7 +687,7 @@ function wpcom_is_domain_claim_completed() {
  */
 function wpcom_add_new_page_check( $post_id, $post ) {
 	// Don't do anything if the task is already complete.
-	if ( wpcom_is_task_option_completed( 'add_new_page' ) ) {
+	if ( wpcom_is_task_option_completed( array( 'id' => 'add_new_page' ) ) ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -308,18 +308,6 @@ function wpcom_mark_launchpad_task_complete( $task_id ) {
 }
 
 /**
- * Check if a task is complete in the launchpad_checklist_tasks_statuses option.
- *
- * @param string $task_id The task ID.
- * @return bool True if the task was marked as complete, false otherwise.
- */
-function wpcom_is_launchpad_task_complete( $task_id ) {
-	$statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
-
-	return isset( $statuses[ $task_id ] ) && $statuses[ $task_id ];
-}
-
-/**
  * Initialize the Launchpad task listener callbacks.
  *
  * @param array $task_definitions The tasks to initialize.
@@ -697,7 +685,7 @@ function wpcom_is_domain_claim_completed() {
  * @return bool True if add_new_page task is completed.
  */
 function wpcom_is_add_new_page_completed() {
-	return wpcom_is_launchpad_task_complete( 'add_new_page' );
+	return wpcom_is_task_option_completed( 'add_new_page' );
 }
 
 /**
@@ -708,7 +696,7 @@ function wpcom_is_add_new_page_completed() {
  */
 function wpcom_add_new_page_check( $post_id, $post ) {
 	// Don't do anything if the task is already complete.
-	if ( wpcom_is_launchpad_task_complete( 'add_new_page' ) ) {
+	if ( wpcom_is_task_option_completed( 'add_new_page' ) ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -705,9 +705,8 @@ function wpcom_is_add_new_page_completed() {
  *
  * @param int    $post_id The ID of the post being updated.
  * @param object $post    The post object.
- * @param bool   $update  Whether this is an existing post being updated or not.
  */
-function wpcom_add_new_page_check( $post_id, $post, $update ) {
+function wpcom_add_new_page_check( $post_id, $post ) {
 	// Don't do anything if the task is already complete.
 	if ( wpcom_is_launchpad_task_complete( 'add_new_page' ) ) {
 		return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -712,13 +712,18 @@ function wpcom_add_new_page_check( $post_id, $post ) {
 		return;
 	}
 
-	// We only care about pages, no other post types.
+	// We only care about pages, ignore other post types.
 	if ( $post->post_type !== 'page' ) {
 		return;
 	}
 
 	// Ensure that Headstart posts don't mark this as complete
 	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+		return;
+	}
+
+	// We only care about published pages. Pages added via the API are not published by default.
+	if ( $post->post_status !== 'publish' ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -135,14 +135,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'design_edited',
 				'domain_claim',
 				'verify_email',
-<<<<<<< HEAD
 				'domain_customize',
-||||||| parent of 4034fe2df7 ([not verified] New task for adding a page to a site)
-				'domain_upsell',
-=======
-				'domain_upsell',
 				'add_new_page',
->>>>>>> 4034fe2df7 ([not verified] New task for adding a page to a site)
 				'drive_traffic',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -135,7 +135,14 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'design_edited',
 				'domain_claim',
 				'verify_email',
+<<<<<<< HEAD
 				'domain_customize',
+||||||| parent of 4034fe2df7 ([not verified] New task for adding a page to a site)
+				'domain_upsell',
+=======
+				'domain_upsell',
+				'add_new_page',
+>>>>>>> 4034fe2df7 ([not verified] New task for adding a page to a site)
 				'drive_traffic',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/77295

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In the "Keep Building" Launchpad task list, this adds a new `add_new_page` task. The task is marked complete after the user adds their first new page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply Calypso PR https://github.com/Automattic/wp-calypso/pull/78643 (or use the calypso.live link).
* Apply this patch to Jetpack on your sandbox and sandbox the public-api.
* Go to `/start` in calypso and create a new site with any plan.
* Select the "Promote myself or business goal"
![image](https://github.com/Automattic/jetpack/assets/917632/a4df5373-2f45-47fa-a7a0-effa4fe3f771)
* Launch the site.
* Upon returning to `/home`, you should see a task list like the following which includes the "Add new page" task which is marked incomplete.
![image](https://github.com/Automattic/jetpack/assets/917632/54142482-671f-42d5-ad87-7584da3f9320)
* Click the "Add new page" task. You should be taken to add a new page. Add any kind of page and publish it.
* After returning to `/home`, the "Add new page" task should be crossed off.
![image](https://github.com/Automattic/jetpack/assets/917632/84910849-d4d5-4847-8c2e-6ba6f94699f7)


