### PR TITLE
Backup and Social: changelog and readme updates for JP 12.3 cycle

### DIFF
--- a/projects/plugins/backup/CHANGELOG.md
+++ b/projects/plugins/backup/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.9-beta] - 2023-06-26
+## [1.9] - 2023-07-05
 ### Added
-- Add authentication to Zendesk chat widget [#31339]
-- Add video section to Backup connect page [#31260]
+- Add authentication to Zendesk chat widget. [#31339]
+- Add video section to Backup connect page. [#31260]
 
 ### Changed
-- Update connection module to have an RNA option that updates the design [#31201]
+- Update connection module to have an RNA option that updates the design. [#31201]
 - Updated package dependencies. [#31308]
 
 ## [1.8] - 2023-06-06
@@ -174,5 +174,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Use `absoluteRuntime` in babel JS build to avoid module not found errors.
 
-[1.9-beta]: https://github.com/Automattic/jetpack-backup-plugin/compare/1.8...1.9-beta
+[1.9]: https://github.com/Automattic/jetpack-backup-plugin/compare/1.8...1.9-beta
 [1.8]: https://github.com/Automattic/jetpack-backup-plugin/compare/1.7...1.8

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -172,9 +172,12 @@ No, Jetpack VaultPress Backup does not currently support split site or split hom
 2. Your site backups are stored in multiple locations on our world-class cloud infrastructure so you can recover them at any moment.
 
 == Changelog ==
-### 1.8 - 2023-06-06
+### 1.9 - 2023-07-05
+#### Added
+- Add video section to Backup connect page.
+
 #### Changed
-- General: update link references to releases in changelog.
+- Update connection module to have an RNA option that updates the design.
 - Updated package dependencies.
 
 --------

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -4,7 +4,7 @@ Tags: jetpack, backup, restore
 Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
-Stable tag: 1.8
+Stable tag: 1.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/projects/plugins/social/CHANGELOG.md
+++ b/projects/plugins/social/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.0.0-beta - 2023-06-26
+## 2.0.0 - 2023-07-05
 ### Added
 - Add authentication to Zendesk chat widget. [#31339]
 
 ### Changed
 - Social: change the admin page plan redirect link. [#31195]
+- Social: update the Readme to better reflect new features. [#31686]
 - Updated package dependencies.
 
 ### Fixed

--- a/projects/plugins/social/changelog/update-social-readme-features
+++ b/projects/plugins/social/changelog/update-social-readme-features
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social: Updated the Readme to better reflect the new features

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -4,7 +4,7 @@ Tags: social-media, publicize, social-media-manager, social-networking, social m
 Requires at least: 6.1
 Requires PHP: 5.6
 Tested up to: 6.2
-Stable tag: 1.11.0
+Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -100,16 +100,13 @@ The easiest way is to use the Custom Message option in the publishing options bo
 4. Manage your Jetpack Social and other Jetpack plugins from My Jetpack.
 
 == Changelog ==
-### 1.11.0 - 2023-06-06
-#### Added
-- Added feature flag for Mastodon preview
-- Jetpack Social: Add a notice to let users know Instagram is available
-
+### 2.0.0 - 2023-07-05
 #### Changed
-- Remove conditional rendering from zendesk chat widget component due to it being handled by an api endpoint now
+- Social: change the admin page plan redirect link.
+- Social: update the Readme to better reflect new features.
 - Updated package dependencies.
-- Updates the enhanced publishing feature check
 
-#### Deprecated
-- Minor changes around upcoming functionality change in Twitter.
+#### Fixed
+- Social: fix the connection state to ensure that new connections are disabled by default when there are no shares left.
+- Social Review Prompt: fix the state so it is shown when Jetpack is also active.
 


### PR DESCRIPTION
## Proposed changes:

- Backup and Social plugin changelog and readme updates from the JP 12.3 cycle.
- Backup and Social plugin stable tag bumps.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Proofread.
