### PR TITLE
Release Script: Check for GH CLI Login

### DIFF
--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -49,6 +49,7 @@ if ! gh auth status &> /dev/null; then
 	gh auth login
 fi
 
+# Get the options passed and parse them.
 while getopts "h" opt; do
 	case ${opt} in
 		h)

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -42,7 +42,13 @@ if ! version_compare "$GH_VER" "2.21.2"; then
 	die "Your version of the GH CLI is out of date. Please upgrade your version$WITH and start again"
 fi
 
-# Get the options passed and parse them.
+# Make sure we're signed into the GitHub CLI.
+if ! gh auth status &> /dev/null; then
+	yellow "You are not signed into the GitHub CLI."
+	proceed_p "Sign in to the GitHub CLI?"
+	gh auth login
+fi
+
 while getopts "h" opt; do
 	case ${opt} in
 		h)

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -43,7 +43,7 @@ if ! version_compare "$GH_VER" "2.21.2"; then
 fi
 
 # Make sure we're signed into the GitHub CLI.
-if ! gh auth status &> /dev/null; then
+if ! gh auth status --hostname github.com &> /dev/null; then
 	yellow "You are not signed into the GitHub CLI."
 	proceed_p "Sign in to the GitHub CLI?"
 	gh auth login


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If we're not logged into the GH CLI, the script will fail when it checks the status of the build. This checks to make sure you're logged in and prompts you to do so before continuing. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

If you're logged in, you can use "gh auth logout" and then run tools/release-plugin.sh jetpack to make sure it asks you to log in. Throw an exit statement on line 51 if you want to test further without running through the whole script.

