### PR TITLE
Jetpack AI: Support different upgrade prompts and free limits

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -321,10 +321,11 @@ class Jetpack_AI_Helper {
 			$requests_limit = \OpenAI_Limit_Usage::get_free_requests_limit( $blog_id );
 			$requests_count = \OpenAI_Request_Count::get_count( $blog_id );
 
-			/*
-			 * Check if the site requires an upgrade.
-			 */
+			// Check if the site requires an upgrade.
 			$require_upgrade = $is_over_limit && ! $has_ai_assistant_feature;
+
+			// Determine the upgrade type
+			$upgrade_type = wpcom_is_vip( $blog_id ) ? 'vip' : 'default';
 
 			return array(
 				'has-feature'          => $has_ai_assistant_feature,
@@ -332,7 +333,7 @@ class Jetpack_AI_Helper {
 				'requests-count'       => $requests_count,
 				'requests-limit'       => $requests_limit,
 				'site-require-upgrade' => $require_upgrade,
-				'upgrade-prompt-type'  => wpcom_is_vip( $blog_id ) ? 'vip' : 'default',
+				'upgrade-type'         => $upgrade_type,
 			);
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -318,7 +318,7 @@ class Jetpack_AI_Helper {
 
 			$blog_id        = get_current_blog_id();
 			$is_over_limit  = \OpenAI_Limit_Usage::is_blog_over_request_limit( $blog_id );
-			$requests_limit = \OpenAI_Limit_Usage::NUM_FREE_REQUESTS_LIMIT;
+			$requests_limit = \OpenAI_Limit_Usage::get_free_requests_limit( $blog_id );
 			$requests_count = \OpenAI_Request_Count::get_count( $blog_id );
 
 			/*

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -332,6 +332,7 @@ class Jetpack_AI_Helper {
 				'requests-count'       => $requests_count,
 				'requests-limit'       => $requests_limit,
 				'site-require-upgrade' => $require_upgrade,
+				'upgrade-prompt-type'  => wpcom_is_vip( $blog_id ) ? 'vip' : 'default',
 			);
 		}
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-refactor-free-requests-getter
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-refactor-free-requests-getter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: Get free requests limit from getter function instead of reading the constant value.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-refactor-free-requests-getter
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-refactor-free-requests-getter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Jetpack AI: Get free requests limit from getter function instead of reading the constant value.
+Jetpack AI: Add support for different limits of free requests and different upgrade prompts.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -15,8 +15,15 @@ import React from 'react';
  */
 import { Nudge } from '../../../../shared/components/upgrade-nudge';
 import useAutosaveAndRedirect from '../../../../shared/use-autosave-and-redirect';
+import useAIFeature from '../../hooks/use-ai-feature';
 
-const UpgradePrompt = () => {
+/**
+ * The default upgrade prompt for the AI Assistant block, containing the Upgrade button and linking
+ * to the checkout page or the Jetpack AI interstitial page.
+ *
+ * @returns {React.ReactNode} the Nudge component with the prompt.
+ */
+const DefaultUpgradePrompt = () => {
 	const wpcomCheckoutUrl = getRedirectUrl( 'jetpack-ai-monthly-plan-ai-assistant-block-banner', {
 		site: getSiteFragment(),
 	} );
@@ -51,6 +58,48 @@ const UpgradePrompt = () => {
 			context={ null }
 		/>
 	);
+};
+
+/**
+ * The VIP upgrade prompt, with a single text message recommending that the user reach
+ * out to their VIP account team.
+ *
+ * @returns {React.ReactNode} the Nudge component with the prompt.
+ */
+const VIPUpgradePrompt = () => {
+	return (
+		<Nudge
+			buttonText={ null }
+			checkoutUrl={ null }
+			className={ 'jetpack-ai-upgrade-banner' }
+			description={ createInterpolateElement(
+				__(
+					"You've reached the Jetpack AI rate limit. <strong>Please reach out to your VIP account team.</strong>",
+					'jetpack'
+				),
+				{
+					strong: <strong />,
+				}
+			) }
+			goToCheckoutPage={ null }
+			isRedirecting={ null }
+			visible={ true }
+			align={ null }
+			title={ null }
+			context={ null }
+		/>
+	);
+};
+
+const UpgradePrompt = () => {
+	const { upgradePromptType } = useAIFeature();
+
+	// If the user is on a VIP site, show the VIP upgrade prompt.
+	if ( upgradePromptType === 'vip' ) {
+		return VIPUpgradePrompt();
+	}
+
+	return DefaultUpgradePrompt();
 };
 
 export default UpgradePrompt;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -23,7 +23,7 @@ import useAIFeature from '../../hooks/use-ai-feature';
  *
  * @returns {React.ReactNode} the Nudge component with the prompt.
  */
-const DefaultUpgradePrompt = () => {
+const DefaultUpgradePrompt = (): React.ReactNode => {
 	const wpcomCheckoutUrl = getRedirectUrl( 'jetpack-ai-monthly-plan-ai-assistant-block-banner', {
 		site: getSiteFragment(),
 	} );
@@ -66,7 +66,7 @@ const DefaultUpgradePrompt = () => {
  *
  * @returns {React.ReactNode} the Nudge component with the prompt.
  */
-const VIPUpgradePrompt = () => {
+const VIPUpgradePrompt = (): React.ReactNode => {
 	return (
 		<Nudge
 			buttonText={ null }
@@ -92,10 +92,10 @@ const VIPUpgradePrompt = () => {
 };
 
 const UpgradePrompt = () => {
-	const { upgradePromptType } = useAIFeature();
+	const { upgradeType } = useAIFeature();
 
 	// If the user is on a VIP site, show the VIP upgrade prompt.
-	if ( upgradePromptType === 'vip' ) {
+	if ( upgradeType === 'vip' ) {
 		return VIPUpgradePrompt();
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -4,6 +4,8 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from 'react';
 
+type UpgradeTypeProp = 'vip' | 'default';
+
 export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'has-feature': boolean;
 	'is-over-limit': boolean;
@@ -13,7 +15,7 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'error-message': string;
 	'error-code': string;
 	'is-playground-visible': boolean;
-	'upgrade-prompt-type': string;
+	'upgrade-type': UpgradeTypeProp;
 };
 
 type AIFeatureProps = {
@@ -24,7 +26,7 @@ type AIFeatureProps = {
 	requireUpgrade: boolean;
 	errorMessage: string;
 	errorCode: string;
-	upgradePromptType: string;
+	upgradeType: UpgradeTypeProp;
 };
 
 const NUM_FREE_REQUESTS_LIMIT = 20;
@@ -39,7 +41,7 @@ export const AI_Assistant_Initial_State = {
 	requireUpgrade: !! aiAssistantFeature?.[ 'site-require-upgrade' ],
 	errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
 	errorCode: aiAssistantFeature?.[ 'error-code' ],
-	upgradePromptType: aiAssistantFeature?.[ 'upgrade-prompt-type' ],
+	upgradeType: aiAssistantFeature?.[ 'upgrade-type' ] || 'default',
 };
 
 export async function getAIFeatures(): Promise< AIFeatureProps > {
@@ -56,7 +58,7 @@ export async function getAIFeatures(): Promise< AIFeatureProps > {
 			requireUpgrade: !! response[ 'site-require-upgrade' ],
 			errorMessage: response[ 'error-message' ],
 			errorCode: response[ 'error-code' ],
-			upgradePromptType: response[ 'upgrade-prompt-type' ],
+			upgradeType: response[ 'upgrade-type' ],
 		};
 	} catch ( error ) {
 		console.error( error ); // eslint-disable-line no-console

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -13,6 +13,7 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 	'error-message': string;
 	'error-code': string;
 	'is-playground-visible': boolean;
+	'upgrade-prompt-type': string;
 };
 
 type AIFeatureProps = {
@@ -23,6 +24,7 @@ type AIFeatureProps = {
 	requireUpgrade: boolean;
 	errorMessage: string;
 	errorCode: string;
+	upgradePromptType: string;
 };
 
 const NUM_FREE_REQUESTS_LIMIT = 20;
@@ -37,6 +39,7 @@ export const AI_Assistant_Initial_State = {
 	requireUpgrade: !! aiAssistantFeature?.[ 'site-require-upgrade' ],
 	errorMessage: aiAssistantFeature?.[ 'error-message' ] || '',
 	errorCode: aiAssistantFeature?.[ 'error-code' ],
+	upgradePromptType: aiAssistantFeature?.[ 'upgrade-prompt-type' ],
 };
 
 export async function getAIFeatures(): Promise< AIFeatureProps > {
@@ -53,6 +56,7 @@ export async function getAIFeatures(): Promise< AIFeatureProps > {
 			requireUpgrade: !! response[ 'site-require-upgrade' ],
 			errorMessage: response[ 'error-message' ],
 			errorCode: response[ 'error-code' ],
+			upgradePromptType: response[ 'upgrade-prompt-type' ],
 		};
 	} catch ( error ) {
 		console.error( error ); // eslint-disable-line no-console


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add support for different upgrade prompts, based on the value of the new `upgrade-prompt-type` flag from the `ai-assistant-feature` endpoint
* Add a different prompt for VIP sites, without the button and the call to action to follow the upgrade path

<img width="600" alt="Screen Shot 2023-07-27 at 14 16 15" src="https://github.com/Automattic/jetpack/assets/6760046/04e8da2d-7ffc-47ac-8485-34cbab10b2cc">

* The D116636-code adds a getter to read the number of free requests available for a given site, so we are changing the Jetpack AI Helper to use it, because this will allow us to set a different limit based on any information linked to the `$blog_id`(site type, for example)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1690380406050879-slack-C054LN8RNVA

pbtFPC-5uC-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the changes from this PR to your sandbox
* Follow the instructions described on D116636-code to mark your test site as VIP (you don't need to follow the testing instructions from there, just the VIP flagging)
* On the API Console, check the result from the `wpcom/v2` `/sites/$wpcom_site/jetpack-ai/ai-assistant-feature` endpoint; it should contain the new field `upgrade-type`, and since you flagged your site as VIP, you will see `upgrade-type: "vip"` on the response:

<img width="400" alt="Screen Shot 2023-07-31 at 18 00 18" src="https://github.com/Automattic/jetpack/assets/6760046/d31db5f0-8462-4ec7-baa1-920556c5747a">

* To test the new upgrade prompt for VIP, we need to simulate that the site reached the limit to be able to see the upgrade prompt; since the limit is 1000, it's hard to test by hand, so we are going to:
   * edit the code for the `jetpack-ai-query.php` file on your sandbox
   * add the following snippet as the first line of the `run_query` function and save the file:

```
return new \WP_Error( 'error_quota_exceeded', 'You exceeded your current quota', array( 'status' => 429 ) );
```

* We also need to point our test site to our sandbox, using the `JETPACK__SANDBOX_DOMAIN` constant; this is necessary for Jurassic Ninja sites or for Atomic sites and can be done using the `Jetpack Constants` page created by Jetpack Beta
* Finally, we also need to enable global http access on the sandbox so requests coming from your JN or Atomic test site are served by it; details here: paJDYF-WR-p2
* With the quota simulation snippet in place, the testing site running this branch and pointing to your sandbox, go to the block editor of your test site, add an AI Assistant block and execute some action (example: `a haiku about the stars`)
* Since the backend will respond with a quota exceeded response, you will see the upgrade banner on the block:

<img width="600" alt="Screen Shot 2023-07-31 at 18 24 50" src="https://github.com/Automattic/jetpack/assets/6760046/97abe461-7ce2-4d75-8f51-d231788e5295">

* Don't forget to remove the snippet from your sandbox
* Don't forget to disable global HTTP access on your sandbox as well