### PR TITLE
gardening: Remove `[Status] Stale` from closed issues/PRs

### DIFF
--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -10,7 +10,7 @@ Here is the current list of tasks handled by this action:
 - Add Milestone (`addMilestone`): Adds a valid milestone to all PRs that get merged and don't already include a milestone.
 - Check Description (`checkDescription`): Checks the contents of a PR description, and ensure it matches our recommendations.
 - Add Labels (`addLabels`): Adds labels to PRs that touch specific features.
-- Clean Labels (`cleanLabels`): Removes Status labels once a PR has been merged.
+- Clean Labels (`cleanLabels`): Removes Status labels once a PR or issue has been closed or merged.
 - WordPress.com Commit Reminder (`wpcomCommitReminder`): Posts a comment on merged PRs to remind Automatticians to commit the matching WordPress.com change.
 - Notify Design (`notifyDesign`): Sends a Slack Notification to the Design team to request feedback, based on labels applied to a PR.
 - Notify Editorial (`notifyEditorial`): Sends a Slack Notification to the Editorial team to request feedback, based on labels applied to a PR.
@@ -36,6 +36,8 @@ on:
   # Refer to src/index.js to see a list of all events each task needs to be listen to.
   pull_request_target:
     types: ['closed', 'labeled']
+  issues:
+    types: ['closed']
 
 jobs:
   repo-gardening:

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-remove-stale-from-closed
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-remove-stale-from-closed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Label cleanup: Remove `[Status] Stale` from closed PRs.

--- a/projects/github-actions/repo-gardening/changelog/update-gardening-remove-stale-from-closed#2
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-remove-stale-from-closed#2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Label cleanup: Task now runs for closed issues as well as PRs.

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "4.0.0",
+	"version": "4.1.0-alpha",
 	"description": "Manage Pull Requests and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/repo-gardening/src/index.js
+++ b/projects/github-actions/repo-gardening/src/index.js
@@ -37,6 +37,11 @@ const automations = [
 		task: cleanLabels,
 	},
 	{
+		event: 'issues',
+		action: [ 'closed' ],
+		task: cleanLabels,
+	},
+	{
 		event: 'pull_request_target',
 		action: [ 'opened', 'reopened', 'synchronize', 'edited', 'labeled' ],
 		task: ifNotClosed( checkDescription ),

--- a/projects/github-actions/repo-gardening/src/tasks/clean-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/clean-labels/index.js
@@ -10,14 +10,14 @@ const getLabels = require( '../../utils/get-labels' );
  * @param {GitHub}                    octokit - Initialized Octokit REST client.
  */
 async function cleanLabels( payload, octokit ) {
-	const { pull_request, repository, action } = payload;
-	const { number } = pull_request;
+	const { pull_request, issue, repository, action } = payload;
+	const { number } = pull_request || issue;
 	const { name: repo, owner } = repository;
 	const ownerLogin = owner.login;
 
 	// Normally this only gets triggered when PRs get closed, but let's be sure.
 	if ( action !== 'closed' ) {
-		debug( `clean-labels: PR #${ number } is not closed. Aborting.` );
+		debug( `clean-labels: PR/Issue #${ number } is not closed. Aborting.` );
 		return;
 	}
 
@@ -39,6 +39,7 @@ async function cleanLabels( payload, octokit ) {
 		'[Status] Needs Copy',
 		'[Status] Needs Copy Review',
 		'[Status] Editorial Input Requested',
+		'[Status] Stale',
 	];
 
 	const labelsToRemoveFromPr = labelsOnPr.filter( label => labelsToRemove.includes( label ) );

--- a/projects/github-actions/repo-gardening/src/tasks/clean-labels/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/clean-labels/readme.md
@@ -1,7 +1,7 @@
 # Clean labels
 
-Removes status labels from merged PRs.
+Removes status labels from merged/closed issues and PRs.
 
 ## Rationale
 
-Removing any status labels left behind when a PR is merged allows us to keep the repo clean.
+Removing any status labels left behind when a PR is merged/closed or an issue is closed allows us to keep the repo clean.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We're trying to better deal with the backlog of stale issues and PRs. It seems like it would help with that to remove the Stale label from them when they're closed.

This also means we have to start running the cleanLabels task when issues are closed. Fortunately we already run the action on issue close for other reasons, so nothing needs to change in the workflow itself.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge then try it.