### PR TITLE
SEO Tools: Update SEO textareas container to be 100% wide

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-seo-input-style
+++ b/projects/plugins/jetpack/changelog/update-fix-seo-input-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update SEO tools textarea in editor plugin container to be 100% wide

--- a/projects/plugins/jetpack/extensions/blocks/seo/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/seo/editor.scss
@@ -1,5 +1,5 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
-.jetpack-seo-message-box textarea {
+.jetpack-seo-message-box {
 	width: 100%;
 }


### PR DESCRIPTION
<table>
<tr>
 <td>
<img width="285" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/9972ecc1-f58e-46ef-851b-dbe86d5f6410">

 <td>
<img width="254" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/caef8266-56b1-4dde-87e8-938909453128">

<tr>
 <td>After
 <td>Before
</table>

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the textarea container to be 100% wide.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None
## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Enable SEO tools in Jetpack -> Settings -> Traffic
* Draft a new post
* Open the Jetpack sidebar in the editor
* Confirm the SEO tools textareas are 100% wide
