### PR TITLE
Portfolios: Make the customizer section only be shown if current theme is not a block theme

### DIFF
--- a/projects/plugins/jetpack/changelog/update-portfolios-customizer-section-scoped-to-old-themes
+++ b/projects/plugins/jetpack/changelog/update-portfolios-customizer-section-scoped-to-old-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Make the portfolios customizer extension only be shown if current theme is not a block theme

--- a/projects/plugins/jetpack/modules/custom-post-types/portfolios.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/portfolios.php
@@ -80,7 +80,9 @@ class Jetpack_Portfolio {
 		add_filter( 'post_updated_messages', array( $this, 'updated_messages' ) );
 		add_filter( sprintf( 'manage_%s_posts_columns', self::CUSTOM_POST_TYPE ), array( $this, 'edit_admin_columns' ) );
 		add_filter( sprintf( 'manage_%s_posts_custom_column', self::CUSTOM_POST_TYPE ), array( $this, 'image_column' ), 10, 2 );
-		add_action( 'customize_register', array( $this, 'customize_register' ) );
+		if ( ! wp_is_block_theme() ) {
+			add_action( 'customize_register', array( $this, 'customize_register' ) );
+		}
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 


### PR DESCRIPTION
Fixes partially #31725

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check if current active theme is a block theme before attempting to add a section to the customizer

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/wp-calypso/issues/71130#issuecomment-1617982587

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Checkout this branch
* Enable Portfolios in Jetpack -> Settings -> Writing
* If you're using a modern theme expect to see no Customizer menu item under Appearance
