### PR TITLE
[Boost] Fix E2E tests yet again

### DIFF
--- a/projects/plugins/boost/changelog/boost-fix-e2e-yet-again
+++ b/projects/plugins/boost/changelog/boost-fix-e2e-yet-again
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed e2e test flakiness
+
+

--- a/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
@@ -78,14 +78,18 @@ export default class JetpackBoostPage extends WpPage {
 	}
 
 	async getSpeedScore( platform ) {
-		const speedBar = await this.page.waitForSelector(
-			`div.jb-score-bar--${ platform }  .jb-score-bar__filler`
-		);
-		await this.page.waitForSelector( '.jb-score-bar__score', {
+		const parent = `div.jb-score-bar--${ platform }  .jb-score-bar__filler`;
+
+		await this.page.waitForSelector( parent + ' .jb-score-bar__score', {
 			state: 'visible',
 			timeout: 40 * 1000,
 		} );
-		return Number( await speedBar.$eval( '.jb-score-bar__score', e => e.textContent ) );
+
+		return Number(
+			await this.page.evaluate(
+				"document.querySelector( '" + parent + " .jb-score-bar__score' ).textContent"
+			)
+		);
 	}
 
 	async isScorebarLoading( platform ) {

--- a/projects/plugins/boost/tests/e2e/playwright.config.cjs
+++ b/projects/plugins/boost/tests/e2e/playwright.config.cjs
@@ -2,4 +2,7 @@ const config = require( 'jetpack-e2e-commons/config/playwright.config.default.cj
 
 config.globalSetup = './lib/setupTests.js';
 
-module.exports = config;
+module.exports = {
+	...config,
+	actionTimeout: 40000,
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes e2e tests

Switches from using `page.$eval` to using `page.evaluate` with `document.querySelector` instead. The code was finding a parent element, then waiting for the child to appear, then using the old reference to the parent element to access the child.

The problem is, with modern JS toolkits you sometimes end up rewriting parts of the DOM and the old parent may not be the parent that's in the DOM after other things chnage.

so this should be more reliable.

## Proposed changes:
* Switches from using `page.$eval` to using `page.evaluate` with `document.querySelector` instead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* let the tests run, ensure they're happy

