### PR TITLE
Update Subscribe modal details

### DIFF
--- a/projects/plugins/jetpack/changelog/update subscribe modal details
+++ b/projects/plugins/jetpack/changelog/update subscribe modal details
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: change copies and categories
+
+

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -28,6 +28,9 @@ class Jetpack_Subscribe_Modal {
 		return self::$instance;
 	}
 
+	const BLOCK_TEMPLATE_PART_SLUG = 'jetpack-subscribe-modal';
+	const BLOCK_TEMPLATE_PART_ID   = 'jetpack//jetpack-subscribe-modal';
+
 	/**
 	 * Jetpack_Subscribe_Modal class constructor.
 	 */
@@ -61,7 +64,7 @@ class Jetpack_Subscribe_Modal {
 		if ( $this->is_front_end_single_post() ) { ?>
 					<div class="jetpack-subscribe-modal">
 						<div class="jetpack-subscribe-modal__modal-content">
-				<?php block_template_part( 'jetpack-subscribe-modal' ); ?>
+				<?php block_template_part( self::BLOCK_TEMPLATE_PART_SLUG ); ?>
 						</div>
 					</div>
 			<?php
@@ -78,10 +81,10 @@ class Jetpack_Subscribe_Modal {
 	 * @return WP_Block_Template
 	 */
 	public function get_block_template_filter( $block_template, $id, $template_type ) {
-		$custom_template = $this->get_custom_template();
-
-		if ( empty( $block_template ) && $template_type === 'wp_template_part' && $id === $custom_template->id ) {
-			$block_template = $custom_template;
+		if ( empty( $block_template ) && $template_type === 'wp_template_part' ) {
+			if ( $id === self::BLOCK_TEMPLATE_PART_ID ) {
+				return $this->get_custom_template();
+			}
 		}
 
 		return $block_template;
@@ -98,6 +101,14 @@ class Jetpack_Subscribe_Modal {
 	 */
 	public function get_block_templates_filter( $query_result, $query, $template_type ) {
 		if ( empty( $query ) && $template_type === 'wp_template_part' ) {
+			if ( is_array( $query_result ) ) {
+				// find the custom template and return early if we have a custom version in the results.
+				foreach ( $query_result as $template ) {
+					if ( $template->id === self::BLOCK_TEMPLATE_PART_ID ) {
+						return $query_result;
+					}
+				}
+			}
 			$query_result[] = $this->get_custom_template();
 		}
 
@@ -111,18 +122,18 @@ class Jetpack_Subscribe_Modal {
 	 */
 	public function get_custom_template() {
 		$template                 = new WP_Block_Template();
-		$template->theme          = get_stylesheet();
-		$template->slug           = 'jetpack-subscribe-modal';
-		$template->id             = $template->theme . '//' . $template->slug;
-		$template->area           = 'footer';
+		$template->theme          = 'jetpack';
+		$template->slug           = self::BLOCK_TEMPLATE_PART_SLUG;
+		$template->id             = self::BLOCK_TEMPLATE_PART_ID;
+		$template->area           = 'uncategorized';
 		$template->content        = $this->get_subscribe_template_content();
 		$template->source         = 'plugin';
 		$template->type           = 'wp_template_part';
-		$template->title          = 'Subscribe Modal Template 2';
+		$template->title          = __( 'Jetpack Subscribe modal', 'jetpack' );
 		$template->status         = 'publish';
 		$template->has_theme_file = false;
 		$template->is_custom      = true;
-		$template->description    = 'Subscribe Modal Templateasdf';
+		$template->description    = __( 'A subscribe form that pops up when someone visits your site', 'jetpack' );
 
 		return $template;
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -29,7 +29,15 @@ class Jetpack_Subscribe_Modal {
 	}
 
 	const BLOCK_TEMPLATE_PART_SLUG = 'jetpack-subscribe-modal';
-	const BLOCK_TEMPLATE_PART_ID   = 'jetpack//jetpack-subscribe-modal';
+
+	/**
+	 * Returns the block template part ID.
+	 *
+	 * @return string
+	 */
+	public static function get_block_template_part_id() {
+		return get_stylesheet() . '//' . self::BLOCK_TEMPLATE_PART_SLUG;
+	}
 
 	/**
 	 * Jetpack_Subscribe_Modal class constructor.
@@ -82,8 +90,8 @@ class Jetpack_Subscribe_Modal {
 	 */
 	public function get_block_template_filter( $block_template, $id, $template_type ) {
 		if ( empty( $block_template ) && $template_type === 'wp_template_part' ) {
-			if ( $id === self::BLOCK_TEMPLATE_PART_ID ) {
-				return $this->get_custom_template();
+			if ( $id === self::get_block_template_part_id() ) {
+				return $this->get_template();
 			}
 		}
 
@@ -104,12 +112,12 @@ class Jetpack_Subscribe_Modal {
 			if ( is_array( $query_result ) ) {
 				// find the custom template and return early if we have a custom version in the results.
 				foreach ( $query_result as $template ) {
-					if ( $template->id === self::BLOCK_TEMPLATE_PART_ID ) {
+					if ( $template->id === self::get_block_template_part_id() ) {
 						return $query_result;
 					}
 				}
 			}
-			$query_result[] = $this->get_custom_template();
+			$query_result[] = $this->get_template();
 		}
 
 		return $query_result;
@@ -120,11 +128,11 @@ class Jetpack_Subscribe_Modal {
 	 *
 	 * @return WP_Block_Template
 	 */
-	public function get_custom_template() {
+	public function get_template() {
 		$template                 = new WP_Block_Template();
-		$template->theme          = 'jetpack';
+		$template->theme          = get_stylesheet();
 		$template->slug           = self::BLOCK_TEMPLATE_PART_SLUG;
-		$template->id             = self::BLOCK_TEMPLATE_PART_ID;
+		$template->id             = self::get_block_template_part_id();
 		$template->area           = 'uncategorized';
 		$template->content        = $this->get_subscribe_template_content();
 		$template->source         = 'plugin';


### PR DESCRIPTION
Fixes #31867

## Proposed changes:

- Changes the name of the modal to: **Jetpack Subscribe modal**
- Adds a description: **A subscribe form that pops up when someone visits your site**
- Moves it from the Footers category to Uncategorized

- Refactor, extract constants and make things relative to Jetpack instead of the current theme
- Fixes this bug:  when switching between areas "Headers", "Footers", "Uncategorized" the template is being added again and again to the lists.



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Add this filter to your test site: `add_filter('jetpack_subscriptions_modal_enabled', '__return_true', 12 );`
* In your wp-admin go to Appearance -> Editor -> Library
* Check that the template shows up under Uncategorized
* Make sure that switching between areas doesn't add the modal template again and again
* Check title and descriptions
* Make edits to the Modal and make sure they get persisted and that the actual modal changes in the frontside
* Enjoy and Thanks!

