### PR TITLE
Search: Disable Customizer UI for block themes

### DIFF
--- a/projects/packages/search/changelog/update-conditionally-enable-search-customizer-integration
+++ b/projects/packages/search/changelog/update-conditionally-enable-search-customizer-integration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Disable Customizer integration for Instant Search if the site is using a block-based theme

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.37.x-dev"
+			"dev-trunk": "0.38.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.37.4",
+	"version": "0.38.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.37.4';
+	const VERSION = '0.38.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -152,9 +152,10 @@ class Initializer {
 		new Settings();
 		// Instantiate "Customberg", the live search configuration interface.
 		Customberg::instance();
-		// Enable configuring instant search within the Customizer.
-		// Not need to check existence of `WP_Customize_Manager`, because which is not loaded all the time.
-		new Customizer();
+		// Enable configuring instant search within the Customizer iff it's not using a block theme.
+		if ( ! function_exists( 'wp_is_block_theme' ) || ( function_exists( 'wp_is_block_theme' ) && ! wp_is_block_theme() ) ) {
+			new Customizer();
+		}
 		return true;
 	}
 

--- a/projects/plugins/jetpack/changelog/update-conditionally-enable-search-customizer-integration
+++ b/projects/plugins/jetpack/changelog/update-conditionally-enable-search-customizer-integration
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2248,7 +2248,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "0506887ef32a40311e91992395a850e3843142e2"
+                "reference": "5d8fb890ccdb6d1da38a6c3b095b4f01f07ed98a"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -2275,7 +2275,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.37.x-dev"
+                    "dev-trunk": "0.38.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/update-conditionally-enable-search-customizer-integration
+++ b/projects/plugins/search/changelog/update-conditionally-enable-search-customizer-integration
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1162,7 +1162,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "0506887ef32a40311e91992395a850e3843142e2"
+                "reference": "5d8fb890ccdb6d1da38a6c3b095b4f01f07ed98a"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1189,7 +1189,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.37.x-dev"
+                    "dev-trunk": "0.38.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #31725.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disables Instant Search's Customizer integration if the site is using a block theme.

Non-block Theme|Block Theme
-|-
<img width="333" alt="image" src="https://github.com/Automattic/jetpack/assets/4044428/902c73d0-d39e-4d7f-8088-5e7a3ee89b43">|<img width="327" alt="image" src="https://github.com/Automattic/jetpack/assets/4044428/06da0698-cb20-40ac-9d9d-401ba72368ea">


## Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to a Jurassic Ninja site.
* Using a non-block theme (e.g., 2021), navigate to the Customizer at `/wp-admin/customize.php`.
* Ensure that the "Jetpack Search" section is available.
* Using a block theme (e.g., 2023), navigate to the Customizer at `/wp-admin/customize.php`.
* Ensure that the "Jetpack Search" section is no longer available.