### PR TITLE
CRM: Time conditions from segments do not get saved

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3164-time-condition-does-not-get-saved
+++ b/projects/plugins/crm/changelog/fix-crm-3164-time-condition-does-not-get-saved
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Segments: Fix bug that prevented dates to be saved in some environments

--- a/projects/plugins/crm/includes/ZeroBSCRM.DataIOValidation.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DataIOValidation.php
@@ -382,9 +382,9 @@ function zeroBSCRM_segments_filterConditions($conditions=array(),$processCharact
 								$local_date_time->setTimezone( new DateTimeZone( 'UTC' ) );
 								$value = $local_date_time->format( 'Y-m-d H:i' );
 
-								$local_date_time = new DateTime( $dates[1], new DateTimeZone( get_option( 'timezone_string' ) ) );
-								$local_date_time->setTimezone( new DateTimeZone( 'UTC' ) );
-								$value_2 = $local_date_time->format( 'Y-m-d H:i' );
+								$local_date_time_2 = new DateTime( $dates[1], new DateTimeZone( get_option( 'timezone_string' ) ) );
+								$local_date_time_2->setTimezone( new DateTimeZone( 'UTC' ) );
+								$value_2 = $local_date_time_2->format( 'Y-m-d H:i' );
 								// Set the converted dates to UTC.
 								$addition['value']  = zeroBSCRM_locale_dateToUTS( $value );
 								$addition['value2'] = zeroBSCRM_locale_dateToUTS( $value_2 );

--- a/projects/plugins/crm/includes/ZeroBSCRM.DataIOValidation.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DataIOValidation.php
@@ -378,16 +378,16 @@ function zeroBSCRM_segments_filterConditions($conditions=array(),$processCharact
                             $dates = explode(' - ', $val);
                             if (count($dates) == 2){
 
-                                $val = $dates[0];
-                                $addition['value'] = zeroBSCRM_locale_dateToUTS( $dates[0] );
-                                $addition['value2'] = zeroBSCRM_locale_dateToUTS( $dates[1] );
+								$local_date_time = new DateTime( $dates[0], new DateTimeZone( get_option( 'timezone_string' ) ) );
+								$local_date_time->setTimezone( new DateTimeZone( 'UTC' ) );
+								$value = $local_date_time->format( 'Y-m-d H:i' );
 
-                                // for those dates used in 'AFTER' this needs to effectively be midnight on the day (start of next day)
-                                if ( $c['operator'] == 'daterange' && !empty( $addition['value2'] ) ) {
-
-                                    $addition['value2'] += (60*60*24);
-
-                                }
+								$local_date_time = new DateTime( $dates[1], new DateTimeZone( get_option( 'timezone_string' ) ) );
+								$local_date_time->setTimezone( new DateTimeZone( 'UTC' ) );
+								$value_2 = $local_date_time->format( 'Y-m-d H:i' );
+								// Set the converted dates to UTC.
+								$addition['value']  = zeroBSCRM_locale_dateToUTS( $value );
+								$addition['value2'] = zeroBSCRM_locale_dateToUTS( $value_2 );
                             }
 
                         }

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
@@ -275,7 +275,7 @@ function zeroBSCRM_segments_typeConversions( $value = '', $type = '', $operator 
             if ($direction == 'in' && $operator != 'daterange' && $operator != 'datetimerange' && $operator != 'nextdays' && $operator != 'previousdays' ) {
                 switch ($available_conditions[$type]['conversion']) {
                     case 'date-to-uts':
-								$local_date_time = new DateTime( $value, new DateTimeZone( get_option( 'timezone_string' ) ) );
+								$local_date_time = new DateTime( $value, wp_timezone() );
 								$local_date_time->setTimezone( new DateTimeZone( 'UTC' ) );
 								$value = $local_date_time->format( 'Y-m-d H:i' );
                         // convert date to uts

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
@@ -275,7 +275,9 @@ function zeroBSCRM_segments_typeConversions( $value = '', $type = '', $operator 
             if ($direction == 'in' && $operator != 'daterange' && $operator != 'datetimerange' && $operator != 'nextdays' && $operator != 'previousdays' ) {
                 switch ($available_conditions[$type]['conversion']) {
                     case 'date-to-uts':
-
+								$local_date_time = new DateTime( $value, new DateTimeZone( get_option( 'timezone_string' ) ) );
+								$local_date_time->setTimezone( new DateTimeZone( 'UTC' ) );
+								$value = $local_date_time->format( 'Y-m-d H:i' );
                         // convert date to uts
                         $value = zeroBSCRM_locale_dateToUTS($value, true);
                     
@@ -302,7 +304,7 @@ function zeroBSCRM_segments_typeConversions( $value = '', $type = '', $operator 
                         }
 
                         // convert uts back to date
-                        $value = zeroBSCRM_date_i18n_plusTime(-1, $value);
+								$value = zeroBSCRM_date_i18n_plusTime( 'Y-m-d', $value );
 
                         break;
                 }

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.segmentedit.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.segmentedit.scss
@@ -203,3 +203,10 @@
 		color:#CCC;
 	}
 }
+
+#zbs-segment-edit-act-save {
+	i {
+		height: unset;
+		margin-left: 5px;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes a bug that prevents date and time conditions from being saved in Segments.

## Proposed changes:
* This PR changes the backend to use the hardcoded time format from the JS files.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack-crm-extensions/issues/698

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Change your locale settings to use a date format other than YYYY/MM/DD and your timezone to something different from UTC (in `wp-admin/options-general.php`)
* Save a segment with a date/time condition (`wp-admin/admin.php?page=manage-segments`)
* Test it with all date conditions:
    * `Before datetime` 
    * `After datetime` 
    * `In date range` 
    * `In datetime range` 
    * `On or Before date` 
    * `On or After date`

In `trunk` the date does not get saved or a wrong date will get saved.

In `fix/crm/3164-time-condition-does-not-get-saved` the correct date gets saved.

