### PR TITLE
Contact Form: remove default title in feedback emails

### DIFF
--- a/projects/packages/forms/changelog/update-form-response-title-email
+++ b/projects/packages/forms/changelog/update-form-response-title-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove the default title ("You got a new response!") added to emails sent for new feedback received.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1399,7 +1399,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 *
 		 * @param string the title of the email
 		 */
-		$title   = apply_filters( 'jetpack_forms_response_email_title', __( 'You got a new response!', 'jetpack-forms' ) );
+		$title   = apply_filters( 'jetpack_forms_response_email_title', '' );
 		$message = self::get_compiled_form_for_email( $post_id, $this );
 
 		if ( is_user_logged_in() ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1689,7 +1689,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'',
 				$template
 			),
-			$title,
+			( ! empty( $title ) ? '<h1>' . $title . '</h1>' : '' ),
 			$body,
 			'',
 			'',

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1399,7 +1399,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 *
 		 * @param string the title of the email
 		 */
-		$title   = apply_filters( 'jetpack_forms_response_email_title', '' );
+		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
 		$message = self::get_compiled_form_for_email( $post_id, $this );
 
 		if ( is_user_logged_in() ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1689,7 +1689,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'',
 				$template
 			),
-			( ! empty( $title ) ? '<h1>' . $title . '</h1>' : '' ),
+			( $title !== '' ? '<h1>' . $title . '</h1>' : '' ),
 			$body,
 			'',
 			'',

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -17,7 +17,7 @@ $template = '
 <html xmlns="http://www.w3.org/1999/xhtml">
 <body>
 <!-- title -->
-<h1>%1$s</h1>
+%1$s
 
 <!-- response -->
 <p>%2$s</p>

--- a/projects/plugins/jetpack/changelog/update-form-response-title-email
+++ b/projects/plugins/jetpack/changelog/update-form-response-title-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Contact Forms: remove the default title ("You got a new response!") added to emails sent for new feedback received.

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -4264,7 +4264,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				'',
 				$template
 			),
-			( ! empty( $title ) ? '<h1>' . $title . '</h1>' : '' ),
+			( $title !== '' ? '<h1>' . $title . '</h1>' : '' ),
 			$body,
 			$response_link,
 			$form_link,

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -3970,7 +3970,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		 *
 		 * @param string the title of the email
 		 */
-		$title   = apply_filters( 'jetpack_forms_response_email_title', '' );
+		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
 		$message = self::get_compiled_form_for_email( $post_id, $this );
 
 		if ( is_user_logged_in() ) {

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -3970,7 +3970,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		 *
 		 * @param string the title of the email
 		 */
-		$title   = apply_filters( 'jetpack_forms_response_email_title', __( 'You got a new response!', 'jetpack' ) );
+		$title   = apply_filters( 'jetpack_forms_response_email_title', '' );
 		$message = self::get_compiled_form_for_email( $post_id, $this );
 
 		if ( is_user_logged_in() ) {

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -4264,7 +4264,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				'',
 				$template
 			),
-			$title,
+			( ! empty( $title ) ? '<h1>' . $title . '</h1>' : '' ),
 			$body,
 			$response_link,
 			$form_link,

--- a/projects/plugins/jetpack/modules/contact-form/grunion-response-email-template.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-response-email-template.php
@@ -17,7 +17,7 @@ $template = '
 <html xmlns="http://www.w3.org/1999/xhtml">
 <body>
 <!-- title -->
-<h1>%1$s</h1>
+%1$s
 
 <!-- response -->
 <p>%2$s</p>


### PR DESCRIPTION
Fixes #31516

## Proposed changes:

Following the feedback we received after adding that title in #30088, let's default to an empty title, while still allowing folks to add their own custom title via the `jetpack_forms_response_email_title` filter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Add a new contact form to one of your pages.
* Visit that page while logged out, and submit a form.
* Check your inbox for the notification email for that submitted form.
    * You should not see any "You got a new response!" title at the top of the email.
