### PR TITLE
Blaze: avoid errors when post type label is not available

### DIFF
--- a/projects/packages/blaze/changelog/fix-error-post-type-label-blaze
+++ b/projects/packages/blaze/changelog/fix-error-post-type-label-blaze
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid errors when the post type label is not defined.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.7.0",
+	"version": "0.7.1-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.7.0';
+	const PACKAGE_VERSION = '0.7.1-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/blaze/src/js/editor.js
+++ b/projects/packages/blaze/src/js/editor.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useEffect } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
 import { getPlugin, registerPlugin } from '@wordpress/plugins';
 import './editor.scss';
@@ -28,7 +28,9 @@ const BlazePostPublishPanel = () => {
 			isPublishingPost: selector( editorStore ).isPublishingPost(),
 			postId: selector( editorStore ).getCurrentPostId(),
 			postType: selector( editorStore ).getCurrentPostType(),
-			postTypeLabel: selector( editorStore ).getPostTypeLabel(),
+			postTypeLabel:
+				// Translators: default post type label.
+				selector( editorStore ).getPostTypeLabel() || _x( 'Post', 'noun', 'jetpack-blaze' ),
 			postVisibility: selector( editorStore ).getEditedPostVisibility(),
 		} ) );
 	const wasPublishing = usePrevious( isPublishingPost );


### PR DESCRIPTION
Fixes #31591

## Proposed changes:

Follow-up from #31399. In some scenarios (like after the post publication for some reason), the post type label isn't immediately available. Let's set a default to avoid that, even if that default will actually never really be shown since the panel is not displayed when the post is already published.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

On a connected Jetpack site:

- Go to Posts > All Posts
- Click on a post that is already published to enter the block editor.
- See no errors when the editor is finished loading.

