### PR TITLE
AI Assistant: Extend blocks when upgrade is required

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-extend-block-when-upgrade-required
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-extend-block-when-upgrade-required
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Extend blocks when upgrade is required

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -32,8 +32,6 @@ type BlockSettingsProps = {
 export const isAiAssistantSupportExtensionEnabled =
 	window?.Jetpack_Editor_Initial_State.available_blocks?.[ AI_ASSISTANT_SUPPORT_NAME ];
 
-const siteRequiresUpgrade = AI_Assistant_Initial_State.requireUpgrade;
-
 /**
  * Check if it is possible to extend the block.
  *
@@ -53,11 +51,6 @@ export function isPossibleToExtendBlock(): boolean {
 	// Do not extend the block if the site is not connected.
 	const connected = isUserConnected();
 	if ( ! connected ) {
-		return false;
-	}
-
-	// Do not extend the block if the site requires an upgrade.
-	if ( siteRequiresUpgrade ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31807

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes check about required upgrade before extending blocks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a site with the 20 free requests already used, create an extended block, like paragraph or heading
* Check that the AI extension menu is enabled

Before | After
-|-
![2023-07-11_13-58-30-before](https://github.com/Automattic/jetpack/assets/8486249/8b4ef9b6-fef8-49c4-a9d4-3ba2a3caa25e) | ![2023-07-11_13-56-44](https://github.com/Automattic/jetpack/assets/8486249/d62ae4ec-d8b1-4ff8-9011-5a1e3a0f11f2)
