### PR TITLE
Launchpad: Add site goals option to Jetpack sync

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-site-goals-to-atomic-sync
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-site-goals-to-atomic-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add site_goals to the jetpack sync options

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -690,6 +690,7 @@ function add_launchpad_options_to_jetpack_sync( $allowed_options ) {
 	$launchpad_options = array(
 		'site_intent',
 		'launchpad_checklist_tasks_statuses',
+		'site_goals',
 	);
 
 	return array_merge( $allowed_options, $launchpad_options );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:
* https://github.com/Automattic/jetpack/pull/32067
* D117113-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Adds the site_goals option to the Jetpack sync, so it can be accessible from Atomic sites. This option will be used to determine if the site has a Free or Paid Newsletter. This way, we can decide which launchpad we display for the user since we have two separate task lists for each case(free or paid).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions on D117113-code