### PR TITLE
Jetpack: Update test for WordPress core change

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-test-for-wp-56037
+++ b/projects/plugins/jetpack/changelog/fix-test-for-wp-56037
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update a PHPUnit test for https://core.trac.wordpress.org/ticket/58235. No change to the plugin itself.
+
+

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.recipe.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.recipe.php
@@ -187,16 +187,16 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 			function_exists( 'wp_lazy_loading_enabled' )
 			&& wp_lazy_loading_enabled( 'img', 'wp_get_attachment_image' )
 		) {
-			$this->assertStringContainsString(
-				'src="' . $url . '" class="jetpack-recipe-image u-photo photo" alt="" loading="lazy" itemprop="image" />',
-				$shortcode_content
-			);
+			// WP 6.3 changes the order of the attributes.
+			if ( function_exists( 'wp_img_tag_add_loading_optimization_attrs' ) ) {
+				$expect = 'src="' . $url . '" class="jetpack-recipe-image u-photo photo" alt="" itemprop="image" loading="lazy" />';
+			} else {
+				$expect = 'src="' . $url . '" class="jetpack-recipe-image u-photo photo" alt="" loading="lazy" itemprop="image" />';
+			}
 		} else {
-			$this->assertStringContainsString(
-				'src="' . $url . '" class="jetpack-recipe-image u-photo photo" alt="" itemprop="image" />',
-				$shortcode_content
-			);
+			$expect = 'src="' . $url . '" class="jetpack-recipe-image u-photo photo" alt="" itemprop="image" />';
 		}
+		$this->assertStringContainsString( $expect, $shortcode_content );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
WordPress core change https://core.trac.wordpress.org/changeset/56037 has changed the ordering of the `<img>` parameters that our test was looking at. Add a check for a function added in that commit to determine which ordering to look for.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1687798900184079-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?