### PR TITLE
Paid Stats: allow return to Stats Dashboard after purchase from My Jetpack

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-add-redirect-to-for-stats-purchase
+++ b/projects/packages/my-jetpack/changelog/update-add-redirect-to-for-stats-purchase
@@ -1,4 +1,4 @@
-Significance: minor
-Type: changed
+Significance: patch
+Type: fixed
 
 My Jetpack: enabled Stats purchase flow returning to Stats Dashboard

--- a/projects/packages/my-jetpack/changelog/update-add-redirect-to-for-stats-purchase
+++ b/projects/packages/my-jetpack/changelog/update-add-redirect-to-for-stats-purchase
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Paid Stats: enabled Stats purchase flow and removed feature flag

--- a/projects/packages/my-jetpack/changelog/update-add-redirect-to-for-stats-purchase
+++ b/projects/packages/my-jetpack/changelog/update-add-redirect-to-for-stats-purchase
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Paid Stats: enabled Stats purchase flow and removed feature flag
+My Jetpack: enabled Stats purchase flow returning to Stats Dashboard

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
+use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Jetpack_Options;
@@ -134,18 +135,24 @@ class Stats extends Module_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		$purchases_data = Wpcom_Products::get_site_current_purchases();
-		if ( is_wp_error( $purchases_data ) ) {
-			return false;
-		}
-		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
-			foreach ( $purchases_data as $purchase ) {
-				if ( 0 === strpos( $purchase->product_slug, 'jetpack_stats' ) ) {
-					return true;
+		// Check if paid stats plans have been enabled.
+		if ( Jetpack_Constants::is_true( 'JETPACK_PAID_STATS_ENABLED' ) ) {
+			$purchases_data = Wpcom_Products::get_site_current_purchases();
+			if ( is_wp_error( $purchases_data ) ) {
+				return false;
+			}
+			if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+				foreach ( $purchases_data as $purchase ) {
+					if ( 0 === strpos( $purchase->product_slug, 'jetpack_stats' ) ) {
+						return true;
+					}
 				}
 			}
+			return false;
 		}
-		return false;
+
+		// Until the new paid stats plans roll out, no plan purchase is required for Jetpack Stats.
+		return true;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
-use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Jetpack_Options;
@@ -135,24 +134,18 @@ class Stats extends Module_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		// Check if paid stats plans have been enabled.
-		if ( Jetpack_Constants::is_true( 'JETPACK_PAID_STATS_ENABLED' ) ) {
-			$purchases_data = Wpcom_Products::get_site_current_purchases();
-			if ( is_wp_error( $purchases_data ) ) {
-				return false;
-			}
-			if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
-				foreach ( $purchases_data as $purchase ) {
-					if ( 0 === strpos( $purchase->product_slug, 'jetpack_stats' ) ) {
-						return true;
-					}
-				}
-			}
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
 			return false;
 		}
-
-		// Until the new paid stats plans roll out, no plan purchase is required for Jetpack Stats.
-		return true;
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				if ( 0 === strpos( $purchase->product_slug, 'jetpack_stats' ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -162,11 +155,9 @@ class Stats extends Module_Product {
 	 */
 	public static function get_purchase_url() {
 		$blog_id = Jetpack_Options::get_option( 'id' );
-		// TODO: Handle unconnected sites without a defined blog_id. (Or check if we need to.)
-		// TODO: Remove the "stats/paid-stats" feature flag from the URL once paid stats has rolled out to the public.
-		// TODO: Consider adding a post-purchase redirect URL as a query string to the purchase URL.
-		// Appending get_manage_url() to the purchase URL would be a good option.
-		return sprintf( 'https://wordpress.com/stats/purchase/%d', $blog_id ) . '?flags=stats/paid-stats';
+		// The returning URL could be customized by adding a `redirect_uri` param with relative path e.g. admin.php?page=stats.
+		// We omitted the param here. As a result, it'd return to the default location - the Stats Dashboard.
+		return sprintf( 'https://wordpress.com/stats/purchase/%d?from=jetpack-my-jetpack', $blog_id );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -155,9 +155,8 @@ class Stats extends Module_Product {
 	 */
 	public static function get_purchase_url() {
 		$blog_id = Jetpack_Options::get_option( 'id' );
-		// The returning URL could be customized by adding a `redirect_uri` param with relative path e.g. admin.php?page=stats.
-		// We omitted the param here. As a result, it'd return to the default location - the Stats Dashboard.
-		return sprintf( 'https://wordpress.com/stats/purchase/%d?from=jetpack-my-jetpack', $blog_id );
+		// The returning URL could be customized by changing the `redirect_uri` param with relative path.
+		return sprintf( 'https://wordpress.com/stats/purchase/%d?from=jetpack-my-jetpack&redirect_uri=%s', $blog_id, rawurldecode( 'admin.php?page=stats' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* Adds `from=jetpack-my-jetpack` for purchase flow initialized from My Jetpack
* Removes feature gating for the purchase of Jetpack Stats

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

1. Remove any Stats purchase from `https://wordpress.com/purchases/subscriptions/${siteSlug}`
2. Purge notice status if previous dismissed:
  * Run `wpsh` in sandbox
  * Run `switch_to_blog($blog_id);`
  * Run `delete_option('stats_dashboard_options');`
3. Build My Jetpack if necessary `jetpack build packages/my-jetpack`
3. Build Jetpack if necessary `jetpack build plugins/jetpack`
4. Build Odyssey Stats locally `STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin yarn dev`
5. Start your local Calypso `yarn start` on branch `add/stats-purchase-return-support` from https://github.com/Automattic/wp-calypso/pull/79595
3. Open your local Jetpack site on `/wp-admin/admin.php?page=my-jetpack`
4. Ensure you the Stats card

<img width="332" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/1467cf39-2419-4eb0-b4a9-fa3118406469">


6. Click `Upgrade`
7. Ensure it redirects to the purchase page on https://wordpress.com
8. Replace the hostname with `http://calypso.localhost:3000`
9. Choose Personal
10. Slide to $0/month, check all the boxes and finish the purchase
11. Ensure you are redirected back to the Stats Dashboard of the Jetpack site
12. Ensure upgrade success notice is showing (Free / Paid)

Repeat for PWYW and Commercial products.