### PR TITLE
Launchpad: Filter tasks by newsletter import goal

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-newsletter-import-callback
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-newsletter-import-callback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Filter tasks by newsletter import goal.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -130,6 +130,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
+			'is_visible_callback'  => 'wpcom_has_goal_import_subscribers',
 		),
 
 		// Link in bio tasks.
@@ -614,6 +615,15 @@ function wpcom_launchpad_is_email_unverified() {
  */
 function wpcom_has_goal_paid_subscribers() {
 	return in_array( 'paid-subscribers', get_option( 'site_goals', array() ), true );
+}
+
+/**
+ * If the site has a import-subscriber goal.
+ *
+ * @return bool True if the site has a import-subscriber goal, false otherwise.
+ */
+function wpcom_has_goal_import_subscribers() {
+	return in_array( 'import-subscribers', get_option( 'site_goals', array() ), true );
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

**Still in progress**

Relates to https://github.com/Automattic/wp-calypso/pull/79022

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds callback method so that the Launchpad's Add Subscriber task for newsletters is only visible when a user has set a site goal for import-subscribers. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The easiest way to test this is alongside [this Calypso PR](https://github.com/Automattic/wp-calypso/pull/79022) which utilizes the new filter added here. 

1) Load this branch in your sandbox using `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-newsletter-import-callback`. Be sure to sandbox public API and the domain names of the test sites you create in steps 3 and 4 below.
2) Checkout [this Calypso PR ](https://github.com/Automattic/wp-calypso/pull/79022).
3) Test 1: With import-subscribers goal. 
   - Start a new newsletter site at http://calypso.localhost:3000/setup/newsletter/intro (and sandbox the domain)
   - Choose the "Import" goal on the Newsletter goals page (just after the setup screen)
   - Proceed to Launchpad, and confirm that the Add Subscribers task shows.  
4) Test 2: Without import-subscribers goal.Start a new newsletter site at 
   - Start a new newsletter site at http://calypso.localhost:3000/setup/newsletter/intro (and sandbox the domain)
   - Choose the "Free" goal on the Newsletter goals page (just after the setup screen)
   - Proceed to Launchpad, and confirm that the Add Subscribers task does NOT show.   
 
