### PR TITLE
Boost: Fix snackbar showing under UI elements on getting started page

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/snackbar.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/snackbar.scss
@@ -6,4 +6,5 @@
 	position: fixed;
 	bottom: 100px;
 	right: 100px;
+	z-index: 10;
 }

--- a/projects/plugins/boost/app/assets/src/css/components/snackbar.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/snackbar.scss
@@ -1,11 +1,9 @@
 /*
  * Styles to make Gutenberg snackbar to integrate into Boost.
  */
-.jb-dashboard {
-    .components-snackbar {
-        box-sizing: content-box;
-        position: fixed;
-        bottom: 100px;
-        right: 100px;
-    }
+.jb-dashboard .components-snackbar {
+	box-sizing: content-box;
+	position: fixed;
+	bottom: 100px;
+	right: 100px;
 }

--- a/projects/plugins/boost/changelog/fix-getting-started-snackbar-under-separators
+++ b/projects/plugins/boost/changelog/fix-getting-started-snackbar-under-separators
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fixed snackbar showing under UI separators on getting started page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/boost-cloud/issues/277

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the z-index of the snackbar on the getting started page, so it shows over UI elements instead of under them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Pre-requisites

* You need a publicly visible website in order for the test to work.
* Note that if you've already connected your website, you'll need to deactivate Boost and reactivate it in order for the snackbar to show up;
* Add this snippet to your website (for example in `mu-plugins`) - This will cause the snackbar to show up when you click either button:

```php
<?php

add_filter( 'rest_pre_dispatch', 'pp_boost_break_rest_calls', 10, 3 );
function pp_boost_break_rest_calls( $result, $server, $request ) {
	if ( false === stripos( $request->get_route(), 'connection' ) ) {
		return $result;
	}

	header( $_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error', true, 500 );
	exit;
}

```

### Test that it breaks

* Setup the trunk version of Boost;
* Navigate to the getting started page (or open Boost Settings page if already connected and append `#getting-started` to the URL) and click either button;
* You should see the snackbar popup with an error message and the UI should be above it (notice the horizontal line is above the snackbar):

<img width="546" alt="CleanShot 2023-07-05 at 23 01 31@2x" src="https://github.com/Automattic/jetpack/assets/11799079/cb6eef43-d271-4c75-ad75-527bf08a4385">


### Test that it works
* Setup the version of Boost from this branch;
* Go through the above steps again (deactivate and reactivate Boost if the snackbar doesn't show up);
* When the snackbar shows up, it should be above the UI elements:

<img width="517" alt="CleanShot 2023-07-05 at 23 09 11@2x" src="https://github.com/Automattic/jetpack/assets/11799079/3bc7bf09-3147-471a-990e-0ffc2f6b29ad">
