### PR TITLE
Sync: revert #31423

### DIFF
--- a/projects/packages/sync/changelog/revert-pr-31423
+++ b/projects/packages/sync/changelog/revert-pr-31423
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Reverts Automattic/jetpack/pull/31423
+Revert dedicated hook endpoint to later in the 'init' hook, as it broke existing code that registers post statuses and such during 'init'.

--- a/projects/packages/sync/changelog/revert-pr-31423
+++ b/projects/packages/sync/changelog/revert-pr-31423
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reverts Automattic/jetpack/pull/31423

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -108,7 +108,7 @@ class Actions {
 		// rely on 'jetpack_sync_before_send_queue_sync' are picked up and added to the queue if needed.
 		if ( Settings::is_dedicated_sync_enabled() && Dedicated_Sender::is_dedicated_sync_request() ) {
 			self::initialize_listener();
-			add_action( 'init', array( __CLASS__, 'add_dedicated_sync_sender_init' ), 0 );
+			add_action( 'init', array( __CLASS__, 'add_dedicated_sync_sender_init' ), 90 );
 			return;
 		}
 


### PR DESCRIPTION
## Proposed changes:

Reverts #31423 

Just getting this up for review now since unless we find a different fix, we'll want to revert this before Jetpack 12.3 ships out.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/31423#issuecomment-1620631547

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread.
