### PR TITLE
Blog Onboarding: Remove site-intent on site launch

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-clean-site-intent-launch-blog-onboarding
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-clean-site-intent-launch-blog-onboarding
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Clean site_intent option when site is launched for blog-onboarding flows
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -524,6 +524,13 @@ function wpcom_track_site_launch_task() {
 	wpcom_mark_launchpad_task_complete_if_active( 'link_in_bio_launched' );
 	wpcom_mark_launchpad_task_complete_if_active( 'videopress_launched' );
 	wpcom_mark_launchpad_task_complete_if_active( 'blog_launched' );
+
+	// Remove site intent for blog onboarding flows and disable launchpad.
+	$site_intent = get_option( 'site_intent' );
+	if ( in_array( $site_intent, array( 'start-writing', 'design-first' ), true ) ) {
+		update_option( 'site_intent', '' );
+		update_option( 'launchpad_screen', 'off' );
+	}
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/2886

## Proposed changes:

Blog Onboarding flows (`start-writing` and `design-first`) clear the `site-intent` when the blog is launched, however the blog can be launched from /settings and the `site_intent` needs to be removed.
Using the `wpcom_track_site_launch_task` hook, we clear the `site_intent` option and also turn off the `launchpad` to prevent the user to enter the build flow.

This should solve issues like [this one](p1688051377866599-slack-CKZHG0QCR)

### Other information:

- [ ] ~~Have you written new tests for your changes, if applicable?~~
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
* On your Sandbox using, run the command `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/clean-site-intent-launch-blog-onboarding`
* With a new user or a user with no sites, go to `/setup/start-writing` or `/setup/design-first`
* Complete some steps but do not launch the blog.
* Go to `/settings` and launch the site.
* You should be redirected to `/home`
* Edit or Create a post, you should see the `W` icon, which means the blog onboarding site-intent is not present.
* Check for the `site_intent` option, should be empty

## Does this pull request change what data or activity we track or use?

My PR doesn't change any on data or privacy