### PR TITLE
Subscriptions: do not display block when user isn't connected

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fatal-subscriptions
+++ b/projects/plugins/jetpack/changelog/fix-fatal-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: avoid Fatal Error when site is connected to WordPress.com, but user is not.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Extensions\Subscriptions;
 
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
 use Automattic\Jetpack\Status;
 use Jetpack;
@@ -42,7 +43,7 @@ function register_block() {
 
 	if (
 		( defined( 'IS_WPCOM' ) && IS_WPCOM )
-		|| ( Jetpack::is_connection_ready() && ! ( new Status() )->is_offline_mode() )
+		|| ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! ( new Status() )->is_offline_mode() )
 	) {
 		Blocks::jetpack_register_block(
 			BLOCK_NAME,


### PR DESCRIPTION
Fixes #26178

## Proposed changes:

Jetpack's Subscribe block relies on the Subscriptions module, which requires a user connection. When only the site is connected, but not the user, we should not attempt to register / display the block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's fully connected to WordPress.com.
* Go to Jetpack > settings and enable Subscriptions.
* Go to Appearance > Themes and swicth to the Twenty Twenty One theme
* Go to Appearance > Widgets and add a Subscribe block to a widget area.
* Go to Jetpack > Dashboard, and scroll down the connections area.
* Disconnect your site from WordPress.com.
* Start reconnecting your site, but do not complete the connection, do not connect your user to WordPress.com.
* Try viewing a page where the widget can be found.
    * The widget should not be displayed, and there should be no errors in your logs.
