### PR TITLE
Update Paywall Block styles

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-block-styles
+++ b/projects/plugins/jetpack/changelog/update-paywall-block-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+update paywall block styles

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -1,19 +1,15 @@
-import { BlockIcon } from '@wordpress/block-editor';
-import { Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import './editor.scss';
-import icon from './icon';
 
 function PaywallEdit( { className } ) {
+	const text = __( 'Paywall', 'jetpack' );
+	const style = {
+		width: `${ text.length + 1.2 }em`,
+	};
+
 	return (
 		<div className={ className }>
-			<Placeholder
-				label={ __( 'Paywall', 'jetpack' ) }
-				instructions={ __( 'Instructions go here.', 'jetpack' ) }
-				icon={ <BlockIcon icon={ icon } /> }
-			>
-				{ __( 'User input goes here?', 'jetpack' ) }
-			</Placeholder>
+			<span style={ style }>{ text }</span>
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/paywall/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/editor.scss
@@ -1,5 +1,40 @@
 /**
  * Editor styles for Paywall
  */
+@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
-.wp-block-jetpack-paywall { }
+.wp-block-jetpack-paywall {
+	display: block;
+	text-align: center;
+	white-space: nowrap;
+
+	// Label
+	span {
+		position: relative;
+		font-size: $default-font-size;
+		text-transform: uppercase;
+		font-weight: 600;
+		font-family: $default-font;
+		color: $gray-700;
+		border: none;
+		box-shadow: none;
+		white-space: nowrap;
+		text-align: center;
+		margin: 0;
+		border-radius: 4px;
+		background: $white;
+		padding: 6px 8px;
+		height: $button-size-small;
+		max-width: 100%;
+	}
+
+	// Dashed line
+	&::before {
+		content: "";
+		position: absolute;
+		top: calc(50%);
+		left: 0;
+		right: 0;
+		border-top: 3px dashed $gray-400;
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/paywall/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/index.js
@@ -18,7 +18,7 @@ export const settings = {
 		src: icon,
 		foreground: getIconColor(),
 	},
-	category: 'grow',
+	category: 'earn',
 	keywords: [],
 	supports: {
 		customClassName: false,

--- a/projects/plugins/jetpack/extensions/blocks/paywall/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/index.js
@@ -21,26 +21,9 @@ export const settings = {
 	category: 'grow',
 	keywords: [],
 	supports: {
-		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
-		align: false /* if set to true, the 'align' option below can be used*/,
-		// Pick which alignment options to display.
-		/*align: [ 'left', 'right', 'full' ],*/
-		// Support for wide alignment, that requires additional support in themes.
-		alignWide: true,
-		// When true, a new field in the block sidebar allows to define an id for the block and a button to copy the direct link.
-		anchor: false,
-		// When true, a new field in the block sidebar allows to define a custom className for the block’s wrapper.
-		customClassName: true,
-		// When false, Gutenberg won't add a class like .wp-block-your-block-name to the root element of your saved markup
-		className: true,
-		// Setting this to false suppress the ability to edit a block’s markup individually. We often set this to false in Jetpack blocks.
+		customClassName: false,
 		html: false,
-		// Passing false hides this block in Gutenberg's visual inserter.
-		/*inserter: true,*/
-		// When false, user will only be able to insert the block once per post.
-		multiple: true,
-		// When false, the block won't be available to be converted into a reusable block.
-		reusable: true,
+		multiple: false,
 	},
 	edit,
 	/* @TODO Write the block editor output */


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add similar styles to the "More" Block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p2-peKye1-fd

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Add define( 'JETPACK_BLOCKS_VARIATION', 'beta' ); to your setup – I use mu-plugins/0-sandbox.php
* Check that the new Paywall block shows like this:

<img width="733" alt="Screenshot 2023-07-26 at 22 44 12" src="https://github.com/Automattic/jetpack/assets/104869/2ff7fb9b-bfad-4926-9f7c-ac05781dd383">



