### PR TITLE
AI Assistant: add dev playground panel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-add-custom-prompt
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-add-custom-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: add dev playground panel

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/attributes.js
@@ -20,4 +20,19 @@ export default {
 		type: 'array',
 		default: [],
 	},
+
+	useGutenbergSyntax: {
+		type: 'boolean',
+		default: false,
+	},
+
+	useGpt4: {
+		type: 'boolean',
+		default: false,
+	},
+
+	customSystemPrompt: {
+		type: 'string',
+		default: '',
+	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -2,9 +2,19 @@
  * External dependencies
  */
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { rawHandler, createBlock } from '@wordpress/blocks';
-import { Flex, FlexBlock, Modal, Notice } from '@wordpress/components';
+import {
+	Flex,
+	FlexBlock,
+	Modal,
+	Notice,
+	PanelBody,
+	PanelRow,
+	TextareaControl,
+	Button,
+	ToggleControl,
+} from '@wordpress/components';
 import { useKeyboardShortcut } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { RawHTML, useState } from '@wordpress/element';
@@ -21,10 +31,14 @@ import useAIFeature from './hooks/use-ai-feature';
 import useSuggestionsFromOpenAI from './hooks/use-suggestions-from-openai';
 import { getImagesFromOpenAI } from './lib/image';
 import './editor.scss';
+import { getInitialSystemPrompt } from './lib/prompt';
 
 const markdownConverter = new MarkdownIt( {
 	breaks: true,
 } );
+
+const isPlaygroundVisible =
+	window?.Jetpack_Editor_Initial_State?.[ 'ai-assistant' ]?.[ 'is-playground-visible' ];
 
 const isInBlockEditor = window?.Jetpack_Editor_Initial_State?.screenBase === 'post';
 
@@ -241,6 +255,14 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		}
 	);
 
+	/*
+	 * Custom prompt modal
+	 */
+	const [ isCustomPrompModalVisible, setIsCustomPrompModalVisible ] = useState( false );
+	const toogleShowCustomPromptModal = () => {
+		setIsCustomPrompModalVisible( ! isCustomPrompModalVisible );
+	};
+
 	return (
 		<div
 			{ ...useBlockProps( {
@@ -263,6 +285,63 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 						<RawHTML>{ markdownConverter.render( attributes.content ) }</RawHTML>
 					</div>
 				</>
+			) }
+			{ isPlaygroundVisible && (
+				<InspectorControls>
+					<PanelBody title={ __( 'AI Playground', 'jetpack' ) } initialOpen={ true }>
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Gutenberg Syntax', 'jetpack' ) }
+								onChange={ check => setAttributes( { useGutenbergSyntax: check } ) }
+								checked={ attributes.useGutenbergSyntax }
+							/>
+						</PanelRow>
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'GPT-4', 'jetpack' ) }
+								onChange={ check => setAttributes( { useGpt4: check } ) }
+								checked={ attributes.useGpt4 }
+							/>
+						</PanelRow>
+						<PanelRow>
+							{ isCustomPrompModalVisible && (
+								<Modal
+									title={ __( 'Custom System Prompt', 'jetpack' ) }
+									onRequestClose={ toogleShowCustomPromptModal }
+								>
+									<TextareaControl
+										rows={ 20 }
+										label={ __( 'Set up the custom system prompt ', 'jetpack' ) }
+										onChange={ value => setAttributes( { customSystemPrompt: value } ) }
+										className="jetpack-ai-assistant__custom-prompt"
+										value={
+											attributes.customSystemPrompt ||
+											getInitialSystemPrompt( {
+												useGutenbergSyntax: attributes.useGutenbergSyntax,
+												useGpt4: attributes.useGpt4,
+											} )?.content
+										}
+									/>
+									<div className="jetpack-ai-assistant__custom-prompt__footer">
+										<Button
+											onClick={ () => setAttributes( { customSystemPrompt: '' } ) }
+											variant="secondary"
+										>
+											{ __( 'Restore the prompt', 'jetpack' ) }
+										</Button>
+
+										<Button onClick={ toogleShowCustomPromptModal } variant="secondary">
+											{ __( 'Close', 'jetpack' ) }
+										</Button>
+									</div>
+								</Modal>
+							) }
+							<Button onClick={ toogleShowCustomPromptModal } variant="secondary">
+								{ __( 'Set system custom prompt', 'jetpack' ) }
+							</Button>
+						</PanelRow>
+					</PanelBody>
+				</InspectorControls>
 			) }
 			<AIControl
 				ref={ aiControlRef }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -286,6 +286,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 					</div>
 				</>
 			) }
+
 			{ isPlaygroundVisible && (
 				<InspectorControls>
 					<PanelBody title={ __( 'AI Playground', 'jetpack' ) } initialOpen={ true }>
@@ -343,6 +344,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 					</PanelBody>
 				</InspectorControls>
 			) }
+
 			<AIControl
 				ref={ aiControlRef }
 				content={ attributes.content }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.scss
@@ -327,3 +327,13 @@
 		}
 	}
 }
+
+.jetpack-ai-assistant__custom-prompt {
+	width: 800px;
+}
+
+.jetpack-ai-assistant__custom-prompt__footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a (dev) Playground panel to the AI Assistant block sidebar. The changes defined by using the panel doesn't affect the prompt yet. That's going to be addressed in a follow-up PR.

Extracted from #31708

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: add dev playground panel

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the playground through of the `JETPACK_AI_ASSISTANT_PLAYGROUND` global var
* Go to the block editor
* Create/edit an AI Assistant block instance
* Open the block sidebar
* Confirm you see the Playground panel

<img width="718" alt="Screenshot 2023-07-07 at 16 57 08" src="https://github.com/Automattic/jetpack/assets/77539/3f8d6b65-21c3-418a-a83d-04d95262f110">

<img width="971" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/e8c154f8-db96-406a-9d5a-7aad4d997c87">

* Set different options by using the toggle controls and also the custom system prompt
* Save the post
* Ensure that the data is retained even after a hard refresh. The setup remains unchanged.

