### PR TITLE
Boost: Fix speed score auto refreshing on page load

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -54,6 +54,16 @@
 		},
 	} );
 
+	let setinitialScoreConfigString = false;
+	$: initialScoreConfigString = () => {
+		if ( ! setinitialScoreConfigString ) {
+			setinitialScoreConfigString = true;
+			return currentScoreConfigString;
+		}
+
+		return false;
+	};
+
 	async function refreshScore( force = false ) {
 		if ( ! siteIsOnline ) {
 			return;
@@ -89,7 +99,7 @@
 	let modalData: ScoreChangeMessage | null = null;
 	$: modalData = ! isLoading && ! scores.isStale && scoreChangeModal( scores );
 
-	$: if ( currentScoreConfigString && $isGenerating === false ) {
+	$: if ( initialScoreConfigString() !== currentScoreConfigString && $isGenerating === false ) {
 		debouncedRefreshScore( true );
 	}
 

--- a/projects/plugins/boost/changelog/fix-speed-score-auto-refreshing-on-page-load
+++ b/projects/plugins/boost/changelog/fix-speed-score-auto-refreshing-on-page-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevented page speed scores from auto refreshing on page load.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31396

### Notes

My idea was to create a helper variable, that holds the state of the config after initial page load. The variable would then be used to prevent auto refreshes. I'm not entirely happy with the solution, though it seems to work. I would love to implement a proper one.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent speed scores from automatically refreshing each time the Boost settings page is loaded.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test if it's broken

* Follow the "Steps to reproduce" section in the ticket - https://github.com/Automattic/jetpack/issues/31396.

### Test that it works

* Setup this version of Boost
* Open the Boost settings page and make sure the speed scores aren't automatically refreshed.