### PR TITLE
Form block: rename newsletter sign-up variation

### DIFF
--- a/projects/packages/forms/changelog/update-newsletter-sign-up-variation-name
+++ b/projects/packages/forms/changelog/update-newsletter-sign-up-variation-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update the name of the Newsletter Sign-up Variation.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.19.7",
+	"version": "0.19.8-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -62,7 +62,7 @@ const variations = compact( [
 	},
 	! isSimpleSite() && {
 		name: 'newsletter-form',
-		title: __( 'Newsletter Sign-up', 'jetpack-forms' ),
+		title: __( 'Sign-up', 'jetpack-forms' ),
 		description: __(
 			'A simple way to collect information from folks visiting your site.',
 			'jetpack-forms'

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.19.7';
+	const PACKAGE_VERSION = '0.19.8-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/plugins/jetpack/changelog/update-newsletter-sign-up-variation-name
+++ b/projects/plugins/jetpack/changelog/update-newsletter-sign-up-variation-name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Contact Form: Update the name of the Newsletter Sign-up Variation.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/variations.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/variations.js
@@ -61,7 +61,7 @@ const variations = compact( [
 	},
 	! isSimpleSite() && {
 		name: 'newsletter-form',
-		title: __( 'Newsletter Sign-up', 'jetpack' ),
+		title: __( 'Sign-up', 'jetpack' ),
 		description: __(
 			'A simple way to collect information from folks visiting your site',
 			'jetpack'


### PR DESCRIPTION
Fixes #31989

## Proposed changes:

We have multiple blocks answering to the "newsletter" keyword nowadays. Since this variation is not a full-fledged newsletter sign-up on its own, let's avoid calling it "Newsletter".

**After the change**

<img width="340" alt="Screenshot 2023-07-20 at 18 39 57" src="https://github.com/Automattic/jetpack/assets/426388/e2e51e19-a133-4ea5-a907-125ea33d57c3">
<img width="380" alt="Screenshot 2023-07-20 at 18 39 46" src="https://github.com/Automattic/jetpack/assets/426388/7dfb6392-b297-4224-8573-8653f3dfacda">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pbNhbs-7sw-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> **Note**
> This variation is not available on WordPress.com simple, so you will not be able to test there.

On a site that's connected to WordPress.com, go to Posts > Add New, and search for "Newsletter". The Form Block variation should not come up. It should, however, come up if you search for "Sign-up".


