### PR TITLE
[Boost] Fix potential savings display

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/row-types/ImageSizeRow.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/row-types/ImageSizeRow.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { __ } from '@wordpress/i18n';
 	import Button from '../../../../elements/Button.svelte';
-	import { getImageSizeDifferencePercent } from '../../../../utils/get-image-size-difference-percent';
 	import Device from '../components/Device.svelte';
 	import Pill from '../components/Pill.svelte';
 	import RowTitle from '../components/RowTitle.svelte';
@@ -14,7 +13,14 @@
 	export let details: ImageDataType;
 
 	const title = details.image.url.split( '/' ).pop();
-	const sizeDifference = getImageSizeDifferencePercent( details.image );
+	const currentSize = details.image.weight.current;
+	const potentialSavings = Math.max(
+		0,
+		Math.min( currentSize - 2, details.image.weight.potential )
+	);
+	const potentialSize = potentialSavings > 0 ? Math.round( currentSize - potentialSavings ) : '?';
+
+	const sizeDifference = ( potentialSavings / currentSize ) * 100;
 	const pillColor = sizeDifference <= 30 ? '#f5e5b3' : '#facfd2';
 </script>
 
@@ -36,7 +42,7 @@
 			<div class="jb-arrow">→</div>
 
 			<Pill color="#d0e6b8">
-				{Math.round( details.image.weight.potential )} KB
+				{potentialSize} KB
 			</Pill>
 		</div>
 
@@ -65,7 +71,7 @@
 				<div class="jb-arrow">→</div>
 
 				<Pill color="#d0e6b8">
-					{Math.round( details.image.weight.potential )} KB
+					{potentialSize} KB
 				</Pill>
 			</div>
 		</div>

--- a/projects/plugins/boost/changelog/boost-fix-potential-savings
+++ b/projects/plugins/boost/changelog/boost-fix-potential-savings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed the way potential savings are shown
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31746

## Proposed changes:
* Correctly use the `potential`(savings) field.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Run ISA report
* View the results
* Ensure the potential size differences seem right(ish)

