### PR TITLE
Container Component: Add "wide" prop to allow the newer 1551px max width

### DIFF
--- a/projects/js-packages/components/changelog/update-container-component-add-wide-option
+++ b/projects/js-packages/components/changelog/update-container-component-add-wide-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Container component: added "wide" prop to allow for 1551px max width

--- a/projects/js-packages/components/components/layout/container/README.md
+++ b/projects/js-packages/components/components/layout/container/README.md
@@ -36,6 +36,20 @@ A custom class to append with the default ones.
 - Default: `undefined`
 - Required: `false`
 
+### wide
+
+It changes the max width from 1128px to 1551px.
+
+- Type: `Boolean`
+- Default: `false`
+- Required: `false`
+
+#### Example
+
+```jsx
+<Container wide />
+```
+
 ### fluid
 
 It makes the container take the entire width and removes the right and left padding.

--- a/projects/js-packages/components/components/layout/container/index.tsx
+++ b/projects/js-packages/components/components/layout/container/index.tsx
@@ -13,6 +13,7 @@ import type React from 'react';
 const Container: React.FC< ContainerProps > = ( {
 	children,
 	fluid = false,
+	wide = false,
 	tagName = 'div',
 	className,
 	horizontalGap = 1,
@@ -30,6 +31,7 @@ const Container: React.FC< ContainerProps > = ( {
 	}, [ horizontalGap, horizontalSpacing ] );
 
 	const containerClassName = classNames( className, styles.container, {
+		[ styles.wide ]: wide,
 		[ styles.fluid ]: fluid,
 	} );
 

--- a/projects/js-packages/components/components/layout/container/style.module.scss
+++ b/projects/js-packages/components/components/layout/container/style.module.scss
@@ -28,6 +28,10 @@
 	@include container( "md" );
 	@include container( "lg" );
 
+	&.wide {
+		--max-container-width: 1551px;
+	}
+
 	&.fluid {
 		max-width: none;
 		padding: unset;

--- a/projects/js-packages/components/components/layout/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/layout/stories/index.stories.tsx
@@ -4,11 +4,12 @@ import Container from '../container';
 import useBreakpointMatch from '../use-breakpoint-match';
 import styles from './styles.module.scss';
 
-const Layout = ( { items, fluid, horizontalGap, horizontalSpacing } ) => {
+const Layout = ( { items, wide, fluid, horizontalGap, horizontalSpacing } ) => {
 	return (
 		<Container
 			className={ styles.container }
 			horizontalSpacing={ horizontalSpacing }
+			wide={ wide }
 			fluid={ fluid }
 			horizontalGap={ horizontalGap }
 		>
@@ -32,7 +33,7 @@ const Layout = ( { items, fluid, horizontalGap, horizontalSpacing } ) => {
 				);
 			} ) }
 			<Col>
-				<Container fluid horizontalSpacing={ 0 } horizontalGap={ 1 }>
+				<Container wide fluid horizontalSpacing={ 0 } horizontalGap={ 1 }>
 					<Col className={ styles.col }>Composition Example</Col>
 					<Col className={ styles.col }>Composition Example</Col>
 				</Container>
@@ -49,6 +50,7 @@ export default {
 const Template = args => <Layout { ...args } />;
 export const Default = Template.bind( {} );
 Default.args = {
+	wide: false,
 	fluid: false,
 	horizontalSpacing: 10,
 	horizontalGap: 5,

--- a/projects/js-packages/components/components/layout/types.ts
+++ b/projects/js-packages/components/components/layout/types.ts
@@ -39,6 +39,11 @@ export type ContainerProps = {
 	tagName?: string;
 
 	/**
+	 * Make the container use Jetpack Emeralds widest max width (1551px).
+	 */
+	wide?: boolean;
+
+	/**
 	 * Make container not having a max width.
 	 */
 	fluid?: boolean;

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.41.0",
+	"version": "0.42.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/zero-bs-crm/issues/3220

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a `wide` prop to the `<container>` component.
* Override `--max-container-width` CSS variable with a new `.wide` class that is appended based on the `wide` prop.
* Update layout story to include `wide` as an argument.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pbhBOz-3Ah-p2#comment-4347

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**TBA**

* Go to '..'
* 