### PR TITLE
AI Client: hit the my-jetpack/v1 endpoint to request JWT

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-client-switch-to-my-jetpack-endpoint-to-get-jwt
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-switch-to-my-jetpack-endpoint-to-get-jwt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: hit the `my-jetpack/v1` endpoint to request JWT

--- a/projects/js-packages/ai-client/src/jwt/index.ts
+++ b/projects/js-packages/ai-client/src/jwt/index.ts
@@ -74,7 +74,7 @@ export default async function requestJwt( {
 			 * Provably we should move it to another package, but for now it's here.
 			 * issue: https://github.com/Automattic/jetpack/issues/31938
 			 */
-			path: '/jetpack/v4/jetpack-ai-jwt?_cacheBuster=' + Date.now(),
+			path: '/my-jetpack/v1/jetpack-ai-jwt?_cacheBuster=' + Date.now(),
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,

--- a/projects/js-packages/ai-client/src/jwt/index.ts
+++ b/projects/js-packages/ai-client/src/jwt/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
+import { isSimpleSite, isAtomicSite } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import debugFactory from 'debug';
 /*
@@ -47,6 +47,7 @@ export default async function requestJwt( {
 	expirationTime = expirationTime || JWT_TOKEN_EXPIRATION_TIME;
 
 	const isSimple = isSimpleSite();
+	const isAtomic = isAtomicSite();
 
 	// Trying to pick the token from localStorage
 	const token = localStorage.getItem( JWT_TOKEN_ID );
@@ -68,13 +69,14 @@ export default async function requestJwt( {
 	let data: TokenDataEndpointResponseProps;
 
 	if ( ! isSimple ) {
+		const endpoint = isAtomic ? '/jetpack/v4/jetpack-ai-jwt' : '/my-jetpack/v1/jetpack-ai-jwt';
 		data = await apiFetch( {
 			/*
 			 * This endpoint is registered in the Jetpack plugin.
 			 * Provably we should move it to another package, but for now it's here.
 			 * issue: https://github.com/Automattic/jetpack/issues/31938
 			 */
-			path: '/my-jetpack/v1/jetpack-ai-jwt?_cacheBuster=' + Date.now(),
+			path: `${ endpoint }?_cacheBuster=${ Date.now() }`,
 			credentials: 'same-origin',
 			headers: {
 				'X-WP-Nonce': apiNonce,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to 
communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# DO NOT MERGE - depends on https://github.com/Automattic/jetpack/pull/31965~

Since https://github.com/Automattic/jetpack/pull/31965 is merged, we're ready to switch to the `my-jetpack/v1` namespace for Jetpack sites.
For Atomic sites and keeping in mind that My Jetpack is not available there, we still uses the same `jetpack/v4` namespace.
Simple sites use a different endpoint (already handled).

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: hit the `my-jetpack/v1` endpoint to request JWT

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Best way to test it is by using the AI Assistant block of the Jetpack plugin

* Go to the block editor
* Create an AI Assistant block instance
* Request a suggestion
* Confirm the block works as expected
* Take a look at the `jetpack-ai-jwt` endpoint request.
* Confirm it hits the `my-jetpack/v1` namespace for Jetpack sites:

<img width="953" alt="Screenshot 2023-07-19 at 15 50 10" src="https://github.com/Automattic/jetpack/assets/77539/7a53aba7-51a7-4098-ae55-2c797d21776a">

* Confirm it hits the `jetpack/v4` namespace for Atomic sites:

<img width="955" alt="Screenshot 2023-07-19 at 16 14 00" src="https://github.com/Automattic/jetpack/assets/77539/8e833d54-da23-4506-8e24-abfb7fa4fb14">

* Confirm it hits the `/wpcom/v2/sites/'<site-id >/jetpack-openai-query/jwt` endpoint for Simple sites:
<img width="950" alt="Screenshot 2023-07-19 at 15 59 59" src="https://github.com/Automattic/jetpack/assets/77539/0953e94b-91b1-4653-bbd3-d6614e224e56">


* Take a look at the response body. Confirm you see the token there.


