### PR TITLE
Fetch credentials to instantiate WP_Filesystem for uploading the helper script

### DIFF
--- a/projects/packages/transport-helper/changelog/fix-helper-script-upload-non-direct-fs
+++ b/projects/packages/transport-helper/changelog/fix-helper-script-upload-non-direct-fs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix helper script upload for sites without direct file system access.

--- a/projects/packages/transport-helper/src/class-helper-script-manager.php
+++ b/projects/packages/transport-helper/src/class-helper-script-manager.php
@@ -372,7 +372,9 @@ class Helper_Script_Manager {
 				require_once ABSPATH . 'wp-admin/includes/file.php';
 			}
 
-			if ( ! \WP_Filesystem() ) {
+			$credentials = request_filesystem_credentials( self_admin_url() );
+
+			if ( ! \WP_Filesystem( $credentials ) ) {
 				return null;
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes uploads of the helper script for sites without direct file system access.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* For sites that don't have direct file system access we must fetch the credentials to instantiate the WP_Filesystem class and be able to do file system operations.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a test site.
* Configure it so it doesn't have direct file system access.
* Configure on your wp-config the FTP_HOST, FTP_USER and FTP_PASS constants.
* Setup Jetpack Scan.
* Try running a scan without applying this patch and verify that it fails.
* Apply this patch, try again and verify that it works.

