### PR TITLE
Top posts widget: add srcset to thumbnails

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-srcset-to-top-posts
+++ b/projects/plugins/jetpack/changelog/update-add-srcset-to-top-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Top posts widget: added srcset to thumbnails

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -726,6 +726,47 @@ class Jetpack_PostImages {
 	}
 
 	/**
+	 * Takes an image and base pixel dimensions and returns a srcset for the
+	 * resized and cropped images, based on a fixed set of multipliers.
+	 *
+	 * @param  array $image Array containing details of the image.
+	 * @param  int   $base_width Base image width (i.e., the width at 1x).
+	 * @param  int   $base_height Base image height (i.e., the height at 1x).
+	 * @return string The srcset for the image.
+	 */
+	public static function generate_cropped_srcset( $image, $base_width, $base_height ) {
+		$srcset = '';
+
+		if ( ! is_array( $image ) || empty( $image['src'] ) || empty( $image['src_width'] ) ) {
+			return $srcset;
+		}
+
+		$multipliers   = array( 1, 2, 3, 4 );
+		$srcset_values = array();
+		foreach ( $multipliers as $multiplier ) {
+			// Forcefully cast to int, in case we ever add decimal multipliers.
+			$srcset_width  = (int) ( $base_width * $multiplier );
+			$srcset_height = (int) ( $base_height * $multiplier );
+			if ( $srcset_width < 1 || $srcset_width > $image['src_width'] ) {
+				break;
+			}
+
+			$srcset_url      = self::fit_image_url(
+				$image['src'],
+				$srcset_width,
+				$srcset_height
+			);
+			$srcset_values[] = "{$srcset_url} {$multiplier}x";
+		}
+
+		if ( count( $srcset_values ) > 1 ) {
+			$srcset = implode( ', ', $srcset_values );
+		}
+
+		return $srcset;
+	}
+
+	/**
 	 * Takes an image URL and pixel dimensions then returns a URL for the
 	 * resized and cropped image.
 	 *

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1507,9 +1507,6 @@ EOT;
 
 			if ( is_array( $post_image ) ) {
 				$img_url = $post_image['src'];
-				if ( ! empty( $post_image['src_width'] ) ) {
-					$src_width = $post_image['src_width'];
-				}
 			} elseif ( class_exists( 'Jetpack_Media_Summary' ) ) {
 				$media = Jetpack_Media_Summary::get( $post_id );
 
@@ -1545,26 +1542,13 @@ EOT;
 				);
 
 				// Add a srcset to handle zoomed views and high-density screens.
-				$multipliers   = array( 1, 2, 3, 4 );
-				$srcset_values = array();
-				foreach ( $multipliers as $multiplier ) {
-					// Forcefully cast to int, in case we ever add decimal multipliers.
-					$srcset_width  = (int) ( $thumbnail_width * $multiplier );
-					$srcset_height = (int) ( $thumbnail_height * $multiplier );
-					if ( empty( $src_width ) || $srcset_width < 1 || $srcset_width > $src_width ) {
-						break;
-					}
-
-					$srcset_url      = Jetpack_PostImages::fit_image_url(
-						$img_url,
-						$srcset_width,
-						$srcset_height
-					);
-					$srcset_values[] = "{$srcset_url} {$multiplier}x";
-				}
-
-				if ( count( $srcset_values ) > 1 ) {
-					$image_params['srcset'] = implode( ', ', $srcset_values );
+				$srcset = Jetpack_PostImages::generate_cropped_srcset(
+					$post_image,
+					$thumbnail_width,
+					$thumbnail_height
+				);
+				if ( ! empty( $srcset ) ) {
+					$image_params['srcset'] = $srcset;
 				}
 			}
 		}

--- a/projects/plugins/jetpack/modules/widgets/top-posts.php
+++ b/projects/plugins/jetpack/modules/widgets/top-posts.php
@@ -12,7 +12,6 @@
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
-use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
 use Automattic\Jetpack\Status;
@@ -428,10 +427,20 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 					);
 
 					if ( $image ) {
+						$post['image'] = Jetpack_PostImages::fit_image_url(
+							$image['src'],
+							$width,
+							$height
+						);
 
-						$post['image'] = $image['src'];
-						if ( 'blavatar' !== $image['from'] && 'gravatar' !== $image['from'] ) {
-							$post['image'] = Image_CDN_Core::cdn_url( $post['image'], array( 'resize' => "$width,$height" ) );
+						$post['image_srcset'] = Jetpack_PostImages::generate_cropped_srcset(
+							$image,
+							$width,
+							$height
+						);
+
+						if ( empty( $post['image_srcset'] ) ) {
+							$post['image_srcset'] = "{$post['image']} 1x";
 						}
 					}
 				}
@@ -467,13 +476,14 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 
 						if ( $post['image'] ) {
 							printf(
-								'<a href="%1$s" title="%2$s" class="bump-view" data-bump-view="tp"%3$s><img width="%4$d" height="%5$d" src="%6$s" alt="%2$s" data-pin-nopin="true"/></a>',
+								'<a href="%1$s" title="%2$s" class="bump-view" data-bump-view="tp"%3$s><img loading="lazy" width="%4$d" height="%5$d" src="%6$s" srcset="%7$s" alt="%2$s" data-pin-nopin="true"/></a>',
 								esc_url( $filtered_permalink ),
 								esc_attr( wp_kses( $post['title'], array() ) ),
 								( get_queried_object_id() === $post['post_id'] ? ' aria-current="page"' : '' ),
 								absint( $width ),
 								absint( $height ),
-								esc_url( $post['image'] )
+								esc_url( $post['image'] ),
+								esc_attr( $post['image_srcset'] )
 							);
 						}
 
@@ -504,13 +514,14 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 
 						if ( $post['image'] ) {
 							printf(
-								'<a href="%1$s" title="%2$s" class="bump-view" data-bump-view="tp"%3$s><img width="%4$d" height="%5$d" src="%6$s" alt="%2$s" data-pin-nopin="true" class="widgets-list-layout-blavatar" /></a>',
+								'<a href="%1$s" title="%2$s" class="bump-view" data-bump-view="tp"%3$s><img loading="lazy" width="%4$d" height="%5$d" src="%6$s" srcset="%7$s" alt="%2$s" data-pin-nopin="true" class="widgets-list-layout-blavatar" /></a>',
 								esc_url( $filtered_permalink ),
 								esc_attr( wp_kses( $post['title'], array() ) ),
 								( get_queried_object_id() === $post['post_id'] ? ' aria-current="page"' : '' ),
 								absint( $width ),
 								absint( $height ),
-								esc_url( $post['image'] )
+								esc_url( $post['image'] ),
+								esc_attr( $post['image_srcset'] )
 							);
 						}
 


### PR DESCRIPTION
## Proposed changes:

In an effort to move away from the `devicepx` script towards native functionality, this PR adds a `srcset` to thumbnails in the top posts widget. The browser will automatically pick the most appropriate image from the options in the `srcset`, depending on the screen pixel ratio and the current zoom value.

* Add a `srcset` attribute to thumbnails in the top posts widget
* Add `loading=lazy` to images in the top posts widget
* Extract `srcset`-generation code in related posts, and promote it to `Jetpack_PostImages`
* Refactor related posts to use the extracted code

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
To ensure that top posts work correctly:
- Add a "Top Posts" widget to your test blog
- Configure it to display as an image list or image grid
- Load a test page and ensure that thumbnails display correctly
- Find a thumbnail whose source is a post image (not a gravatar or blavatar), and ensure that it has a `srcset` with different pixel ratios (up to 4x, if the source image is large enough).

To ensure that related posts continue to work correctly after the refactor:
- Enable the "Related Posts" feature for your test blog (`Settings -> Traffic -> Show related content after posts`).
- Enable related posts thumbnails (`Show a thumbnail image where available` in the same place).
- Open a post that has related posts with thumbnails.
- Smoke-test for any breakage.
- Verify that the thumbnails include a `srcset` with different pixel ratios (up to 4x, if the source image is large enough).

