### PR TITLE
Like/Sharing buttons: Make the controls in the Jetpack sidebar be toggles

### DIFF
--- a/projects/plugins/jetpack/changelog/update-share-likes-panel-to-use-toggles
+++ b/projects/plugins/jetpack/changelog/update-share-likes-panel-to-use-toggles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Make the likes and sharing buttons controls in the Jetpack sidebar be toggles

--- a/projects/plugins/jetpack/extensions/blocks/likes/likes-checkbox.js
+++ b/projects/plugins/jetpack/extensions/blocks/likes/likes-checkbox.js
@@ -1,4 +1,4 @@
-import { CheckboxControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { PostTypeSupportCheck } from '@wordpress/editor';
@@ -8,8 +8,8 @@ import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-
 const LikesCheckbox = ( { areLikesEnabled, editPost } ) => (
 	<PostTypeSupportCheck supportKeys="jetpack-post-likes">
 		<JetpackLikesAndSharingPanel>
-			<CheckboxControl
-				label={ __( 'Show likes.', 'jetpack' ) }
+			<ToggleControl
+				label={ __( 'Show likes', 'jetpack' ) }
 				checked={ areLikesEnabled }
 				onChange={ value => {
 					editPost( { jetpack_likes_enabled: value } );

--- a/projects/plugins/jetpack/extensions/plugins/sharing/components/show-sharing-control/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/sharing/components/show-sharing-control/index.js
@@ -1,4 +1,4 @@
-import { CheckboxControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore, PostTypeSupportCheck } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
@@ -6,8 +6,8 @@ import JetpackLikesAndSharingPanel from '../../../../shared/jetpack-likes-and-sh
 
 function ShowSharingCheckbox( { checked, onChange } ) {
 	return (
-		<CheckboxControl
-			label={ __( 'Show sharing buttons.', 'jetpack' ) }
+		<ToggleControl
+			label={ __( 'Show sharing buttons', 'jetpack' ) }
 			checked={ checked }
 			onChange={ value => {
 				onChange( { jetpack_sharing_enabled: value } );


### PR DESCRIPTION
<table>
<tr>


 <td><img width="278" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/333d85bc-0d11-4f5a-9fa8-92b7171bd60b">
 <td>
<img width="271" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/cd27ab85-cd67-4009-9386-22099c86fae1">

<tr>
 <td>After
 <td>Before
</table>

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Enable Like and Sharing buttons tools in Jetpack -> Settings -> Sharing
* Draft a new post
* Open the Jetpack sidebar in the editor
* Confirm the Like and Sharing button controls are toggles
