### PR TITLE
Live Branches: Don't allow selecting unbuilt plugins

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -33,7 +33,7 @@
 		}
 
 		#jetpack-live-branches label.disabled {
-			color: rgba(0,0,0,0.5);
+			color: var( --color-fg-muted, #7d8590 );
 		}
 	`;
 

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.28
+// @version      1.29
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      jurassic.ninja
@@ -17,6 +17,25 @@
 	const $ = jQuery.noConflict();
 	const markdownBodySelector = '.pull-discussion-timeline .markdown-body';
 	let pluginsList = null;
+
+	const style = document.createElement( 'style' );
+	style.innerHTML = `
+		#jetpack-live-branches .optionslist {
+			list-style: none;
+			padding-left: 0;
+			margin-top: 24px;
+			display: flex;
+			flex-wrap: wrap;
+		}
+
+		#jetpack-live-branches label {
+			font-weight: inherit;
+		}
+
+		#jetpack-live-branches label.disabled {
+			color: rgba(0,0,0,0.5);
+		}
+	`;
 
 	// Watch for relevant DOM changes that indicate we need to re-run `doit()`:
 	// - Adding a new `.markdown-body`.
@@ -99,7 +118,9 @@
 			);
 		} else {
 			if ( ! pluginsList ) {
-				pluginsList = dofetch( `${ host }/wp-json/jurassic.ninja/jetpack-beta/plugins` );
+				pluginsList = dofetch(
+					`${ host }/wp-json/jurassic.ninja/jetpack-beta/branches/${ repo }/${ currentBranch }`
+				);
 			}
 			pluginsList
 				.then( body => {
@@ -109,21 +130,30 @@
 						const labels = new Set(
 							$.map( $( '.js-issue-labels a.IssueLabel' ), e => $( e ).data( 'name' ) )
 						);
-						Object.keys( body.data ).forEach( k => {
-							const data = body.data[ k ];
-							if ( data.repo === repo ) {
-								plugins.push( {
-									name: `branches.${ k }`,
-									value: currentBranch,
-									label: encodeHtmlEntities( data.name ),
-									checked: data.labels && data.labels.some( l => labels.has( l ) ),
-								} );
-							}
+						Object.keys( body.data.plugins ).forEach( k => {
+							const data = body.data.plugins[ k ];
+							plugins.push( {
+								name: `branches.${ k }`,
+								value: currentBranch,
+								label: encodeHtmlEntities( data.name ),
+								checked:
+									data.pr !== null && data.labels && data.labels.some( l => labels.has( l ) ),
+								disabled:
+									data.pr === null ? `${ data.name } has not been built for this PR` : false,
+							} );
 						} );
 						if ( ! plugins.length ) {
 							throw new Error( `No plugins are configured for ${ repo }` );
 						}
 						plugins.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+
+						if ( ! plugins.some( p => ! p.disabled ) ) {
+							appendHtml(
+								markdownBody,
+								'<p><strong>No plugins have been built for this PR.</strong> (<a href="#" class="refresh">refresh</a>)</p>'
+							);
+							return;
+						}
 					} else if ( body.code === 'rest_no_route' ) {
 						plugins.push( {
 							name: 'branch',
@@ -268,7 +298,7 @@
 					appendHtml(
 						markdownBody,
 						// prettier-ignore
-						`<p><strong>Error while fetching data for live testing: ${ encodeHtmlEntities( e.message ) }.</strong></p>`
+						`<p><strong>Error while fetching data for live testing: ${ encodeHtmlEntities( e.message ) }.</strong> (<a href="#" class="refresh">retry</a>)</p>`
 					);
 				} );
 		}
@@ -350,7 +380,7 @@
 		 * @param {string} opts.name - Checkbox name.
 		 * @param {string} [opts.value] - Checkbox value, if any.
 		 * @param {boolean} [opts.checked] - Whether the checkbox is default checked.
-		 * @param {boolean} [opts.disabled] - Whether the checkbox is disabled.
+		 * @param {boolean|string} [opts.disabled] - Whether the checkbox is disabled. If a string, the string is used as a title attribute on the label.
 		 * @param {boolean} [opts.invert] - Whether the sense of the checkbox is inverted.
 		 * @param {number} columnWidth - Column width.
 		 * @returns {string} HTML.
@@ -361,12 +391,12 @@
 		) {
 			// prettier-ignore
 			return `
-			<li style="min-width: ${ columnWidth }%">
-				<label style="font-weight: inherit; ">
-					<input type="checkbox" name="${ encodeHtmlEntities( name ) }" value="${ encodeHtmlEntities( value ) }"${ checked ? ' checked' : '' }${ disabled ? ' disabled' : '' }${ invert ? ' data-invert' : '' }>
-					${ label }
-				</label>
-			</li>
+				<li style="min-width: ${ columnWidth }%">
+					<label class="${ disabled ? 'disabled' : '' }" ${ typeof disabled === 'string' ? 'title="' + encodeHtmlEntities( disabled ) + '"' : '' }>
+						<input type="checkbox" name="${ encodeHtmlEntities( name ) }" value="${ encodeHtmlEntities( value ) }"${ checked ? ' checked' : '' }${ disabled ? ' disabled' : '' }${ invert ? ' data-invert' : '' }>
+						${ label }
+					</label>
+				</li>
 			`;
 		}
 
@@ -378,13 +408,10 @@
 		 * @returns {string} HTML.
 		 */
 		function getOptionsList( options, columnWidth ) {
+			// prettier-ignore
 			return `
-				<ul style="list-style: none; padding-left: 0; margin-top: 24px; display: flex; flex-wrap: wrap;">
-					${ options
-						.map( option => {
-							return getOption( option, columnWidth );
-						} )
-						.join( '' ) }
+				<ul class="optionslist">
+					${ options.map( option => getOption( option, columnWidth ) ).join( '' ) }
 				</ul>
 			`;
 		}
@@ -403,10 +430,10 @@
 				`<h2>Jetpack Live Branches</h2> ${ contents }`
 			);
 			$( '#jetpack-live-branches' ).remove();
+			liveBranches.prepend( style );
 			$el.append( liveBranches );
-			liveBranches
-				.find( 'input[type=checkbox]' )
-				.each( () => this.addEventListener( 'change', onInputChanged ) );
+			liveBranches.find( 'input[type=checkbox]' ).on( 'change', onInputChanged );
+			liveBranches.find( 'a.refresh' ).on( 'click', onRefreshClick );
 		}
 
 		/**
@@ -423,6 +450,21 @@
 				e.target.removeAttribute( 'checked' );
 			}
 			updateLink();
+		}
+
+		/**
+		 * Refresh link click handler.
+		 *
+		 * @param {Event} e - Event object.
+		 * @returns {false} False.
+		 */
+		function onRefreshClick( e ) {
+			e.stopPropagation();
+			e.preventDefault();
+			pluginsList = null;
+			$( '#jetpack-live-branches' ).remove();
+			doit();
+			return false;
 		}
 
 		/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Jurassic Ninja now has an API endpoint that can list which plugins are built for a particular branch. Use that to disable checkboxes for plugins that have not been built.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1680802118831319-slack-C043B54G6V7

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the updated version of the script (e.g. with [this link](https://github.com/Automattic/jetpack/raw/update/live-branches-check-built-plugins/tools/jetpack-live-branches/jetpack-live-branches.user.js)).
* Check that Live Branches on this PR shows a "No plugins have been built for this PR." message. The refresh link should refresh to that same message.
* Go to an open PR that did build some (but not all) plugins. Check that Live Branches works, and only allows selecting the plugins that were actually built.