### PR TITLE
addMilestone: don't add PRs to frozen milestones

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-add-milestone-consider-code-freeze
+++ b/projects/github-actions/repo-gardening/changelog/update-add-milestone-consider-code-freeze
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+addMilestone task: if a milestone description contains a string with "Code Freeze: YYYY-MM-DD" or "Branch Cut: YYYY-MM-DD", and that date has elapsed, then don't add PRs to that milestone. This prevents merged PRs from being automatically added to milestones that have entered a code freeze.

--- a/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
+++ b/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
@@ -52,6 +52,19 @@ async function getNextValidMilestone( octokit, owner, repo, plugin = 'jetpack' )
 	const reg = new RegExp( '^' + plugin + '\\/\\d+\\.\\d' );
 	const milestones = ( await getOpenMilestones( octokit, owner, repo ) )
 		.filter( m => m.title.match( reg ) )
+		.filter( m => {
+			/**
+			 * If a milestone description contains a string with "Code Freeze: YYYY-MM-DD" or "Branch Cut: YYYY-MM-DD",
+			 * and that date has elapsed, then filter out the milestone. This prevents merged PRs from being
+			 * automatically added to milestones that have entered a code freeze.
+			 */
+			const match = m.description.match( /(?:Code Freeze|Branch Cut): (\d{4}-\d{2}-\d{2})/ );
+			if ( match && moment( match[ 1 ] ).isBefore( moment() ) ) {
+				return false;
+			}
+
+			return m;
+		} )
 		.sort( ( m1, m2 ) =>
 			compareVersions( m1.title.split( '/' )[ 1 ], m2.title.split( '/' )[ 1 ] )
 		);

--- a/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
+++ b/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
@@ -59,11 +59,7 @@ async function getNextValidMilestone( octokit, owner, repo, plugin = 'jetpack' )
 			 * automatically added to milestones that have entered a code freeze.
 			 */
 			const match = m.description.match( /(?:Code Freeze|Branch Cut): (\d{4}-\d{2}-\d{2})/ );
-			if ( match && moment( match[ 1 ] ).isBefore( moment() ) ) {
-				return false;
-			}
-
-			return m;
+			return ! ( match && moment( match[ 1 ] ) < moment() );
 		} )
 		.sort( ( m1, m2 ) =>
 			compareVersions( m1.title.split( '/' )[ 1 ], m2.title.split( '/' )[ 1 ] )


### PR DESCRIPTION
## Proposed changes:

addMilestone task: if a milestone description contains a string with "Code Freeze: YYYY-MM-DD" or "Branch Cut: YYYY-MM-DD", and that date has elapsed, then don't add PRs to that milestone. This prevents merged PRs from being automatically added to milestones that have entered a code freeze.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal: p9dueE-7z3-p2#comment-9885

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

I don't think there is a super graceful way to test this -- I tested using a personal repo and similar code as in `projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js` to fetch milestones and check the newly filtered array list with some local console logging.