### PR TITLE
[Boost] Fix image guide header

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/button.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/button.scss
@@ -18,7 +18,7 @@
 	color: $gray_90;
 	font-size: 14pt;
 	text-decoration: none;
-	margin-bottom: 20px;
+	margin-bottom: 8px;
 
 	&.is-link {
 		margin-left: auto;

--- a/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
@@ -48,23 +48,6 @@
 	}
 }
 
-.jb-dashboard-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	height: 120px;
-	position: relative;
-
-	&__logo {
-		max-width: 240px;
-		max-height: 42px;
-
-		svg {
-			height: auto;
-		}
-	}
-}
-
 .jb-dashboard-footer {
 	@extend .jb-container;
 

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsPage.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { __ } from '@wordpress/i18n';
 	import Footer from '../../sections/Footer.svelte';
 	import Header from '../../sections/Header.svelte';
 	import Hero from './recommendations/Hero.svelte';
@@ -17,7 +18,7 @@
 </script>
 
 <div id="jb-dashboard" class="jb-dashboard">
-	<Header />
+	<Header subPage={__( 'Image analysis report', 'jetpack-boost' )} />
 	<div class="recommendations-page jb-container jb-section--alt">
 		<Hero />
 		<Tabs />

--- a/projects/plugins/boost/app/assets/src/js/sections/Header.svelte
+++ b/projects/plugins/boost/app/assets/src/js/sections/Header.svelte
@@ -6,7 +6,7 @@
 
 	const navigate = useNavigate();
 
-	export let subPage: string | undefined;
+	export let subPage: string | null = null;
 </script>
 
 <div class="jb-dashboard-header">

--- a/projects/plugins/boost/app/assets/src/js/sections/Header.svelte
+++ b/projects/plugins/boost/app/assets/src/js/sections/Header.svelte
@@ -1,33 +1,85 @@
 <script lang="ts">
 	import { useNavigate } from 'svelte-navigator';
+	import BackButton from '../elements/BackButton.svelte';
+	import ChevronRight from '../svg/chevron-right.svg';
 	import Logo from '../svg/logo.svg';
+
 	const navigate = useNavigate();
+
+	export let subPage: string | undefined;
 </script>
 
 <div class="jb-dashboard-header">
-	<div class="jb-container">
-		<!-- svelte-ignore a11y-click-events-have-key-events -->
-		<div class="jb-dashboard-header__logo" on:click={() => navigate( '/' )}>
-			<Logo />
+	<div class="jb-container masthead">
+		<div class="nav-area">
+			<!-- svelte-ignore a11y-click-events-have-key-events -->
+			<div class="jb-dashboard-header__logo" on:click={() => navigate( '/' )}>
+				<Logo />
+			</div>
+
+			{#if subPage}
+				<div class="chevron">
+					<ChevronRight />
+				</div>
+
+				<div class="subpage">
+					{subPage}
+				</div>
+			{/if}
 		</div>
 
 		<slot />
 	</div>
+
+	{#if subPage}
+		<div class="jb-container back-button">
+			<BackButton />
+		</div>
+	{/if}
 </div>
 
 <style lang="scss">
 	.jb-dashboard-header {
 		background-color: var( --primary-white );
 	}
-	.jb-dashboard-header__logo {
-		cursor: pointer;
-	}
 
-	.jb-container {
+	.masthead {
 		display: flex;
 		justify-content: space-between;
+		margin-top: 40px;
+		margin-bottom: 20px;
 		align-items: center;
 		flex-wrap: wrap;
 		gap: 24px;
+	}
+
+	.nav-area {
+		display: flex;
+		align-items: center;
+		flex-direction: row;
+
+		.jb-dashboard-header__logo {
+			cursor: pointer;
+
+			:global( svg ) {
+				height: 42px;
+				width: 100%;
+			}
+		}
+
+		.chevron {
+			margin-left: 16px;
+			margin-right: 16px;
+			width: 24px;
+			height: 24px;
+			padding-top: 2px;
+			text-align: center;
+		}
+
+		.subpage {
+			color: var( --gray-40 );
+			font-size: 16px;
+			margin-top: -2px;
+		}
 	}
 </style>

--- a/projects/plugins/boost/changelog/boost-fix-ig-header
+++ b/projects/plugins/boost/changelog/boost-fix-ig-header
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Updated Image Guide header to match designs, added a back button
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Update the header on the image guide page to include a back button, and tweak the image sizes / layouts to match the designs. p1HpG7-lar-p2

## Proposed changes:
* Tweak header layout and add Go back button to IG page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Generate a report
* Look at the header on the main boost page
* Look at the header on the IG report page
* Make sure they look good 😎 