### PR TITLE
Custom CSS: display a notice to recommend global styles when folks use a block theme

### DIFF
--- a/projects/plugins/jetpack/_inc/client/scss/style.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/style.scss
@@ -60,3 +60,4 @@
 @import '../security/style';
 @import '../settings/style';
 @import '../traffic/style';
+@import '../writing/style';

--- a/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
@@ -1,0 +1,141 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { FormLegend } from 'components/forms';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import { ModuleToggle } from 'components/module-toggle';
+import SettingsGroup from 'components/settings-group';
+import analytics from 'lib/analytics';
+import React from 'react';
+import { connect } from 'react-redux';
+import { currentThemeIsBlockTheme, getSiteAdminUrl } from 'state/initial-state';
+import { getModule } from 'state/modules';
+
+const trackVisitGlobalStyles = () => {
+	analytics.tracks.recordJetpackClick( {
+		target: 'visit-global-styles',
+		feature: 'custom-css',
+		extra: 'not-supported-link',
+	} );
+};
+
+const trackVisitCustomizer = () => {
+	analytics.tracks.recordJetpackClick( {
+		target: 'visit-customizer',
+		feature: 'custom-css',
+		extra: 'not-supported-link',
+	} );
+};
+
+/**
+ * Custom CSS settings component.
+ *
+ * @param {object} props - Component props.
+ * @returns {React.Component} Custom CSS settings component.
+ */
+function CustomCss( props ) {
+	const {
+		customCssActive,
+		customCssModule: { name, description, module },
+		isBlockThemeActive,
+		isSavingAnyOption,
+		siteAdminUrl,
+		toggleModuleNow,
+	} = props;
+
+	const recommendGlobalStyles = () => {
+		return (
+			<p>
+				{ createInterpolateElement(
+					__(
+						'Since you use a Block theme, we recommend that you use Global Styles to customize the look of your site. <a>Access Global styles</a>',
+						'jetpack'
+					),
+					{
+						a: (
+							<a
+								onClick={ trackVisitGlobalStyles }
+								href={ `${ siteAdminUrl }site-editor.php?path=%2Fwp_global_styles&canvas=edit` }
+								title={ __( 'Customize every aspect of your site with Global Styles.', 'jetpack' ) }
+							/>
+						),
+					}
+				) }
+			</p>
+		);
+	};
+
+	const customizerLink = () => {
+		return (
+			<>
+				<p>
+					{ createInterpolateElement(
+						__(
+							'Additional CSS can be added from the Customizer. Enable the enhanced Custom CSS feature below to add additional features. <a>Access the Customizer here.</a>',
+							'jetpack'
+						),
+						{
+							a: (
+								<a
+									onClick={ trackVisitCustomizer }
+									href={ `${ siteAdminUrl }customize.php?autofocus%5Bsection%5D=custom_css` }
+									title={ __(
+										'Edit and add CSS directly on your site from the Customizer.',
+										'jetpack'
+									) }
+								/>
+							),
+						}
+					) }
+				</p>
+			</>
+		);
+	};
+
+	const toggleModule = () => {
+		// If we're using a block theme and the feature is disabled, we don't want to show the toggle.
+		if ( isBlockThemeActive && ! customCssActive ) {
+			return null;
+		}
+
+		return (
+			<ModuleToggle
+				slug="custom-css"
+				activated={ !! customCssActive }
+				toggling={ isSavingAnyOption( [ 'custom-css' ] ) }
+				disabled={ isSavingAnyOption( [ 'custom-css' ] ) }
+				toggleModule={ toggleModuleNow }
+			>
+				<span className="jp-form-toggle-explanation">
+					{ __( 'Enhance CSS customization panel', 'jetpack' ) }
+				</span>
+			</ModuleToggle>
+		);
+	};
+
+	return (
+		<SettingsGroup
+			module={ { module } }
+			support={ {
+				text: description,
+				link: getRedirectUrl( 'jetpack-support-custom-css' ),
+			} }
+		>
+			<FormLegend className="jp-form-label-wide">{ name }</FormLegend>
+			{ isBlockThemeActive && recommendGlobalStyles() }
+			{ ! isBlockThemeActive && customizerLink() }
+			{ toggleModule() }
+		</SettingsGroup>
+	);
+}
+
+export default withModuleSettingsFormHelpers(
+	connect( ( state, ownProps ) => {
+		return {
+			customCssActive: ownProps.getOptionValue( 'custom-css' ),
+			customCssModule: getModule( state, 'custom-css' ),
+			isBlockThemeActive: currentThemeIsBlockTheme( state ),
+			siteAdminUrl: getSiteAdminUrl( state ),
+		};
+	} )( CustomCss )
+);

--- a/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
@@ -47,41 +47,39 @@ function CustomCss( props ) {
 
 	const recommendSiteEditor = () => {
 		return (
-			<p>
-				{ createInterpolateElement(
-					__(
-						'Hurray! Your theme supports site editing with blocks. <a>Tell me more.</a>',
-						'jetpack'
-					),
-					{
-						a: (
-							<ExternalLink
-								href="https://wordpress.org/documentation/article/site-editor/"
-								title={ __(
-									'Customize every aspect of your site with the Site Editor.',
-									'jetpack'
-								) }
-							/>
+			<div className="jp-custom-css-site-editor">
+				<div className="jp-custom-css-site-editor__text">
+					{ createInterpolateElement(
+						__(
+							'Hurray! Your theme supports site editing with blocks. <a>Tell me more.</a>',
+							'jetpack'
 						),
-					}
+						{
+							a: (
+								<ExternalLink
+									href="https://wordpress.org/documentation/article/site-editor/"
+									title={ __(
+										'Customize every aspect of your site with the Site Editor.',
+										'jetpack'
+									) }
+								/>
+							),
+						}
+					) }
+				</div>
+				{ ! customCssActive && (
+					<div className="jp-custom-css-site-editor__button">
+						<Button
+							rna
+							onClick={ trackVisitGlobalStyles }
+							href={ `${ siteAdminUrl }site-editor.php?path=%2Fwp_global_styles&canvas=edit` }
+							primary={ true }
+						>
+							{ __( 'Use Site Editor', 'jetpack' ) }
+						</Button>
+					</div>
 				) }
-			</p>
-		);
-	};
-
-	const siteEditorButton = () => {
-		// If we're using a block theme and the feature is enabled, we don't want to show the button.
-		if ( isBlockThemeActive && customCssActive ) {
-			return null;
-		}
-
-		return (
-			<Button
-				onClick={ trackVisitGlobalStyles }
-				href={ `${ siteAdminUrl }site-editor.php?path=%2Fwp_global_styles&canvas=edit` }
-			>
-				{ __( 'Use Site Editor', 'jetpack' ) }
-			</Button>
+			</div>
 		);
 	};
 
@@ -145,7 +143,6 @@ function CustomCss( props ) {
 			{ isBlockThemeActive && recommendSiteEditor() }
 			{ ! isBlockThemeActive && customizerLink() }
 			{ toggleModule() }
-			{ siteEditorButton() }
 		</SettingsGroup>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Button from 'components/button';
@@ -54,7 +55,7 @@ function CustomCss( props ) {
 					),
 					{
 						a: (
-							<a
+							<ExternalLink
 								href="https://wordpress.org/documentation/article/site-editor/"
 								title={ __(
 									'Customize every aspect of your site with the Site Editor.',

--- a/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
@@ -1,6 +1,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import Button from 'components/button';
 import { FormLegend } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
@@ -43,25 +44,43 @@ function CustomCss( props ) {
 		toggleModuleNow,
 	} = props;
 
-	const recommendGlobalStyles = () => {
+	const recommendSiteEditor = () => {
 		return (
 			<p>
 				{ createInterpolateElement(
 					__(
-						'Since you use a Block theme, we recommend that you use Global Styles to customize the look of your site. <a>Access Global styles</a>',
+						'Hurray! Your theme supports site editing with blocks. <a>Tell me more.</a>',
 						'jetpack'
 					),
 					{
 						a: (
 							<a
-								onClick={ trackVisitGlobalStyles }
-								href={ `${ siteAdminUrl }site-editor.php?path=%2Fwp_global_styles&canvas=edit` }
-								title={ __( 'Customize every aspect of your site with Global Styles.', 'jetpack' ) }
+								href="https://wordpress.org/documentation/article/site-editor/"
+								title={ __(
+									'Customize every aspect of your site with the Site Editor.',
+									'jetpack'
+								) }
 							/>
 						),
 					}
 				) }
 			</p>
+		);
+	};
+
+	const siteEditorButton = () => {
+		// If we're using a block theme and the feature is enabled, we don't want to show the button.
+		if ( isBlockThemeActive && customCssActive ) {
+			return null;
+		}
+
+		return (
+			<Button
+				onClick={ trackVisitGlobalStyles }
+				href={ `${ siteAdminUrl }site-editor.php?path=%2Fwp_global_styles&canvas=edit` }
+			>
+				{ __( 'Use Site Editor', 'jetpack' ) }
+			</Button>
 		);
 	};
 
@@ -122,9 +141,10 @@ function CustomCss( props ) {
 			} }
 		>
 			<FormLegend className="jp-form-label-wide">{ name }</FormLegend>
-			{ isBlockThemeActive && recommendGlobalStyles() }
+			{ isBlockThemeActive && recommendSiteEditor() }
 			{ ! isBlockThemeActive && customizerLink() }
 			{ toggleModule() }
+			{ siteEditorButton() }
 		</SettingsGroup>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/writing/style.scss
+++ b/projects/plugins/jetpack/_inc/client/writing/style.scss
@@ -1,0 +1,47 @@
+@import '../scss/calypso-colors';
+
+/* Custom CSS settings */
+.jp-custom-css-site-editor {
+	@include breakpoint('>660px') {
+		display: flex;
+		flex-wrap: nowrap;
+		flex-direction: row;
+		align-items: center;
+	}
+}
+
+.jp-custom-css-site-editor__text {
+	font-size: $font-body-small;
+	line-height: 1.5;
+	letter-spacing: -0.3px;
+	color: $gray-80;
+	flex-grow: 1;
+
+	@include breakpoint('<660px') {
+		padding: 0 0 rem(16px);
+	}
+
+	@include breakpoint('>660px') {
+		flex-basis: 50%;
+		padding: 0 rem(16px) 0 0;
+	}
+}
+
+.jp-custom-css-site-editor__button {
+	text-align: left;
+
+	button.dops-button.is-primary {
+		padding: 4px 20px;
+		font-size: $font-body-small;
+
+		&:focus {
+			border: 1px solid $white;
+			box-shadow: 0 0 0 1px $black;
+		}
+	}
+
+	@include breakpoint('>660px') {
+		flex-grow: 0;
+		margin-left: 64px;
+	}
+}

--- a/projects/plugins/jetpack/_inc/client/writing/theme-enhancements.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/theme-enhancements.jsx
@@ -3,15 +3,15 @@ import { __ } from '@wordpress/i18n';
 import { FormLabel, FormLegend } from 'components/forms';
 import ModuleOverriddenBanner from 'components/module-overridden-banner';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
-import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
 import React from 'react';
 import { connect } from 'react-redux';
-import { currentThemeSupports, currentThemeIsBlockTheme } from 'state/initial-state';
+import { currentThemeSupports } from 'state/initial-state';
 import { getModule } from 'state/modules';
 import { isModuleFound } from 'state/search';
+import CustomCss from './custom-css';
 
 class ThemeEnhancements extends React.Component {
 	/**
@@ -83,14 +83,6 @@ class ThemeEnhancements extends React.Component {
 		} );
 	};
 
-	trackVisitCustomizer = () => {
-		analytics.tracks.recordJetpackClick( {
-			target: 'visit-customizer',
-			feature: 'custom-css',
-			extra: 'not-supported-link',
-		} );
-	};
-
 	/**
 	 * Get options for initial state.
 	 *
@@ -115,7 +107,6 @@ class ThemeEnhancements extends React.Component {
 		}
 
 		const infScr = this.props.getModule( 'infinite-scroll' );
-		const customCSS = this.props.getModule( 'custom-css' );
 
 		const infiniteScrollDisabledByOverride =
 			'inactive' === this.props.getModuleOverride( 'infinite-scroll' );
@@ -194,44 +185,7 @@ class ThemeEnhancements extends React.Component {
 						) }
 					</SettingsGroup>
 				) }
-				{ ! this.props.isBlockThemeActive && foundCustomCSS && (
-					<SettingsGroup
-						module={ { module: customCSS.module } }
-						support={ {
-							text: customCSS.description,
-							link: getRedirectUrl( 'jetpack-support-custom-css' ),
-						} }
-					>
-						<FormLegend className="jp-form-label-wide">{ customCSS.name }</FormLegend>
-						<p>
-							{ __(
-								'Additional CSS can be added from the Customizer. Enable the enhanced Custom CSS feature below to add additional features.',
-								'jetpack'
-							) + ' ' }
-							<a
-								onClick={ this.trackVisitCustomizer }
-								href={ `${ this.props.siteAdminUrl }customize.php?autofocus%5Bsection%5D=custom_css` }
-								title={ __(
-									'Edit and add CSS directly on your site from the Customizer.',
-									'jetpack'
-								) }
-							>
-								{ __( 'Access the Customizer here.', 'jetpack' ) }
-							</a>
-						</p>
-						<ModuleToggle
-							slug="custom-css"
-							activated={ !! this.props.getOptionValue( 'custom-css' ) }
-							toggling={ this.props.isSavingAnyOption( [ 'custom-css' ] ) }
-							disabled={ this.props.isSavingAnyOption( [ 'custom-css' ] ) }
-							toggleModule={ this.props.toggleModuleNow }
-						>
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Enhance CSS customization panel', 'jetpack' ) }
-							</span>
-						</ModuleToggle>
-					</SettingsGroup>
-				) }
+				{ foundCustomCSS && <CustomCss /> }
 			</SettingsCard>
 		);
 	}
@@ -240,7 +194,6 @@ class ThemeEnhancements extends React.Component {
 export default connect( state => {
 	return {
 		module: module_name => getModule( state, module_name ),
-		isBlockThemeActive: currentThemeIsBlockTheme( state ),
 		isInfiniteScrollSupported: currentThemeSupports( state, 'infinite-scroll' ),
 		isModuleFound: module_name => isModuleFound( state, module_name ),
 	};

--- a/projects/plugins/jetpack/changelog/update-custom-css-card
+++ b/projects/plugins/jetpack/changelog/update-custom-css-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Custom CSS: display a notice to recommend the use of Global Styles when you use a Block theme on your site.


### PR DESCRIPTION
> **Warning**
> This PR is not against `trunk`, but against #31413. It builds upon it with the changes detailed below.

## Proposed changes:

When a site owner uses a block theme, let's recommend that they use Global Styles to customize the look of their site, instead of using Custom CSS.

- When the custom CSS module is active, we display the recommendation but still allow them to turn the module off.
- When the custom CSS module is inactive, we remove the toggle to turn the feature on.

**Block theme, Custom CSS active**

<img width="1081" alt="Screenshot 2023-06-27 at 18 23 19" src="https://github.com/Automattic/jetpack/assets/426388/eb5b0126-36fb-4181-80e1-727770469379">

**Block theme, Custom CSS inactive**

<img width="1088" alt="Screenshot 2023-06-27 at 18 22 37" src="https://github.com/Automattic/jetpack/assets/426388/59bdfdaa-9998-469f-9ee5-930c0eae5312">

**Classic theme, Custom CSS active**

<img width="1125" alt="Screenshot 2023-06-27 at 18 23 55" src="https://github.com/Automattic/jetpack/assets/426388/9f9ea346-12f6-4570-99e5-106ff0c03e1a">

> **Note**
> The link to the Global styles panel in the site editor only seems to work when you use the Gutenberg plugin. I did not manage to find a way to link to that panel when using only the latest version of WordPress.

**To do**

If we decide to go for something like this, I wonder if it would be worth displaying the notice a bit differently, so it stands out a bit more compared to regular text.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* See discussion on the previous PR: https://github.com/Automattic/jetpack/pull/31413#issuecomment-1607220524

## Does this pull request change what data or activity we track or use?

* Yes, it adds a Tracks event when you click on the link to access Global Styles, matching the existing link to the customizer.

## Testing instructions:

1. Start with a site connected to WordPress.com, with a classic theme like Twenty Twenty One.
2. Go to Jetpack > Settings > Writing
    * You should be able to turn the Custom CSS feature on and off.
    * Leave the feature on.
3. Now go to Appearance > Themes and switch to the Twenty Twenty Three theme.
4. Go back to Jetpack > Settings > Writing.
    * You should still have the option to turn the feature off, but a notice now recommends Global styles instead of the Customizer.
5. Turn the feature off
    * The toggle should disappear.
