### PR TITLE
Launchpad: removed edit site task from keepbuilding

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rm-edit-site-task-from-keepbuilding
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rm-edit-site-task-from-keepbuilding
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removed task from Launchpad checklist
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -132,7 +132,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'title'               => 'Keep Building',
 			'task_ids'            => array(
 				'site_title',
-				'design_edited',
 				'domain_claim',
 				'verify_email',
 				'domain_customize',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/79143

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed edit site task from the keep-building Launchpad checklist

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox
* Create a new site with `build` intent
* Launch your site
* Check the customer-home checklist
* The `Edit site design` check should not be there anymore

Before:
![image](https://github.com/Automattic/jetpack/assets/3801502/d0ea6c81-fb1b-489b-ad07-ee1656f4eab9)

After:
![image](https://github.com/Automattic/jetpack/assets/3801502/085fc371-e92a-4918-9431-9bd8594196c5)

