### PR TITLE
Subscriptions: Change conditions for displaying modal

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-checks
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-checks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subcribe modal: add conditions for display.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -57,7 +57,7 @@ class Jetpack_Subscribe_Modal {
 	 * @return void
 	 */
 	public function enqueue_assets() {
-		if ( $this->is_front_end_single_post() ) {
+		if ( $this->should_user_see_modal() ) {
 			wp_enqueue_style( 'subscribe-modal-css', plugins_url( 'subscribe-modal.css', __FILE__ ), array(), JETPACK__VERSION );
 			wp_enqueue_script( 'subscribe-modal-js', plugins_url( 'subscribe-modal.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
 		}
@@ -69,7 +69,7 @@ class Jetpack_Subscribe_Modal {
 	 * @return void
 	 */
 	public function add_subscribe_modal_to_frontend() {
-		if ( $this->is_front_end_single_post() ) { ?>
+		if ( $this->should_user_see_modal() ) { ?>
 					<div class="jetpack-subscribe-modal">
 						<div class="jetpack-subscribe-modal__modal-content">
 				<?php block_template_part( self::BLOCK_TEMPLATE_PART_SLUG ); ?>
@@ -147,19 +147,6 @@ class Jetpack_Subscribe_Modal {
 	}
 
 	/**
-	 * Returns true if we are on frontend of single post.
-	 * Note: Because of how WordPress works, this function will
-	 * only return the correct value after a certain point in the
-	 * WordPress loading process. You cannot, for example, use this
-	 * method in the class contructor method - it will always return false.
-	 *
-	 * @return bool
-	 */
-	public function is_front_end_single_post() {
-		return ! is_admin() && is_singular( 'post' );
-	}
-
-	/**
 	 * Returns the initial content of the Subscribe Modal template.
 	 * This can then be edited by the user.
 	 *
@@ -211,6 +198,48 @@ HTML;
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Returns true if a site visitor should see
+	 * the Subscribe Modal.
+	 *
+	 * @return bool
+	 */
+	public function should_user_see_modal() {
+		// Only show when viewing frontend single post.
+		if ( is_admin() || ! is_singular( 'post' ) ) {
+			return false;
+		}
+
+		// Don't show if subscribe query param is set.
+		// It is set when user submits the subscribe form.
+		if ( isset( $_GET['subscribe'] ) ) {
+			return false;
+		}
+
+		// Don't show if user has subscription cookie.
+		// It is set (sometimes) if user subscribed to blog.
+		if ( $this->has_subscription_cookie() ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Returns true if site visitor has subscribed
+	 * to the blog and has a subscription cookie.
+	 *
+	 * @return bool
+	 */
+	public function has_subscription_cookie() {
+		$cookies = $_COOKIE;
+		foreach ( $cookies as $name => $value ) {
+			if ( strpos( $name, 'jetpack_blog_subscribe_' ) !== false ) {
+				return true;
+			}
+		}
+		return false;
 	}
 }
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -214,6 +214,7 @@ HTML;
 
 		// Don't show if subscribe query param is set.
 		// It is set when user submits the subscribe form.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['subscribe'] ) ) {
 			return false;
 		}

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -219,6 +219,11 @@ HTML;
 			return false;
 		}
 
+		// Dont show if user is member of site.
+		if ( is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
+			return false;
+		}
+
 		// Don't show if user is subscribed to blog.
 		require_once __DIR__ . '/../views.php';
 		if ( $this->has_subscription_cookie() || Jetpack_Subscriptions_Widget::is_current_user_subscribed() ) {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -219,9 +219,9 @@ HTML;
 			return false;
 		}
 
-		// Don't show if user has subscription cookie.
-		// It is set (sometimes) if user subscribed to blog.
-		if ( $this->has_subscription_cookie() ) {
+		// Don't show if user is subscribed to blog.
+		require_once __DIR__ . '/../views.php';
+		if ( $this->has_subscription_cookie() || Jetpack_Subscriptions_Widget::is_current_user_subscribed() ) {
 			return false;
 		}
 		return true;

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -2,12 +2,14 @@ const { domReady } = wp;
 
 domReady( function () {
 	const modal = document.getElementsByClassName( 'jetpack-subscribe-modal' )[ 0 ];
-	const close = document.getElementsByClassName( 'jetpack-subscribe-modal__close' )[ 0 ];
 
 	if ( ! modal ) {
 		return;
 	}
 
+	const close = document.getElementsByClassName( 'jetpack-subscribe-modal__close' )[ 0 ];
+	const modalDismissedCookie = 'jetpack_subscribe_modal_dismissed';
+	const hasModalDismissedCookie = document.cookie.indexOf( modalDismissedCookie ) > -1;
 	let hasLoaded = false;
 	let isScrolling;
 
@@ -15,7 +17,7 @@ domReady( function () {
 		window.clearTimeout( isScrolling );
 
 		isScrolling = setTimeout( function () {
-			if ( ! hasLoaded ) {
+			if ( ! hasLoaded && ! hasModalDismissedCookie ) {
 				modal.classList.toggle( 'open' );
 				hasLoaded = true;
 			}
@@ -24,11 +26,19 @@ domReady( function () {
 
 	close.onclick = function () {
 		modal.classList.toggle( 'open' );
+		setModalDismissedCookie();
 	};
 
 	window.onclick = function ( event ) {
 		if ( event.target === modal ) {
 			modal.style.display = 'none';
+			setModalDismissedCookie();
 		}
 	};
+
+	function setModalDismissedCookie() {
+		// Expires in 1 day
+		const expires = new Date( Date.now() + 86400 * 1000 ).toUTCString();
+		document.cookie = `${ modalDismissedCookie }=true; expires=${ expires };`;
+	}
 } );

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -9,7 +9,8 @@ domReady( function () {
 
 	const close = document.getElementsByClassName( 'jetpack-subscribe-modal__close' )[ 0 ];
 	const modalDismissedCookie = 'jetpack_subscribe_modal_dismissed';
-	const hasModalDismissedCookie = document.cookie.indexOf( modalDismissedCookie ) > -1;
+	const hasModalDismissedCookie =
+		document.cookie && document.cookie.indexOf( modalDismissedCookie ) > -1;
 	let hasLoaded = false;
 	let isScrolling;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds extra checks and conditions for displaying (or not) the subscribe modal. Collectively these all avoid a situation where a user keeps re-seeing the subscribe modal even though they have subscribed or dismissed it.
* Do not show if user has already subscribed (`jetpack_blog_subscribe_` cookie is set).
* Do not show if `subscribe` query parameter is set (set when user first submits the subscribe form)
* If user dismisses the cookie, we add 1-day `jetpack-subscribe-modal-dismissed` cookie, and do not re-show the modal while that cookie exists.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Setup
   - Load this branch in your local Jetpack environment - you will need a jurassic tube connected site. 
   - Add the `add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 );` filter. The feature is behind a feature flag, and this will enable it. You can add this to tools/docker/mu-plugins/0-sandbox.php, or temporarily in any file that loads on your instance. 
   - Go to Jetpack > Settings > Discussion > Newsletters and enable the "Enable subscriber modal". If you do not see that option enable "Let visitors subscribe to new posts and comments via email" and refresh the page.

2) Test dismissing the modal. 
   - Go to any single post on the front end, scroll, and confirm the modal shows. 
   - Dismiss the modal, refresh the page, and confirm the modal does not show again.
   - Open Dev Tools > Applications > Cookies, and confirm the `jetpack-subscribe-modal-dismissed` is set. 
   
3) Test the subscribe query parameter.
   - Delete the `jetpack-subscribe-modal-dismissed` cookie from the last test so the modal will show again. 
   - Add `?subscribe=anythinghere` to the url and refresh the page.
   - Confirm the modal never show.

4) Test subscribing to the blog.
   - Remove the subscribe query parameter from the last test.
   - Visit any single post, scroll down, add a comment, check the boxes to subscribe to the blog, and submit.
   - Once page reloads, confirm you see the `jetpack_blog_subscribe_...` cookie. 
   - If needed, delete the `jetpack-subscribe-modal-dismissed` cookie again. 
   - Refresh the page and confirm the modal never shows. 