### PR TITLE
Launchpad: Add the Free and Paid newsletter task lists

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-newsletter-task-lists
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-newsletter-task-lists
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the Free and Paid Newsletter task list

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -24,7 +24,7 @@ require_once __DIR__ . '/launchpad-task-definitions.php';
  */
 function wpcom_launchpad_get_task_list_definitions() {
 	$core_task_list_definitions = array(
-		'build'           => array(
+		'build'                  => array(
 			'title'               => 'Build',
 			'task_ids'            => array(
 				'setup_general',
@@ -36,7 +36,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		'free'            => array(
+		'free'                   => array(
 			'title'               => 'Free',
 			'task_ids'            => array(
 				'plan_selected',
@@ -49,7 +49,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		'link-in-bio'     => array(
+		'link-in-bio'            => array(
 			'title'               => 'Link In Bio',
 			'task_ids'            => array(
 				'design_selected',
@@ -60,7 +60,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		'link-in-bio-tld' => array(
+		'link-in-bio-tld'        => array(
 			'title'               => 'Link In Bio',
 			'task_ids'            => array(
 				'design_selected',
@@ -71,7 +71,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		'newsletter'      => array(
+		'newsletter'             => array(
 			'title'               => 'Newsletter',
 			'task_ids'            => array(
 				'setup_newsletter',
@@ -84,7 +84,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		'videopress'      => array(
+		'videopress'             => array(
 			'title'               => 'Videopress',
 			'task_ids'            => array(
 				'videopress_setup',
@@ -94,7 +94,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		'write'           => array(
+		'write'                  => array(
 			'title'               => 'Write',
 			'task_ids'            => array(
 				'setup_write',
@@ -105,7 +105,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		'start-writing'   => array(
+		'start-writing'          => array(
 			'title'               => 'Start Writing',
 			'task_ids'            => array(
 				'first_post_published',
@@ -116,7 +116,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		'design-first'    => array(
+		'design-first'           => array(
 			'title'               => 'Pick a Design',
 			'task_ids'            => array(
 				'design_completed',
@@ -168,6 +168,26 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'drive_traffic',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_intent_write_enabled',
+		),
+		'intent-free-newsletter' => array(
+			'title'               => 'Free Newsletter',
+			'task_ids'            => array(
+				'verify_email',
+				'domain_claim',
+				'domain_customize',
+				'share_site',
+			),
+			'is_enabled_callback' => 'wpcom_launchpad_is_free_newsletter_enabled',
+		),
+		'intent-paid-newsletter' => array(
+			'title'               => 'Paid Newsletter',
+			'task_ids'            => array(
+				'verify_email',
+				'domain_claim',
+				'domain_customize',
+				'share_site',
+			),
+			'is_enabled_callback' => 'wpcom_launchpad_is_paid_newsletter_enabled',
 		),
 	);
 
@@ -611,6 +631,24 @@ function wpcom_launchpad_is_keep_building_enabled() {
  */
 function wpcom_launchpad_is_intent_write_enabled() {
 	return apply_filters( 'is_launchpad_intent_write_enabled', false );
+}
+
+/**
+ * Checks if the Free Newsletter flow task list is enabled.
+ *
+ * @return bool True if the task list is enabled, false otherwise.
+ */
+function wpcom_launchpad_is_free_newsletter_enabled() {
+	return apply_filters( 'is_launchpad_intent_free_newsletter_enabled', false );
+}
+
+/**
+ * Checks if the Paid Newsletter flow task list is enabled.
+ *
+ * @return bool True if the task list is enabled, false otherwise.
+ */
+function wpcom_launchpad_is_paid_newsletter_enabled() {
+	return apply_filters( 'is_launchpad_intent_paid_newsletter_enabled', false );
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -639,7 +639,7 @@ function wpcom_launchpad_is_intent_write_enabled() {
  * @return bool True if the task list is enabled, false otherwise.
  */
 function wpcom_launchpad_is_free_newsletter_enabled() {
-	return apply_filters( 'is_launchpad_intent_free_newsletter_enabled', false );
+	return apply_filters( 'wpcom_launchpad_intent_free_newsletter_enabled', false );
 }
 
 /**
@@ -648,7 +648,7 @@ function wpcom_launchpad_is_free_newsletter_enabled() {
  * @return bool True if the task list is enabled, false otherwise.
  */
 function wpcom_launchpad_is_paid_newsletter_enabled() {
-	return apply_filters( 'is_launchpad_intent_paid_newsletter_enabled', false );
+	return apply_filters( 'wpcom_launchpad_intent_paid_newsletter_enabled', false );
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -129,7 +129,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
 		// @TODO: Remove the following task list once the migration/rename is complete across WP.com and Calypso.
-		'keep-building'   => array(
+		'keep-building'          => array(
 			'title'               => 'Keep Building',
 			'task_ids'            => array(
 				'site_title',
@@ -143,7 +143,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
-		'intent-build'    => array(
+		'intent-build'           => array(
 			'title'               => 'Keep Building',
 			'task_ids'            => array(
 				'site_title',
@@ -157,7 +157,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
-		'intent-write'    => array(
+		'intent-write'           => array(
 			'title'               => 'Blog',
 			'task_ids'            => array(
 				'site_title',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/79631 https://github.com/Automattic/wp-calypso/issues/79632

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds the Free and Paid Newsletter tasks lists on the back end so we can start working on and testing it. This will give us a base for us to start creating the front-end components and adding them to the setup view list.

* Adds the Free Newsletter task list
* Adds the Paid Newsletter task list

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch on your sandbox: https://github.com/Automattic/jetpack/pull/31981#issuecomment-1643032346
* Make sure you have the public API sandboxed.
* Add the following code in your `0-sandbox.php` file
```php
add_filter( 'is_launchpad_intent_free_newsletter_enabled', '__return_true', 20 );
add_filter( 'is_launchpad_intent_paid_newsletter_enabled', '__return_true', 20 );
```
* Navigate to the console: https://developer.wordpress.com/docs/api/console/
* Make the following requests to `WP REST API` -> `wpcom/v2`:
   - /sites/{YOUR_SIMPLE_SITE}/launchpad?_locale=user&checklist_slug=intent-free-newsletter
   - /sites/{YOUR_SIMPLE_SITE}/launchpad?_locale=user&checklist_slug=intent-paid-newsletter
* Both requests should work

