### PR TITLE
WP Super Cache: Check that URI is not null/not set before using it

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-uri_checking_rejected_function
+++ b/projects/plugins/super-cache/changelog/fix-uri_checking_rejected_function
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+WP Super Cache: reject unkown URIs so they're not cached.

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -1825,6 +1825,10 @@ function wpsc_is_rejected_cookie() {
 function wp_cache_is_rejected( $uri ) {
 	global $cache_rejected_uri;
 
+	if ( empty( $uri ) ) {
+		return true; // do not cache if we don't know the URI.
+	}
+
 	$auto_rejected = array( '/wp-admin/', 'xmlrpc.php', 'wp-app.php' );
 	foreach ( $auto_rejected as $u ) {
 		if ( strstr( $uri, $u ) ) {


### PR DESCRIPTION
PHP 8.1 issues a warning when false is converted to an array, which [highlighted a missing check](https://wordpress.org/support/topic/php-8-1-php-deprecated-strstr/#post-16876951) in `wp_cache_is_rejected( $uri )`
This patch adds a check there and returns true, which means the page is rejected and won't be cached.

This patch reverses the current return value if $uri is null or empty. The first foreach loop in wp_cache_is_rejected will never return true if $uri is false or null. Instead it passes through to the next checks, returning false at the end.
This patch will instead return true if $uri is false or null, and the page will not be cached.
I believe this is safer as the URI is unknown and can't be cached anyway.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* return true in wp_cache_is_rejected if the URI is false/empty. That will cause a page to be not cached.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
I don't know how to replicate this bug.
The function, wp_cache_is_rejected(), is only called in two places, once in preload and also during initialisation of the plugin. It may well be that there's a bug in `wpsc_remove_tracking_params_from_uri` where the URI is generated but it might also be a misconfiguration of a web server.
