### PR TITLE
Deletes hello-world default post for users at design-first flow

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-remove-hello-world-post-after-first-post-published
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-remove-hello-world-post-after-first-post-published
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+While in the design_first flow, if the user creates a post, deletes the default hello-world.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "3.5.x-dev"
+			"dev-trunk": "3.6.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "3.5.0",
+	"version": "3.6.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '3.5.0';
+	const PACKAGE_VERSION = '3.6.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -541,7 +541,7 @@ function wpcom_track_site_launch_task() {
 
 	// While in the design_first flow, if the user creates a post, deletes the default hello-world.
 	$first_post_published = wpcom_launchpad_checklists()->is_task_id_complete( 'first_post_published' );
-	if ( in_array( $site_intent, array( 'design-first' ) ) && $first_post_published ) {
+	if ( in_array( $site_intent, array( 'design-first' ), true ) && $first_post_published ) {
 		$posts = get_posts( array( 'name' => 'hello-world' ) );
 
 		if ( count( $posts ) > 0 ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -538,6 +538,16 @@ function wpcom_track_site_launch_task() {
 		update_option( 'site_intent', '' );
 		update_option( 'launchpad_screen', 'off' );
 	}
+
+	// While in the design_first flow, if the user creates a post, deletes the default hello-world.
+	$first_post_published = wpcom_launchpad_checklists()->is_task_id_complete( 'first_post_published' );
+	if ( in_array( $site_intent, array( 'design-first' ) ) && $first_post_published ) {
+		$posts = get_posts( array( 'name' => 'hello-world' ) );
+
+		if ( count( $posts ) > 0 ) {
+			wp_delete_post( $posts[0]->ID, true );
+		}
+	}
 }
 
 /**

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-remove-hello-world-post-after-first-post-published
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-remove-hello-world-post-after-first-post-published
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_3"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_4_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "05dc16c5e87471de1e32e4a8a2e663fbaf7302ba"
+                "reference": "e8b46caf659ca9da824f2e1c3bb42395e338e02c"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.3
+ * Version: 1.6.4-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.3",
+	"version": "1.6.4-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
Task-related: 2833-gh-Automattic/dotcom-forge

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* While in the `design_first` flow, if the user creates a post, we want to delete the default hello-world post.

Unit tests created here: D115358-code

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With a new user user or a user having no sites, create a new site at the /setup/design-first flow
* Selects the `Hey` theme
* Follow all flow steps including creating your first post
* After publishing your blog, you shouldn't see the `Hello Wolrd` anymore. Both in the preview + site:

<img width="1256" alt="image" src="https://github.com/Automattic/jetpack/assets/1044309/cc80c32f-5028-4d4e-8fba-f38a4efd671e">