### PR TITLE
[paid-newsletters] Only display the "Newsletter" column if a Payment Plan was created

### DIFF
--- a/projects/plugins/jetpack/changelog/add-prevent-displaying-nl-column-if-newsletters-have-not-been-published
+++ b/projects/plugins/jetpack/changelog/add-prevent-displaying-nl-column-if-newsletters-have-not-been-published
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Only display the "NL access" column if we have published one paid-newsletter

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -136,6 +136,11 @@ function is_wpcom() {
  * @return array An array of column names.
  */
 function register_newsletter_access_column( $columns ) {
+	if ( ! Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' ) ) {
+		// We only display the "NL access" column if we have published one paid-newsletter
+		return $columns;
+	}
+
 	$position   = array_search( 'title', array_keys( $columns ), true );
 	$new_column = array( NEWSLETTER_COLUMN_ID => '<span>' . __( 'Newsletter', 'jetpack' ) . '</span>' );
 	return array_merge(


### PR DESCRIPTION
Fixes #31831

## Proposed changes:

* Only display the "NL access" column if a payment plan was created for that site.

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

1. On a brand new site, go to Jetpack > Settings > Discussion and activate the Subscriptions feature.
2. Go to Posts > All Posts
    * You should not see a Newsletter column.
4. Go to Posts > Add New
5. In the Newsletter visibility section, follow the prompts to set up a payment plan.
6. Go back to Posts > All Posts in wp-admin
    * You should now see a Newsletter column.


