### PR TITLE
Subscribe Modal: Fix header styling for long site names

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-title-styles
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-title-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: No changelog entry for one-line style change.
+
+

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -176,8 +176,8 @@ class Jetpack_Subscribe_Modal {
     <div class='wp-block-group' style='padding-top:50px;padding-right:20px;padding-bottom:50px;padding-left:20px'>
         <!-- wp:group {"style":{"dimensions":{"minHeight":"0px"},"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
         <div class='wp-block-group' style='min-height:0px'>
-            <!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","fontSize":"26px"},"layout":{"selfStretch":"fit","flexSize":null}}} -->
-            <h2 class='wp-block-heading' style='font-size:26px;font-style:normal;font-weight:600'>$discover_more_from</h2>
+            <!-- wp:heading {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"600","fontSize":"26px"},"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} -->
+            <h2 class="wp-block-heading has-text-align-center" style="margin-top:4px;margin-bottom:4px;font-size:26px;font-style:normal;font-weight:600">$discover_more_from</h2>
             <!-- /wp:heading -->
             </div>
         <!-- /wp:group -->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -188,8 +188,8 @@ class Jetpack_Subscribe_Modal {
 
         <!-- wp:jetpack/subscriptions {"buttonBackgroundColor":"primary","textColor":"secondary","borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->
         
-        <!-- wp:paragraph {"align":"center","style":{"color":{"text":"#666666"},"typography":{"fontSize":"14px","textDecoration":"underline"}},"className":"jetpack-subscribe-modal__close"} -->
-        <p class='has-text-align-center jetpack-subscribe-modal__close has-text-color' style='color:#666666;font-size:14px;text-decoration:underline'><a href='#'>$continue_reading</a></p>
+        <!-- wp:paragraph {"align":"center","style":{"color":{"text":"#666666"},"typography":{"fontSize":"14px","textDecoration":"none"}},"className":"jetpack-subscribe-modal__close"} -->
+        <p class='has-text-align-center jetpack-subscribe-modal__close has-text-color' style='color:#666666;font-size:14px;text-decoration:none'><a href='#'>$continue_reading</a></p>
         <!-- /wp:paragraph -->
     </div>
     <!-- /wp:group -->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
@@ -29,26 +29,12 @@
 	transition: all 0.4s;
 }
 
-.jetpack-subscribe-modal__modal-content .wp-block-group {
-    justify-content: center;
-	gap: 0;
-}
-
 .jetpack-subscribe-modal__modal-content > .wp-block-group {
     max-width: 450px;
 	margin: 0 auto;
 }
 
-.jetpack-subscribe-modal__modal-content h2 {
-    margin: 4px;
-	text-align: center;
-}
-
 .jetpack-subscribe-modal.open .jetpack-subscribe-modal__modal-content {
 	top: 0;
 	visibility: visible;
-}
-
-.jetpack-subscribe-modal__close {
-	cursor: pointer;
 }

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
@@ -34,6 +34,10 @@
 	margin: 0 auto;
 }
 
+.jetpack-subscribe-modal__modal-content > .wp-block-group a {
+    text-decoration: none;
+}
+
 .jetpack-subscribe-modal.open .jetpack-subscribe-modal__modal-content {
 	top: 0;
 	visibility: visible;

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
@@ -52,6 +52,7 @@
 
 .jetpack-subscribe-modal__modal-content h2 {
     margin: 4px;
+	text-align: center;
 }
 
 .jetpack-subscribe-modal.open .jetpack-subscribe-modal__modal-content {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
@@ -39,17 +39,6 @@
 	margin: 0 auto;
 }
 
-.jetpack-subscribe-modal__modal-content > .wp-block-group:before {
-	content: '\f160';
-    text-align: center;
-    display: block;
-    font-family: 'Dashicons';
-    color: black;
-    font-size: 24px;
-    margin-bottom: 24px;
-    line-height: 1;
-}
-
 .jetpack-subscribe-modal__modal-content h2 {
     margin: 4px;
 	text-align: center;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes a minor style issue in the new subscribe modal: when the site title is long enough for the heading to wrap, it appears left aligned. After this change, it stays centered. 
* Removes the lock icon from the top of the modal. We're not actually locking anything with this modal.
* Where possible, moves the new styles inside the block/site editor rather than using a custom css file.
* Removes a few other css lines that were having no impact.
* UPDATE: In response to feedback, also removed underline from Continue Reading link. Because it was added after, that change isn't visible in the 'after' screenshot below. 

<img width="1205" alt="modal styles" src="https://github.com/Automattic/jetpack/assets/21228350/a64d8eb8-ee6b-4d56-a9fb-7d071c5d5e42">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**To test via simple sites:**
1) Setup: 
   - Run `bin/jetpack-downloader test jetpack fix/subscribe-modal-title-styles` to load this branch in your sandbox.
   - Be sure to sandbox public-api and the domain of your test site. 
   - You'll need to enable the feature flag by adding `add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 );` to wp-content/mu-plugins/0-sandbox.php
   - Enable the modal on your test site by going to Settings > Reading and toggling the subcribe modal option on. 
2) Go to any single blog post, and scroll, the modal should load. If your site title is not long enough to make the modal header wrap, just right click, open dev tools / inspector, and manually update the name to something longer.
3) Confirm that when the header wraps, it still appears centered. 

**To test in a self hosted jetpack environemnt:**
1) Setup: 
  - You'll need to set up a Jetpack dev environment and a jurassic tube test site
  - You'll need to enable the feature flag by. You can add `add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 );` to tools/docker/mu-plugins/0-sandbox.php. You may need to rebuild WordPress. 
   - If you haven't already, Go to Jetpack > Settings > Discussion, scroll to subscription options and enable the modal.
2) Go to any single blog post, and scroll, the modal should load. If your site title is not long enough to make the modal header wrap, just right click, open dev tools / inspector, and manually update the name to something longer.
3) Confirm that when the header wraps, it still appears centered. 

