### PR TITLE
CRM: Fix Emerald issues 3186 3217 3218 

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3186-3217-3218-several-emerald-fixes
+++ b/projects/plugins/crm/changelog/fix-crm-3186-3217-3218-several-emerald-fixes
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Fixed issues introduced by the Emerald design: margins of export pages, 'Invoicing Pro:' upsell misplaced header, removed the html custom element jpcrm-top-menu

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -270,7 +270,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 		})
 		</script>
 		<!---  // mobile only menu -->
-	<jpcrm-top-menu id="jpcrm-top-menu">
+	<div id="jpcrm-top-menu">
 		<div class="logo-cube <?php echo esc_attr( $admin_menu_state ); ?>">
 			<div class="cube-side side1">
 				<img alt="Jetpack CRM logo" src="<?php echo esc_url( jpcrm_get_logo( false ) ); ?>">
@@ -720,7 +720,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 		</menu-section>
 		</menu-bar><!-- end .menu-bar -->
 
-	</jpcrm-top-menu>
+	</div>
 		<?php
 
 	}

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
@@ -205,8 +205,7 @@ function zeroBSCRM_render_invoiceslist_page() { // phpcs:ignore WordPress.Naming
 
 	if ( ! zeroBSCRM_isExtensionInstalled( 'invpro' ) ) {
 		if ( ! $bundle ) {
-			$upsell_box_html  = '<!-- Inv PRO box --><div class="">';
-			$upsell_box_html .= '<h4>Invoicing Pro:</h4>';
+			$upsell_box_html = '<!-- Inv PRO box --><div class="">';
 
 			$up_title  = esc_html__( 'Supercharged Invoicing', 'zero-bs-crm' );
 			$up_desc   = esc_html__( 'Get more out of invoicing, like accepting online payments!', 'zero-bs-crm' );
@@ -216,8 +215,7 @@ function zeroBSCRM_render_invoiceslist_page() { // phpcs:ignore WordPress.Naming
 			$upsell_box_html .= zeroBSCRM_UI2_squareFeedbackUpsell( $up_title, $up_desc, $up_button, $up_target );
 			$upsell_box_html .= '</div><!-- / Inv PRO box -->';
 		} else {
-			$upsell_box_html  = '<!-- Inv PRO box --><div class="">';
-			$upsell_box_html .= '<h4>Invoicing Pro:</h4>';
+			$upsell_box_html = '<!-- Inv PRO box --><div class="">';
 
 			$up_title  = esc_html__( 'Supercharged Invoicing', 'zero-bs-crm' );
 			$up_desc   = esc_html__( 'You have Invoicing Pro available because you are using a bundle. Please download and install from your account:', 'zero-bs-crm' );

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -207,14 +207,14 @@ function zbscrm_JS_adminMenuDropdown() {
 
 		// if calypso, loading on an embed page, already full screen, need to run this to re-adjust/hide:
 		setTimeout( function () {
-			if ( ! jQuery( 'jpcrm-top-menu .logo-cube' ).hasClass( 'menu-open' ) ) {
-				zbscrm_JS_fullscreenModeOn( jQuery( 'jpcrm-top-menu .logo-cube' ) );
+			if ( ! jQuery( '#jpcrm-top-menu .logo-cube' ).hasClass( 'menu-open' ) ) {
+				zbscrm_JS_fullscreenModeOn( jQuery( '#jpcrm-top-menu .logo-cube' ) );
 			}
 		}, 0 );
 	}
 
 	// bind the toggle
-	jQuery( 'jpcrm-top-menu .logo-cube' )
+	jQuery( '#jpcrm-top-menu .logo-cube' )
 		.off( 'click' )
 		.on( 'click', function ( e ) {
 			if ( ! window.zbscrmjs_adminMenuBlocker ) {

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.export.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.export.scss
@@ -12,6 +12,7 @@
     
     margin-top:1em;
     margin-right:1em;
+	 padding: 0px 40px;
 
 
     #zbs-export-fields-wrap, #zbs-export-filetype-wrap {

--- a/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
+++ b/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
@@ -1,4 +1,4 @@
-jpcrm-top-menu#jpcrm-top-menu {
+#jpcrm-top-menu {
 	padding: 20px 20px 0px 20px;
 	display: block;
 	background-color: white;

--- a/projects/plugins/crm/tests/codeception/acceptance/12_JPCRM_Admin_Views_Cest.php
+++ b/projects/plugins/crm/tests/codeception/acceptance/12_JPCRM_Admin_Views_Cest.php
@@ -25,7 +25,7 @@ class JPCRM_Admin_Views_Cest {
 		);
 
 		foreach ( $expectedAdminMenus as $menu ) {
-			$I->see( $menu, 'jpcrm-top-menu .item' );
+			$I->see( $menu, '#jpcrm-top-menu .item' );
 		}
 	}
 	public function see_jpcrm_dashboard( AcceptanceTester $I ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes issues introduced by the Emerald design: margins of export pages, 'Invoicing Pro:' upsell misplaced header, removed the html custom element jpcrm-top-menu

## Proposed changes:

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3186
https://github.com/Automattic/zero-bs-crm/issues/3217
https://github.com/Automattic/zero-bs-crm/issues/3218

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Go to all export pages (e.g. `wp-admin/admin.php?page=zbs-export-tools`)
* Ensure the margins look good and aligned

* Open the invoicing page (`wp-admin/admin.php?page=manage-invoices`)
* Scroll all the way down
* Ensure the upsell box doesn't look too weird

* Check the html code for our top menu (element id = `jpcrm-top-menu`)
* Ensure no undefined custom elements are being used
* Ensure the menu works normally

* Run our codeception tests