### PR TITLE
Jetpack 12.3: backport maintenance releases

### DIFF
--- a/projects/github-actions/required-review/CHANGELOG.md
+++ b/projects/github-actions/required-review/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2023-07-06
+### Added
+- Added `consume` option for requirements. [#29317]
+- Option to request review if requirement is not satisfied. [#30653]
+
+### Changed
+- Updated package dependencies. [#29855]
+
+### Fixed
+- Don't fail on case mismatch for `@singleuser` pseudo-teams. [#29322]
+
 ## [3.0.2] - 2023-02-07
 ### Changed
 - Minor internal updates.
@@ -64,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
+[3.1.0]: https://github.com/Automattic/action-required-review/compare/v3.0.2...v3.1.0
 [3.0.2]: https://github.com/Automattic/action-required-review/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Automattic/action-required-review/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/Automattic/action-required-review/compare/v2.2.2...v3.0.0

--- a/projects/github-actions/required-review/changelog/add-required-review-consume-option
+++ b/projects/github-actions/required-review/changelog/add-required-review-consume-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added `consume` option for requirements.

--- a/projects/github-actions/required-review/changelog/fix-required-review-username-case
+++ b/projects/github-actions/required-review/changelog/fix-required-review-username-case
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Don't fail on case mismatch for `@singleuser` pseudo-teams.

--- a/projects/github-actions/required-review/changelog/renovate-vercel-ncc-0.x
+++ b/projects/github-actions/required-review/changelog/renovate-vercel-ncc-0.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/github-actions/required-review/changelog/request-review-if-not-satisfied
+++ b/projects/github-actions/required-review/changelog/request-review-if-not-satisfied
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Option to request review if requirement is not satisfied.

--- a/projects/github-actions/required-review/package.json
+++ b/projects/github-actions/required-review/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "required-review",
-	"version": "3.1.0-alpha",
+	"version": "3.1.0",
 	"description": "Check that a Pull Request has reviews from required teams.",
 	"main": "index.js",
 	"author": "Automattic",

--- a/projects/js-packages/storybook/CHANGELOG.md
+++ b/projects/js-packages/storybook/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 - 2023-07-06
+### Added
+- Import root styles from js-packages to load root variables used by components [#30037]
+
+### Changed
+- Updated package dependencies.
+
+### Fixed
+- Update config to work around some bugs so `NODE_PATH` is no longer needed when running storybook. [#31607]
+
 ## 0.3.2 - 2023-04-07
 ### Added
 - Include VideoPress block editor folder to the stories

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-major-storybook-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/storybook/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#4
+++ b/projects/js-packages/storybook/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/storybook/changelog/update-boost-score-bar-to-react-component
+++ b/projects/js-packages/storybook/changelog/update-boost-score-bar-to-react-component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Import root styles from js-packages to load root variables used by components

--- a/projects/js-packages/storybook/changelog/update-postcss-configs
+++ b/projects/js-packages/storybook/changelog/update-postcss-configs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Postcss config no longer needs NODE_PATH, but storybook still does. Update comment accordingly. No change to the project itself.
-
-

--- a/projects/js-packages/storybook/changelog/update-storybook-config
+++ b/projects/js-packages/storybook/changelog/update-storybook-config
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Update config to work around some bugs so `NODE_PATH` is no longer needed when running storybook.

--- a/projects/js-packages/storybook/package.json
+++ b/projects/js-packages/storybook/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-storybook",
-	"version": "0.4.0-alpha",
+	"version": "0.4.0",
 	"description": "Jetpack components storybook",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/storybook/#readme",
 	"bugs": {

--- a/projects/packages/heartbeat/CHANGELOG.md
+++ b/projects/packages/heartbeat/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3] - 2023-07-06
+### Added
+- Add Jetpack Autoloader package suggestion. [#29988]
+
 ## [1.5.2] - 2023-02-07
 ### Changed
 - Updated package dependencies.
@@ -120,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use new heartbeat package
 - Creates the Jetpack Heartbeat package
 
+[1.5.3]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/Automattic/jetpack-heartbeat/compare/v1.4.1...v1.5.0

--- a/projects/packages/heartbeat/changelog/add-package-suggestions
+++ b/projects/packages/heartbeat/changelog/add-package-suggestions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add Jetpack Autoloader package suggestion.

--- a/projects/packages/tracking/CHANGELOG.md
+++ b/projects/packages/tracking/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.13] - 2023-07-06
+### Added
+- Add Jetpack Autoloader package suggestion. [#29988]
+
 ## [1.14.12] - 2023-01-11
 ### Changed
 - Updated package dependencies.
@@ -258,6 +262,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create package for Jetpack Tracking
 
+[1.14.13]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.12...v1.14.13
 [1.14.12]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.11...v1.14.12
 [1.14.11]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.10...v1.14.11
 [1.14.10]: https://github.com/Automattic/jetpack-tracking/compare/v1.14.9...v1.14.10

--- a/projects/packages/tracking/changelog/add-package-suggestions
+++ b/projects/packages/tracking/changelog/add-package-suggestions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add Jetpack Autoloader package suggestion.

--- a/projects/packages/transport-helper/CHANGELOG.md
+++ b/projects/packages/transport-helper/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2023-07-06
+### Added
+- Add Jetpack Autoloader package suggestion. [#29988]
+
 ## [0.1.4] - 2023-03-29
 ### Changed
 - Minor internal updates.
@@ -29,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies.
 
+[0.1.5]: https://github.com/Automattic/jetpack-transport-helper/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/Automattic/jetpack-transport-helper/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Automattic/jetpack-transport-helper/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Automattic/jetpack-transport-helper/compare/v0.1.1...v0.1.2

--- a/projects/packages/transport-helper/changelog/add-package-suggestions
+++ b/projects/packages/transport-helper/changelog/add-package-suggestions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add Jetpack Autoloader package suggestion.

--- a/projects/packages/transport-helper/package.json
+++ b/projects/packages/transport-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-transport-helper",
-	"version": "0.1.5-alpha",
+	"version": "0.1.5",
 	"description": "Package to help transport server communication",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/transport-helper/#readme",
 	"bugs": {

--- a/projects/packages/transport-helper/src/class-package-version.php
+++ b/projects/packages/transport-helper/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Transport_Helper;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.1.5-alpha';
+	const PACKAGE_VERSION = '0.1.5';
 
 	const PACKAGE_SLUG = 'transport-helper';
 

--- a/projects/packages/yoast-promo/CHANGELOG.md
+++ b/projects/packages/yoast-promo/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2023-07-06
+### Changed
+- Updated package dependencies.
+
 ## [0.1.1] - 2023-05-01
 ### Added
 - Add Jetpack Autoloader package suggestion. [#29988]
@@ -18,4 +22,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generate initial package for Yoast promo components [#29627]
 - Initialize yoast promo package in jetpack plugin [#29641]
 
+[0.1.2]: https://github.com/automattic/jetpack-yoast-promo/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/automattic/jetpack-yoast-promo/compare/v0.1.0...v0.1.1

--- a/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#2
+++ b/projects/packages/yoast-promo/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#3
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#4
+++ b/projects/packages/yoast-promo/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/yoast-promo/changelog/update-postcss-configs
+++ b/projects/packages/yoast-promo/changelog/update-postcss-configs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Remove unneeded `NODE_PATH` incorrectly copy-pasted from elsewhere. (Correct copy-pasting would have had it before the `webpack`, not before the `pnpm run clean`...)
-
-

--- a/projects/packages/yoast-promo/package.json
+++ b/projects/packages/yoast-promo/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-yoast-promo",
-	"version": "0.1.2-alpha",
+	"version": "0.1.2",
 	"description": "Components used to promote Yoast as part of our collaboration",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/yoast-promo/#readme",
 	"bugs": {

--- a/projects/packages/yoast-promo/src/class-yoast-promo.php
+++ b/projects/packages/yoast-promo/src/class-yoast-promo.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack;
  */
 class Yoast_Promo {
 
-	const PACKAGE_VERSION = '0.1.2-alpha';
+	const PACKAGE_VERSION = '0.1.2';
 
 	/**
 	 * Script handle for the JS file we enqueue in the post editor.

--- a/projects/plugins/starter-plugin/CHANGELOG.md
+++ b/projects/plugins/starter-plugin/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 - 2023-07-06
+### Added
+- Add authentication to zendesk chat widget [#31339]
+
+### Changed
+- General: indicate full compatibility with the latest version of WordPress, 6.2. [#29341]
+- Remove conditional rendering from zendesk chat widget component due to it being handled by an api endpoint now [#29942]
+- Updated package dependencies.
+- Update WordPress version requirements. Now requires version 6.1. [#30120]
+
 ## 0.2.0 - 2023-03-08
 ### Added
 - Add support for JITMs to starter plugin [#25880]

--- a/projects/plugins/starter-plugin/changelog/add-composer-dev-keywords
+++ b/projects/plugins/starter-plugin/changelog/add-composer-dev-keywords
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-golden-token-experience
+++ b/projects/plugins/starter-plugin/changelog/add-golden-token-experience
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-integrate-ip-package
+++ b/projects/plugins/starter-plugin/changelog/add-integrate-ip-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-license-key-activation-link
+++ b/projects/plugins/starter-plugin/changelog/add-license-key-activation-link
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-loaded-extensions-sync-callable
+++ b/projects/plugins/starter-plugin/changelog/add-loaded-extensions-sync-callable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-my-jetpack-jetpack-ai-interstitial
+++ b/projects/plugins/starter-plugin/changelog/add-my-jetpack-jetpack-ai-interstitial
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-my-jetpack-pricing-table-boost
+++ b/projects/plugins/starter-plugin/changelog/add-my-jetpack-pricing-table-boost
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-my-jetpack-pricing-table-boost#2
+++ b/projects/plugins/starter-plugin/changelog/add-my-jetpack-pricing-table-boost#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-my-jetpack-product-detail-table
+++ b/projects/plugins/starter-plugin/changelog/add-my-jetpack-product-detail-table
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-offline-mode-standalone-plugins
+++ b/projects/plugins/starter-plugin/changelog/add-offline-mode-standalone-plugins
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-package-suggestions
+++ b/projects/plugins/starter-plugin/changelog/add-package-suggestions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-package-suggestions#2
+++ b/projects/plugins/starter-plugin/changelog/add-package-suggestions#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-reader-views-toggle
+++ b/projects/plugins/starter-plugin/changelog/add-reader-views-toggle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: composer.lock file change
-
-

--- a/projects/plugins/starter-plugin/changelog/add-stats-product-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/add-stats-product-my-jetpack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-w.org-assets
+++ b/projects/plugins/starter-plugin/changelog/add-w.org-assets
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Only adding w.org assets that already exist.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-yoast-promo-prepublish-panel
+++ b/projects/plugins/starter-plugin/changelog/add-yoast-promo-prepublish-panel
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-zendesk-chat-authentication
+++ b/projects/plugins/starter-plugin/changelog/add-zendesk-chat-authentication
@@ -1,4 +1,0 @@
-Significance: major
-Type: added
-
-Add authentication to zendesk chat widget

--- a/projects/plugins/starter-plugin/changelog/add-zendesk-chat-module
+++ b/projects/plugins/starter-plugin/changelog/add-zendesk-chat-module
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-zendesk-chat-module#2
+++ b/projects/plugins/starter-plugin/changelog/add-zendesk-chat-module#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/backport-cherry-pick-12.1-beta
+++ b/projects/plugins/starter-plugin/changelog/backport-cherry-pick-12.1-beta
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/feat-rest-api-jetpack-block
+++ b/projects/plugins/starter-plugin/changelog/feat-rest-api-jetpack-block
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-akismet-upgrade-screen
+++ b/projects/plugins/starter-plugin/changelog/fix-akismet-upgrade-screen
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-disconnect-wpcom-offline-mode
+++ b/projects/plugins/starter-plugin/changelog/fix-disconnect-wpcom-offline-mode
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-jetpack-icon-menu-bar
+++ b/projects/plugins/starter-plugin/changelog/fix-jetpack-icon-menu-bar
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/monthly-branch-2023-04-25
+++ b/projects/plugins/starter-plugin/changelog/monthly-branch-2023-04-25
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease
+++ b/projects/plugins/starter-plugin/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/renovate-automattic-wordbless-0.x
+++ b/projects/plugins/starter-plugin/changelog/renovate-automattic-wordbless-0.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-npm-webpack-vulnerability
+++ b/projects/plugins/starter-plugin/changelog/renovate-npm-webpack-vulnerability
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#5
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/starter-plugin/changelog/update-jetpack-module-tags-i18n
+++ b/projects/plugins/starter-plugin/changelog/update-jetpack-module-tags-i18n
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-zendesk-chat-show-conditionally-with-api
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-zendesk-chat-show-conditionally-with-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Remove conditional rendering from zendesk chat widget component due to it being handled by an api endpoint now

--- a/projects/plugins/starter-plugin/changelog/update-pnpm-8
+++ b/projects/plugins/starter-plugin/changelog/update-pnpm-8
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unneeded "engines" in e2e package.json files.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-use-assets-enqueue-stats
+++ b/projects/plugins/starter-plugin/changelog/update-use-assets-enqueue-stats
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-wp-requirements
+++ b/projects/plugins/starter-plugin/changelog/update-wp-requirements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update WordPress version requirements. Now requires version 6.1.

--- a/projects/plugins/starter-plugin/changelog/update-wp-tested-up-to
+++ b/projects/plugins/starter-plugin/changelog/update-wp-tested-up-to
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: indicate full compatibility with the latest version of WordPress, 6.2.

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -68,6 +68,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_starter_pluginⓥ0_3_0_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_starter_pluginⓥ0_3_0"
 	}
 }

--- a/projects/plugins/starter-plugin/jetpack-starter-plugin.php
+++ b/projects/plugins/starter-plugin/jetpack-starter-plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Starter Plugin
  * Plugin URI: https://wordpress.org/plugins/jetpack-starter-plugin
  * Description: plugin--description.
- * Version: 0.3.0-alpha
+ * Version: 0.3.0
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/vaultpress/CHANGELOG.md
+++ b/projects/plugins/vaultpress/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.2.4 - 2023-07-06
+### Changed
+- General: indicate full compatibility with the latest version of WordPress, 6.2. [#29341]
+- Updated package dependencies.
+
 ## 2.2.3 - 2023-03-08
 ### Changed
 - Add a note to README (visible in wordpress.org) that Jetpack VaultPress is deprecated. [#27465]

--- a/projects/plugins/vaultpress/changelog/add-package-suggestions
+++ b/projects/plugins/vaultpress/changelog/add-package-suggestions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/add-package-suggestions#2
+++ b/projects/plugins/vaultpress/changelog/add-package-suggestions#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/add-w.org-assets
+++ b/projects/plugins/vaultpress/changelog/add-w.org-assets
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Only adding w.org assets that already exist.
-
-

--- a/projects/plugins/vaultpress/changelog/fix-jetpack-icon-menu-bar
+++ b/projects/plugins/vaultpress/changelog/fix-jetpack-icon-menu-bar
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#4
+++ b/projects/plugins/vaultpress/changelog/renovate-lock-file-maintenance#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/vaultpress/changelog/update-phpcs-rules
+++ b/projects/plugins/vaultpress/changelog/update-phpcs-rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Standardize on certain PHP function aliases over others, e.g. `implode` rather than `join`.
-
-

--- a/projects/plugins/vaultpress/changelog/update-phpcs-rules#2
+++ b/projects/plugins/vaultpress/changelog/update-phpcs-rules#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Replace multi-arg `isset()` for better clarity and new phpcs sniff.
-
-

--- a/projects/plugins/vaultpress/changelog/update-wp-tested-up-to
+++ b/projects/plugins/vaultpress/changelog/update-wp-tested-up-to
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: indicate full compatibility with the latest version of WordPress, 6.2.

--- a/projects/plugins/vaultpress/composer.json
+++ b/projects/plugins/vaultpress/composer.json
@@ -35,7 +35,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ2_2_4_alpha",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_vaultpressⓥ2_2_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true
 		}

--- a/projects/plugins/vaultpress/readme.txt
+++ b/projects/plugins/vaultpress/readme.txt
@@ -32,12 +32,10 @@ View our full list of FAQs at [http://help.vaultpress.com/faq/](http://help.vaul
 A Jetpack VaultPress subscription is for a single WordPress site.
 
 == Changelog ==
-### 2.2.3 - 2023-03-08
+### 2.2.4 - 2023-07-06
 #### Changed
-- Add a note to README (visible in wordpress.org) that Jetpack VaultPress is deprecated.
-- Compatibility: WordPress 6.1 compatibility
+- General: indicate full compatibility with the latest version of WordPress, 6.2.
 - Updated package dependencies.
-- Update README references from VaultPress to Jetpack VaultPress
 
 --------
 

--- a/projects/plugins/vaultpress/readme.txt
+++ b/projects/plugins/vaultpress/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, annezazu, apokalyptik, bjorsch, briancolinger, dsmart,
 Tags: security, malware, virus, archive, back up, back ups, backup, backups, scanning, restore, wordpress backup, site backup, website backup
 Requires at least: 5.2
 Tested up to: 6.2
-Stable tag: 2.2.2
+Stable tag: 2.2.3
 Requires PHP: 5.6
 License: GPLv2
 

--- a/projects/plugins/vaultpress/vaultpress.php
+++ b/projects/plugins/vaultpress/vaultpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: VaultPress
  * Plugin URI: http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * Description: Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href="http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">VaultPress</a>. Activate, enter your registration key, and never worry again. <a href="http://vaultpress.com/help/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0" rel="nofollow">Need some help?</a>
- * Version: 2.2.4-alpha
+ * Version: 2.2.4
  * Author: Automattic
  * Author URI: http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0
  * License: GPL2+
@@ -17,7 +17,7 @@
 defined( 'ABSPATH' ) || die();
 
 define( 'VAULTPRESS__MINIMUM_PHP_VERSION', '5.6' );
-define( 'VAULTPRESS__VERSION', '2.2.4-alpha' );
+define( 'VAULTPRESS__VERSION', '2.2.4' );
 define( 'VAULTPRESS__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 /**


### PR DESCRIPTION
## Proposed changes:

Backport maintenance releases of stale packages/plugins as of the Jetpack 12.3 release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Proofread. I'll be smoke testing the VaultPress plugin release prior to updating its stable tag.
