### PR TITLE
AI Assistant: Only append flag if there's no error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-playground-flag
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-playground-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Only append flag if no error

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -667,14 +667,15 @@ class Jetpack_Gutenberg {
 		}
 
 		// AI Assistant
-		$ai_assistant_state                          = Jetpack_AI_Helper::get_ai_assistance_feature();
-		$ai_assistant_state['is-playground-visible'] = Constants::is_true( 'JETPACK_AI_ASSISTANT_PLAYGROUND' );
+		$ai_assistant_state = Jetpack_AI_Helper::get_ai_assistance_feature();
 
 		if ( is_wp_error( $ai_assistant_state ) ) {
 			$ai_assistant_state = array(
 				'error-message' => $ai_assistant_state->get_error_message(),
 				'error-code'    => $ai_assistant_state->get_error_code(),
 			);
+		} else {
+			$ai_assistant_state['is-playground-visible'] = Constants::is_true( 'JETPACK_AI_ASSISTANT_PLAYGROUND' );
 		}
 
 		$screen_base = null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move ai playground flag to be inserted only if there's no error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert block
* Force some error
* Check if doesn't generate some fatal if had some error.

