### PR TITLE
Jetpack: backport 12.3 changelog and readme updates

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 12.3-beta - 2023-06-26
+## 12.3 - 2023-07-05
 ### Enhancements
 - AI Assistant: extend AI features to select core blocks.
 - AI Extension: add ask assistant menu option. [#31568]
@@ -21,24 +21,27 @@
 - AI Extension: use ID on error notices to prevent stacking multiple notices. [#31584]
 - Customizer: fix an issue which was preventing the Customize menu from appearing for plugins that still require it to be present. [#31452]
 - Newsletters: properly gate newsletters based on the correct subscription product. [#31450]
+- Sharing Buttons: remove Reddit's official iframe sharing button, it is no longer working. Use icon+text sharing button instead. [#31666]
 - Social Review Prompt: fix the state so it is shown when Jetpack is also active. [#31456]
+- Subscriptions: avoid fatal error when site is connected to WordPress.com, but user account is not. [#31635]
 - Subscriptions: fix visibility misalignment. [#31544]
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
-- AI Assistant: replace imported store constants with strings. [#31585]
 - AI Assistant: add a specific delimiter for content in the prompts. [#31515]
 - AI Assistant: add transform from core to AI Assistant block. [#31442]
 - AI Assistant: change delimiter and remove it from responses. [#31518]
 - AI Assistant: disable toolbar tooltip when streaming suggestion. [#31581]
 - AI Assistant: remove page content from prompt. [#31465]
+- AI Assistant: replace imported store constants with strings. [#31585]
 - AI Extension: disable the AI toolbar button when the block doesn't have content. [#31559]
 - AI Extension: dispatch action to update extended block attributes. [#31437]
+- AI Extension: do not extend block sidebar. [#31476]
 - AI Extension: do not extend core blocks when the user decided to hide the AI Assistant block. [#31557]
 - AI Extension: extend core list item core block. [#31496]
 - AI Extension: handle errors from extended blocks actions. [#31497]
 - AI Extension: handle multiple blocks editing. [#31491]
-- AI Extension: improve block transform process for Heading core block type. [#31571]
 - AI Extension: improve block transform process. [#31481]
+- AI Extension: improve block transform process for Heading core block type. [#31571]
 - AI Extension: improve prompt when using the AI Assistant in extended blocks. [#31449]
 - AI Extension: iterate over prompt to try to keep the lang of the content. [#31482]
 - AI Extension: iterate over spelling and grammar prompt item. [#31509]
@@ -47,7 +50,6 @@
 - AI Extension: reorganize prompt items for the AI extension. [#31514]
 - AI Extension: tweak the tone prompt. [#31466]
 - AI Extension: winking toolbar color when requesting. [#31474]
-- AI Extension: do not extend block sidebar. [#31476]
 - Blaze: introduce module, instead of automatically initializing the feature. [#31479]
 - Connection: update visual used in banner. [#31440]
 - Dependency update. [#31394]
@@ -56,6 +58,7 @@
 - Newsletters: add tracks to email preview feature. [#31566]
 - Tock Block: avoid PHP warning when restaurant name isn't set. [#31577]
 - Updated package dependencies.
+- Upudate to-test.md for 12.3 [#31586]
 - Zendesk Chat Widget: add authentication to the widget. [#31339]
 
 ## 12.3-a.7 - 2023-06-19

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
-## 12.3 - 2023-07-05
+## [12.3] - 2023-07-05
 ### Enhancements
 - AI Assistant: extend AI features to select core blocks.
 - AI Extension: add ask assistant menu option. [#31568]
@@ -8333,13 +8333,14 @@ Other bugfixes and enhancements at https://github.com/Automattic/jetpack/commits
 
 - Initial release
 
-[11.6]: https://wp.me/p1moTy-PLI
+[12.3]: https://wp.me/p1moTy-Uk3
 [12.2]: https://wp.me/p1moTy-Tzw
 [12.1]: https://wp.me/p1moTy-TA2
 [12.0]: https://wp.me/p1moTy-RGw
 [11.9]: https://wp.me/p1moTy-RdX
 [11.8]: https://wp.me/p1moTy-QEM
 [11.7]: https://wp.me/p1moTy-Q9t
+[11.6]: https://wp.me/p1moTy-PLI
 [11.5]: https://wp.me/p1moTy-Ppq
 [11.4]: https://wp.me/p1moTy-O5I
 [11.3]: https://wp.me/p1moTy-M5i

--- a/projects/plugins/jetpack/changelog/fix-fatal-subscriptions
+++ b/projects/plugins/jetpack/changelog/fix-fatal-subscriptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Subscriptions: avoid Fatal Error when site is connected to WordPress.com, but user is not.

--- a/projects/plugins/jetpack/changelog/modify-ai-extended-blocks
+++ b/projects/plugins/jetpack/changelog/modify-ai-extended-blocks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Stop extending list items with AI
-
-

--- a/projects/plugins/jetpack/changelog/update-jetpack-12.3-to-test
+++ b/projects/plugins/jetpack/changelog/update-jetpack-12.3-to-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Upudate to-test.md for 12.3

--- a/projects/plugins/jetpack/changelog/update-reddit-official-button
+++ b/projects/plugins/jetpack/changelog/update-reddit-official-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Sharing: remove Reddit's Oofficial iFramed sharing button, it is no longer working. Use icon+text sharing button instead.

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -293,7 +293,7 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 12.3-beta - 2023-06-26
+### 12.3 - 2023-07-05
 #### Enhancements
 - AI Assistant: add and use ImproveToolbarDropdownMenu in block toolbar.
 - AI Assistant: add Expand option into AI Assistant dropdown menu.
@@ -369,7 +369,9 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 - Newsletters: remove Newsletter column on products post type.
 - Newsletters: show paid subscriber reach numbers in the past tense when the post has been already been published.
 - Newsletters: verify the access level should be gated before checking subscriptions.
+- Sharing Buttons: remove Reddit's official iframe sharing button, it is no longer working. Use icon+text sharing button instead.
 - Social Review Prompt: fix the state so it is shown when Jetpack is also active.
+- Subscriptions: avoid fatal error when site is connected to WordPress.com, but user account is not.
 - Subscriptions: fix visibility misalignment.
 - Tock Block: fix the embed rendering on WordPress.com sites.
 - WPcom: fix output of static script path on WordPress.com sites.

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, batmoo, barry, beaulebens, bindlegirl, biskobe, blobaugh, bjorsch, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, robertbpugh, roccotripaldi, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, wpkaren, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
-Stable tag: 12.2.1
+Stable tag: 12.3
 Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -295,67 +295,28 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 == Changelog ==
 ### 12.3 - 2023-07-05
 #### Enhancements
-- AI Assistant: add and use ImproveToolbarDropdownMenu in block toolbar.
-- AI Assistant: add Expand option into AI Assistant dropdown menu.
-- AI Assistant: add keyboard shortcuts.
-- AI Assistant: add Summarize option to the AI Assistant dropdown menu.
-- AI Assistant: add tone into AI Assistant dropdown menu.
-- AI Assistant: add translate option in extensions.
-- AI Assistant: build prompt from AI Assistant toolbar menu.
-- AI Assistant: change icon on AI disclaimer message.
-- AI Assistant: collect, store and send prompt history.
-- AI Assistant: create function to build the post data prompt.
-- AI Assistant: do not extend if the AI Assistant block is not registered.
 - AI Assistant: extend AI features to select core blocks.
-- AI Assistant: extend blocks toolbar.
-- AI Assistant: extract and use block content utils.
-- AI Assistant: fix generating prompt when requesting suggestion.
-- AI Assistant: improve the process of getting post content.
-- AI Assistant: introduce function to create the initial system prompt.
-- AI Assistant: introduce jetpack/ai supports.
-- AI Assistant: iterate over custom hook to request suggestions.
-- AI Assistant: move caret to end of generated content when accepting.
-- AI Assistant: register ai-assistant-support beta extension.
-- AI Assistant: remove shortcuts labels from block area.
-- AI Assistant: replace tone button icon for clarity.
-- AI Assistant: separate prompt text from relevant content for extensions.
-- AI Assistant: show message when content generated.
-- AI Assistant: tidy some block components.
-- AI Assistant: tweak content generated message.
-- AI Assistant: update block content once AI response is ready.
 - AI Extension: add ask assistant menu option.
-- Backup: add video section to Backup connect page.
 - Blocks: add a new Tock block.
-- Blocks: add new Tock block to beta blocks.
 - Blocks: load block stylesheets inline when possible for improved performance.
-- Customizer: hide the customizer submenu for block based themes. [#31353, #31376]
+- Customizer: hide the customizer submenu for block based themes.
 - Newsletters: add an Email Preview feature.
-- Newsletters: silence creation of the default membership product in a newsletter context.
 - Newsletters: update Paid newsletter panel designs.
 - Related Posts: add srcset for the thumbnails.
 - Sharing Buttons: add a Nextdoor sharing button.
 - Social Logos: update to include a Nextdoor and a Fediverse logo.
 - Stats: display the links to a post's stats in the Posts list as soon as the user has access to stats.
 - Subscribers: add menu item to Calypso interface.
-- Tock Block: update the block settings interface.
 
 #### Improved compatibility
 - Blocks: introduce standardized messaging system to display notices when a block is no longer supported on a site.
 - Blocks: remove retired Revue Block.
-- PHP8 compatibility updates. [#31240, #31242, #31243, #31250]
+- PHP8 compatibility updates.
 - Tiled Galleries: avoid PHP deprecation notices on sites using PHP 8.2.
 - WordPress.com Toolbar: avoid PHP warnings with PHP 8.2.
 
 #### Bug fixes
-- AI Assistant: block query requests when upgrade required.
-- AI Assistant: check if the block is in the block editor context before enabling accept title action.
-- AI Assistant: close event stream of completions when the block gets deleted.
-- AI Assistant: fix empty content on P2.
-- AI Assistant: fix translation feature.
-- AI Assistant: request completion JWT token as the user, not the blog.
-- AI Assistant: show Jetpack AI product in the plan products list.
-- AI Extension: extend the block when the edit post store is undefined (P2).
-- AI Extension: use ID on error notices to prevent stacking multiple notices.
+- AI Assistant: several bug fixes this release, check the CHANGELOG.md file for more info.
 - Connection: fix redirecting users who click back button before approving connection to Jetpack Dashboard.
 - Customizer: fix an issue which was preventing the Customize menu from appearing for plugins that still require it to be present.
 - Dashboard: display an external icon next to the link to the Subscribers list.
@@ -363,17 +324,11 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 - Memberships: correctly gate posts rendered on pages.
 - Memberships: fix an issue where Jetpack_Memberships::user_can_view_post would cache the wrong value.
 - Memberships: fix potential class not found error.
-- Newsletters: do not display Newsletter plans in the Premium Content and Recurring Payment blocks.
-- Newsletters: make the subscribers reach sentence future-tense for scheduled posts.
-- Newsletters: properly gate newsletters based on the correct subscription product.
-- Newsletters: remove Newsletter column on products post type.
-- Newsletters: show paid subscriber reach numbers in the past tense when the post has been already been published.
-- Newsletters: verify the access level should be gated before checking subscriptions.
+- Newsletters: several bug fixes this release, check the CHANGELOG.md file for more info.
 - Sharing Buttons: remove Reddit's official iframe sharing button, it is no longer working. Use icon+text sharing button instead.
 - Social Review Prompt: fix the state so it is shown when Jetpack is also active.
 - Subscriptions: avoid fatal error when site is connected to WordPress.com, but user account is not.
 - Subscriptions: fix visibility misalignment.
-- Tock Block: fix the embed rendering on WordPress.com sites.
 - WPcom: fix output of static script path on WordPress.com sites.
 
 --------


### PR DESCRIPTION
## Proposed changes:

- Jetpack: backport 12.3 changelog and readme updates from the release branch.
- Update Jetpack stable tag in readme.txt to 12.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Proofread.
