### PR TITLE
Stats Admin: site plan and products

### DIFF
--- a/projects/packages/stats-admin/changelog/add-odyssey-site-plan-products
+++ b/projects/packages/stats-admin/changelog/add-odyssey-site-plan-products
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats Admin: add plan and product for site

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -51,7 +51,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.11.x-dev"
+			"dev-trunk": "0.12.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.11.0",
+	"version": "0.12.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.11.0';
+	const VERSION = '0.12.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -37,9 +37,8 @@ class Odyssey_Config_Data {
 	public function get_data() {
 		global $wp_version;
 
-		$blog_id      = Jetpack_Options::get_option( 'id' );
-		$empty_object = json_decode( '{}' );
-		$host         = new Host();
+		$blog_id = Jetpack_Options::get_option( 'id' );
+		$host    = new Host();
 
 		return array(
 			'admin_page_base'                => $this->get_admin_path(),
@@ -81,8 +80,8 @@ class Odyssey_Config_Data {
 							'jetpack'      => true,
 							'visible'      => true,
 							'capabilities' => $this->get_current_user_capabilities(),
-							'products'     => array(),
-							'plan'         => $empty_object, // we need this empty object, otherwise the front end would crash on insight page.
+							'products'     => Jetpack_Plan::get_products(),
+							'plan'         => $this->get_plan(),
 							'options'      => array(
 								'wordads'               => ( new Modules() )->is_active( 'wordads' ),
 								'admin_url'             => admin_url(),
@@ -176,6 +175,18 @@ class Odyssey_Config_Data {
 			return array();
 		}
 		return $plan['features'];
+	}
+
+	/**
+	 * Get the current plan.
+	 *
+	 * @return array
+	 */
+	protected function get_plan() {
+		$plan = Jetpack_Plan::get();
+		unset( $plan['features'] );
+		unset( $plan['supports'] );
+		return $plan;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-odyssey-site-plan-products
+++ b/projects/plugins/jetpack/changelog/add-odyssey-site-plan-products
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2392,7 +2392,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "857b8f2a389c1daa46ad3e98755b1aea8778bcf7"
+                "reference": "e0895310c76cf3314c87e55650bc0591da4c1f58"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2415,7 +2415,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.11.x-dev"
+                    "dev-trunk": "0.12.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
Fixes #31477 

## Proposed changes:

The PR adds plan and products support for Odyssey, which allow Odyssey to determine whether the site has valid plan for Stats.

* Adds `config.intial_state.sites.items.${site_id}.plan`
* Adds `config.intial_state.sites.items.${site_id}.products`

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Build the branch for Odyssey
    * `STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Build Jetpack if necessary
    * `jetpack build plugins/jetpack`
* Open `/wp-admin/admin.php?page=stats`
* Open dev console
* Ensure `config.intial_state.sites.items.${site_id}.plan` and `config.intial_state.sites.items.${site_id}.products`
 have all the values in the screenshot

![Image](https://github.com/Automattic/jetpack/assets/1425433/da7623d9-e9b4-47b5-8edd-bd3cf6c5efd2)

