### PR TITLE
External Sources in Media Inserter: Added Google Photos to the Media Inserter

### DIFF
--- a/projects/plugins/jetpack/changelog/add-google-photos-to-media-inserter
+++ b/projects/plugins/jetpack/changelog/add-google-photos-to-media-inserter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added Google Photos integration to Gutenberg's Media Sidebar for Jetpack connected sites.

--- a/projects/plugins/jetpack/extensions/shared/external-media/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/index.js
@@ -4,7 +4,11 @@ import { select, dispatch } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { waitFor } from '../wait-for';
 import MediaButton from './media-button';
-import { getPexelsMediaCategory } from './media-category';
+import {
+	getPexelsMediaCategory,
+	getGooglePhotosMediaCategory,
+	isGooglePhotosConnected,
+} from './media-category';
 import { mediaSources } from './sources';
 import './editor.scss';
 
@@ -25,9 +29,14 @@ if ( isCurrentUserConnected() && 'function' === typeof useBlockEditContext ) {
 		select( 'core/edit-site' )?.isInserterOpened() ||
 		select( 'core/edit-widgets' )?.isInserterOpened?.();
 
-	waitFor( isInserterOpened ).then( () =>
-		dispatch( 'core/block-editor' )?.registerInserterMediaCategory?.( getPexelsMediaCategory() )
-	);
+	waitFor( isInserterOpened ).then( () => {
+		dispatch( 'core/block-editor' )?.registerInserterMediaCategory?.( getPexelsMediaCategory() );
+		isGooglePhotosConnected( () =>
+			dispatch( 'core/block-editor' )?.registerInserterMediaCategory?.(
+				getGooglePhotosMediaCategory()
+			)
+		);
+	} );
 
 	const isFeaturedImage = props =>
 		props.unstableFeaturedImageFlow ||

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-category/index.ts
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-category/index.ts
@@ -7,7 +7,7 @@ const PEXELS_ID = 'pexels';
 const PEXELS_NAME = __( 'Pexels Free Photos', 'jetpack' );
 const PEXELS_SEARCH_PLACEHOLDER = __( 'Search Pexels Free Photos', 'jetpack' );
 const DEFAULT_PEXELS_SEARCH: MediaSearch = {
-	per_page: 25,
+	per_page: 10,
 	search: 'mountain',
 };
 
@@ -131,7 +131,7 @@ const buildMediaCategory = (
 	fetch: async ( mediaCategorySearch: MediaSearch ) =>
 		await apiFetch( {
 			path: getMediaApiUrl( source, {
-				per_page: mediaCategorySearch?.per_page || defaultSearch.per_page,
+				per_page: defaultSearch.per_page,
 				search:
 					mediaCategorySearch?.search === '' ? defaultSearch.search : mediaCategorySearch.search,
 			} ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/3180

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added Google Photos to Gutenberg's Media Sidebar
![Captura de Pantalla 2023-07-18 a las 15 07 11](https://github.com/Automattic/jetpack/assets/1989914/723aec6e-d6a1-45aa-9992-b9e1fc4285a6)
### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Keep in mind that this branch hasn't been created from trunk and branches off the branch where we [add pexels to the sidebar](https://github.com/Automattic/jetpack/pull/31914).

* Go to a Jetpack-connected site.
* Edit or create a new Post.
* Make sure you already have the Google Photos service authorized. You can do this through the Image block.
* Open the Media Sidebar.
* You should see the Google Photos integration.