### PR TITLE
Boost: Image Size Analysis - make groups on progress report UI clickable

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
@@ -2,6 +2,7 @@
 	import { sprintf, __ } from '@wordpress/i18n';
 	import ProgressBar from '../../elements/ProgressBar.svelte';
 	import Spinner from '../../elements/Spinner.svelte';
+	import { Link } from '../../utils/router';
 	import { isaGroupLabels, isaSummary } from './store/isa-summary';
 
 	function safePercent( value: number, outOf: number ): number {
@@ -27,26 +28,32 @@
 			{#if progress > 0 && progress < 100}
 				<Spinner />
 			{:else}
-				<span class="jb-bubble" class:done={isDone}>
-					{isDone ? '✓' : index + 1}
-				</span>
+				<Link class="jb-navigator-link" to="/image-size-analysis/{group}/1">
+					<span class="jb-bubble" class:done={isDone}>
+						{isDone ? '✓' : index + 1}
+					</span>
+				</Link>
 			{/if}
 
 			<div class="jb-category-name">
-				{isaGroupLabels[ group ] || group}
+				<Link class="jb-navigator-link" to="/image-size-analysis/{group}/1">
+					{isaGroupLabels[ group ] || group}
+				</Link>
 			</div>
 
 			{#if isDone || hasIssues}
 				<div class="jb-status" class:has-issues={hasIssues}>
-					{#if hasIssues}
-						{sprintf(
-							/* translators: %d is the number of items in this list hidden behind this link */
-							__( '%d issues', 'jetpack-boost' ),
-							summary.issue_count
-						)}
-					{:else}
-						{__( 'No issues', 'jetpack-boost' )}
-					{/if}
+					<Link class="jb-navigator-link" to="/image-size-analysis/{group}/1">
+						{#if hasIssues}
+							{sprintf(
+								/* translators: %d is the number of items in this list hidden behind this link */
+								__( '%d issues', 'jetpack-boost' ),
+								summary.issue_count
+							)}
+						{:else}
+							{__( 'No issues', 'jetpack-boost' )}
+						{/if}
+					</Link>
 				</div>
 			{/if}
 		</div>
@@ -72,6 +79,9 @@
 			'progress progress progress'
 			'bubble category category'
 			'bubble status status';
+		:global( a ) {
+			text-decoration: none;
+		}
 	}
 	.jb-bubble {
 		grid-area: bubble;
@@ -91,6 +101,7 @@
 	.jb-status {
 		grid-area: status;
 		font-size: 0.875rem;
+		:global( a ),
 		&.has-issues {
 			color: var( --color_warning );
 		}

--- a/projects/plugins/boost/changelog/update-boost-image-size-analysis-make-groups-clickable
+++ b/projects/plugins/boost/changelog/update-boost-image-size-analysis-make-groups-clickable
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Make progress report UI groups clickable.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31453

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add links to the groups in the main report UI.

<img width="723" alt="CleanShot 2023-06-30 at 12 18 09@2x" src="https://github.com/Automattic/jetpack/assets/11799079/8e272b3d-a226-42ed-ac3b-375c93421ff6">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost with Image Size Analysis;
* Request a report;
* Make sure groups are clickable and lead to their detailed pages.