### PR TITLE
Newsletter panel: update copy for activating subscribers feature

### DIFF
--- a/projects/plugins/jetpack/changelog/Update newsletter panel copy when subscriptions feature is disabled
+++ b/projects/plugins/jetpack/changelog/Update newsletter panel copy when subscriptions feature is disabled
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Just simple copy change.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -38,7 +38,7 @@ const SubscriptionsPanelPlaceholder = ( { children } ) => {
 		<Flex align="center" gap={ 4 } direction="column" style={ { alignItems: 'center' } }>
 			<FlexItem>
 				{ __(
-					"In order to send posts to your subscribers, activate the Subscriptions feature.",
+					'In order to send posts to your subscribers, activate the Subscriptions feature.',
 					'jetpack'
 				) }
 			</FlexItem>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -45,7 +45,7 @@ const SubscriptionsPanelPlaceholder = ( { children } ) => {
 			<FlexItem>{ children }</FlexItem>
 			<FlexItem>
 				<ExternalLink href="https://jetpack.com/support/subscriptions/">
-					{ __( 'Learn more', 'jetpack' ) }
+					{ __( 'Learn more about Subscriptions', 'jetpack' ) }
 				</ExternalLink>
 			</FlexItem>
 		</Flex>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -38,14 +38,14 @@ const SubscriptionsPanelPlaceholder = ( { children } ) => {
 		<Flex align="center" gap={ 4 } direction="column" style={ { alignItems: 'center' } }>
 			<FlexItem>
 				{ __(
-					"In order to share your posts with your subscribers, you'll need to activate the Subscriptions feature.",
+					"Activate the Subscriptions feature to share posts with your subscribers.",
 					'jetpack'
 				) }
 			</FlexItem>
 			<FlexItem>{ children }</FlexItem>
 			<FlexItem>
 				<ExternalLink href="https://jetpack.com/support/subscriptions/">
-					{ __( 'Learn more about the Subscriptions feature.', 'jetpack' ) }
+					{ __( 'Learn more', 'jetpack' ) }
 				</ExternalLink>
 			</FlexItem>
 		</Flex>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -38,7 +38,7 @@ const SubscriptionsPanelPlaceholder = ( { children } ) => {
 		<Flex align="center" gap={ 4 } direction="column" style={ { alignItems: 'center' } }>
 			<FlexItem>
 				{ __(
-					"Activate the Subscriptions feature to share posts with your subscribers.",
+					"In order to share posts as emails with your subscribers, activate the Subscriptions feature.",
 					'jetpack'
 				) }
 			</FlexItem>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -38,7 +38,7 @@ const SubscriptionsPanelPlaceholder = ( { children } ) => {
 		<Flex align="center" gap={ 4 } direction="column" style={ { alignItems: 'center' } }>
 			<FlexItem>
 				{ __(
-					"In order to share posts as emails with your subscribers, activate the Subscriptions feature.",
+					"In order to send posts to your subscribers, activate the Subscriptions feature.",
 					'jetpack'
 				) }
 			</FlexItem>


### PR DESCRIPTION
- Remove "yours" which can sound a bit off for multi-author sites
- Condense
- Add "sending" to imply emails instead of other kinds of sharing

**Before**

<img src="https://github.com/Automattic/jetpack/assets/87168/7b646583-1947-4aed-b15f-82d9d2f82c6c" alt="" />

**After**

> In order to send posts to your subscribers, activate the Subscriptions feature.
>
> Activate Subscriptions
> 
> Learn more about Subscriptions

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On Jetpack site with subscriptions module disabled
* Go to post editor, and open Newsletter panel

