### PR TITLE
Boost: Add Upgrade CTA under image guide

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/UpgradeCTA.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/UpgradeCTA.svelte
@@ -9,6 +9,8 @@
 
 	const { navigate } = routerHistory;
 
+	export let description = '';
+
 	onMount( () => {
 		// Throw away promise, as we don't need to wait for it.
 		void recordBoostEvent( 'view_upsell_cta_in_settings_page_in_plugin', {} );
@@ -28,7 +30,7 @@
 
 <button class="jb-premium-cta" on:click={showBenefits}>
 	<div class="jb-premium-cta__content">
-		<p>{__( 'Save time by upgrading to Automatic Critical CSS generation', 'jetpack-boost' )}</p>
+		<p>{description}</p>
 		<p class="jb-premium-cta__action-line">
 			{sprintf(
 				/* translators: %s is the price including the currency symbol in front. */

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -16,16 +16,17 @@
 	} from '../../../stores/critical-css-state';
 	import { suggestRegenerateDS } from '../../../stores/data-sync-client';
 	import { minifyJsExcludesStore, minifyCssExcludesStore } from '../../../stores/minify';
+	import { modulesState } from '../../../stores/modules';
 	import { startPollingCloudStatus, stopPollingCloudCssStatus } from '../../../utils/cloud-css';
 	import externalLinkTemplateVar from '../../../utils/external-link-template-var';
 	import CloudCssMeta from '../elements/CloudCssMeta.svelte';
 	import CriticalCssMeta from '../elements/CriticalCssMeta.svelte';
 	import MinifyMeta from '../elements/MinifyMeta.svelte';
 	import Module from '../elements/Module.svelte';
-	import PremiumCTA from '../elements/PremiumCTA.svelte';
 	import PremiumTooltip from '../elements/PremiumTooltip.svelte';
 	import ResizingUnavailable from '../elements/ResizingUnavailable.svelte';
 	import SuperCacheInfo from '../elements/SuperCacheInfo.svelte';
+	import UpgradeCTA from '../elements/UpgradeCTA.svelte';
 
 	const criticalCssLink = getRedirectUrl( 'jetpack-boost-critical-css' );
 	const deferJsLink = getRedirectUrl( 'jetpack-boost-defer-js' );
@@ -98,9 +99,14 @@
 			/>
 		</div>
 
-		<div slot="cta">
-			<PremiumCTA />
-		</div>
+		<svelte:fragment slot="cta">
+			<UpgradeCTA
+				description={__(
+					'Save time by upgrading to Automatic Critical CSS generation',
+					'jetpack-boost'
+				)}
+			/>
+		</svelte:fragment>
 	</Module>
 
 	<Module
@@ -233,6 +239,17 @@
 			{#if false === Jetpack_Boost.site.canResizeImages}
 				<ResizingUnavailable />
 			{/if}
+
+			<svelte:fragment slot="cta">
+				{#if ! $modulesState.image_size_analysis.available}
+					<UpgradeCTA
+						description={__(
+							'Upgrade to search your whole site for issues - automatically!',
+							'jetpack-boost'
+						)}
+					/>
+				{/if}
+			</svelte:fragment>
 		</Module>
 
 		<Module slug="image_size_analysis" toggle={false}>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -244,7 +244,7 @@
 				{#if ! $modulesState.image_size_analysis.available}
 					<UpgradeCTA
 						description={__(
-							'Upgrade to search your whole site for issues - automatically!',
+							'Upgrade to scan your site for issues - automatically!',
 							'jetpack-boost'
 						)}
 					/>

--- a/projects/plugins/boost/changelog/add-image-guide-upgrade-cta
+++ b/projects/plugins/boost/changelog/add-image-guide-upgrade-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Image Guide: Added an upgrade CTA


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/boost-cloud#305

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added CTA under image guide to upgrade to premium

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Use free version of boost
* Go to boost settings page
* Toggle on image-guide
* Ensure the CTA is visible

![image](https://github.com/Automattic/jetpack/assets/3737780/85307369-2076-4dcd-a469-5f9275ee1217)
