### PR TITLE
AI Client: fix completion restart issue when changing tabs

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-assistant-fix-completion-restart-when-changing-tabs
+++ b/projects/js-packages/ai-client/changelog/update-ai-assistant-fix-completion-restart-when-changing-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: stop using smart document visibility handling on the fetchEventSource library, so it does not restart the completion when changing tabs.

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -93,6 +93,7 @@ export default class SuggestionsEventSource extends EventTarget {
 		}
 
 		await fetchEventSource( url, {
+			openWhenHidden: true,
 			method: 'POST',
 			headers: {
 				'Content-type': 'application/json',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31994.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Stop using the [fetchEventSource](https://www.npmjs.com/package/@microsoft/fetch-event-source) built-in smart handling of connections ([look for `openWhenHidden` here](https://github.com/Azure/fetch-event-source/blob/main/src/fetch.ts)) so the completion will not stop and restart when changing tabs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the steps to reproduce the issue:

1. On a new post editor, insert the AI block
2. Ask it to write something long, for example "Write a long blog post about fishing"
3. Navigate to another tab when the text generation starts
4. Navigate back to the editor

Before the fix:

* Text generation stops when I switch to another tab
* Text generation starts from the beginning (in addition to the existing text in the block) when I switch back to the editor tab; a new request to the backend can be found on the network logs

After the fix:

* The text generation continues in the background and the second request to the backend does not happen
