### PR TITLE
My Jetpack: register jetpack-ai-jwt endpoint

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: register jetpack-ai-jwt endpoint

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -74,7 +74,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.1.x-dev"
+			"dev-trunk": "3.2.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.1.3",
+	"version": "3.2.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -223,6 +223,7 @@ class Initializer {
 		new REST_Products();
 		new REST_Purchases();
 		new REST_Zendesk_Chat();
+		new REST_AI();
 
 		register_rest_route(
 			'my-jetpack/v1',

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.1.3';
+	const PACKAGE_VERSION = '3.2.0-alpha';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/my-jetpack/src/class-rest-ai.php
+++ b/projects/packages/my-jetpack/src/class-rest-ai.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Sets up the AI REST API endpoints.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Client as Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Jetpack_Options;
+use WP_Error;
+
+/**
+ * Registers the REST routes for AI.
+ */
+class REST_AI {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		register_rest_route(
+			'my-jetpack/v1',
+			'jetpack-ai-jwt',
+			array(
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::get_openai_jwt',
+				'permission_callback' => function () {
+					return ( new Connection_Manager( 'jetpack' ) )->is_user_connected() && current_user_can( 'edit_posts' );
+				},
+			)
+		);
+	}
+
+	/**
+	 * Ask WPCOM for a JWT token to use for OpenAI completion.
+	 */
+	public static function get_openai_jwt() {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+
+		$response = Client::wpcom_json_api_request_as_user(
+			"/sites/$blog_id/jetpack-openai-query/jwt",
+			'2',
+			array(
+				'method'  => 'POST',
+				'headers' => array( 'Content-Type' => 'application/json; charset=utf-8' ),
+			),
+			wp_json_encode( array() ),
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$json = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( ! isset( $json->token ) ) {
+			return new WP_Error( 'no-token', 'No token returned from WPCOM' );
+		}
+
+		return array(
+			'token'   => $json->token,
+			'blog_id' => $blog_id,
+		);
+	}
+
+}

--- a/projects/plugins/backup/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/backup/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -896,7 +896,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "ef8035e8d192d699d0680374eef9636596885a0f"
+                "reference": "d5b04f8d45d0f213dbb195f443687183eea9ba7e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -926,7 +926,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/boost/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -950,7 +950,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "ef8035e8d192d699d0680374eef9636596885a0f"
+                "reference": "d5b04f8d45d0f213dbb195f443687183eea9ba7e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -980,7 +980,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1696,7 +1696,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "ef8035e8d192d699d0680374eef9636596885a0f"
+                "reference": "d5b04f8d45d0f213dbb195f443687183eea9ba7e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1726,7 +1726,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/migration/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -896,7 +896,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "ef8035e8d192d699d0680374eef9636596885a0f"
+                "reference": "d5b04f8d45d0f213dbb195f443687183eea9ba7e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -926,7 +926,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/protect/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "ef8035e8d192d699d0680374eef9636596885a0f"
+                "reference": "d5b04f8d45d0f213dbb195f443687183eea9ba7e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/search/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "ef8035e8d192d699d0680374eef9636596885a0f"
+                "reference": "d5b04f8d45d0f213dbb195f443687183eea9ba7e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/social/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "ef8035e8d192d699d0680374eef9636596885a0f"
+                "reference": "d5b04f8d45d0f213dbb195f443687183eea9ba7e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "ef8035e8d192d699d0680374eef9636596885a0f"
+                "reference": "d5b04f8d45d0f213dbb195f443687183eea9ba7e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/update-my-jetpack=-register-ai-jwt-endpoint
+++ b/projects/plugins/videopress/changelog/update-my-jetpack=-register-ai-jwt-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "ef8035e8d192d699d0680374eef9636596885a0f"
+                "reference": "d5b04f8d45d0f213dbb195f443687183eea9ba7e"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "3.2.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR registers the `jetpack-ai-jwt` endpoint in the `my-jetpack/v1` namespace.
Currently, the [endpoint is registered by the Jetpack plugin](https://github.com/Automattic/jetpack/blob/7785086b2b4337f6db1bef8b1d2731154ba250d9/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php#L80), meaning it's only available when it's activated on the site which can be considered a blocker for those projects that are independent of the plugin and want to use it.

Moving the endpoint to My Jetpack guarantees its availability at least in the Jetpack environment. Almost all Jetpack products depend on My Jetpack. For instance, it would be possible to hit the endpoint from VideoPress or Social self-hosted plugins.

_**But it's worth mentioning that it could be considered a temporary solution, too.**_

Fixes https://github.com/Automattic/jetpack/issues/31938

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: register jetpack-ai-jwt endpoint

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Since the endpoint is not being used yet, the testing steps are quite simple.

* Confirm the endpoint register in the `my-jetpack/v1` namespace. You can list all endpoints by using the `wp-json` URL. For instance, in your local dev-env:

<img width="739" alt="Screenshot 2023-07-19 at 11 59 56" src="https://github.com/Automattic/jetpack/assets/77539/35792315-3dbc-4a4e-aaae-9d29b8ff8260">


* You can try to hit the endpoint by using the dev console tool.
* Ensure replacing `<your-site-here>` for the site hostname:

```
fetch("http://<your-site-here>/wp-json/my-jetpack/v1/jetpack-ai-jwt?_cacheBuster=1689778884847&_locale=user", {
  "headers": {
    "accept": "application/json, */*;q=0.1",
    "accept-language": "en,es;q=0.9,es-419;q=0.8,it;q=0.7,pt;q=0.6,fr;q=0.5,nb;q=0.4,pl;q=0.3",
    "sec-ch-ua": "\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Google Chrome\";v=\"114\"",
    "sec-ch-ua-mobile": "?0",
    "sec-ch-ua-platform": "\"macOS\"",
    "sec-fetch-dest": "empty",
    "sec-fetch-mode": "cors",
    "sec-fetch-site": "same-origin",
    "x-wp-api-fetch-from-editor": "true",
    "x-wp-nonce": "e8e40ece26"
  },
  "referrer": "http://localhost/wp-admin/post.php?post=1559&action=edit",
  "referrerPolicy": "strict-origin-when-cross-origin",
  "body": null,
  "method": "POST",
  "mode": "cors",
  "credentials": "include"
});
```
* run that command
* Open the network tab
* Confirm you see the token and post ID

<img width="749" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/a1afb472-1fea-46bf-ae28-5556fef1ba01">

