### PR TITLE
[Boost] Refresh ISA data on completed.

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -122,8 +122,8 @@
 		<div class="button-area">
 			<Button href="#image-size-analysis/all/1" disabled={requestingReport}>
 				{$isaSummary.status === ISAStatus.Completed
-					? __( 'View report in progress', 'jetpack-boost' )
-					: __( 'See full report', 'jetpack-boost' )}
+					? __( 'See full report', 'jetpack-boost' )
+					: __( 'View report in progress', 'jetpack-boost' )}
 			</Button>
 		</div>
 	{/if}

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -5,6 +5,7 @@
 	import ErrorNotice from '../../elements/ErrorNotice.svelte';
 	import RefreshIcon from '../../svg/refresh.svg';
 	import MultiProgress from './MultiProgress.svelte';
+	import { resetIsaQuery } from './store/isa-data';
 	import {
 		requestImageAnalysis,
 		initializeIsaSummary,
@@ -55,6 +56,7 @@
 			errorMessage = undefined;
 			requestingReport = true;
 			await requestImageAnalysis();
+			resetIsaQuery();
 		} catch ( err ) {
 			errorMessage = err.message;
 		} finally {

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsPage.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
 	import { __ } from '@wordpress/i18n';
 	import Footer from '../../sections/Footer.svelte';
 	import Header from '../../sections/Header.svelte';
@@ -7,22 +8,37 @@
 	import Pagination from './recommendations/Pagination.svelte';
 	import Table from './recommendations/Table.svelte';
 	import Tabs from './recommendations/Tabs.svelte';
-	import { initializeIsaData } from './store/isa-data';
-	import { initializeIsaSummary } from './store/isa-summary';
+	import { initializeIsaData, isaData, refreshIsaData } from './store/isa-data';
+	import { initializeIsaSummary, totalIssueCount } from './store/isa-summary';
 
 	initializeIsaData();
 
 	onMount( () => {
 		initializeIsaSummary();
 	} );
+
+	// Keep track of the total count from the summary the last time we got a data update.
+	// Useful for identify when a summary change might mean we need a refresh.
+	let countAtLastDataUpdate = 0;
+	isaData.subscribe( () => {
+		countAtLastDataUpdate = get( totalIssueCount );
+	} );
+
+	$: needsRefresh = $totalIssueCount > countAtLastDataUpdate;
+
+	async function refresh() {
+		// Don't let the UI show a refresh button until we get fresh ISA data.
+		countAtLastDataUpdate = Infinity;
+		await refreshIsaData();
+	}
 </script>
 
 <div id="jb-dashboard" class="jb-dashboard">
 	<Header subPage={__( 'Image analysis report', 'jetpack-boost' )} />
 	<div class="recommendations-page jb-container jb-section--alt">
-		<Hero />
+		<Hero {needsRefresh} {refresh} />
 		<Tabs />
-		<Table />
+		<Table {needsRefresh} {refresh} />
 		<Pagination />
 		<Footer />
 	</div>

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Hero.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Hero.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import { quadOut } from 'svelte/easing';
+	import { get } from 'svelte/store';
 	import { fade } from 'svelte/transition';
-	import { isaData } from '../store/isa-data';
-	import { imageDataActiveGroup } from '../store/isa-summary';
+	import { __ } from '@wordpress/i18n';
+	import TemplatedString from '../../../elements/TemplatedString.svelte';
+	import actionLinkTemplateVar from '../../../utils/action-link-template-var';
+	import { isaData, refreshIsaData } from '../store/isa-data';
+	import { imageDataActiveGroup, totalIssueCount } from '../store/isa-summary';
 
 	const formatter = new Intl.DateTimeFormat( 'en-US', {
 		month: 'long',
@@ -11,6 +15,21 @@
 		minute: 'numeric',
 		hour12: true,
 	} );
+
+	// Keep track of the total count from the summary the last time we got a data update.
+	// Useful for identify when a summary change might mean we need a refresh.
+	let countAtLastDataUpdate = 0;
+	isaData.subscribe( () => {
+		countAtLastDataUpdate = get( totalIssueCount );
+	} );
+
+	async function refresh() {
+		// Don't let the UI show a refresh button until we get fresh ISA data.
+		countAtLastDataUpdate = Infinity;
+		await refreshIsaData();
+	}
+
+	$: needsRefresh = $totalIssueCount > countAtLastDataUpdate;
 </script>
 
 {#if $imageDataActiveGroup && $isaData.data.last_updated}
@@ -23,6 +42,16 @@
 				{$imageDataActiveGroup.issue_count}
 				Image Recommendations
 			</h1>
+		{/if}
+
+		{#if needsRefresh}
+			<TemplatedString
+				template={__(
+					'More recommendations have been found. <refresh>Refresh</refresh> to see the latest recommendations.',
+					'jetpack-boost'
+				)}
+				vars={actionLinkTemplateVar( () => refresh(), 'refresh' )}
+			/>
 		{/if}
 	</div>
 {:else}

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Hero.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Hero.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import { quadOut } from 'svelte/easing';
-	import { get } from 'svelte/store';
 	import { fade } from 'svelte/transition';
 	import { __ } from '@wordpress/i18n';
 	import TemplatedString from '../../../elements/TemplatedString.svelte';
 	import actionLinkTemplateVar from '../../../utils/action-link-template-var';
-	import { isaData, refreshIsaData } from '../store/isa-data';
-	import { imageDataActiveGroup, totalIssueCount } from '../store/isa-summary';
+	import { isaData } from '../store/isa-data';
+	import { imageDataActiveGroup } from '../store/isa-summary';
+
+	export let needsRefresh: boolean;
+	export let refresh: () => Promise< void >;
 
 	const formatter = new Intl.DateTimeFormat( 'en-US', {
 		month: 'long',
@@ -15,21 +17,6 @@
 		minute: 'numeric',
 		hour12: true,
 	} );
-
-	// Keep track of the total count from the summary the last time we got a data update.
-	// Useful for identify when a summary change might mean we need a refresh.
-	let countAtLastDataUpdate = 0;
-	isaData.subscribe( () => {
-		countAtLastDataUpdate = get( totalIssueCount );
-	} );
-
-	async function refresh() {
-		// Don't let the UI show a refresh button until we get fresh ISA data.
-		countAtLastDataUpdate = Infinity;
-		await refreshIsaData();
-	}
-
-	$: needsRefresh = $totalIssueCount > countAtLastDataUpdate;
 </script>
 
 {#if $imageDataActiveGroup && $isaData.data.last_updated}

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Table.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Table.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import Spinner from '../../../elements/Spinner.svelte';
+	import TemplatedString from '../../../elements/TemplatedString.svelte';
+	import actionLinkTemplateVar from '../../../utils/action-link-template-var';
 	import { ISA_Data, isaData, isaDataLoading } from '../store/isa-data';
 	import { ISAStatus, isaSummary } from '../store/isa-summary';
 	import BrokenDataRow from './row-types/BrokenDataRow.svelte';
@@ -9,6 +11,9 @@
 	import LoadingRow from './row-types/LoadingRow.svelte';
 
 	$: activeFilter = $isaData.query.group === 'ignored' ? 'ignored' : 'active';
+
+	export let needsRefresh: boolean;
+	export let refresh: () => Promise< void >;
 
 	let isLoading = false;
 	let ignoreStatusUpdated = false;
@@ -47,9 +52,19 @@
 
 {#if ! isLoading && activeImages.length === 0}
 	<h1>
-		{jobFinished
-			? __( '🥳 No image size issues found!', 'jetpack-boost' )
-			: __( 'No image size issues found yet…', 'jetpack-boost' )}
+		{#if needsRefresh}
+			<TemplatedString
+				template={__(
+					'<refresh>Refresh</refresh> to see the latest recommendations.',
+					'jetpack-boost'
+				)}
+				vars={actionLinkTemplateVar( () => refresh(), 'refresh' )}
+			/>
+		{:else}
+			{jobFinished
+				? __( '🥳 No image size issues found!', 'jetpack-boost' )
+				: __( 'No image size issues found yet…', 'jetpack-boost' )}
+		{/if}
 	</h1>
 {:else}
 	<div class="jb-table" class:jb-loading={isLoading}>

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-data.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-data.ts
@@ -23,6 +23,10 @@ export const isaIgnoredImages = derived( [ isaData ], ( [ $data ] ) => {
 	return $data.data.images.filter( image => image.status === 'ignored' ).map( image => image.id );
 } );
 
+export function refreshIsaData() {
+	image_size_analysis.refresh();
+}
+
 export function updateIsaQuery( group: string, page = 1, search = '' ) {
 	image_size_analysis.store.update( value => {
 		return {

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-data.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-data.ts
@@ -2,7 +2,7 @@ import { derived } from 'svelte/store';
 import { useParams } from 'svelte-navigator';
 import { z } from 'zod';
 import { jetpack_boost_ds } from '../../../stores/data-sync-client';
-import { ImageData, ImageSizeAnalysis } from './zod-types';
+import { ImageData, ImageSizeAnalysis, emptyImageSizeAnalysisData } from './zod-types';
 
 /**
  * Initialize the stores
@@ -50,6 +50,14 @@ export function initializeIsaData() {
 	queryParams.subscribe( $params => {
 		updateIsaQuery( $params.group, parseInt( $params.page ), $params.search );
 	} );
+}
+
+/**
+ * Whenever a new report is requested, clear the search results from the store otherwise
+ * it might show old data when you visit the table view.
+ */
+export function resetIsaQuery() {
+	image_size_analysis.store.override( emptyImageSizeAnalysisData );
 }
 
 type ISA = z.infer< typeof ImageSizeAnalysis >;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import api from '../../../api/api';
 import { jetpack_boost_ds } from '../../../stores/data-sync-client';
 import { setPromiseInterval } from '../../../utils/set-promise-interval';
-import { isaData, refreshIsaData } from './isa-data';
+import { isaData } from './isa-data';
 
 /**
  * Valid values for the status field.
@@ -122,14 +122,11 @@ isaSummary.subscribe( summary => {
 	const shouldPoll = [ 'new', 'queued' ].includes( summary.status );
 
 	if ( shouldPoll && ! clearPromiseInterval ) {
-		clearPromiseInterval = setPromiseInterval( () => image_size_analysis_summary.refresh(), 3000 );
+		clearPromiseInterval = setPromiseInterval( async () => {
+			await image_size_analysis_summary.refresh();
+		}, 3000 );
 	} else if ( ! shouldPoll && clearPromiseInterval ) {
 		clearPromiseInterval();
 		clearPromiseInterval = undefined;
-
-		// We're stopping polling. Neat! But if we've just become completed, we should tell ISAData to refresh.
-		if ( summary.status === ISAStatus.Completed ) {
-			refreshIsaData();
-		}
 	}
 } );

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
@@ -122,9 +122,7 @@ isaSummary.subscribe( summary => {
 	const shouldPoll = [ 'new', 'queued' ].includes( summary.status );
 
 	if ( shouldPoll && ! clearPromiseInterval ) {
-		clearPromiseInterval = setPromiseInterval( () => {
-			image_size_analysis_summary.refresh();
-		}, 3000 );
+		clearPromiseInterval = setPromiseInterval( () => image_size_analysis_summary.refresh(), 3000 );
 	} else if ( ! shouldPoll && clearPromiseInterval ) {
 		clearPromiseInterval();
 		clearPromiseInterval = undefined;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { __ } from '@wordpress/i18n';
 import api from '../../../api/api';
 import { jetpack_boost_ds } from '../../../stores/data-sync-client';
+import { setPromiseInterval } from '../../../utils/set-promise-interval';
 import { isaData, refreshIsaData } from './isa-data';
 
 /**
@@ -112,7 +113,7 @@ export function initializeIsaSummary() {
 /**
  * Automatically poll if the state is an active one.
  */
-let pollIntervalId: number | undefined;
+let clearPromiseInterval: ReturnType< typeof setPromiseInterval > | undefined;
 isaSummary.subscribe( summary => {
 	if ( ! summary ) {
 		return;
@@ -120,13 +121,13 @@ isaSummary.subscribe( summary => {
 
 	const shouldPoll = [ 'new', 'queued' ].includes( summary.status );
 
-	if ( shouldPoll && ! pollIntervalId ) {
-		pollIntervalId = setInterval( () => {
+	if ( shouldPoll && ! clearPromiseInterval ) {
+		clearPromiseInterval = setPromiseInterval( () => {
 			image_size_analysis_summary.refresh();
 		}, 3000 );
-	} else if ( ! shouldPoll && pollIntervalId ) {
-		clearInterval( pollIntervalId );
-		pollIntervalId = undefined;
+	} else if ( ! shouldPoll && clearPromiseInterval ) {
+		clearPromiseInterval();
+		clearPromiseInterval = undefined;
 
 		// We're stopping polling. Neat! But if we've just become completed, we should tell ISAData to refresh.
 		if ( summary.status === ISAStatus.Completed ) {

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { __ } from '@wordpress/i18n';
 import api from '../../../api/api';
 import { jetpack_boost_ds } from '../../../stores/data-sync-client';
-import { isaData } from './isa-data';
+import { isaData, refreshIsaData } from './isa-data';
 
 /**
  * Valid values for the status field.
@@ -127,5 +127,10 @@ isaSummary.subscribe( summary => {
 	} else if ( ! shouldPoll && pollIntervalId ) {
 		clearInterval( pollIntervalId );
 		pollIntervalId = undefined;
+
+		// We're stopping polling. Neat! But if we've just become completed, we should tell ISAData to refresh.
+		if ( summary.status === ISAStatus.Completed ) {
+			refreshIsaData();
+		}
 	}
 } );

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/zod-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/zod-types.ts
@@ -41,6 +41,19 @@ export const ImageData = z
 
 export type ImageDataType = z.infer< typeof ImageData >;
 
+export const emptyImageSizeAnalysisData = {
+	query: {
+		page: 0,
+		group: '',
+		search: '',
+	},
+	data: {
+		last_updated: 0,
+		total_pages: 0,
+		images: [],
+	},
+};
+
 export const ImageSizeAnalysis = z
 	.object( {
 		query: z.object( {
@@ -55,15 +68,4 @@ export const ImageSizeAnalysis = z
 		} ),
 	} )
 	// Prevent fatal error when this module isn't available.
-	.catch( {
-		query: {
-			page: 0,
-			group: '',
-			search: '',
-		},
-		data: {
-			last_updated: 0,
-			total_pages: 0,
-			images: [],
-		},
-	} );
+	.catch( emptyImageSizeAnalysisData );

--- a/projects/plugins/boost/app/assets/src/js/utils/set-promise-interval.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/set-promise-interval.ts
@@ -1,0 +1,18 @@
+/**
+ * Promise-friendly version of setInterval. Accepts a function that returns a promise,
+ * and ensures that each interval occurs <ms> after the previous one resolves
+ *
+ * @param {Function} fn Function that returns a promise
+ * @param {number}   ms Interval in milliseconds
+ */
+export function setPromiseInterval( fn: () => Promise< void >, ms: number ) {
+	let timer: number;
+
+	async function loop() {
+		await fn();
+		timer = setTimeout( loop, ms );
+	}
+
+	timer = setTimeout( loop, ms );
+	return () => clearTimeout( timer );
+}

--- a/projects/plugins/boost/app/assets/src/js/utils/set-promise-interval.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/set-promise-interval.ts
@@ -7,12 +7,20 @@
  */
 export function setPromiseInterval( fn: () => Promise< void >, ms: number ) {
 	let timer: number;
+	let stopped = false;
 
 	async function loop() {
 		await fn();
-		timer = setTimeout( loop, ms );
+
+		if ( ! stopped ) {
+			timer = setTimeout( loop, ms );
+		}
 	}
 
 	timer = setTimeout( loop, ms );
-	return () => clearTimeout( timer );
+
+	return () => {
+		stopped = true;
+		clearTimeout( timer );
+	};
 }

--- a/projects/plugins/boost/changelog/boost-refresh-isa-on-finished
+++ b/projects/plugins/boost/changelog/boost-refresh-isa-on-finished
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: When ISA summary changes to completed, force refresh of table
+
+


### PR DESCRIPTION
This includes a number of fixes, including:

- When a report updates while viewing the table, show options to refresh the table.
- When a report updates *when viewing an empty table*, the 'empty table' text gets replaced with a prompt to refresh
- The 'view report in progress' / 'view full report' text was showing in the inverse situation.
- ISASummary polling was starting a new polling attempt before the previous one finished. This starts the 3s countdown from the _end_ of the last poll.
- When you click 'analyze again', the ISAData store is reset, ensuring the ui will not show an old report again.


## Proposed changes:
- When a report updates while viewing the table, show options to refresh the table.
- When a report updates *when viewing an empty table*, the 'empty table' text gets replaced with a prompt to refresh
- The 'view report in progress' / 'view full report' text was showing in the inverse situation.
- ISASummary polling was starting a new polling attempt before the previous one finished. This starts the 3s countdown from the _end_ of the last poll.
- When you click 'analyze again', the ISAData store is reset, ensuring the ui will not show an old report again.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* test each of the above.
