### PR TITLE
Related Posts: Make the customizer extension only be shown if current theme is a block theme

### DIFF
--- a/projects/plugins/jetpack/changelog/update-related-posts-customizer-section-scoped-to-old-themes
+++ b/projects/plugins/jetpack/changelog/update-related-posts-customizer-section-scoped-to-old-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Make the Related Posts customizer extension only be shown if current theme is not a block theme

--- a/projects/plugins/jetpack/modules/related-posts/class.related-posts-customize.php
+++ b/projects/plugins/jetpack/modules/related-posts/class.related-posts-customize.php
@@ -34,8 +34,10 @@ class Jetpack_Related_Posts_Customize {
 	 * @since 4.4.0
 	 */
 	public function __construct() {
-		add_action( 'customize_register', array( $this, 'customize_register' ) );
-		add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_controls_enqueue_scripts' ) );
+		if ( ! wp_is_block_theme() ) {
+			add_action( 'customize_register', array( $this, 'customize_register' ) );
+			add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_controls_enqueue_scripts' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes partially #31725

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check if current active theme is a block theme before attempting to add a section to the customizer

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/wp-calypso/issues/71130#issuecomment-1617982587

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Checkout this branch
* Enable Related in Jetpack -> Settings -> Traffic
* If you're using a modern theme expect to see no Customizer menu item under Appearance
