### PR TITLE
Tiled Galleries: fix PHP 8.2 deprecation notices

### DIFF
--- a/projects/plugins/jetpack/changelog/update-tiled-gallery-php82
+++ b/projects/plugins/jetpack/changelog/update-tiled-gallery-php82
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Tiled Galleries: fix deprecation notices that may appear in logs when using PHP 8.2.

--- a/projects/plugins/jetpack/modules/tiled-gallery/math/class-constrained-array-rounding.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/math/class-constrained-array-rounding.php
@@ -69,7 +69,12 @@ class Jetpack_Constrained_Array_Rounding {
 	 * @param int   $adjustment - how much we're adjusting the array.
 	 */
 	private static function adjust_constrained_array( &$bound_array_int, $adjustment ) {
-		usort( $bound_array_int, array( 'self', 'cmp_desc_fraction' ) );
+		usort(
+			$bound_array_int,
+			static function ( $a, $b ) {
+				return strcmp( $b['fraction'], $a['fraction'] );
+			}
+		);
 
 		$start  = 0;
 		$end    = $adjustment - 1;
@@ -79,36 +84,11 @@ class Jetpack_Constrained_Array_Rounding {
 			++$bound_array_int[ $i % $length ]['floor'];
 		}
 
-		usort( $bound_array_int, array( 'self', 'cmp_asc_index' ) );
-	}
-
-	/**
-	 * Compare fraction values of two arrays.
-	 *
-	 * @param array $a - the first array we're comparing.
-	 * @param array $b - the second array we're comparing.
-	 *
-	 * @return int
-	 */
-	private static function cmp_desc_fraction( $a, $b ) {
-		if ( $a['fraction'] === $b['fraction'] ) {
-			return 0;
-		}
-		return $a['fraction'] > $b['fraction'] ? -1 : 1;
-	}
-
-	/**
-	 * Compare index values of two arrays.
-	 *
-	 * @param array $a - the first array.
-	 * @param array $b - the second array.
-	 *
-	 * @return int
-	 */
-	private static function cmp_asc_index( $a, $b ) {
-		if ( $a['index'] === $b['index'] ) {
-			return 0;
-		}
-		return $a['index'] < $b['index'] ? -1 : 1;
+		usort(
+			$bound_array_int,
+			static function ( $a, $b ) {
+				return strcmp( $a['index'], $b['index'] );
+			}
+		);
 	}
 }

--- a/projects/plugins/jetpack/modules/tiled-gallery/math/class-constrained-array-rounding.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/math/class-constrained-array-rounding.php
@@ -69,12 +69,7 @@ class Jetpack_Constrained_Array_Rounding {
 	 * @param int   $adjustment - how much we're adjusting the array.
 	 */
 	private static function adjust_constrained_array( &$bound_array_int, $adjustment ) {
-		usort(
-			$bound_array_int,
-			static function ( $a, $b ) {
-				return strcmp( $b['fraction'], $a['fraction'] );
-			}
-		);
+		usort( $bound_array_int, array( self::class, 'cmp_desc_fraction' ) );
 
 		$start  = 0;
 		$end    = $adjustment - 1;
@@ -84,11 +79,36 @@ class Jetpack_Constrained_Array_Rounding {
 			++$bound_array_int[ $i % $length ]['floor'];
 		}
 
-		usort(
-			$bound_array_int,
-			static function ( $a, $b ) {
-				return strcmp( $a['index'], $b['index'] );
-			}
-		);
+		usort( $bound_array_int, array( self::class, 'cmp_asc_index' ) );
+	}
+
+	/**
+	 * Compare fraction values of two arrays.
+	 *
+	 * @param array $a - the first array we're comparing.
+	 * @param array $b - the second array we're comparing.
+	 *
+	 * @return int
+	 */
+	private static function cmp_desc_fraction( $a, $b ) {
+		if ( $a['fraction'] === $b['fraction'] ) {
+			return 0;
+		}
+		return $a['fraction'] > $b['fraction'] ? -1 : 1;
+	}
+
+	/**
+	 * Compare index values of two arrays.
+	 *
+	 * @param array $a - the first array.
+	 * @param array $b - the second array.
+	 *
+	 * @return int
+	 */
+	private static function cmp_asc_index( $a, $b ) {
+		if ( $a['index'] === $b['index'] ) {
+			return 0;
+		}
+		return $a['index'] < $b['index'] ? -1 : 1;
 	}
 }

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-layout.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-layout.php
@@ -56,7 +56,7 @@ abstract class Jetpack_Tiled_Gallery_Layout {
 	/**
 	 * Attachment link
 	 *
-	 * @var string
+	 * @var bool
 	 */
 	public $needs_attachment_link;
 

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-layout.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-layout.php
@@ -54,6 +54,13 @@ abstract class Jetpack_Tiled_Gallery_Layout {
 	public $columns;
 
 	/**
+	 * Attachment link
+	 *
+	 * @var string
+	 */
+	public $needs_attachment_link;
+
+	/**
 	 * Constructor function.
 	 *
 	 * @param object $attachments - the attachmed image.

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
@@ -93,7 +93,7 @@ class Jetpack_Tiled_Gallery_Grouper {
 	);
 
 	/**
-	 * The last shape.
+	 * Shape of the last row in gallery.
 	 *
 	 * @var string
 	 */

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
@@ -292,21 +292,21 @@ class Jetpack_Tiled_Gallery_Row {
 	/**
 	 * Groups of images
 	 *
-	 * @var array
+	 * @var object[]
 	 */
 	public $groups;
 
 	/**
 	 * Image ratio.
 	 *
-	 * @var int
+	 * @var float
 	 */
 	public $ratio;
 
 	/**
 	 * Weighted ratio based on all the images.
 	 *
-	 * @var int
+	 * @var float
 	 */
 	public $weighted_ratio;
 
@@ -341,7 +341,7 @@ class Jetpack_Tiled_Gallery_Row {
 	/**
 	 * Constructor class.
 	 *
-	 * @param object $groups - the group of images.
+	 * @param object[] $groups - the group of images.
 	 */
 	public function __construct( $groups ) {
 		$this->groups         = $groups;
@@ -352,7 +352,7 @@ class Jetpack_Tiled_Gallery_Row {
 	/**
 	 * Get the ratio.
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public function get_ratio() {
 		$ratio = 0;
@@ -365,7 +365,7 @@ class Jetpack_Tiled_Gallery_Row {
 	/**
 	 * Get weighted ratio.
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public function get_weighted_ratio() {
 		$weighted_ratio = 0;
@@ -384,14 +384,14 @@ class Jetpack_Tiled_Gallery_Group {
 	/**
 	 * Images to be displayed in group.
 	 *
-	 * @var array
+	 * @var object[]
 	 */
 	public $images;
 
 	/**
 	 * Image ratio.
 	 *
-	 * @var int
+	 * @var float
 	 */
 	public $ratio;
 
@@ -426,7 +426,7 @@ class Jetpack_Tiled_Gallery_Group {
 	/**
 	 * Constructor class.
 	 *
-	 * @param object $images - the images.
+	 * @param object[] $images - the images.
 	 */
 	public function __construct( $images ) {
 		$this->images = $images;
@@ -436,7 +436,7 @@ class Jetpack_Tiled_Gallery_Group {
 	/**
 	 * Get the ratio.
 	 *
-	 * @return int
+	 * @return float
 	 */
 	public function get_ratio() {
 		$ratio = 0;

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
@@ -93,6 +93,27 @@ class Jetpack_Tiled_Gallery_Grouper {
 	);
 
 	/**
+	 * The last shape.
+	 *
+	 * @var string
+	 */
+	public $last_shape = '';
+
+	/**
+	 * All images to be displayed.
+	 *
+	 * @var array
+	 */
+	public $images = array();
+
+	/**
+	 * Array of tiled gallery rows (groups of images).
+	 *
+	 * @var array
+	 */
+	public $grouped_images = array();
+
+	/**
 	 * Constructor function.
 	 *
 	 * @param object $attachments - the attachments.
@@ -268,6 +289,26 @@ class Jetpack_Tiled_Gallery_Grouper {
  * Jetpack tiled row class.
  */
 class Jetpack_Tiled_Gallery_Row {
+	/**
+	 * Groups of images
+	 *
+	 * @var array
+	 */
+	public $groups;
+
+	/**
+	 * Image ratio.
+	 *
+	 * @var int
+	 */
+	public $ratio;
+
+	/**
+	 * Weighted ratio based on all the images.
+	 *
+	 * @var int
+	 */
+	public $weighted_ratio;
 
 	/**
 	 * Constructor class.
@@ -312,6 +353,20 @@ class Jetpack_Tiled_Gallery_Row {
  * Tiled gallery group class.
  */
 class Jetpack_Tiled_Gallery_Group {
+	/**
+	 * Images to be displayed in group.
+	 *
+	 * @var array
+	 */
+	public $images;
+
+	/**
+	 * Image ratio.
+	 *
+	 * @var int
+	 */
+	public $ratio;
+
 	/**
 	 * Constructor class.
 	 *

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php
@@ -311,6 +311,34 @@ class Jetpack_Tiled_Gallery_Row {
 	public $weighted_ratio;
 
 	/**
+	 * Rounded value of the raw width.
+	 *
+	 * @var int
+	 */
+	public $width;
+
+	/**
+	 * Rounded value of the raw height.
+	 *
+	 * @var int
+	 */
+	public $height;
+
+	/**
+	 * Raw width of the row.
+	 *
+	 * @var int
+	 */
+	public $raw_width;
+
+	/**
+	 * Raw height of the row.
+	 *
+	 * @var int
+	 */
+	public $raw_height;
+
+	/**
 	 * Constructor class.
 	 *
 	 * @param object $groups - the group of images.
@@ -366,6 +394,34 @@ class Jetpack_Tiled_Gallery_Group {
 	 * @var int
 	 */
 	public $ratio;
+
+	/**
+	 * Rounded value of the raw width.
+	 *
+	 * @var int
+	 */
+	public $width;
+
+	/**
+	 * Rounded value of the raw height.
+	 *
+	 * @var int
+	 */
+	public $height;
+
+	/**
+	 * Raw width of the group.
+	 *
+	 * @var int
+	 */
+	public $raw_width;
+
+	/**
+	 * Raw height of the group.
+	 *
+	 * @var int
+	 */
+	public $raw_height;
 
 	/**
 	 * Constructor class.

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -15,7 +15,7 @@ class Jetpack_Tiled_Gallery_Shape {
 	/**
 	 * The images to include in gallery.
 	 *
-	 * @var object
+	 * @var object[]
 	 */
 	protected $images;
 
@@ -29,7 +29,7 @@ class Jetpack_Tiled_Gallery_Shape {
 	/**
 	 * Constructor class.
 	 *
-	 * @param object $images - the images.
+	 * @param object[] $images - the images.
 	 */
 	public function __construct( $images ) {
 		$this->images      = $images;

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -20,7 +20,7 @@ class Jetpack_Tiled_Gallery_Shape {
 	protected $images;
 
 	/**
-	 * The images left.
+	 * How many images are left after each row.
 	 *
 	 * @var int
 	 */

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php
@@ -13,6 +13,20 @@ class Jetpack_Tiled_Gallery_Shape {
 	public static $shapes_used = array();
 
 	/**
+	 * The images to include in gallery.
+	 *
+	 * @var object
+	 */
+	protected $images;
+
+	/**
+	 * The images left.
+	 *
+	 * @var int
+	 */
+	protected $images_left;
+
+	/**
 	 * Constructor class.
 	 *
 	 * @param object $images - the images.


### PR DESCRIPTION
Follow-up from #31296

## Proposed changes:

Avoid PHP deprecation notices when running PHP 8.2. Here are some examples:

```
PHP Deprecated:  Use of "self" in callables is deprecated in wp-content/plugins/jetpack-dev/modules/tiled-gallery/math/class-constrained-array-rounding.php on line 74
PHP Deprecated:  Use of "self" in callables is deprecated in wp-content/plugins/jetpack-dev/modules/tiled-gallery/math/class-constrained-array-rounding.php on line 84
PHP Deprecated:  Creation of dynamic property Jetpack_Tiled_Gallery_Group::$width is deprecated in wp-content/plugins/jetpack-dev/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php on line 237
PHP Deprecated:  Creation of dynamic property Jetpack_Tiled_Gallery_Row::$weighted_ratio is deprecated in wp-content/plugins/jetpack-dev/modules/tiled-gallery/tiled-gallery/tiled-gallery-rectangular.php on line 280
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* #27927

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

On a site connected to WordPress.com, with the Site Accelerator active:

* You should still be able to insert and display all types of tiled galleries via the Tiled Gallery block;
* but also via the old tiled gallery types when using a classic block and inserting a gallery, then selecting a gallery type.

None of that should generate any warning.
