### PR TITLE
Repo Gardening: support "Branch Cut" in milestone descriptions

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-description-task-code-freeze
+++ b/projects/github-actions/repo-gardening/changelog/update-description-task-code-freeze
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Check description task: support different phrasing in milestone descriptiion. "Code Freeze" can also be "Branch cut".

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -94,7 +94,7 @@ async function getMilestoneDates( plugin, nextMilestone ) {
 		releaseDate = moment( nextMilestone.due_on ).format( 'LL' );
 
 		// Look for a code freeze date in the milestone description.
-		const dateRegex = /^Code Freeze: (\d{4}-\d{2}-\d{2})\s*$/m;
+		const dateRegex = /^(?:Code Freeze|Branch Cut): (\d{4}-\d{2}-\d{2})\s*$/m;
 		const freezeDateDescription = nextMilestone.description.match( dateRegex );
 
 		// If we have a date and it is valid, use it, otherwise set code freeze to a week before the release.


### PR DESCRIPTION
## Proposed changes:

We currently look for "Code Freeze" in the milestones' descriptions to help us build the description comment that gets posted on each PR. However, we'd like to start supporting other phrasing in milestone descriptions: "Branch cut".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p9dueE-5mH-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This isn't necessarily easy to test, you would need a fork where you've set a milestone