### PR TITLE
Boost: Image guide/more realistic size estimates

### DIFF
--- a/projects/js-packages/image-guide/changelog/image-guide-more-realistic-size-estimates
+++ b/projects/js-packages/image-guide/changelog/image-guide-more-realistic-size-estimates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add more realistic estimations for file size

--- a/projects/plugins/boost/changelog/image-guide-more-realistic-size-estimates
+++ b/projects/plugins/boost/changelog/image-guide-more-realistic-size-estimates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add more realistic estimations for file size


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Make more realistic estimates of image file size savings when shrinking images, taking mimetype and typical compression ratios into account.

## Proposed changes:
* Update Image Guide to add a method to fetch the mimetype of an image
* Update image guide to accept a mimetype when estimating the size of an image
* Update Boost to use the new Image Guide method updates.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try out the image guide.
* Look at its size estimates.
* See they are generally more realistic. :) 

