### PR TITLE
Social: Added upsell links to the sharing section of the Jetpack plugin

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/index.jsx
@@ -28,7 +28,7 @@ class Sharing extends Component {
 			siteRawUrl: this.props.siteRawUrl,
 			siteAdminUrl: this.props.siteAdminUrl,
 			userCanManageModules: this.props.userCanManageModules,
-			activeFeatures: this.props.hasSocialBasicFeatures,
+			activeFeatures: this.props.activeFeatures,
 			hasSocialBasicFeatures: this.props.hasSocialBasicFeatures,
 			hasSocialAdvancedFeatures: this.props.hasSocialAdvancedFeatures,
 		};
@@ -77,7 +77,7 @@ export default connect( state => {
 		siteRawUrl: getSiteRawUrl( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
 		hasSocialBasicFeatures: siteHasFeature( state, 'social-shares-1000' ),
-		activeFeature: getActiveFeatures( state ),
+		activeFeatures: getActiveFeatures( state ),
 		hasSocialAdvancedFeatures: siteHasFeature( state, 'social-enhanced-publishing' ),
 		userCanManageModules: userCanManageModules( state ),
 	};

--- a/projects/plugins/jetpack/_inc/client/sharing/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/index.jsx
@@ -12,10 +12,10 @@ import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/init
 import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { getSettings } from 'state/settings';
+import { siteHasFeature, getActiveFeatures } from 'state/site';
 import { Likes } from './likes';
 import { Publicize } from './publicize';
 import { ShareButtons } from './share-buttons';
-
 class Sharing extends Component {
 	render() {
 		const commonProps = {
@@ -28,6 +28,9 @@ class Sharing extends Component {
 			siteRawUrl: this.props.siteRawUrl,
 			siteAdminUrl: this.props.siteAdminUrl,
 			userCanManageModules: this.props.userCanManageModules,
+			activeFeatures: this.props.hasSocialBasicFeatures,
+			hasSocialBasicFeatures: this.props.hasSocialBasicFeatures,
+			hasSocialAdvancedFeatures: this.props.hasSocialAdvancedFeatures,
 		};
 
 		const foundPublicize = this.props.isModuleFound( 'publicize' ),
@@ -73,6 +76,9 @@ export default connect( state => {
 		connectUrl: getConnectUrl( state ),
 		siteRawUrl: getSiteRawUrl( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
+		hasSocialBasicFeatures: siteHasFeature( state, 'social-shares-1000' ),
+		activeFeature: getActiveFeatures( state ),
+		hasSocialAdvancedFeatures: siteHasFeature( state, 'social-enhanced-publishing' ),
 		userCanManageModules: userCanManageModules( state ),
 	};
 } )( Sharing );

--- a/projects/plugins/jetpack/_inc/client/sharing/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/index.jsx
@@ -8,7 +8,12 @@ import {
 	isCurrentUserLinked,
 	getConnectUrl,
 } from 'state/connection';
-import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
+import {
+	getSiteRawUrl,
+	getSiteAdminUrl,
+	userCanManageModules,
+	isAtomicSite,
+} from 'state/initial-state';
 import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { getSettings } from 'state/settings';
@@ -31,6 +36,7 @@ class Sharing extends Component {
 			activeFeatures: this.props.activeFeatures,
 			hasSocialBasicFeatures: this.props.hasSocialBasicFeatures,
 			hasSocialAdvancedFeatures: this.props.hasSocialAdvancedFeatures,
+			isAtomicSite: this.props.isAtomicSite,
 		};
 
 		const foundPublicize = this.props.isModuleFound( 'publicize' ),
@@ -80,5 +86,6 @@ export default connect( state => {
 		activeFeatures: getActiveFeatures( state ),
 		hasSocialAdvancedFeatures: siteHasFeature( state, 'social-enhanced-publishing' ),
 		userCanManageModules: userCanManageModules( state ),
+		isAtomicSite: isAtomicSite( state ),
 	};
 } )( Sharing );

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -24,6 +24,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 				isLinked = this.props.isLinked,
 				isOfflineMode = this.props.isOfflineMode,
 				siteRawUrl = this.props.siteRawUrl,
+				siteAdminUrl = this.props.siteAdminUrl,
 				isActive = this.props.getOptionValue( 'publicize' ),
 				hasSocialBasicFeatures = this.props.hasSocialBasicFeatures,
 				hasSocialAdvancedFeatures = this.props.hasSocialAdvancedFeatures,
@@ -38,11 +39,8 @@ export const Publicize = withModuleSettingsFormHelpers(
 				isActive &&
 				! hasSocialAdvancedFeatures;
 
-			const jetpackSocialText = __(
-				'Connect your website to the social media networks you use and share your content across all your social accounts with a single click. When you publish a post, it will appear on all connected accounts.',
-				'jetpack'
-			);
-
+			// We need to strip off the trailing slash for the pricing modal to open correctly.
+			const redirectUrl = encodeURIComponent( siteAdminUrl.replace( /\/$/, '' ) );
 			const configCard = () => {
 				if ( unavailableInOfflineMode ) {
 					return;
@@ -88,9 +86,14 @@ export const Publicize = withModuleSettingsFormHelpers(
 								link: getRedirectUrl( 'jetpack-support-publicize' ),
 							} }
 						>
-							<p>{ jetpackSocialText }</p>
+							<p>
+								{ __(
+									'Connect your website to the social media networks you use and share your content across all your social accounts with a single click. When you publish a post, it will appear on all connected accounts.',
+									'jetpack'
+								) }
+							</p>
 							{ showUpgradeLink && (
-								<React.Fragment>
+								<>
 									<p>
 										{ ! hasSocialBasicFeatures
 											? createInterpolateElement(
@@ -105,9 +108,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 																	'jetpack-plugin-admin-page-sharings-screen',
 																	{
 																		site: siteRawUrl,
-																		query:
-																			'redirect_to=' +
-																			encodeURIComponent( window.location.href.split( '#' )[ 0 ] ),
+																		query: 'redirect_to=' + redirectUrl,
 																	}
 																) }
 															/>
@@ -126,9 +127,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 																	'jetpack-plugin-admin-page-sharings-screen',
 																	{
 																		site: siteRawUrl,
-																		query:
-																			'redirect_to=' +
-																			encodeURIComponent( window.location.href.split( '#' )[ 0 ] ),
+																		query: 'redirect_to=' + redirectUrl,
 																	}
 																) }
 															/>
@@ -136,7 +135,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 													}
 											  ) }
 									</p>
-								</React.Fragment>
+								</>
 							) }
 							<ModuleToggle
 								slug="publicize"

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -44,6 +44,16 @@ export const Publicize = withModuleSettingsFormHelpers(
 				'jetpack'
 			);
 
+			const jetpackSocialBasicUpgradeTextSuffix = __(
+				'to get unlimited shares and advanced media sharing options.',
+				'jetpack'
+			);
+
+			const jetpackSocialAdvancedUpgradeTextSuffix = __(
+				'to get advanced media sharing options.',
+				'jetpack'
+			);
+
 			const configCard = () => {
 				if ( unavailableInOfflineMode ) {
 					return;
@@ -105,11 +115,8 @@ export const Publicize = withModuleSettingsFormHelpers(
 										</a>
 										&nbsp;
 										{ showUpgradeLink && ! hasSocialBasicFeatures
-											? __(
-													'to get unlimited shares and advanced media sharing options.',
-													'jetpack'
-											  )
-											: __( 'to get advanced media sharing options.', 'jetpack' ) }
+											? jetpackSocialBasicUpgradeTextSuffix
+											: jetpackSocialAdvancedUpgradeTextSuffix }
 									</p>
 								</React.Fragment>
 							) }

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { __, _x } from '@wordpress/i18n';
 import Card from 'components/card';
 import ConnectUserBar from 'components/connect-user-bar';
@@ -24,7 +25,18 @@ export const Publicize = withModuleSettingsFormHelpers(
 				isOfflineMode = this.props.isOfflineMode,
 				siteRawUrl = this.props.siteRawUrl,
 				isActive = this.props.getOptionValue( 'publicize' ),
+				hasSocialBasicFeatures = this.props.hasSocialBasicFeatures,
+				hasSocialAdvancedFeatures = this.props.hasSocialAdvancedFeatures,
+				activeFeatures = this.props.activeFeatures,
 				userCanManageModules = this.props.userCanManageModules;
+
+			const showUpgradeLink =
+				activeFeatures && activeFeatures.length > 0 && isActive && ! hasSocialAdvancedFeatures;
+
+			const jetpackSocialText = __(
+				'Connect your website to the social media networks you use and share your content across all your social accounts with a single click. When you publish a post, it will appear on all connected accounts.',
+				'jetpack'
+			);
 
 			const configCard = () => {
 				if ( unavailableInOfflineMode ) {
@@ -71,12 +83,30 @@ export const Publicize = withModuleSettingsFormHelpers(
 								link: getRedirectUrl( 'jetpack-support-publicize' ),
 							} }
 						>
-							<p>
-								{ __(
-									'Connect your website to the social media networks you use and share your content across all your social accounts with a single click. When you publish a post, it will appear on all connected accounts.',
-									'jetpack'
-								) }
-							</p>
+							<p>{ jetpackSocialText }</p>
+							{ showUpgradeLink && (
+								<React.Fragment>
+									<p>
+										<a
+											href={ getRedirectUrl( 'jetpack-connections-sharing-screen', {
+												site: getSiteFragment(),
+												query: 'redirect_to=' + encodeURIComponent( window.location.href ),
+											} ) }
+										>
+											{ showUpgradeLink && ! hasSocialBasicFeatures
+												? __( 'Upgrade to a Jetpack Social plan', 'jetpack' )
+												: __( 'Upgrade to the Jetpack Social Advanced plan', 'jetpack' ) }
+										</a>
+										&nbsp;
+										{ showUpgradeLink && ! hasSocialBasicFeatures
+											? __(
+													'to get unlimited shares and advanced media sharing options.',
+													'jetpack'
+											  )
+											: __( 'to get advanced media sharing options.', 'jetpack' ) }
+									</p>
+								</React.Fragment>
+							) }
 							<ModuleToggle
 								slug="publicize"
 								disabled={ unavailableInOfflineMode || ! this.props.isLinked }

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -38,6 +38,12 @@ export const Publicize = withModuleSettingsFormHelpers(
 				'jetpack'
 			);
 
+			const jetpackSocialBasicUpgradeText = __( 'Upgrade to a Jetpack Social plan', 'jetpack' );
+			const jetpackSocialAdvancedText = __(
+				'Upgrade to the Jetpack Social Advanced plan',
+				'jetpack'
+			);
+
 			const configCard = () => {
 				if ( unavailableInOfflineMode ) {
 					return;
@@ -94,8 +100,8 @@ export const Publicize = withModuleSettingsFormHelpers(
 											} ) }
 										>
 											{ showUpgradeLink && ! hasSocialBasicFeatures
-												? __( 'Upgrade to a Jetpack Social plan', 'jetpack' )
-												: __( 'Upgrade to the Jetpack Social Advanced plan', 'jetpack' ) }
+												? jetpackSocialBasicUpgradeText
+												: jetpackSocialAdvancedText }
 										</a>
 										&nbsp;
 										{ showUpgradeLink && ! hasSocialBasicFeatures

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import Card from 'components/card';
 import ConnectUserBar from 'components/connect-user-bar';
@@ -26,30 +27,19 @@ export const Publicize = withModuleSettingsFormHelpers(
 				isActive = this.props.getOptionValue( 'publicize' ),
 				hasSocialBasicFeatures = this.props.hasSocialBasicFeatures,
 				hasSocialAdvancedFeatures = this.props.hasSocialAdvancedFeatures,
+				isAtomicSite = this.props.isAtomicSite,
 				activeFeatures = this.props.activeFeatures,
 				userCanManageModules = this.props.userCanManageModules;
 
 			const showUpgradeLink =
-				activeFeatures && activeFeatures.length > 0 && isActive && ! hasSocialAdvancedFeatures;
+				! isAtomicSite &&
+				activeFeatures &&
+				activeFeatures.length > 0 &&
+				isActive &&
+				! hasSocialAdvancedFeatures;
 
 			const jetpackSocialText = __(
 				'Connect your website to the social media networks you use and share your content across all your social accounts with a single click. When you publish a post, it will appear on all connected accounts.',
-				'jetpack'
-			);
-
-			const jetpackSocialBasicUpgradeText = __( 'Upgrade to a Jetpack Social plan', 'jetpack' );
-			const jetpackSocialAdvancedText = __(
-				'Upgrade to the Jetpack Social Advanced plan',
-				'jetpack'
-			);
-
-			const jetpackSocialBasicUpgradeTextSuffix = __(
-				'to get unlimited shares and advanced media sharing options.',
-				'jetpack'
-			);
-
-			const jetpackSocialAdvancedUpgradeTextSuffix = __(
-				'to get advanced media sharing options.',
 				'jetpack'
 			);
 
@@ -102,22 +92,49 @@ export const Publicize = withModuleSettingsFormHelpers(
 							{ showUpgradeLink && (
 								<React.Fragment>
 									<p>
-										<a
-											href={ getRedirectUrl( 'jetpack-plugin-admin-page-sharings-screen', {
-												site: siteRawUrl,
-												query:
-													'redirect_to=' +
-													encodeURIComponent( window.location.href.split( '#' )[ 0 ] ),
-											} ) }
-										>
-											{ showUpgradeLink && ! hasSocialBasicFeatures
-												? jetpackSocialBasicUpgradeText
-												: jetpackSocialAdvancedText }
-										</a>
-										&nbsp;
-										{ showUpgradeLink && ! hasSocialBasicFeatures
-											? jetpackSocialBasicUpgradeTextSuffix
-											: jetpackSocialAdvancedUpgradeTextSuffix }
+										{ ! hasSocialBasicFeatures
+											? createInterpolateElement(
+													__(
+														'<moreInfo>Upgrade to a Jetpack Social plan</moreInfo> to get unlimited shares and advanced media sharing options.',
+														'jetpack'
+													),
+													{
+														moreInfo: (
+															<a
+																href={ getRedirectUrl(
+																	'jetpack-plugin-admin-page-sharings-screen',
+																	{
+																		site: siteRawUrl,
+																		query:
+																			'redirect_to=' +
+																			encodeURIComponent( window.location.href.split( '#' )[ 0 ] ),
+																	}
+																) }
+															/>
+														),
+													}
+											  )
+											: createInterpolateElement(
+													__(
+														'<moreInfo>Upgrade to the Jetpack Social Advanced plan</moreInfo> to get advanced media sharing options.',
+														'jetpack'
+													),
+													{
+														moreInfo: (
+															<a
+																href={ getRedirectUrl(
+																	'jetpack-plugin-admin-page-sharings-screen',
+																	{
+																		site: siteRawUrl,
+																		query:
+																			'redirect_to=' +
+																			encodeURIComponent( window.location.href.split( '#' )[ 0 ] ),
+																	}
+																) }
+															/>
+														),
+													}
+											  ) }
 									</p>
 								</React.Fragment>
 							) }

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -1,5 +1,4 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { __, _x } from '@wordpress/i18n';
 import Card from 'components/card';
 import ConnectUserBar from 'components/connect-user-bar';
@@ -104,9 +103,11 @@ export const Publicize = withModuleSettingsFormHelpers(
 								<React.Fragment>
 									<p>
 										<a
-											href={ getRedirectUrl( 'jetpack-connections-sharing-screen', {
-												site: getSiteFragment(),
-												query: 'redirect_to=' + encodeURIComponent( window.location.href ),
+											href={ getRedirectUrl( 'jetpack-plugin-admin-page-sharings-screen', {
+												site: siteRawUrl,
+												query:
+													'redirect_to=' +
+													encodeURIComponent( window.location.href.split( '#' )[ 0 ] ),
 											} ) }
 										>
 											{ showUpgradeLink && ! hasSocialBasicFeatures

--- a/projects/plugins/jetpack/changelog/add-jetpack-social-notices
+++ b/projects/plugins/jetpack/changelog/add-jetpack-social-notices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Social: Added upsell links in the sharing section of the Jetpack plugin.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1205003617340866-as-1205091696786991

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adde upsell links in the Jetpack Social section of the Sharing screen

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, if the upsell links are clicked, they will be tracked

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the sharing screen of the Jetpack plugin and make sure that you don't have a paid jetpack social plan. 
* When you're on the free plan, you will see a link like this asking you to upgrade. 
<img width="1296" alt="Screenshot 2023-07-24 at 19 44 36" src="https://github.com/Automattic/jetpack/assets/6594561/a13ba9c1-437b-4c25-91ce-4dbf15a51b91">

* Click on the link to upgrade, finish the checkout, and come back to the sharing screen to see the advanced plan's upsell link which will look as shown in the screenshot below
<img width="1206" alt="Screenshot 2023-07-25 at 17 57 15" src="https://github.com/Automattic/jetpack/assets/6594561/6962357f-b204-4b06-8a45-058c052eea46">

* Finish the upgrade and ensure that no upsell links show up when you return to the sharing screen 
