### PR TITLE
Donation block preserves invalid amounts across tabs

### DIFF
--- a/projects/plugins/jetpack/changelog/earn-donation-unstick-invalid-amounts
+++ b/projects/plugins/jetpack/changelog/earn-donation-unstick-invalid-amounts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix tab switching by adding a value handler for the Amount component.

--- a/projects/plugins/jetpack/extensions/blocks/donations/amount.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/amount.js
@@ -78,6 +78,11 @@ const Amount = ( {
 		setEditedValue( formatCurrency( value, currency, { symbol: '' } ) );
 	}, [ currency, isFocused, isInvalid, setAmount, value ] );
 
+	useEffect( () => {
+		setAmount( formatCurrency( value, currency, { symbol: '' } ) );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ value ] );
+
 	return (
 		<div
 			className={ classnames( 'donations__amount', className, {


### PR DESCRIPTION
Fixes #30669.

## Proposed changes:
* Adds effect handler when the Amount component value changes.

This change effectively "forgets" the invalid amount when the tab is switched.  This approach might need additional consideration.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get the code into your testing environment. (For WPCOM run `bin/jetpack-downloader test jetpack  earn/donation/unstick-invalid-amounts`)
* Load a donations block
* Set currency to USD
* Set an amount to less than $0.50.
* Change the tab
* View that the amount changes.
* Also notice that switching back to "error" tab the value is the last valid amount.

