### PR TITLE
AI Extensions: Check for null and undefined blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/modify-ai-extended-blocks
+++ b/projects/plugins/jetpack/changelog/modify-ai-extended-blocks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Stop extending list items with AI
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -17,7 +17,7 @@ import { isUserConnected } from '../../lib/connection';
 export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
 
 // List of blocks that can be extended.
-export const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading', 'core/list-item' ] as const;
+export const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading' ] as const;
 
 export type ExtendedBlockProp = ( typeof EXTENDED_BLOCKS )[ number ];
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -17,7 +17,7 @@ import { isUserConnected } from '../../lib/connection';
 export const AI_ASSISTANT_SUPPORT_NAME = 'ai-assistant-support';
 
 // List of blocks that can be extended.
-export const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading' ] as const;
+export const EXTENDED_BLOCKS = [ 'core/paragraph', 'core/heading', 'core/list-item' ] as const;
 
 export type ExtendedBlockProp = ( typeof EXTENDED_BLOCKS )[ number ];
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/block-content.ts
@@ -84,7 +84,10 @@ export function getTextContentFromSelectedBlocks(): GetTextContentFromBlocksProp
 		count: blocks.length,
 		clientIds,
 		content: blocks
-			? blocks.map( block => getBlockTextContent( block.clientId ) ).join( HTML_JOIN_CHARACTERS )
+			? blocks
+					.filter( block => block !== null && block !== undefined ) // Safeguard against null or undefined blocks
+					.map( block => getBlockTextContent( block.clientId ) )
+					.join( HTML_JOIN_CHARACTERS )
 			: '',
 	};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/p2/issues/6150 , where  `is select( 'core/block-editor' ).getBlocksByClientId( clientIds ); `returns an array with null values, and is breaking lists and certain following blocks on the p2 comments box

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a safeguard check for null and undefined values.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1687946664807469-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch in your sandbox
* Point a p2 page to your sandbox and confirm that the error does not occur anymore
* Test it on a simple site in the editor