### PR TITLE
[Boost] Fix atomic caching

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -169,7 +169,7 @@ class Concatenate_CSS extends WP_Styles {
 					} else {
 						$path_str = implode( ',', $css );
 					}
-					$path_str = "$path_str?m=$mtime";
+					$path_str = "$path_str?m=$mtime&cb=" . jetpack_boost_minify_cache_buster();
 
 					if ( $this->allow_gzip_compression ) {
 						// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode

--- a/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_JS.php
@@ -228,7 +228,7 @@ class Concatenate_JS extends WP_Scripts {
 					} else {
 						$path_str = implode( ',', $js_array['paths'] );
 					}
-					$path_str = "$path_str?m=$mtime";
+					$path_str = "$path_str?m=$mtime&cb=" . jetpack_boost_minify_cache_buster();
 
 					if ( $this->allow_gzip_compression ) {
 						// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -4,6 +4,14 @@ use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\Dependency_Path_Mapping;
 
 /**
+ * Get an extra cache key for requests. We can manually bump this when we want
+ * to ensure a new version of Jetpack Boost never reuses old cached URLs.
+ */
+function jetpack_boost_minify_cache_buster() {
+	return 1;
+}
+
+/**
  * Cleanup the given cache folder, removing all files older than $file_age seconds.
  *
  * @param string $cache_folder The path to the cache folder to cleanup.

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -314,6 +314,10 @@ function jetpack_boost_page_optimize_build_output() {
 		}
 	}
 
+	// Don't let trailing whitespace ruin everyone's day. Seems to get stripped by batcache
+	// resulting in ns_error_net_partial_transfer errors.
+	$output = rtrim( $output );
+
 	$headers = array(
 		'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $last_modified ) . ' GMT',
 		'Content-Length: ' . ( strlen( $pre_output ) + strlen( $output ) ),

--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -320,7 +320,6 @@ function jetpack_boost_page_optimize_build_output() {
 
 	$headers = array(
 		'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $last_modified ) . ' GMT',
-		'Content-Length: ' . ( strlen( $pre_output ) + strlen( $output ) ),
 		"Content-Type: $mime_type",
 	);
 

--- a/projects/plugins/boost/changelog/fix-atomic-caching
+++ b/projects/plugins/boost/changelog/fix-atomic-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Minify CSS/JS: Fixed an odd caching issue on Atomic hosts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/31672

It seems that Atomic's caching layer can sometimes get messed up by trailing whitespace in minified js files, resulting in `NS_ERROR_NET_PARTIAL_TRANSFER` errors when fetching minified content.

This PR fixes it by stripping trailing whitespace out of minified content before outputting it, preventing it from getting further shortened by Atomic's caching layer.

Also adds a cache-busting number we can bump in future versions of boost that affect our minify service - just in case.

## Proposed changes:
* Add a cache-buster to the minify service we can manually bump for future releases that affect the minifier
* Strips trailing whitespace from minified content before storing it, or passing it off to the host's caching layer.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:

### Note
The testing steps below do not work if you proxy the Atomic site, as that bypasses the Atomic caching layer. Please follow the steps without proxying.

### Part 1: replicating the issue
* Install Jetpack Beta in an Atomic site.
* Create a page with a Jetpack Slideshow on it with a couple of images in it.
* Use Jetpack Beta to install Boost 1.9.1 and turn on Minify CSS and JavaScript.
* View the page with the Jetpack Slideshow. It works.
* Use Jetpack Beta to install Boost 1.9.3.
* View the page with the Jetpack Slideshow again - this time, add a cachebusting `?x=123` to the URL to ensure that Atomic's caching layer doesn't server you the 1.9.1 version again.
* Open your network tab and refresh the page a few times. 
* You'll see errors that look like this:
![image](https://github.com/Automattic/jetpack/assets/1369626/6b663f5b-740c-4a4a-ad6f-aec0ddfdbda4)

### Part 2: proving this fixes it
* Go back to Jetpack Boost 1.9.1
* Reload the slider page again - use another cache-buster GET param to ensure you get a clean version, make sure it looks happy
* Use Jetpack beta to install this branch (`fix/atomic-caching`)
* Go back to the slider page again, update the cache-buster to ensure you're not viewing a cached 1.9.1 version of the page
* Open the network tab and refresh the page a few times.
* There should be no more network errors. Just happiness and sunshine.
