### PR TITLE
Custom CSS: adjust wording in dashboard card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
@@ -51,7 +51,7 @@ function CustomCss( props ) {
 				<div className="jp-custom-css-site-editor__text">
 					{ createInterpolateElement(
 						__(
-							'Hurray! Your theme supports site editing with blocks. <a>Tell me more.</a>',
+							'Your site has a block theme that allows you to apply custom CSS from the Site Editor. <a>Learn more.</a>',
 							'jetpack'
 						),
 						{

--- a/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
@@ -57,7 +57,7 @@ function CustomCss( props ) {
 						{
 							a: (
 								<ExternalLink
-									href="https://wordpress.org/documentation/article/site-editor/"
+									href="https://wordpress.org/documentation/article/styles-overview/#applying-custom-css"
 									title={ __(
 										'Customize every aspect of your site with the Site Editor.',
 										'jetpack'

--- a/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-css.jsx
@@ -130,14 +130,19 @@ function CustomCss( props ) {
 		);
 	};
 
+	const supportText = () => {
+		if ( isBlockThemeActive ) {
+			return {};
+		}
+
+		return {
+			text: description,
+			link: getRedirectUrl( 'jetpack-support-custom-css' ),
+		};
+	};
+
 	return (
-		<SettingsGroup
-			module={ { module } }
-			support={ {
-				text: description,
-				link: getRedirectUrl( 'jetpack-support-custom-css' ),
-			} }
-		>
+		<SettingsGroup module={ { module } } support={ supportText() }>
 			<FormLegend className="jp-form-label-wide">{ name }</FormLegend>
 			{ isBlockThemeActive && recommendSiteEditor() }
 			{ ! isBlockThemeActive && customizerLink() }

--- a/projects/plugins/jetpack/changelog/update-custom-css-card-wording
+++ b/projects/plugins/jetpack/changelog/update-custom-css-card-wording
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: update wording for Custom CSS section when using a Block theme.


### PR DESCRIPTION
## Proposed changes:

Following up from #31413, based on feedback in https://github.com/Automattic/jetpack/pull/31413#issuecomment-1612567000

1. Update the wording of the notice recommending global styles.
2. Conditionally display the custom css support info (text and link). If a site uses a block theme, we don't want to say too much about the module to avoid confusing people. Let's only display that info for folks using classic themes.

**Block theme, custom CSS module inactive**

<img width="1106" alt="Screenshot 2023-06-29 at 12 41 30" src="https://github.com/Automattic/jetpack/assets/426388/373caa4a-d493-49a3-8497-8c9f4e9ff408">

**Block theme, custom CSS module active**

<img width="1087" alt="Screenshot 2023-06-29 at 12 41 22" src="https://github.com/Automattic/jetpack/assets/426388/e045d0c1-42af-4215-a12d-e03a610539e5">

**Classic theme**

<img width="1095" alt="Screenshot 2023-06-29 at 12 40 57" src="https://github.com/Automattic/jetpack/assets/426388/83e369ca-b459-44f3-8345-60ea3eee4954">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

1. Start with a site connected to WordPress.com, either self-hosted on WoA, with a classic theme like Twenty Twenty One.
4. Go to Jetpack > Settings > Writing
    * Check wording in the Custom CSS card.
    * You should see the "i" icon and info about the Custom CSS module.
5. Now go to Appearance > Themes and switch to the Twenty Twenty Three theme.
6. Go back to Jetpack > Settings > Writing.
    * Check wording again.
    * The "i" icon should be gone now.
