### PR TITLE
My Jetpack: Enable Jetpack Stats card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -16,10 +16,6 @@ import VideopressCard from './videopress-card';
  *
  * @returns {object} ProductCardsSection React component.
  */
-
-// flag for enabling stats card.
-const { jetpackStats = false } = window.myJetpackInitialState?.myJetpackFlags ?? {};
-
 const ProductCardsSection = () => {
 	return (
 		<Container fluid horizontalSpacing={ 0 } horizontalGap={ 3 }>
@@ -41,11 +37,9 @@ const ProductCardsSection = () => {
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
 				<VideopressCard admin={ true } />
 			</Col>
-			{ jetpackStats && (
-				<Col sm={ 4 } md={ 4 } lg={ 4 }>
-					<StatsCard admin={ true } />
-				</Col>
-			) }
+			<Col sm={ 4 } md={ 4 } lg={ 4 }>
+				<StatsCard admin={ true } />
+			</Col>
 			<Col sm={ 4 } md={ 4 } lg={ 4 }>
 				<CrmCard admin={ true } />
 			</Col>

--- a/projects/packages/my-jetpack/changelog/add-jetpack-stats-to-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-stats-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added Jetpack Stats card to My Jetpack

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -199,7 +199,6 @@ class Initializer {
 	public static function get_my_jetpack_flags() {
 		$flags = array(
 			'videoPressStats' => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
-			'jetpackStats'    => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_STATS_ENABLED' ),
 		);
 
 		return $flags;

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 
@@ -133,18 +134,24 @@ class Stats extends Module_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		$purchases_data = Wpcom_Products::get_site_current_purchases();
-		if ( is_wp_error( $purchases_data ) ) {
-			return false;
-		}
-		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
-			foreach ( $purchases_data as $purchase ) {
-				if ( 0 === strpos( $purchase->product_slug, 'jetpack_stats' ) ) {
-					return true;
+		// Check if paid stats plans have been enabled.
+		if ( Jetpack_Constants::is_true( 'JETPACK_PAID_STATS_ENABLED' ) ) {
+			$purchases_data = Wpcom_Products::get_site_current_purchases();
+			if ( is_wp_error( $purchases_data ) ) {
+				return false;
+			}
+			if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+				foreach ( $purchases_data as $purchase ) {
+					if ( 0 === strpos( $purchase->product_slug, 'jetpack_stats' ) ) {
+						return true;
+					}
 				}
 			}
+			return false;
 		}
-		return false;
+
+		// Until the new paid stats plans roll out, no plan purchase is required for Jetpack Stats.
+		return true;
 	}
 
 	/**
@@ -153,6 +160,7 @@ class Stats extends Module_Product {
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
+		// NOTE: Alternatively, use 'admin.php?page=jetpack#/settings?term=jetpack stats' to send visitors to Stats settings.
 		return admin_url( 'admin.php?page=stats' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #31343.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
<img width="374" alt="image" src="https://github.com/Automattic/jetpack/assets/4044428/65575f07-864c-42fd-86ce-84fc4ff090d2">

* Adds Jetpack Stats to My Jetpack as a module product requiring no purchase.
* Adds support for a new feature flag, `JETPACK_PAID_STATS_ENABLED`, which is used to gate state purchasing functionality.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try this PR in Jurassic Nina via the Jetpack plugin and a standalone plugin.
* Ensure that Jetpack Stats can be installed, activated, and deactivated.

