### PR TITLE
Blaze: ensure the Dashboard menu is only inserted once.

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-menu-masterbar
+++ b/projects/packages/blaze/changelog/update-blaze-menu-masterbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard Menu: change priority.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -103,7 +103,18 @@ class Blaze {
 
 		$blaze_dashboard = new Blaze_Dashboard();
 
-		if ( ( new Host() )->is_wpcom_platform() ) {
+		if ( self::is_dashboard_enabled() ) {
+			$page_suffix = add_submenu_page(
+				'tools.php',
+				esc_attr__( 'Advertising', 'jetpack-blaze' ),
+				__( 'Advertising', 'jetpack-blaze' ),
+				'manage_options',
+				'advertising',
+				array( $blaze_dashboard, 'render' ),
+				1
+			);
+			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
+		} elseif ( ( new Host() )->is_wpcom_platform() ) {
 			$domain      = ( new Jetpack_Status() )->get_site_suffix();
 			$page_suffix = add_submenu_page(
 				'tools.php',
@@ -112,17 +123,6 @@ class Blaze {
 				'manage_options',
 				'https://wordpress.com/advertising/' . $domain,
 				null,
-				1
-			);
-			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
-		} elseif ( self::is_dashboard_enabled() ) {
-			$page_suffix = add_submenu_page(
-				'tools.php',
-				esc_attr__( 'Advertising', 'jetpack-blaze' ),
-				__( 'Advertising', 'jetpack-blaze' ),
-				'manage_options',
-				'advertising',
-				array( $blaze_dashboard, 'render' ),
 				1
 			);
 			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -99,7 +99,7 @@ class Blaze {
 				'manage_options',
 				'advertising',
 				array( $blaze_dashboard, 'render' ),
-				100
+				1
 			);
 			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
 		}

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -87,22 +87,29 @@ class Blaze {
 	 * @return void
 	 */
 	public static function enable_blaze_menu() {
-		if (
-			self::should_initialize()
-			&& self::is_dashboard_enabled()
-		) {
-			$blaze_dashboard = new Blaze_Dashboard();
-			$page_suffix     = add_submenu_page(
-				'tools.php',
-				esc_attr__( 'Advertising', 'jetpack-blaze' ),
-				__( 'Advertising', 'jetpack-blaze' ),
-				'manage_options',
-				'advertising',
-				array( $blaze_dashboard, 'render' ),
-				1
-			);
-			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
+		if ( ! self::should_initialize() ) {
+			return;
 		}
+
+		$blaze_dashboard = new Blaze_Dashboard();
+		$domain          = ( new Jetpack_Status() )->get_site_suffix();
+		$menu_slug       = self::is_dashboard_enabled()
+			? 'advertising'
+			: 'https://wordpress.com/advertising/' . $domain;
+		$menu_function   = self::is_dashboard_enabled()
+			? array( $blaze_dashboard, 'render' )
+			: null;
+
+		$page_suffix = add_submenu_page(
+			'tools.php',
+			esc_attr__( 'Advertising', 'jetpack-blaze' ),
+			__( 'Advertising', 'jetpack-blaze' ),
+			'manage_options',
+			$menu_slug,
+			$menu_function,
+			1
+		);
+		add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -68,18 +68,27 @@ class Blaze {
 
 	/**
 	 * Is the wp-admin Dashboard enabled?
+	 * That dashboard is not available or necessary on WordPress.com sites.
 	 *
 	 * @return bool
 	 */
 	public static function is_dashboard_enabled() {
+		// Right now the dashboard is disabled by default.
+		$is_dashboard_enabled = false;
+
+		// On WordPress.com sites, the dashboard is not needed.
+		if ( ( new Host() )->is_wpcom_platform() ) {
+			$is_dashboard_enabled = false;
+		}
+
 		/**
 		 * Enable a wp-admin dashboard for Blaze campaign management.
 		 *
 		 * @since 0.7.0
 		 *
-		 * @param bool $should_enable Should the dashboard be enabled? False by default for now.
+		 * @param bool $should_enable Should the dashboard be enabled?
 		 */
-		return apply_filters( 'jetpack_blaze_dashboard_enable', false );
+		return apply_filters( 'jetpack_blaze_dashboard_enable', $is_dashboard_enabled );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Status as Jetpack_Status;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Sync\Settings as Sync_Settings;
 
 /**
@@ -92,24 +93,31 @@ class Blaze {
 		}
 
 		$blaze_dashboard = new Blaze_Dashboard();
-		$domain          = ( new Jetpack_Status() )->get_site_suffix();
-		$menu_slug       = self::is_dashboard_enabled()
-			? 'advertising'
-			: 'https://wordpress.com/advertising/' . $domain;
-		$menu_function   = self::is_dashboard_enabled()
-			? array( $blaze_dashboard, 'render' )
-			: null;
 
-		$page_suffix = add_submenu_page(
-			'tools.php',
-			esc_attr__( 'Advertising', 'jetpack-blaze' ),
-			__( 'Advertising', 'jetpack-blaze' ),
-			'manage_options',
-			$menu_slug,
-			$menu_function,
-			1
-		);
-		add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
+		if ( ( new Host() )->is_wpcom_platform() ) {
+			$domain      = ( new Jetpack_Status() )->get_site_suffix();
+			$page_suffix = add_submenu_page(
+				'tools.php',
+				esc_attr__( 'Advertising', 'jetpack-blaze' ),
+				__( 'Advertising', 'jetpack-blaze' ),
+				'manage_options',
+				'https://wordpress.com/advertising/' . $domain,
+				null,
+				1
+			);
+			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
+		} elseif ( self::is_dashboard_enabled() ) {
+			$page_suffix = add_submenu_page(
+				'tools.php',
+				esc_attr__( 'Advertising', 'jetpack-blaze' ),
+				__( 'Advertising', 'jetpack-blaze' ),
+				'manage_options',
+				'advertising',
+				array( $blaze_dashboard, 'render' ),
+				1
+			);
+			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-blaze-menu-masterbar
+++ b/projects/plugins/jetpack/changelog/update-blaze-menu-masterbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com Toolbar: only add Blaze Dashboard link once.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -350,9 +350,6 @@ class Admin_Menu extends Base_Admin_Menu {
 		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'export.php' ) ) {
 			$submenus_to_update['export.php'] = 'https://wordpress.com/export/' . $this->domain;
 		}
-		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'tools.php?page=advertising' ) ) {
-			$submenus_to_update['tools.php?page=advertising'] = 'https://wordpress.com/advertising/' . $this->domain;
-		}
 		$this->update_submenus( 'tools.php', $submenus_to_update );
 
 		$this->hide_submenu_page( 'tools.php', 'tools.php' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -350,6 +350,9 @@ class Admin_Menu extends Base_Admin_Menu {
 		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'export.php' ) ) {
 			$submenus_to_update['export.php'] = 'https://wordpress.com/export/' . $this->domain;
 		}
+		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'tools.php?page=advertising' ) ) {
+			$submenus_to_update['tools.php?page=advertising'] = 'https://wordpress.com/advertising/' . $this->domain;
+		}
 		$this->update_submenus( 'tools.php', $submenus_to_update );
 
 		$this->hide_submenu_page( 'tools.php', 'tools.php' );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -382,7 +382,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// performance settings already have a link to Page Optimize settings page.
 		$this->hide_submenu_page( 'options-general.php', 'page-optimize' );
 
-		if ( Blaze::should_initialize() ) {
+		if ( Blaze::should_initialize() && ! Blaze::is_dashboard_enabled() ) {
 			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
 		}
 	}

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
-use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\Status;
@@ -381,10 +380,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// would conflict with our own Settings > Performance that links to Calypso, so we hide it it since the Calypso
 		// performance settings already have a link to Page Optimize settings page.
 		$this->hide_submenu_page( 'options-general.php', 'page-optimize' );
-
-		if ( Blaze::should_initialize() && ! Blaze::is_dashboard_enabled() ) {
-			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
-		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
-use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 
 require_once __DIR__ . '/class-admin-menu.php';
@@ -244,9 +243,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_tools_menu() {
 		add_menu_page( esc_attr__( 'Tools', 'jetpack' ), __( 'Tools', 'jetpack' ), 'publish_posts', 'tools.php', null, 'dashicons-admin-tools', 75 );
-		if ( Blaze::should_initialize() && ! Blaze::is_dashboard_enabled() ) {
-			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
-		}
+
 		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain );
 		add_submenu_page( 'tools.php', esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain );
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -244,7 +244,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 	 */
 	public function add_tools_menu() {
 		add_menu_page( esc_attr__( 'Tools', 'jetpack' ), __( 'Tools', 'jetpack' ), 'publish_posts', 'tools.php', null, 'dashicons-admin-tools', 75 );
-		if ( Blaze::should_initialize() ) {
+		if ( Blaze::should_initialize() && ! Blaze::is_dashboard_enabled() ) {
 			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
 		}
 		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -367,7 +367,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_options_menu() {
 		parent::add_options_menu();
 
-		if ( Blaze::should_initialize() ) {
+		if ( Blaze::should_initialize() && ! Blaze::is_dashboard_enabled() ) {
 			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
 		}
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 10 );

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
-use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Status;
 use Jetpack_Custom_CSS;
 use JITM;
@@ -367,9 +366,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 	public function add_options_menu() {
 		parent::add_options_menu();
 
-		if ( Blaze::should_initialize() && ! Blaze::is_dashboard_enabled() ) {
-			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
-		}
 		add_submenu_page( 'options-general.php', esc_attr__( 'Hosting Configuration', 'jetpack' ), __( 'Hosting Configuration', 'jetpack' ), 'manage_options', 'https://wordpress.com/hosting-config/' . $this->domain, null, 10 );
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-jetpack-admin-menu.php
@@ -126,8 +126,6 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_tools_menu() {
 		global $submenu;
 
-		// Enable blaze
-		add_filter( 'jetpack_blaze_enabled', '__return_true' );
 		static::$admin_menu->add_tools_menu();
 
 		// Check Import/Export menu always links to WP Admin.
@@ -136,7 +134,6 @@ class Test_Jetpack_Admin_Menu extends WP_UnitTestCase {
 
 		$this->assertSame( 'https://wordpress.com/earn/' . static::$domain, array_pop( $submenu['tools.php'] )[2] );
 		$this->assertSame( 'https://wordpress.com/marketing/tools/' . static::$domain, array_pop( $submenu['tools.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/advertising/' . static::$domain, array_pop( $submenu['tools.php'] )[2] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

This fixes issues on WoA sites and WordPress.com Simple sites, where when the new dashboard is enabled, the navigation menu (under Tools > Advertising) is added by the package, while the old Calypso link is also added, via the masterbar.

To solve this problem, we rely on the package, and only the package, to register the menu. **We do point WoA and simple site owners to the Calypso advertising page (and not the wp-admin advertising page) at all times, since they have nav-unification on and are logged in to WordPress. com at all times.**

This PR also changes the order of the new menu added by the package, to ensure it's always added at the top of the Tools menu.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1687955577164529/1687894794.905929-slack-C053FAERCDP

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

You'll want to test this on all three site types (WoA, Simple, self-hosted).

- On WoA sites, you should see a Tools > Advertising menu item pointing you to Calypso at all times.
- On Simple sites, you should see a Tools > Advertising menu item pointing you to Calypso at all times.
- On self-hosted sites, you should not see any Tools > Advertising menu item by default.
    - If you enable the Blaze feature under Jetpack > Settings > Traffic, you should still see no new menu item.
    - If you enable the Blaze dashboard with `add_filter( 'jetpack_blaze_dashboard_enable', '__return_true' );`, you should see a new menu item, pointing you to the wp-admin advertising page.
