### PR TITLE
Boost: Fix ISA details page not loading if an image from the batch was not ok

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/zod-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/modules/image-size-analysis/store/zod-types.ts
@@ -37,6 +37,7 @@ export const ImageData = z
 	.catch( {
 		id: '',
 		type: 'bad_entry',
+		status: 'active', // We still want to show the UI for this.
 	} );
 
 export type ImageDataType = z.infer< typeof ImageData >;

--- a/projects/plugins/boost/app/modules/image-size-analysis/data-sync/init.php
+++ b/projects/plugins/boost/app/modules/image-size-analysis/data-sync/init.php
@@ -55,6 +55,12 @@ $image_data = Schema::as_assoc_array(
 		),
 
 	)
+)->fallback(
+	array(
+		'id'     => '',
+		'type'   => 'bad_entry',
+		'status' => 'active',
+	)
 );
 
 $image_size_analysis = Schema::as_assoc_array(

--- a/projects/plugins/boost/changelog/fix-isa-not-loading-if-image-not-ok
+++ b/projects/plugins/boost/changelog/fix-isa-not-loading-if-image-not-ok
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix endpoint returning report data erroring with 500 if an image was missing a required property.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This was discovered while investigating https://github.com/Automattic/boost-cloud/issues/321 There were instances where the detailed report page wouldn't load, with several error 500 from the `wp-json/jetpack-boost-ds/image-size-analysis/set` endpoint. I couldn't find a consistent way of reproducing this.

<details><summary>screenshot</summary>
<img src="https://github.com/Automattic/jetpack/assets/11799079/4e8afe62-9011-41be-9aef-dedd332f1b9b" />

</details>

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes ISA details page not loading.
* Also fixes the 'bad entry' listing item not showing, due to getting filtered out because of a missing status.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

During testing, I noticed that an SVG image didn't have width in the database (the value was empty). Since the schema requires a number, in order to consistently reproduce this and break it, you can just delete the value of `fileSize_weight` (from the meta table `boost_report_issue_meta`) for an image.

### Test that it breaks

* Setup Boost with ISA and make sure you have some pages with images;
* Break an image following the instructions above;
* Request a report;
* Check the network tab, to make sure there's an error 500 for the `set` endpoint;
* Wait for the UI to finish polling;
* No issues will load.

### Test that it works

* Apply the fix;
* Request a report;
* Check the network tab, to make sure the `set` endpoint returns 200;
* The UI should properly load and display a "broken item" element.

![CleanShot 2023-07-18 at 16 45 05](https://github.com/Automattic/jetpack/assets/11799079/1c062b0e-3100-45d1-98c9-f77ac829d0f7)
