### PR TITLE
Boost: cut off image filenames in the IG analysis report at 20 characters to avoid overflow

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/components/RowTitle.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/components/RowTitle.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+	import { truncateString } from '../../../../utils/truncate-string';
 	export let title: string;
 	export let url: string;
 	const maxTitleLength = 20;
 
 	const urlWithoutProtocol = url.replace( /^https?:\/\/(www\.)?/, '' );
-	const croppedTitle =
-		title.length > maxTitleLength ? title.slice( 0, maxTitleLength ) + '...' : title;
+	const croppedTitle = truncateString( title, maxTitleLength );
 </script>
 
 <b>{croppedTitle}</b>

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/components/RowTitle.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/components/RowTitle.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	export let title: string;
 	export let url: string;
+	const maxTitleLength = 20;
 
 	const urlWithoutProtocol = url.replace( /^https?:\/\/(www\.)?/, '' );
+	const croppedTitle =
+		title.length > maxTitleLength ? title.slice( 0, maxTitleLength ) + '...' : title;
 </script>
 
-<b>{title}</b>
+<b>{croppedTitle}</b>
 <a href={url} target="_blank">
 	{urlWithoutProtocol}
 </a>

--- a/projects/plugins/boost/app/assets/src/js/utils/truncate-string.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/truncate-string.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns a string truncated to a given length.
+ * If truncated, the string will end with an ellipsis.
+ *
+ * @param {string} str       string to truncate
+ * @param {number} maxLength maximum length of the string
+ */
+export function truncateString( str: string, maxLength?: number ): string {
+	if ( ! maxLength ) {
+		maxLength = 20;
+	}
+
+	return str.length > maxLength ? str.slice( 0, maxLength ) + '…' : str;
+}

--- a/projects/plugins/boost/app/assets/src/js/utils/truncate-string.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/truncate-string.ts
@@ -5,10 +5,6 @@
  * @param {string} str       string to truncate
  * @param {number} maxLength maximum length of the string
  */
-export function truncateString( str: string, maxLength?: number ): string {
-	if ( ! maxLength ) {
-		maxLength = 20;
-	}
-
+export function truncateString( str: string, maxLength = 20 ): string {
 	return str.length > maxLength ? str.slice( 0, maxLength ) + '…' : str;
 }

--- a/projects/plugins/boost/changelog/fix-overflowing_filenames_image_guide_analysis
+++ b/projects/plugins/boost/changelog/fix-overflowing_filenames_image_guide_analysis
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Boost: Cut off image titles at 20 characters in the Image Guide Analysis report


### PR DESCRIPTION
The Image Guide Size Analysis report lists images, but if the titles of any image are very long they will overflow and break the UI. This PR fixes that by cutting the filename at 20 characters and adding "..." at the end.

Fixes #31430 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. On a test site create a post with an image with a filename that is over twenty characters long.
2. Install Jetpack Beta to install Boost. Look for the "fix/overflowing_filenames_image_guide_analysis" feature branch.
3. Upgrade to a premium subscription
4. Enable image size analysis by defining the constant JETPACK_BOOST_IMAGE_SIZE_ANALYSIS.
5. Go to the Boost page and enable and run "Image Size Analysis".
6. The report will show the filename of the image cut off at 20 characters and "..." at the end of it.

