### PR TITLE
My Jetpack: rename the namespace of the JWT endpoint

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-rename-jwt-endpoint-namespace
+++ b/projects/packages/my-jetpack/changelog/update-rename-jwt-endpoint-namespace
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Rename the namespace of the JWT endpoint, and register it only when it isn't already registered

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.2.0",
+	"version": "3.2.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.2.0';
+	const PACKAGE_VERSION = '3.2.1-alpha';
 
 	/**
 	 * Initialize My Jetpack

--- a/projects/packages/my-jetpack/src/class-rest-ai.php
+++ b/projects/packages/my-jetpack/src/class-rest-ai.php
@@ -20,17 +20,39 @@ class REST_AI {
 	 * Constructor.
 	 */
 	public function __construct() {
-		register_rest_route(
-			'my-jetpack/v1',
-			'jetpack-ai-jwt',
-			array(
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => __CLASS__ . '::get_openai_jwt',
-				'permission_callback' => function () {
-					return ( new Connection_Manager( 'jetpack' ) )->is_user_connected() && current_user_can( 'edit_posts' );
-				},
-			)
-		);
+		/*
+		 * Check if the `jetpack/v4/jetpack-ai-jwt` endpoint is registered
+		 * by the Jetpack plugin to avoid registering it again.
+		 * In case it's not registered, register it
+		 * to make it available for Jetpack products that depend on it.
+		 */
+		if ( ! self::is_rest_endpoint_registered( 'jetpack/v4', '/jetpack-ai-jwt' ) ) {
+			register_rest_route(
+				'jetpack/v4',
+				'jetpack-ai-jwt',
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => __CLASS__ . '::get_openai_jwt',
+					'permission_callback' => function () {
+						return ( new Connection_Manager( 'jetpack' ) )->is_user_connected() && current_user_can( 'edit_posts' );
+					},
+				)
+			);
+		}
+	}
+
+	/**
+	 * Check if a specific REST endpoint is registered.
+	 *
+	 * @param string $namespace - The namespace of the endpoint.
+	 * @param string $route     - The route of the endpoint.
+	 * @return bool               True if the endpoint is registered, false otherwise.
+	 */
+	public static function is_rest_endpoint_registered( $namespace, $route ) {
+		$server        = rest_get_server();
+		$routes        = $server->get_routes();
+		$full_endpoint = '/' . trim( $namespace, '/' ) . $route;
+		return isset( $routes[ $full_endpoint ] );
 	}
 
 	/**
@@ -65,5 +87,4 @@ class REST_AI {
 			'blog_id' => $blog_id,
 		);
 	}
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR:

* Rename the namespace of the JWT endpoint from `my-jetpack/v1` to `jetpack/v4`
* Register the endpoint only if it isn't registered. Currently, [it's registered by the Jetpack plugin](https://github.com/Automattic/jetpack/blob/96f64ddaa59d36b244814311017cd4ebd40d348f/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php#L81).

The idea behind these changes is to be able to have always the JWT endpoint available, at least for all projects that rely on My Jetpack.

_About avoiding an endpoint double registration. I tested registering the same endpoint twice. It doesn't break the app, but still, it's better to check it._

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* My Jetpack: rename the namespace of the JWT endpoint, and register it only when it isn't already registered

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Take a testing site
* Do not enable any Jetpack plugin/product. No Jetpack plugin and other plugins that depend on My Jetpack
* Confirm the `jetpack/v4/jetpack-ai-jwt` endpoint is not available
* Active the Jetpack plugin
* Confirm now it's available
* Active another product that depends on My Jetpack, for instance, the Social standalone plugin
* Confirm the endpoint is available 
* Deactivate the Jetpack plugin 
* Confirm that the endpoint is still available

You can hit the `<your-testing-site>/wp-json/jetpack/v4/` to check if the endpoint is registered.

<img width="798" alt="Screenshot 2023-07-26 at 11 59 37" src="https://github.com/Automattic/jetpack/assets/77539/90d53220-cb64-40f9-8d27-900b297d94e6">

