### PR TITLE
Prevent use of JP_Memberships to get connected account ID

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -208,7 +208,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 			require_lib( 'memberships' );
-			$connected_destination_account_id = Jetpack_Memberships::get_connected_account_id();
+			$connected_destination_account_id = get_connected_account_id_for_site( get_current_blog_id() );
 			if ( ! $connected_destination_account_id ) {
 				return new WP_Error( 'no-destination-account', __( 'Please set up a Stripe account for this site first', 'jetpack' ) );
 			}

--- a/projects/plugins/jetpack/changelog/add-prevent-use-of-memberships-get-connected-account-id
+++ b/projects/plugins/jetpack/changelog/add-prevent-use-of-memberships-get-connected-account-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+


### PR DESCRIPTION
No change in feature. Just use DB based on blog id when on WPCOM

Duplicate from D116913-code
