### PR TITLE
Launchpad: Add validation for required tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-required-tasks-validation
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-required-tasks-validation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add validation for required tasks.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -434,6 +434,12 @@ class Launchpad_Task_Lists {
 			return false;
 		}
 
+		// If we have required tasks, make sure they all exist in the array of `task_ids`.
+		if ( isset( $task_list['required_task_ids'] ) && count( array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) ) === count( $task_list['required_task_ids'] ) ) {
+			_doing_it_wrong( 'validate_task_list', 'The required_task_ids must be a subset of the task_ids', '6.1' );
+			return false;
+		}
+
 		if ( isset( $task_list['require_last_task_completion'] ) && ! is_bool( $task_list['require_last_task_completion'] ) ) {
 			_doing_it_wrong( 'validate_task_list', 'The require_last_task_completion attribute must be a boolean', '6.1' );
 			return false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -435,7 +435,7 @@ class Launchpad_Task_Lists {
 		}
 
 		// If we have required tasks, make sure they all exist in the array of `task_ids`.
-		if ( isset( $task_list['required_task_ids'] ) && array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) === $task_list['required_task_ids'] ) {
+		if ( isset( $task_list['required_task_ids'] ) && array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) !== $task_list['required_task_ids'] ) {
 			_doing_it_wrong( 'validate_task_list', 'The required_task_ids must be a subset of the task_ids', '6.1' );
 			return false;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -435,7 +435,7 @@ class Launchpad_Task_Lists {
 		}
 
 		// If we have required tasks, make sure they all exist in the array of `task_ids`.
-		if ( isset( $task_list['required_task_ids'] ) && count( array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) ) === count( $task_list['required_task_ids'] ) ) {
+		if ( isset( $task_list['required_task_ids'] ) && array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) === $task_list['required_task_ids'] ) {
 			_doing_it_wrong( 'validate_task_list', 'The required_task_ids must be a subset of the task_ids', '6.1' );
 			return false;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/77941

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If we've specified some required tasks, ensure all the required task IDs are present in the array of all task IDs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

