### PR TITLE
Boost: Fix cloud CSS regeneration when module is toggled on

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -6,7 +6,7 @@
 	import ReactComponent from '../../elements/ReactComponent.svelte';
 	import TemplatedString from '../../elements/TemplatedString.svelte';
 	import { regenerateCriticalCss } from '../../stores/critical-css-state';
-	import { modulesState } from '../../stores/modules';
+	import { modulesState, modulesStatePending } from '../../stores/modules';
 	import Logo from '../../svg/jetpack-green.svg';
 	import externalLinkTemplateVar from '../../utils/external-link-template-var';
 
@@ -15,9 +15,17 @@
 	// svelte-ignore unused-export-let - Ignored values supplied by svelte-navigator.
 	export let location, navigate;
 
-	onMount( async () => {
+	onMount( () => {
+		// Enable cloud css module on upgrade.
 		$modulesState.cloud_css.active = true;
-		await regenerateCriticalCss();
+
+		// Ones the module is enabled and synced, regenerate critical css.
+		const unsubscribe = modulesStatePending.subscribe( pending => {
+			if ( ! pending ) {
+				regenerateCriticalCss();
+				unsubscribe();
+			}
+		} );
 	} );
 </script>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/PurchaseSuccess.svelte
@@ -5,8 +5,7 @@
 	import { __ } from '@wordpress/i18n';
 	import ReactComponent from '../../elements/ReactComponent.svelte';
 	import TemplatedString from '../../elements/TemplatedString.svelte';
-	import { regenerateCriticalCss } from '../../stores/critical-css-state';
-	import { modulesState, modulesStatePending } from '../../stores/modules';
+	import { modulesState } from '../../stores/modules';
 	import Logo from '../../svg/jetpack-green.svg';
 	import externalLinkTemplateVar from '../../utils/external-link-template-var';
 
@@ -18,14 +17,6 @@
 	onMount( () => {
 		// Enable cloud css module on upgrade.
 		$modulesState.cloud_css.active = true;
-
-		// Ones the module is enabled and synced, regenerate critical css.
-		const unsubscribe = modulesStatePending.subscribe( pending => {
-			if ( ! pending ) {
-				regenerateCriticalCss();
-				unsubscribe();
-			}
-		} );
 	} );
 </script>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
 	import Toggle from '../../../elements/Toggle.svelte';
-	import { modulesState } from '../../../stores/modules';
+	import { modulesState, modulesStatePending } from '../../../stores/modules';
 
 	export let toggle = true;
 	export let slug: string;
@@ -13,9 +13,18 @@
 
 	async function handleToggle() {
 		const toggledState = ! isModuleActive;
-		$modulesState[ slug ].active = toggledState;
 		const eventName = toggledState === true ? 'enabled' : 'disabled';
-		dispatch( eventName );
+
+		// Toggle the module.
+		$modulesState[ slug ].active = toggledState;
+
+		// Attach a listener to the modulesStatePending store to dispatch an event after the pending state is resolved.
+		const unsubscribe = modulesStatePending.subscribe( isPending => {
+			if ( ! isPending ) {
+				dispatch( eventName );
+				unsubscribe();
+			}
+		} );
 	}
 
 	onMount( async () => {

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/Module.svelte
@@ -12,19 +12,21 @@
 	$: isModuleAvailable = $modulesState[ slug ].available;
 
 	async function handleToggle() {
-		const toggledState = ! isModuleActive;
-		const eventName = toggledState === true ? 'enabled' : 'disabled';
+		$modulesState[ slug ].active = ! isModuleActive;
+	}
 
-		// Toggle the module.
-		$modulesState[ slug ].active = toggledState;
-
-		// Attach a listener to the modulesStatePending store to dispatch an event after the pending state is resolved.
-		const unsubscribe = modulesStatePending.subscribe( isPending => {
-			if ( ! isPending ) {
-				dispatch( eventName );
-				unsubscribe();
+	/**
+	 * Watch for changes in state and dispatch an event when the state is no longer pending.
+	 */
+	let lastToggledState = $modulesState[ slug ].active;
+	$: {
+		if ( ! $modulesStatePending ) {
+			const newState = $modulesState[ slug ].active;
+			if ( lastToggledState !== newState ) {
+				lastToggledState = newState;
+				dispatch( newState ? 'enabled' : 'disabled' );
 			}
-		} );
+		}
 	}
 
 	onMount( async () => {

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -111,7 +111,7 @@
 
 	<Module
 		slug="cloud_css"
-		on:enabled={regenerateCriticalCss}
+		on:enabled={startPollingCloudStatus}
 		on:disabled={stopPollingCloudCssStatus}
 		on:mountEnabled={startPollingCloudStatus}
 	>

--- a/projects/plugins/boost/app/lib/critical-css/Regenerate.php
+++ b/projects/plugins/boost/app/lib/critical-css/Regenerate.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Lib\Critical_CSS;
+
+use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
+use Automattic\Jetpack_Boost\Modules\Modules_Setup;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS_Followup;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Generator;
+
+class Regenerate {
+	/** @var Critical_CSS_State */
+	private $state;
+
+	public function is_cloud_css() {
+		$optimizations = ( new Modules_Setup() )->get_status();
+		return isset( $optimizations[ Cloud_CSS::get_slug() ] ) && $optimizations[ Cloud_CSS::get_slug() ];
+	}
+
+	public function start() {
+		// Get Critical CSS Source URLs
+		$source_providers = new Source_Providers();
+		$providers        = $source_providers->get_provider_sources();
+
+		// Store those URLs in the Critical CSS State
+		$this->state = new Critical_CSS_State();
+		$this->state->prepare_request()
+				->set_pending_providers( $providers )
+				->save();
+
+		// Get the data
+		$data = $this->state->get();
+
+		if ( $this->is_cloud_css() ) {
+			// If this is a cloud CSS request, we need to trigger the generation
+			// of the CSS and return the URL to the CSS file.
+			$cloud_css = new Cloud_CSS();
+			$cloud_css->regenerate_cloud_css();
+			Cloud_CSS_Followup::schedule();
+		} else {
+			$generator = new Generator();
+			$data      = array_merge( $data, $generator->get_generation_metadata() );
+		}
+
+		// Clear previous Critical CSS From storage
+		$storage = new Critical_CSS_Storage();
+		$storage->clear();
+
+		// Dismiss admin notices
+		Regenerate_Admin_Notice::dismiss();
+
+		return $data;
+	}
+
+	public function get_state() {
+		return $this->state;
+	}
+}

--- a/projects/plugins/boost/app/modules/Modules_Setup.php
+++ b/projects/plugins/boost/app/modules/Modules_Setup.php
@@ -3,8 +3,10 @@
 namespace Automattic\Jetpack_Boost\Modules;
 
 use Automattic\Jetpack_Boost\Contracts\Has_Setup;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Regenerate;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Status;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\REST_API;
 
@@ -82,6 +84,10 @@ class Modules_Setup implements Has_Setup {
 	public function on_module_status_update( $module_slug, $is_activated ) {
 		$status = new Status( $module_slug );
 		$status->on_update( $is_activated );
+
+		if ( $module_slug == Cloud_CSS::get_slug() && $is_activated ) {
+			( new Regenerate() )->start();
+		}
 	}
 
 }

--- a/projects/plugins/boost/app/modules/Modules_Setup.php
+++ b/projects/plugins/boost/app/modules/Modules_Setup.php
@@ -85,7 +85,7 @@ class Modules_Setup implements Has_Setup {
 		$status = new Status( $module_slug );
 		$status->on_update( $is_activated );
 
-		if ( $module_slug == Cloud_CSS::get_slug() && $is_activated ) {
+		if ( $module_slug === Cloud_CSS::get_slug() && $is_activated ) {
 			( new Regenerate() )->start();
 		}
 	}

--- a/projects/plugins/boost/app/rest-api/endpoints/Critical_CSS_Start.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/Critical_CSS_Start.php
@@ -2,14 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\REST_API\Endpoints;
 
-use Automattic\Jetpack_Boost\Admin\Regenerate_Admin_Notice;
-use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
-use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
-use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
-use Automattic\Jetpack_Boost\Modules\Modules_Setup;
-use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
-use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS_Followup;
-use Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Generator;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Regenerate;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Endpoint;
 use Automattic\Jetpack_Boost\REST_API\Permissions\Current_User_Admin;
 
@@ -19,43 +12,10 @@ class Critical_CSS_Start implements Endpoint {
 		return \WP_REST_Server::EDITABLE;
 	}
 
-	public function is_cloud_css() {
-		$optimizations = ( new Modules_Setup() )->get_status();
-		return isset( $optimizations[ Cloud_CSS::get_slug() ] ) && $optimizations[ Cloud_CSS::get_slug() ];
-	}
-
 	public function response( $_request ) {
-
-		// Get Critical CSS Source URLs
-		$source_providers = new Source_Providers();
-		$providers        = $source_providers->get_provider_sources();
-
-		// Store those URLs in the Critical CSS State
-		$state = new Critical_CSS_State();
-		$state->prepare_request()
-				->set_pending_providers( $providers )
-				->save();
-
-		// Get the data
-		$data = $state->get();
-
-		if ( $this->is_cloud_css() ) {
-			// If this is a cloud CSS request, we need to trigger the generation
-			// of the CSS and return the URL to the CSS file.
-			$cloud_css = new Cloud_CSS();
-			$cloud_css->regenerate_cloud_css();
-			Cloud_CSS_Followup::schedule();
-		} else {
-			$generator = new Generator();
-			$data      = array_merge( $data, $generator->get_generation_metadata() );
-		}
-
-		// Clear previous Critical CSS From storage
-		$storage = new Critical_CSS_Storage();
-		$storage->clear();
-
-		// Dismiss admin notices
-		Regenerate_Admin_Notice::dismiss();
+		$regenerate = new Regenerate();
+		$data       = $regenerate->start();
+		$state      = $regenerate->get_state();
 
 		return rest_ensure_response(
 			array(

--- a/projects/plugins/boost/changelog/fix-module-toggle-action
+++ b/projects/plugins/boost/changelog/fix-module-toggle-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cloud CSS: Fixed automatic start of cloud CSS regeneration when module is toggled on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/boost-cloud#275

## Proposed changes:
* When a module is toggled, wait until the status is synced before dispatching an event
* On purchase success page, wait until the status is synced before starting to generate cloud CSS

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
None

## Testing instructions:
* Keep the network tab on browser devtools open
* Upgrade boost, on the purchase success page, ensure request to the endpoint `/wp-json/jetpack-boost/v1/critical-css/start` isn't a 404.
* On boost settings page, toggle off and on cloud CSS module and make sure the cloud CSS job starts with a successful request to `/wp-json/jetpack-boost/v1/critical-css/start`.

