### PR TITLE
Jetpack Related Posts: fix for 31861

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-31861
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-31861
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Follow-up fix for Automattic/jetpack/pull/31861

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -286,7 +286,7 @@ class Jetpack_RelatedPosts {
 			'isServerRendered'  => true,
 		);
 
-		return $this->render_block( $block_rp_settings );
+		return $this->render_block( $block_rp_settings, '' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

Follow-up to #31861 which changed `render_block()` to include a `$content` param, but the function call in `get_server_rendered_html()` was not updated to pass that new param.

See more details in internal: D115970-code

CC: @jeherve 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See more details in internal: D115970-code

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Proofread, related posts functionality should remain unchanged.