### PR TITLE
WPCOM REST API: fix PHP 8.2 notice

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-php82-dynamic-properties-json-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-php82-dynamic-properties-json-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+WordPress.com REST API: avoid PHP notice when using PHP 8.2

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
@@ -72,6 +72,13 @@ class WPCOM_JSON_API_List_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint { 
 	public $page_handle = array();
 
 	/**
+	 * Performed query
+	 *
+	 * @var array
+	 */
+	public $performed_query = array();
+
+	/**
 	 * API callback.
 	 *
 	 * @param string $path - the path.


### PR DESCRIPTION
## Proposed changes:

Avoid this notice:

```
PHP Deprecated:  Creation of dynamic property WPCOM_JSON_API_List_Media_v1_1_Endpoint::$performed_query is deprecated in json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php on line 161
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* Primary issue: #27927

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* In Calypso, open your site and go to the Media menu.
* View your site's images
* Check your logs, you should see no notices.
