### PR TITLE
[Boost] Change _static dir for minify

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -179,7 +179,7 @@ class Concatenate_CSS extends WP_Styles {
 						}
 					}
 
-					$href = $siteurl . '/_static/??' . $path_str;
+					$href = $siteurl . '/_jb_static/??' . $path_str;
 				} else {
 					$href = jetpack_boost_page_optimize_cache_bust_mtime( current( $css ), $siteurl );
 				}

--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -179,7 +179,7 @@ class Concatenate_CSS extends WP_Styles {
 						}
 					}
 
-					$href = $siteurl . '/_jb_static/??' . $path_str;
+					$href = $siteurl . jetpack_boost_get_static_prefix() . '??' . $path_str;
 				} else {
 					$href = jetpack_boost_page_optimize_cache_bust_mtime( current( $css ), $siteurl );
 				}

--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -238,7 +238,7 @@ class Concatenate_JS extends WP_Scripts {
 						}
 					}
 
-					$href = $siteurl . '/_static/??' . $path_str;
+					$href = $siteurl . '/_jb_static/??' . $path_str;
 				} elseif ( isset( $js_array['paths'] ) && is_array( $js_array['paths'] ) ) {
 					$href = jetpack_boost_page_optimize_cache_bust_mtime( $js_array['paths'][0], $siteurl );
 				}

--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -238,7 +238,7 @@ class Concatenate_JS extends WP_Scripts {
 						}
 					}
 
-					$href = $siteurl . '/_jb_static/??' . $path_str;
+					$href = $siteurl . jetpack_boost_get_static_prefix() . '??' . $path_str;
 				} elseif ( isset( $js_array['paths'] ) && is_array( $js_array['paths'] ) ) {
 					$href = jetpack_boost_page_optimize_cache_bust_mtime( $js_array['paths'][0], $siteurl );
 				}

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -260,7 +260,7 @@ function jetpack_boost_page_optimize_cache_bust_mtime( $path, $siteurl ) {
 }
 
 /**
- * Detects requests within the `/_static/` directory, and serves minified content.
+ * Detects requests within the `/_jb_static/` directory, and serves minified content.
  *
  * @return void
  */
@@ -270,7 +270,7 @@ function jetpack_boost_minify_serve_concatenated() {
 	if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_path = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) )[0];
-		if ( '/_static/' === substr( $request_path, -9, 9 ) ) {
+		if ( '/_jb_static/' === substr( $request_path, -9, 9 ) ) {
 			require_once __DIR__ . '/functions-service.php';
 			jetpack_boost_page_optimize_service_request();
 			exit;

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -260,6 +260,14 @@ function jetpack_boost_page_optimize_cache_bust_mtime( $path, $siteurl ) {
 }
 
 /**
+ * Get the URL prefix for static minify/concat resources. Defaults to /jb_static/, but can be
+ * overridden by defining JETPACK_BOOST_STATIC_PREFIX. Please include leading and trailing slashes.
+ */
+function jetpack_boost_get_static_prefix() {
+	return defined( 'JETPACK_BOOST_STATIC_PREFIX' ) ? JETPACK_BOOST_STATIC_PREFIX : '/_jb_static/';
+}
+
+/**
  * Detects requests within the `/_jb_static/` directory, and serves minified content.
  *
  * @return void
@@ -270,7 +278,8 @@ function jetpack_boost_minify_serve_concatenated() {
 	if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_path = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) )[0];
-		if ( '/_jb_static/' === substr( $request_path, -9, 9 ) ) {
+		$prefix       = jetpack_boost_get_static_prefix();
+		if ( $prefix === substr( $request_path, -strlen( $prefix ), strlen( $prefix ) ) ) {
 			require_once __DIR__ . '/functions-service.php';
 			jetpack_boost_page_optimize_service_request();
 			exit;

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -261,10 +261,16 @@ function jetpack_boost_page_optimize_cache_bust_mtime( $path, $siteurl ) {
 
 /**
  * Get the URL prefix for static minify/concat resources. Defaults to /jb_static/, but can be
- * overridden by defining JETPACK_BOOST_STATIC_PREFIX. Please include leading and trailing slashes.
+ * overridden by defining JETPACK_BOOST_STATIC_PREFIX.
  */
 function jetpack_boost_get_static_prefix() {
-	return defined( 'JETPACK_BOOST_STATIC_PREFIX' ) ? JETPACK_BOOST_STATIC_PREFIX : '/_jb_static/';
+	$prefix = defined( 'JETPACK_BOOST_STATIC_PREFIX' ) ? JETPACK_BOOST_STATIC_PREFIX : '/_jb_static/';
+
+	if ( substr( $prefix, 0, 1 ) !== '/' ) {
+		$prefix = '/' . $prefix;
+	}
+
+	return trailingslashit( $prefix );
 }
 
 /**

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -199,7 +199,7 @@ function jetpack_boost_page_optimize_build_output() {
 	// We can't assume that the root serves the same content as the subdir.
 	$subdir_path_prefix = '';
 	$request_path       = $utils->parse_url( $request_uri, PHP_URL_PATH );
-	$_static_index      = strpos( $request_path, '/_jb_static/' );
+	$_static_index      = strpos( $request_path, jetpack_boost_get_static_prefix() );
 	if ( $_static_index > 0 ) {
 		$subdir_path_prefix = substr( $request_path, 0, $_static_index );
 	}

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -13,7 +13,7 @@ function jetpack_boost_page_optimize_types() {
 }
 
 /**
- * Handle serving a minified / concatenated file from the virtual _static dir.
+ * Handle serving a minified / concatenated file from the virtual _jb_static dir.
  */
 function jetpack_boost_page_optimize_service_request() {
 	$use_wp = defined( 'JETPACK_BOOST_CONCAT_USE_WP' ) && JETPACK_BOOST_CONCAT_USE_WP;
@@ -153,9 +153,9 @@ function jetpack_boost_page_optimize_build_output() {
 	}
 
 	// Ensure the path follows one of these forms:
-	// /_static/??/foo/bar.css,/foo1/bar/baz.css?m=293847g
+	// /_jb_static/??/foo/bar.css,/foo1/bar/baz.css?m=293847g
 	// -- or --
-	// /_static/??-eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
+	// /_jb_static/??-eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $utils->unslash( $_SERVER['REQUEST_URI'] ) : '';
 	$args        = $utils->parse_url( $request_uri, PHP_URL_QUERY );
@@ -166,7 +166,7 @@ function jetpack_boost_page_optimize_build_output() {
 	$args = substr( $args, strpos( $args, '?' ) + 1 );
 
 	// Detect paths with - in their filename - this implies a base64 encoded gzipped string for the file list.
-	// e.g.: /_static/??-eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
+	// e.g.: /_jb_static/??-eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
 	if ( '-' === $args[0] ) {
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged,WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$args = @gzuncompress( base64_decode( substr( $args, 1 ) ) );
@@ -199,7 +199,7 @@ function jetpack_boost_page_optimize_build_output() {
 	// We can't assume that the root serves the same content as the subdir.
 	$subdir_path_prefix = '';
 	$request_path       = $utils->parse_url( $request_uri, PHP_URL_PATH );
-	$_static_index      = strpos( $request_path, '/_static/' );
+	$_static_index      = strpos( $request_path, '/_jb_static/' );
 	if ( $_static_index > 0 ) {
 		$subdir_path_prefix = substr( $request_path, 0, $_static_index );
 	}

--- a/projects/plugins/boost/changelog/boost-alternate-minify-subdir
+++ b/projects/plugins/boost/changelog/boost-alternate-minify-subdir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Minify CSS/JS: Added a new way for site owners to override the default _jb_static/ path prefix for Boost's Minified CSS and JS URLs

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -68,7 +68,7 @@ if ( ! defined( 'JETPACK_BOOST_PLUGINS_DIR_URL' ) ) {
 if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	$request_path = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) )[0];
-	if ( '/_static/' === substr( $request_path, -9, 9 ) ) {
+	if ( '/_jb_static/' === substr( $request_path, -9, 9 ) ) {
 		define( 'JETPACK_BOOST_CONCAT_USE_WP', true );
 
 		require_once JETPACK_BOOST_DIR_PATH . '/serve-minified-content.php';

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -68,7 +68,9 @@ if ( ! defined( 'JETPACK_BOOST_PLUGINS_DIR_URL' ) ) {
 if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	$request_path = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) )[0];
-	if ( '/_jb_static/' === substr( $request_path, -9, 9 ) ) {
+
+	$static_prefix = defined( 'JETPACK_BOOST_STATIC_PREFIX' ) ? JETPACK_BOOST_STATIC_PREFIX : '/_jb_static/';
+	if ( $static_prefix === substr( $request_path, -strlen( $static_prefix ) ) ) {
 		define( 'JETPACK_BOOST_CONCAT_USE_WP', true );
 
 		require_once JETPACK_BOOST_DIR_PATH . '/serve-minified-content.php';

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -69,6 +69,7 @@ if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	$request_path = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) )[0];
 
+	// Handling JETPACK_BOOST_STATIC_PREFIX constant inline to avoid loading the minify module until we know we want it.
 	$static_prefix = defined( 'JETPACK_BOOST_STATIC_PREFIX' ) ? JETPACK_BOOST_STATIC_PREFIX : '/_jb_static/';
 	if ( $static_prefix === substr( $request_path, -strlen( $static_prefix ) ) ) {
 		define( 'JETPACK_BOOST_CONCAT_USE_WP', true );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes jpop-issue 8371

Users on the Atomic platform who have uninstalled Page Optimize get 404 errors when loading minified CSS and JS via Boost's Minify JS and CSS features. This occurs because they both use the same base path (`/_static/`) for minified content, and Atomic has inbuilt rules for that path.

This PR fixes this in two ways:
1. It changes Jetpack's minify path base to `/_jb_static/` to remove that collision, and
2. It makes the path configurable by defining a constant `JETPACK_BOOST_STATIC_PREFIX`.

## Proposed changes:
* Changes Jetpack's minify path base to `/_jb_static/` to remove that collision, and
* Make the path configurable by defining a constant `JETPACK_BOOST_STATIC_PREFIX`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
* Turn on CSS and JS minify
* Ensure that assets correctly load from `/_jb_static/`.
* Define an alternate base (include the slashes!), like so: `define( 'JETPACK_BOOST_STATIC_PREFIX', '/.my-path/' );`
* Check that your minified content is now served correctly from the new path.

