### PR TITLE
Boost: Fix ISA edit link

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/row-types/ImageSizeRow.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/recommendations/row-types/ImageSizeRow.svelte
@@ -135,11 +135,13 @@
 				{__( 'How to fix', 'jetpack-boost' )}
 			</h4>
 			<p>{details.instructions}</p>
-			<div class="jb-actions">
-				<Button width="auto" href={details.page.edit_url} fill>
-					{__( 'Fix on page', 'jetpack-boost' )}
-				</Button>
-			</div>
+			{#if details.page.edit_url}
+				<div class="jb-actions">
+					<Button width="auto" href={details.page.edit_url} fill>
+						{__( 'Fix on page', 'jetpack-boost' )}
+					</Button>
+				</div>
+			{/if}
 		</div>
 	</svelte:fragment>
 </TableRow>

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
@@ -31,9 +31,9 @@ const image_size_analysis_summary = jetpack_boost_ds.createAsyncStore(
 			report_id: z.number().optional(),
 			groups: z
 				.object( {
-					front_page: zGroup,
-					page: zGroup.optional(),
-					post: zGroup.optional(),
+					core_front_page: zGroup,
+					singular_page: zGroup.optional(),
+					singular_post: zGroup.optional(),
 					other: zGroup.optional(),
 				} )
 				.nullable()
@@ -47,14 +47,14 @@ image_size_analysis_summary.setSyncAction( async ( _, value ) => value );
 
 export const isaSummary = image_size_analysis_summary.store;
 export const isaGroups = derived( isaSummary, () => ( {
-	front_page: { name: 'Front Page', progress: 10, issues: 0, done: false },
+	core_front_page: { name: 'Front Page', progress: 10, issues: 0, done: false },
 } ) );
 
 export const isaGroupLabels = {
 	all: __( 'All', 'jetpack-boost' ),
-	front_page: __( 'Homepage', 'jetpack-boost' ),
-	page: __( 'Pages', 'jetpack-boost' ),
-	post: __( 'Posts', 'jetpack-boost' ),
+	core_front_page: __( 'Homepage', 'jetpack-boost' ),
+	singular_page: __( 'Pages', 'jetpack-boost' ),
+	singular_post: __( 'Posts', 'jetpack-boost' ),
 	other: __( 'Other', 'jetpack-boost' ),
 };
 

--- a/projects/plugins/boost/app/lib/class-site-urls.php
+++ b/projects/plugins/boost/app/lib/class-site-urls.php
@@ -29,27 +29,27 @@ class Site_Urls {
 
 		$front_page = get_option( 'page_on_front' );
 		if ( ! empty( $front_page ) ) {
-			$urls['front_page'] = array(
+			$urls['core_front_page'] = array(
 				'url'      => get_permalink( $front_page ),
 				'modified' => get_post_modified_time( 'Y-m-d H:i:s', false, $front_page ),
-				'group'    => 'front_page',
+				'group'    => 'core_front_page',
 			);
 		}
 
 		$posts_page = get_option( 'page_for_posts' );
 		if ( ! empty( $posts_page ) ) {
-			$urls['posts_page'] = array(
+			$urls['core_posts_page'] = array(
 				'url'      => get_permalink( $posts_page ),
 				'modified' => get_post_modified_time( 'Y-m-d H:i:s', false, $posts_page ),
-				'group'    => 'posts_page',
+				'group'    => 'other',
 			);
 		}
 
 		if ( empty( $front_page ) && empty( $posts_page ) ) {
-			$urls['posts_page'] = array(
+			$urls['core_posts_page'] = array(
 				'url'      => home_url( '/' ),
 				'modified' => current_time( 'Y-m-d H:i:s' ),
-				'group'    => 'front_page',
+				'group'    => 'core_front_page',
 			);
 		}
 
@@ -142,7 +142,7 @@ class Site_Urls {
 	private static function get_post_group( $p ) {
 		$post_type = get_post_type( $p->ID );
 		if ( 'post' === $post_type || 'page' === $post_type ) {
-			return $post_type;
+			return 'singular_' . $post_type;
 		}
 
 		return 'other';

--- a/projects/plugins/boost/app/modules/image-size-analysis/data-sync/init.php
+++ b/projects/plugins/boost/app/modules/image-size-analysis/data-sync/init.php
@@ -102,10 +102,10 @@ $summary_schema = Schema::as_assoc_array(
 		'report_id' => Schema::as_number()->nullable(),
 		'groups'    => Schema::as_assoc_array(
 			array(
-				'front_page' => $group_schema,
-				'page'       => $group_schema,
-				'post'       => $group_schema,
-				'other'      => $group_schema,
+				'core_front_page' => $group_schema,
+				'singular_page'   => $group_schema,
+				'singular_post'   => $group_schema,
+				'other'           => $group_schema,
 			)
 		)->nullable(),
 	)

--- a/projects/plugins/boost/changelog/fix-isa-edit-link
+++ b/projects/plugins/boost/changelog/fix-isa-edit-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/boost-cloud#307

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Made provider keys for groups consistent with critical CSS
* Hide "Fix in place" link if no edit link exists
* Fixed static front page edit link

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
None

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure boost is upgraded
* Set a static page with oversized image
* Run image analysis
* Check to see that the "Fix in page" links to the static page edit
* Now, without the front page as static, rig it to show an oversized image and run analysis again
* "Fix in page" should not be visible for front page

