### PR TITLE
AI Assistant: do not pre-populate inner blocks if Gutenberg syntax is not enabled

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-issue-populating-inner-blocks-from-content
+++ b/projects/plugins/jetpack/changelog/update-fix-issue-populating-inner-blocks-from-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: do not pre-populate inner blocks if Gutenberg syntax is not enabled

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -119,20 +119,34 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	/*
 	 * Populate the block with inner blocks if:
 	 * - It's the first time the block is rendered
+	 * - It's Gutenberg syntax enabled
 	 * - The block doesn't have children blocks
 	 * - The `content` attribute contains contains blocks definition
 	 */
 	const initialContent = useRef( attributes?.content );
 	useEffect( () => {
+		// Check if is Gutenberg syntax enabled
+		if ( ! attributes?.useGutenbergSyntax ) {
+			return;
+		}
+
+		// Bail out if the block doesn't have content (via attribute)
 		if ( ! initialContent?.current?.length ) {
 			return;
 		}
 
+		// Bail out if the block already has children blocks
 		const block = getBlock();
 		if ( block?.innerBlocks?.length ) {
 			return;
 		}
 
+		/*
+		 * Bail out if the content doesn't contain blocks definition
+		 * This is a very basic check, but it's enough for now.
+		 * If the content hasn't blocks defined by using Gutenberg syntax,
+		 * it can parse undesired blocks. Eg: `core/freeform` block :scream:
+		 */
 		const storedInnerBlocks = parse( initialContent.current );
 		if ( ! storedInnerBlocks?.length ) {
 			return;
@@ -140,7 +154,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 
 		// Populate block inner blocks
 		replaceBlocks( clientId, storedInnerBlocks );
-	}, [ initialContent, clientId, replaceBlocks, getBlock ] );
+	}, [ initialContent, clientId, replaceBlocks, getBlock, attributes?.useGutenbergSyntax ] );
 
 	const saveImage = async image => {
 		if ( loadingImages ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: do not pre-populate inner blocks if Gutenberg syntax is not enabled

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Paragraph block
* Transform the block to an AI Assistant block instance

<img width="406" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/3316ba4f-5457-43d9-9912-e067d0947391">

### BEFORE
* Confirm it creates a classic block instance

<img width="789" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/1a7eeee6-d463-45c9-b456-0a5e18116043">

### AFTER
* It transforms the block into an AI Assistant instance

**Disclaimer**
If you try to use Gutenberg Syntax to an AI Assistant block containing blocks defined by Markdown syntax, it will trigger the same issue. Let's address something in a follow-up since Gutenberg syntax is beta.

<img width="1028" alt="Screenshot 2023-07-11 at 15 51 19" src="https://github.com/Automattic/jetpack/assets/77539/458694ed-2b12-4e27-9f3f-a562435747a6">

