### PR TITLE
Related Posts: do not display block outside of WP context

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-emails
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Related Posts: do not display them in emails and outside of WordPress context.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -460,10 +460,15 @@ EOT;
 	/**
 	 * Render the related posts markup.
 	 *
-	 * @param array $attributes Block attributes.
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    String containing the related Posts block content.
 	 * @return string
 	 */
-	public function render_block( $attributes ) {
+	public function render_block( $attributes, $content ) {
+		if ( ! jetpack_is_frontend() ) {
+			return $content;
+		}
+
 		$wrapper_attributes = array();
 		$post_id            = get_the_ID();
 		$block_attributes   = array(


### PR DESCRIPTION
Fixes #31802

## Proposed changes:

Since Related Posts rely on extra CSS to be displayed nicely, let's not try to display them in context where CSS is not present.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pejTkB-yT-p2#comment-626

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

There are different ways to test this:

* Start with a site with a lot of published posts, where the Related Posts feature is active.
* Edit an existing post where you have related posts, and add the Related Posts block to the post content
    * Alternatively, you can also publish a brand new post with some content and the related posts block. Just make sure it has enough content to start getting related posts right away.
* View that post on your site
    * the related posts should be displayed nicely.

**Via [the WordPress.com API console](https://developer.wordpress.com/docs/api/console/)**

* Load that same post via the /posts/id endpoint.
* Ensure the related posts block is not displayed in the API response.

**Via email**

* Apply this branch to your WordPress.com sandbox.
* Sandbox a site where you have related posts
* Publish a new post with a Related Posts block
* run `php ./bin/subscriptions/send.php <BLOG_ID> post <POST_ID> <YOUR_EMAIL>`
* The email you receive should not include a related posts block.
