### PR TITLE
CRM: Show the email sender log if it has notes

### DIFF
--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -41,7 +41,6 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 				'withOwner'                  => true,
 				'withValues'                 => true,
 				'withExternalSourcesGrouped' => true,
-				'withDND'                    => true,
 
 				// but we limit to the top 20 (quotes, invs, trans etc.)
 				// note that this means we have to add calls to specific_obj_type_count_for_assignee, but it protects against contacts with 1000 objs etc.

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -41,6 +41,7 @@ function jpcrm_render_contact_view_page( $id = -1 ) {
 				'withOwner'                  => true,
 				'withValues'                 => true,
 				'withExternalSourcesGrouped' => true,
+				'withDND'                    => true,
 
 				// but we limit to the top 20 (quotes, invs, trans etc.)
 				// note that this means we have to add calls to specific_obj_type_count_for_assignee, but it protects against contacts with 1000 objs etc.

--- a/projects/plugins/crm/changelog/fix-crm-3176-unsubscription-flag-does-not-appear-and-email-sender-log-not-useful
+++ b/projects/plugins/crm/changelog/fix-crm-3176-unsubscription-flag-does-not-appear-and-email-sender-log-not-useful
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: added
 
-Now, unsubscriber contacts are showed in their page as a flag
+Allow to retrieve only logs with notes from the Cron Log System. 

--- a/projects/plugins/crm/changelog/fix-crm-3176-unsubscription-flag-does-not-appear-and-email-sender-log-not-useful
+++ b/projects/plugins/crm/changelog/fix-crm-3176-unsubscription-flag-does-not-appear-and-email-sender-log-not-useful
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Now, unsubscriber contacts are showed in their page as a flag

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -6182,6 +6182,9 @@ class zbsDAL {
         global $ZBSCRM_t,$wpdb; 
         $wheres = array('direct'=>array()); $whereStr = ''; $additionalWhere = ''; $params = array(); $res = array();
 
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$whereStr .= "WHERE jobnotes <> ''";
+
         #} Build query
         $query = "SELECT * FROM ".$ZBSCRM_t['cronmanagerlogs'];
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -6180,11 +6180,6 @@ class zbsDAL {
         global $ZBSCRM_t,$wpdb; 
         $wheres = array('direct'=>array()); $whereStr = ''; $additionalWhere = ''; $params = array(); $res = array();
 
-		if ( $with_notes ) {
-			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			$whereStr .= "WHERE jobnotes <> ''";
-		}
-
         #} Build query
         $query = "SELECT * FROM ".$ZBSCRM_t['cronmanagerlogs'];
 
@@ -6192,6 +6187,10 @@ class zbsDAL {
 
             #} job
             if (!empty($job) && $job > 0) $wheres['job'] = array('job','=','%s',$job);
+
+		if ( $with_notes ) {
+			$wheres['notes'] = array( 'jobnotes', '<>', '%s', '' );
+		}
 
         #} ============ / WHERE ===============
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -6156,20 +6156,18 @@ class zbsDAL {
      */
     public function getCronLogs($args=array()){
 
-        #} ============ LOAD ARGS =============
-        $defaultArgs = array(
+		// ============ LOAD ARGS =============
+		$with_notes = true;
 
-
-            'job'  => '', 
-
-
-            'sortByField'   => 'ID',
-            'sortOrder'     => 'DESC',
-            'page'          => 0,
-            'perPage'       => 100,
-
-            // permissions
-            'ignoreowner'   => false // this'll let you not-check the owner of obj
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$defaultArgs = array(
+			'job'         => '',
+			'sortByField' => 'ID', // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			'sortOrder'   => 'DESC', // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			'page'        => 0,
+			'perPage'     => 100, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			'with_notes'  => true,
+			'ignoreowner' => false, // this'll let you not-check the owner of obj
 
         ); foreach ($defaultArgs as $argK => $argV){ $$argK = $argV; if (is_array($args) && isset($args[$argK])) {  if (is_array($args[$argK])){ $newData = $$argK; if (!is_array($newData)) $newData = array(); foreach ($args[$argK] as $subK => $subV){ $newData[$subK] = $subV; }$$argK = $newData;} else { $$argK = $args[$argK]; } } }
         #} =========== / LOAD ARGS =============
@@ -6182,8 +6180,10 @@ class zbsDAL {
         global $ZBSCRM_t,$wpdb; 
         $wheres = array('direct'=>array()); $whereStr = ''; $additionalWhere = ''; $params = array(); $res = array();
 
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		$whereStr .= "WHERE jobnotes <> ''";
+		if ( $with_notes ) {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$whereStr .= "WHERE jobnotes <> ''";
+		}
 
         #} Build query
         $query = "SELECT * FROM ".$ZBSCRM_t['cronmanagerlogs'];


### PR DESCRIPTION
Fixes: https://github.com/Automattic/zero-bs-crm/issues/3176

## Proposed changes:

This PR adds the possibility to show only system logs if they have notes. For debugging and issue investigation is useful to be able to filter logs and show only logs with notes. Show only log with notes is the default behavior. The `getCronLogs` method is only used by Mail Campaign.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- You need the Mail Campaign extension installed and activated. And [with this PR/branch applied.](https://github.com/Automattic/zero-bs-crm-mailcampaigns/pull/335) to be able to test it well
- Run some mail campaigns if you don't have any done. If you have a testing site with an old mail campaign it'd be ideal, it will already have many logs, so you can check it better.
- [Check the testing instructions for the MC PR](https://github.com/Automattic/zero-bs-crm-mailcampaigns/pull/335)

