### PR TITLE
Introduce 'jetpack_woocommerce_analytics_event_props' filter

### DIFF
--- a/projects/plugins/jetpack/changelog/add-filter-woocommerce-analytics-event-props
+++ b/projects/plugins/jetpack/changelog/add-filter-woocommerce-analytics-event-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+WooCommerce Analytics events: Introduce 'jetpack_woocommerce_analytics_event_props' filter

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -143,6 +143,15 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		}
 		$product_details = $this->get_product_details( $product );
 
+		/**
+		 * Allow defining custom event properties in WooCommerce Analytics.
+		 *
+		 * @module woocommerce-analytics
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $all_props Array of event props to be filtered.
+		 */
 		$all_props = apply_filters(
 			'jetpack_woocommerce_analytics_event_props',
 			array_merge(

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -143,9 +143,12 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		}
 		$product_details = $this->get_product_details( $product );
 
-		$all_props = array_merge(
-			$properties,
-			$this->get_common_properties()
+		$all_props = apply_filters(
+			'jetpack_woocommerce_analytics_event_props',
+			array_merge(
+				$properties,
+				$this->get_common_properties()
+			)
 		);
 
 		$js = "{


### PR DESCRIPTION
Fixes #32050
- #32050 

**Related Project Thread**
peapX7-2Vz-p2#comment-3798

## Proposed changes:

Introduces a filter to modify/append WooCommerce analytics event properties. Will be utilized to add a Woo Express `host` parameter. 

I considered adding a `host` key directly, but decided to take the filter approach to make it easier for others to add props in the future.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

N/A