### PR TITLE
Boost: Remove BETA tag from Concatenate CSS/JS and Image CDN settings

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -170,6 +170,56 @@
 		</p>
 	</Module>
 
+	<Module slug="minify_js">
+		<h3 slot="title">{__( 'Concatenate JS', 'jetpack-boost' )}</h3>
+		<p slot="description">
+			{__(
+				'Scripts are grouped by their original placement, concatenated and minified to reduce site loading time and reduce the number of requests.',
+				'jetpack-boost'
+			)}
+		</p>
+
+		<div slot="meta">
+			<MinifyMeta
+				inputLabel={__( 'Exclude JS Strings:', 'jetpack-boost' )}
+				buttonText={__( 'Exclude JS Strings', 'jetpack-boost' )}
+				placeholder={__( 'Comma separated list of JS scripts to exclude', 'jetpack-boost' )}
+				value={$minifyJsExcludesStore}
+				on:save={e => ( $minifyJsExcludesStore = e.detail )}
+			/>
+		</div>
+	</Module>
+
+	<Module slug="minify_css">
+		<h3 slot="title">{__( 'Concatenate CSS', 'jetpack-boost' )}</h3>
+		<p slot="description">
+			{__(
+				'Styles are grouped by their original placement, concatenated and minified to reduce site loading time and reduce the number of requests.',
+				'jetpack-boost'
+			)}
+		</p>
+
+		<div slot="meta">
+			<MinifyMeta
+				inputLabel={__( 'Exclude CSS Strings:', 'jetpack-boost' )}
+				buttonText={__( 'Exclude CSS Strings', 'jetpack-boost' )}
+				placeholder={__( 'Comma separated list of CSS stylesheets to exclude', 'jetpack-boost' )}
+				value={$minifyCssExcludesStore}
+				on:save={e => ( $minifyCssExcludesStore = e.detail )}
+			/>
+		</div>
+	</Module>
+
+	<Module slug="image_cdn">
+		<h3 slot="title">{__( 'Image CDN', 'jetpack-boost' )}</h3>
+		<p slot="description">
+			{__(
+				`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
+				'jetpack-boost'
+			)}
+		</p>
+	</Module>
+
 	<div class="settings">
 		<Module slug="image_guide">
 			<h3 slot="title">{__( 'Image Guide', 'jetpack-boost' )}<span class="beta">Beta</span></h3>
@@ -201,56 +251,6 @@
 			</svelte:fragment>
 		</Module>
 	</div>
-
-	<Module slug="minify_js">
-		<h3 slot="title">{__( 'Concatenate JS', 'jetpack-boost' )}<span class="beta">Beta</span></h3>
-		<p slot="description">
-			{__(
-				'Scripts are grouped by their original placement, concatenated and minified to reduce site loading time and reduce the number of requests.',
-				'jetpack-boost'
-			)}
-		</p>
-
-		<div slot="meta">
-			<MinifyMeta
-				inputLabel={__( 'Exclude JS Strings:', 'jetpack-boost' )}
-				buttonText={__( 'Exclude JS Strings', 'jetpack-boost' )}
-				placeholder={__( 'Comma separated list of JS scripts to exclude', 'jetpack-boost' )}
-				value={$minifyJsExcludesStore}
-				on:save={e => ( $minifyJsExcludesStore = e.detail )}
-			/>
-		</div>
-	</Module>
-
-	<Module slug="minify_css">
-		<h3 slot="title">{__( 'Concatenate CSS', 'jetpack-boost' )}<span class="beta">Beta</span></h3>
-		<p slot="description">
-			{__(
-				'Styles are grouped by their original placement, concatenated and minified to reduce site loading time and reduce the number of requests.',
-				'jetpack-boost'
-			)}
-		</p>
-
-		<div slot="meta">
-			<MinifyMeta
-				inputLabel={__( 'Exclude CSS Strings:', 'jetpack-boost' )}
-				buttonText={__( 'Exclude CSS Strings', 'jetpack-boost' )}
-				placeholder={__( 'Comma separated list of CSS stylesheets to exclude', 'jetpack-boost' )}
-				value={$minifyCssExcludesStore}
-				on:save={e => ( $minifyCssExcludesStore = e.detail )}
-			/>
-		</div>
-	</Module>
-
-	<Module slug="image_cdn">
-		<h3 slot="title">{__( 'Image CDN', 'jetpack-boost' )}<span class="beta">Beta</span></h3>
-		<p slot="description">
-			{__(
-				`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
-				'jetpack-boost'
-			)}
-		</p>
-	</Module>
 
 	<SuperCacheInfo />
 </div>

--- a/projects/plugins/boost/changelog/update-boost_settings_page_beta_apps
+++ b/projects/plugins/boost/changelog/update-boost_settings_page_beta_apps
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack Boost: take beta tag off Concatenate CSS/JS and Image settings


### PR DESCRIPTION
Remove the BETA tag from the Concatenate CSS/JS and Image CDN functions as they have been fairly well tested.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the BETA span from the appropriate settings titles.
* Move them up, to separate them from the remaining beta functionality.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Apply patch
* Load the Boost settings page and make sure the BETA tag is removed from the Concatenate CSS/JS and Image CDN titles.
