### PR TITLE
Add Paywall block scaffold

### DIFF
--- a/projects/plugins/jetpack/changelog/add-paywall-block-scaffold
+++ b/projects/plugins/jetpack/changelog/add-paywall-block-scaffold
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add Paywall block scaffold

--- a/projects/plugins/jetpack/extensions/blocks/paywall/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/attributes.js
@@ -1,0 +1,3 @@
+export default {
+	// @TODO - Add block attributes here
+};

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -1,31 +1,16 @@
 import { BlockIcon } from '@wordpress/block-editor';
-import { Placeholder, withNotices } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import icon from './icon';
 
-function PaywallEdit( { attributes, className, noticeOperations, noticeUI, setAttributes } ) {
-	/**
-	 * Write the block editor UI.
-	 *
-	 * @returns {object} The UI displayed when user edits this block.
-	 */
-	const [ notice, setNotice ] = useState();
-
-	/* Call this function when you want to show an error in the placeholder. */
-	const setErrorNotice = () => {
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( __( 'Put error message here.', 'jetpack' ) );
-	};
-
+function PaywallEdit( { className } ) {
 	return (
 		<div className={ className }>
 			<Placeholder
 				label={ __( 'Paywall', 'jetpack' ) }
 				instructions={ __( 'Instructions go here.', 'jetpack' ) }
 				icon={ <BlockIcon icon={ icon } /> }
-				notices={ noticeUI }
 			>
 				{ __( 'User input goes here?', 'jetpack' ) }
 			</Placeholder>

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -1,0 +1,36 @@
+import { BlockIcon } from '@wordpress/block-editor';
+import { Placeholder, withNotices } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import './editor.scss';
+import icon from './icon';
+
+function PaywallEdit( { attributes, className, noticeOperations, noticeUI, setAttributes } ) {
+	/**
+	 * Write the block editor UI.
+	 *
+	 * @returns {object} The UI displayed when user edits this block.
+	 */
+	const [ notice, setNotice ] = useState();
+
+	/* Call this function when you want to show an error in the placeholder. */
+	const setErrorNotice = () => {
+		noticeOperations.removeAllNotices();
+		noticeOperations.createErrorNotice( __( 'Put error message here.', 'jetpack' ) );
+	};
+
+	return (
+		<div className={ className }>
+			<Placeholder
+				label={ __( 'Paywall', 'jetpack' ) }
+				instructions={ __( 'Instructions go here.', 'jetpack' ) }
+				icon={ <BlockIcon icon={ icon } /> }
+				notices={ noticeUI }
+			>
+				{ __( 'User input goes here?', 'jetpack' ) }
+			</Placeholder>
+		</div>
+	);
+}
+
+export default PaywallEdit;

--- a/projects/plugins/jetpack/extensions/blocks/paywall/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/editor.js
@@ -1,0 +1,4 @@
+import registerJetpackBlock from '../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/projects/plugins/jetpack/extensions/blocks/paywall/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/editor.scss
@@ -1,0 +1,5 @@
+/**
+ * Editor styles for Paywall
+ */
+
+.wp-block-jetpack-paywall { }

--- a/projects/plugins/jetpack/extensions/blocks/paywall/icon.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/icon.js
@@ -1,0 +1,8 @@
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
+	<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
+	</SVG>
+);

--- a/projects/plugins/jetpack/extensions/blocks/paywall/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/index.js
@@ -1,5 +1,3 @@
-import { ExternalLink } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';

--- a/projects/plugins/jetpack/extensions/blocks/paywall/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/index.js
@@ -1,0 +1,56 @@
+import { ExternalLink } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { getIconColor } from '../../shared/block-icons';
+import attributes from './attributes';
+import edit from './edit';
+import icon from './icon';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
+
+export const name = 'paywall';
+export const title = __( 'Paywall', 'jetpack' );
+export const settings = {
+	title,
+	description: __( 'Paywall', 'jetpack' ),
+	icon: {
+		src: icon,
+		foreground: getIconColor(),
+	},
+	category: 'grow',
+	keywords: [],
+	supports: {
+		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
+		align: false /* if set to true, the 'align' option below can be used*/,
+		// Pick which alignment options to display.
+		/*align: [ 'left', 'right', 'full' ],*/
+		// Support for wide alignment, that requires additional support in themes.
+		alignWide: true,
+		// When true, a new field in the block sidebar allows to define an id for the block and a button to copy the direct link.
+		anchor: false,
+		// When true, a new field in the block sidebar allows to define a custom className for the block’s wrapper.
+		customClassName: true,
+		// When false, Gutenberg won't add a class like .wp-block-your-block-name to the root element of your saved markup
+		className: true,
+		// Setting this to false suppress the ability to edit a block’s markup individually. We often set this to false in Jetpack blocks.
+		html: false,
+		// Passing false hides this block in Gutenberg's visual inserter.
+		/*inserter: true,*/
+		// When false, user will only be able to insert the block once per post.
+		multiple: true,
+		// When false, the block won't be available to be converted into a reusable block.
+		reusable: true,
+	},
+	edit,
+	/* @TODO Write the block editor output */
+	save: () => null,
+	attributes,
+	example: {
+		attributes: {
+			// @TODO: Add default values for block attributes, for generating the block preview.
+		},
+	},
+};

--- a/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Paywall Block.
+ *
+ * @since 12.1
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Paywall;
+
+use Automattic\Jetpack\Blocks;
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'paywall';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	Blocks::jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Paywall block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Paywall block attributes.
+ * @param string $content String containing the Paywall block content.
+ *
+ * @return string
+ */
+function load_assets( $attr, $content ) {
+	/*
+	 * Enqueue necessary scripts and styles.
+	 */
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
+
+	return sprintf(
+		'<div class="%1$s">%2$s</div>',
+		esc_attr( Blocks::classes( FEATURE_NAME, $attr ) ),
+		$content
+	);
+}

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -63,7 +63,8 @@
 		"post-publish-promote-post-panel",
 		"recipe",
 		"v6-video-frame-poster",
-		"videopress/video-chapters"
+		"videopress/video-chapters",
+		"paywall"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],
 	"no-post-editor": [


### PR DESCRIPTION
## Proposed changes:
* Adds a Paywall block scaffold – `jetpack docker wp jetpack scaffold block "Paywall" --slug="paywall" --description="Gate content for paid subscribers with the Paywall block"`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p2-peKye1-fd

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Add `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to your setup – I use `mu-plugins/0-sandbox.php`
* Check that the new Paywall block shows up in the editor no js errors.
<img width="1320" alt="Screenshot 2023-07-26 at 16 17 11" src="https://github.com/Automattic/jetpack/assets/104869/ee23db97-1218-400e-bc17-0fb2cda147a6">



