### PR TITLE
[Boost] Fix getting started loop

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { derived, get, writable } from 'svelte/store';
+	import { derived, writable } from 'svelte/store';
 	import { Snackbar } from '@wordpress/components';
 	import ActivateLicense from '../../elements/ActivateLicense.svelte';
 	import ReactComponent from '../../elements/ReactComponent.svelte';
@@ -8,7 +8,6 @@
 	import Header from '../../sections/Header.svelte';
 	import config, { markGetStartedComplete } from '../../stores/config';
 	import { connection } from '../../stores/connection';
-	import { modulesState, modulesStatePending } from '../../stores/modules';
 	import { recordBoostEvent } from '../../utils/analytics';
 	import { getUpgradeURL } from '../../utils/upgrade';
 
@@ -32,83 +31,77 @@
 		}
 	);
 
-	const ensureConnection = async () => {
-		let connectionStore;
-		connection.subscribe( value => {
-			connectionStore = value;
-		} );
+	/**
+	 * Mark that getting started is completed, and head to the next page.
+	 *
+	 * @param {string} externalPage If specified, head to the external page instead of staying on the dashboard.
+	 */
+	function finishGettingStarted( externalPage?: string ) {
+		markGetStartedComplete();
 
-		if ( connectionStore.connected ) {
-			recordBoostEvent( 'using_existing_connection', {} );
-			return;
+		if ( externalPage ) {
+			window.location.href = externalPage;
+		} else {
+			navigate( '/', { replace: true } );
 		}
+	}
 
-		await connection.initialize();
-
-		if ( ! connectionStore.connected ) {
-			throw connectionStore.error;
-		}
-
-		recordBoostEvent( 'established_connection', {} );
-	};
-
-	const chooseFreePlan = async () => {
+	/**
+	 * User clicked "Free plan"
+	 */
+	async function chooseFreePlan() {
 		initiatingFreePlan = true;
 
 		try {
-			await ensureConnection();
+			// Make sure there is a Jetpack connection and record this selection.
+			await Promise.all( [
+				connection.initialize(),
+				recordBoostEvent( 'free_cta_from_getting_started_page_in_plugin', {} ),
+			] );
 
-			// Allow opening the boost settings page. The actual flag is changed in the backend by enabling the critical-css module below.
-			markGetStartedComplete();
-			await recordBoostEvent( 'free_cta_from_getting_started_page_in_plugin', {} );
-
-			// Wait for the module to become active.
-			// Otherwise Critical CSS Generation will fail to start.
-			$modulesState.critical_css.active = true;
-			const unsubscribe = modulesStatePending.subscribe( isPending => {
-				if ( isPending === false ) {
-					unsubscribe();
-					navigate( '/' );
-				}
-			} );
+			// Head to the settings page.
+			finishGettingStarted();
 		} catch ( e ) {
+			// Un-dismiss snackbar on error. Actual error comes from connection object.
 			dismissedSnackbar.set( false );
 		} finally {
 			initiatingFreePlan = false;
 		}
-	};
+	}
 
-	const choosePaidPlan = async () => {
+	/**
+	 * User clicked Premium.
+	 */
+	async function choosePaidPlan() {
 		initiatingPaidPlan = true;
 
 		try {
-			await ensureConnection();
+			// Make sure there is a Jetpack connection and record this selection.
+			await Promise.all( [
+				connection.initialize(),
+				recordBoostEvent( 'premium_cta_from_getting_started_page_in_plugin', {} ),
+			] );
 
 			// Check if the site is already on a premium plan and go directly to settings if so.
-			if ( get( config ).isPremium ) {
-				// Allow opening the boost settings page.
-				markGetStartedComplete();
-				await recordBoostEvent( 'premium_cta_from_getting_started_page_in_plugin', {} );
-
-				navigate( '/', { replace: true } );
+			if ( $config.isPremium ) {
+				finishGettingStarted();
 				return;
 			}
 
-			window.location.href = getUpgradeURL();
+			// Go to the purchase flow.
+			finishGettingStarted( getUpgradeURL() );
 		} catch ( e ) {
+			// Un-dismiss snackbar on error. Actual error comes from connection object.
 			dismissedSnackbar.set( false );
 		} finally {
 			initiatingPaidPlan = false;
 		}
-	};
+	}
 
 	onMount( () => {
 		// If we don't have pricing data, we should skip the page and go directly to settings.
 		if ( typeof pricing.yearly === 'undefined' ) {
-			// Allow opening the boost settings page.
-			markGetStartedComplete();
-
-			navigate( '/', { replace: true } );
+			finishGettingStarted();
 		}
 	} );
 </script>

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -26,6 +26,7 @@ use Automattic\Jetpack_Boost\Lib\Connection;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Site_Health;
+use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Modules\Modules_Setup;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Config_State;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Site_Urls;
@@ -107,6 +108,7 @@ class Jetpack_Boost {
 		add_action( 'init', array( $this, 'init_textdomain' ) );
 
 		add_action( 'handle_environment_change', array( $this, 'handle_environment_change' ), 10, 2 );
+		add_action( 'jetpack_boost_connection_established', array( $this, 'handle_jetpack_connection' ) );
 
 		// Fired when plugin ready.
 		do_action( 'jetpack_boost_loaded', $this );
@@ -137,6 +139,19 @@ class Jetpack_Boost {
 		// Make sure user sees the "Get Started" when first time opening.
 		Config::set_getting_started( true );
 		Analytics::record_user_event( 'activate_plugin' );
+	}
+
+	/**
+	 * Plugin connected to Jetpack handler.
+	 */
+	public function handle_jetpack_connection() {
+		if ( Config::is_getting_started() ) {
+			// Special case: when getting started, ensure that the Critical CSS module is enabled.
+			$status = new Status( 'critical_css' );
+			$status->update( true );
+		}
+
+		Config::clear_getting_started();
 	}
 
 	/**

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -213,16 +213,23 @@ class Jetpack_Boost {
 		$this->deactivate();
 
 		// Delete all Jetpack Boost options.
-		$wpdb->query(
+		//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$option_names = $wpdb->get_col(
 			"
-			DELETE
-			FROM    `$wpdb->options`
-			WHERE   `option_name` LIKE 'jetpack_boost_%'
-		"
+				SELECT `option_name`
+				FROM   `$wpdb->options`
+				WHERE  `option_name` LIKE 'jetpack_boost_%';
+			"
 		);
+		//phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		foreach ( $option_names as $option_name ) {
+			delete_option( $option_name );
+		}
 
 		// Delete stored Critical CSS.
 		( new Critical_CSS_Storage() )->clear();
+
 		// Delete all transients created by boost.
 		Transient::delete_by_prefix( '' );
 

--- a/projects/plugins/boost/app/lib/class-connection.php
+++ b/projects/plugins/boost/app/lib/class-connection.php
@@ -12,6 +12,7 @@ namespace Automattic\Jetpack_Boost\Lib;
 use Automattic\Jetpack\Config as Jetpack_Config;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Terms_Of_Service;
+use Automattic\Jetpack_Boost\Admin\Config;
 
 /**
  * Class Connection
@@ -129,7 +130,8 @@ class Connection {
 	 */
 	public function register() {
 		if ( $this->is_connected() ) {
-			Analytics::record_user_event( 'connect_site' );
+			Analytics::record_user_event( 'using_existing_connection' );
+			Config::clear_getting_started();
 
 			return true;
 		}
@@ -137,7 +139,11 @@ class Connection {
 		$result = $this->manager->register();
 
 		if ( ! is_wp_error( $result ) ) {
-			Analytics::record_user_event( 'connect_site' );
+			Analytics::record_user_event( 'established_connection' );
+			Config::clear_getting_started();
+
+			// Special case: when connecting for the first time, ensure critical_css module is enabled.
+			update_option( 'jetpack_boost_status_critical_css', true, false );
 
 			Premium_Features::clear_cache();
 		}

--- a/projects/plugins/boost/app/lib/class-connection.php
+++ b/projects/plugins/boost/app/lib/class-connection.php
@@ -12,7 +12,6 @@ namespace Automattic\Jetpack_Boost\Lib;
 use Automattic\Jetpack\Config as Jetpack_Config;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Terms_Of_Service;
-use Automattic\Jetpack_Boost\Admin\Config;
 
 /**
  * Class Connection
@@ -131,8 +130,6 @@ class Connection {
 	public function register() {
 		if ( $this->is_connected() ) {
 			Analytics::record_user_event( 'using_existing_connection' );
-			Config::clear_getting_started();
-
 			return true;
 		}
 
@@ -140,11 +137,6 @@ class Connection {
 
 		if ( ! is_wp_error( $result ) ) {
 			Analytics::record_user_event( 'established_connection' );
-			Config::clear_getting_started();
-
-			// Special case: when connecting for the first time, ensure critical_css module is enabled.
-			update_option( 'jetpack_boost_status_critical_css', true, false );
-
 			Premium_Features::clear_cache();
 		}
 
@@ -209,6 +201,8 @@ class Connection {
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
+
+		do_action( 'jetpack_boost_connection_established' );
 
 		return rest_ensure_response( $this->get_connection_api_response() );
 	}

--- a/projects/plugins/boost/changelog/boost-fix-getting-started-loop
+++ b/projects/plugins/boost/changelog/boost-fix-getting-started-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a potential 'loop' getting stuck in Getting started state.

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -19,7 +19,6 @@
 	"projects/packages/sync/src/replicastore/class-table-checksum-users.php",
 	"projects/packages/sync/src/replicastore/class-table-checksum.php",
 	"projects/plugins/beta/src/class-utils.php",
-	"projects/plugins/boost/app/class-jetpack-boost.php",
 	"projects/plugins/crm/ZeroBSCRM.php",
 	"projects/plugins/crm/admin/activation/before-you-go.php",
 	"projects/plugins/crm/admin/activation/welcome-to-jpcrm.php",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31540

If a user deactivates Jetpack Boost, then reactivates it, then Boost can sometimes get stuck in a Getting Started loop - where the Getting Started page will appear every time they visit the Boost dashboard.

This PR fixes it by simplifying and streamlining the getting started process.

As a bonus, it also fixes the way options are deleted on uninstallation, as that *may* be related to the issue. Sometimes.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set the 'getting started' flag appropriate on site connection
* Simplify the logic in the Getting Started component
* Clean up the way options are deleted on uninstallation.
* Handle the tracks events for connection on the server-side.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
* Install this on a JN site.
* Make sure you can connect properly (free plan)
* Deactivate the plugin
* Connect again (free plan)
* reload the dashboard, make sure the getting started page doesn't appear
* Repeat the process for premium.
