### PR TITLE
Super Cache: remove unused "object cache" code

### DIFF
--- a/projects/plugins/super-cache/changelog/update-remove_oc_code
+++ b/projects/plugins/super-cache/changelog/update-remove_oc_code
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+WP Super Cache: removed unused "object cache" code.

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -1040,45 +1040,17 @@ function supercache_filename() {
 }
 
 function get_oc_version() {
-	$wp_cache_oc_key = wp_cache_get( 'wp_cache_oc_key' );
-	if ( ! $wp_cache_oc_key ) {
-		$wp_cache_oc_key['key'] = reset_oc_version();
-	} elseif ( $wp_cache_oc_key['ts'] < time() - 600 ) {
-		wp_cache_set(
-			'wp_cache_oc_key',
-			array(
-				'ts'  => time(),
-				'key' => $wp_cache_oc_key['key'],
-			)
-		);
-	}
-	return $wp_cache_oc_key['key'];
+	_deprecated_function( __FUNCTION__, '$$next-version$$' );
 }
 
+// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 function reset_oc_version( $version = 1 ) {
-	if ( $version == 1 ) {
-		$version = mt_rand();
-	}
-	wp_cache_set(
-		'wp_cache_oc_key',
-		array(
-			'ts'  => time(),
-			'key' => $version,
-		)
-	);
-
-	return $version;
+	_deprecated_function( __FUNCTION__, '$$next-version$$' );
 }
 
+// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 function get_oc_key( $url = false ) {
-	global $wp_cache_gzip_encoding, $WPSC_HTTP_HOST;
-
-	if ( $url ) {
-		$key = intval( $_SERVER['SERVER_PORT'] ) . preg_replace( '/:.*$/', '', $WPSC_HTTP_HOST ) . $url;
-	} else {
-		$key = get_current_url_supercache_dir();
-	}
-	return $key . $wp_cache_gzip_encoding . get_oc_version();
+	_deprecated_function( __FUNCTION__, '$$next-version$$' );
 }
 
 function wp_supercache_cache_for_admins() {
@@ -2385,7 +2357,6 @@ function wp_cache_get_ob( &$buffer ) {
 	}
 
 	$added_cache = 0;
-	$oc_key      = get_oc_key();
 	$buffer      = apply_filters( 'wpsupercache_buffer', $buffer );
 	wp_cache_append_tag( $buffer );
 

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -1040,17 +1040,17 @@ function supercache_filename() {
 }
 
 function get_oc_version() {
-	_deprecated_function( __FUNCTION__, '$$next-version$$' );
+	_deprecated_function( __FUNCTION__, '1.10.0' );
 }
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 function reset_oc_version( $version = 1 ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$' );
+	_deprecated_function( __FUNCTION__, '1.10.0' );
 }
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 function get_oc_key( $url = false ) {
-	_deprecated_function( __FUNCTION__, '$$next-version$$' );
+	_deprecated_function( __FUNCTION__, '1.10.0' );
 }
 
 function wp_supercache_cache_for_admins() {


### PR DESCRIPTION
This code hasn't been used in many years and was recently [mentioned in a bug report](https://wordpress.org/support/topic/php-8-1-php-deprecated-strstr/#post-16876951) on the forum. Three functions have been deprecated now.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Deprecate get_oc_version, reset_oc_version, and get_oc_key.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Apply patch
* Use WP Super Cache. The settings page should operate just fine.