### PR TITLE
AI Extension: transform to AI Assistant block when requesting a suggestion

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-transform-to-block
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-transform-to-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: transform to AI Assistant block when requesting suggestion

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
@@ -17,7 +17,7 @@ export default {
 	},
 
 	autoRequestPrompt: {
-		type: 'string',
+		type: 'object',
 	},
 
 	messages: {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
@@ -16,6 +16,10 @@ export default {
 		default: [],
 	},
 
+	autoRequestPrompt: {
+		type: 'string',
+	},
+
 	messages: {
 		type: 'array',
 		default: [],

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
@@ -16,10 +16,6 @@ export default {
 		default: [],
 	},
 
-	autoRequestPrompt: {
-		type: 'object',
-	},
-
 	messages: {
 		type: 'array',
 		default: [],

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -110,6 +110,24 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		requireUpgrade,
 	} );
 
+	// Auto request if the block has the autoRequestPrompt attribute
+	useEffect( () => {
+		if ( ! attributes?.autoRequestPrompt?.type ) {
+			return;
+		}
+
+		const { type, options } = attributes.autoRequestPrompt;
+		setAttributes( { autoRequestPrompt: undefined } );
+
+		/*
+		 * Add a small delay to race condition with the block editor.
+		 * Todo: Let's clean this up when we have a better way to handle this.
+		 */
+		setTimeout( () => {
+			getSuggestionFromOpenAI( type, options );
+		}, 200 );
+	}, [ attributes.autoRequestPrompt, getSuggestionFromOpenAI, setAttributes ] );
+
 	useEffect( () => {
 		if ( errorData ) {
 			setErrorDismissed( false );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -113,7 +113,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 
 	/*
 	 * Auto request the prompt if we detect
-	 * it was previsulay defined in the local storage.
+	 * it was previously defined in the local storage.
 	 */
 	const storeBlockId = getStoreBlockId( clientId );
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -17,7 +17,7 @@ import { isUserConnected } from '../../lib/connection';
 export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
 
 // List of blocks that can be extended.
-export const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading', 'core/list-item' ] as const;
+export const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading' ] as const;
 
 export type ExtendedBlockProp = ( typeof EXTENDED_BLOCKS )[ number ];
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -165,7 +165,14 @@ export const withAIAssistant = createHigherOrderComponent(
 					JSON.stringify( storeObject )
 				);
 
+				/*
+				 * Replace the first block with the new AI Assistant block instance.
+				 * This block contains the original content,
+				 * even for multiple blocks selection.
+				 */
 				replaceBlock( firstClientId, newAIAssistantBlock );
+
+				// It removes the rest of the blocks in case there are more than one.
 				removeBlocks( otherBlocksIds );
 			},
 			[ blocks, clientIds, content, blockType, replaceBlock, removeBlocks ]

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -16,7 +16,7 @@ import AiAssistantDropdown, {
 import useSuggestionsFromAI, { SuggestionError } from '../../hooks/use-suggestions-from-ai';
 import useTextContentFromSelectedBlocks from '../../hooks/use-text-content-from-selected-blocks';
 import { getRawTextFromHTML } from '../../lib/utils/block-content';
-import { transfromToAIAssistantBlock } from '../../transforms';
+import { transformToAIAssistantBlock } from '../../transforms';
 /*
  * Types
  */
@@ -140,7 +140,7 @@ export const withAIAssistant = createHigherOrderComponent(
 					content,
 				};
 
-				const newAIAssistantBlock = transfromToAIAssistantBlock(
+				const newAIAssistantBlock = transformToAIAssistantBlock(
 					extendedBlockAttributes,
 					blockType
 				);
@@ -180,7 +180,7 @@ export const withAIAssistant = createHigherOrderComponent(
 
 			replaceBlock(
 				firstClientId,
-				transfromToAIAssistantBlock( extendedBlockAttributes, blockType )
+				transformToAIAssistantBlock( extendedBlockAttributes, blockType )
 			);
 
 			removeBlocks( otherBlocksIds );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -139,7 +139,7 @@ export const withAIAssistant = createHigherOrderComponent(
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				const newAIAssistantBlock = transfromToAIAssistantBlock( { content }, { blockType } );
+				const newAIAssistantBlock = transfromToAIAssistantBlock( { content }, blockType );
 
 				/*
 				 * Store in the local storage the client id

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -26,6 +26,10 @@ type StoredPromptProps = {
 	messages: Array< PromptItemProps >;
 };
 
+export function getStoreBlockId( clientId ) {
+	return `ai-assistant-block-${ clientId }`;
+}
+
 /*
  * An identifier to use on the extension error notices,
  * so a existing notice with the same ID gets replaced
@@ -135,14 +139,25 @@ export const withAIAssistant = createHigherOrderComponent(
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				const autoRequestPrompt = {
+				const newAIAssistantBlock = transfromToAIAssistantBlock( { content }, { blockType } );
+
+				/*
+				 * Store in the local storage the client id
+				 * of the block that need to auto-trigger the AI Assistant request.
+				 * @todo: find a better way to update the content,
+				 * probably using a new store triggering an action.
+				 */
+
+				// Storage client Id, prompt type, and options.
+				const storeObject = {
+					clientId: props.clientId,
 					type: promptType,
 					options,
 				};
 
-				const newAIAssistantBlock = transfromToAIAssistantBlock(
-					{ content, autoRequestPrompt },
-					{ blockType }
+				localStorage.setItem(
+					getStoreBlockId( newAIAssistantBlock.clientId ),
+					JSON.stringify( storeObject )
 				);
 
 				replaceBlock( props.clientId, newAIAssistantBlock );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -134,6 +134,7 @@ export const withAIAssistant = createHigherOrderComponent(
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				const [ firstBlock ] = blocks;
+				const [ firstClientId, ...otherBlocksIds ] = clientIds;
 
 				const extendedBlockAttributes = {
 					...( firstBlock?.attributes || {} ), // firstBlock.attributes should never be undefined, but still add a fallback
@@ -154,7 +155,7 @@ export const withAIAssistant = createHigherOrderComponent(
 
 				// Storage client Id, prompt type, and options.
 				const storeObject = {
-					clientId: props.clientId,
+					clientId: firstClientId,
 					type: promptType,
 					options: { ...options, contentType: 'generated' }, // When converted, the original content must be treated as generated
 				};
@@ -164,9 +165,10 @@ export const withAIAssistant = createHigherOrderComponent(
 					JSON.stringify( storeObject )
 				);
 
-				replaceBlock( props.clientId, newAIAssistantBlock );
+				replaceBlock( firstClientId, newAIAssistantBlock );
+				removeBlocks( otherBlocksIds );
 			},
-			[ blockType, blocks, content, props.clientId, replaceBlock ]
+			[ blocks, clientIds, content, blockType, replaceBlock, removeBlocks ]
 		);
 
 		const replaceWithAiAssistantBlock = useCallback( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -156,7 +156,7 @@ export const withAIAssistant = createHigherOrderComponent(
 				const storeObject = {
 					clientId: props.clientId,
 					type: promptType,
-					options,
+					options: { ...options, contentType: 'generated' }, // When converted, the original content must be treated as generated
 				};
 
 				localStorage.setItem(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -133,7 +133,17 @@ export const withAIAssistant = createHigherOrderComponent(
 
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
-				const newAIAssistantBlock = transfromToAIAssistantBlock( { content }, blockType );
+				const [ firstBlock ] = blocks;
+
+				const extendedBlockAttributes = {
+					...( firstBlock?.attributes || {} ), // firstBlock.attributes should never be undefined, but still add a fallback
+					content,
+				};
+
+				const newAIAssistantBlock = transfromToAIAssistantBlock(
+					extendedBlockAttributes,
+					blockType
+				);
 
 				/*
 				 * Store in the local storage the client id
@@ -156,7 +166,7 @@ export const withAIAssistant = createHigherOrderComponent(
 
 				replaceBlock( props.clientId, newAIAssistantBlock );
 			},
-			[ blockType, content, props.clientId, replaceBlock ]
+			[ blockType, blocks, content, props.clientId, replaceBlock ]
 		);
 
 		const replaceWithAiAssistantBlock = useCallback( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -452,7 +452,7 @@ export function getPrompt(
 	options: PromptOptionsProps
 ): Array< PromptItemProps > {
 	debug( 'Addressing prompt type: %o %o', type, options );
-	const { prevMessages } = options;
+	const { prevMessages = [] } = options;
 
 	const context =
 		'You are an advanced polyglot ghostwriter.' +

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -291,7 +291,13 @@ export const buildPromptTemplate = ( {
 	return messages;
 };
 
-type BuildPromptOptions = {
+export type BuildPromptOptionsProps = {
+	contentType?: 'generated' | string;
+	tone?: ToneProp;
+	language?: string;
+};
+
+type BuildPromptProps = {
 	generatedContent: string;
 	allPostContent?: string;
 	postContentAbove?: string;
@@ -301,11 +307,7 @@ type BuildPromptOptions = {
 	isGeneratingTitle?: boolean;
 	useGutenbergSyntax?: boolean;
 	customSystemPrompt?: string;
-	options: {
-		contentType?: 'generated' | string;
-		tone?: ToneProp;
-		language?: string;
-	};
+	options: BuildPromptOptionsProps;
 };
 
 type GetPromptOptionsProps = {
@@ -375,7 +377,7 @@ export function promptTextFor(
  * Builds a prompt based on the type of prompt.
  * Meant for use by the block, not the extensions.
  *
- * @param {BuildPromptOptions} options - The prompt options.
+ * @param {BuildPromptProps} options - The prompt options.
  * @returns {Array< PromptItemProps >} The prompt.
  * @throws {Error} If the type is not recognized.
  */
@@ -390,7 +392,7 @@ export function buildPromptForBlock( {
 	isGeneratingTitle,
 	useGutenbergSyntax,
 	customSystemPrompt,
-}: BuildPromptOptions ): Array< PromptItemProps > {
+}: BuildPromptProps ): Array< PromptItemProps > {
 	const isContentGenerated = options?.contentType === 'generated';
 	const promptText = promptTextFor( type, isGeneratingTitle, options );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -12,14 +12,10 @@ import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assis
  * Types
  */
 import type { ExtendedBlockProp } from '../extensions/ai-assistant';
-import type { BuildPromptOptionsProps, PromptItemProps, PromptTypeProp } from '../lib/prompt';
+import type { PromptItemProps } from '../lib/prompt';
 
 type transfromToAIAssistantBlockOptionsProps = {
 	blockType: ExtendedBlockProp;
-	autoRequestPrompt?: {
-		type: PromptTypeProp;
-		options?: BuildPromptOptionsProps;
-	};
 };
 
 const turndownService = new TurndownService( { emDelimiter: '_', headingStyle: 'atx' } );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -30,16 +30,11 @@ const from = [];
  * @param {transfromToAIAssistantBlockOptionsProps} blockType - Block type.
  * @returns {object}                                            AI Assistant block instance.
  */
-<<<<<<< HEAD
-export function transfromToAIAssistantBlock( attrs, blockType: ExtendedBlockProp ) {
-	const { content, ...otherAttrs } = attrs;
-=======
 export function transfromToAIAssistantBlock(
 	attrs,
 	{ blockType }: transfromToAIAssistantBlockOptionsProps
 ) {
 	const { content, ...restAttrs } = attrs;
->>>>>>> 5bdb725a5a (change transfromToAIAssistantBlockOptionsProps API)
 	// Create a temporary block to get the HTML content.
 	const temporaryBlock = createBlock( blockType, { content } );
 	let htmlContent = getBlockContent( temporaryBlock );
@@ -66,7 +61,7 @@ export function transfromToAIAssistantBlock(
 	];
 
 	return createBlock( blockName, {
-		...otherAttrs,
+		...restAttrs,
 		content: aiAssistantBlockcontent,
 		originalContent: aiAssistantBlockcontent,
 		messages,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -12,11 +12,14 @@ import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assis
  * Types
  */
 import type { ExtendedBlockProp } from '../extensions/ai-assistant';
-import type { PromptItemProps } from '../lib/prompt';
+import type { BuildPromptOptionsProps, PromptItemProps, PromptTypeProp } from '../lib/prompt';
 
 type transfromToAIAssistantBlockOptionsProps = {
 	blockType: ExtendedBlockProp;
-	autoRequestPrompt?: string;
+	autoRequestPrompt?: {
+		type: PromptTypeProp;
+		options?: BuildPromptOptionsProps;
+	};
 };
 
 const turndownService = new TurndownService( { emDelimiter: '_', headingStyle: 'atx' } );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -25,7 +25,7 @@ const from = [];
  * @param {ExtendedBlockProp} blockType - Block type.
  * @returns {object}                                            AI Assistant block instance.
  */
-export function transfromToAIAssistantBlock( attrs, blockType: ExtendedBlockProp ) {
+export function transformToAIAssistantBlock( attrs, blockType: ExtendedBlockProp ) {
 	const { content, ...restAttrs } = attrs;
 	// Create a temporary block to get the HTML content.
 	const temporaryBlock = createBlock( blockType, { content } );
@@ -69,7 +69,7 @@ for ( const blockType of EXTENDED_BLOCKS ) {
 		type: 'block',
 		blocks: [ blockType ],
 		isMatch: () => isPossibleToExtendBlock(),
-		transform: attrs => transfromToAIAssistantBlock( attrs, blockType ),
+		transform: attrs => transformToAIAssistantBlock( attrs, blockType ),
 	} );
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -7,15 +7,17 @@ import TurndownService from 'turndown';
  * Internal dependencies
  */
 import { blockName } from '..';
-import {
-	EXTENDED_BLOCKS,
-	ExtendedBlockProp,
-	isPossibleToExtendBlock,
-} from '../extensions/ai-assistant';
+import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assistant';
 /**
  * Types
  */
-import { PromptItemProps } from '../lib/prompt';
+import type { ExtendedBlockProp } from '../extensions/ai-assistant';
+import type { PromptItemProps } from '../lib/prompt';
+
+type transfromToAIAssistantBlockOptionsProps = {
+	blockType: ExtendedBlockProp;
+	autoRequestPrompt?: string;
+};
 
 const turndownService = new TurndownService( { emDelimiter: '_', headingStyle: 'atx' } );
 
@@ -24,12 +26,20 @@ const from = [];
 /**
  * Return an AI Assistant block instance from a given block type.
  *
- * @param {object} attrs                - Block attributes.
- * @param {ExtendedBlockProp} blockType - Block type.
- * @returns {object}                      AI Assistant block instance.
+ * @param {object} attrs                                      - Block attributes.
+ * @param {transfromToAIAssistantBlockOptionsProps} blockType - Block type.
+ * @returns {object}                                            AI Assistant block instance.
  */
+<<<<<<< HEAD
 export function transfromToAIAssistantBlock( attrs, blockType: ExtendedBlockProp ) {
 	const { content, ...otherAttrs } = attrs;
+=======
+export function transfromToAIAssistantBlock(
+	attrs,
+	{ blockType }: transfromToAIAssistantBlockOptionsProps
+) {
+	const { content, ...restAttrs } = attrs;
+>>>>>>> 5bdb725a5a (change transfromToAIAssistantBlockOptionsProps API)
 	// Create a temporary block to get the HTML content.
 	const temporaryBlock = createBlock( blockType, { content } );
 	let htmlContent = getBlockContent( temporaryBlock );
@@ -72,7 +82,7 @@ for ( const blockType of EXTENDED_BLOCKS ) {
 		type: 'block',
 		blocks: [ blockType ],
 		isMatch: () => isPossibleToExtendBlock(),
-		transform: attrs => transfromToAIAssistantBlock( attrs, blockType ),
+		transform: attrs => transfromToAIAssistantBlock( attrs, { blockType } ),
 	} );
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -14,10 +14,6 @@ import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assis
 import type { ExtendedBlockProp } from '../extensions/ai-assistant';
 import type { PromptItemProps } from '../lib/prompt';
 
-type transfromToAIAssistantBlockOptionsProps = {
-	blockType: ExtendedBlockProp;
-};
-
 const turndownService = new TurndownService( { emDelimiter: '_', headingStyle: 'atx' } );
 
 const from = [];
@@ -26,13 +22,10 @@ const from = [];
  * Return an AI Assistant block instance from a given block type.
  *
  * @param {object} attrs                                      - Block attributes.
- * @param {transfromToAIAssistantBlockOptionsProps} blockType - Block type.
+ * @param {ExtendedBlockProp} blockType - Block type.
  * @returns {object}                                            AI Assistant block instance.
  */
-export function transfromToAIAssistantBlock(
-	attrs,
-	{ blockType }: transfromToAIAssistantBlockOptionsProps
-) {
+export function transfromToAIAssistantBlock( attrs, blockType: ExtendedBlockProp ) {
 	const { content, ...restAttrs } = attrs;
 	// Create a temporary block to get the HTML content.
 	const temporaryBlock = createBlock( blockType, { content } );
@@ -76,7 +69,7 @@ for ( const blockType of EXTENDED_BLOCKS ) {
 		type: 'block',
 		blocks: [ blockType ],
 		isMatch: () => isPossibleToExtendBlock(),
-		transform: attrs => transfromToAIAssistantBlock( attrs, { blockType } ),
+		transform: attrs => transfromToAIAssistantBlock( attrs, blockType ),
 	} );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

With the changes added to this PR, the extended blocks are transformed into AI Assistant block instances. When it happens, the block performs an auto-request based on the original content of the block.

Fixes https://github.com/Automattic/jetpack/issues/31599
Fixes https://github.com/Automattic/jetpack/issues/31819

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: transform to AI Assistant block when requesting a suggestion

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to 'the block editor
* Create some context using a Paragraph block
* Change its content by using the AI Extension dropdown
* Confirm the core block transforms to an AI Assistant block
* Confirm it automatically requests the suggestion
* Confirm it continues working as usual
* Confirm it doesn't perform the automatic request when the block is transformed using the `Ask AI Assistant` of the Transform block tool.

https://github.com/Automattic/jetpack/assets/77539/f31bdc84-b4e1-470c-a884-7f93e2a739bd


