### PR TITLE
 CRM: Automations Event triggers for new and deleted

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-3240-3258-automations-backend-trigger-event-new-deleted
+++ b/projects/plugins/crm/changelog/add-crm-3240-3258-automations-backend-trigger-event-new-deleted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Automation: Added event triggers for new and deleted 

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
@@ -11,13 +11,14 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**
  * Adds the Event_Deleted class.
- * 
+ *
  * @since $$next-version$$
  */
 class Event_Deleted extends Base_Trigger {
 
 	/**
 	 * Get the slug name of the trigger.
+	 *
 	 * @return string
 	 */
 	public static function get_slug(): string {
@@ -26,6 +27,7 @@ class Event_Deleted extends Base_Trigger {
 
 	/**
 	 * Get the title of the trigger.
+	 *
 	 * @return string
 	 */
 	public static function get_title(): string {
@@ -34,6 +36,7 @@ class Event_Deleted extends Base_Trigger {
 
 	/**
 	 * Get the description of the trigger.
+	 *
 	 * @return string
 	 */
 	public static function get_description(): string {
@@ -42,6 +45,7 @@ class Event_Deleted extends Base_Trigger {
 
 	/**
 	 * Get the category of the trigger.
+	 *
 	 * @return string
 	 */
 	public static function get_category(): ?string {

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
@@ -34,7 +34,7 @@ class Event_Deleted extends Base_Trigger {
 	 * Get the description of the trigger.
 	 * @return string
 	 */
-	public static function get_description(): ?string {
+	public static function get_description(): string {
 		return __( 'Triggered when a event is deleted', 'zero-bs-crm' );
 	}
 

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
@@ -49,7 +49,7 @@ class Event_Deleted extends Base_Trigger {
 	 * @return string
 	 */
 	public static function get_category(): ?string {
-		return __( 'event', 'zero-bs-crm' );
+		return 'event';
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
@@ -26,7 +26,7 @@ class Event_Deleted extends Base_Trigger {
 	 * Get the title of the trigger.
 	 * @return string
 	 */
-	public static function get_title(): ?string {
+	public static function get_title(): string {
 		return __( 'Event Deleted', 'zero-bs-crm' );
 	}
 

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Jetpack CRM Automation Event_Deleted trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Event_Deleted class.
+ */
+class Event_Deleted extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger.
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/event_deleted';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'Delete Event', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a event is deleted', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'event', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_event_delete',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
@@ -27,7 +27,7 @@ class Event_Deleted extends Base_Trigger {
 	 * @return string
 	 */
 	public static function get_title(): ?string {
-		return __( 'Delete Event', 'zero-bs-crm' );
+		return __( 'Event Deleted', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
@@ -11,6 +11,8 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**
  * Adds the Event_Deleted class.
+ * 
+ * @since $$next-version$$
  */
 class Event_Deleted extends Base_Trigger {
 

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
@@ -37,7 +37,7 @@ class Event_Deleted extends Base_Trigger {
 	 * @return string
 	 */
 	public static function get_description(): string {
-		return __( 'Triggered when a event is deleted', 'zero-bs-crm' );
+		return __( 'Triggered when an event is deleted', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-deleted.php
@@ -48,7 +48,7 @@ class Event_Deleted extends Base_Trigger {
 	 *
 	 * @return string
 	 */
-	public static function get_category(): ?string {
+	public static function get_category(): string {
 		return 'event';
 	}
 

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
@@ -55,7 +55,7 @@ class Event_New extends Base_Trigger {
 	/**
 	 * Listen to this trigger's target event.
 	 */
-	protected function listen_to_event() {
+	protected function listen_to_event(): void {
 		add_action(
 			'jpcrm_event_new',
 			array( $this, 'execute_workflow' )

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
@@ -11,6 +11,8 @@ use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**
  * Adds the Event_New class.
+ *
+ * @since $$next-version$$
  */
 class Event_New extends Base_Trigger {
 

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
@@ -49,7 +49,7 @@ class Event_New extends Base_Trigger {
 	 * @return string
 	 */
 	public static function get_category(): string {
-		return __( 'event', 'zero-bs-crm' );
+		return 'event';
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
@@ -26,7 +26,7 @@ class Event_New extends Base_Trigger {
 	 * Get the title of the trigger.
 	 * @return string
 	 */
-	public static function get_title(): ?string {
+	public static function get_title(): string {
 		return __( 'New Event', 'zero-bs-crm' );
 	}
 

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Jetpack CRM Automation Event_New trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Event_New class.
+ */
+class Event_New extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger.
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/event_new';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'New Event', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a new event status is added', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'event', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_event_new',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
@@ -39,7 +39,7 @@ class Event_New extends Base_Trigger {
 	 *
 	 * @return string
 	 */
-	public static function get_description(): ?string {
+	public static function get_description(): string {
 		return __( 'Triggered when a new event status is added', 'zero-bs-crm' );
 	}
 

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
@@ -48,7 +48,7 @@ class Event_New extends Base_Trigger {
 	 *
 	 * @return string
 	 */
-	public static function get_category(): ?string {
+	public static function get_category(): string {
 		return __( 'event', 'zero-bs-crm' );
 	}
 

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-new.php
@@ -16,6 +16,7 @@ class Event_New extends Base_Trigger {
 
 	/**
 	 * Get the slug name of the trigger.
+	 *
 	 * @return string
 	 */
 	public static function get_slug(): string {
@@ -24,6 +25,7 @@ class Event_New extends Base_Trigger {
 
 	/**
 	 * Get the title of the trigger.
+	 *
 	 * @return string
 	 */
 	public static function get_title(): string {
@@ -32,6 +34,7 @@ class Event_New extends Base_Trigger {
 
 	/**
 	 * Get the description of the trigger.
+	 *
 	 * @return string
 	 */
 	public static function get_description(): ?string {
@@ -40,6 +43,7 @@ class Event_New extends Base_Trigger {
 
 	/**
 	 * Get the category of the trigger.
+	 *
 	 * @return string
 	 */
 	public static function get_category(): ?string {

--- a/projects/plugins/crm/tests/codeception/acceptance.suite.dist.yml
+++ b/projects/plugins/crm/tests/codeception/acceptance.suite.dist.yml
@@ -8,8 +8,8 @@ actor: AcceptanceTester
 modules:
     enabled:
         - Db:
-            user: 'some_db_user'
-            password: 'some_db_pass'
+            user: 'gogdzl'
+            password: 'pass'
             dsn: 'mysql:host=localhost;dbname=jpcrm_testing'
             initial_queries:
                 - 'DROP DATABASE IF EXISTS jpcrm_testing'
@@ -27,5 +27,5 @@ modules:
             wp_prefix: 'wp_'
             jpcrm_prefix: 'wp_zbs_'
             server_host: 'localhost:8000'
-            wp_path: '/path/to/test/file/must-overwrite-it-in-acceptance.suite.yml'
+            wp_path: '/Users/diegorodrigues/Dsk/avengers/jetpack_crm_tests'
 step_decorators: ~

--- a/projects/plugins/crm/tests/codeception/acceptance.suite.dist.yml
+++ b/projects/plugins/crm/tests/codeception/acceptance.suite.dist.yml
@@ -8,8 +8,8 @@ actor: AcceptanceTester
 modules:
     enabled:
         - Db:
-            user: 'gogdzl'
-            password: 'pass'
+            user: 'some_db_user'
+            password: 'some_db_pass'
             dsn: 'mysql:host=localhost;dbname=jpcrm_testing'
             initial_queries:
                 - 'DROP DATABASE IF EXISTS jpcrm_testing'
@@ -27,5 +27,5 @@ modules:
             wp_prefix: 'wp_'
             jpcrm_prefix: 'wp_zbs_'
             server_host: 'localhost:8000'
-            wp_path: '/Users/diegorodrigues/Dsk/avengers/jetpack_crm_tests'
+            wp_path: '/path/to/test/file/must-overwrite-it-in-acceptance.suite.yml'
 step_decorators: ~

--- a/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
@@ -13,7 +13,8 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation's event triggers
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Event_Deleted
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Event_New
  */
 class Event_Trigger_Test extends BaseTestCase {
 

--- a/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
@@ -44,7 +44,7 @@ class Event_Trigger_Test extends BaseTestCase {
 		// Fake event data.
 		$event_data = $this->automation_faker->event_data();
 
-		// We expect the workflow to be executed on event_new event with the event data
+		// We expect the workflow to be executed on event_new event with the event data.
 		$workflow->expects( $this->once() )
 		->method( 'execute' )
 		->with(
@@ -76,7 +76,7 @@ class Event_Trigger_Test extends BaseTestCase {
 		// Fake event data.
 		$event_data = $this->automation_faker->event_data();
 
-		// We expect the workflow to be executed on event_deleted event with the event data
+		// We expect the workflow to be executed on event_deleted event with the event data.
 		$workflow->expects( $this->once() )
 		->method( 'execute' )
 		->with(

--- a/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
@@ -29,7 +29,6 @@ class Event_Trigger_Test extends BaseTestCase {
 	 * @testdox Test the event new trigger executes the workflow with an action
 	 */
 	public function test_event_new_trigger() {
-
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/event_new' );
 
 		// Build a PHPUnit mock Automation_Workflow
@@ -61,7 +60,6 @@ class Event_Trigger_Test extends BaseTestCase {
 	 * @testdox Test the event deleted trigger executes the workflow with an action
 	 */
 	public function test_event_deleted_trigger() {
-
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/event_deleted' );
 
 		$trigger = new Event_Deleted();

--- a/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
@@ -1,0 +1,92 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\CRM\Automation\Tests;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Engine;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Triggers\Event_Deleted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Event_New;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '../../tools/class-automation-faker.php';
+
+/**
+ * Test Automation's event triggers
+ *
+ * @covers Automattic\Jetpack\CRM\Automation
+ */
+class Event_Trigger_Test extends BaseTestCase {
+
+	private $automation_faker;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->automation_faker = Automation_Faker::instance();
+	}
+
+	/**
+	 * @testdox Test the event new trigger executes the workflow with an action
+	 */
+	public function test_event_new_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/event_new' );
+
+		$trigger = new Event_New();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Event_New trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$event_data = $this->automation_faker->event_data();
+
+		// We expect the workflow to be executed on event_new event with the event data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $event_data )
+		);
+
+		// Run the event_new action.
+		do_action( 'jpcrm_event_new', $event_data );
+	}
+
+	/**
+	 * @testdox Test the event deleted trigger executes the workflow with an action
+	 */
+	public function test_event_deleted_trigger() {
+
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/event_deleted' );
+
+		$trigger = new Event_Deleted();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Event_Deleted trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$event_data = $this->automation_faker->event_data();
+
+		// We expect the workflow to be executed on event_deleted event with the event data
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $event_data )
+		);
+
+		// Run the event_deleted action.
+		do_action( 'jpcrm_event_delete', $event_data );
+	}
+}

--- a/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
@@ -32,8 +32,6 @@ class Event_Trigger_Test extends BaseTestCase {
 
 		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/event_new' );
 
-		$trigger = new Event_New();
-
 		// Build a PHPUnit mock Automation_Workflow
 		$workflow = $this->getMockBuilder( Automation_Workflow::class )
 			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
@@ -41,6 +39,7 @@ class Event_Trigger_Test extends BaseTestCase {
 			->getMock();
 
 		// Init the Event_New trigger.
+		$trigger = new Event_New();
 		$trigger->init( $workflow );
 
 		// Fake event data.

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -123,6 +123,17 @@ class Automation_Faker {
 	}
 
 	/**
+	 * Return dummy event triggers name list
+	 * @return array
+	 */
+	public function event_triggers(): array {
+		return array(
+			'jpcrm/event_new',
+			'jpcrm/event_deleted',
+		);
+	}
+
+	/**
 	 * Return a workflow with a condition and an action
 	 * @return array
 	 */

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -124,6 +124,7 @@ class Automation_Faker {
 
 	/**
 	 * Return dummy event triggers name list
+	 *
 	 * @return array
 	 */
 	public function event_triggers(): array {
@@ -242,6 +243,7 @@ class Automation_Faker {
 
 	/**
 	 * Return data for a dummy company
+	 *
 	 * @return array
 	 */
 	public function company_data() {
@@ -255,6 +257,7 @@ class Automation_Faker {
 
 	/**
 	 * Return data for a dummy event
+	 *
 	 * @return array
 	 */
 	public function event_data() {
@@ -277,6 +280,7 @@ class Automation_Faker {
 
 	/**
 	 * Return a empty workflow, without triggers and initial step
+	 *
 	 * @return array
 	 */
 	public function empty_workflow(): array {

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -254,6 +254,28 @@ class Automation_Faker {
 	}
 
 	/**
+	 * Return data for a dummy event
+	 * @return array
+	 */
+	public function event_data() {
+		return array(
+			'id'   => 1,
+			'data' => array(
+				'title'          => 'Some event title',
+				'desc'           => 'Some desc',
+				'hash'           => 'V8jAlsi0#$ksm0Plsxp',
+				'start'          => 1676000000,
+				'end'            => 1676923766,
+				'complete'       => false,
+				'show_on_portal' => true,
+				'show_on_cal'    => true,
+				'created'        => 1675000000,
+				'lastupdated'    => 1675000000,
+			),
+		);
+	}
+
+	/**
 	 * Return a empty workflow, without triggers and initial step
 	 * @return array
 	 */


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds the following triggers to events with their respective tests:
  * New event
  * Event deleted

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3258
https://github.com/Automattic/zero-bs-crm/issues/3240

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).
* You can test manually the objects being passed to the actions within each trigger by being creative (e.g. using the error_log).
