### PR TITLE
Fix Forms dropdown required validation

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dropdown-validation
+++ b/projects/packages/forms/changelog/fix-forms-dropdown-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Forms dropdown required validation

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -204,7 +204,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * Validates the form input
 	 */
 	public function validate() {
-		error_log( print_r( $this, true ) );
 		// If it's not required, there's nothing to validate
 		if ( ! $this->get_attribute( 'required' ) ) {
 			return;
@@ -717,7 +716,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	public function render_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
 		$field  = $this->render_label( 'select', $id, $label, $required, $required_field_text );
-		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . "aria-hidden='true' tabindex='-1'>\n";
+		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . ">\n";
 
 		if ( $this->get_attribute( 'togglelabel' ) ) {
 			$field .= "\t\t<option value=''>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -717,7 +717,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	public function render_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
 		$field  = $this->render_label( 'select', $id, $label, $required, $required_field_text );
-		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . ">\n";
+		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . "aria-hidden='true' tabindex='-1'>\n";
 
 		if ( $this->get_attribute( 'togglelabel' ) ) {
 			$field .= "\t\t<option value=''>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -204,6 +204,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * Validates the form input
 	 */
 	public function validate() {
+		error_log( print_r( $this, true ) );
 		// If it's not required, there's nothing to validate
 		if ( ! $this->get_attribute( 'required' ) ) {
 			return;
@@ -719,7 +720,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . ">\n";
 
 		if ( $this->get_attribute( 'togglelabel' ) ) {
-			$field .= "\t\t<option>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";
+			$field .= "\t\t<option value=''>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";
 		}
 
 		foreach ( (array) $this->get_attribute( 'options' ) as $option_index => $option ) {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -60,6 +60,20 @@
 	min-width: 150px;
 }
 
+/*
+	On Grunion Forms, the regular HTML select is replaced by a custom select by jQuery UI.
+ 	To keep the required validation working the select can't be 'display: none'
+ 	This solution will keep the select hidden without using 'display: none'
+ */
+.contact-form .contact-form-dropdown {
+	position: absolute;
+	z-index: -1;
+	width: 100%;
+	display: block !important;
+	opacity: 0;
+	pointer-events: none;
+}
+
 .contact-form input[type='radio'],
 .contact-form input[type='checkbox'] {
 	width: 1rem;
@@ -209,6 +223,7 @@
 
 .wp-block-jetpack-contact-form .grunion-field-wrap {
 	box-sizing: border-box;
+	position: relative;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-25-wrap {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -65,7 +65,7 @@
  	To keep the required validation working the select can't be 'display: none'
  	This solution will keep the select hidden without using 'display: none'
  */
-.contact-form .contact-form-dropdown {
+.contact-form .contact-form-dropdown[aria-hidden="true"] {
 	position: absolute;
 	z-index: -1;
 	width: 100%;

--- a/projects/packages/forms/src/contact-form/js/dropdown.js
+++ b/projects/packages/forms/src/contact-form/js/dropdown.js
@@ -18,9 +18,8 @@ jQuery( function ( $ ) {
 				'ui-selectmenu-button': 'contact-form-dropdown__button',
 				'ui-selectmenu-menu': 'contact-form-dropdown__menu',
 			},
-		} );
-
-		$( '.contact-form .contact-form-dropdown' ).attr( 'aria-hidden', true );
-		$( '.contact-form .contact-form-dropdown' ).prop( 'tabindex', -1 );
+		} )
+		.attr( 'aria-hidden', true )
+		.prop( 'tabindex', -1 );
 	}
 } );

--- a/projects/packages/forms/src/contact-form/js/dropdown.js
+++ b/projects/packages/forms/src/contact-form/js/dropdown.js
@@ -19,5 +19,8 @@ jQuery( function ( $ ) {
 				'ui-selectmenu-menu': 'contact-form-dropdown__menu',
 			},
 		} );
+
+		$( '.contact-form .contact-form-dropdown' ).attr( 'aria-hidden', true );
+		$( '.contact-form .contact-form-dropdown' ).prop( 'tabindex', -1 );
 	}
 } );

--- a/projects/plugins/jetpack/changelog/fix-forms-dropdown-validation
+++ b/projects/plugins/jetpack/changelog/fix-forms-dropdown-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix Forms dropdown required validation

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -65,7 +65,7 @@
  	To keep the required validation working the select can't be 'display: none'
  	This solution will keep the select hidden without using 'display: none'
  */
-.contact-form .contact-form-dropdown {
+.contact-form .contact-form-dropdown[aria-hidden="true"] {
 	position: absolute;
 	z-index: -1;
 	width: 100%;

--- a/projects/plugins/jetpack/modules/contact-form/css/grunion.css
+++ b/projects/plugins/jetpack/modules/contact-form/css/grunion.css
@@ -60,6 +60,20 @@
 	min-width: 150px;
 }
 
+/*
+	On Grunion Forms, the regular HTML select is replaced by a custom select by jQuery UI.
+ 	To keep the required validation working the select can't be 'display: none'
+ 	This solution will keep the select hidden without using 'display: none'
+ */
+.contact-form .contact-form-dropdown {
+	position: absolute;
+	z-index: -1;
+	width: 100%;
+	display: block !important;
+	opacity: 0;
+	pointer-events: none;
+}
+
 .contact-form :where(input[type='radio'], input[type='checkbox']) {
 	width: 1rem;
 	height: 1rem;
@@ -211,6 +225,7 @@
 
 .wp-block-jetpack-contact-form .grunion-field-wrap {
 	box-sizing: border-box;
+	position: relative;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-25-wrap {

--- a/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form/grunion-contact-form.php
@@ -5025,7 +5025,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . ">\n";
 
 		if ( $this->get_attribute( 'togglelabel' ) ) {
-			$field .= "\t\t<option>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";
+			$field .= "\t\t<option value=''>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";
 		}
 
 		foreach ( (array) $this->get_attribute( 'options' ) as $option_index => $option ) {

--- a/projects/plugins/jetpack/modules/contact-form/js/dropdown.js
+++ b/projects/plugins/jetpack/modules/contact-form/js/dropdown.js
@@ -18,9 +18,8 @@ jQuery( function ( $ ) {
 				'ui-selectmenu-button': 'contact-form-dropdown__button',
 				'ui-selectmenu-menu': 'contact-form-dropdown__menu',
 			},
-		} );
-
-		$( '.contact-form .contact-form-dropdown' ).attr( 'aria-hidden', true );
-		$( '.contact-form .contact-form-dropdown' ).prop( 'tabindex', -1 );
+		} )
+		.attr( 'aria-hidden', true )
+		.prop( 'tabindex', -1 );
 	}
 } );

--- a/projects/plugins/jetpack/modules/contact-form/js/dropdown.js
+++ b/projects/plugins/jetpack/modules/contact-form/js/dropdown.js
@@ -19,5 +19,8 @@ jQuery( function ( $ ) {
 				'ui-selectmenu-menu': 'contact-form-dropdown__menu',
 			},
 		} );
+
+		$( '.contact-form .contact-form-dropdown' ).attr( 'aria-hidden', true );
+		$( '.contact-form .contact-form-dropdown' ).prop( 'tabindex', -1 );
 	}
 } );


### PR DESCRIPTION
Fixes pdWQjU-n2-p2

## Proposed changes:

* Fix Forms dropdown required validation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Create a Form and add a Dropdown field
* Make the dropdown required and publish the page
* Go to the published page and try to submit the form without selecting a value for the  dropdown
* You should see a validation error message and the form shouldn't be submitted