### PR TITLE
Prevent race conditions during dedicated syncs & plugin update routines

### DIFF
--- a/projects/packages/sync/changelog/fix-race-conditions-with-db-locks
+++ b/projects/packages/sync/changelog/fix-race-conditions-with-db-locks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Jetpack & Jetpack Sync: Added cache check when trying to spawn dedicated sync or update JETPACK__VERSION to avoid additional requests to the DB if external cache is available.

--- a/projects/plugins/jetpack/changelog/fix-race-conditions-with-db-locks
+++ b/projects/plugins/jetpack/changelog/fix-race-conditions-with-db-locks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack & Jetpack Sync: Added cache check when trying to spawn dedicated sync or update JETPACK__VERSION to avoid additional requests to the DB if external ca


### PR DESCRIPTION
## Proposed changes:

(this is a proof of concept right now, wanting to open up a discussion about it)

Relying on SELECT queries from the database for important locks does not work very well at high scale. Read queries can come from replica databases with a somewhat stale value (or during times of trouble the query could altogether fail). 

The best way to truly prevent race conditions and stampedes is to utilize `wp_cache_add()` when an external object cache is in use. This function should only return `true` if it was able to save the lock & the lock did not exist beforehand. With this you can ensure one request and one request only is the "claimer" of the lock. The other patterns of GETTING, then CHECKING, then SETTING are always going to be super prone to race conditions under heavy traffic. Whereas `wp_cache_add()` does it all in one go.

I've applied changes to both the dedicated sync and plugin update logic to utilize this safer version of locking - which is especially important since both of these bits of functionality run on all frontend requests - highly increasing the likelihood of stampedes.

## Questions:

I'm still a bit uncertain about freeing this new optional cache lock in the dedicated sync portion, as it appears the lock is released before the actual syncing even takes place: https://github.com/Automattic/jetpack/blob/dfb6431ed5af7a0956e8d4c27ba9d72728b421a0/projects/packages/sync/src/class-sender.php#L401-L404

 So it's not really gating things to only one sync at a time because of this? I'm curious for the reasoning here?

## Testing instructions:
Ensure dedicated sync and plugin update routines are still able to complete per usual.
