### PR TITLE
Testimonials: Make the testimonials customizer extension only be shown if current theme is not a block theme

### DIFF
--- a/projects/plugins/jetpack/changelog/update-testimonial-customizer-section-scoped-to-old-themes
+++ b/projects/plugins/jetpack/changelog/update-testimonial-customizer-section-scoped-to-old-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Makes the testimonials customizer section be shown only if current theme is not a block theme

--- a/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
@@ -84,7 +84,9 @@ class Jetpack_Testimonial {
 		add_filter( 'enter_title_here', array( $this, 'change_default_title' ) );
 		add_filter( sprintf( 'manage_%s_posts_columns', self::CUSTOM_POST_TYPE ), array( $this, 'edit_title_column_label' ) );
 		add_filter( 'post_updated_messages', array( $this, 'updated_messages' ) );
-		add_action( 'customize_register', array( $this, 'customize_register' ) );
+		if ( ! wp_is_block_theme() ) {
+			add_action( 'customize_register', array( $this, 'customize_register' ) );
+		}
 
 		// Only add the 'Customize' sub-menu if the theme supports it.
 		if ( is_admin() && current_theme_supports( self::CUSTOM_POST_TYPE ) && ! empty( self::count_testimonials() ) ) {

--- a/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
@@ -84,7 +84,7 @@ class Jetpack_Testimonial {
 		add_filter( 'enter_title_here', array( $this, 'change_default_title' ) );
 		add_filter( sprintf( 'manage_%s_posts_columns', self::CUSTOM_POST_TYPE ), array( $this, 'edit_title_column_label' ) );
 		add_filter( 'post_updated_messages', array( $this, 'updated_messages' ) );
-		if ( ! wp_is_block_theme() ) {
+		if ( ! function_exists( 'wp_is_block_theme' ) || ( function_exists( 'wp_is_block_theme' ) && ! wp_is_block_theme() ) ) {
 			add_action( 'customize_register', array( $this, 'customize_register' ) );
 		}
 

--- a/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/testimonial.php
@@ -84,7 +84,7 @@ class Jetpack_Testimonial {
 		add_filter( 'enter_title_here', array( $this, 'change_default_title' ) );
 		add_filter( sprintf( 'manage_%s_posts_columns', self::CUSTOM_POST_TYPE ), array( $this, 'edit_title_column_label' ) );
 		add_filter( 'post_updated_messages', array( $this, 'updated_messages' ) );
-		if ( ! function_exists( 'wp_is_block_theme' ) || ( function_exists( 'wp_is_block_theme' ) && ! wp_is_block_theme() ) ) {
+		if ( ! wp_is_block_theme() ) {
 			add_action( 'customize_register', array( $this, 'customize_register' ) );
 		}
 


### PR DESCRIPTION

Fixes partially #31725

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check if current active theme is a block theme before attempting to add a section to the customizer

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/wp-calypso/issues/71130#issuecomment-1617982587

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Checkout this branch
* Enable testimonials in Jetpack -> Settings -> Writing
* If you're using a modern theme expect to see no Customizer menu item under Appearance
