### PR TITLE
k6 tests: make the output more verbose for debug

### DIFF
--- a/.github/files/jetpack-staging-sites/k6-backend.js
+++ b/.github/files/jetpack-staging-sites/k6-backend.js
@@ -34,26 +34,26 @@ export default function () {
 			// Jetpack connection test.
 			let res = http.get( `${ site.url }/wp-json/jetpack/v4/connection/test`, params );
 			check( res, {
-				'status was 200': r => r.status == 200,
+				'connection status was 200': r => r.status == 200,
 				'verify connection message': r => r.body.includes( 'All connection tests passed' ),
 			} );
 
 			// Jetpack sync status.
 			res = http.get( `${ site.url }/wp-json/jetpack/v4/sync/status`, params );
 			check( res, {
-				'status was 200': r => r.status == 200,
+				'sync status was 200': r => r.status == 200,
 			} );
 
 			// /wp-json/wp/v2/posts
 			res = http.get( `${ site.url }/wp-json/wp/v2/posts`, params );
 			check( res, {
-				'status was 200': r => r.status == 200,
+				'posts status was 200': r => r.status == 200,
 			} );
 
 			// /wp-json/wp/v2/categories
 			res = http.get( `${ site.url }/wp-json/wp/v2/categories`, params );
 			check( res, {
-				'status was 200': r => r.status == 200,
+				'categories status was 200': r => r.status == 200,
 			} );
 
 			// /wp-json/wp-site-health/v1/tests/dotorg-communication
@@ -62,7 +62,7 @@ export default function () {
 				params
 			);
 			check( res, {
-				'status was 200': r => r.status == 200,
+				'dotorg-communication status was 200': r => r.status == 200,
 				'verify communication message': r =>
 					r.body.includes( 'Can communicate with WordPress.org' ),
 			} );

--- a/.github/files/jetpack-staging-sites/k6-frontend.js
+++ b/.github/files/jetpack-staging-sites/k6-frontend.js
@@ -24,7 +24,7 @@ export const options = {
  */
 export default function () {
 	sites.forEach( site => {
-		group( `Fronted tests for site: ${ site.url } ( ${ site.blog_id } )`, () => {
+		group( `Frontend tests for site: ${ site.url } ( ${ site.blog_id } )`, () => {
 			// Homepage.
 			let res = http.get( site.url );
 			check( res, {

--- a/.github/files/jetpack-staging-sites/k6-frontend.js
+++ b/.github/files/jetpack-staging-sites/k6-frontend.js
@@ -1,5 +1,5 @@
 /* eslint-disable eqeqeq */
-import { check, sleep } from 'k6';
+import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 import { sites } from './k6-shared.js';
 
@@ -24,26 +24,29 @@ export const options = {
  */
 export default function () {
 	sites.forEach( site => {
-		// Homepage.
-		let res = http.get( site.url );
-		check( res, {
-			'status was 200': r => r.status == 200,
-		} );
-
-		// A random post.
-		res = http.get( `${ site.url }/?random` );
-		check( res, {
-			'status was 200': r => r.status == 200,
-		} );
-
-		// Jetpack Blocks test post.
-		if ( site.url !== 'https://jetpackedgeprivate.wpcomstaging.com' ) {
-			res = http.get( `${ site.url }/2023/06/09/jetpack-blocks/` );
+		group( `Fronted tests for site: ${ site.url } ( ${ site.blog_id } )`, () => {
+			// Homepage.
+			let res = http.get( site.url );
 			check( res, {
-				'status was 200': r => r.status == 200,
-				'verify post end contents': r => r.body.includes( 'End of Jetpack Blocks post content' ),
+				'homepage status was 200': r => r.status == 200,
 			} );
-		}
+
+			// A random post.
+			res = http.get( `${ site.url }/?random` );
+			check( res, {
+				'random post status was 200': r => r.status == 200,
+			} );
+
+			// Jetpack Blocks test post.
+			if ( site.url !== 'https://jetpackedgeprivate.wpcomstaging.com' ) {
+				res = http.get( `${ site.url }/2023/06/09/jetpack-blocks/` );
+				check( res, {
+					'blocks test post status was 200': r => r.status == 200,
+					'verify blocks post end contents': r =>
+						r.body.includes( 'End of Jetpack Blocks post content' ),
+				} );
+			}
+		} );
 	} );
 
 	sleep( 1 );


### PR DESCRIPTION
## Proposed changes:

Have the k6 tests be more verbose in their output so when threshold checks fail, it's easier to look at the logs and pinpoint which site/check needs investigation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1688465769846799/1688407369.958339-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread, and once merged, will give it a go with manual action dispatch at:  https://github.com/Automattic/jetpack/actions/workflows/jetpack-staging-sites-k6-tests.yml