### PR TITLE
Option: Sync wpcom_site_setup site option

### DIFF
--- a/projects/packages/sync/changelog/add-wpcom-site-setup-option-sync
+++ b/projects/packages/sync/changelog/add-wpcom-site-setup-option-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync wpcom_site_setup site option

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -180,6 +180,7 @@ class Defaults {
 		'wpcom_subscription_emails_use_excerpt',
 		'videopress_private_enabled_for_site',
 		'wpcom_gifting_subscription',
+		'wpcom_site_setup',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.50.0';
+	const PACKAGE_VERSION = '1.50.1-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/changelog/add-wpcom-site-setup-option-sync
+++ b/projects/plugins/jetpack/changelog/add-wpcom-site-setup-option-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Sync wpcom_site_setup site option

--- a/projects/plugins/jetpack/changelog/add-wpcom-site-setup-option-sync
+++ b/projects/plugins/jetpack/changelog/add-wpcom-site-setup-option-sync
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: other
 
 Sync wpcom_site_setup site option

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -232,7 +232,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'launchpad_checklist_tasks_statuses'           => array(),
 			'launchpad_screen'                             => 'full',
 			'wpcom_reader_views_enabled'                   => true,
-
+			'wpcom_site_setup'                             => '',
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/wp-calypso/pull/78852

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added the option to the whitelist to be able to:
  * Sync the option
  * An attempt to solve the error `option_name_not_in_whitelist` when updating the option using `WPCOM_JSON_API_Update_Option_Endpoint`  

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

- N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* It will be tested together with D115078-code