### PR TITLE
Jetpack Sync: Extract Sync Queue storage handling to an external class.

### DIFF
--- a/projects/packages/sync/changelog/add-jetpack-sync-refactor-extract-queue-table-to-class
+++ b/projects/packages/sync/changelog/add-jetpack-sync-refactor-extract-queue-table-to-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Extract Sync Queue storage handling to an external class to prepare for Custom Table migration

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Sync\Queue\Queue_Storage_Options;
 use WP_Error;
 
 /**
@@ -38,6 +39,15 @@ class Queue {
 	public $random_int;
 
 	/**
+	 * Queue Storage instance where we'll store the queue items.
+	 *
+	 * For now it's only the Options table. To be updated to include the Custom table in future updates.
+	 *
+	 * @var Queue_Storage_Options|null
+	 */
+	public $queue_storage = null;
+
+	/**
 	 * Queue constructor.
 	 *
 	 * @param string $id Name of the queue.
@@ -46,6 +56,9 @@ class Queue {
 		$this->id           = str_replace( '-', '_', $id ); // Necessary to ensure we don't have ID collisions in the SQL.
 		$this->row_iterator = 0;
 		$this->random_int   = wp_rand( 1, 1000000 );
+
+		// Initialize the storage with the Options table backend. To be changed in subsequent updates to include the logic to switch to Custom Table.
+		$this->queue_storage = new Queue_Storage_Options( $this->id );
 	}
 
 	/**
@@ -54,34 +67,27 @@ class Queue {
 	 * @param object $item Event object to add to queue.
 	 */
 	public function add( $item ) {
-		global $wpdb;
 		$added = false;
 
 		// If empty, don't add.
 		if ( empty( $item ) ) {
-			return;
+			return false;
 		}
 
 		// Attempt to serialize data, if an exception (closures) return early.
 		try {
 			$item = serialize( $item ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 		} catch ( \Exception $ex ) {
-			return;
+			return new WP_Error( 'queue_unable_to_serialize', 'Unable to serialize item' );
 		}
 
 		// This basically tries to add the option until enough time has elapsed that
 		// it has a unique (microtime-based) option key.
 		while ( ! $added ) {
-			$rows_added = $wpdb->query(
-				$wpdb->prepare(
-					"INSERT INTO $wpdb->options (option_name, option_value, autoload) VALUES (%s, %s,%s)",
-					$this->get_next_data_row_option_name(),
-					$item,
-					'no'
-				)
-			);
-			$added      = ( 0 !== $rows_added );
+			$added = $this->queue_storage->insert_item( $this->get_next_data_row_option_name(), $item );
 		}
+
+		return $added;
 	}
 
 	/**
@@ -92,33 +98,15 @@ class Queue {
 	 * @return bool|\WP_Error
 	 */
 	public function add_all( $items ) {
-		global $wpdb;
+		// TODO check and figure out if it's used at all and if we can optimize it.
 		$base_option_name = $this->get_next_data_row_option_name();
 
-		$query = "INSERT INTO $wpdb->options (option_name, option_value, autoload) VALUES ";
-
-		$rows        = array();
-		$count_items = count( $items );
-		for ( $i = 0; $i < $count_items; ++$i ) {
-			// skip empty items.
-			if ( empty( $items[ $i ] ) ) {
-				continue;
-			}
-			try {
-				$option_name  = esc_sql( $base_option_name . '-' . $i );
-				$option_value = esc_sql( serialize( $items[ $i ] ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
-				$rows[]       = "('$option_name', '$option_value', 'no')";
-			} catch ( \Exception $e ) {
-				// Item cannot be serialized so skip.
-				continue;
-			}
-		}
-
-		$rows_added = $wpdb->query( $query . implode( ',', $rows ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows_added = $this->queue_storage->add_all( $items, $base_option_name );
 
 		if ( count( $items ) !== $rows_added ) {
 			return new WP_Error( 'row_count_mismatch', "The number of rows inserted didn't match the size of the input array" );
 		}
+
 		return true;
 	}
 
@@ -159,49 +147,21 @@ class Queue {
 	 * Lag is the difference in time between the age of the oldest item
 	 * (aka first or frontmost item) and the current time.
 	 *
-	 * @param microtime $now The current time in microtime.
+	 * @param float $now The current time in microtime.
 	 *
-	 * @return float|int|mixed|null
+	 * @return float
 	 */
 	public function lag( $now = null ) {
-		global $wpdb;
-
-		$first_item_name = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT 1",
-				"jpsq_{$this->id}-%"
-			)
-		);
-
-		if ( ! $first_item_name ) {
-			return 0;
-		}
-
-		if ( null === $now ) {
-			$now = microtime( true );
-		}
-
-		// Break apart the item name to get the timestamp.
-		$matches = null;
-		if ( preg_match( '/^jpsq_' . $this->id . '-(\d+\.\d+)-/', $first_item_name, $matches ) ) {
-			return $now - (float) $matches[1];
-		} else {
-			return 0;
-		}
+		return (float) $this->queue_storage->get_lag( $now );
 	}
 
 	/**
 	 * Resets the queue.
 	 */
 	public function reset() {
-		global $wpdb;
 		$this->delete_checkout_id();
-		$wpdb->query(
-			$wpdb->prepare(
-				"DELETE FROM $wpdb->options WHERE option_name LIKE %s",
-				"jpsq_{$this->id}-%"
-			)
-		);
+
+		$this->queue_storage->clear_queue();
 	}
 
 	/**
@@ -210,14 +170,7 @@ class Queue {
 	 * @return int
 	 */
 	public function size() {
-		global $wpdb;
-
-		return (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT count(*) FROM $wpdb->options WHERE option_name LIKE %s",
-				"jpsq_{$this->id}-%"
-			)
-		);
+		return $this->queue_storage->get_item_count();
 	}
 
 	/**
@@ -228,15 +181,7 @@ class Queue {
 	 * @return bool
 	 */
 	public function has_any_items() {
-		global $wpdb;
-		$value = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT exists( SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s )",
-				"jpsq_{$this->id}-%"
-			)
-		);
-
-		return ( '1' === $value );
+		return $this->size() > 0;
 	}
 
 	/**
@@ -251,7 +196,8 @@ class Queue {
 			return new WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
 		}
 
-		$buffer_id = uniqid();
+		// TODO check if adding a prefix is going to be a problem
+		$buffer_id = uniqid( '', true );
 
 		$result = $this->set_checkout_id( $buffer_id );
 
@@ -269,9 +215,7 @@ class Queue {
 			return false;
 		}
 
-		$buffer = new Queue_Buffer( $buffer_id, array_slice( $items, 0, $buffer_size ) );
-
-		return $buffer;
+		return new Queue_Buffer( $buffer_id, array_slice( $items, 0, $buffer_size ) );
 	}
 
 	/**
@@ -319,14 +263,14 @@ class Queue {
 	 * @param int $max_memory (bytes) Maximum memory threshold.
 	 * @param int $max_buffer_size Maximum buffer size (number of items).
 	 *
-	 * @return Automattic\Jetpack\Sync\Queue_Buffer|bool|int|\WP_Error
+	 * @return \Automattic\Jetpack\Sync\Queue_Buffer|bool|int|\WP_Error
 	 */
 	public function checkout_with_memory_limit( $max_memory, $max_buffer_size = 500 ) {
 		if ( $this->get_checkout_id() ) {
 			return new WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
 		}
 
-		$buffer_id = uniqid();
+		$buffer_id = uniqid( '', true );
 
 		$result = $this->set_checkout_id( $buffer_id );
 
@@ -334,31 +278,22 @@ class Queue {
 			return $result;
 		}
 
-		// Get the map of buffer_id -> memory_size.
-		global $wpdb;
-
-		$items_with_size = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT option_name AS id, LENGTH(option_value) AS value_size FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT %d",
-				"jpsq_{$this->id}-%",
-				$max_buffer_size
-			),
-			OBJECT
-		);
-
-		if ( ! is_countable( $items_with_size ) ) {
-			return false;
-		}
-
-		if ( count( $items_with_size ) === 0 ) {
-			return false;
-		}
-
+		// How much memory is currently being used by the items.
 		$total_memory = 0;
-		$max_item_id  = $items_with_size[0]->id;
-		$min_item_id  = $max_item_id;
 
-		foreach ( $items_with_size as $id => $item_with_size ) {
+		// Store the items to return
+		$items = array();
+
+		$current_items_ids = $this->queue_storage->get_items_ids_with_size( $max_buffer_size - count( $items ) );
+
+		// If no valid items are returned or no items are returned, continue.
+		if ( ! is_countable( $current_items_ids ) || count( $current_items_ids ) === 0 ) {
+			return false;
+		}
+
+		$item_ids_to_fetch = array();
+
+		foreach ( $current_items_ids as $id => $item_with_size ) {
 			$total_memory += $item_with_size->value_size;
 
 			// If this is the first item and it exceeds memory, allow loop to continue
@@ -367,34 +302,37 @@ class Queue {
 				break;
 			}
 
-			$max_item_id = $item_with_size->id;
+			$item_ids_to_fetch[] = $item_with_size->id;
 		}
 
-		$query = $wpdb->prepare(
-			"SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name >= %s and option_name <= %s ORDER BY option_name ASC",
-			$min_item_id,
-			$max_item_id
-		);
+		$current_items = $this->queue_storage->fetch_items_by_ids( $item_ids_to_fetch );
 
-		$items = $wpdb->get_results( $query, OBJECT ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$items_count = is_countable( $items ) ? count( $items ) : 0;
+		$items_count = is_countable( $current_items ) ? count( $current_items ) : 0;
 
 		if ( $items_count > 0 ) {
-			foreach ( $items as $item ) {
+			/**
+			 * Save some memory by moving things one by one to the array of items being returned, instead of
+			 * unserializing all and then merging them with other items.
+			 *
+			 * PHPCS ignore is because this is the expected behavior - we're assigning a variable in the condition part of the loop.
+			 */
+			// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+			while ( ( $current_item = array_shift( $current_items ) ) !== null ) {
 				// @codingStandardsIgnoreStart
-				$item->value = @unserialize( $item->value );
+				$current_item->value = unserialize( $current_item->value );
 				// @codingStandardsIgnoreEnd
+
+				$items[] = $current_item;
 			}
 		}
 
-		if ( $items_count === 0 ) {
+		if ( count( $items ) === 0 ) {
 			$this->delete_checkout_id();
+
 			return false;
 		}
 
-		$buffer = new Queue_Buffer( $buffer_id, $items );
-
-		return $buffer;
+		return new Queue_Buffer( $buffer_id, $items );
 	}
 
 	/**
@@ -459,11 +397,10 @@ class Queue {
 		if ( array() === $ids ) {
 			return 0;
 		}
-		global $wpdb;
-		$sql   = "DELETE FROM $wpdb->options WHERE option_name IN (" . implode( ', ', array_fill( 0, count( $ids ), '%s' ) ) . ')';
-		$query = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $ids ) );
 
-		return $wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$this->queue_storage->delete_items_by_ids( $ids );
+
+		return true;
 	}
 
 	/**
@@ -667,26 +604,7 @@ class Queue {
 	 * @return array|object|null
 	 */
 	private function fetch_items( $limit = null ) {
-		global $wpdb;
-
-		if ( $limit ) {
-			$items = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT %d",
-					"jpsq_{$this->id}-%",
-					$limit
-				),
-				OBJECT
-			);
-		} else {
-			$items = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC",
-					"jpsq_{$this->id}-%"
-				),
-				OBJECT
-			);
-		}
+		$items = $this->queue_storage->fetch_items( $limit );
 
 		return $this->unserialize_values( $items );
 	}
@@ -699,26 +617,7 @@ class Queue {
 	 * @return array|object|null
 	 */
 	private function fetch_items_by_id( $items_ids ) {
-		global $wpdb;
-
-		// return early if $items_ids is empty or not an array.
-		if ( empty( $items_ids ) || ! is_array( $items_ids ) ) {
-			return null;
-		}
-
-		$ids_placeholders        = implode( ', ', array_fill( 0, count( $items_ids ), '%s' ) );
-		$query_with_placeholders = "SELECT option_name AS id, option_value AS value
-				FROM $wpdb->options
-				WHERE option_name IN ( $ids_placeholders )";
-		$items                   = $wpdb->get_results(
-			$wpdb->prepare(
-				$query_with_placeholders, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-				$items_ids
-			),
-			OBJECT
-		);
-
-		return $this->unserialize_values( $items );
+		return $this->unserialize_values( $this->queue_storage->fetch_items_by_ids( $items_ids ) );
 	}
 
 	/**

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -65,6 +65,8 @@ class Queue {
 	 * Add a single item to the queue.
 	 *
 	 * @param object $item Event object to add to queue.
+	 *
+	 * @return bool|WP_Error
 	 */
 	public function add( $item ) {
 		$added = false;

--- a/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
+++ b/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * The class responsible for storing Queue events in the `wp_options` table.
+ *
+ * Used by class Queue.
+ *
+ * @see \Automattic\Jetpack\Sync\Queue
+ *
+ * @package automattic/jetpack-sync
+ */
+
+namespace Automattic\Jetpack\Sync\Queue;
+
+/**
+ * `wp_options` storage backend for the Queue.
+ */
+class Queue_Storage_Options {
+	/**
+	 * What queue is this instance responsible for.
+	 *
+	 * @var string
+	 */
+	public $queue_id = '';
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param string $queue_id The queue name this instance will be responsible for.
+	 *
+	 * @throws \Exception If queue name was not provided.
+	 */
+	public function __construct( $queue_id ) {
+		if ( empty( $queue_id ) ) {
+			// TODO what should we return here or throw an exception?
+			throw new \Exception( 'Invalid queue_id provided' );
+		}
+
+		// TODO validate the value maybe?
+		$this->queue_id = $queue_id;
+	}
+
+	/**
+	 * Insert an item in the queue.
+	 *
+	 * @param string $item_id The item ID.
+	 * @param string $item Serialized item data.
+	 *
+	 * @return bool If the item was added.
+	 */
+	public function insert_item( $item_id, $item ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$rows_added = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO $wpdb->options (option_name, option_value, autoload) VALUES (%s, %s,%s)",
+				$item_id,
+				$item,
+				'no'
+			)
+		);
+
+		return ( 0 !== $rows_added );
+	}
+
+	/**
+	 * Fetch items from the queue.
+	 *
+	 * @param int|null $item_count How many items to fetch from the queue.
+	 *                             The parameter is null-able, if no limit on the amount of items.
+	 *
+	 * @return array|object|\stdClass[]|null
+	 */
+	public function fetch_items( $item_count ) {
+		global $wpdb;
+
+		// TODO make it more simple for the $item_count
+		if ( $item_count ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$items = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT %d",
+					"jpsq_{$this->queue_id}-%",
+					$item_count
+				),
+				OBJECT
+			);
+		} else {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$items = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC",
+					"jpsq_{$this->queue_id}-%"
+				),
+				OBJECT
+			);
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Fetches items with specific IDs from the Queue.
+	 *
+	 * @param array $items_ids Items IDs to fetch from the queue.
+	 *
+	 * @return array|object|\stdClass[]|null
+	 */
+	public function fetch_items_by_ids( $items_ids ) {
+		global $wpdb;
+
+		// return early if $items_ids is empty or not an array.
+		if ( empty( $items_ids ) || ! is_array( $items_ids ) ) {
+			return array();
+		}
+
+		$ids_placeholders = implode( ', ', array_fill( 0, count( $items_ids ), '%s' ) );
+
+		$query_with_placeholders = "SELECT option_name AS id, option_value AS value
+				FROM $wpdb->options
+				WHERE option_name IN ( $ids_placeholders )";
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$items = $wpdb->get_results(
+			$wpdb->prepare(
+				$query_with_placeholders, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				$items_ids
+			),
+			OBJECT
+		);
+
+		return $items;
+	}
+
+	/**
+	 * Clear out the queue.
+	 *
+	 * @return bool|int|\mysqli_result|resource|null
+	 */
+	public function clear_queue() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		return $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM $wpdb->options WHERE option_name LIKE %s",
+				"jpsq_{$this->queue_id}-%"
+			)
+		);
+	}
+
+	/**
+	 * Check how many items are in the queue.
+	 *
+	 * @return int
+	 */
+	public function get_item_count() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT count(*) FROM $wpdb->options WHERE option_name LIKE %s",
+				"jpsq_{$this->queue_id}-%"
+			)
+		);
+	}
+
+	/**
+	 * Return the lag amount for the queue.
+	 *
+	 * @param float|int|null $now A timestamp to use as starting point when calculating the lag.
+	 *
+	 * @return float|int The lag amount.
+	 */
+	public function get_lag( $now = null ) {
+		global $wpdb;
+
+		// TODO replace with peek and a flag to fetch only the name.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$first_item_name = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_name FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT 1",
+				"jpsq_{$this->queue_id}-%"
+			)
+		);
+
+		if ( ! $first_item_name ) {
+			return 0;
+		}
+
+		if ( null === $now ) {
+			$now = microtime( true );
+		}
+
+		// Break apart the item name to get the timestamp.
+		$matches = null;
+		if ( preg_match( '/^jpsq_' . $this->queue_id . '-(\d+\.\d+)-/', $first_item_name, $matches ) ) {
+			return $now - (float) $matches[1];
+		} else {
+			return 0;
+		}
+	}
+
+	/**
+	 * Add multiple items to the queue at once.
+	 *
+	 * @param array  $items Array of items to add.
+	 * @param string $id_prefix Prefix to use for all the items.
+	 *
+	 * @return bool|int|\mysqli_result|resource|null
+	 */
+	public function add_all( $items, $id_prefix ) {
+		global $wpdb;
+
+		$query = "INSERT INTO $wpdb->options (option_name, option_value, autoload) VALUES ";
+
+		$rows        = array();
+		$count_items = count( $items );
+		for ( $i = 0; $i < $count_items; ++$i ) {
+			// skip empty items.
+			if ( empty( $items[ $i ] ) ) {
+				continue;
+			}
+			try {
+				$option_name  = esc_sql( $id_prefix . '-' . $i );
+				$option_value = esc_sql( serialize( $items[ $i ] ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				$rows[]       = "('$option_name', '$option_value', 'no')";
+			} catch ( \Exception $e ) {
+				// Item cannot be serialized so skip.
+				continue;
+			}
+		}
+
+		$rows_added = $wpdb->query( $query . implode( ',', $rows ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		return $rows_added;
+	}
+
+	/**
+	 * Return $max_count items from the queue, including their value string length.
+	 *
+	 * @param int $max_count How many items to fetch from the queue.
+	 *
+	 * @return array|object|\stdClass[]|null
+	 */
+	public function get_items_ids_with_size( $max_count ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT option_name AS id, LENGTH(option_value) AS value_size FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT %d",
+				"jpsq_{$this->queue_id}-%",
+				$max_count
+			),
+			OBJECT
+		);
+	}
+
+	/**
+	 * Delete items with specific IDs from the queue.
+	 *
+	 * @param array $ids IDs of the items to remove from the queue.
+	 *
+	 * @return bool|int|\mysqli_result|resource|null
+	 */
+	public function delete_items_by_ids( $ids ) {
+		global $wpdb;
+		// TODO check if it's working properly - no need to delete all options in the table if the params are not right
+		$ids_placeholders = implode( ', ', array_fill( 0, count( $ids ), '%s' ) );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery
+		return $wpdb->query(
+			$wpdb->prepare(
+			/**
+			 * Ignoring the linting warning, as there's still no placeholder replacement for DB field name,
+			 * in this case this is `$ids_placeholders`, as we're preparing them above and are a dynamic count.
+			 */
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				"DELETE FROM {$wpdb->options} WHERE option_name IN ( $ids_placeholders )",
+				$ids
+			)
+		);
+	}
+}

--- a/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
+++ b/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
@@ -267,6 +267,11 @@ class Queue_Storage_Options {
 	 */
 	public function delete_items_by_ids( $ids ) {
 		global $wpdb;
+
+		if ( ! is_array( $ids ) || empty( $ids ) ) {
+			return false;
+		}
+
 		// TODO check if it's working properly - no need to delete all options in the table if the params are not right
 		$ids_placeholders = implode( ', ', array_fill( 0, count( $ids ), '%s' ) );
 

--- a/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
+++ b/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
@@ -104,7 +104,7 @@ class Queue_Storage_Options {
 	 *
 	 * @param array $items_ids Items IDs to fetch from the queue.
 	 *
-	 * @return array|object|\stdClass[]|null
+	 * @return \stdClass[]|null
 	 */
 	public function fetch_items_by_ids( $items_ids ) {
 		global $wpdb;

--- a/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
+++ b/projects/packages/sync/src/sync-queue/class-queue-storage-options.php
@@ -242,7 +242,7 @@ class Queue_Storage_Options {
 	 *
 	 * @param int $max_count How many items to fetch from the queue.
 	 *
-	 * @return array|object|\stdClass[]|null
+	 * @return \stdClass[]|null
 	 */
 	public function get_items_ids_with_size( $max_count ) {
 		global $wpdb;


### PR DESCRIPTION
This is a spin-off of #31318

## Proposed changes:

Extract storage of Sync Queue actions to a separate class. This is to make the merge of Custom Table work easier and in smaller batches, to avoid reviewing and testing a huge PR.

### Other information:

- [x] Have you written new tests for your changes, if applicable? Tests are in #31318
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p9dueE-7e6-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Apply PR
* Make sure Jetpack Sync works
* Run the Docker PHPUnit tests - `jetpack docker phpunit` and make sure they pass.

