### PR TITLE
Subscriptions: Remove feature flag for subcribe modal

### DIFF
--- a/projects/plugins/jetpack/changelog/upddate-remove-subscribe-modal-feature-flag
+++ b/projects/plugins/jetpack/changelog/upddate-remove-subscribe-modal-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscriptions: Remove subscribe modal feature flag.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -255,15 +255,6 @@ HTML;
 		}
 		return false;
 	}
-
-	/**
-	 * Check if we're in WordPress.com.
-	 *
-	 * @return bool
-	 */
-	public static function is_wpcom() {
-		return defined( 'IS_WPCOM' ) && IS_WPCOM;
-	}
 }
 
 add_filter(

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -257,25 +257,6 @@ add_filter(
 	)
 );
 
-/*
- * The following line is being added temporarily as a feature flag.
- *
- * It disables the subscribe modal feature using the
- * jetpack_subscriptions_modal_enabled filter. If you want to test
- * this feature, you'll need to override the line below by adding
- *
- * add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 );
- *
- * to your test site. When we are ready for full release of this
- * feature, we will remove this line, but will leave the
- * jetpack_subscriptions_modal_enabled filter in place.
- * The filter is documented just below and defaults to false.
- * But for production purposes, the value of this filter is
- * determined by add_filter() call just above, which uses the
- * should_load_subscriber_modal() method.
- */
-add_filter( 'jetpack_subscriptions_modal_enabled', '__return_false', 11 );
-
 /**
  * Filter for enabling or disabling the Jetpack Subscribe Modal
  * feature. We use this filter here and in several other places

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -191,6 +191,9 @@ HTML;
 	 * @return bool
 	 */
 	public static function should_load_subscriber_modal() {
+		if ( ! self::is_wpcom() ) {
+			return false;
+		}
 		if ( 'lettre' !== get_option( 'stylesheet' ) && 'newsletter' !== get_option( 'site_intent' ) ) {
 			return false;
 		}
@@ -246,6 +249,15 @@ HTML;
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Check if we're in WordPress.com.
+	 *
+	 * @return bool
+	 */
+	public static function is_wpcom() {
+		return defined( 'IS_WPCOM' ) && IS_WPCOM;
 	}
 }
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -6,6 +6,8 @@
  * @since 12.4
  */
 
+use Automattic\Jetpack\Status\Host;
+
 /**
  * Jetpack_Subscribe_Modal class.
  */

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -191,7 +191,10 @@ HTML;
 	 * @return bool
 	 */
 	public static function should_load_subscriber_modal() {
-		if ( ! self::is_wpcom() ) {
+		// Adding extra check/flag to load only on WP.com
+		// When ready for Jetpack release, remove this.
+		$is_wpcom = ( new Host() )->is_wpcom_platform();
+		if ( ! $is_wpcom ) {
 			return false;
 		}
 		if ( 'lettre' !== get_option( 'stylesheet' ) && 'newsletter' !== get_option( 'site_intent' ) ) {

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscribe-modal.php
@@ -37,54 +37,29 @@ class WP_Test_Jetpack_Subscribe_Modal extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_all_filters( 'jetpack_is_connection_ready' );
-
-		// FEATURE FLAG:
-		// Reapply feature flag. This should be removed when feature flag is removed.
-		add_filter( 'jetpack_subscriptions_modal_enabled', '__return_false', 11 );
+		remove_all_filters( 'jetpack_subscriptions_modal_enabled' );
 		parent::tear_down();
 	}
 
 	/**
-	 * Test that jetpack_subscriptions_modal_enabled is set correctly,
-	 * and thus that Jetpack Subscribe Modal loads, as expected.
-	 *
-	 * Removed tests around sm_enabled since we no longer use that option
-	 * to set should_load_subscriber_modal() or the filter.
-	 *
-	 * This includes test of our defacto feature flag - we are setting
-	 * jetpack_subscriptions_modal_enabled to false, which should prevent
-	 * the modal from loading even if all conditions are met.
-	 *
-	 * #1 feature flag -> jetpack_subscriptions_modal_enabled false by default
-	 *                    AND even if all normal conditions are met.
-	 * #2 site_intent === newsletter (in this case, not relevant if theme is lettre or not)
-	 * #3 block theme is active
+	 * Test that the Jetpack Subscribe Modal does not load by default.
+	 * We are removing a feature flag, but adding a check to load this
+	 * feature only on WordPress.com sites.
 	 */
 	public function test_subscriber_modal_enabled_under_correct_conditions() {
 		// Test that the modal is not enabled by default.
 		$this->assertFalse( apply_filters( 'jetpack_subscriptions_modal_enabled', false ) );
 
-		// FEATURE FLAG:
-		// This is a test for the feature flag.
-		// Test that modal will no load even if all normal conditions are met.
-		// We are irectly setting jetpack_subscriptions_modal_enabled
-		// to false as a feature flag. This test should change upon full release.
+		// Test that the modal is not enabled even when
+		// other needed conditions are met.
 		switch_theme( 'block-theme' );
 		update_option( 'site_intent', 'newsletter' );
 		$this->assertFalse( apply_filters( 'jetpack_subscriptions_modal_enabled', false ) );
 
-		// Test modal is enabled with feature flag removed, all conditions met.
-		remove_filter( 'jetpack_subscriptions_modal_enabled', '__return_false', 11 );
+		// Test that feature can be enabled by manually adding
+		// feature flag filter.
+		add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 11 );
 		$this->assertTrue( apply_filters( 'jetpack_subscriptions_modal_enabled', false ) );
-
-		// Test that modal is disabled if site_intent !== newsletter
-		update_option( 'site_intent', 'write' );
-		$this->assertFalse( apply_filters( 'jetpack_subscriptions_modal_enabled', false ) );
-
-		// Test that modal is disabled if no block theme
-		update_option( 'site_intent', 'newsletter' );
-		switch_theme( 'default' );
-		$this->assertFalse( apply_filters( 'jetpack_subscriptions_modal_enabled', false ) );
 	}
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* REMOVE the feature flag for the subscribe modal. 
* As an extra safety check, ADD a check for whether we're in the WordPress.com environment. This will allow us to test this feature on WordPress.com sites without exposing it yet to self-hosted Jetpack sites. You can still force the feature to be active on self-hosted jetpack by adding this filter: `add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 );`
* The two changes above means this feature will be exposed to (a) WordPress.com sites that (b) have newsletter as site intent OR have the lettre theme active. Even in these conditions, the modal will still be disabled by default - you will just be able to enable it via normal settings rather than needing to add a filter / feature flag. 
   
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Possibly. It means users can now have subscribers, which mean collecting and storing the email for each subscriber.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Test the modal CANNOT be loaded on self-hosted Jetpack without adding a filter/feature flag.
   - Test in your Jetpack dev environment with Jurassic tube test site configured. 
   - If you have tested the Subscribe Modal before, you may need to undo specific changes. First, remove any filters you added to enable the feature flag before. Second, if you enabled the Subscribe modal before, disable it.
   - Activate the Lettre theme. Before adding the is_wpcom() method in this PR, the only way to see this modal on a self-hosted site was to have Lettre theme active. 
   - Go to Jetpack > Settings > Discussion > Newsletters and enable the option to "Let visitors subscribe to new posts and comments via email. This will enable the Jetpack subscriptions module in general. Then refresh the page. 
   - Confirm you do not see the option for "Enable subscriber modal"

2) Test that the modal CAN be enabled Simple sites. 
   - You will need a a WordPress.com simple site with site_intent of newsletter, or Lettre theme active.
   - Run `bin/jetpack-downloader test jetpack upddate/remove-subscribe-modal-feature-flag` to load this branch in your sandbox. Be sure to sandbox public-api and the domain of your test site. 
   - You will need to access WordPress.com via a local calypso dev environment (there is currently a feature flag such that the setting to enable the modal on WordPress.com only shows in a calypso dev environment). 
   - Go to Settings > Reading > Newsletters, confirm the option to enable the modal shows, and enable it. 
   - On the frontend, go to to any single post on the frontend, scroll, and confirm the modal does not load after scrolling.
   - On the admin side, go to Jetpack > Settings > Discussion > Newsletters and confirm the option to enable the modal does not show. 
   - As an extra check, return to Settings > Reading > Newsletters, disable the modal, and confirm it no longer loads on the frontend.
   
<img width="1506" alt="jetpack-subscribe-flag" src="https://github.com/Automattic/jetpack/assets/21228350/972b2604-6aa5-4426-b93b-35174d397159">

  