### PR TITLE
Boost: Fix Image Guide UI (bubble/details) not showing properly

### DIFF
--- a/projects/plugins/boost/app/modules/image-guide/src/index.ts
+++ b/projects/plugins/boost/app/modules/image-guide/src/index.ts
@@ -133,7 +133,7 @@ function initialize() {
 		// wait for isImageTiny() to return true/false for each image.
 		const tinyImages = await Promise.all( measurableImages.map( image => image.isImageTiny() ) );
 		stores.push(
-			...attachGuides( measurableImages.filter( ( _, index ) => tinyImages[ index ] ) )
+			...attachGuides( measurableImages.filter( ( _, index ) => ! tinyImages[ index ] ) )
 		);
 
 		ImageGuideAnalytics.trackPage( stores );

--- a/projects/plugins/boost/changelog/fix-image-guide-ui-not-showing
+++ b/projects/plugins/boost/changelog/fix-image-guide-ui-not-showing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix image guide UI bubble not showing for large images. Was broken during refactoring.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/31747

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes image guide UI not showing up for images. Was broken by https://github.com/Automattic/jetpack/pull/31632.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup this version of Boost;
* Enable Image Guide (free);
* Add an image to a page;
* Make sure the Image Guide bubble is showing and is working properly.

<img width="505" alt="CleanShot 2023-07-07 at 18 22 29@2x" src="https://github.com/Automattic/jetpack/assets/11799079/d88d0619-855b-4537-a123-df31f6f61265">
