### PR TITLE
CRM: Start new cycle after 6.1.0 release

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 6.1.0
+ * Version: 6.1.1-alpha
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/init-release-cycle
+++ b/projects/plugins/crm/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 6.1.1-alpha
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -45,7 +45,7 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_1_0",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_1_1_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "6.1.0",
+	"version": "6.1.1-alpha",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",


### PR DESCRIPTION
* This PR starts a new cycle after the 6.1.0 release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Proof read to ensure the new version cycle is correct.