### PR TITLE
CRM: Fix error 200 using api connector

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3224-error-200-using-api-connector
+++ b/projects/plugins/crm/changelog/fix-crm-3224-error-200-using-api-connector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+API: Fixed error 200 while saving new api connections

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.Checks.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.Checks.php
@@ -170,7 +170,7 @@ function zeroBSCRM_isAPIRequest() {
 	// below is more reliable as QUERY_STRING will always be set for API requests.
 
 	// lazy, non-wp way of doing this
-	if ( isset( $_SERVER['QUERY_STRING'] ) && strpos( '#' . $_SERVER['QUERY_STRING'], 'api_key=zbscrm_' ) > 0 ) {
+	if ( isset( $_SERVER['QUERY_STRING'] ) && ( strpos( '#' . sanitize_text_field( wp_unslash( $_SERVER['QUERY_STRING'] ) ), 'api_key=zbscrm_' ) > 0 || strpos( '#' . sanitize_text_field( wp_unslash( $_SERVER['QUERY_STRING'] ) ), 'api_key=jpcrm_' ) ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
## Proposed changes:
This PR fixes a problem with new api connector sites giving an error 200 while testing the connection.

It simply updates our API key prefix to `jpcrm_`, while keeping compatibility with the previous one (`zbscrm_`). 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3224

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- Set up a API Connector on an external site
- Set up a CRM site with API module enabled
- On the CRM site, disable frontend in CRM Settings.
- Copy over CRM site's API secrets/keys, etc. Re-save permalinks
- Test the API connector connection and find 200 error (without this PR)
- On the CRM site, enable frontend in CRM settings
- Test the API connector connection and find that it works.

With this PR it should work even with the frontend disabled.
