### PR TITLE
Fix launchpad errors identified by broader tests

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-errors-identified-by-broader-tests
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-errors-identified-by-broader-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added some guards around calls to wpcom_get_theme_annotation() to avoid errors

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -829,10 +829,14 @@ function wpcom_get_site_about_page_id() {
  * @return int|null The page ID of the 'About' page if it exists, null otherwise.
  */
 function wpcom_find_site_about_page_id() {
+	if ( ! function_exists( 'wpcom_get_theme_annotation' ) ) {
+		return null;
+	}
+
 	$annotation = wpcom_get_theme_annotation( get_stylesheet() );
 
-	// Return null if there is no annotation or the annotation doesn't have any content.
-	if ( ! $annotation || ! isset( $annotation['content'] ) || ! is_array( $annotation['content'] ) ) {
+	// Return null if there is no annotation, an error, or the annotation doesn't have any content.
+	if ( ! $annotation || ! is_array( $annotation ) || ! isset( $annotation['content'] ) || ! is_array( $annotation['content'] ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR addresses a bug in the launchpad that was introduced by https://github.com/Automattic/jetpack/pull/31966, as flagged by the Jetpack Crew folks in this thread: p1690318718005339/1690315980.977129-slack-C01U2KGS2PQ
  - The primary issue they tripped over was an unrelated unit test failure due to the code not handling a returned `WP_Error` instance, but I also realised that the same code block was calling a function that probably doesn't exist on Atomic sites. This PR addresses both issues.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No product changes.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No data collection changes.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your WordPress.com sandbox using the instructions [here](https://github.com/Automattic/jetpack/pull/32078#issuecomment-1651389189)
* Run the following command on your WordPress.com to verify that the unit test failure is addressed:
```sh
phpunit -c ~/public_html/bin/tests/isolated/phpunit.xml --testsuite=template-api
```
* Inspect the code to confirm that the guards don't introduce any unexpected functional changes