### PR TITLE
Launchpad: Fix edit site design visibility

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-edit-site-design-visibility
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-edit-site-design-visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Don't hide design_edited task if complete

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -129,8 +129,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		'keep-building'   => array(
-			'title'                  => 'Keep Building',
-			'task_ids'               => array(
+			'title'               => 'Keep Building',
+			'task_ids'            => array(
 				'site_title',
 				'design_edited',
 				'domain_claim',
@@ -138,7 +138,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'domain_customize',
 				'drive_traffic',
 			),
-			'is_enabled_callback'    => 'wpcom_launchpad_is_keep_building_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -139,7 +139,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'drive_traffic',
 			),
 			'is_enabled_callback'    => 'wpcom_launchpad_is_keep_building_enabled',
-			'visible_tasks_callback' => 'wpcom_launchpad_keep_building_visible_tasks',
 		),
 	);
 
@@ -570,33 +569,6 @@ function wpcom_launchpad_is_keep_building_enabled() {
 	}
 
 	return false;
-}
-
-/**
- * Filter task visibility for the Keep building task list.
- *
- * @param array $task_list The task array.
- *
- * @return array The filtered array of task IDs.
- */
-function wpcom_launchpad_keep_building_visible_tasks( $task_list ) {
-	$task_ids = $task_list['task_ids'];
-
-	if ( ! $task_ids ) {
-		return array();
-	}
-
-	return array_filter(
-		$task_ids,
-		function ( $task_id ) {
-			// Only show design_edited/site_edited if it hasn't been marked as complete.
-			if ( in_array( $task_id, array( 'design_edited', 'site_edited' ), true ) ) {
-				return ! wpcom_is_checklist_task_complete( $task_id );
-			}
-
-			return true;
-		}
-	);
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#78743

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The logic for hiding the "Edit site design" task doesn't work because it hides the task regardless of when the task was completed (during onboarding, or after). We don't have a way to determine the context in which a task was completed; we only know if it's complete or incomplete.
* Let's just show the "Edit site design" task regardless; if completed during onboarding, it will show up in the Keep Building task list as complete. 🤷‍♀️ 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox
* Create a new site from `/start` with the "Promote myself or business" intent
* Complete the "Edit site design" task during onboarding
* Launch your site 
* You should see "Edit site design" task in the Keep Building task list in Customer Home, marked as completed
* Create a second new site following the same process, but don't complete the "Edit site design" task during onboarding
* You should see the task in the Keep Building task list, not complete
* Clicking on the task should mark it as complete
