### PR TITLE
Jetpack: Fix warning in API list posts endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-php-warning-in-api-list-posts-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-php-warning-in-api-list-posts-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+API: Fix PHP warning in list posts endpoint.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -445,8 +445,9 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 							if ( ! isset( $return[ $key ] ) ) {
 								$return[ $key ] = (object) array();
 							}
-							if ( isset( $last_post['ID'] ) ) {
-								$return[ $key ]->next_page = $this->build_page_handle( $last_post, $query );
+							$handle = $this->build_page_handle( $last_post, $query );
+							if ( $handle !== null ) {
+								$return[ $key ]->next_page = $handle;
 							}
 						}
 					}
@@ -477,6 +478,9 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		$column = $query['orderby'];
 		if ( ! $column ) {
 			$column = 'date';
+		}
+		if ( ! isset( $post['ID'] ) || ! isset( $post[ $column ] ) ) {
+			return null;
 		}
 		return build_query(
 			array(

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -413,8 +413,9 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 								$return[ $key ] = (object) array();
 							}
 
-							if ( isset( $last_post['ID'] ) ) {
-								$return[ $key ]->next_page = $this->build_page_handle( $last_post, $query );
+							$handle = $this->build_page_handle( $last_post, $query );
+							if ( $handle !== null ) {
+								$return[ $key ]->next_page = $handle;
 							}
 						}
 					}
@@ -445,6 +446,9 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 		$column = $query['orderby'];
 		if ( ! $column ) {
 			$column = 'date';
+		}
+		if ( ! isset( $post['ID'] ) || ! isset( $post[ $column ] ) ) {
+			return null;
 		}
 		return build_query(
 			array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If `fields` is used to restrict output to a set of fields and that set contains "ID" but not the `orderby` field (default "date"), a PHP warning will be issued when trying to calculate the value for .meta.next_page. The value output for .meta.next_page in this case is also broken.

This adds a check for the situation and doesn't output any .meta.next_page in that case.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #31836

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use https://developer.wordpress.com/docs/api/console/ to hit the endpoints (`/sites/$site/posts` in WP.COM API v1.1 and v1.2) with values for `fields` that include and do not include "ID" and the field specified as `orderby`. Verify no PHP warnings logged and that `.meta.next_page` when present looks sensible.

