### PR TITLE
Launchpad: Update is_enabled_callback for Keep Building checklist

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-keep-building-logic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-keep-building-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update keep building task list visibility logic to check if a site is launched

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -564,8 +564,10 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
 function wpcom_launchpad_is_keep_building_enabled() {
 	$intent                  = get_option( 'site_intent', false );
 	$launchpad_task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
-	$launched                = isset( $launchpad_task_statuses['site_launched'] ) && $launchpad_task_statuses['site_launched'];
-	$blog_id                 = get_current_blog_id();
+
+	// We don't care about the other *_launched tasks, since this is specific to the Build flow.
+	$launched = isset( $launchpad_task_statuses['site_launched'] ) && $launchpad_task_statuses['site_launched'];
+	$blog_id  = get_current_blog_id();
 
 	if ( 'build' === $intent && $blog_id > 220443356 && $launched ) {
 		return true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -562,10 +562,12 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
  * @return bool True if the task list is enabled, false otherwise.
  */
 function wpcom_launchpad_is_keep_building_enabled() {
-	$intent  = get_option( 'site_intent', false );
-	$blog_id = get_current_blog_id();
+	$intent                  = get_option( 'site_intent', false );
+	$launchpad_task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
+	$launched                = isset( $launchpad_task_statuses['site_launched'] ) && $launchpad_task_statuses['site_launched'];
+	$blog_id                 = get_current_blog_id();
 
-	if ( 'build' === $intent && $blog_id > 220443356 ) {
+	if ( 'build' === $intent && $blog_id > 220443356 && $launched ) {
 		return true;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/wp-calypso#78199 and Automattic/wp-calypso#78752

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add some logic to the is_enabled_callback for the Keep Building checklist to only enable it if a site has launched.
* This will allow us to determine where to send people after checkout for the domain task; if this task list is enabled, send them to `/home`, if not, send them to `/setup/intent/etc.`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox the API
* Create a new site from `/start` with the "Promote myself or site" intent
* Do not launch the new site yet
* Go to the developer console and GET from WP REST API `/wpcomv2/sites/siteSlug/launchpad?checklist_slug=keep-building`
* `is_enabled` should be `false`
* Launch your new site
* Go back to the developer console and fetch the same data
* `is_enabled` should now be `true`