### PR TITLE
Boost: Add ISA scanned count

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -12,6 +12,8 @@
 		initializeIsaSummary,
 		isaSummary,
 		ISAStatus,
+		totalPagesCount,
+		scannedPagesCount,
 	} from './store/isa-summary';
 
 	onMount( () => {
@@ -48,6 +50,29 @@
 		( $isaSummary?.status === ISAStatus.New && __( 'Warming up the engine…', 'jetpack-boost' ) ) ||
 		( $isaSummary?.status === ISAStatus.Queued &&
 			__( 'Give us a few minutes while we go through your images…', 'jetpack-boost' ) );
+
+	$: foundIssuesMessage =
+		$totalPagesCount > 100
+			? sprintf(
+					// translators: 1: Number of scanned issues found 2: Number of scanned pages
+					__( 'Found a total of %1$d issues from %2$d latest pages scanned.', 'jetpack-boost' ),
+					totalIssues,
+					$scannedPagesCount
+			  )
+			: sprintf(
+					// translators: %d: Number of scanned issues found
+					__( 'Found a total of %d issues.', 'jetpack-boost' ),
+					$scannedPagesCount
+			  );
+
+	$: noIssuesMessage =
+		$totalPagesCount > 100
+			? sprintf(
+					// translators: %d: Number of pages scanned
+					__( 'Congratulations; no issues found from %d latest pages scanned.', 'jetpack-boost' ),
+					$scannedPagesCount
+			  )
+			: __( 'Congratulations; no issues found.', 'jetpack-boost' );
 
 	/**
 	 * Start a new image analysis job.
@@ -90,15 +115,11 @@
 			{#if totalIssues > 0}
 				<div class="has-issues summary">
 					<WarningIcon class="icon" />
-					{sprintf(
-						/* translators: %d is the number of issues that were found */
-						__( 'Found a total of %d issues', 'jetpack-boost' ),
-						totalIssues
-					)}
+					{foundIssuesMessage}
 				</div>
 			{:else}
 				<div class="summary">
-					{__( 'Congratulations; no issues found.', 'jetpack-boost' )}
+					{noIssuesMessage}
 				</div>
 			{/if}
 

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -12,7 +12,6 @@
 		initializeIsaSummary,
 		isaSummary,
 		ISAStatus,
-		totalPagesCount,
 		scannedPagesCount,
 	} from './store/isa-summary';
 
@@ -50,29 +49,6 @@
 		( $isaSummary?.status === ISAStatus.New && __( 'Warming up the engine…', 'jetpack-boost' ) ) ||
 		( $isaSummary?.status === ISAStatus.Queued &&
 			__( 'Give us a few minutes while we go through your images…', 'jetpack-boost' ) );
-
-	$: foundIssuesMessage =
-		$totalPagesCount === 100
-			? sprintf(
-					// translators: 1: Number of scanned issues found 2: Number of scanned pages
-					__( 'Found a total of %1$d issues from %2$d latest pages scanned.', 'jetpack-boost' ),
-					totalIssues,
-					$scannedPagesCount
-			  )
-			: sprintf(
-					// translators: %d: Number of scanned issues found
-					__( 'Found a total of %d issues.', 'jetpack-boost' ),
-					$scannedPagesCount
-			  );
-
-	$: noIssuesMessage =
-		$totalPagesCount === 100
-			? sprintf(
-					// translators: %d: Number of pages scanned
-					__( 'Congratulations; no issues found from %d latest pages scanned.', 'jetpack-boost' ),
-					$scannedPagesCount
-			  )
-			: __( 'Congratulations; no issues found.', 'jetpack-boost' );
 
 	/**
 	 * Start a new image analysis job.
@@ -115,11 +91,20 @@
 			{#if totalIssues > 0}
 				<div class="has-issues summary">
 					<WarningIcon class="icon" />
-					{foundIssuesMessage}
+					{sprintf(
+						// translators: 1: Number of scanned issues found 2: Number of scanned pages
+						__( 'Found a total of %1$d issues from %2$d latest pages scanned.', 'jetpack-boost' ),
+						totalIssues,
+						$scannedPagesCount
+					)}
 				</div>
 			{:else}
 				<div class="summary">
-					{noIssuesMessage}
+					{sprintf(
+						// translators: %d: Number of pages scanned
+						__( 'Congratulations; no issues found from %d latest pages scanned.', 'jetpack-boost' ),
+						$scannedPagesCount
+					)}
 				</div>
 			{/if}
 

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -52,7 +52,7 @@
 			__( 'Give us a few minutes while we go through your images…', 'jetpack-boost' ) );
 
 	$: foundIssuesMessage =
-		$totalPagesCount > 100
+		$totalPagesCount === 100
 			? sprintf(
 					// translators: 1: Number of scanned issues found 2: Number of scanned pages
 					__( 'Found a total of %1$d issues from %2$d latest pages scanned.', 'jetpack-boost' ),
@@ -66,7 +66,7 @@
 			  );
 
 	$: noIssuesMessage =
-		$totalPagesCount > 100
+		$totalPagesCount === 100
 			? sprintf(
 					// translators: %d: Number of pages scanned
 					__( 'Congratulations; no issues found from %d latest pages scanned.', 'jetpack-boost' ),

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/RecommendationsMeta.svelte
@@ -93,7 +93,10 @@
 					<WarningIcon class="icon" />
 					{sprintf(
 						// translators: 1: Number of scanned issues found 2: Number of scanned pages
-						__( 'Found a total of %1$d issues from %2$d latest pages scanned.', 'jetpack-boost' ),
+						__(
+							'Found a total of %1$d issues after scanning your %2$d most recent pages.',
+							'jetpack-boost'
+						),
 						totalIssues,
 						$scannedPagesCount
 					)}
@@ -102,7 +105,10 @@
 				<div class="summary">
 					{sprintf(
 						// translators: %d: Number of pages scanned
-						__( 'Congratulations; no issues found from %d latest pages scanned.', 'jetpack-boost' ),
+						__(
+							'Congratulations; no issues found after scanning your %d most recent pages.',
+							'jetpack-boost'
+						),
 						$scannedPagesCount
 					)}
 				</div>

--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/isa-summary.ts
@@ -68,6 +68,24 @@ export const totalIssueCount = derived( isaSummary, $isaSummary => {
 } );
 
 /**
+ * Derived store tracking the number of scanned pages.
+ */
+export const scannedPagesCount = derived( isaSummary, $isaSummary => {
+	return Object.values( $isaSummary?.groups || {} )
+		.map( group => group.scanned_pages )
+		.reduce( ( a, b ) => a + b, 0 );
+} );
+
+/**
+ * Derived store tracking the number of total pages being scanned.
+ */
+export const totalPagesCount = derived( isaSummary, $isaSummary => {
+	return Object.values( $isaSummary?.groups || {} )
+		.map( group => group.total_pages )
+		.reduce( ( a, b ) => a + b, 0 );
+} );
+
+/**
  * Derived store which describes tabs to display in the UI.
  */
 export const imageDataGroupTabs = derived(

--- a/projects/plugins/boost/changelog/add-isa-scanned-count
+++ b/projects/plugins/boost/changelog/add-isa-scanned-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Image Size Analysis: Included the number of scanned pages in the summary message


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/boost-cloud#319

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include the number of pages scanned if we are unable to scan all the pages

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Create a site with more than 100 pages.
* Make sure you see the updated messages


![Screenshot 2023-07-18 at 2 54 13 PM](https://github.com/Automattic/jetpack/assets/3737780/ddd9f63b-b3dc-4a07-986c-215eb978bed4)
![Screenshot 2023-07-18 at 2 57 34 PM](https://github.com/Automattic/jetpack/assets/3737780/b54b2396-d202-4cad-9a62-497905a4d26f)

