### PR TITLE
Search: fix link to add a Search Widget in the Jetpack dashboard, when using a block theme

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
@@ -82,6 +82,14 @@ class DashSearch extends Component {
 		} );
 	};
 
+	trackAddSearchBlockLink = () => {
+		analytics.tracks.recordJetpackClick( {
+			type: 'search-block-link',
+			target: 'at-a-glance',
+			feature: 'search',
+		} );
+	};
+
 	activateSearch = () => {
 		this.props.updateOptions( {
 			search: true,
@@ -182,6 +190,16 @@ class DashSearch extends Component {
 							onClick={ this.trackAddSearchWidgetLink }
 						>
 							{ __( 'Add Search (Jetpack) Widget', 'jetpack' ) }
+						</Card>
+					) }
+					{ ! this.props.hasInstantSearch && this.props.isBlockThemeActive && (
+						<Card
+							compact
+							className="jp-search-config-aag"
+							href="site-editor.php"
+							onClick={ this.trackAddSearchBlockLink }
+						>
+							{ __( 'Add a Search Block', 'jetpack' ) }
 						</Card>
 					) }
 				</div>

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
@@ -16,6 +16,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
+import { currentThemeIsBlockTheme } from 'state/initial-state';
 import { siteHasFeature, isFetchingSitePurchases } from 'state/site';
 
 const SEARCH_DESCRIPTION = __(
@@ -28,7 +29,7 @@ const SEARCH_SUPPORT = __( 'Search supports many customizations. ', 'jetpack' );
 /**
  * Displays a card for Search based on the props given.
  *
- * @param   {object} props Settings to render the card.
+ * @param {object} props - Settings to render the card
  * @returns {object}       Search card
  */
 const renderCard = props => (
@@ -163,7 +164,7 @@ class DashSearch extends Component {
 							{ __( 'Jetpack Search is powering search on your site.', 'jetpack' ) }
 						</p>
 					</DashItem>
-					{ this.props.hasInstantSearch ? (
+					{ this.props.hasInstantSearch && (
 						<Card
 							compact
 							className="jp-search-config-aag"
@@ -172,7 +173,8 @@ class DashSearch extends Component {
 						>
 							{ SEARCH_CUSTOMIZE_CTA }
 						</Card>
-					) : (
+					) }
+					{ ! this.props.hasInstantSearch && ! this.props.isBlockThemeActive && (
 						<Card
 							compact
 							className="jp-search-config-aag"
@@ -205,6 +207,7 @@ class DashSearch extends Component {
 export default connect(
 	state => {
 		return {
+			isBlockThemeActive: currentThemeIsBlockTheme( state ),
 			isOfflineMode: isOfflineMode( state ),
 			isFetching: isFetchingSitePurchases( state ),
 			hasClassicSearch: siteHasFeature( state, 'search' ),

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -373,6 +373,16 @@ export function currentThemeSupports( state, feature ) {
 }
 
 /**
+ * Check that the current theme is a block theme.
+ *
+ * @param {object} state - Global state tree.
+ * @returns {boolean} True if the current theme is a block theme, false otherwise.
+ */
+export function currentThemeIsBlockTheme( state ) {
+	return get( state.jetpack.initialState.themeData, [ 'isBlockTheme' ], false );
+}
+
+/**
  * Check if backups UI should be displayed.
  *
  * @param {object} state Global state tree

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -194,9 +194,10 @@ class Jetpack_Redux_State_Helper {
 				'latestBoostSpeedScores'     => $speed_score_history->latest(),
 			),
 			'themeData'                   => array(
-				'name'      => $current_theme->get( 'Name' ),
-				'hasUpdate' => (bool) get_theme_update_available( $current_theme ),
-				'support'   => array(
+				'name'         => $current_theme->get( 'Name' ),
+				'hasUpdate'    => (bool) get_theme_update_available( $current_theme ),
+				'isBlockTheme' => (bool) $current_theme->is_block_theme(),
+				'support'      => array(
 					'infinite-scroll' => current_theme_supports( 'infinite-scroll' ) || in_array( $current_theme->get_stylesheet(), $inf_scr_support_themes, true ),
 					'widgets'         => current_theme_supports( 'widgets' ),
 					'webfonts'        => (

--- a/projects/plugins/jetpack/changelog/update-search-widget-block-themes
+++ b/projects/plugins/jetpack/changelog/update-search-widget-block-themes
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Search: do when using a block theme, do not display a link to add a wSearch widget in the Jetpack dashboard.
+Search: when using a block theme, display a link to add a Search Block instead of a Search Widget in the Jetpack dashboard.

--- a/projects/plugins/jetpack/changelog/update-search-widget-block-themes
+++ b/projects/plugins/jetpack/changelog/update-search-widget-block-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: do when using a block theme, do not display a link to add a wSearch widget in the Jetpack dashboard.

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -1,6 +1,5 @@
 [
 	"projects/plugins/jetpack/_inc/client/admin.js",
-	"projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx",
 	"projects/plugins/jetpack/_inc/client/components/count/index.jsx",
 	"projects/plugins/jetpack/_inc/client/components/global-notices/state/notices/actions.js",
 	"projects/plugins/jetpack/_inc/client/components/global-notices/state/notices/reducer.js",


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/78485

## Proposed changes:

In Jetpack's At A Glance dashboard, we display a Search card, with different content based on your site details. If your site does not support Instant Search, we currently show a link to add a Search Widget to your site. That option is really only useful if you use a classic theme; with a block theme, you should use a search block in one of your template parts instead.

**Before**

<img width="535" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/c6797fba-b91f-437c-8ac3-6db2519502b0">

**After**

<img width="558" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/3aaaa190-bfca-4244-a0f6-a9a8599aea1d">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* Yes, it adds a new link to the site editor, and clicks on that link are tracked, just like for the other links in that section.

## Testing instructions:

* Go to https://woocommerce.com/express/
* Click "Try for free" and follow the flow to create a new Woo Express site.
* Once you've created your site, go to Plugins > Add New
* Upload and activate [the Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/)
* Go to Jetpack > Beta > Jetpacak
* Switch to this branch
* Go to Jetpack > Dashboard
    * Check the link in the Search card towards the bottom of the page.
* Go to Appearance > Themes
* Install the Twenty Twenty One theme, and activate it.
    * The link should be updated accordingly.
