### PR TITLE
[Boost] Remove Image Analyzer toggle

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -3,6 +3,7 @@
 	import Toggle from '../../../elements/Toggle.svelte';
 	import { modulesState } from '../../../stores/modules';
 
+	export let toggle = true;
 	export let slug: string;
 
 	const dispatch = createEventDispatcher();
@@ -27,8 +28,15 @@
 {#if isModuleAvailable}
 	<div class="jb-feature-toggle">
 		<div class="jb-feature-toggle__toggle">
-			<Toggle id={`jb-feature-toggle-${ slug }`} checked={isModuleActive} on:click={handleToggle} />
+			{#if toggle}
+				<Toggle
+					id={`jb-feature-toggle-${ slug }`}
+					checked={isModuleActive}
+					on:click={handleToggle}
+				/>
+			{/if}
 		</div>
+
 		<div class="jb-feature-toggle__content">
 			<slot name="title" />
 
@@ -50,3 +58,9 @@
 		</div>
 	</div>
 {/if}
+
+<style>
+	.jb-feature-toggle__toggle {
+		min-width: 36px;
+	}
+</style>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -184,6 +184,22 @@
 				<ResizingUnavailable />
 			{/if}
 		</Module>
+
+		<Module slug="image_size_analysis" toggle={false}>
+			<h3 slot="title">
+				{__( 'Image Size Analysis', 'jetpack-boost' )}<span class="beta">Beta</span>
+			</h3>
+			<p slot="description">
+				{__(
+					`This tool will search your site for images that are too large and have an impact your visitors experience, page loading times, and search rankings. Once finished, it will give you a report of all improperly sized images with suggestions on how to fix them.`,
+					'jetpack-boost'
+				)}
+			</p>
+
+			<svelte:fragment slot="meta">
+				<RecommendationsMeta />
+			</svelte:fragment>
+		</Module>
 	</div>
 
 	<Module slug="minify_js">
@@ -224,22 +240,6 @@
 				on:save={e => ( $minifyCssExcludesStore = e.detail )}
 			/>
 		</div>
-	</Module>
-
-	<Module slug="image_size_analysis">
-		<h3 slot="title">
-			{__( 'Image Size Analysis', 'jetpack-boost' )}<span class="beta">Beta</span>
-		</h3>
-		<p slot="description">
-			{__(
-				`This tool will search your site for images that are too large and have an impact your visitors experience, page loading times, and search rankings. Once finished, it will give you a report of all improperly sized images with suggestions on how to fix them.`,
-				'jetpack-boost'
-			)}
-		</p>
-
-		<svelte:fragment slot="meta">
-			<RecommendationsMeta />
-		</svelte:fragment>
 	</Module>
 
 	<Module slug="image_cdn">

--- a/projects/plugins/boost/app/contracts/Is_Always_On.php
+++ b/projects/plugins/boost/app/contracts/Is_Always_On.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Contracts;
+
+/**
+ * Modules can implement this interface to indicate that they are always on if available.
+ */
+interface Is_Always_On {}

--- a/projects/plugins/boost/app/data-sync/Modules_State_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Modules_State_Entry.php
@@ -38,8 +38,6 @@ class Modules_State_Entry implements Entry_Can_Get, Entry_Can_Merge {
 	}
 
 	public function set( $value ) {
-		$index = new Modules_Index();
-
 		foreach ( $value as $module_slug => $module_state ) {
 			$option_name = $this->get_module_option_name( $module_slug );
 			$updated     = update_option( $option_name, $module_state['active'] );

--- a/projects/plugins/boost/app/data-sync/Modules_State_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Modules_State_Entry.php
@@ -18,11 +18,18 @@ class Modules_State_Entry implements Entry_Can_Get, Entry_Can_Merge {
 		 * We combining the states of all modules into a single record and attaching the availability of the module.
 		 */
 		foreach ( $modules as $module ) {
-			$slug        = $module::get_slug();
-			$option_name = $this->get_module_option_name( $slug );
+			$slug      = $module::get_slug();
+			$always_on = is_subclass_of( $module, 'Automattic\Jetpack_Boost\Contracts\Is_Always_On' );
+
+			if ( $always_on ) {
+				$is_on = true;
+			} else {
+				$option_name = $this->get_module_option_name( $slug );
+				$is_on       = (bool) get_option( $option_name, false );
+			}
 
 			$modules_state[ $slug ] = array(
-				'active'    => isset( $available_modules[ $slug ] ) && get_option( $option_name, false ),
+				'active'    => isset( $available_modules[ $slug ] ) && $is_on,
 				'available' => isset( $available_modules[ $slug ] ),
 			);
 		}
@@ -31,6 +38,8 @@ class Modules_State_Entry implements Entry_Can_Get, Entry_Can_Merge {
 	}
 
 	public function set( $value ) {
+		$index = new Modules_Index();
+
 		foreach ( $value as $module_slug => $module_state ) {
 			$option_name = $this->get_module_option_name( $module_slug );
 			$updated     = update_option( $option_name, $module_state['active'] );

--- a/projects/plugins/boost/app/modules/image-size-analysis/Image_Size_Analysis.php
+++ b/projects/plugins/boost/app/modules/image-size-analysis/Image_Size_Analysis.php
@@ -2,12 +2,13 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Image_Size_Analysis;
 
+use Automattic\Jetpack_Boost\Contracts\Is_Always_On;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Image_Analysis_Start;
 
-class Image_Size_Analysis implements Pluggable, Has_Endpoints {
+class Image_Size_Analysis implements Pluggable, Has_Endpoints, Is_Always_On {
 
 	public function setup() {
 		// noop

--- a/projects/plugins/boost/changelog/boost-ig-always-on
+++ b/projects/plugins/boost/changelog/boost-ig-always-on
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove checkbox for image guide
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In line with original designs, don't show a toggle on the image size analysis tool
See: p1HpG7-lar-p2 

## Proposed changes:
* Set the image size analysis tool to always be on
* Remove its toggle from the UI

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Visit the Boost dashboard
* Ensure the Image Size analysis tool is always available (if you have the right plan) but is not toggle-able.