### PR TITLE
AI Extension: avoid error notice stacking

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-extension-avoid-error-notice-stacking
+++ b/projects/plugins/jetpack/changelog/fix-ai-extension-avoid-error-notice-stacking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Extension: Use ID on error notices to prevent stacking multiple notices.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -32,6 +32,13 @@ type StoredPromptProps = {
 };
 
 /*
+ * An identifier to use on the extension error notices,
+ * so a existing notice with the same ID gets replaced
+ * by a new one, avoiding the stacking of notices.
+ */
+const AI_ASSISTANT_NOTICE_ID = 'ai-assistant';
+
+/*
  * Extend the withAIAssistant function of the block
  * to implement multiple blocks edition
  */
@@ -61,6 +68,7 @@ export const withAIAssistant = createHigherOrderComponent(
 			( suggestionError: SuggestionError ) => {
 				createNotice( suggestionError.status, suggestionError.message, {
 					isDismissible: true,
+					id: AI_ASSISTANT_NOTICE_ID,
 				} );
 			},
 			[ createNotice ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31569

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Start adding a notice ID on the notices generated by the extension; if we use the same ID, any previous notice is replaced with the new one
* Use `ai-assistant` as the ID

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Discussion: p1687558335821679-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To test this, you need to force some errors on the backend; refer to the "How to force errors on the backend" section below to see how to do it
* With the backend changed to force an error return, go to the block editor
* Write some content on a paragraph
* Click the AI Assistant extension button and select some action:

<img width="753" alt="Screen Shot 2023-06-26 at 15 57 35" src="https://github.com/Automattic/jetpack/assets/6760046/1f49433b-3cb9-4213-8760-a1de4e1dbb36">

* Since you are forcing an error on the backend, you will see a notice on the top of the editor:

<img width="752" alt="Screen Shot 2023-06-26 at 15 58 10" src="https://github.com/Automattic/jetpack/assets/6760046/b09ce5a4-9aec-438e-ae07-b351fcba818a">

* Execute another action
* Since you are still forcing backend errors, another notice will be generated
* Before the fix, a second notice would be showed on top of the first; any new notice would be stacked upon the previous ones

![image](https://github.com/Automattic/jetpack/assets/6760046/4c684299-e4a7-4ecb-a642-80db7b53c29b)

* After the fix, the new notice will replace the existing one, in the case there was one; only notices generated by the AI Extension will be replaced:

_Request 1:_
 
<img width="753" alt="Screen Shot 2023-06-26 at 15 54 48" src="https://github.com/Automattic/jetpack/assets/6760046/0109710d-5fc4-4bcc-be98-6e98efb44c6f">

_Request 2:_

<img width="750" alt="Screen Shot 2023-06-26 at 15 55 17" src="https://github.com/Automattic/jetpack/assets/6760046/cd2661b1-b3fb-4e4b-a23c-0045b879e356">

* Experiment changing the `status` code returned on the backend error to the following values and repeat the test
   * 422
   * 429
   * 500
   * 503
* Each `status` code has it's own message on the frontend, so you will see different messages on each occasion, and the new message will replace the existing one

### How to force errors on the backend

* Sandbox your `public-api`
* If you are running this branch on JN, don't forget to point it to your sandbox
* Update the `jetpack-ai-query.php` file on your sandbox to add the following snippet:

```
return new \WP_Error( 'error_jetpack_ai', __( 'Generic error message.' ), [ 'status' => 503 ] );
```

* Add it as the first line of the function:

<img width="772" alt="Screen Shot 2023-06-21 at 19 29 33" src="https://github.com/Automattic/jetpack/assets/6760046/67a1c3ba-1f2f-400c-aa48-926d22cb1eb7">

* You will test changing the `status` value, so keep the file open and ready to edit