### PR TITLE
Contact Form: avoid Fatal errors when exporting to CSV

### DIFF
--- a/projects/packages/forms/changelog/fix-bad-extra-fields
+++ b/projects/packages/forms/changelog/fix-bad-extra-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid Fatal errors when exporting fields that were not saved with the correct value.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1262,7 +1262,7 @@ class Contact_Form_Plugin {
 		$all_fields     = isset( $content_fields['_feedback_all_fields'] ) ? $content_fields['_feedback_all_fields'] : array();
 		$md             = $has_json_data
 			? array_diff_key( $all_fields, array_flip( array( 'entry_title', 'email_marketing_consent', 'entry_permalink', 'feedback_id' ) ) )
-			: get_post_meta( $post_id, '_feedback_extra_fields', true );
+			: (array) get_post_meta( $post_id, '_feedback_extra_fields', true );
 
 		$md['-3_response_date'] = get_the_date( 'Y-m-d H:i:s', $post_id );
 		$md['93_ip_address']    = ( isset( $content_fields['_feedback_ip'] ) ) ? $content_fields['_feedback_ip'] : 0;

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1741,7 +1741,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			foreach ( $vars as $key => $data ) {
 				$value->{$key} = $this->addslashes_deep( $data );
 			}
-			return $value;
+			return (array) $value;
 		}
 
 		return addslashes( $value );

--- a/projects/plugins/jetpack/changelog/fix-bad-extra-fields
+++ b/projects/plugins/jetpack/changelog/fix-bad-extra-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Contact Form: avoid Fatal errors when exporting form data to CSV.

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -1357,7 +1357,7 @@ class Grunion_Contact_Form_Plugin {
 	 * @return mixed
 	 */
 	public function get_post_meta_for_csv_export( $post_id ) {
-		$md                     = get_post_meta( $post_id, '_feedback_extra_fields', true );
+		$md                     = (array) get_post_meta( $post_id, '_feedback_extra_fields', true );
 		$md['-3_response_date'] = get_the_date( 'Y-m-d H:i:s', $post_id );
 		$content_fields         = self::parse_fields_from_content( $post_id );
 		$md['93_ip_address']    = ( isset( $content_fields['_feedback_ip'] ) ) ? $content_fields['_feedback_ip'] : 0;
@@ -4304,7 +4304,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			foreach ( $vars as $key => $data ) {
 				$value->{$key} = $this->addslashes_deep( $data );
 			}
-			return $value;
+			return (array) $value;
 		}
 
 		return addslashes( $value );


### PR DESCRIPTION
Fixes #31855

## Proposed changes:

In some scenarios, `_feedback_extra_fields` may have been saved incorrectly.

1. Let's ensure it will always be saved as an array in the future.
2. Let's avoid Fatal errors when trying to handle existing form data that may not be an array.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On WordPress.com Simple, sandbox test site mentioned in p1689233805753299/1689212150.356039-slack-C03TY6J1A
* Apply patch
* Tail logs
* Try to export form data
* See that the data exported is there and you have no errors in logs.
