### PR TITLE
Launchpad: Renamed keep-building tasklist

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rename-launchpad-tasklist
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rename-launchpad-tasklist
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Rename the keep-building Launchpad checklist to intent-build

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -128,7 +128,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		'keep-building'   => array(
+		'intent-build'    => array(
 			'title'               => 'Keep Building',
 			'task_ids'            => array(
 				'site_title',
@@ -140,7 +140,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'edit_page',
 				'share_site',
 			),
-			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_is_intent_build_enabled',
 		),
 		'intent-write'    => array(
 			'title'               => 'Blog',
@@ -574,7 +574,7 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
  *
  * @return bool True if the task list is enabled, false otherwise.
  */
-function wpcom_launchpad_is_keep_building_enabled() {
+function wpcom_launchpad_is_intent_build_enabled() {
 	$intent                  = get_option( 'site_intent', false );
 	$launchpad_task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -128,6 +128,21 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
+		// @TODO: Remove the following task list once the migration/rename is complete across WP.com and Calypso.
+		'keep-building'   => array(
+			'title'               => 'Keep Building',
+			'task_ids'            => array(
+				'site_title',
+				'domain_claim',
+				'verify_email',
+				'domain_customize',
+				'add_new_page',
+				'drive_traffic',
+				'edit_page',
+				'share_site',
+			),
+			'is_enabled_callback' => 'wpcom_launchpad_is_intent_build_enabled',
+		),
 		'intent-build'    => array(
 			'title'               => 'Keep Building',
 			'task_ids'            => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -141,7 +141,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'edit_page',
 				'share_site',
 			),
-			'is_enabled_callback' => 'wpcom_launchpad_is_intent_build_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
 		'intent-build'    => array(
 			'title'               => 'Keep Building',
@@ -155,7 +155,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'edit_page',
 				'share_site',
 			),
-			'is_enabled_callback' => 'wpcom_launchpad_is_intent_build_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
 		'intent-write'    => array(
 			'title'               => 'Blog',
@@ -589,7 +589,7 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
  *
  * @return bool True if the task list is enabled, false otherwise.
  */
-function wpcom_launchpad_is_intent_build_enabled() {
+function wpcom_launchpad_is_keep_building_enabled() {
 	$intent                  = get_option( 'site_intent', false );
 	$launchpad_task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/79461

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a copy of the `keep-building` task list with new name `intent-write` to follow the naming conventions we want to switch to.
* Don't rename the gate function `wpcom_launchpad_is_keep_building_enabled` since this is also used on the WP.com side; renaming it will break the My Home views on WP.com.
* This ensures that Atomic sites can still access the old checklist during the "in-between" phase where jetpack-mu-wpcom is synced to WP.com Simple sites but not Atomic ones.

## Testing instructions:

See https://github.com/Automattic/wp-calypso/pull/79461

## Does this pull request change what data or activity we track or use?

No.
