### PR TITLE
AI Assistant: Enable custom prompt if provided

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-enable-custom-prompt
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-enable-custom-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Enable custom prompt if provided

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -148,6 +148,7 @@ const useSuggestionsFromOpenAI = ( {
 				userPrompt,
 				type,
 				isGeneratingTitle: attributes.promptType === 'generateTitle',
+				customSystemPrompt: attributes?.customSystemPrompt,
 			} );
 
 			/*
@@ -276,6 +277,7 @@ const useSuggestionsFromOpenAI = ( {
 					userPrompt,
 					type,
 					isGeneratingTitle: attributes.promptType === 'generateTitle',
+					customSystemPrompt: attributes?.customSystemPrompt,
 				} );
 
 				setLastPrompt( [ ...prompt, ...updatedMessages, lastUserPrompt ] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Extracted from #31708

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enables the custom prompt if provided

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an AI Assistant block
* Click on `Set system custom prompt` in the sidebar
* Provide a custom system prompt
* Send a request
* Check that the provided system prompt is used
