### PR TITLE
[Boost] Reduce URL scrape limit to 100 for ISA beta

### DIFF
--- a/projects/plugins/boost/app/lib/class-site-urls.php
+++ b/projects/plugins/boost/app/lib/class-site-urls.php
@@ -4,11 +4,7 @@ namespace Automattic\Jetpack_Boost\Lib;
 
 class Site_Urls {
 
-	public static function get( $limit = 1000 ) {
-		// @todo - after removing the core urls from the post urls,
-		// there might be core urls left that aren't in the posts urls
-		// and combining the two would result in a list over the $limit
-
+	public static function get( $limit = 100 ) {
 		$core_urls = self::get_wp_core_urls();
 		$post_urls = self::cleanup_post_urls(
 			self::get_post_urls( $limit ),
@@ -18,9 +14,13 @@ class Site_Urls {
 			)
 		);
 
-		return array_merge(
-			$core_urls,
-			$post_urls
+		return array_slice(
+			array_merge(
+				$core_urls,
+				$post_urls
+			),
+			0,
+			$limit
 		);
 	}
 

--- a/projects/plugins/boost/changelog/boost-fix-site-url-limit
+++ b/projects/plugins/boost/changelog/boost-fix-site-url-limit
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Decrease URL scrape to 100
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Reduce the URL scraper to max out at 100 for now, until we decide how to handle limits in production.

## Proposed changes:
* Reduce the number of URLs our scraper returns to 100.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Run the Image Size Analyzer, ensure it works.