### PR TITLE
My Jetpack: Release Paid Stats Interstitial Card

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-remove-paid-stats-feature-lock
+++ b/projects/packages/my-jetpack/changelog/update-remove-paid-stats-feature-lock
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: release Paid Stats to the public

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
-use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Jetpack_Options;
@@ -135,24 +134,18 @@ class Stats extends Module_Product {
 	 * @return boolean
 	 */
 	public static function has_required_plan() {
-		// Check if paid stats plans have been enabled.
-		if ( Jetpack_Constants::is_true( 'JETPACK_PAID_STATS_ENABLED' ) ) {
-			$purchases_data = Wpcom_Products::get_site_current_purchases();
-			if ( is_wp_error( $purchases_data ) ) {
-				return false;
-			}
-			if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
-				foreach ( $purchases_data as $purchase ) {
-					if ( 0 === strpos( $purchase->product_slug, 'jetpack_stats' ) ) {
-						return true;
-					}
-				}
-			}
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
 			return false;
 		}
-
-		// Until the new paid stats plans roll out, no plan purchase is required for Jetpack Stats.
-		return true;
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				if ( 0 === strpos( $purchase->product_slug, 'jetpack_stats' ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Related: #31343 

## Proposed changes:

* Remove Paid Stats feature lock in My Jetpack

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Spin up a JN site with Jetpack on current branch `update/remove-paid-stats-feature-lock`
* Connect site
* Open `/wp-admin/admin.php?page=my-jetpack`
* Ensure you see the Stats upgrade card

<img width="365" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/d90c491f-34b0-46c7-8d16-430ddc421c27">


