### PR TITLE
AI Assistant: Fix site-require-upgrade flag to be site-type agnostic

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -327,11 +327,7 @@ class Jetpack_AI_Helper {
 			 * should support site-type handling.
 			 * @todo: research how to do it.
 			 */
-			$blogs_details   = get_blog_details( $blog_id );
-			$is_jetpack_site = is_blog_jetpack( $blogs_details ) && ! is_blog_atomic( $blogs_details );
-			$require_upgrade = $is_jetpack_site ?
-				$is_over_limit && ! $has_ai_assistant_feature :
-				false;
+			$require_upgrade = $is_over_limit && ! $has_ai_assistant_feature;
 
 			return array(
 				'has-feature'          => $has_ai_assistant_feature,

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-site-require-upgrade-flag
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-site-require-upgrade-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: Fix site-require-upgrade flag to be site-type agnostic, so even WPCOM sites may demand an upgrade.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the logic of the `site-require-upgrade` flag from the `wpcom/v2` `sites/$wpcom_site/jetpack-ai/ai-assistant-feature` endpoint to ignore the site type, so sites from WPCOM can start demanding an upgrade as well

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

<!--
* This change impacts sites from WPCOM
* Apply this change to your sandbox (using jetpack-downloader or rsync command)
* Sandbox the `public-api` domain and your WPCOM test site
* Go to the block editor
-->

* TBD
