### PR TITLE
Launchpad: check for function existence

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-check-for-function-existence
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-check-for-function-existence
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Check that the function jetpack_is_atomic_site exists before using it.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "3.3.x-dev"
+			"dev-trunk": "3.4.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "3.3.0",
+	"version": "3.4.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '3.3.0';
+	const PACKAGE_VERSION = '3.4.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -611,11 +611,11 @@ if ( class_exists( 'WPCOM_Launchpad' ) ) {
  */
 function add_launchpad_options_to_jetpack_sync( $allowed_options ) {
 	// We are not either in Simple or Atomic
-	if ( ! class_exists( 'Automattic\Jetpack\Host' ) ) {
+	if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
 		return $allowed_options;
 	}
 
-	if ( ! ( new Host() )->is_woa_site() ) {
+	if ( ! ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
 		return $allowed_options;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -611,12 +611,11 @@ if ( class_exists( 'WPCOM_Launchpad' ) ) {
  */
 function add_launchpad_options_to_jetpack_sync( $allowed_options ) {
 	// We are not either in Simple or Atomic
-	if ( ! function_exists( 'jetpack_is_atomic_site' ) ) {
+	if ( ! class_exists( 'Automattic\Jetpack\Host' ) ) {
 		return $allowed_options;
 	}
 
-	// Bail if not on an Atomic site
-	if ( ! jetpack_is_atomic_site() ) {
+	if ( ! ( new Host() )->is_woa_site() ) {
 		return $allowed_options;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -610,6 +610,11 @@ if ( class_exists( 'WPCOM_Launchpad' ) ) {
  * @param array $allowed_options The allowed options.
  */
 function add_launchpad_options_to_jetpack_sync( $allowed_options ) {
+	// We are not either in Simple or Atomic
+	if ( ! function_exists( 'jetpack_is_atomic_site' ) ) {
+		return $allowed_options;
+	}
+
 	// Bail if not on an Atomic site
 	if ( ! jetpack_is_atomic_site() ) {
 		return $allowed_options;

--- a/projects/plugins/mu-wpcom-plugin/changelog/launchpad-fix-unexisting-function
+++ b/projects/plugins/mu-wpcom-plugin/changelog/launchpad-fix-unexisting-function
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "fae0090a87945d6500d10a75a0b1f81de6fb5f21"
+                "reference": "2e7328c5d9608c07a7ddddfac069af1cefa418f1"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.3.x-dev"
+                    "dev-trunk": "3.4.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In some contexts the jetpack_is_atomic_site function does not exists. This PR checks for its existence before using it.

More context: p1687881152482789-slack-C02Q5922VGC


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*