### PR TITLE
My Jetpack: hide Stats card for standalone plugins

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.jsx
@@ -12,6 +12,9 @@ import StatsCard from './stats-card';
 import styles from './style.module.scss';
 import VideopressCard from './videopress-card';
 
+// flag for enabling stats card.
+const { showJetpackStatsCard = false } = window.myJetpackInitialState?.myJetpackFlags ?? {};
+
 /**
  * Product cards section component.
  *
@@ -25,11 +28,14 @@ const ProductCardsSection = () => {
 		BoostCard,
 		SearchCard,
 		VideopressCard,
-		StatsCard,
 		CrmCard,
 		SocialCard,
 		AiCard,
 	];
+
+	if ( showJetpackStatsCard ) {
+		items.splice( 6, 0, StatsCard );
+	}
 
 	return (
 		<Container

--- a/projects/packages/my-jetpack/changelog/update-only-show-stats-card-for-jetpack
+++ b/projects/packages/my-jetpack/changelog/update-only-show-stats-card-for-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: hide Stats card for standalone plugins

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -198,7 +198,8 @@ class Initializer {
 	 */
 	public static function get_my_jetpack_flags() {
 		$flags = array(
-			'videoPressStats' => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
+			'videoPressStats'      => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
+			'showJetpackStatsCard' => class_exists( 'Jetpack' ),
 		);
 
 		return $flags;


### PR DESCRIPTION
Related: https://github.com/Automattic/jetpack/issues/31343#issuecomment-1619876084

## Proposed changes:

When only standalone plugins are installed, the Stats card would redirect user to purchase page on Calypso, which could possibly not exist as the site might not have Jetpack plugin or connected yet.

The PR proposed to only show the Stats card when Jetpack plugin is active. And we'll tackle the issue mentioned above in follow up PRs.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1688465049532809-slack-C82FZ5T4G

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

- Spin up a JN site with Jetpack Beta and only a bleeding edge standalone plugin, for example Search
- Open `/wp-admin/admin.php?page=my-jetpack`
- Ensure Stats card is not shown
- Install Jetpack latest stable
- Ensure Stats card is shown and functional