### PR TITLE
Add/test blockratize comments sticker to jetpack iframe [Work in progress]

### DIFF
--- a/projects/plugins/jetpack/changelog/add-test-blockratize-comments-sticker-to-jetpack-iframe
+++ b/projects/plugins/jetpack/changelog/add-test-blockratize-comments-sticker-to-jetpack-iframe
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add test-blockratize-comments sticker to jetpack iframe query params

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -294,16 +294,16 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		}
 
 		$params = array(
-			'blogid'                 => Jetpack_Options::get_option( 'id' ),
-			'postid'                 => get_the_ID(),
-			'comment_registration'   => ( get_option( 'comment_registration' ) ? '1' : '0' ), // Need to explicitly send a '1' or a '0' for these.
-			'require_name_email'     => ( get_option( 'require_name_email' ) ? '1' : '0' ),
-			'stc_enabled'            => $stc_enabled,
-			'stb_enabled'            => $stb_enabled,
-			'show_avatars'           => ( get_option( 'show_avatars' ) ? '1' : '0' ),
-			'avatar_default'         => get_option( 'avatar_default' ),
-			'greeting'               => get_option( 'highlander_comment_form_prompt', __( 'Leave a Reply', 'jetpack' ) ),
-			'jetpack_comments_nonce' => wp_create_nonce( 'jetpack_comments_nonce-' . get_the_ID() ),
+			'blogid'                                       => Jetpack_Options::get_option( 'id' ),
+			'postid'                                       => get_the_ID(),
+			'comment_registration'                         => ( get_option( 'comment_registration' ) ? '1' : '0' ), // Need to explicitly send a '1' or a '0' for these.
+			'require_name_email'                           => ( get_option( 'require_name_email' ) ? '1' : '0' ),
+			'stc_enabled'                                  => $stc_enabled,
+			'stb_enabled'                                  => $stb_enabled,
+			'show_avatars'                                 => ( get_option( 'show_avatars' ) ? '1' : '0' ),
+			'avatar_default'                               => get_option( 'avatar_default' ),
+			'greeting'                                     => get_option( 'highlander_comment_form_prompt', __( 'Leave a Reply', 'jetpack' ) ),
+			'jetpack_comments_nonce'                       => wp_create_nonce( 'jetpack_comments_nonce-' . get_the_ID() ),
 			/**
 			 * Changes the comment form prompt.
 			 *
@@ -313,14 +313,15 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			 *
 			 * @param string $var Default is "Leave a Reply to %s."
 			 */
-			'greeting_reply'         => apply_filters(
+			'greeting_reply'                               => apply_filters(
 				'jetpack_comment_form_prompt_reply',
 				/* translators: %s is the displayed username of the post (or comment) author */
 				__( 'Leave a Reply to %s', 'jetpack' )
 			),
-			'color_scheme'           => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
-			'lang'                   => get_locale(),
-			'jetpack_version'        => JETPACK__VERSION,
+			'color_scheme'                                 => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
+			'lang'                                         => get_locale(),
+			'jetpack_version'                              => JETPACK__VERSION,
+			'is_test_blockratize_comments_sticker_enabled' => get_option( 'blockratize_comments_sticker_enabled', Jetpack_Options::get_option( 'id' ) ),
 		);
 
 		// Extra parameters for logged in user.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -336,7 +336,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			'color_scheme'           => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
 			'lang'                   => get_locale(),
 			'jetpack_version'        => JETPACK__VERSION,
-			'should_blockratize'     => blockratize_comments_sticker_exists(),
+			'should_blockratize'     => $this->blockratize_comments_sticker_exists(),
 		);
 
 		// Extra parameters for logged in user.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -238,6 +238,21 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 	}
 
 	/**
+	 * Check if site has test-blockratize-comments sticker
+	 *
+	 * @since JetpackComments (1.4)
+	 */
+	public function blockratize_comments_sticker_exists() {
+		if ( function_exists( 'has_blog_sticker' ) ) {
+			return has_blog_sticker( 'test-blockratize-comments' );
+		} elseif ( function_exists( 'wpcomsh_is_site_sticker_active' ) ) {
+			// For atomic sites
+			return wpcomsh_is_site_sticker_active( 'test-blockratize-comments' );
+		}
+		return false;
+	}
+
+	/**
 	 * Noop the default comment form output, get some options, and output our
 	 * tricked out totally radical comment form.
 	 *
@@ -294,16 +309,16 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 		}
 
 		$params = array(
-			'blogid'                                       => Jetpack_Options::get_option( 'id' ),
-			'postid'                                       => get_the_ID(),
-			'comment_registration'                         => ( get_option( 'comment_registration' ) ? '1' : '0' ), // Need to explicitly send a '1' or a '0' for these.
-			'require_name_email'                           => ( get_option( 'require_name_email' ) ? '1' : '0' ),
-			'stc_enabled'                                  => $stc_enabled,
-			'stb_enabled'                                  => $stb_enabled,
-			'show_avatars'                                 => ( get_option( 'show_avatars' ) ? '1' : '0' ),
-			'avatar_default'                               => get_option( 'avatar_default' ),
-			'greeting'                                     => get_option( 'highlander_comment_form_prompt', __( 'Leave a Reply', 'jetpack' ) ),
-			'jetpack_comments_nonce'                       => wp_create_nonce( 'jetpack_comments_nonce-' . get_the_ID() ),
+			'blogid'                 => Jetpack_Options::get_option( 'id' ),
+			'postid'                 => get_the_ID(),
+			'comment_registration'   => ( get_option( 'comment_registration' ) ? '1' : '0' ), // Need to explicitly send a '1' or a '0' for these.
+			'require_name_email'     => ( get_option( 'require_name_email' ) ? '1' : '0' ),
+			'stc_enabled'            => $stc_enabled,
+			'stb_enabled'            => $stb_enabled,
+			'show_avatars'           => ( get_option( 'show_avatars' ) ? '1' : '0' ),
+			'avatar_default'         => get_option( 'avatar_default' ),
+			'greeting'               => get_option( 'highlander_comment_form_prompt', __( 'Leave a Reply', 'jetpack' ) ),
+			'jetpack_comments_nonce' => wp_create_nonce( 'jetpack_comments_nonce-' . get_the_ID() ),
 			/**
 			 * Changes the comment form prompt.
 			 *
@@ -313,15 +328,15 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			 *
 			 * @param string $var Default is "Leave a Reply to %s."
 			 */
-			'greeting_reply'                               => apply_filters(
+			'greeting_reply'         => apply_filters(
 				'jetpack_comment_form_prompt_reply',
 				/* translators: %s is the displayed username of the post (or comment) author */
 				__( 'Leave a Reply to %s', 'jetpack' )
 			),
-			'color_scheme'                                 => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
-			'lang'                                         => get_locale(),
-			'jetpack_version'                              => JETPACK__VERSION,
-			'is_test_blockratize_comments_sticker_enabled' => has_blog_sticker( 'test-blockratize-comments', Jetpack_Options::get_option( 'id' ) ),
+			'color_scheme'           => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
+			'lang'                   => get_locale(),
+			'jetpack_version'        => JETPACK__VERSION,
+			'should_blockratize'     => blockratize_comments_sticker_exists(),
 		);
 
 		// Extra parameters for logged in user.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -336,7 +336,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			'color_scheme'           => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
 			'lang'                   => get_locale(),
 			'jetpack_version'        => JETPACK__VERSION,
-			'should_blockratize'     => $this->blockratize_comments_sticker_exists(),
+			'should_blockratize'     => ( $this->blockratize_comments_sticker_exists() ? '1' : '0' ),
 		);
 
 		// Extra parameters for logged in user.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -321,7 +321,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 			'color_scheme'                                 => get_option( 'jetpack_comment_form_color_scheme', $this->default_color_scheme ),
 			'lang'                                         => get_locale(),
 			'jetpack_version'                              => JETPACK__VERSION,
-			'is_test_blockratize_comments_sticker_enabled' => get_option( 'blockratize_comments_sticker_enabled', Jetpack_Options::get_option( 'id' ) ),
+			'is_test_blockratize_comments_sticker_enabled' => has_blog_sticker( 'test-blockratize-comments', Jetpack_Options::get_option( 'id' ) ),
 		);
 
 		// Extra parameters for logged in user.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

