### PR TITLE
Boost: Improve UX when speed score drops

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/rating-card.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/rating-card.scss
@@ -3,7 +3,7 @@
 
 	// Wrapper is necessary to prevent the pop out from affecting the width of the page
 	&__wrapper {
-		width: 340px;
+		width: 400px;
 		position: absolute;
 		top: 40px;
 		right: 0;

--- a/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
+++ b/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
@@ -57,7 +57,7 @@ export function scoreChangeModal( scores: SpeedScoresSet ): ScoreChangeMessage |
 			cta: __( 'Rate the Plugin', 'jetpack-boost' ),
 			ctaLink: 'https://wordpress.org/support/plugin/jetpack-boost/reviews/#new-post',
 		};
-	} else if ( changePercentage < -5 && Jetpack_Boost.preferences.prioritySupport ) {
+	} else if ( changePercentage < -5 ) {
 		return {
 			id: 'score-decrease',
 			title: __( 'Speed score has fallen', 'jetpack-boost' ),

--- a/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
+++ b/projects/plugins/boost/app/assets/src/js/api/speed-scores.ts
@@ -1,5 +1,6 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import { SupportUrl } from '../utils/paid-plan';
+import { TemplateVars } from '../utils/copy-dom-template';
 
 type SpeedScores = {
 	mobile: number;
@@ -36,7 +37,10 @@ export function getScoreMovementPercentage( scores: SpeedScoresSet ): number {
 export type ScoreChangeMessage = {
 	id: string;
 	title: string;
-	message: string;
+	message: {
+		text: string;
+		vars?: TemplateVars;
+	};
 	cta: string;
 	ctaLink: string;
 };
@@ -47,7 +51,9 @@ export function scoreChangeModal( scores: SpeedScoresSet ): ScoreChangeMessage |
 		return {
 			id: 'score-increase',
 			title: __( 'Your site got faster', 'jetpack-boost' ),
-			message: __( `That's great! If you’re happy, why not rate Boost?`, 'jetpack-boost' ),
+			message: {
+				text: __( `That's great! If you’re happy, why not rate Boost?`, 'jetpack-boost' ),
+			},
 			cta: __( 'Rate the Plugin', 'jetpack-boost' ),
 			ctaLink: 'https://wordpress.org/support/plugin/jetpack-boost/reviews/#new-post',
 		};
@@ -55,12 +61,14 @@ export function scoreChangeModal( scores: SpeedScoresSet ): ScoreChangeMessage |
 		return {
 			id: 'score-decrease',
 			title: __( 'Speed score has fallen', 'jetpack-boost' ),
-			message: __(
-				'Jetpack Boost should not slow down your site. Try refreshing your score. If the problem persists please contact support',
-				'jetpack-boost'
-			),
-			cta: __( 'Contact Support', 'jetpack-boost' ),
-			ctaLink: SupportUrl,
+			message: {
+				text: __(
+					'Most of the time Jetpack Boost will increase your site speed, but there may be cases where your score does not increase.<br/><br/>Try refreshing your score, and if it doesn’t help, check our guide on improving your site speed score:',
+					'jetpack-boost'
+				),
+			},
+			cta: __( 'Read the guide', 'jetpack-boost' ),
+			ctaLink: getRedirectUrl( 'boost-improve-site-speed-score' ),
 		};
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
@@ -5,12 +5,16 @@
 	import { createEventDispatcher } from 'svelte';
 	import { __ } from '@wordpress/i18n/';
 	import CloseButton from '../../../elements/CloseButton.svelte';
+	import TemplatedString from '../../../elements/TemplatedString.svelte';
 	import { dismissedPopOuts } from '../../../stores/config';
 	import slideRightTransition from '../../../utils/slide-right-transition';
 
 	export let id = '';
 	export let title = '';
-	export let message = '';
+	export let message = {
+		text: '',
+		vars: {},
+	};
 	export let ctaLink = '';
 	export let cta = '';
 
@@ -30,7 +34,7 @@
 				{title}
 			</h3>
 			<p class="jb-rating-card__paragraph">
-				{message}
+				<TemplatedString template={message.text} vars={message.vars} />
 			</p>
 			<a
 				class="jb-button--primary"

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PopOut.svelte
@@ -62,3 +62,9 @@
 		</div>
 	</div>
 {/if}
+
+<style>
+	.jb-link {
+		float: right;
+	}
+</style>

--- a/projects/plugins/boost/changelog/update-ux-speed-score-dropped
+++ b/projects/plugins/boost/changelog/update-ux-speed-score-dropped
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update 'score dropped' card copy, change button URL and make card show up for free users as well.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32008

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update 'score dropped' card UI
   <details><summary>before</summary>
   <img src="https://github.com/Automattic/jetpack/assets/11799079/d29defc3-1ec0-42e9-bd86-48777990d89a" />
   </details>
   <details><summary>after</summary>
   <img src="https://github.com/Automattic/jetpack/assets/11799079/46b0d16e-70d5-4aa2-951d-d4c475f204c0" />
   </details>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-1U9-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup boost;
* Wait for the speed scores to finish loading;
* Right the scores to be lower than the first one (with at least 5 points). You can use the boost developer plugin to do that;
* Wait for the speed scores to finish loading;
* Make sure the text is right and that the button leads to the "boost speed score improvement" guide page.