### PR TITLE
Akismet: show correct logo for all Jetpack plans that include Akismet

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-akismet-logo-all-antispam-plans
+++ b/projects/plugins/jetpack/changelog/fix-akismet-logo-all-antispam-plans
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Akismet: show Jetpack Akismet Anti-Spam logo for all Jetpack plans including Akismet
+Akismet: show correct logo for all Jetpack plans that include Akismet

--- a/projects/plugins/jetpack/changelog/fix-akismet-logo-all-antispam-plans
+++ b/projects/plugins/jetpack/changelog/fix-akismet-logo-all-antispam-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Akismet: show Jetpack Akismet Anti-Spam logo for all Jetpack plans including Akismet

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -77,10 +77,11 @@ class Jetpack_Admin {
 		add_action( 'jetpack_unrecognized_action', array( $this, 'handle_unrecognized_action' ) );
 
 		if ( class_exists( 'Akismet_Admin' ) ) {
-			// If the site has Jetpack Anti-Spam, change the Akismet menu label accordingly.
-			$site_products      = Jetpack_Plan::get_products();
-			$anti_spam_products = array( 'jetpack_anti_spam_monthly', 'jetpack_anti_spam' );
-			if ( ! empty( array_intersect( $anti_spam_products, array_column( $site_products, 'product_slug' ) ) ) ) {
+			// If the site has Jetpack Anti-Spam, change the Akismet menu label and logo accordingly.
+			$site_products         = array_column( Jetpack_Plan::get_products(), 'product_slug' );
+			$has_anti_spam_product = count( array_intersect( array( 'jetpack_anti_spam', 'jetpack_anti_spam_monthly' ), $site_products ) ) > 0;
+
+			if ( Jetpack_Plan::supports( 'antispam' ) || $has_anti_spam_product ) {
 				// Prevent Akismet from adding a menu item.
 				add_action(
 					'admin_menu',
@@ -111,7 +112,7 @@ class Jetpack_Admin {
 	}
 
 	/**
-	 * Generate styles to replace Akismet logo for the Jetpack logo.
+	 * Generate styles to replace Akismet logo for the Jetpack Akismet Anti-Spam logo.
 		Without this, we would have to change the logo from Akismet codebase and we want to avoid that.
 	 */
 	public function akismet_logo_replacement_styles() {


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/pull/31464#pullrequestreview-1518928280, @jeherve noted:

> I wonder if in a follow-up PR, we could take that opportunity to fix what types of plans we look for before we overwrite the logo. We currently only look for Anti-spam plans, while I think we should also look for bundles that include Anti-spam, like the security bundle.

## Proposed changes:
Check to see if the user's plan/bundle supports Anti-Spam, and show the appropriate logo and menu item if it does.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

### Site with Anti-spam

1. Set up a Jurassic Ninja site with the Jetpack Beta plugin, and switch to the feature branch `fix/akismet-logo-all-antispam-plans`. 
2. Set up and Jetpack and purchase Jetpack Security bundle.
3. Visit `/wp-admin/admin.php?page=akismet-key-config`.

You should see the updated logo, and the menu item should be called "Anti-Spam":
<img width="785" alt="Screenshot 2023-07-13 at 2 23 30 PM" src="https://github.com/Automattic/jetpack/assets/17325/e3df0c5d-8fbc-4e94-96e3-0662f7211949">
<img width="155" alt="Screenshot 2023-07-13 at 2 23 21 PM" src="https://github.com/Automattic/jetpack/assets/17325/dd6a593d-5436-47a7-99f7-e243a4ff1b59">

### Site without Anti-spam

1. Set up a fresh Jurassic Ninja site with the Jetpack Beta plugin, and switch to the feature branch `fix/akismet-logo-all-antispam-plans`. 
2. Set up and Jetpack and purchase Jetpack Scan or any other plan that doesn't include Akismet.
3. Go to /wp-admin/plugins.php and activate the Akismet plugin.
4. Visit `/wp-admin/admin.php?page=akismet-key-config`.

You should see the standard Akismet logo, and the menu item should be called "Akismet Anti-Spam":
<img width="776" alt="Screenshot 2023-07-13 at 2 22 46 PM" src="https://github.com/Automattic/jetpack/assets/17325/4f74ae80-7baf-44ad-adfe-c1c32e851fa0">
<img width="159" alt="Screenshot 2023-07-13 at 2 22 50 PM" src="https://github.com/Automattic/jetpack/assets/17325/ab1ccf27-56b2-427a-82b2-298bbafbdf19">

