### PR TITLE
CRM: Fix WP user not being generated after v6.0.0

### DIFF
--- a/projects/plugins/crm/admin/contact/contact.ajax.php
+++ b/projects/plugins/crm/admin/contact/contact.ajax.php
@@ -76,7 +76,7 @@ function zeroBSCRM_generateClientPortalUser() { // phpcs:ignore WordPress.Naming
 		// $email_exists will be either false/int (id of wp user)
 		$email_exists = email_exists( $email );
 
-		if ( ! empty( $contact_id ) && null === $email_exists && ! empty( $email ) ) {
+		if ( ! empty( $contact_id ) && ( null === $email_exists || false === $email_exists ) && ! empty( $email ) ) {
 
 			global $zbs;
 

--- a/projects/plugins/crm/changelog/fix-crm-3163-generate-wp-user-does-not-work-after-6-0-0
+++ b/projects/plugins/crm/changelog/fix-crm-3163-generate-wp-user-does-not-work-after-6-0-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contacts: Fix bug that prevented the creation of contacts WP user for the Client Portal


### PR DESCRIPTION
## Proposed changes:
* After Jetpack CRM's v.6.0.0 release WP user creation for the Client Portal stopped working. This PR fixes this issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3163

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Go to to a contact's view page (e.g. `wp-admin/admin.php?page=zbs-add-edit&action=view&zbstype=contact&zbsid=2`)
* Click on the button `Generate WordPress User` in the Client Portal sidebar.

In `trunk` an error is displayed: `Error: User already exists or invalid email!`

In `fix/crm/3163-generate-wp-user-does-now-work-after-6-0-0` the user is created with no errors.

