### PR TITLE
Launchpad: Remove design edit task for post-launch Write sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-design-edited-post-launch
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-design-edited-post-launch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove `design_edited` task from post-launch task list.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -146,7 +146,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'title'               => 'Blog',
 			'task_ids'            => array(
 				'site_title',
-				'design_edited',
 				'domain_claim',
 				'verify_email',
 				'domain_customize',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We didn't find the "Edit site design" task moved the needle on the post-launch checklist for Build sites, so this PR removes it from the Write checklist as well.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox the API
* Create a new site from `/start` with the "Write & publish" intent
* Launch the site without doing any tasks in the onboarding Launchpad.
* Ensure you do not see the "Edit site design" task in the list.
