### PR TITLE
CRM: Automations Quotes triggers

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-automation-triggers-quotes
+++ b/projects/plugins/crm/changelog/add-crm-automation-triggers-quotes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Automation: Added quote triggers

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-accepted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-accepted.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Jetpack CRM Automation Quote_Accepted trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Quote_Accepted class.
+ */
+class Quote_Accepted extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger.
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/quote_accepted';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Accepted Quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a quote is accepted', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_quote_accepted',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-deleted.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Jetpack CRM Automation Quote_Deleted trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Quote_Deleted class.
+ */
+class Quote_Deleted extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger.
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/quote_deleted';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Delete Quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a quote is deleted', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_quote_delete',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-new.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Jetpack CRM Automation Quote_New trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Quote_New class.
+ */
+class Quote_New extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger.
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/quote_new';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'New Quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a new quote status is added', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_quote_new',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-status-updated.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Jetpack CRM Automation Quote_Status_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Quote_Status_Updated class.
+ */
+class Quote_Status_Updated extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger.
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/quote_status_updated';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Quote Status Updated', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a quote status is updated', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_quote_status_update',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-updated.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Jetpack CRM Automation Quote_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Quote_Updated class.
+ */
+class Quote_Updated extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/quote_updated';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Quote Updated', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a quote is updated', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_quote_update',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/tests/php/automation/quotes/class-quote-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/quotes/class-quote-trigger-test.php
@@ -1,0 +1,194 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\CRM\Automation\Tests;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Engine;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Triggers\Quote_Accepted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Quote_Deleted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Quote_New;
+use Automattic\Jetpack\CRM\Automation\Triggers\Quote_Status_Updated;
+use Automattic\Jetpack\CRM\Automation\Triggers\Quote_Updated;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '../../tools/class-automation-faker.php';
+
+/**
+ * Test Automation's quote triggers
+ *
+ * @covers Automattic\Jetpack\CRM\Automation
+ */
+class Quote_Trigger_Test extends BaseTestCase {
+
+	private $automation_faker;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->automation_faker = Automation_Faker::instance();
+	}
+
+	/**
+	 * @testdox Test the quote updated trigger executes the workflow with an action
+	 */
+	public function test_quote_updated_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/quote_updated' );
+
+		$trigger = new Quote_Updated();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Quote_Updated trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$quote_data = $this->automation_faker->quote_data();
+
+		// We expect the workflow to be executed on quote_update event with the quote data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $quote_data )
+		);
+
+		// Run the quote_update action.
+		do_action( 'jpcrm_quote_update', $quote_data );
+	}
+
+	/**
+	 * @testdox Test the quote status updated trigger executes the workflow with an action
+	 */
+	public function test_quote_status_updated_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/quote_status_updated' );
+
+		$trigger = new Quote_Status_Updated();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Quote_Updated trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$quote_data = $this->automation_faker->quote_data();
+
+		// We expect the workflow to be executed on quote_status_update event with the quote data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $quote_data )
+		);
+
+		// Run the quote_status_update action.
+		do_action( 'jpcrm_quote_status_update', $quote_data );
+	}
+
+	/**
+	 * @testdox Test the quote new trigger executes the workflow with an action
+	 */
+	public function test_quote_new_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/quote_new' );
+
+		$trigger = new Quote_New();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Quote_New trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$quote_data = $this->automation_faker->quote_data();
+
+		// We expect the workflow to be executed on quote_new event with the quote data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $quote_data )
+		);
+
+		// Run the quote_new action.
+		do_action( 'jpcrm_quote_new', $quote_data );
+	}
+
+	/**
+	 * @testdox Test the quote new trigger executes the workflow with an action
+	 */
+	public function test_quote_accepted_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/quote_accepted' );
+
+		$trigger = new Quote_Accepted();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Quote_New trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$quote_data = $this->automation_faker->quote_data();
+
+		// We expect the workflow to be executed on quote_new event with the quote data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $quote_data )
+		);
+
+		// Run the quote_new action.
+		do_action( 'jpcrm_quote_accepted', $quote_data );
+	}
+
+	/**
+	 * @testdox Test the quote deleted trigger executes the workflow with an action
+	 */
+	public function test_quote_deleted_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/quote_deleted' );
+
+		$trigger = new Quote_Deleted();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Quote_Deleted trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$quote_data = $this->automation_faker->quote_data();
+
+		// We expect the workflow to be executed on quote_deleted event with the quote data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $quote_data )
+		);
+
+		// Run the quote_deleted action.
+		do_action( 'jpcrm_quote_delete', $quote_data );
+	}
+}

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -111,6 +111,20 @@ class Automation_Faker {
 	}
 
 	/**
+	 * Return dummy quote triggers name list
+	 * @return array
+	 */
+	public function quote_triggers(): array {
+		return array(
+			'jpcrm/quote_new',
+			'jpcrm/quote_accepted',
+			'jpcrm/quote_updated',
+			'jpcrm/quote_status_updated',
+			'jpcrm/quote_deleted',
+		);
+	}
+
+	/**
 	 * Return dummy invoice triggers name list
 	 * @return array
 	 */

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -253,7 +253,6 @@ class Automation_Faker {
 			'data' => array(
 				'id_override' => '1',
 				'title'       => '',
-				'status'      => 'Unpaid',
 				'hash'        => 'V8jAlsi0#$ksm0Plsxp',
 				'accepted'    => 1676923766,
 				'created'     => 1676000000,

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -244,6 +244,24 @@ class Automation_Faker {
 	}
 
 	/**
+	 * Return data for a dummy quote
+	 * @return array
+	 */
+	public function quote_data() {
+		return array(
+			'id'   => 1,
+			'data' => array(
+				'id_override' => '1',
+				'title'       => '',
+				'status'      => 'Unpaid',
+				'hash'        => 'V8jAlsi0#$ksm0Plsxp',
+				'accepted'    => 1676923766,
+				'created'     => 1676000000,
+			),
+		);
+	}
+
+	/**
 	 * Return data for a dummy company
 	 * @return array
 	 */


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds all quotes triggers to Automation with their respective tests.
  * New quote
  * Quote accepted
  * Quote updated
  * Quote's status updated
  * Quote deleted

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3244
https://github.com/Automattic/zero-bs-crm/issues/3245
https://github.com/Automattic/zero-bs-crm/issues/3246

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).
* You can test manually the objects being passed to the actions within each trigger by being creative (e.g. using the error_log).
