### PR TITLE
Launchpad: Additional task list validation test

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/77939-update-task-list-validation-cleanup
+++ b/projects/packages/jetpack-mu-wpcom/changelog/77939-update-task-list-validation-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added additional tests for launchpad tasklist validation

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -433,7 +433,7 @@ class Launchpad_Task_Lists {
 			_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );
 			$error_messages[] = $msg;
 		} elseif ( isset( $task_list['required_task_ids'] ) ) {
-				// Ensure we have a valid array.
+			// Ensure we have a valid array.
 			if ( ! is_array( $task_list['required_task_ids'] ) ) {
 				$msg = 'The required_task_ids attribute must be an array';
 				_doing_it_wrong( 'validate_task_list', esc_html( $msg ), '6.1' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-list-validation-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-list-validation-test.php
@@ -90,6 +90,15 @@ class Launchpad_Task_List_Validation_Test extends \WorDBless\BaseTestCase {
 				),
 				new WP_Error( 'invalid-task-list', 'The require_last_task_completion attribute must be a boolean' ),
 			),
+			'required_task_ids are not a subset of task_ids' => array(
+				array(
+					'id'                           => 'task_list_1',
+					'task_ids'                     => array( 'task_1', 'task_2' ),
+					'required_task_ids'            => array( 'task_3' ),
+					'require_last_task_completion' => 'true',
+				),
+				new WP_Error( 'invalid-task-list', 'The required_task_ids must be a subset of the task_ids' ),
+			),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to [77939](https://github.com/Automattic/wp-calypso/issues/77939)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
As noted in [31834](https://github.com/Automattic/jetpack/pull/31834#pullrequestreview-1539275095), we were missing a test case for task list validation. This adds the new test case.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `cd` into the `jetpack-mu-wpcom` directory.
* Run the feature tests (you may need to do `composer install` first).
```
./vendor/bin/phpunit -c ./phpunit.xml.dist --testsuite=features
```
* Tests should pass.

