### PR TITLE
Fix/boost e2e

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/GettingStarted.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { derived, writable } from 'svelte/store';
 	import { Snackbar } from '@wordpress/components';
 	import ActivateLicense from '../../elements/ActivateLicense.svelte';
@@ -97,13 +96,6 @@
 			initiatingPaidPlan = false;
 		}
 	}
-
-	onMount( () => {
-		// If we don't have pricing data, we should skip the page and go directly to settings.
-		if ( typeof pricing.yearly === 'undefined' ) {
-			finishGettingStarted();
-		}
-	} );
 </script>
 
 <div id="jb-dashboard" class="jb-dashboard jb-dashboard--main">
@@ -111,29 +103,27 @@
 		<ActivateLicense />
 	</Header>
 
-	{#if pricing.yearly}
-		<div class="jb-section jb-section--alt">
-			<div class="jb-container">
-				<div class="jb-pricing-table">
+	<div class="jb-section jb-section--alt">
+		<div class="jb-container">
+			<div class="jb-pricing-table">
+				<ReactComponent
+					this={BoostPricingTable}
+					{pricing}
+					onPremiumCTA={choosePaidPlan}
+					onFreeCTA={chooseFreePlan}
+					chosenFreePlan={initiatingFreePlan}
+					chosenPaidPlan={initiatingPaidPlan}
+				/>
+				{#if $snackbarMessage}
 					<ReactComponent
-						this={BoostPricingTable}
-						{pricing}
-						onPremiumCTA={choosePaidPlan}
-						onFreeCTA={chooseFreePlan}
-						chosenFreePlan={initiatingFreePlan}
-						chosenPaidPlan={initiatingPaidPlan}
+						this={Snackbar}
+						children={$snackbarMessage}
+						onDismiss={() => dismissedSnackbar.set( true )}
 					/>
-					{#if $snackbarMessage}
-						<ReactComponent
-							this={Snackbar}
-							children={$snackbarMessage}
-							onDismiss={() => dismissedSnackbar.set( true )}
-						/>
-					{/if}
-				</div>
+				{/if}
 			</div>
 		</div>
-	{/if}
+	</div>
 </div>
 
 <style lang="scss">

--- a/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/BoostPricingTable.tsx
@@ -109,6 +109,11 @@ export const BoostPricingTable = ( {
 	chosenFreePlan,
 	chosenPaidPlan,
 } ) => {
+	// If no pricing info is available, set up a fake object to avoid errors.
+	if ( ! pricing || ! pricing.yearly ) {
+		pricing = { yearly: {} };
+	}
+
 	// If the first year discount ends, we want to remove the label without updating the plugin.
 	const promoLabel = pricing.yearly.isIntroductoryOffer
 		? __( 'First Year Discount', 'jetpack-boost' )

--- a/projects/plugins/boost/changelog/fix-boost-e2e
+++ b/projects/plugins/boost/changelog/fix-boost-e2e
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed e2e tests
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I've noticed our E2e tests have been failing lately. This is an attempt to fix it. The issue I found in testing was a redirection loop --> prices failed to load, so it kept on redirecting back adn forth between the getting started page and the dashboard.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Don't skip the getting started page if the pricing info fails to load - getting started is a must-use connection point now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* make sure you can use the plugin ok
* Make sure the plugin still works even if loading pricing information fails
* Make sure e2e tests pass

