### PR TITLE
VideoPress: handle uploading video files when dropping in the editor canvas

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2129,6 +2129,9 @@ importers:
       '@wordpress/api-fetch':
         specifier: 6.34.0
         version: 6.34.0
+      '@wordpress/blob':
+        specifier: 3.37.0
+        version: 3.37.0
       '@wordpress/block-editor':
         specifier: 12.5.0
         version: 12.5.0(@types/react-dom@18.2.6)(@types/react@18.2.14)(react-dom@18.2.0)(react@18.2.0)

--- a/projects/packages/videopress/changelog/update-videopress-handle-dropping-videos
+++ b/projects/packages/videopress/changelog/update-videopress-handle-dropping-videos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+VideoPress: handle uploading video files when dropping in the editor canvas

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.14.11",
+	"version": "0.14.12-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -67,6 +67,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@storybook/addon-actions": "7.1.0",
 		"@wordpress/api-fetch": "6.34.0",
+		"@wordpress/blob": "3.37.0",
 		"@wordpress/block-editor": "12.5.0",
 		"@wordpress/blocks": "12.14.0",
 		"@wordpress/components": "25.3.0",

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.14.11';
+	const PACKAGE_VERSION = '0.14.12-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -29,6 +29,7 @@ import {
 import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
 import { usePreview } from '../../hooks/use-preview';
 import { useSyncMedia } from '../../hooks/use-sync-media';
+import { isVideoFile } from '../../utils/video';
 import ConnectBanner from './components/banner/connect-banner';
 import ColorPanel from './components/color-panel';
 import DetailsPanel from './components/details-panel';
@@ -171,6 +172,10 @@ export default function VideoPressEdit( {
 		// Get the file from the blob URL.
 		const file = getBlobByURL( src );
 		if ( ! file ) {
+			return;
+		}
+
+		if ( ! isVideoFile( file ) ) {
 			return;
 		}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -154,36 +154,6 @@ export default function VideoPressEdit( {
 
 	const [ showCaption, setShowCaption ] = useState( !! caption );
 
-	/*
-	 * Check if the video URL is a blob URL.
-	 * If so, it means that the video needs to be uploaded.
-	 * This scenario happens when the user drops a video file
-	 * into the editor canvas (transformFromFile).
-	 */
-	useEffect( () => {
-		if ( ! src ) {
-			return;
-		}
-
-		if ( ! isBlobURL( src ) ) {
-			return;
-		}
-
-		// Get the file from the blob URL.
-		const file = getBlobByURL( src );
-		if ( ! file ) {
-			return;
-		}
-
-		if ( ! isVideoFile( file ) ) {
-			return;
-		}
-
-		// Set state to start the upload process.
-		setIsUploadingFile( true );
-		setFileToUpload( file );
-	}, [ src ] );
-
 	const {
 		videoData,
 		isRequestingVideoData,
@@ -333,7 +303,39 @@ export default function VideoPressEdit( {
 	// Setting video media process
 	const [ isUploadingFile, setIsUploadingFile ] = useState( ! guid );
 	const [ fileToUpload, setFileToUpload ] = useState( null );
+	/*
+	 * Check if the video URL is a blob URL.
+	 * If so, it means that the video needs to be uploaded.
+	 * This scenario happens when the user drops a video file
+	 * into the editor canvas (transformFromFile).
+	 */
+	useEffect( () => {
+		if ( ! src ) {
+			return;
+		}
 
+		if ( ! isBlobURL( src ) ) {
+			return;
+		}
+
+		// Get the file from the blob URL.
+		const file = getBlobByURL( src );
+		if ( ! file ) {
+			return;
+		}
+
+		// Check if the file is a video file.
+		if ( ! isVideoFile( file ) ) {
+			return;
+		}
+
+		// Clean the src attribute.
+		setAttributes( { src: undefined } );
+
+		// Set state to start the upload process.
+		setIsUploadingFile( true );
+		setFileToUpload( file );
+	}, [ src ] );
 	const { replaceBlock } = useDispatch( blockEditorStore );
 
 	// Replace video state

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { isBlobURL, getBlobByURL } from '@wordpress/blob';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
 	BlockIcon,
@@ -151,6 +152,32 @@ export default function VideoPressEdit( {
 	const chapter = tracks?.filter( track => track.kind === 'chapters' )?.[ 0 ];
 
 	const [ showCaption, setShowCaption ] = useState( !! caption );
+
+	/*
+	 * Check if the video URL is a blob URL.
+	 * If so, it means that the video needs to be uploaded.
+	 * This scenario happens when the user drops a video file
+	 * into the editor canvas (transformFromFile).
+	 */
+	useEffect( () => {
+		if ( ! src ) {
+			return;
+		}
+
+		if ( ! isBlobURL( src ) ) {
+			return;
+		}
+
+		// Get the file from the blob URL.
+		const file = getBlobByURL( src );
+		if ( ! file ) {
+			return;
+		}
+
+		// Set state to start the upload process.
+		setIsUploadingFile( true );
+		setFileToUpload( file );
+	}, [ src ] );
 
 	const {
 		videoData,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { createBlobURL } from '@wordpress/blob';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { dispatch, select } from '@wordpress/data';
@@ -46,6 +47,26 @@ const transformFromCoreEmbed = {
 
 		return createBlock( 'videopress/video', { guid, src } );
 	},
+};
+
+const transformFromFile = {
+	type: 'files',
+	// Check if the files array contains a video file.
+	isMatch: files => {
+		if ( ! files || ! files.length ) {
+			return false;
+		}
+
+		return files.some( ( file: File ) => file?.type.startsWith( 'video/' ) );
+	},
+
+	priority: 8, // higher priority (lower number) than v5's core/video transform (9).
+	transform: ( files: File[] ) =>
+		files.map( ( file: File ) =>
+			createBlock( 'videopress/video', {
+				src: createBlobURL( file ),
+			} )
+		),
 };
 
 const transformToCoreEmbed = {
@@ -117,7 +138,7 @@ const transformFromPastingVideoPressURL = {
 	},
 };
 
-const from = [ transformFromCoreEmbed, transformFromPastingVideoPressURL ];
+const from = [ transformFromFile, transformFromCoreEmbed, transformFromPastingVideoPressURL ];
 const to = [ transformToCoreEmbed ];
 
 export default { from, to };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -18,6 +18,7 @@ import {
 /**
  * Types
  */
+import { isVideoFile } from '../../../utils/video';
 import { CoreEmbedVideoPressVariationBlockAttributes, VideoBlockAttributes } from '../types';
 
 const transformFromCoreEmbed = {
@@ -57,7 +58,7 @@ const transformFromFile = {
 			return false;
 		}
 
-		return files.some( ( file: File ) => file?.type.startsWith( 'video/' ) );
+		return files.some( isVideoFile );
 	},
 
 	priority: 8, // higher priority (lower number) than v5's core/video transform (9).

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/transforms/index.tsx
@@ -18,7 +18,7 @@ import {
 /**
  * Types
  */
-import { isVideoFile } from '../../../utils/video';
+import { filterVideoFiles, isVideoFile } from '../../../utils/video';
 import { CoreEmbedVideoPressVariationBlockAttributes, VideoBlockAttributes } from '../types';
 
 const transformFromCoreEmbed = {
@@ -63,7 +63,7 @@ const transformFromFile = {
 
 	priority: 8, // higher priority (lower number) than v5's core/video transform (9).
 	transform: ( files: File[] ) =>
-		files.map( ( file: File ) =>
+		filterVideoFiles( files ).map( ( file: File ) =>
 			createBlock( 'videopress/video', {
 				src: createBlobURL( file ),
 			} )

--- a/projects/packages/videopress/src/client/block-editor/utils/video.ts
+++ b/projects/packages/videopress/src/client/block-editor/utils/video.ts
@@ -12,3 +12,13 @@ export function isVideoFile( file: File ): boolean {
 
 	return file.type.startsWith( 'video/' );
 }
+
+/**
+ * Filter an array of files to only include video files.
+ *
+ * @param {File[]} files - Array of files to filter.
+ * @returns {File[]}       Array of video files.
+ */
+export function filterVideoFiles( files: File[] ): File[] {
+	return files.filter( isVideoFile );
+}

--- a/projects/packages/videopress/src/client/block-editor/utils/video.ts
+++ b/projects/packages/videopress/src/client/block-editor/utils/video.ts
@@ -1,0 +1,14 @@
+/**
+ * Pretty basic helper to check if a file is a video
+ * based on its mime type.
+ *
+ * @param {File} file - File to check.
+ * @returns {boolean}   Whether the file is a video.
+ */
+export function isVideoFile( file: File ): boolean {
+	if ( ! file?.type ) {
+		return false;
+	}
+
+	return file.type.startsWith( 'video/' );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR implements the proper block transform in the VideoPress video block to be able to handle the uploading process when the user drops off the video in the editor canvas 

Fixes #30584

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideoPress: handle uploading video files when dropping in the editor canvas

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Test with `Jetpack plugin` and/or `VideoPress plugin` activated.
* Drop off some files in the editor canvas
* Confirm the app creates a VideoPress video instance ONLY for video files
* Confirm the videos are uploaded as usual

In the example below, I'm dropping four files where only two are video files

https://github.com/Automattic/jetpack/assets/77539/807114ce-5056-404e-a918-5bc77d5a97cf

