### PR TITLE
[Boost] Fix handling of broken background-image urls in the Image Guide

### DIFF
--- a/projects/js-packages/image-guide/changelog/fix-missing-null-filter
+++ b/projects/js-packages/image-guide/changelog/fix-missing-null-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image Guide: Fix for broken background-images causing the image guide not to load

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-image-guide",
-	"version": "0.5.0",
+	"version": "0.5.1-alpha",
 	"description": "Go through the dom to analyze image size on screen vs actual file size.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/image-guide/#readme",
 	"type": "module",

--- a/projects/js-packages/image-guide/src/find-image-elements.ts
+++ b/projects/js-packages/image-guide/src/find-image-elements.ts
@@ -86,7 +86,7 @@ export async function getMeasurableImages(
 		return null;
 	} );
 
-	return images;
+	return images.filter( i => i !== null );
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31788.

It looks like a filter to remove `null` MeasurableImage objects was removed. That is needed to remove images that were rejected either for being SVGs (ignored by the Image Guide), or for having malformed URLs in a background-image CSS style.

This PR reinstates the filter, preventing bad background-images from breaking the Image Guide.

## Proposed changes:
* Filter out null ImageMeasurements from the Image Guide.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Rig your site to render a bad or ignored background-image URL via custom CSS. e.g.: `h1 { background-image: url(/.svg); }` ought to do it.
* Make sure the Image Guide still functions.