### PR TITLE
Launchpad: Refactored task list validation

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/77939-update-task-list-validation
+++ b/projects/packages/jetpack-mu-wpcom/changelog/77939-update-task-list-validation
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Updated launchpad task list validation return types to be more useful. Previously, we just returned a simple bool. Now we return a WP_Error where appropriate.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "3.7.x-dev"
+			"dev-trunk": "4.0.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "3.7.0",
+	"version": "4.0.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '3.7.0';
+	const PACKAGE_VERSION = '4.0.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -452,12 +452,6 @@ class Launchpad_Task_Lists {
 			$error_messages[] = $msg;
 		}
 
-		if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
-			$msg = 'The visible_tasks_callback attribute must be callable';
-			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-			$error_messages[] = $msg;
-		}
-
 		if ( isset( $task_list['require_last_task_completion'] ) && ! is_bool( $task_list['require_last_task_completion'] ) ) {
 			$msg = 'The require_last_task_completion attribute must be a boolean';
 			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -57,7 +57,7 @@ class Launchpad_Task_Lists {
 	 * @return bool True if successfully registered, false if not.
 	 */
 	public function register_task_list( $task_list = array() ) {
-		if ( ! $this->validate_task_list( $task_list ) ) {
+		if ( self::validate_task_list( $task_list ) !== null ) {
 			return false;
 		}
 
@@ -407,45 +407,53 @@ class Launchpad_Task_Lists {
 	 *
 	 * @param Task_List $task_list Task List.
 	 *
-	 * @return bool True if valid, false if not.
+	 * @return null | WP_Error Null if valid, WP_Error if not.
 	 */
 	public static function validate_task_list( $task_list ) {
+		$error_code = 'validate_task_list';
+
 		if ( ! is_array( $task_list ) ) {
-			return false;
+			return new WP_Error( $error_code, 'Invalid task list' );
 		}
 
 		if ( ! isset( $task_list['id'] ) ) {
-			_doing_it_wrong( 'validate_task_list', 'The Launchpad task list being registered requires a "id" attribute', '6.1' );
-			return false;
+			$msg = 'The Launchpad task list being registered requires a "id" attribute';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			return new WP_Error( $error_code, $msg );
 		}
 
 		if ( ! isset( $task_list['task_ids'] ) ) {
-			_doing_it_wrong( 'validate_task_list', 'The Launchpad task list being registered requires a "task_ids" attribute', '6.1' );
-			return false;
+			$msg = 'The Launchpad task list being registered requires a "task_ids" attribute';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			return new WP_Error( $error_code, $msg );
 		}
 
 		if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
-			_doing_it_wrong( 'validate_task_list', 'The visible_tasks_callback attribute must be callable', '6.1' );
-			return false;
+			$msg = 'The visible_tasks_callback attribute must be callable';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			return new WP_Error( $error_code, $msg );
 		}
 
 		if ( isset( $task_list['required_task_ids'] ) && ! is_array( $task_list['required_task_ids'] ) ) {
-			_doing_it_wrong( 'validate_task_list', 'The required_task_ids attribute must be an array', '6.1' );
-			return false;
+			$msg = 'The required_task_ids attribute must be an array';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			return new WP_Error( $error_code, $msg );
 		}
 
 		// If we have required tasks, make sure they all exist in the array of `task_ids`.
 		if ( isset( $task_list['required_task_ids'] ) && array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) !== $task_list['required_task_ids'] ) {
-			_doing_it_wrong( 'validate_task_list', 'The required_task_ids must be a subset of the task_ids', '6.1' );
-			return false;
+			$msg = 'The required_task_ids must be a subset of the task_ids';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			return new WP_Error( $error_code, $msg );
 		}
 
 		if ( isset( $task_list['require_last_task_completion'] ) && ! is_bool( $task_list['require_last_task_completion'] ) ) {
-			_doing_it_wrong( 'validate_task_list', 'The require_last_task_completion attribute must be a boolean', '6.1' );
-			return false;
+			$msg = 'The require_last_task_completion attribute must be a boolean';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			return new WP_Error( $error_code, $msg );
 		}
 
-		return true;
+		return null;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -407,7 +407,7 @@ class Launchpad_Task_Lists {
 	 *
 	 * @param Task_List $task_list Task List.
 	 *
-	 * @return null | WP_Error Null if valid, WP_Error if not.
+	 * @return null|WP_Error Null if valid, WP_Error if not.
 	 */
 	public static function validate_task_list( $task_list ) {
 		$error_code = 'validate_task_list';

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -414,50 +414,54 @@ class Launchpad_Task_Lists {
 		$error_messages = array();
 
 		if ( ! is_array( $task_list ) ) {
-			// If we don't have an array, skip later validation.
-			return new WP_Error( $error_code, 'Invalid task list' );
+			// Ensure we have a valid task list array.
+			$msg = 'Invalid task list';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			return new WP_Error( $error_code, $msg );
 		}
 
 		if ( ! isset( $task_list['id'] ) ) {
+			// Ensure we have an id.
 			$msg = 'The Launchpad task list being registered requires a "id" attribute';
 			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
 			$error_messages[] = $msg;
-		} elseif ( ! isset( $task_list['task_ids'] ) ) {
+		}
+
+		if ( ! isset( $task_list['task_ids'] ) ) {
+			// Ensure we have task_ids.
 			$msg = 'The Launchpad task list being registered requires a "task_ids" attribute';
 			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
 			$error_messages[] = $msg;
-		} else {
-			if ( isset( $task_list['required_task_ids'] ) ) {
+		} elseif ( isset( $task_list['required_task_ids'] ) ) {
 				// Ensure we have a valid array.
-				if ( ! is_array( $task_list['required_task_ids'] ) ) {
-					$msg = 'The required_task_ids attribute must be an array';
-					_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-					$error_messages[] = $msg;
-					// Ensure all required tasks actually exist in the task list - we need the value to be an array for this to work.
-				} elseif ( array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) !== $task_list['required_task_ids'] ) {
-					$msg = 'The required_task_ids must be a subset of the task_ids';
-					_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-					$error_messages[] = $msg;
-				}
-			}
-
-			if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
-				$msg = 'The visible_tasks_callback attribute must be callable';
+			if ( ! is_array( $task_list['required_task_ids'] ) ) {
+				$msg = 'The required_task_ids attribute must be an array';
+				_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+				$error_messages[] = $msg;
+				// Ensure all required tasks actually exist in the task list - we need the value to be an array for this to work.
+			} elseif ( array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) !== $task_list['required_task_ids'] ) {
+				$msg = 'The required_task_ids must be a subset of the task_ids';
 				_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
 				$error_messages[] = $msg;
 			}
+		}
 
-			if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
-				$msg = 'The visible_tasks_callback attribute must be callable';
-				_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-				$error_messages[] = $msg;
-			}
+		if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
+			$msg = 'The visible_tasks_callback attribute must be callable';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			$error_messages[] = $msg;
+		}
 
-			if ( isset( $task_list['require_last_task_completion'] ) && ! is_bool( $task_list['require_last_task_completion'] ) ) {
-				$msg = 'The require_last_task_completion attribute must be a boolean';
-				_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-				$error_messages[] = $msg;
-			}
+		if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
+			$msg = 'The visible_tasks_callback attribute must be callable';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			$error_messages[] = $msg;
+		}
+
+		if ( isset( $task_list['require_last_task_completion'] ) && ! is_bool( $task_list['require_last_task_completion'] ) ) {
+			$msg = 'The require_last_task_completion attribute must be a boolean';
+			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+			$error_messages[] = $msg;
 		}
 
 		if ( array() !== $error_messages ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -421,38 +421,43 @@ class Launchpad_Task_Lists {
 		if ( ! isset( $task_list['id'] ) ) {
 			$msg = 'The Launchpad task list being registered requires a "id" attribute';
 			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-			return new WP_Error( $error_code, $msg );
-		}
-
-		if ( ! isset( $task_list['task_ids'] ) ) {
+			$error_messages[] = $msg;
+		} elseif ( ! isset( $task_list['task_ids'] ) ) {
 			$msg = 'The Launchpad task list being registered requires a "task_ids" attribute';
 			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-			return new WP_Error( $error_code, $msg );
-		}
-
-		if ( isset( $task_list['required_task_ids'] ) && ! is_array( $task_list['required_task_ids'] ) ) {
-			$msg = 'The required_task_ids attribute must be an array';
-			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-			return new WP_Error( $error_code, $msg );
-		}
-
-		if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
-			$msg = 'The visible_tasks_callback attribute must be callable';
-			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
 			$error_messages[] = $msg;
-		}
+		} else {
+			if ( isset( $task_list['required_task_ids'] ) ) {
+				// Ensure we have a valid array.
+				if ( ! is_array( $task_list['required_task_ids'] ) ) {
+					$msg = 'The required_task_ids attribute must be an array';
+					_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+					$error_messages[] = $msg;
+					// Ensure all required tasks actually exist in the task list - we need the value to be an array for this to work.
+				} elseif ( array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) !== $task_list['required_task_ids'] ) {
+					$msg = 'The required_task_ids must be a subset of the task_ids';
+					_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+					$error_messages[] = $msg;
+				}
+			}
 
-		// If we have required tasks, make sure they all exist in the array of `task_ids`.
-		if ( isset( $task_list['required_task_ids'] ) && array_intersect( $task_list['required_task_ids'], $task_list['task_ids'] ) !== $task_list['required_task_ids'] ) {
-			$msg = 'The required_task_ids must be a subset of the task_ids';
-			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-			$error_messages[] = $msg;
-		}
+			if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
+				$msg = 'The visible_tasks_callback attribute must be callable';
+				_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+				$error_messages[] = $msg;
+			}
 
-		if ( isset( $task_list['require_last_task_completion'] ) && ! is_bool( $task_list['require_last_task_completion'] ) ) {
-			$msg = 'The require_last_task_completion attribute must be a boolean';
-			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
-			$error_messages[] = $msg;
+			if ( isset( $task_list['visible_tasks_callback'] ) && ! is_callable( $task_list['visible_tasks_callback'] ) ) {
+				$msg = 'The visible_tasks_callback attribute must be callable';
+				_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+				$error_messages[] = $msg;
+			}
+
+			if ( isset( $task_list['require_last_task_completion'] ) && ! is_bool( $task_list['require_last_task_completion'] ) ) {
+				$msg = 'The require_last_task_completion attribute must be a boolean';
+				_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
+				$error_messages[] = $msg;
+			}
 		}
 
 		if ( array() !== $error_messages ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-list-validation-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-list-validation-test.php
@@ -18,8 +18,7 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 	 *
 	 *   'test key' => array(
 	 *     (array) $task_list,
-	 *     (null | WP_Error) $expected_result,
-	 *     (bool) $expected_is_wp_error,
+	 *     (null | WP_Error) $expected_result
 	 *   )
 	 *
 	 * @return array
@@ -34,7 +33,6 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'require_last_task_completion' => true,
 				),
 				null,
-				false,
 			),
 			'Valid task list with last task completion'   => array(
 				array(
@@ -43,7 +41,6 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'require_last_task_completion' => true,
 				),
 				null,
-				false,
 			),
 			'Valid task list with only required task IDs' => array(
 				array(
@@ -52,7 +49,6 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'required_task_ids' => array( 'task_1' ),
 				),
 				null,
-				false,
 			),
 			'Valid task list with minimal validation'     => array(
 				array(
@@ -60,7 +56,6 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'task_ids' => array( 'task_1', 'task_2' ),
 				),
 				null,
-				false,
 			),
 			'Invalid task list with no id'                => array(
 				array(
@@ -68,8 +63,7 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'required_task_ids'            => array( 'task_1' ),
 					'require_last_task_completion' => true,
 				),
-				new WP_Error( 'invalid-task-list', 'Task list is missing an ID.' ),
-				true,
+				new WP_Error( 'invalid-task-list', 'The Launchpad task list being registered requires a "id" attribute' ),
 			),
 			'Invalid task list with no task_ids'          => array(
 				array(
@@ -77,8 +71,7 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'required_task_ids'            => array( 'task_1' ),
 					'require_last_task_completion' => true,
 				),
-				new WP_Error( 'invalid-task-list', 'Task list is missing task IDs.' ),
-				true,
+				new WP_Error( 'invalid-task-list', 'The Launchpad task list being registered requires a "task_ids" attribute' ),
 			),
 			'Invalid task list with invalid required_task_ids' => array(
 				array(
@@ -86,8 +79,7 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'task_ids'          => array( 'task_1', 'task_2' ),
 					'required_task_ids' => 'task_1',
 				),
-				new WP_Error( 'invalid-task-list', 'Task list required task IDs must be an array.' ),
-				true,
+				new WP_Error( 'invalid-task-list', 'The required_task_ids attribute must be an array' ),
 			),
 			'Invalid task list with invalid require_last_task_completion' => array(
 				array(
@@ -96,8 +88,7 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'required_task_ids'            => array( 'task_1' ),
 					'require_last_task_completion' => 'true',
 				),
-				new WP_Error( 'invalid-task-list', 'Task list require last task completion must be a boolean.' ),
-				true,
+				new WP_Error( 'invalid-task-list', 'The require_last_task_completion attribute must be a boolean' ),
 			),
 		);
 	}
@@ -107,18 +98,16 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 	 *
 	 * @param array $task_list       Task list to validate.
 	 * @param bool  $expected_result Expected validation result.
-	 * @param bool  $expected_is_wp_error Flag to signal if the expected result is a WP_Error.
 	 * @dataProvider provide_validate_task_list_test_cases
 	 */
-	public function test_validate_task_list( $task_list, $expected_result, $expected_is_wp_error ) {
+	public function test_validate_task_list( $task_list, $expected_result ) {
 		$result = Launchpad_Task_Lists::validate_task_list( $task_list );
 
-		if ( $expected_is_wp_error ) {
-			$this->assertTrue( is_wp_error( $result ) );
-			return;
+		if ( is_wp_error( $result ) ) {
+			$this->assertEquals( $result->get_error_message(), $expected_result->get_error_message() );
+		} else {
+			$this->assertSame( $expected_result, $result );
 		}
-
-		$this->assertSame( $expected_result, $result );
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-list-validation-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-list-validation-test.php
@@ -14,6 +14,14 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Data provider for test_validate_task_list.
 	 *
+	 * The test data is in the format of:
+	 *
+	 *   'test key' => array(
+	 *     (array) $task_list,
+	 *     (null | WP_Error) $expected_result,
+	 *     (bool) $expected_is_wp_error,
+	 *   )
+	 *
 	 * @return array
 	 */
 	public function provide_validate_task_list_test_cases() {
@@ -25,7 +33,8 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'required_task_ids'            => array( 'task_1' ),
 					'require_last_task_completion' => true,
 				),
-				true,
+				null,
+				false,
 			),
 			'Valid task list with last task completion'   => array(
 				array(
@@ -33,7 +42,8 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'task_ids'                     => array( 'task_1', 'task_2' ),
 					'require_last_task_completion' => true,
 				),
-				true,
+				null,
+				false,
 			),
 			'Valid task list with only required task IDs' => array(
 				array(
@@ -41,14 +51,16 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'task_ids'          => array( 'task_1', 'task_2' ),
 					'required_task_ids' => array( 'task_1' ),
 				),
-				true,
+				null,
+				false,
 			),
 			'Valid task list with minimal validation'     => array(
 				array(
 					'id'       => 'task_list_1',
 					'task_ids' => array( 'task_1', 'task_2' ),
 				),
-				true,
+				null,
+				false,
 			),
 			'Invalid task list with no id'                => array(
 				array(
@@ -56,7 +68,8 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'required_task_ids'            => array( 'task_1' ),
 					'require_last_task_completion' => true,
 				),
-				false,
+				new WP_Error( 'invalid-task-list', 'Task list is missing an ID.' ),
+				true,
 			),
 			'Invalid task list with no task_ids'          => array(
 				array(
@@ -64,7 +77,8 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'required_task_ids'            => array( 'task_1' ),
 					'require_last_task_completion' => true,
 				),
-				false,
+				new WP_Error( 'invalid-task-list', 'Task list is missing task IDs.' ),
+				true,
 			),
 			'Invalid task list with invalid required_task_ids' => array(
 				array(
@@ -72,7 +86,8 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'task_ids'          => array( 'task_1', 'task_2' ),
 					'required_task_ids' => 'task_1',
 				),
-				false,
+				new WP_Error( 'invalid-task-list', 'Task list required task IDs must be an array.' ),
+				true,
 			),
 			'Invalid task list with invalid require_last_task_completion' => array(
 				array(
@@ -81,7 +96,8 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 					'required_task_ids'            => array( 'task_1' ),
 					'require_last_task_completion' => 'true',
 				),
-				false,
+				new WP_Error( 'invalid-task-list', 'Task list require last task completion must be a boolean.' ),
+				true,
 			),
 		);
 	}
@@ -91,10 +107,16 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 	 *
 	 * @param array $task_list       Task list to validate.
 	 * @param bool  $expected_result Expected validation result.
+	 * @param bool  $expected_is_wp_error Flag to signal if the expected result is a WP_Error.
 	 * @dataProvider provide_validate_task_list_test_cases
 	 */
-	public function test_validate_task_list( $task_list, $expected_result ) {
+	public function test_validate_task_list( $task_list, $expected_result, $expected_is_wp_error ) {
 		$result = Launchpad_Task_Lists::validate_task_list( $task_list );
+
+		if ( $expected_is_wp_error ) {
+			$this->assertTrue( is_wp_error( $result ) );
+			return;
+		}
 
 		$this->assertSame( $expected_result, $result );
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -94,7 +94,15 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 		);
 
 		return array(
-			// tasks, expected, task_list_options
+			/**
+			 * Test data is in the format of:
+			 *
+			 * 'test name' => array(
+			 *   array( $task1, $task2, ... ),
+			 *   $expected,
+			 *   array( $task_list_options ) (optional)
+			 * )
+			 */
 			'all tasks incomplete should be incomplete using default options'
 				=> array( array( $incomplete_task, $incomplete_task ), false ),
 			'all tasks complete should be complete using default options'

--- a/projects/plugins/mu-wpcom-plugin/changelog/77939-update-task-list-validation
+++ b/projects/plugins/mu-wpcom-plugin/changelog/77939-update-task-list-validation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "8771d7e07a819ec260ba9d61518bf4995d451d16"
+                "reference": "34bbd4fae1060d0617c377e139466db1687b6dbb"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "3.7.x-dev"
+                    "dev-trunk": "4.0.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [77939](https://github.com/Automattic/wp-calypso/issues/77939)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Updated launchpad task list validation return types to be more useful. Previously, we just returned a simple bool. Now we return a WP_Error where appropriate.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `cd` into the `jetpack-mu-wpcom` directory.
* Run the feature tests (you may need to do `composer install` first).
```
./vendor/bin/phpunit -c ./phpunit.xml.dist --testsuite=features
```
* Tests should pass.

