### PR TITLE
AI Client: handle properly passing the post_id parameter to endpoint

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6104,8 +6104,8 @@ packages:
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
-  /@eslint-community/regexpp@4.6.1:
-    resolution: {integrity: sha512-O7x6dMstWLn2ktjcoiNLDkAGG2EjveHL+Vvc+n0fXumkJYAcSqcVYKtwDU+hDZ0uDUsnUagSYaZrOLAYE8un1A==}
+  /@eslint-community/regexpp@4.6.2:
+    resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
@@ -15544,7 +15544,7 @@ packages:
     hasBin: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.44.0)
-      '@eslint-community/regexpp': 4.6.1
+      '@eslint-community/regexpp': 4.6.2
       '@eslint/eslintrc': 2.1.0
       '@eslint/js': 8.44.0
       '@humanwhocodes/config-array': 0.11.10

--- a/projects/js-packages/ai-client/changelog/update-ai-client-improve-post-id-parameter
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-improve-post-id-parameter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: handle properly passing the post_id parameter to endpoint

--- a/projects/js-packages/ai-client/src/ask-question/Readme.md
+++ b/projects/js-packages/ai-client/src/ask-question/Readme.md
@@ -11,7 +11,7 @@ function askQuestion(
 ): Promise< SuggestionsEventSource >
 ```
 
-## Parameters
+<h2 id="ask-question-parameters">Parameters</h2>
 
 - `question` (**string** | **PromptItemProps[]**):
     - The question to ask. 

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/Readme.md
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/Readme.md
@@ -22,7 +22,6 @@ Invokes the custom hook with the provided options.
 
 - `prompt: PromptItemProps[]` (optional): An array of request prompts.
 - `autoRequest: boolean` (optional, defaults to `false`): Determines whether to request suggestions automatically.
-- `postId: number`: When defined, will be passed to the askQuestion function.
 - `askQuestionOptions: AskQuestionOptionsArgProps` (optional): Options for the askQuestion function.
 - `onSuggestion: ( suggestion: string ) => void` (optional): A callback function that gets triggered when a suggestion is received.
 - `onDone: ( content: string ) => void` (optional): A callback function that gets triggered when the process is complete.

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/Readme.md
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/Readme.md
@@ -22,7 +22,7 @@ Invokes the custom hook with the provided options.
 
 - `prompt: PromptItemProps[]` (optional): An array of request prompts.
 - `autoRequest: boolean` (optional, defaults to `false`): Determines whether to request suggestions automatically.
-- `askQuestionOptions: AskQuestionOptionsArgProps` (optional): Options for the askQuestion function.
+- `askQuestionOptions: AskQuestionOptionsArgProps` (optional): [Options for the askQuestion](../../ask-question/Readme.md#ask-question-parameters) function.
 - `onSuggestion: ( suggestion: string ) => void` (optional): A callback function that gets triggered when a suggestion is received.
 - `onDone: ( content: string ) => void` (optional): A callback function that gets triggered when the process is complete.
 - `onError: ( error: SuggestionErrorProps ) => void` (optional): A callback function that gets triggered when an error occurs.

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -50,12 +50,6 @@ type useAiSuggestionsOptions = {
 	 */
 	autoRequest?: boolean;
 
-	/*
-	 * The post ID.
-	 * It's value, when defined, will be passed to the askQuestion function.
-	 */
-	postId?: number;
-
 	/**
 	 * AskQuestion options.
 	 */
@@ -178,7 +172,6 @@ export default function useAiSuggestions( {
 	prompt,
 	autoRequest = false,
 	askQuestionOptions = {},
-	postId,
 	onSuggestion,
 	onDone,
 	onError,
@@ -257,18 +250,8 @@ export default function useAiSuggestions( {
 			// Set the request status.
 			setRequestingState( 'requesting' );
 
-			const options = {
-				...askQuestionOptions,
-			};
-
-			// Pass the post ID to the askQuestion function, when defined.
-			if ( postId ) {
-				debug( 'Post ID: %s', postId );
-				options.postId = postId;
-			}
-
 			try {
-				eventSourceRef.current = await askQuestion( promptArg, options );
+				eventSourceRef.current = await askQuestion( promptArg, askQuestionOptions );
 
 				if ( ! eventSourceRef?.current ) {
 					return;
@@ -295,7 +278,6 @@ export default function useAiSuggestions( {
 			}
 		},
 		[
-			postId,
 			handleDone,
 			handleErrorQuotaExceededError,
 			handleUnclearPromptError,

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -7,20 +7,20 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import askQuestion, { AskQuestionOptionsArgProps } from '../../ask-question';
+import askQuestion from '../../ask-question';
 import {
 	ERROR_MODERATION,
 	ERROR_NETWORK,
 	ERROR_QUOTA_EXCEEDED,
 	ERROR_SERVICE_UNAVAILABLE,
 	ERROR_UNCLEAR_PROMPT,
-	type PromptItemProps,
-	type SuggestionErrorCode,
 } from '../../types';
 /**
  * Types & constants
  */
+import type { AskQuestionOptionsArgProps } from '../../ask-question';
 import type SuggestionsEventSource from '../../suggestions-event-source';
+import type { PromptItemProps, SuggestionErrorCode } from '../../types';
 
 export type SuggestionErrorProps = {
 	/*

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -68,7 +68,17 @@ export default class SuggestionsEventSource extends EventTarget {
 		token,
 		options = {},
 	}: SuggestionsEventSourceConstructorArgs ) {
-		const bodyData = { post_id: options?.postId, messages: [], question: '', feature: '' };
+		const bodyData: {
+			post_id?: number;
+			messages?: PromptItemProps[];
+			question?: string;
+			feature?: string;
+		} = {};
+
+		// Populate body data with post id
+		if ( options?.postId ) {
+			bodyData.post_id = options.postId;
+		}
 
 		// If the url is not provided, we use the default one
 		if ( ! url ) {

--- a/projects/plugins/jetpack/changelog/update-ai-client-improve-post-id-parameter
+++ b/projects/plugins/jetpack/changelog/update-ai-client-improve-post-id-parameter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistance plugin: do not pass postId to suggestions hook. It isn't required.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
@@ -59,7 +59,9 @@ export default function Proofread() {
 	};
 
 	const { request, requestingState } = useAiSuggestions( {
-		postId,
+		askQuestionOptions: {
+			postId,
+		},
 		onSuggestion: handleSuggestion,
 		onDone: handleDone,
 		onError: handleSuggestionError,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR iterates over the main `useAiSuggestion()` hook and the `SuggestionsEventSource` class to propagate properly the optional `postId` value.
The issue is that when the `postId` parameter is not defined, the libs populate the request body with a `null` post_id, which is not desired. Also, it updates the documentation.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: handle properly passing the post_id parameter to the endpoint

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Easy way to test these changes is simply by using the proofread feature.


* Go to the block editor
* Get a post with some content
* Use the proofread to get feedback about the post content
<img width="835" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/b0c4f3f5-c7b8-48cc-8d24-46c86352791f">

* Additionally, you can check that the app populates the request body with the `post_id`. You can use the network tab of your client.

<img width="705" alt="Screenshot 2023-07-27 at 11 15 03" src="https://github.com/Automattic/jetpack/assets/77539/e042b209-b4ac-4159-9ab1-e3302b52898a">


