### PR TITLE
Launchpad: Update initial state of subscribers task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-launchpad-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-launchpad-tasks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated initial state of Launchpad subscribers task.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -129,7 +129,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => '__return_true',
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_has_goal_import_subscribers',
 		),
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the initial state of the Launchpad subscribers_added task from true/complete to whatever the option is set as, which will be false/incomplete for new tasks. This is because we're now only showing the subscriber screen AFTER someone arrives on Launchpad, rather than before. 

**Associated frontend PR.** This PR can be tested with an [associated Calypos frontend PR](https://github.com/Automattic/wp-calypso/pull/79568) removes the Add Subscribers screen in onboarding and adds new task completion logic for the subscribers_added task.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**You can test this on Simple sites.**

1) Setup
   - Load the [Calypso frontend PR](https://github.com/Automattic/wp-calypso/pull/79568) in your local calypso environment. 
   - Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/newsletter-launchpad-tasks` to load the Jetpack backend PR branch in your sandbox.
   - Be sure to sandbox public-api and the domain of each test site as you go through testing. 
2) Test
      - Start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro. Select "Import existing newsletter" as your goal. When you arrive at Launchpad, confirm you see the Add Subscribers task and *the task now shows as incomplete.*
      - Click the task and go to the Add Subscribers screen. Click 'Skip for now', and when you return to Launchpad, confirm the task now shows as completed.

