### PR TITLE
Boost: Various ISA UI tweaks

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/elements/OtherGroupContext.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/OtherGroupContext.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { __ } from '@wordpress/i18n';
+</script>
+
+<div class="jb-score-context">
+	<span class="jb-score-context__info-icon">i</span>
+	<div class="jb-score-context__info-container">
+		<p>
+			{__(
+				'In addition to the Homepage, Pages and Posts, Boost will also analyze the following custom post types found on your site:',
+				'jetpack-boost'
+			)}
+		</p>
+		<ul>
+			<li>Testimonials</li>
+			<li>Portfolio</li>
+			<li>Projects</li>
+		</ul>
+		<i />
+	</div>
+</div>
+
+<style scope="scss">
+	ul {
+		list-style: outside;
+		margin-left: 20px;
+	}
+
+	ul:last-of-type {
+		margin-bottom: 0;
+	}
+</style>

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
@@ -121,6 +121,7 @@
 	.jb-status {
 		grid-area: status;
 		font-size: 0.875rem;
+		color: var( --gray-50 );
 		:global( a ),
 		&.has-issues {
 			color: var( --color_warning );

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { sprintf, __ } from '@wordpress/i18n';
 	import ConditionalLink from '../../elements/ConditionalLink.svelte';
+	import OtherGroupContext from '../../elements/OtherGroupContext.svelte';
 	import ProgressBar from '../../elements/ProgressBar.svelte';
 	import Spinner from '../../elements/Spinner.svelte';
 	import { isaGroupLabels, isaSummary } from './store/isa-summary';
@@ -47,6 +48,9 @@
 				>
 					{isaGroupLabels[ group ] || group}
 				</ConditionalLink>
+				{#if 'other' === group}
+					<OtherGroupContext />
+				{/if}
 			</div>
 
 			{#if isDone || hasIssues}
@@ -125,5 +129,31 @@
 	.jb-category-name {
 		grid-area: category;
 		display: flex;
+
+		:global( .jb-score-context ) {
+			top: 2px;
+		}
+
+		:global( .jb-score-context__info-icon ) {
+			width: 14px;
+			height: 14px;
+			font-size: 10px;
+		}
+
+		:global( .jb-score-context__info-container ) {
+			top: 24px;
+			@media ( min-width: 782px ) {
+				left: -112px;
+			}
+			@media ( max-width: 782px ) {
+				left: 112px;
+			}
+		}
+
+		:global( .jb-score-context__info-container i ) {
+			@media ( max-width: 782px ) {
+				left: 41px;
+			}
+		}
 	}
 </style>

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/MultiProgress.svelte
@@ -77,6 +77,10 @@
 		width: 100%;
 		display: flex;
 		gap: 8px;
+
+		@media ( max-width: 782px ) {
+			flex-direction: column;
+		}
 	}
 	.jb-progress {
 		grid-area: progress;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -165,6 +165,7 @@
 		margin-right: 5px;
 		flex-grow: 1;
 		position: relative;
+		color: $jetpack-green;
 	}
 
 	.has-issues {

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -152,12 +152,20 @@
 		flex-direction: row;
 		align-items: flex-start;
 		margin-bottom: 17px;
+
+		@media ( max-width: 600px ) {
+			flex-direction: column;
+		}
 	}
 
 	.summary-line button {
 		:global( svg ) {
 			margin: 4px 4px 2px 0;
 			fill: $jetpack-green;
+		}
+
+		@media ( max-width: 600px ) {
+			margin-top: 15px;
 		}
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -3,6 +3,7 @@
 	import { __, sprintf } from '@wordpress/i18n';
 	import Button from '../../elements/Button.svelte';
 	import ErrorNotice from '../../elements/ErrorNotice.svelte';
+	import NoticeIcon from '../../svg/notice-outline.svg';
 	import RefreshIcon from '../../svg/refresh.svg';
 	import MultiProgress from './MultiProgress.svelte';
 	import { resetIsaQuery } from './store/isa-data';
@@ -88,6 +89,7 @@
 		<div class="summary-line">
 			{#if totalIssues > 0}
 				<div class="has-issues summary">
+					<NoticeIcon class="icon" />
 					{sprintf(
 						/* translators: %d is the number of issues that were found */
 						__( 'Found a total of %d issues', 'jetpack-boost' ),
@@ -167,6 +169,13 @@
 
 	.has-issues {
 		color: $red_50;
+	}
+
+	.has-issues :global( svg ) {
+		width: 22px;
+		height: 22px;
+		top: 4px;
+		position: relative;
 	}
 
 	.wait-notice {

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -140,7 +140,9 @@
 	{/if}
 {/if}
 
-<style>
+<style lang="scss">
+	@use '../../../css/main/variables.scss' as *;
+
 	.summary-line {
 		font-size: 14px;
 		line-height: 22px;
@@ -157,7 +159,7 @@
 	}
 
 	.has-issues {
-		color: var( --red_50 );
+		color: $red_50;
 	}
 
 	.wait-notice {

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -152,6 +152,13 @@
 		margin-bottom: 17px;
 	}
 
+	.summary-line button {
+		:global( svg ) {
+			margin: 4px 4px 2px 0;
+			fill: $jetpack-green;
+		}
+	}
+
 	.summary {
 		margin-right: 5px;
 		flex-grow: 1;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Hero.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Hero.svelte
@@ -50,7 +50,7 @@
 
 <style lang="scss">
 	.jb-hero {
-		padding: 50px 0;
+		padding: 50px 0 30px;
 		display: flex;
 		flex-direction: column;
 		gap: calc( var( --gap ) / 2 );

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Tabs.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/Tabs.svelte
@@ -113,7 +113,7 @@
 		display: flex;
 		border-bottom: 1px solid var( --gray-5 );
 		margin-bottom: 32px;
-		gap: var( --gap );
+		gap: var( --expanded-gap );
 
 		/* Hide on narrow screens. */
 		@media ( max-width: 782px ) {
@@ -122,7 +122,7 @@
 	}
 
 	.jb-tab {
-		min-width: 100px;
+		min-width: 90px;
 		display: flex;
 		justify-content: center;
 		margin-bottom: -1px; // offset border
@@ -143,7 +143,7 @@
 
 	.jb-tabs :global( .jb-navigator-link ) {
 		background: none;
-		padding: 10px 16px;
+		padding: 8px 16px;
 		border: 0;
 		cursor: pointer;
 		text-decoration: none;

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/row-types/TableRow.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/row-types/TableRow.svelte
@@ -149,6 +149,10 @@
 				display: none;
 			}
 		}
+
+		.jb-table-row__page a {
+			text-decoration: none;
+		}
 	}
 
 	.jb-table-row__expand {

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -261,8 +261,8 @@
 		padding-top: 20px;
 	}
 	.beta {
-		background: hsl( 0, 0%, 90% );
-		color: hsl( 0, 0%, 20% );
+		background: var( --jp-green-5 );
+		color: var( --jp-green-60 );
 		padding: 2px 5px;
 		border-radius: 3px;
 		font-size: 0.8rem;

--- a/projects/plugins/boost/changelog/update-isa-ui-tweaks
+++ b/projects/plugins/boost/changelog/update-isa-ui-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Various tweaks to the Image Size Analysis UI, to get it closer to designs.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31772 and #31773.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update groups UI, to look better on smaller screens (#31772);
  * <details>
     <summary>screenshot</summary>
      <img width="563" alt="CleanShot 2023-07-10 at 18 26 31@2x" src="https://github.com/Automattic/jetpack/assets/11799079/e8412b47-d5c3-4576-a7aa-685e97d38ed6">

      </details>
   * <details>
     <summary>max-width: 600px</summary>
     <img width="517" alt="CleanShot 2023-07-10 at 18 18 16@2x" src="https://github.com/Automattic/jetpack/assets/11799079/1c69c9b0-a06c-442f-9b53-936e7b756a3d">

      </details>

* Fix discrepancies between UI and designs (#31773):
  * "has issues" label now has an icon and is colored red;
  * The arrow in front of "Analyze again" is now green;
  * There is now an info box next to "Other", that shows a tooltip when hovered over. **Note, that the list of post types is hard-coded. We should either add an endpoint that returns the custom post types analyzed in a report, or remove this for now**;
  * The "No issues" label has been updated to use a gray color, that matches the original design.
  * <details>
     <summary>screenshot before</summary>
     <img width="724" alt="image" src="https://github.com/Automattic/jetpack/assets/11799079/e3d03e19-e124-4e5f-9f57-0201daf99c69">
     </details>
  * <details>
     <summary>screenshot after</summary>
     <img width="727" alt="image" src="https://github.com/Automattic/jetpack/assets/11799079/510b3f7e-3bf5-4b03-8bb7-0152d21c7d70">
     </details>

* Additional tweaks include:
  * Removed underline from page name on "latest report page" listing;
  * spacing adjustments in header of "latest report page";
  * Updated 'Beta' pill colors to be green instead of gray (visible on first screenshot).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost with Image Size Analysis;
* Go over list of changes and make sure everything looks okay.