### PR TITLE
SAL: Add wpcom_site_setup property to /sites/{siteId} endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-wpcom-site-setup-to-sites-endpoint
+++ b/projects/plugins/jetpack/changelog/add-wpcom-site-setup-to-sites-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add wpcom_site_setup property to /sites/{siteId} endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -79,6 +79,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_staging_site'       => '(bool) If the site is a WP.com staging site.',
 		'user_interactions'           => '(array) An array of user interactions with a site.',
 		'was_ecommerce_trial'         => '(bool) If the site ever used an eCommerce trial.',
+		'wpcom_site_setup'            => '(string) The WP.com site setup identifier.',
 	);
 
 	/**
@@ -201,6 +202,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'wpcom_production_blog_id',
 		'wpcom_staging_blog_ids',
 		'can_blaze',
+		'wpcom_site_setup',
 	);
 
 	/**
@@ -877,6 +879,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'can_blaze':
 					$options[ $key ] = $site->can_blaze();
+					break;
+				case 'wpcom_site_setup':
+					$options[ $key ] = $site->get_wpcom_site_setup();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1501,4 +1501,13 @@ abstract class SAL_Site {
 	public function can_blaze() {
 		return (bool) Blaze::site_supports_blaze( $this->blog_id );
 	}
+
+	/**
+	 * Return site's setup identifier.
+	 *
+	 * @return string
+	 */
+	public function get_wpcom_site_setup() {
+		return get_option( 'wpcom_site_setup' );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/jetpack/pull/31662 https://github.com/Automattic/wp-calypso/pull/78852

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `wpcom_site_setup` property to `/sites/{siteId}` endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Sandbox the API
* Make a request to ` /sites/{siteId}`
* Verify the response contains the property `wpcom_site_setup` in `options` 
  * The value will be `false` if it's not set, or can be `assembler` if you are reusing that site

**Tested on a Simple site**

<img width="461" alt="Screenshot 2566-07-03 at 14 42 21" src="https://github.com/Automattic/jetpack/assets/1881481/97bd6685-716f-4376-bb27-d979301af8d5">

<img width="456" alt="Screenshot 2566-07-03 at 14 36 34" src="https://github.com/Automattic/jetpack/assets/1881481/2321ede2-09d4-4f97-8197-d6fd5dd2d8b1">

**Tested on an Atomic site**

<img width="567" alt="Screenshot 2566-07-03 at 15 06 02" src="https://github.com/Automattic/jetpack/assets/1881481/a4a4ba94-9f64-4ba0-9b66-b48f38dd0bcf">
