### PR TITLE
Recommendations Wizard: use Jetpack redirects for all links

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -312,8 +312,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'The Jetpack Newsletter Form combined with Creative Mail by Constant Contact can help automatically gather subscribers and send them beautiful emails. <ExternalLink>Learn more</ExternalLink>',
 					'jetpack'
 				),
-				descriptionLink:
-					'https://jetpack.com/support/jetpack-blocks/form-block/newsletter-sign-up-form/',
+				descriptionLink: getRedirectUrl( 'jetpack-support-jetpack-blocks-newsletter-sign-up' ),
 				ctaText: __( 'Install Creative Mail', 'jetpack' ),
 				illustration: 'assistant-creative-mail',
 			};
@@ -325,7 +324,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'With Jetpack Newsletter you can keep your audience engaged by automatically sending your content via email. <ExternalLink>Learn more</ExternalLink>',
 					'jetpack'
 				),
-				descriptionLink: 'https://jetpack.com/newsletter/',
+				descriptionLink: getRedirectUrl( 'jetpack-newsletter-landing' ),
 				ctaText: __( 'Enable Newsletter', 'jetpack' ),
 				illustration: 'assistant-creative-mail',
 			};
@@ -340,7 +339,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'If your site ever goes down, Downtime Monitoring will send you an email or push notitification to let you know. <ExternalLink>Learn more</ExternalLink>',
 					'jetpack'
 				),
-				descriptionLink: 'https://jetpack.com/support/monitor/',
+				descriptionLink: getRedirectUrl( 'jetpack-support-monitor' ),
 				ctaText: __( 'Enable Downtime Monitoring', 'jetpack' ),
 				illustration: 'assistant-downtime-monitoring',
 			};
@@ -355,7 +354,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'Displaying Related Posts at the end of your content keeps visitors engaged and on your site. <ExternalLink>Learn more</ExternalLink>',
 					'jetpack'
 				),
-				descriptionLink: 'https://jetpack.com/support/related-posts/',
+				descriptionLink: getRedirectUrl( 'jetpack-support-related-posts' ),
 				ctaText: __( 'Enable Related Posts', 'jetpack' ),
 				illustration: 'assistant-related-post',
 			};
@@ -367,7 +366,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'Faster sites get better ranking in search engines and help keep visitors on your site longer. Jetpack will automatically optimize and load your images and files from our global Content Delivery Network (CDN). <ExternalLink>Learn more</ExternalLink>',
 					'jetpack'
 				),
-				descriptionLink: 'https://jetpack.com/support/site-accelerator/',
+				descriptionLink: getRedirectUrl( 'jetpack-support-site-accelerator' ),
 				ctaText: __( 'Enable Site Accelerator', 'jetpack' ),
 				illustration: 'assistant-site-accelerator',
 			};
@@ -426,7 +425,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					'We’re partnered with <strong>WooCommerce</strong> — a customizable, open-source eCommerce platform built for WordPress. It’s everything you need to start selling products today. <ExternalLink>Learn more</ExternalLink>',
 					'jetpack'
 				),
-				descriptionLink: 'https://woocommerce.com/woocommerce-features/',
+				descriptionLink: getRedirectUrl( 'woocommerce-features-landing' ),
 				ctaText: __( 'Install WooCommerce', 'jetpack' ),
 				illustration: 'assistant-woo-commerce',
 			};

--- a/projects/plugins/jetpack/changelog/update-recommendations-links
+++ b/projects/plugins/jetpack/changelog/update-recommendations-links
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Recommendations: update links to use Jetpack Redirects for all links.
+
+


### PR DESCRIPTION
## Proposed changes:

No functional changes here, we just switch to tracked links for all info links in the recommendations wizard.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See https://github.com/Automattic/jetpack/pull/31940#discussion_r1267854728
## Does this pull request change what data or activity we track or use?

* Yes, some more links will be tracked from now on.

## Testing instructions:

* Start a brand new site and connect it to WordPress.com.
* When back in wp-admin, follow the steps in the Recommendations banner that pops up.
* Click the links and ensure that they still work.
