### PR TITLE
My Jetpack: Enable skipping interstitial page for Stats

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -22,13 +22,23 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 		installStandalonePlugin,
 		deactivateStandalonePlugin,
 	} = useProduct( slug );
-	const { name, description, manageUrl, requiresUserConnection, standalonePluginInfo, status } =
-		detail;
+	const {
+		name,
+		description,
+		manageUrl,
+		purchaseUrl,
+		requiresUserConnection,
+		standalonePluginInfo,
+		status,
+	} = detail;
 	const [ installingStandalone, setInstallingStandalone ] = useState( false );
 	const [ deactivatingStandalone, setDeactivatingStandalone ] = useState( false );
 
 	const navigateToConnectionPage = useMyJetpackNavigate( '/connection' );
 	const navigateToAddProductPage = useMyJetpackNavigate( `add-${ slug }` );
+	const navigateToPurchasePage = useCallback( () => {
+		window.location = purchaseUrl;
+	}, [ purchaseUrl ] );
 
 	/* Menu Handling */
 	const hasStandalonePlugin = standalonePluginInfo?.hasStandalonePlugin;
@@ -114,7 +124,8 @@ const ConnectedProductCard = ( { admin, slug, children, showMenu = false, menuIt
 			onDeactivate={ deactivate }
 			slug={ slug }
 			onActivate={ handleActivate }
-			onAdd={ navigateToAddProductPage }
+			// Use purchaseUrl if available, otherwise use interstitial product page.
+			onAdd={ purchaseUrl ? navigateToPurchasePage : navigateToAddProductPage }
 			onManage={ onManage }
 			onFixConnection={ navigateToConnectionPage }
 			showMenu={ menuIsActive }

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
@@ -65,21 +65,26 @@ const ActionButton = ( {
 						) }
 				</Button>
 			);
-		case PRODUCT_STATUSES.NEEDS_PURCHASE:
+		case PRODUCT_STATUSES.NEEDS_PURCHASE: {
+			const upgradeText = __( 'Upgrade', 'jetpack-my-jetpack' );
+			const purchaseText = __( 'Purchase', 'jetpack-my-jetpack' );
+			const buttonText = slug === 'stats' ? upgradeText : purchaseText;
 			return (
 				<Button { ...buttonState } size="small" weight="regular" onClick={ onAdd }>
-					{ slug === 'stats'
-						? __( 'Upgrade', 'jetpack-my-jetpack' )
-						: __( 'Purchase', 'jetpack-my-jetpack' ) }
+					{ buttonText }
 				</Button>
 			);
+		}
 		case PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE:
 			return (
 				<Button { ...buttonState } size="small" weight="regular" onClick={ onAdd }>
 					{ __( 'Start for free', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
-		case PRODUCT_STATUSES.ACTIVE:
+		case PRODUCT_STATUSES.ACTIVE: {
+			const viewText = __( 'View', 'jetpack-my-jetpack' );
+			const manageText = __( 'Manage', 'jetpack-my-jetpack' );
+			const buttonText = slug === 'stats' ? viewText : manageText;
 			return (
 				<Button
 					{ ...buttonState }
@@ -89,11 +94,10 @@ const ActionButton = ( {
 					variant="secondary"
 					onClick={ onManage }
 				>
-					{ slug === 'stats'
-						? __( 'View', 'jetpack-my-jetpack' )
-						: __( 'Manage', 'jetpack-my-jetpack' ) }
+					{ buttonText }
 				</Button>
 			);
+		}
 		case PRODUCT_STATUSES.ERROR:
 			return (
 				<Button { ...buttonState } size="small" weight="regular" onClick={ onFixConnection }>

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-buton.jsx
@@ -16,6 +16,7 @@ const ActionButton = ( {
 	status,
 	admin,
 	name,
+	slug,
 	onActivate,
 	onManage,
 	onFixConnection,
@@ -67,7 +68,9 @@ const ActionButton = ( {
 		case PRODUCT_STATUSES.NEEDS_PURCHASE:
 			return (
 				<Button { ...buttonState } size="small" weight="regular" onClick={ onAdd }>
-					{ __( 'Purchase', 'jetpack-my-jetpack' ) }
+					{ slug === 'stats'
+						? __( 'Upgrade', 'jetpack-my-jetpack' )
+						: __( 'Purchase', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
 		case PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE:
@@ -86,7 +89,9 @@ const ActionButton = ( {
 					variant="secondary"
 					onClick={ onManage }
 				>
-					{ __( 'Manage', 'jetpack-my-jetpack' ) }
+					{ slug === 'stats'
+						? __( 'View', 'jetpack-my-jetpack' )
+						: __( 'Manage', 'jetpack-my-jetpack' ) }
 				</Button>
 			);
 		case PRODUCT_STATUSES.ERROR:

--- a/projects/packages/my-jetpack/changelog/update-jetpack-stats-card-on-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-stats-card-on-my-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack Stats: Enable skipping interstitial page

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -139,6 +139,7 @@ abstract class Product {
 			'has_required_plan'        => static::has_required_plan(),
 			'has_required_tier'        => static::has_required_tier(),
 			'manage_url'               => static::get_manage_url(),
+			'purchase_url'             => static::get_purchase_url(),
 			'post_activation_url'      => static::get_post_activation_url(),
 			'standalone_plugin_info'   => static::get_standalone_info(),
 			'class'                    => static::class,
@@ -205,6 +206,16 @@ abstract class Product {
 	 * @return array
 	 */
 	abstract public static function get_pricing_for_ui();
+
+	/**
+	 * Get the URL where the user can purchase the product iff it doesn't have an interstitial page in My Jetpack.
+	 *
+	 * @return ?string
+	 */
+	public static function get_purchase_url() {
+		// Declare as concrete method as most Jetpack products use an interstitial page within My Jetpack.
+		return null;
+	}
 
 	/**
 	 * Get the URL where the user manages the product

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\My_Jetpack\Products;
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+use Jetpack_Options;
 
 /**
  * Class responsible for handling the Jetpack Stats product
@@ -155,12 +156,25 @@ class Stats extends Module_Product {
 	}
 
 	/**
+	 * Get the WordPress.com URL for purchasing Jetpack Stats for the current site.
+	 *
+	 * @return ?string
+	 */
+	public static function get_purchase_url() {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+		// TODO: Handle unconnected sites without a defined blog_id. (Or check if we need to.)
+		// TODO: Remove the "stats/paid-stats" feature flag from the URL once paid stats has rolled out to the public.
+		// TODO: Consider adding a post-purchase redirect URL as a query string to the purchase URL.
+		// Appending get_manage_url() to the purchase URL would be a good option.
+		return sprintf( 'https://wordpress.com/stats/purchase/%d', $blog_id ) . '?flags=stats/paid-stats';
+	}
+
+	/**
 	 * Get the URL where the user manages the product
 	 *
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
-		// NOTE: Alternatively, use 'admin.php?page=jetpack#/settings?term=jetpack stats' to send visitors to Stats settings.
 		return admin_url( 'admin.php?page=stats' );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #31343

## Proposed changes:

Before Purchase|After Purchase
-|-
![SCR-20230628-lys](https://github.com/Automattic/jetpack/assets/4044428/1280931b-9dc7-49e1-a7c4-088fcfaf02bb)|![SCR-20230628-ly8-2](https://github.com/Automattic/jetpack/assets/4044428/81be802c-f40b-4223-92b6-06689f2a4fed)

* Adds support for `purchase_url` for `Product` classes, which can be used to skip the product's interstitial page.
* Adds a direct purchase link for the Stats card.
* Tweaks the text shown for the action button on the Stats card.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your Jetpack site.

* Navigate to My Jetpack at`/wp-admin/admin.php?page=my-jetpack`.
* Ensure the Jetpack Stats card renders with a `View` button.
* Ensure the `View` button takes you to the Jetpack Stats dashboard in wp-admin.

* Declare `JETPACK_PAID_STATS_ENABLED` as `true` in your mu-plugins
  * `define( 'JETPACK_PAID_STATS_ENABLED', true );`
* Build the My Jetpack package and navigate to `/wp-admin/admin.php?page=my-jetpack`.
* Ensure the Jetpack Stats card renders with the `Upgrade` button.
* Ensure the `Upgrade` button takes you to `https://wordpress.com/stats/purchase/{:siteId}?flags=stats/paid-stats`.