### PR TITLE
Users: Remove include_viewers parameter from search

### DIFF
--- a/projects/plugins/jetpack/changelog/users-remove-include_viewers-parameter-from-search
+++ b/projects/plugins/jetpack/changelog/users-remove-include_viewers-parameter-from-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove include_viewers parameter from users GET endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -16,13 +16,13 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 		),
 
 		'query_parameters'     => array(
-			'number'          => '(int=20) Limit the total number of authors returned.',
-			'offset'          => '(int=0) The first n authors to be skipped in the returned array.',
-			'order'           => array(
+			'number'         => '(int=20) Limit the total number of authors returned.',
+			'offset'         => '(int=0) The first n authors to be skipped in the returned array.',
+			'order'          => array(
 				'DESC' => 'Return authors in descending order.',
 				'ASC'  => 'Return authors in ascending order.',
 			),
-			'order_by'        => array(
+			'order_by'       => array(
 				'ID'           => 'Order by ID (default).',
 				'login'        => 'Order by username.',
 				'nicename'     => 'Order by nicename.',
@@ -32,12 +32,11 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 				'display_name' => 'Order by display name.',
 				'post_count'   => 'Order by number of posts published.',
 			),
-			'authors_only'    => '(bool) Set to true to fetch authors only',
-			'include_viewers' => '(bool) Set to true to include viewers for Simple sites. When you pass in this parameter, order, order_by and search_columns are ignored. Currently, `search` is limited to the first page of results.',
-			'type'            => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
-			'search'          => '(string) Find matching users.',
-			'search_columns'  => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
-			'role'            => '(string) Specify a specific user role to fetch.',
+			'authors_only'   => '(bool) Set to true to fetch authors only',
+			'type'           => "(string) Specify the post type to query authors for. Only works when combined with the `authors_only` flag. Defaults to 'post'. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
+			'search'         => '(string) Find matching users.',
+			'search_columns' => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
+			'role'           => '(string) Specify a specific user role to fetch.',
 		),
 
 		'response_format'      => array(
@@ -163,47 +162,11 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		remove_filter( 'user_search_columns', array( $this, 'api_user_override_search_columns' ) );
 
-		$is_wpcom        = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$include_viewers = (bool) isset( $args['include_viewers'] ) && $args['include_viewers'] && $is_wpcom;
-
-		$page    = ( (int) ( $args['offset'] / $args['number'] ) ) + 1;
-		$viewers = $include_viewers ? get_private_blog_users(
-			$blog_id,
-			array(
-				'page'     => $page,
-				'per_page' => $args['number'],
-			)
-		) : array();
-		$viewers = array_map( array( $this, 'get_author' ), $viewers );
-
-		// we restrict search field to name when include_viewers is true.
-		if ( $include_viewers && ! empty( $args['search'] ) ) {
-			$viewers = array_filter(
-				$viewers,
-				function ( $viewer ) use ( $args ) {
-					// remove special database search characters from search term
-					$search_term = str_replace( '*', '', $args['search'] );
-					return strpos( $viewer->name, $search_term ) !== false;
-				}
-			);
-		}
-
 		$return = array();
 		foreach ( array_keys( $this->response_format ) as $key ) {
 			switch ( $key ) {
 				case 'found':
-					$user_count = (int) $user_query->get_total();
-
-					$viewer_count = 0;
-					if ( $include_viewers ) {
-						if ( empty( $args['search'] ) ) {
-							$viewer_count = (int) get_count_private_blog_users( $blog_id );
-						} else {
-							$viewer_count = count( $viewers );
-						}
-					}
-
-					$return[ $key ] = $user_count + $viewer_count;
+					$return[ $key ] = (int) $user_query->get_total();
 					break;
 				case 'users':
 					$users        = array();
@@ -220,19 +183,7 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 						}
 					}
 
-					$combined_users = array_merge( $users, $viewers );
-
-					// When viewers are included, we ignore the order & orderby parameters.
-					if ( $include_viewers ) {
-						usort(
-							$combined_users,
-							function ( $a, $b ) {
-								return strcmp( strtolower( $a->name ), strtolower( $b->name ) );
-							}
-						);
-					}
-
-					$return[ $key ] = $combined_users;
+					$return[ $key ] = $users;
 					break;
 			}
 		}


### PR DESCRIPTION
## Proposed changes:

Removes `include_viewers` from the filters of the `/users/%s` GET endpoint.

This is the second part of https://github.com/Automattic/wp-calypso/pull/79028.

## Does this pull request change what data or activity we track or use?

No.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

Try to run any search query within this endpoint and verify that viewers for a certain site are not returned even if `?include_viewers=true` is specified.