### PR TITLE
Launchpad: New task for edit_page

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/78951-update-edit-page-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/78951-update-edit-page-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad task for editing a page

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "3.6.x-dev"
+			"dev-trunk": "3.7.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "3.6.1-alpha",
+	"version": "3.7.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '3.6.1-alpha';
+	const PACKAGE_VERSION = '3.7.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -237,6 +237,14 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 		),
 
+		'edit_page'                       => array(
+			'get_title'            => function () {
+				return __( 'Edit a page', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_is_edit_page_task_visible',
+		),
+
 		'domain_customize'                => array(
 			'id_map'               => 'domain_customize_deferred',
 			'get_title'            => function () {
@@ -733,6 +741,62 @@ function wpcom_add_new_page_check( $post_id, $post ) {
 	wpcom_mark_launchpad_task_complete( 'add_new_page' );
 }
 add_action( 'wp_insert_post', 'wpcom_add_new_page_check', 10, 3 );
+
+/**
+ * Determine `edit_page` task visibility. The task is visible if there is at least one page and the add_new_page task is complete.
+ *
+ * @return bool True if we should show the task, false otherwise.
+ */
+function wpcom_is_edit_page_task_visible() {
+	if ( ! wpcom_is_task_option_completed( array( 'id' => 'add_new_page' ) ) ) {
+		return false;
+	}
+
+	return ! empty(
+		get_posts(
+			array(
+				'numberposts' => 1,
+				'post_type'   => 'page',
+			)
+		)
+	);
+}
+
+/**
+ * When a page is updated, check to see if it's the About page and mark the task complete accordingly.
+ *
+ * @param int     $post_id The ID of the post being updated.
+ * @param WP_Post $post The post object.
+ */
+function wpcom_edit_page_check( $post_id, $post ) {
+	// Don't do anything if the task is already complete.
+	if ( wpcom_is_task_option_completed( array( 'id' => 'edit_page' ) ) ) {
+		return;
+	}
+
+	// Don't do anything if the add_new_page task is incomplete.
+	if ( ! wpcom_is_task_option_completed( array( 'id' => 'add_new_page' ) ) ) {
+		return false;
+	}
+
+	// We only care about pages, ignore other post types.
+	if ( $post->post_type !== 'page' ) {
+		return;
+	}
+
+	// Ensure that Headstart posts don't mark this as complete
+	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+		return;
+	}
+
+	// We only care about published pages. Pages added via the API are not published by default.
+	if ( $post->post_status !== 'publish' ) {
+		return;
+	}
+
+	wpcom_mark_launchpad_task_complete( 'edit_page' );
+}
+add_action( 'post_updated', 'wpcom_edit_page_check', 10, 3 );
 
 /**
  * Returns if the site has domain or bundle purchases.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -763,7 +763,7 @@ function wpcom_is_edit_page_task_visible() {
 }
 
 /**
- * When a page is updated, check to see if it's the About page and mark the task complete accordingly.
+ * When a page is updated, check to see if we've already completed the `add_new_page` task and mark the `edit_page` task complete accordingly.
  *
  * @param int     $post_id The ID of the post being updated.
  * @param WP_Post $post The post object.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -137,6 +137,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'domain_customize',
 				'add_new_page',
 				'drive_traffic',
+				'edit_page',
 				'share_site',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',

--- a/projects/plugins/mu-wpcom-plugin/changelog/78951-update-edit-page-task
+++ b/projects/plugins/mu-wpcom-plugin/changelog/78951-update-edit-page-task
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "e8b46caf659ca9da824f2e1c3bb42395e338e02c"
+                "reference": "8771d7e07a819ec260ba9d61518bf4995d451d16"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.6.x-dev"
+                    "dev-trunk": "3.7.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #78951

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
As a first step, instead of adding an "Update About page" task, we're adding an overall "Edit page" task. This adds the Calypso handler for that new task in the dashboard.

If the `add_new_page` task is complete and the site has at least one page, we show a new `edit_page` task.
    
This task is marked as complete when a page is edited.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* If you want the new `edit_page` task to be clickable, you'll want to run [79204](https://github.com/Automattic/wp-calypso/pull/79204) locally or use the calypso.live link.
* Apply this patch to Jetpack on your sandbox and sandbox the public-api.
* Go to `/start` and create a new site. Using the Free plan is fine and you can skip selecting a theme.
* Select the "Promote myself or busienss goals" intent
![image](https://github.com/Automattic/jetpack/assets/917632/dd063710-cf35-4e09-ae48-22468f593753)
* Launch the site.
* Once you reach the dashboard, you should see the "Add a new page" task but _not_ the "Edit a page" task.
![image](https://github.com/Automattic/jetpack/assets/917632/ce1b81f6-2ac7-41ab-885e-cd14e733b1ad)
* Click the "Add a new page" task and add a new page and publish it.
* Now the "Add a new page" task should be complete and the "Edit a page" task should be visible. 
![image](https://github.com/Automattic/jetpack/assets/917632/f144510b-b7ca-4a30-9419-04721848b0af)
* At this point, you can click on "Edit a page" if you're using the Calypso branch listed above. Otherwise simply go to `/pages` and edit any page on the site.
* After editing a page, the task should be marked as complete.
![image](https://github.com/Automattic/jetpack/assets/917632/849d00ba-96fa-4206-90be-46718545d180)



