### PR TITLE
Launchpad: Add/share site task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-share_site_task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-share_site_task
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Adding a new task to launchpad
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -245,6 +245,13 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_is_domain_customize_completed',
 			'is_visible_callback'  => 'wpcom_is_domain_customize_task_visible',
 		),
+
+		'share_site'                      => array(
+			'get_title'            => function () {
+				return __( 'Share your site', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -138,6 +138,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'domain_customize',
 				'add_new_page',
 				'drive_traffic',
+				'share_site',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),


### PR DESCRIPTION
Relates to https://github.com/Automattic/wp-calypso/issues/78856

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added share site launchpad task

Works together with https://github.com/Automattic/wp-calypso/pull/78860

## Testing instructions:

* Apply/use https://github.com/Automattic/wp-calypso/pull/78860
* Create a new site with `build` intent (`/start`)
* Launch the site and go to customer home
* Check the Launchpad
* Click on the `Share Site` task
* Click on the `Copy` button
* Check the URL is copied
* Check the task is marked as completed

Design:

![image](https://github.com/Automattic/wp-calypso/assets/3801502/02e540b5-56c2-4f64-8846-947b9b2be6e2)


Screenshots:
![image](https://github.com/Automattic/wp-calypso/assets/3801502/488ef521-d132-4786-8c05-23108e231a90)
![image](https://github.com/Automattic/wp-calypso/assets/3801502/8bcf9a74-e080-467f-8706-c1683046f84b)

## Does this pull request change what data or activity we track or use?

It tracks the click on the `Share site` task
