### PR TITLE
Add a login link to newsletter paywall

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-paywall-add-login-link
+++ b/projects/plugins/jetpack/changelog/update-subscribe-paywall-add-login-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add login link to newsletter paywall

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -832,7 +832,7 @@ function get_locked_content_placeholder_text( $newsletter_access_level ) {
 			<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->
 
 			<!-- wp:paragraph {"align":"center"} -->
-			<p class="has-text-align-center">' . esc_html( $access_question ) . ' <a href="#">' . esc_html__( 'Login', 'jetpack' ) . '</a></p>
+			<p class="has-text-align-center">' . esc_html( $access_question ) . ' <a href="#" class="jetpack-subscriber-paywall-login">' . esc_html__( 'Login', 'jetpack' ) . '</a></p>
 			<!-- /wp:paragraph -->
 
 			</div>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -809,29 +809,32 @@ function maybe_gate_existing_comments( $comment ) {
  * @return string
  */
 function get_locked_content_placeholder_text( $newsletter_access_level ) {
-	// Default to subscribers
-	$access_level = __( 'subscribers', 'jetpack' );
+	// Only display paid texts when Stripe is connected and the post is marked for paid subscribers
+	$is_paid_post = $newsletter_access_level === 'paid_subscribers'
+		&& ! empty( Jetpack_Memberships::get_connected_account_id() );
 
-	// Only display this text when Stripe is connected and the post is marked for paid subscribers
-	if (
-		$newsletter_access_level === 'paid_subscribers'
-		&& ! empty( Jetpack_Memberships::get_connected_account_id() )
-	) {
-		$access_level = __( 'paid subscribers', 'jetpack' );
-	}
+	$access_heading = $is_paid_post
+		? __( 'This post is for paid subscribers', 'jetpack' )
+		: __( 'This post is for subscribers', 'jetpack' );
+
+	$access_question = $is_paid_post
+		? __( 'Already a paid subscriber?', 'jetpack' )
+		: __( 'Already a subscriber?', 'jetpack' );
 
 	return do_blocks(
 		'<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","right":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80"}},"border":{"width":"1px","radius":"4px"}},"borderColor":"primary","layout":{"type":"constrained","contentSize":"400px"}} -->
-			<div class="wp-block-group has-border-color has-primary-border-color" style="border-width:1px;border-radius:4px;padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--80)"><!-- wp:heading {"textAlign":"center","style":{"typography":{"fontSize":"24px"},"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} -->
-			<h2 class="wp-block-heading has-text-align-center" style="margin-bottom:var(--wp--preset--spacing--60);font-size:24px">' .
+			<div class="wp-block-group has-border-color has-primary-border-color" style="border-width:1px;border-radius:4px;padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--80)">
 
-			/* translators: Newsletter access. Possible values are "paid newsletters" and "subscribers" */
-			sprintf( esc_html__( 'This post is for %s', 'jetpack' ), $access_level )
-
-			. '</h2>
+			<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontSize":"24px"},"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} -->
+			<h2 class="wp-block-heading has-text-align-center" style="margin-bottom:var(--wp--preset--spacing--60);font-size:24px">' . esc_html( $access_heading ) . '</h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->
+
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">' . esc_html( $access_question ) . ' <a href="#">' . esc_html__( 'Login', 'jetpack' ) . '</a></p>
+			<!-- /wp:paragraph -->
+
 			</div>
 		<!-- /wp:group -->'
 	);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -832,7 +832,7 @@ function get_locked_content_placeholder_text( $newsletter_access_level ) {
 			<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->
 
 			<!-- wp:paragraph {"align":"center"} -->
-			<p class="has-text-align-center">' . esc_html( $access_question ) . ' <a href="#" class="jetpack-subscriber-paywall-login">' . esc_html__( 'Login', 'jetpack' ) . '</a></p>
+			<p class="has-text-align-center">' . esc_html( $access_question ) . ' <a href="#" class="jetpack-subscriber-paywall-login">' . esc_html__( 'Sign in', 'jetpack' ) . '</a></p>
 			<!-- /wp:paragraph -->
 
 			</div>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -1,15 +1,64 @@
 /* global tb_show, tb_remove */
 
+import domReady from '@wordpress/dom-ready';
 import './view.scss';
 import '../../shared/memberships.scss';
-
-import domReady from '@wordpress/dom-ready';
 import {
 	setPurchaseResultCookie,
 	reloadPageWithPremiumContentQueryString,
 } from '../../../extensions/shared/memberships';
 
-domReady( function () {
+//TODO: Unify this code across premium content, subscribe and payment button.
+const handleIframeResult = function ( eventFromIframe ) {
+	if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
+		let premiumContentJWTToken = '';
+
+		const data = JSON.parse( eventFromIframe.data );
+		if ( data && data.result && data.result.jwt_token ) {
+			// We save the token for now, doing nothing.
+			premiumContentJWTToken = data.result.jwt_token;
+			setPurchaseResultCookie( premiumContentJWTToken );
+		} else if ( data && data.action === 'close' && premiumContentJWTToken ) {
+			// The token was set during the purchase flow, we want to relead the whole page with token in query string so it recognizes that the user is logged in.
+			reloadPageWithPremiumContentQueryString( premiumContentJWTToken, {
+				subscribe: 'success',
+			} );
+		} else if ( data && data.action === 'close' ) {
+			// User just aborted.
+			window.removeEventListener( 'message', handleIframeResult );
+			tb_remove();
+		}
+	}
+};
+
+function handleShowingFormModal( form, email ) {
+	if ( form.resubmitted || ! email ) {
+		return;
+	}
+
+	const url =
+		'https://subscribe.wordpress.com/memberships/?' +
+		'blog=' +
+		form.dataset.blog +
+		'&plan=newsletter' +
+		'&source=jetpack_subscribe' +
+		'&post_access_level=' +
+		form.dataset.post_access_level +
+		'&display=alternate&' +
+		'email=' +
+		encodeURIComponent( email );
+	window.scrollTo( 0, 0 );
+	tb_show( null, url + '&TB_iframe=true', null );
+
+	window.addEventListener( 'message', handleIframeResult, false );
+	const tbWindow = document.querySelector( '#TB_window' );
+	tbWindow.classList.add( 'jetpack-memberships-modal' );
+
+	// This line has to come after the Thickbox has opened otherwise Firefox doesnt scroll to the top.
+	window.scrollTo( 0, 0 );
+}
+
+function initializeSubscriberPayWallLoginLink() {
 	const loginLink = document.querySelector( '.jetpack-subscriber-paywall-login' );
 	if ( ! loginLink ) {
 		return;
@@ -24,107 +73,31 @@ domReady( function () {
 
 		const email = prompt( 'Please enter your email' );
 
-		let premiumContentJWTToken = '';
-		const url =
-			'https://subscribe.wordpress.com/memberships/?' +
-			'blog=' +
-			form.dataset.blog +
-			'&plan=newsletter' +
-			'&source=jetpack_subscribe' +
-			'&post_access_level=' +
-			form.dataset.post_access_level +
-			'&display=alternate&' +
-			'email=' +
-			encodeURIComponent( email );
-		window.scrollTo( 0, 0 );
-		tb_show( null, url + '&TB_iframe=true', null );
+		if ( ! email ) {
+			return;
+		}
 
-		//TODO: Unify this code across premium content, subscribe and payment button.
-		const handleIframeResult = function ( eventFromIframe ) {
-			if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
-				const data = JSON.parse( eventFromIframe.data );
-				if ( data && data.result && data.result.jwt_token ) {
-					// We save the token for now, doing nothing.
-					premiumContentJWTToken = data.result.jwt_token;
-					setPurchaseResultCookie( premiumContentJWTToken );
-				} else if ( data && data.action === 'close' && premiumContentJWTToken ) {
-					// The token was set during the purchase flow, we want to relead the whole page with token in query string so it recognizes that the user is logged in.
-					reloadPageWithPremiumContentQueryString( premiumContentJWTToken, {
-						subscribe: 'success',
-					} );
-				} else if ( data && data.action === 'close' ) {
-					// User just aborted.
-					window.removeEventListener( 'message', handleIframeResult );
-					tb_remove();
-				}
-			}
-		};
-		window.addEventListener( 'message', handleIframeResult, false );
-		const tbWindow = document.querySelector( '#TB_window' );
-		tbWindow.classList.add( 'jetpack-memberships-modal' );
-
-		// This line has to come after the Thickbox has opened otherwise Firefox doesnt scroll to the top.
-		window.scrollTo( 0, 0 );
+		handleShowingFormModal( form, email );
 	} );
-} );
+}
 
-domReady( function () {
+function initializeSubscriberForm() {
 	const form = document.querySelector( '.wp-block-jetpack-subscriptions__container form' );
 	if ( ! form ) {
 		return;
 	}
-	let premiumContentJWTToken = '';
+
 	if ( ! form.payments_attached ) {
 		form.payments_attached = true;
 		form.addEventListener( 'submit', function ( event ) {
-			const email = form.querySelector( 'input[type=email]' ).value;
-			if ( form.resubmitted || ! email ) {
-				return;
-			}
 			event.preventDefault();
-			const url =
-				'https://subscribe.wordpress.com/memberships/?' +
-				'blog=' +
-				form.dataset.blog +
-				'&plan=newsletter' +
-				'&source=jetpack_subscribe' +
-				'&post_access_level=' +
-				form.dataset.post_access_level +
-				'&display=alternate&' +
-				'email=' +
-				encodeURIComponent( email );
-			window.scrollTo( 0, 0 );
-			tb_show( null, url + '&TB_iframe=true', null );
-
-			//TODO: Unify this code across premium content, subscribe and payment button.
-			const handleIframeResult = function ( eventFromIframe ) {
-				if (
-					eventFromIframe.origin === 'https://subscribe.wordpress.com' &&
-					eventFromIframe.data
-				) {
-					const data = JSON.parse( eventFromIframe.data );
-					if ( data && data.result && data.result.jwt_token ) {
-						// We save the token for now, doing nothing.
-						premiumContentJWTToken = data.result.jwt_token;
-						setPurchaseResultCookie( premiumContentJWTToken );
-					} else if ( data && data.action === 'close' && premiumContentJWTToken ) {
-						// The token was set during the purchase flow, we want to relead the whole page with token in query string so it recognizes that the user is logged in.
-						reloadPageWithPremiumContentQueryString( premiumContentJWTToken, {
-							subscribe: 'success',
-						} );
-					} else if ( data && data.action === 'close' ) {
-						// User just aborted.
-						window.removeEventListener( 'message', handleIframeResult );
-						tb_remove();
-					}
-				}
-			};
-			window.addEventListener( 'message', handleIframeResult, false );
-			const tbWindow = document.querySelector( '#TB_window' );
-			tbWindow.classList.add( 'jetpack-memberships-modal' );
-
-			// This line has to come after the Thickbox has opened otherwise Firefox doesnt scroll to the top.
-			window.scrollTo( 0, 0 );
+			const email = form.querySelector( 'input[type=email]' ).value;
+			handleShowingFormModal( form, email );
 		} );
 	}
+}
+
+domReady( function () {
+	initializeSubscriberPayWallLoginLink();
+	initializeSubscriberForm();
 } );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -10,6 +10,65 @@ import {
 } from '../../../extensions/shared/memberships';
 
 domReady( function () {
+	const loginLink = document.querySelector( '.jetpack-subscriber-paywall-login' );
+	if ( ! loginLink ) {
+		return;
+	}
+
+	loginLink.addEventListener( 'click', function ( event ) {
+		event.preventDefault();
+		const form = document.querySelector( '.wp-block-jetpack-subscriptions__container form' );
+		if ( ! form ) {
+			return;
+		}
+
+		const email = prompt( 'Please enter your email' );
+
+		let premiumContentJWTToken = '';
+		const url =
+			'https://subscribe.wordpress.com/memberships/?' +
+			'blog=' +
+			form.dataset.blog +
+			'&plan=newsletter' +
+			'&source=jetpack_subscribe' +
+			'&post_access_level=' +
+			form.dataset.post_access_level +
+			'&display=alternate&' +
+			'email=' +
+			encodeURIComponent( email );
+		window.scrollTo( 0, 0 );
+		tb_show( null, url + '&TB_iframe=true', null );
+
+		//TODO: Unify this code across premium content, subscribe and payment button.
+		const handleIframeResult = function ( eventFromIframe ) {
+			if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
+				const data = JSON.parse( eventFromIframe.data );
+				if ( data && data.result && data.result.jwt_token ) {
+					// We save the token for now, doing nothing.
+					premiumContentJWTToken = data.result.jwt_token;
+					setPurchaseResultCookie( premiumContentJWTToken );
+				} else if ( data && data.action === 'close' && premiumContentJWTToken ) {
+					// The token was set during the purchase flow, we want to relead the whole page with token in query string so it recognizes that the user is logged in.
+					reloadPageWithPremiumContentQueryString( premiumContentJWTToken, {
+						subscribe: 'success',
+					} );
+				} else if ( data && data.action === 'close' ) {
+					// User just aborted.
+					window.removeEventListener( 'message', handleIframeResult );
+					tb_remove();
+				}
+			}
+		};
+		window.addEventListener( 'message', handleIframeResult, false );
+		const tbWindow = document.querySelector( '#TB_window' );
+		tbWindow.classList.add( 'jetpack-memberships-modal' );
+
+		// This line has to come after the Thickbox has opened otherwise Firefox doesnt scroll to the top.
+		window.scrollTo( 0, 0 );
+	} );
+} );
+
+domReady( function () {
 	const form = document.querySelector( '.wp-block-jetpack-subscriptions__container form' );
 	if ( ! form ) {
 		return;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -12,8 +12,8 @@ import {
 const handleIframeResult = function ( eventFromIframe ) {
 	if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
 		let premiumContentJWTToken = '';
-
 		const data = JSON.parse( eventFromIframe.data );
+
 		if ( data && data.result && data.result.jwt_token ) {
 			// We save the token for now, doing nothing.
 			premiumContentJWTToken = data.result.jwt_token;
@@ -31,7 +31,7 @@ const handleIframeResult = function ( eventFromIframe ) {
 	}
 };
 
-function handleShowingFormModal( form, email ) {
+function showPaidSubscriptionsModal( form, email ) {
 	if ( form.resubmitted || ! email ) {
 		return;
 	}
@@ -58,7 +58,30 @@ function handleShowingFormModal( form, email ) {
 	window.scrollTo( 0, 0 );
 }
 
-function initializeSubscriberPayWallLoginLink() {
+/**
+ * Initialize the free/paid subscription modal that triggers from submitting subscription form.
+ */
+function initializeSubscriptionsForm() {
+	const form = document.querySelector( '.wp-block-jetpack-subscriptions__container form' );
+	if ( ! form ) {
+		return;
+	}
+
+	if ( ! form.payments_attached ) {
+		form.payments_attached = true;
+		form.addEventListener( 'submit', function ( event ) {
+			event.preventDefault();
+			const email = form.querySelector( 'input[type=email]' ).value;
+			showPaidSubscriptionsModal( form, email );
+		} );
+	}
+}
+
+/**
+ * Initiatlize "login" link in the paywall / subscriber wall, which opens the modal from subscribe block .
+ * The wall already contains subscriber block we can rely form being there.
+ */
+function initializeLockedContent() {
 	const loginLink = document.querySelector( '.jetpack-subscriber-paywall-login' );
 	if ( ! loginLink ) {
 		return;
@@ -77,27 +100,11 @@ function initializeSubscriberPayWallLoginLink() {
 			return;
 		}
 
-		handleShowingFormModal( form, email );
+		showPaidSubscriptionsModal( form, email );
 	} );
 }
 
-function initializeSubscriberForm() {
-	const form = document.querySelector( '.wp-block-jetpack-subscriptions__container form' );
-	if ( ! form ) {
-		return;
-	}
-
-	if ( ! form.payments_attached ) {
-		form.payments_attached = true;
-		form.addEventListener( 'submit', function ( event ) {
-			event.preventDefault();
-			const email = form.querySelector( 'input[type=email]' ).value;
-			handleShowingFormModal( form, email );
-		} );
-	}
-}
-
 domReady( function () {
-	initializeSubscriberPayWallLoginLink();
-	initializeSubscriberForm();
+	initializeSubscriptionsForm();
+	initializeLockedContent();
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/jetpack/issues/31857

TODO:

- [ ] Better looking email prompt
- [ ] ~Splitting code into separate files in a way that makes sense for subscribe block and paywall separately~. I looked into this but concluded it isn't worth it at least yet; we're adding small amount of JS for the link, but duplicating the rest would actually mean _more_ JS in total for anyone with paywall showing up. That might change if we add some styles/JS into the mix for asking the email, but it's also a good follow-up PR.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Cleans out translations so that we send full sentences for translations; partial ones are kind of impossible to translate in many languages. I could split that to its own PR though.
* Adds "login" links to the paywall

<img width="694" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/43928bee-4ba4-4f62-949c-260bb78c4a57">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have subscriptions module enabled in Jetpack, or use WP.com simple site
* Connect Stripe and set payments from WP.com `/earn` page or use links at post editor's "Newsletter" sidepanel
* Create two new posts; one for subscribers only, another for paid subscribers only.
* Create a new free subscriber at the site, and paid subscriber
* Try login for both posts with both users

