### PR TITLE
[Boost] Conditional Image Guide links

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/elements/ConditionalLink.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/ConditionalLink.svelte
@@ -1,0 +1,12 @@
+<!-- Utility: Show a <Link> if a condition is met. Otherwise, just show the contents. -->
+<script>
+	import { Link } from '../utils/router';
+
+	export let isLink = true;
+</script>
+
+{#if isLink}
+	<Link {...$$props}><slot /></Link>
+{:else}
+	<slot />
+{/if}

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { sprintf, __ } from '@wordpress/i18n';
+	import ConditionalLink from '../../elements/ConditionalLink.svelte';
 	import ProgressBar from '../../elements/ProgressBar.svelte';
 	import Spinner from '../../elements/Spinner.svelte';
-	import { Link } from '../../utils/router';
 	import { isaGroupLabels, isaSummary } from './store/isa-summary';
 
 	function safePercent( value: number, outOf: number ): number {
@@ -28,22 +28,34 @@
 			{#if progress > 0 && progress < 100}
 				<Spinner />
 			{:else}
-				<Link class="jb-navigator-link" to="/image-size-analysis/{group}/1">
+				<ConditionalLink
+					isLink={hasIssues}
+					class="jb-navigator-link"
+					to="/image-size-analysis/{group}/1"
+				>
 					<span class="jb-bubble" class:done={isDone}>
 						{isDone ? '✓' : index + 1}
 					</span>
-				</Link>
+				</ConditionalLink>
 			{/if}
 
 			<div class="jb-category-name">
-				<Link class="jb-navigator-link" to="/image-size-analysis/{group}/1">
+				<ConditionalLink
+					isLink={hasIssues}
+					class="jb-navigator-link"
+					to="/image-size-analysis/{group}/1"
+				>
 					{isaGroupLabels[ group ] || group}
-				</Link>
+				</ConditionalLink>
 			</div>
 
 			{#if isDone || hasIssues}
 				<div class="jb-status" class:has-issues={hasIssues}>
-					<Link class="jb-navigator-link" to="/image-size-analysis/{group}/1">
+					<ConditionalLink
+						isLink={hasIssues}
+						class="jb-navigator-link"
+						to="/image-size-analysis/{group}/1"
+					>
 						{#if hasIssues}
 							{sprintf(
 								/* translators: %d is the number of items in this list hidden behind this link */
@@ -53,7 +65,7 @@
 						{:else}
 							{__( 'No issues', 'jetpack-boost' )}
 						{/if}
-					</Link>
+					</ConditionalLink>
 				</div>
 			{/if}
 		</div>

--- a/projects/plugins/boost/changelog/boost-conditional-ig-links
+++ b/projects/plugins/boost/changelog/boost-conditional-ig-links
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Made the image guide links unclickable where there is no report to show
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Make the categories in the image guide only clickable if there are issues to show there. Linking to an empty page seems weird.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make the categories in the image guide only clickable if there are issues to show there. Linking to an empty page seems weird.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Generate an image guide report
* Ensure that any category with nothing to show doesn't have a clickable link.

