### PR TITLE
pre-commit hook: Clean up PHP linting

### DIFF
--- a/tools/js-tools/git-hooks/pre-commit-hook.js
+++ b/tools/js-tools/git-hooks/pre-commit-hook.js
@@ -354,9 +354,11 @@ function runPHPLinter( toLintFiles ) {
 
 /**
  * Runs PHPCS against checked PHP files. Exits if the check fails.
+ *
+ * @param {Array} toLintFiles - List of files to lint
  */
-function runPHPCS() {
-	const phpcsResult = spawnSync( 'composer', [ 'phpcs:lint:errors', ...phpcsFiles ], {
+function runPHPCS( toLintFiles ) {
+	const phpcsResult = spawnSync( 'composer', [ 'phpcs:lint', ...toLintFiles ], {
 		stdio: 'inherit',
 	} );
 
@@ -378,19 +380,21 @@ function runPHPCS() {
 
 /**
  * Runs PHPCBF against checked PHP files
+ *
+ * @param {Array} toFixFiles - List of files to fix
  */
-function runPHPCbf() {
-	const toPhpCbf = phpcsFiles.filter( file => checkFileAgainstDirtyList( file, dirtyFiles ) );
+function runPHPCbf( toFixFiles ) {
+	const toPhpCbf = toFixFiles.filter( file => checkFileAgainstDirtyList( file, dirtyFiles ) );
 	if ( toPhpCbf.length === 0 ) {
 		return;
 	}
 
-	const phpCbfResult = spawnSync( 'vendor/bin/phpcbf', [ ...toPhpCbf ], {
+	const phpCbfResult = spawnSync( 'composer', [ 'phpcs:fix', ...toPhpCbf ], {
 		stdio: 'inherit',
 	} );
 
 	if ( phpCbfResult && phpCbfResult.status ) {
-		spawnSync( 'git', [ 'add', ...phpcsFiles ], { stdio: 'inherit' } );
+		spawnSync( 'git', [ 'add', ...toFixFiles ], { stdio: 'inherit' } );
 		console.log( chalk.yellow( 'PHPCS issues detected and automatically fixed via PHPCBF.' ) );
 	}
 }
@@ -526,8 +530,8 @@ if ( phpFiles.length > 0 ) {
 }
 
 if ( phpcsFiles.length > 0 ) {
-	runPHPCbf();
-	runPHPCS();
+	runPHPCbf( phpcsFiles );
+	runPHPCS( phpcsFiles );
 }
 if ( phpcsChangedFiles.length > 0 ) {
 	runPHPCSChanged( phpcsChangedFiles );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Run `composer phpcs:fix` instead of running `vendor/bin/phpcbf` directly.
* Run `composer phpcs:lint` rather than `composer phpcs:lint:errors`. Our CI checks will run the former, so there's not much point to ignoring the warnings for pre-commit.
* Pass the list of files to the functions instead of using the global, like we do everywhere else.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1689956907073589-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add something like `$foobar  = 42;` to `jetpack.php` or some other non-excluded php file. Try to commit. The double-space (Generic.Formatting.MultipleStatementAlignment.IncorrectWarning) should get fixed, but then the unused variable warning (VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable) should prevent the commit.