### PR TITLE
[Boost] Allow us to view other reports

### DIFF
--- a/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Entry.php
+++ b/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Entry.php
@@ -17,8 +17,9 @@ class Image_Size_Analysis_Entry implements Lazy_Entry, Entry_Can_Get, Entry_Can_
 	private $search_query = '';
 
 	public function get() {
-		$data = Boost_API::get(
-			'image-guide/reports/latest/issues',
+		$report_id = defined( 'JETPACK_BOOST_FORCE_REPORT_ID' ) ? JETPACK_BOOST_FORCE_REPORT_ID : 'latest';
+		$data      = Boost_API::get(
+			'image-guide/reports/' . $report_id . '/issues',
 			array(
 				'page'     => $this->page,
 				'group'    => $this->group,

--- a/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Summary.php
+++ b/projects/plugins/boost/app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Summary.php
@@ -9,7 +9,8 @@ use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Lazy_Entry;
 class Image_Size_Analysis_Summary implements Lazy_Entry, Entry_Can_Get {
 
 	public function get() {
-		$report = Boost_API::get( 'image-guide/reports/latest' );
+		$report_id = defined( 'JETPACK_BOOST_FORCE_REPORT_ID' ) ? JETPACK_BOOST_FORCE_REPORT_ID : 'latest';
+		$report    = Boost_API::get( 'image-guide/reports/' . $report_id );
 
 		if ( is_wp_error( $report ) ) {
 			// If no report is found, return it as a status.

--- a/projects/plugins/boost/changelog/boost-force-report-id
+++ b/projects/plugins/boost/changelog/boost-force-report-id
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added a hidden define we can use to view any report_id from the Boost UI
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds a hidden define we can use to force the Boost UI to show us a specific report when using a sandboxed environment. Note this companion diff: D116523-code

## Proposed changes:
* Add a hidden define to allow us to view different image analyzer reports.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Set the define `JETPACK_BOOST_FORCE_REPORT_ID`.
* View the Boost dashboard.