### PR TITLE
Launchpad: Add count properties to task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-count-properties-to-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-count-properties-to-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds the count propertis to the task definitions

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -292,6 +292,11 @@ class Launchpad_Task_Lists {
 		$built_task['badge_text']   = $this->load_value_from_callback( $task, 'badge_text_callback' );
 		$built_task['isLaunchTask'] = isset( $task['isLaunchTask'] ) ? $task['isLaunchTask'] : false;
 
+		if ( isset( $task['target_repetitions'] ) ) {
+			$built_task['target_repetitions'] = $task['target_repetitions'];
+			$built_task['repetition_count']   = $this->load_repetition_count( $task );
+		}
+
 		return $built_task;
 	}
 
@@ -348,6 +353,16 @@ class Launchpad_Task_Lists {
 			$task['subtitle'];
 		}
 		return '';
+	}
+
+	/**
+	 * Loads the repetition count for a task, calling the callback if it exists.
+	 *
+	 * @param Task $task A task definition.
+	 * @return int|null The repetition count for the task.
+	 */
+	private function load_repetition_count( $task ) {
+		return $this->load_value_from_callback( $task, 'repetition_count_callback' );
 	}
 
 	/**
@@ -610,6 +625,14 @@ class Launchpad_Task_Lists {
 
 		if ( ! $has_valid_title ) {
 			_doing_it_wrong( 'validate_task', 'The Launchpad task being registered requires a "title" attribute or a "get_title" callback', '6.2' );
+			return false;
+		}
+
+		$has_any_repetition_properties  = isset( $task['target_repetitions'] ) || isset( $task['repetition_count_callback'] );
+		$has_both_repetition_properties = isset( $task['target_repetitions'] ) && isset( $task['repetition_count_callback'] );
+
+		if ( $has_any_repetition_properties && ! $has_both_repetition_properties ) {
+			_doing_it_wrong( 'validate_task', 'The Launchpad task being registered requires both a "target_repetitions" attribute and a "repetition_count_callback" callback', '6.3' );
 			return false;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/79611

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Some of the new tasks for the Newsletter launchpad require repetition in the task to mark it as complete. For example, we'll have the "Write 3 posts" task, which requires the user to write 3 posts to complete the task. The properties added in this PR will provide the data so we can use show these numbers in the interface, as the image below suggests.

<img width="948" alt="Screenshot 2023-07-19 at 08 42 38" src="https://github.com/Automattic/jetpack/assets/1234758/57e2bb01-b4e1-4532-ab8d-763f370c8794">

* Adds the `target_repetitions ` property: This property is used to define the number of repetitions to reach to complete the task.
* Adds the `repetition_count_callback` property: This callback will be used to calculate how many times the task was repeated.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The properties added in this PR are not being used yet, but I added some unit tests. Run:
```bash
cd projects/packages/jetpack-mu-wpcom; ./vendor/bin/phpunit --filter=Launchpad_Task_Lists_Test; cd -
```

