### PR TITLE
Drop off emails: Added a new email campaign trigger for blog-onboarding

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-new-email-campaign-trigger
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-new-email-campaign-trigger
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a new email campaign trigger for blog-onboarding

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "3.4.x-dev"
+			"dev-trunk": "3.5.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "3.4.0",
+	"version": "3.5.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '3.4.0';
+	const PACKAGE_VERSION = '3.5.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -775,3 +775,24 @@ function wpcom_mark_domain_tasks_complete( $blog_id, $user_id, $product_id ) {
 	wpcom_mark_launchpad_task_complete( 'domain_upsell_deferred' );
 }
 add_action( 'activate_product', 'wpcom_mark_domain_tasks_complete', 10, 6 );
+
+/**
+ * Re-trigger email campaigns for blog onboarding after user edit one of the fields in the launchpad.
+ */
+function wpcom_trigger_email_campaign() {
+	$site_intent = get_option( 'site_intent' );
+	if ( ! $site_intent ) {
+		return;
+	}
+
+	if ( ! in_array( $site_intent, array( 'start-writing', 'design-first' ), true ) ) {
+		return;
+	}
+
+	MarketingEmailCampaigns::start_tailored_use_case_new_site_workflows_if_eligible(
+		get_current_user_id(),
+		get_current_blog_id(),
+		$site_intent
+	);
+}
+add_action( 'update_option_launchpad_checklist_tasks_statuses', 'wpcom_trigger_email_campaign', 10, 3 );

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-new-email-campaign-trigger
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-new-email-campaign-trigger
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_2"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_3_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "2e7328c5d9608c07a7ddddfac069af1cefa418f1"
+                "reference": "05dc16c5e87471de1e32e4a8a2e663fbaf7302ba"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.2
+ * Version: 1.6.3-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.2",
+	"version": "1.6.3-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Task-related: 2834-gh-Automattic/dotcom-forge

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a new email campaign trigger for blog-onboarding

### Other information:

- [x] Have you written new tests for your changes, if applicable? Tests are in the diff code: D114665-code
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
In the diff code: D114665-code