### PR TITLE
My Jetpack: Fix Stats features wording

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-stats-no-ads-wording
+++ b/projects/packages/my-jetpack/changelog/fix-stats-no-ads-wording
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: changed Stats features wording

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -72,9 +72,8 @@ class Stats extends Module_Product {
 	 */
 	public static function get_features() {
 		return array(
-			__( 'Access to all-time data', 'jetpack-my-jetpack' ),
+			__( 'Instant access to upcoming features', 'jetpack-my-jetpack' ),
 			__( 'Priority support', 'jetpack-my-jetpack' ),
-			__( 'No upsell or ads in the Stats page', 'jetpack-my-jetpack' ),
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -91,6 +91,7 @@ class Stats extends Module_Product {
 				'wpcom_pwyw_product_slug' => static::get_wpcom_pwyw_product_slug(),
 			),
 			// TODO: replace with `Wpcom_Products::get_product_pricing` once available.
+			// This is not yet used anywhere, so it's fine to leave it as is for now.
 			array(
 				'currency_code'  => 'USD',
 				'full_price'     => 10,


### PR DESCRIPTION
Related https://github.com/Automattic/wp-calypso/issues/79810

## Proposed changes:

* Match features wording on WPCOM

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Ensure all tests pass
* Ensure wording looks good

