### PR TITLE
[Boost] Fix super-cache measurements

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -40,7 +40,7 @@ declare global {
 		superCache: {
 			pluginActive: boolean;
 			cacheEnabled: boolean;
-			disableCacheKey?: string;
+			cachePageSecret?: string;
 		};
 		site: {
 			domain: string;

--- a/projects/plugins/boost/app/assets/src/js/utils/measure-super-cache-saving.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/measure-super-cache-saving.ts
@@ -13,8 +13,8 @@ export async function measureSuperCacheSaving(): Promise< number > {
 	const url = Jetpack_Boost.site.url;
 	const uncachedUrl = addGetParameter(
 		url,
-		'donotcache',
-		Jetpack_Boost.superCache.disableCacheKey
+		'donotcachepage',
+		Jetpack_Boost.superCache.cachePageSecret
 	);
 
 	const uncachedTime = await measureFetch( uncachedUrl, false );

--- a/projects/plugins/boost/changelog/boost-fix-super-cache-measure
+++ b/projects/plugins/boost/changelog/boost-fix-super-cache-measure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Super Cache Measurement Tool: Fixed the use of the donotcachepage option during tests, which may have produced understated results


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The Boost dashboard has a tool to measure the effectiveness of Super Cache if it's installed and enabled alongside Boost. The tool uses the `donotcachepage` GET param to prevent caching during some of its tests. However, it had the GET param name wrong, and used the wrong variable name in passing the caching secret from the back-end to the admin UI.

That means that our Super Cache effectiveness tool has been likely understating the impact of Super Cache.

## Proposed changes:
* Correct the GET param name and value used to turn off caching during super cache tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have super cache installed alongside Jetpack Boost
* Use the tool at the bottom of the Boost dashboard to measure the performance of Super Cache
* Watch your network tab, and look for fetch requests with `?donotcachepage=` in the URL. Check the bottom of the returned HTML documents from them to ensure there are no `<!-- super cache comments -->` at the bottom of the response, indicating the cache was successfully deactivated.

