### PR TITLE
My Jetpack: Organize cards in list

### DIFF
--- a/projects/js-packages/components/changelog/fix-my-jp-card-list
+++ b/projects/js-packages/components/changelog/fix-my-jp-card-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add tagName prop to Col and Container

--- a/projects/js-packages/components/components/layout/col/README.md
+++ b/projects/js-packages/components/components/layout/col/README.md
@@ -16,7 +16,7 @@ import { Container, Col, Text } from '@automattic/jetpack-components';
 		<Text>Hello</Text>
 		<Text>World!</Text>
 	</Col>
-</Container>;
+</Container>
 ```
 
 ## Props

--- a/projects/js-packages/components/components/layout/col/README.md
+++ b/projects/js-packages/components/components/layout/col/README.md
@@ -16,10 +16,18 @@ import { Container, Col, Text } from '@automattic/jetpack-components';
 		<Text>Hello</Text>
 		<Text>World!</Text>
 	</Col>
-</Container>
+</Container>;
 ```
 
 ## Props
+
+### tagName
+
+The HTML tag of the column element.
+
+- Type: `String`
+- Default: `div`
+- Required: `false`
 
 ### className
 

--- a/projects/js-packages/components/components/layout/col/index.tsx
+++ b/projects/js-packages/components/components/layout/col/index.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import { createElement } from 'react';
 import { ColProps } from '../types';
 import styles from './style.module.scss';
 import type React from 'react';
@@ -14,7 +15,7 @@ const lgCols = Number( styles.lgCols );
  * @returns {React.ReactElement}   Col component.
  */
 const Col: React.FC< ColProps > = props => {
-	const { children, className } = props;
+	const { children, tagName = 'div', className } = props;
 
 	const sm = Math.min( smCols, typeof props.sm === 'number' ? props.sm : smCols ); // max of 4, if undefined = 4
 	const smStart = Math.min( smCols, typeof props.sm === 'object' ? props.sm.start : 0 ); // max of 4, if undefined = 0
@@ -43,7 +44,13 @@ const Col: React.FC< ColProps > = props => {
 		[ styles[ `col-lg-${ lgEnd }-end` ] ]: lgEnd > 0,
 	} );
 
-	return <div className={ colClassName }>{ children }</div>;
+	return createElement(
+		tagName,
+		{
+			className: colClassName,
+		},
+		children
+	);
 };
 
 export default Col;

--- a/projects/js-packages/components/components/layout/container/README.md
+++ b/projects/js-packages/components/components/layout/container/README.md
@@ -15,10 +15,18 @@ import { Container, Col, Button } from '@automattic/jetpack-components';
 	<Col>
 		<Button>Click me!</Button>
 	</Col>
-</Container>
+</Container>;
 ```
 
 ## Props
+
+### tagName
+
+The HTML tag of the container.
+
+- Type: `String`
+- Default: `div`
+- Required: `false`
 
 ### className
 
@@ -56,7 +64,7 @@ Value is multiplied by `8px`, following our specs.
 
 ```jsx
 // Space will be 16px
-<Container horizontalSpacing={ 2 } />
+<Container horizontalSpacing={2} />
 ```
 
 ### horizontalGap
@@ -73,5 +81,5 @@ Value is multiplied by `8px`, following our specs.
 
 ```jsx
 // Space will be 24px
-<Container horizontalGap={ 3 } />
+<Container horizontalGap={3} />
 ```

--- a/projects/js-packages/components/components/layout/container/README.md
+++ b/projects/js-packages/components/components/layout/container/README.md
@@ -15,7 +15,7 @@ import { Container, Col, Button } from '@automattic/jetpack-components';
 	<Col>
 		<Button>Click me!</Button>
 	</Col>
-</Container>;
+</Container>
 ```
 
 ## Props
@@ -64,7 +64,7 @@ Value is multiplied by `8px`, following our specs.
 
 ```jsx
 // Space will be 16px
-<Container horizontalSpacing={2} />
+<Container horizontalSpacing={ 2 } />
 ```
 
 ### horizontalGap
@@ -81,5 +81,5 @@ Value is multiplied by `8px`, following our specs.
 
 ```jsx
 // Space will be 24px
-<Container horizontalGap={3} />
+<Container horizontalGap={ 3 } />
 ```

--- a/projects/js-packages/components/components/layout/container/index.tsx
+++ b/projects/js-packages/components/components/layout/container/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useMemo } from 'react';
+import { createElement, useMemo } from 'react';
 import { ContainerProps } from '../types';
 import styles from './style.module.scss';
 import type React from 'react';
@@ -13,6 +13,7 @@ import type React from 'react';
 const Container: React.FC< ContainerProps > = ( {
 	children,
 	fluid = false,
+	tagName = 'div',
 	className,
 	horizontalGap = 1,
 	horizontalSpacing = 1,
@@ -32,10 +33,13 @@ const Container: React.FC< ContainerProps > = ( {
 		[ styles.fluid ]: fluid,
 	} );
 
-	return (
-		<div className={ containerClassName } style={ containerStyle }>
-			{ children }
-		</div>
+	return createElement(
+		tagName,
+		{
+			className: containerClassName,
+			style: containerStyle,
+		},
+		children
 	);
 };
 

--- a/projects/js-packages/components/components/layout/types.ts
+++ b/projects/js-packages/components/components/layout/types.ts
@@ -2,6 +2,11 @@ type ColSpan = number | { start: number; end: number };
 
 export type ColProps = {
 	/**
+	 * Tag name of the column element.
+	 */
+	tagName?: string;
+
+	/**
 	 * Custom className to be inserted.
 	 */
 	className?: string;
@@ -28,6 +33,11 @@ export type ColProps = {
 };
 
 export type ContainerProps = {
+	/**
+	 * Tag name of the container.
+	 */
+	tagName?: string;
+
 	/**
 	 * Make container not having a max width.
 	 */

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -9,6 +9,7 @@ import ScanAndProtectCard from './scan-protect-card';
 import SearchCard from './search-card';
 import SocialCard from './social-card';
 import StatsCard from './stats-card';
+import styles from './style.module.scss';
 import VideopressCard from './videopress-card';
 
 /**
@@ -31,7 +32,13 @@ const ProductCardsSection = () => {
 	];
 
 	return (
-		<Container tagName="ul" fluid horizontalSpacing={ 0 } horizontalGap={ 3 }>
+		<Container
+			className={ styles.cardlist }
+			tagName="ul"
+			fluid
+			horizontalSpacing={ 0 }
+			horizontalGap={ 3 }
+		>
 			{ items.map( ( Item, index ) => (
 				<Col tagName="li" sm={ 4 } md={ 4 } lg={ 4 } key={ index }>
 					<Item admin={ true } />

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -17,38 +17,26 @@ import VideopressCard from './videopress-card';
  * @returns {object} ProductCardsSection React component.
  */
 const ProductCardsSection = () => {
+	const items = [
+		BackupCard,
+		ScanAndProtectCard,
+		AntiSpamCard,
+		BoostCard,
+		SearchCard,
+		VideopressCard,
+		StatsCard,
+		CrmCard,
+		SocialCard,
+		AiCard,
+	];
+
 	return (
-		<Container fluid horizontalSpacing={ 0 } horizontalGap={ 3 }>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<BackupCard admin={ true } />
-			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<ScanAndProtectCard admin={ true } />
-			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<AntiSpamCard admin={ true } />
-			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<BoostCard admin={ true } />
-			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<SearchCard admin={ true } />
-			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<VideopressCard admin={ true } />
-			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<StatsCard admin={ true } />
-			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<CrmCard admin={ true } />
-			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<SocialCard admin={ true } />
-			</Col>
-			<Col sm={ 4 } md={ 4 } lg={ 4 }>
-				<AiCard admin={ true } />
-			</Col>
+		<Container tagName="ul" fluid horizontalSpacing={ 0 } horizontalGap={ 3 }>
+			{ items.map( ( Item, index ) => (
+				<Col tagName="li" sm={ 4 } md={ 4 } lg={ 4 } key={ index }>
+					<Item admin={ true } />
+				</Col>
+			) ) }
 		</Container>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
@@ -50,3 +50,9 @@
 .loading-placeholder {
 	margin-top: calc( var( --spacing-base ) / 2 ); // 4px
 }
+
+.cardlist {
+	> li {
+		margin-bottom: 0; // Reset base style
+	}
+}

--- a/projects/packages/my-jetpack/changelog/fix-my-jp-card-list
+++ b/projects/packages/my-jetpack/changelog/fix-my-jp-card-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add tagName prop to Col and Container

--- a/projects/packages/my-jetpack/changelog/fix-my-jp-card-list
+++ b/projects/packages/my-jetpack/changelog/fix-my-jp-card-list
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Add tagName prop to Col and Container
+Organize product cards in list


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31605

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR organizes the product cards of the My Jetpack page in a list. The list groups the product cards, conveying accessibly that they have a common and shared purpose.

In more details, it updates the `@automattic/jetpack-components` package so that we can specify a tag to the `Col` and `Container` components.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pedMtX-Rg-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a test site with this branch
* Visit the _My Jetpack_ page
* Check its design is similar as before
* Notice in the markup that cards are included in a list

<img width="500" alt="Screenshot 2023-06-27 at 2 11 11 PM" src="https://github.com/Automattic/jetpack/assets/1620183/e1d70dc7-e834-43a9-9d47-a0f3ef4e577e">
