### PR TITLE
CRM: Fix for Multiline items in the top-right menu

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3152-multiline-names-in-menu
+++ b/projects/plugins/crm/changelog/fix-crm-3152-multiline-names-in-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Menu: Improved alignment for items in the menu

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -269,8 +269,6 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 			});
 		})
 		</script>
-		<style>
-		</style>
 		<!---  // mobile only menu -->
 	<jpcrm-top-menu id="jpcrm-top-menu">
 		<div class="logo-cube <?php echo esc_attr( $admin_menu_state ); ?>">

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -269,6 +269,8 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 			});
 		})
 		</script>
+		<style>
+		</style>
 		<!---  // mobile only menu -->
 	<jpcrm-top-menu id="jpcrm-top-menu">
 		<div class="logo-cube <?php echo esc_attr( $admin_menu_state ); ?>">
@@ -564,23 +566,51 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 
 			// if admin, settings + datatools
 			if ( zeroBSCRM_isZBSAdminOrAdmin() ) {
-				$popout_menu['col1'][] = '<a id="zbs-settings2-top-menu" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['settings'] ) . '" class="item"><i class="settings icon"></i> ' . __( 'Settings', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = sprintf(
+					'<div class="jpcrm-user-menu-link"><a id="zbs-settings2-top-menu" href="%s" class="item"><i class="settings icon"></i> %s</a></div>',
+					zeroBSCRM_getAdminURL( $zbs->slugs['settings'] ),
+					__( 'Settings', 'zero-bs-crm' )
+				);
 				##WLREMOVE
-				$popout_menu['col1'][] = '<a id="zbs-datatools-top-menu" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['datatools'] ) . '" class="item"><i class="wrench icon"></i> ' . __( 'Data Tools', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = sprintf(
+					'<div class="jpcrm-user-menu-link"><a id="zbs-datatools-top-menu" href="%s" class="item"><i class="wrench icon"></i> %s</a></div>',
+					zeroBSCRM_getAdminURL( $zbs->slugs['datatools'] ),
+					__( 'Data Tools', 'zero-bs-crm' )
+				);
 				##/WLREMOVE
 			}
-			// teams page for WP Admin or Jetpack CRM Full Admin
+			// teams page for WP Admin or Jetpack CRM Full Admin.
 			if ( current_user_can( 'manage_options' ) ) {
-				$popout_menu['col1'][] = '<a id="zbs-team-top-menu" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['team'] ) . '" class="item"><i class="icon users"></i> ' . __( 'Team', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = sprintf(
+					'<div class="jpcrm-user-menu-link"><a id="zbs-team-top-menu" href="%s" class="item"><i class="icon users"></i> %s</a></div>',
+					zeroBSCRM_getAdminURL( $zbs->slugs['team'] ),
+					__( 'Team', 'zero-bs-crm' )
+				);
 			}
 
 			// if admin, system status + extensions
 			if ( zeroBSCRM_isZBSAdminOrAdmin() ) {
-				$popout_menu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['systemstatus'] ) . '"><i class="server icon" aria-hidden="true"></i> ' . __( 'System Assistant', 'zero-bs-crm' ) . '</a>';
-				$popout_menu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['emails'] ) . '"><i class="envelope icon" aria-hidden="true"></i> ' . __( 'Emails', 'zero-bs-crm' ) . '</a>';
-				$popout_menu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['modules'] ) . '"><i class="icon th" aria-hidden="true"></i> ' . __( 'Core Modules', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = sprintf(
+					'<div class="jpcrm-user-menu-link"><a class="item" href="%s"><i class="server icon" aria-hidden="true"></i> %s</a></div>',
+					zeroBSCRM_getAdminURL( $zbs->slugs['systemstatus'] ),
+					__( 'System Assistant', 'zero-bs-crm' )
+				);
+				$popout_menu['col1'][] = sprintf(
+					'<div class="jpcrm-user-menu-link"><a class="item" href="%s"><i class="envelope icon" aria-hidden="true"></i> %s</a></div>',
+					zeroBSCRM_getAdminURL( $zbs->slugs['emails'] ),
+					__( 'Emails', 'zero-bs-crm' )
+				);
+				$popout_menu['col1'][] = sprintf(
+					'<div class="jpcrm-user-menu-link"><a class="item" href="%s"><i class="icon th" aria-hidden="true"></i> %s</a></div>',
+					zeroBSCRM_getAdminURL( $zbs->slugs['modules'] ),
+					__( 'Core Modules', 'zero-bs-crm' )
+				);
 				##WLREMOVE
-				$popout_menu['col1'][] = '<a class="item" href="' . zeroBSCRM_getAdminURL( $zbs->slugs['extensions'] ) . '"><i class="icon plug" aria-hidden="true"></i> ' . __( 'Extensions', 'zero-bs-crm' ) . '</a>';
+				$popout_menu['col1'][] = sprintf(
+					'<div class="jpcrm-user-menu-link"><a class="item" href="%s"><i class="icon plug" aria-hidden="true"></i> %s</a></div>',
+					zeroBSCRM_getAdminURL( $zbs->slugs['extensions'] ),
+					__( 'Extensions', 'zero-bs-crm' )
+				);
 				##/WLREMOVE
 
 			}
@@ -623,16 +653,28 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 				<div class="column">
 					<h4 class="ui header"><?php esc_html_e( 'Support', 'zero-bs-crm' ); ?></h4>
 					<div class="ui link list">
-						<a href="<?php echo esc_url( $zbs->urls['docs'] ); ?>" class="item" target="_blank"><i class="file text outline icon"></i> <?php esc_html_e( 'Knowledge base', 'zero-bs-crm' ); ?></a>
-						<a href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['support'] ) ); ?>" class="item"><i class="icon user md"></i> <?php esc_html_e( 'Support', 'zero-bs-crm' ); ?></a>
-						<a href="<?php echo esc_url( $zbs->urls['twitter'] ); ?>" class="item" target="_blank"><i class="icon twitter"></i> <?php esc_html_e( '@jetpackcrm', 'zero-bs-crm' ); ?></a>
-						<a class="item" href="<?php echo esc_url( $zbs->urls['rateuswporg'] ); ?>"><i class="star icon" aria-hidden="true"></i> <?php esc_html_e( 'Leave a review', 'zero-bs-crm' ); ?></a>
+						<div class="jpcrm-user-menu-link">
+							<a href="<?php echo esc_url( $zbs->urls['docs'] ); ?>" class="item" target="_blank"><i class="file text outline icon"></i> <?php esc_html_e( 'Knowledge base', 'zero-bs-crm' ); ?></a>
+						</div>
+						<div class="jpcrm-user-menu-link">
+							<a href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['support'] ) ); ?>" class="item"><i class="icon user md"></i> <?php esc_html_e( 'Support', 'zero-bs-crm' ); ?></a>
+						</div>
+						<div class="jpcrm-user-menu-link">
+							<a href="<?php echo esc_url( $zbs->urls['twitter'] ); ?>" class="item" target="_blank"><i class="icon twitter"></i> <?php esc_html_e( '@jetpackcrm', 'zero-bs-crm' ); ?></a>
+						</div>
+						<div class="jpcrm-user-menu-link">
+							<a class="item" href="<?php echo esc_url( $zbs->urls['rateuswporg'] ); ?>"><i class="star icon" aria-hidden="true"></i> <?php esc_html_e( 'Leave a review', 'zero-bs-crm' ); ?></a>
+						</div>
 						<?php
 						// welcome tour and crm resources page for admins :)
 						if ( zeroBSCRM_isZBSAdminOrAdmin() ) {
 							?>
-							<a id="zbs-tour-top-menu-dash" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['dash'] ) ); ?>&zbs-welcome-tour=1" class="item"><i class="icon magic"></i> <?php esc_html_e( 'Welcome Tour', 'zero-bs-crm' ); ?></a>
-							<a id="crm-resources-top-menu-dash" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['crmresources'] ) ); ?>" class="item"><i class="icon building"></i> <?php esc_html_e( 'Resources', 'zero-bs-crm' ); ?></a>
+							<div class="jpcrm-user-menu-link">
+								<a id="zbs-tour-top-menu-dash" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['dash'] ) ); ?>&zbs-welcome-tour=1" class="item"><i class="icon magic"></i> <?php esc_html_e( 'Welcome Tour', 'zero-bs-crm' ); ?></a>
+							</div>
+							<div class="jpcrm-user-menu-link">
+								<a id="crm-resources-top-menu-dash" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['crmresources'] ) ); ?>" class="item"><i class="icon building"></i> <?php esc_html_e( 'Resources', 'zero-bs-crm' ); ?></a>
+							</div>
 							<?php
 						}
 						?>
@@ -645,13 +687,17 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 					<h4 class="ui header"><?php echo esc_html( $currentUser->display_name ); ?></h4>
 					<div class="ui link list">
 
-					<a id="zbs-profile-top-menu" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['your-profile'] ) ); ?>" class="item"><i class="icon user"></i> <?php esc_html_e( 'Your Profile', 'zero-bs-crm' ); ?></a>
+					<div class="jpcrm-user-menu-link">
+						<a id="zbs-profile-top-menu" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['your-profile'] ) ); ?>" class="item"><i class="icon user"></i> <?php esc_html_e( 'Your Profile', 'zero-bs-crm' ); ?></a>
+					</div>
 
 					<?php
 					if ( zeroBSCRM_getSetting( 'feat_calendar' ) > 0 ) {
 						$cID = get_current_user_id();
 						?>
-					<a id="zbs-events2-top-menu" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['manage-events'] ) ); ?>&zbsowner=<?php echo esc_attr( $cID ); ?>" class="item"><i class="icon tasks"></i> <?php esc_html_e( 'Your Tasks', 'zero-bs-crm' ); ?></a>
+					<div class="jpcrm-user-menu-link">
+						<a id="zbs-events2-top-menu" href="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['manage-events'] ) ); ?>&zbsowner=<?php echo esc_attr( $cID ); // phpcs:ignore ?>" class="item"><i class="icon tasks"></i> <?php esc_html_e( 'Your Tasks', 'zero-bs-crm' ); ?></a>
+					</div>
 					<?php } ?>
 
 					<?php
@@ -659,13 +705,16 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 					if ( ! zeroBSCRM_hasPaidExtensionActivated() && zeroBSCRM_isZBSAdminOrAdmin() ) {
 						?>
 						
-						<a class="item" href="<?php echo esc_url( $zbs->urls['pricing'] ); ?>" target="_blank"><i class="rocket icon" aria-hidden="true"></i> <?php esc_html_e( 'Plans', 'zero-bs-crm' ); ?></a>
-
+						<div class="jpcrm-user-menu-link">
+							<a class="item" href="<?php echo esc_url( $zbs->urls['pricing'] ); ?>" target="_blank"><i class="rocket icon" aria-hidden="true"></i> <?php esc_html_e( 'Plans', 'zero-bs-crm' ); ?></a>
+						</div>
 					<?php } ##/WLREMOVE ?>
 
-					<div class="ui divider"></div>
+						<div class="ui divider"></div>
 
-					<a href="<?php echo esc_url( wp_logout_url() ); ?>" class="item"><i class="icon sign out"></i> <?php esc_html_e( 'Log Out', 'zero-bs-crm' ); ?></a>
+						<div class="jpcrm-user-menu-link">
+							<a href="<?php echo esc_url( wp_logout_url() ); ?>" class="item"><i class="icon sign out"></i> <?php esc_html_e( 'Log Out', 'zero-bs-crm' ); ?></a>
+						</div>
 					</div>
 				</div>
 				</div>

--- a/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
+++ b/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
@@ -57,7 +57,6 @@ jpcrm-top-menu#jpcrm-top-menu {
 				color: var(--jp-black);
 				padding: 1em;
 				line-height: 1;
-				white-space: nowrap;
 
 				&.current_menu_item {
 					border-bottom: 2px solid var(--jp-black);
@@ -75,7 +74,28 @@ jpcrm-top-menu#jpcrm-top-menu {
 				min-width:580px;
 
 				i.icon {
-					margin-right: 5px;
+					margin-right: 8px;
+				}
+			}
+
+			.jpcrm-user-menu-link {
+				display: flex;
+				align-items: flex-start;
+
+				.item {
+					display: flex;
+					align-items: center;
+
+					i {
+						margin-right: 10px;
+						color: rgba(0, 0, 0, 0.4);
+					}
+				}
+
+				&:hover {
+					.item i {
+						color: rgba(0, 0, 0, 0.87);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Proposed changes:
* This PR enhances the alignment of the top right menu items. Previously, when the text was too long, it would wrap under the icon, but now it respects the alignment and wraps appropriately within its own space.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3152

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Change the language to spanish

In `trunk` you should get something like this:
![image](https://github.com/Automattic/jetpack/assets/37049295/dc4744fc-b084-4b12-bf3b-834f385cbf72)

In `fix/crm/3152-multiline-names-in-menu` you should see the items alignment as the screenshot below:
![image](https://github.com/Automattic/jetpack/assets/37049295/c8292f99-54b4-45b0-830a-b8c5f06ca4b8)



