### PR TITLE
CRM: Port back 6.1.0 release changelog, readme and package updates

### DIFF
--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4] - 2023-07-24
+
 ## [0.6.3] - 2023-07-11
 ### Changed
 - Updated package dependencies. [#31785]
@@ -198,6 +200,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.4]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.3...0.6.4
 [0.6.3]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.2...0.6.3
 [0.6.2]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.1...0.6.2
 [0.6.1]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.0...0.6.1

--- a/projects/js-packages/base-styles/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-storybook-monorepo
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unnecessary `.npmrc`.
-
-

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.4-alpha",
+	"version": "0.6.4",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.41.0] - 2023-07-24
+### Added
+- Jetpack Footer: added generic links [#31627]
+
+### Changed
+- Updated package dependencies. [#31999]
+
 ## [0.40.4] - 2023-07-18
 ### Changed
 - Use Connection initial state for fetching Calypso Env. [#31906]
@@ -772,6 +779,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.41.0]: https://github.com/Automattic/jetpack-components/compare/0.40.4...0.41.0
 [0.40.4]: https://github.com/Automattic/jetpack-components/compare/0.40.3...0.40.4
 [0.40.3]: https://github.com/Automattic/jetpack-components/compare/0.40.2...0.40.3
 [0.40.2]: https://github.com/Automattic/jetpack-components/compare/0.40.1...0.40.2

--- a/projects/js-packages/components/changelog/add-jetpack-footer-generic-links
+++ b/projects/js-packages/components/changelog/add-jetpack-footer-generic-links
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Jetpack Footer: added generic links

--- a/projects/js-packages/components/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/components/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.41.0-alpha",
+	"version": "0.41.0",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/composer-plugin/CHANGELOG.md
+++ b/projects/packages/composer-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.12] - 2023-07-24
+### Fixed
+- Allow `beta-plugin-slug` for cases when a `wp-plugin-slug` doesn't exist yet but is planned to. [#31551]
+
 ## [1.1.11] - 2023-05-22
 ### Added
 - Set keywords in `composer.json`. [#30756]
@@ -78,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the Jetpack Installer package.
 
+[1.1.12]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.11...v1.1.12
 [1.1.11]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.10...v1.1.11
 [1.1.10]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.9...v1.1.10
 [1.1.9]: https://github.com/Automattic/jetpack-composer-plugin/compare/v1.1.8...v1.1.9

--- a/projects/packages/composer-plugin/changelog/add-project-for-jetpack-inspect
+++ b/projects/packages/composer-plugin/changelog/add-project-for-jetpack-inspect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Allow `beta-plugin-slug` for cases when a `wp-plugin-slug` doesn't exist yet but is planned to.

--- a/projects/plugins/crm/CHANGELOG.md
+++ b/projects/plugins/crm/CHANGELOG.md
@@ -5,6 +5,22 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0] - 2023-07-24
+### Added
+- Listing pages: Add a new setting that allows listing pages to utilize the full width of the screen [#31904]
+
+### Changed
+- General: indicate full compatibility with the latest version of WordPress, 6.3. [#31910]
+
+### Fixed
+- API: Fixed error 200 while saving new api connections [#32003]
+- Contacts: Fix bug that prevented the creation of contacts WP user for the Client Portal [#31710]
+- Contacts: Fix Filter options not available on the main contacts listing [#31517]
+- File Uploads: Fix bug that prevented file uploads from working in environments where the PHP finfo_open function was not available [#31527]
+- Menu: Improved alignment for items in the menu [#31846]
+- OAuth/Gmail: Fix to enable sending links and images in the email content, supporting text/plain [#31943]
+- Segments: Fix bug that prevented dates to be saved in some environments [#31628]
+
 ## [6.0.0] - 2023-06-21
 ### Added
 - CRM: Revamped CRM User Interface - Merge the sleek aesthetics of Jetpack’s style, bringing a new level of sophistication and seamless navigation to your CRM experience [#30916]
@@ -188,6 +204,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved: Added a migration to remove outdated AKA lines
 
 [5.5.4-a.1]: https://github.com/Automattic/jetpack-crm/compare/v5.5.3...v5.5.4-a.1
+[6.1.0]: https://github.com/Automattic/jetpack-crm/compare/6.0.0...6.1.0
 [6.0.0]: https://github.com/Automattic/jetpack-crm/compare/5.8.0...6.0.0
 [5.8.0]: https://github.com/Automattic/jetpack-crm/compare/5.7.0...5.8.0
 [5.7.0]: https://github.com/Automattic/jetpack-crm/compare/v5.6.0...v5.7.0

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 6.1.0-alpha
+ * Version: 6.1.0
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/add-codesniffer-compat-rulesets
+++ b/projects/plugins/crm/changelog/add-codesniffer-compat-rulesets
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update `.phpcs.dir.phpcompatibility.xml` to use the new `Jetpack-Compat-72` ruleset. No change to the plugin itself.
-
-

--- a/projects/plugins/crm/changelog/add-crm-3178-add-setting-to-allow-full-width
+++ b/projects/plugins/crm/changelog/add-crm-3178-add-setting-to-allow-full-width
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Listing pages: Add a new setting that allows listing pages to utilize the full width of the screen

--- a/projects/plugins/crm/changelog/add-crm-automations-admin-root
+++ b/projects/plugins/crm/changelog/add-crm-automations-admin-root
@@ -1,3 +1,0 @@
-Significance: patch
-Type: added
-Comment: This PR is establishing the base of a React app. The changelog should only announce when the app is released.

--- a/projects/plugins/crm/changelog/add-crm-automations-admin-routing
+++ b/projects/plugins/crm/changelog/add-crm-automations-admin-routing
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: This PR adds client-side routing to the Automations admin page which is currently under development
-
-

--- a/projects/plugins/crm/changelog/add-crm-base-foundation-for-new-api
+++ b/projects/plugins/crm/changelog/add-crm-base-foundation-for-new-api
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Adding foundational logic for a new version of our API. It doesn't change any existing logic nor does it introduce anyt new user-facing features.
-
-

--- a/projects/plugins/crm/changelog/fix-crm-3082-add-check-for-fifo-open
+++ b/projects/plugins/crm/changelog/fix-crm-3082-add-check-for-fifo-open
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-File Uploads: Fix bug that prevented file uploads from working in environments where the PHP finfo_open function was not available

--- a/projects/plugins/crm/changelog/fix-crm-3109-plain-text-email-does-not-work-with-gmail-api
+++ b/projects/plugins/crm/changelog/fix-crm-3109-plain-text-email-does-not-work-with-gmail-api
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-OAuth/Gmail fix to allow send links and images in the email content, supporting text/plain.

--- a/projects/plugins/crm/changelog/fix-crm-3147-learn-menu-buttons-overlapping
+++ b/projects/plugins/crm/changelog/fix-crm-3147-learn-menu-buttons-overlapping
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed buttons overlapping introduced by the Emerald project

--- a/projects/plugins/crm/changelog/fix-crm-3152-multiline-names-in-menu
+++ b/projects/plugins/crm/changelog/fix-crm-3152-multiline-names-in-menu
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Menu: Improved alignment for items in the menu

--- a/projects/plugins/crm/changelog/fix-crm-3157-filter-options-not-available-for-contacts
+++ b/projects/plugins/crm/changelog/fix-crm-3157-filter-options-not-available-for-contacts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Contacts: Fix Filter options not available on the main contacts listing

--- a/projects/plugins/crm/changelog/fix-crm-3161-update-screenshots-on-wporg
+++ b/projects/plugins/crm/changelog/fix-crm-3161-update-screenshots-on-wporg
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update JPCRM screenshots on WP.org

--- a/projects/plugins/crm/changelog/fix-crm-3163-generate-wp-user-does-not-work-after-6-0-0
+++ b/projects/plugins/crm/changelog/fix-crm-3163-generate-wp-user-does-not-work-after-6-0-0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Contacts: Fix bug that prevented the creation of contacts WP user for the Client Portal

--- a/projects/plugins/crm/changelog/fix-crm-3164-time-condition-does-not-get-saved
+++ b/projects/plugins/crm/changelog/fix-crm-3164-time-condition-does-not-get-saved
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Segments: Fix bug that prevented dates to be saved in some environments

--- a/projects/plugins/crm/changelog/fix-crm-3176-unsubscription-flag-does-not-appear-and-email-sender-log-not-useful
+++ b/projects/plugins/crm/changelog/fix-crm-3176-unsubscription-flag-does-not-appear-and-email-sender-log-not-useful
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Allow to retrieve only logs with notes from the Cron Log System. 

--- a/projects/plugins/crm/changelog/fix-crm-3186-3217-3218-several-emerald-fixes
+++ b/projects/plugins/crm/changelog/fix-crm-3186-3217-3218-several-emerald-fixes
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed issues introduced by the Emerald design: margins of export pages, 'Invoicing Pro:' upsell misplaced header, removed the html custom element jpcrm-top-menu

--- a/projects/plugins/crm/changelog/fix-crm-3224-error-200-using-api-connector
+++ b/projects/plugins/crm/changelog/fix-crm-3224-error-200-using-api-connector
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-API: Fixed error 200 while saving new api connections

--- a/projects/plugins/crm/changelog/fix-onboarding-unit-test
+++ b/projects/plugins/crm/changelog/fix-onboarding-unit-test
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: This only fixes a single failing test
-
-

--- a/projects/plugins/crm/changelog/init-release-cycle
+++ b/projects/plugins/crm/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Init 6.0.1-alpha
-
-

--- a/projects/plugins/crm/changelog/remove-crm-composer-config-platform-php
+++ b/projects/plugins/crm/changelog/remove-crm-composer-config-platform-php
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove composer `.config.platform.php` setting. No change to the plugin itself, and apparently no change to the non-dev deps either.
-
-

--- a/projects/plugins/crm/changelog/remove-unused-js-deps
+++ b/projects/plugins/crm/changelog/remove-unused-js-deps
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unused JS deps. No change to the project itself.
-
-

--- a/projects/plugins/crm/changelog/renovate-babel-monorepo
+++ b/projects/plugins/crm/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-definitelytyped
+++ b/projects/plugins/crm/changelog/renovate-definitelytyped
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/crm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/crm/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/crm/changelog/update-crm-enable-js-tests
+++ b/projects/plugins/crm/changelog/update-crm-enable-js-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: This PR adds a script to composer.json for our internal tooling which users won't benefit from learning about
-
-

--- a/projects/plugins/crm/changelog/update-dry-in-phpcodesniffer-exclusions
+++ b/projects/plugins/crm/changelog/update-dry-in-phpcodesniffer-exclusions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: DRY in phpcs config. No change to the project itself.
-
-

--- a/projects/plugins/crm/changelog/update-postcss-configs
+++ b/projects/plugins/crm/changelog/update-postcss-configs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update postcss configs to use array syntax for plugins. No change to the project itself.
-
-

--- a/projects/plugins/crm/changelog/update-tested-up-to-63
+++ b/projects/plugins/crm/changelog/update-tested-up-to-63
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: indicate full compatibility with the latest version of WordPress, 6.3.

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -45,7 +45,7 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_1_0_alpha",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_1_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -24,14 +24,14 @@ final class ZeroBSCRM {
 	 *
 	 * @var string
 	 */
-	public $version = '6.0.0';
+	public $version = '6.1.0';
 
 	/**
 	 * WordPress version tested with.
 	 *
 	 * @var string
 	 */
-	public $wp_tested = '6.1';
+	public $wp_tested = '6.3';
 
 	/**
 	 * WordPress update API version.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
@@ -595,7 +595,7 @@ function zeroBSCRM_addUserRoles() { // phpcs:ignore WordPress.NamingConventions.
 /**
  * Determine if a user is allowed to manage contacts.
  *
- * @since $$next-version$$
+ * @since 6.1.0
  *
  * @param WP_User $user The WP User to check permission access for.
  * @param int     $contact_id (Optional) The ID of the CRM contact.
@@ -605,7 +605,7 @@ function jpcrm_can_user_manage_contacts( WP_User $user, $contact_id = null ) {
 	/**
 	 * Allow third party plugins to modify the permission conditions for contacts.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 *
 	 * @param boolean  $allowed A boolean that represents the permission state.
 	 * @param WP_User  $user The WP User to check permission access for.
@@ -622,7 +622,7 @@ function jpcrm_can_user_manage_contacts( WP_User $user, $contact_id = null ) {
 /**
  * Determine if the current user is allowed to manage contacts.
  *
- * @deprecated $$next-version$$ Use jpcrm_can_user_manage_contacts()
+ * @deprecated 6.1.0 Use jpcrm_can_user_manage_contacts()
  *
  * @return bool
  *

--- a/projects/plugins/crm/includes/ZeroBSCRM.REST.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.REST.php
@@ -101,7 +101,7 @@ add_action( 'rest_api_init', function () {
 	 * Feature flag to conditionally load in development API.
 	 *
 	 * @ignore
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 *
 	 * @param bool Determine if we should initialize the new REST APIs.
 	 */

--- a/projects/plugins/crm/modules/automations/admin/admin-page-init.php
+++ b/projects/plugins/crm/modules/automations/admin/admin-page-init.php
@@ -59,7 +59,7 @@ function render_initial_state() {
 	/**
 	 * Allow external plugins to modify Automations UI hydration data.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 *
 	 * @param array {
 	 *     Array of default data we need to render our React UI.

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "6.1.0-alpha",
+	"version": "6.1.0",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -389,26 +389,18 @@ We offer a full, no-hassle refund within 14 days. You can read more about that, 
 
 
 == Changelog ==
-### 6.0.0 - 2023-06-21
+### 6.1.0 - 2023-07-24
 #### Added
-- CRM: Revamped CRM User Interface - Merge the sleek aesthetics of Jetpack’s style, bringing a new level of sophistication and seamless navigation to your CRM experience
-- API: Now it retrieves contacts with tags
-- Contacts: Allow unsubscribe flag to be removed
+- Listing pages: Add a new setting that allows listing pages to utilize the full width of the screen
 
 #### Changed
-- User roles: Further restricted capabilities on some roles
-- Contacts: Use sha256 instead of md5 for gravatar images
+- General: indicate full compatibility with the latest version of WordPress, 6.3
 
 #### Fixed
-- Client Portal: Fix a fatal error initializing endpoints and shortcodes
-- CRM: Fix new lines display in quote templates
-- CRM: Fix whitelabel bug with full menu layout
-- CRM: Page layout now has a max width of 1551px
-- CRM: Welcome tour now goes through all steps
-- Extensions: Catch PHP notice if offline
-- Invoices: Show assigned contact/company link
-- Listview: Per-page settings no longer reset
-- Listview: PHP notice no longer shows when saving settings
-- Quotes: Fix sort by status
-- White label: JPCRM support and resources pages no longer show
-
+- API: Fixed error 200 while saving new api connections
+- Contacts: Fix bug that prevented the creation of contacts WP user for the Client Portal
+- Contacts: Fix Filter options not available on the main contacts listing
+- File Uploads: Fix bug that prevented file uploads from working in environments where the PHP finfo_open function was not available
+- Menu: Improved alignment for items in the menu
+- OAuth/Gmail: Fix to enable sending links and images in the email content, supporting text/plain
+- Segments: Fix bug that prevented dates to be saved in some environments

--- a/projects/plugins/crm/src/rest-api/v4/class-rest-base-controller.php
+++ b/projects/plugins/crm/src/rest-api/v4/class-rest-base-controller.php
@@ -15,14 +15,14 @@ defined( 'ABSPATH' ) || exit;
  * Abstract base controller class.
  *
  * @package Automattic\Jetpack\CRM
- * @since $$next-version$$
+ * @since 6.1.0
  */
 abstract class REST_Base_Controller extends WP_REST_Controller {
 
 	/**
 	 * Constructor.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 */
 	public function __construct() {
 		$this->namespace = 'jetpack-crm/v4';

--- a/projects/plugins/crm/src/rest-api/v4/class-rest-base-objects-controller.php
+++ b/projects/plugins/crm/src/rest-api/v4/class-rest-base-objects-controller.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * Abstract base controller class for DAL objects.
  *
  * @package Automattic\Jetpack\CRM
- * @since $$next-version$$
+ * @since 6.1.0
  */
 abstract class REST_Base_Objects_Controller extends REST_Base_Controller {
 
@@ -25,7 +25,7 @@ abstract class REST_Base_Objects_Controller extends REST_Base_Controller {
 	 * The main reason why we lazy load DAL is to allow tests to override the
 	 * global instance with a mock before it's required by any endpoints.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 *
 	 * @return zbsDAL_ObjectLayer
 	 */
@@ -36,7 +36,7 @@ abstract class REST_Base_Objects_Controller extends REST_Base_Controller {
 	/**
 	 * Prepare object links for the request.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 *
 	 * @param int $item_id The unique object ID.
 	 * @return array Links for the given object.

--- a/projects/plugins/crm/src/rest-api/v4/class-rest-contacts-controller.php
+++ b/projects/plugins/crm/src/rest-api/v4/class-rest-contacts-controller.php
@@ -20,14 +20,14 @@ defined( 'ABSPATH' ) || exit;
  * REST contacts controller.
  *
  * @package Automattic\Jetpack\CRM
- * @since $$next-version$$
+ * @since 6.1.0
  */
 final class REST_Contacts_Controller extends REST_Base_Objects_Controller {
 
 	/**
 	 * Constructor.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 */
 	public function __construct() {
 		parent::__construct();
@@ -38,7 +38,7 @@ final class REST_Contacts_Controller extends REST_Base_Objects_Controller {
 	/**
 	 * Registers the routes for the objects of the controller.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 * @see register_rest_route()
 	 *
 	 * @return void
@@ -80,7 +80,7 @@ final class REST_Contacts_Controller extends REST_Base_Objects_Controller {
 	/**
 	 * Get a contact.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_Error|WP_REST_Response
@@ -116,7 +116,7 @@ final class REST_Contacts_Controller extends REST_Base_Objects_Controller {
 	/**
 	 * Checks if a given request has access to get a specific item.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
@@ -145,7 +145,7 @@ final class REST_Contacts_Controller extends REST_Base_Objects_Controller {
 	/**
 	 * Prepares the item for the REST response.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 * @todo Implement item schema and only output fields that are part of the schema.
 	 *
 	 * @param array           $item WordPress' representation of the item.
@@ -165,7 +165,7 @@ final class REST_Contacts_Controller extends REST_Base_Objects_Controller {
 		/**
 		 * Filters the REST API response for a contact.
 		 *
-		 * @since $$next-version$$
+		 * @since 6.1.0
 		 *
 		 * @param WP_REST_Response $response The response object.
 		 * @param array $item The raw contact data.
@@ -177,7 +177,7 @@ final class REST_Contacts_Controller extends REST_Base_Objects_Controller {
 	/**
 	 * Get contacts service.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.1.0
 	 *
 	 * @return zbsDAL_contacts
 	 */


### PR DESCRIPTION
## Proposed changes:

* This PR ports the changelog, readme and package updates for the CRM 6.1.0 release back to trunk

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read - check that versions are as expected.

