### PR TITLE
SEO Tools: Update "hide page from search engines" control from checkbox to toggle

### DIFF
--- a/projects/plugins/jetpack/changelog/update-seo-hide-pages-control
+++ b/projects/plugins/jetpack/changelog/update-seo-hide-pages-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update SEO hide page control from checkbox to toggle

--- a/projects/plugins/jetpack/extensions/blocks/seo/noindex-panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/seo/noindex-panel.js
@@ -1,4 +1,4 @@
-import { CheckboxControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { withSeoHelper } from './with-seo-helper';
@@ -9,7 +9,7 @@ const SeoNoindexPanel = ( { metaValue, updateMetaValue } ) => {
 	};
 
 	return (
-		<CheckboxControl
+		<ToggleControl
 			label={ __( 'Hide page from search engines', 'jetpack' ) }
 			help={ __(
 				"If selected, a 'noindex' tag will help instruct search engines to not include this page in search results. This page will also be removed from the Jetpack sitemap.",


### PR DESCRIPTION
Make the setting look a bit more like the "Share this post" control.

<table>
<tr>
 <td><img width="272" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/823872b4-d353-4792-b4da-6831bd62250e">

 <td>
<img width="255" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/186db398-e9b7-42da-b3db-fab8331e63bb">

<tr>
 <td>After
 <td>Before
</table>

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:


* Enable SEO tools in Jetpack -> Settings -> Traffic
* Draft a new post
* Open the Jetpack sidebar in the editor
* Confirm the SEO tools show a toggle instead of a checkbox for the "Hide page from search engines" setting.

