### PR TITLE
Add was_migration_trial flag for wpcom sites

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -807,16 +807,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "886a728571ab2faca3642c96954886b078b32195"
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/886a728571ab2faca3642c96954886b078b32195",
-                "reference": "886a728571ab2faca3642c96954886b078b32195",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
                 "shasum": ""
             },
             "require": {
@@ -876,7 +876,7 @@
                 "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
                 "source": "https://github.com/PHPCSStandards/PHPCSUtils"
             },
-            "time": "2023-07-10T13:56:07+00:00"
+            "time": "2023-07-16T21:39:41+00:00"
         },
         {
             "name": "sirbrillig/phpcs-changed",

--- a/projects/plugins/jetpack/changelog/add-was-migration-trial-flag-for-wpcom-sites
+++ b/projects/plugins/jetpack/changelog/add-was-migration-trial-flag-for-wpcom-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+SSites API: add was_migration_trial flag to data returned for site details

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -279,8 +279,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @var array $jetpack_enabled_trials
 	 */
 	public static $jetpack_enabled_trials = array(
-		'ecommerce',
-		'migration',
+		'ecommerce' => 'was_ecommerce_trial',
+		'migration' => 'was_migration_trial',
 	);
 
 	/**
@@ -591,10 +591,10 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$response[ $key ] = $this->site->get_p2_thumbnail_elements();
 				break;
 			case 'was_ecommerce_trial':
-				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials[0] );
+				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials['ecommerce'] );
 				break;
 			case 'was_migration_trial':
-				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials[1] );
+				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials['migration'] );
 				break;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -79,6 +79,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_staging_site'       => '(bool) If the site is a WP.com staging site.',
 		'user_interactions'           => '(array) An array of user interactions with a site.',
 		'was_ecommerce_trial'         => '(bool) If the site ever used an eCommerce trial.',
+		'was_migration_trial'         => '(bool) If the site ever used a migration trial.',
 		'wpcom_site_setup'            => '(string) The WP.com site setup identifier.',
 	);
 
@@ -227,6 +228,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_owner',
 		'is_wpcom_staging_site',
 		'was_ecommerce_trial',
+		'was_migration_trial',
 	);
 
 	/**
@@ -269,6 +271,16 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'blogging_prompts_settings',
 		'wpcom_production_blog_id',
 		'wpcom_staging_blog_ids',
+	);
+
+	/**
+	 * Current enabled trials.
+	 *
+	 * @var array $jetpack_enabled_trials
+	 */
+	public static $jetpack_enabled_trials = array(
+		'ecommerce',
+		'migration',
 	);
 
 	/**
@@ -579,7 +591,10 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$response[ $key ] = $this->site->get_p2_thumbnail_elements();
 				break;
 			case 'was_ecommerce_trial':
-				$response[ $key ] = $this->site->was_ecommerce_trial();
+				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials[0] );
+				break;
+			case 'was_migration_trial':
+				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials[1] );
 				break;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -279,8 +279,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @var array $jetpack_enabled_trials
 	 */
 	public static $jetpack_enabled_trials = array(
-		'ecommerce' => 'was_ecommerce_trial',
-		'migration' => 'was_migration_trial',
+		'was_ecommerce_trial' => 'ecommerce',
+		'was_migration_trial' => 'migration',
 	);
 
 	/**
@@ -591,10 +591,10 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$response[ $key ] = $this->site->get_p2_thumbnail_elements();
 				break;
 			case 'was_ecommerce_trial':
-				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials['ecommerce'] );
+				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials['was_ecommerce_trial'] );
 				break;
 			case 'was_migration_trial':
-				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials['migration'] );
+				$response[ $key ] = $this->site->was_trial( self::$jetpack_enabled_trials['was_migration_trial'] );
 				break;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -74,6 +74,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'is_wpcom_atomic'             => '(bool) If the site is a WP.com Atomic one.',
 		'is_wpcom_staging_site'       => '(bool) If the site is a WP.com staging site.',
 		'was_ecommerce_trial'         => '(bool) If the site ever used an eCommerce trial.',
+		'was_migration_trial'         => '(bool) If the site ever used a migration trial.',
 	);
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -489,13 +489,15 @@ abstract class SAL_Site {
 	}
 
 	/**
-	 * Indicate whether this site was ever an eCommerce trial.
+	 * Indicate whether this site was ever a specific trial.
+	 *
+	 * @param string $trial The trial type to check for.
 	 *
 	 * @return bool
 	 */
-	public function was_ecommerce_trial() {
+	public function was_trial( $trial ) {
 		if ( function_exists( 'has_blog_sticker' ) ) {
-			return has_blog_sticker( 'had-ecommerce-trial' );
+			return has_blog_sticker( "had-{$trial}-trial" );
 		}
 		return false;
 	}

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
@@ -84,7 +84,7 @@ class WP_Test_Jetpack_Site_Json_Api_Endpoints extends WP_UnitTestCase {
 		global $blog_id;
 
 		// Current trials.
-		$trials = WPCOM_JSON_API_GET_Site_Endpoint::$jetpack_enabled_trials;
+		$trials = array_keys( WPCOM_JSON_API_GET_Site_Endpoint::$jetpack_enabled_trials );
 
 		$admin = self::factory()->user->create_and_get(
 			array(
@@ -104,25 +104,25 @@ class WP_Test_Jetpack_Site_Json_Api_Endpoints extends WP_UnitTestCase {
 		 * All even flags are set to true and all odd flags are set to false.
 		 */
 		$i = 0;
-		foreach ( $trials as $value ) {
-			update_option( $value, (bool) ( $i & 2 ) );
+		foreach ( $trials as $trial ) {
+			update_option( $trial, (bool) ( $i & 2 ) );
 			++$i;
 		}
 
 		$response = $endpoint->callback( '', $blog_id );
 
 		$i = 0;
-		foreach ( $trials as $value ) {
+		foreach ( $trials as $trial ) {
 			if ( (bool) ( $i & 2 ) ) {
-				$this->assertTrue( $response[ $value ] );
+				$this->assertTrue( $response[ $trial ] );
 			} else {
-				$this->assertFalse( $response[ $value ] );
+				$this->assertFalse( $response[ $trial ] );
 			}
 		}
 
 		// Remove all the options used.
-		foreach ( $trials as $value ) {
-			delete_option( $response[ $value ] );
+		foreach ( $trials as $trial ) {
+			delete_option( $response[ $trial ] );
 			++$i;
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
@@ -81,13 +81,7 @@ class WP_Test_Jetpack_Site_Json_Api_Endpoints extends WP_UnitTestCase {
 		global $blog_id;
 
 		// Current trials.
-		$trials   = WPCOM_JSON_API_GET_Site_Endpoint::$jetpack_enabled_trials;
-		$stickers = array();
-
-		// Create a list of stickers to test.
-		foreach ( $trials as $trial ) {
-			$stickers[] = 'had-' . $trial . '-trial';
-		}
+		$trials = WPCOM_JSON_API_GET_Site_Endpoint::$jetpack_enabled_trials;
 
 		$admin = self::factory()->user->create_and_get(
 			array(
@@ -97,19 +91,11 @@ class WP_Test_Jetpack_Site_Json_Api_Endpoints extends WP_UnitTestCase {
 
 		wp_set_current_user( $admin->ID );
 
-		foreach ( $stickers as $sticker ) {
-			update_option( $sticker, true );
-		}
-
 		$endpoint = $this->create_get_site_endpoint();
 		$response = $endpoint->callback( '', $blog_id );
 
 		foreach ( $trials as $trial ) {
-			$this->assertTrue( $response[ 'was_' . $trial . '_trial' ] );
-		}
-
-		foreach ( $stickers as $sticker ) {
-			delete_option( $sticker );
+			$this->assertFalse( $response[ 'was_' . $trial . '_trial' ] );
 		}
 	}
 

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
@@ -75,7 +75,10 @@ class WP_Test_Jetpack_Site_Json_Api_Endpoints extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Unit test for the `/sites/%s` endpoint.
+	 * Test that trial flags are returned for sites that have them.
+	 *
+	 * @author zaerl
+	 * @covers WPCOM_JSON_API_GET_Site_Endpoint::build_current_site_response
 	 */
 	public function test_get_site_trials_list() {
 		global $blog_id;
@@ -94,8 +97,8 @@ class WP_Test_Jetpack_Site_Json_Api_Endpoints extends WP_UnitTestCase {
 		$endpoint = $this->create_get_site_endpoint();
 		$response = $endpoint->callback( '', $blog_id );
 
-		foreach ( $trials as $trial ) {
-			$this->assertFalse( $response[ 'was_' . $trial . '_trial' ] );
+		foreach ( $trials as $key => $value ) {
+			$this->assertFalse( $response[ $value ] );
 		}
 	}
 

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
@@ -97,7 +97,7 @@ class WP_Test_Jetpack_Site_Json_Api_Endpoints extends WP_UnitTestCase {
 		$endpoint = $this->create_get_site_endpoint();
 		$response = $endpoint->callback( '', $blog_id );
 
-		foreach ( $trials as $key => $value ) {
+		foreach ( $trials as $value ) {
 			$this->assertFalse( $response[ $value ] );
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
@@ -13,7 +13,7 @@ if ( ! function_exists( 'has_blog_sticker' ) ) {
 	 * "Mock" WPCOM sticker function with 'get_site_option'
 	 */
 	function has_blog_sticker( $sticker ) {
-		return get_option( $sticker );
+		return false;
 	}
 }
 

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php
@@ -122,7 +122,7 @@ class WP_Test_Jetpack_Site_Json_Api_Endpoints extends WP_UnitTestCase {
 
 		// Remove all the options used.
 		foreach ( $trials as $trial ) {
-			delete_option( $response[ $trial ] );
+			delete_option( $trial );
 			++$i;
 		}
 	}


### PR DESCRIPTION
This PR adds the `was_migration_trial` flag to the site data we return from the site REST APIs. This value will always be false for normal Jetpack sites, as the Migration trial is only available from WordPress.com.

Fixes https://github.com/Automattic/dotcom-forge/issues/2977

## Proposed changes:
1. Add the `was_migration_trial` flag to the site data
2. Add tests for `ecommerce` and `migration` trials

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `jetpack docker phpunit -- --filter=WP_Test_Jetpack_Site_Json_Api_Endpoints --debug --verbose`
* Follow instruction found [here](https://github.com/Automattic/jetpack/pull/31907#issuecomment-1637606726)
* Install `add/was-migration-trial-flag-for-wpcom-sites` beta
* Open https://developer.wordpress.com/docs/api/console/
* Test `/sites/__ID__` and check for `was_ecommerce_trial` and `was_migration_trial` fields

