### PR TITLE
WP Super Cache: fix bug when dynamic caching and gzip compression are enabled

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-dynamic_caching_gzipped
+++ b/projects/plugins/super-cache/changelog/fix-dynamic_caching_gzipped
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: fix bug serving gzipped content to known users when dynamic caching is enabled.

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -158,7 +158,9 @@ function wp_cache_serve_cache_file() {
 
 	extract( wp_super_cache_init() ); // $key, $cache_filename, $meta_file, $cache_file, $meta_pathname
 
-	// Look for wp-cache file+meta for the current URL
+	// Look for wp-cache file + meta file for the current URL
+	// If we can't find them, we will look for supercache html files. These files don't have any meta data
+	// which is why the code below does more work setting up the headers, etc.
 	if (
 		! defined( 'WPSC_SUPERCACHE_ONLY' ) &&
 		(

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -158,6 +158,7 @@ function wp_cache_serve_cache_file() {
 
 	extract( wp_super_cache_init() ); // $key, $cache_filename, $meta_file, $cache_file, $meta_pathname
 
+	// Look for wp-cache file+meta for the current URL
 	if (
 		! defined( 'WPSC_SUPERCACHE_ONLY' ) &&
 		(
@@ -189,12 +190,11 @@ function wp_cache_serve_cache_file() {
 			@unlink( $cache_file );
 			return true;
 		}
-	} else { // no $cache_file
+	} else { // no wp-cache file, look for a supercache file
 		global $wpsc_save_headers;
 		global $cache_max_time;
 		// last chance, check if a supercache file exists. Just in case .htaccess rules don't work on this host
-		$filename = supercache_filename();
-		$file     = get_current_url_supercache_dir() . $filename;
+		$file = get_current_url_supercache_dir() . supercache_filename();
 		if ( false == file_exists( $file ) ) {
 			wp_cache_debug( "No Super Cache file found for current URL: $file" );
 			return false;
@@ -315,16 +315,24 @@ function wp_cache_serve_cache_file() {
 
 	$cache_file = do_cacheaction( 'wp_cache_served_cache_file', $cache_file );
 	// Sometimes the gzip headers are lost. Make sure html returned isn't compressed!
-	if ( $cache_compression && $wp_cache_gzip_encoding && ! in_array( 'Content-Encoding: ' . $wp_cache_gzip_encoding, $meta['headers'] ) ) {
-		$ungzip = true;
-		wp_cache_debug( 'GZIP headers not found. Force uncompressed output.', 1 );
-	} else {
-		$ungzip = false;
+	$do_not_serve_gzip_data = true;
+	if ( $cache_compression && $wp_cache_gzip_encoding ) {
+		if ( ! in_array( 'Content-Encoding: ' . $wp_cache_gzip_encoding, $meta['headers'], true ) ) {
+			wp_cache_debug( 'GZIP headers not found. Force uncompressed output.' );
+		} else {
+			$do_not_serve_gzip_data = false;
+			if ( isset( $meta['dynamic'] ) ) {
+				unset( $meta['headers']['Content-Length'] ); // this is set later after the output data is compressed
+			}
+			wp_cache_debug( 'GZIP headers found. Serving compressed output.' );
+		}
 	}
+
 	foreach ( $meta['headers'] as $t => $header ) {
 		// godaddy fix, via http://blog.gneu.org/2008/05/wp-supercache-on-godaddy/ and http://www.littleredrails.com/blog/2007/09/08/using-wp-cache-on-godaddy-500-error/
 		if ( strpos( $header, 'Last-Modified:' ) === false ) {
 			header( $header );
+			wp_cache_debug( 'Sending Header: ' . $header );
 		}
 	}
 	if ( isset( $wpsc_served_header ) && $wpsc_served_header ) {
@@ -332,37 +340,46 @@ function wp_cache_serve_cache_file() {
 	}
 	if ( isset( $meta['dynamic'] ) ) {
 		wp_cache_debug( 'Serving wp-cache dynamic file', 5 );
-		if ( $ungzip ) {
+		if ( $do_not_serve_gzip_data ) {
 			// attempt to uncompress the cached file just in case it's gzipped
 			$cache        = wp_cache_get_legacy_cache( $cache_file );
 			$uncompressed = @gzuncompress( $cache );
 			if ( $uncompressed ) {
-				wp_cache_debug( 'Uncompressed gzipped cache file from wp-cache', 1 );
-				unset( $cache );
-				echo do_cacheaction( 'wpsc_cachedata', $uncompressed );
-			} else {
-				echo do_cacheaction( 'wpsc_cachedata', $cache );
+				wp_cache_debug( 'Uncompressed gzipped cache from wp-cache: ' . $cache_file );
+				$cache = $uncompressed;
+				unset( $uncompressed );
 			}
+			$cache = do_cacheaction( 'wpsc_cachedata', $cache );
 		} else {
-			echo do_cacheaction( 'wpsc_cachedata', wp_cache_get_legacy_cache( $cache_file ) );
+			wp_cache_debug( 'Compressed cache data from wp-cache: ' . $cache_file );
+			$cache = gzencode(
+				do_cacheaction(
+					'wpsc_cachedata',
+					wp_cache_get_legacy_cache( $cache_file )
+				),
+				6,
+				FORCE_GZIP
+			);
+			$size  = function_exists( 'mb_strlen' ) ? mb_strlen( $cache, '8bit' ) : strlen( $cache );
+			wp_cache_debug( 'Sending Header: Content-Length: ' . $size );
+			header( 'Content-Length: ' . $size );
+		}
+	} elseif ( $do_not_serve_gzip_data ) {
+		$cache        = wp_cache_get_legacy_cache( $cache_file );
+		$uncompressed = gzuncompress( $cache );
+		if ( $uncompressed ) {
+			$cache = $uncompressed;
+			unset( $uncompressed );
+			wp_cache_debug( 'Uncompressed gzipped cache data from wp-cache file: ' . $cache_file );
+		} else {
+			wp_cache_debug( 'Sending already uncompressed cache file from wp-cache to browser: ' . $cache_file );
 		}
 	} else {
-		wp_cache_debug( 'Serving wp-cache static file', 5 );
-		if ( $ungzip ) {
-			$cache        = wp_cache_get_legacy_cache( $cache_file );
-			$uncompressed = gzuncompress( $cache );
-			if ( $uncompressed ) {
-				wp_cache_debug( 'Uncompressed gzipped cache file from wp-cache', 1 );
-				echo $uncompressed;
-			} else {
-				wp_cache_debug( 'Compressed gzipped cache file from wp-cache', 1 );
-				echo $cache;
-			}
-		} else {
-			wp_cache_debug( 'Getting legacy cache file ' . $cache_file, 1 );
-			echo( wp_cache_get_legacy_cache( $cache_file ) );
-		}
+		wp_cache_debug( 'Sending wp-cache file to browser: ' . $cache_file );
+		$cache = wp_cache_get_legacy_cache( $cache_file );
 	}
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- this is the cached version of the current page. It will have been escaped already.
+	echo $cache;
 	wp_cache_debug( 'exit request', 5 );
 	die();
 }


### PR DESCRIPTION
The function "wp_cache_serve_cache_file()" serves cached content to web site visitors. It can serve both wp-cache and supercache files. Serving supercache files to anonymous users works fine. However, if compression and dynamic caching are enabled logged in/known users will see a "content negotiation" error when they view a cached page.

This happened because the system that builds cache file does not create a compressed file if dynamic caching is enabled. However, the "Content-Encoding: gzip" header was still added to the associated meta file. This resulted in the browser being sent that header, followed by uncompressed output. The Content-Length was incorrect too.


Fixes #32074 

## Proposed changes:
* Modify some of the debug logging to make it clearer what's happening.
* Add extra debug logging.
* Fix the Content-Length header when serving dynamic content.
* Compress the cached content after applying the `wpsc_cachedata` filter to run the dynamic content.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Apply PR to test site.
* Make sure that dynamic caching and "Compress pages so they’re served more quickly to visitors." are enabled on the Advanced settings page.
* Visit a page on your blog as a logged in user. Reload the page.
* Visit a page in a private/incognito browser.
* Repeat tests with dynamic caching disabled.
* Repeat tests with compression disabled.

To see the problem in action, test trunk in the same way. You'll get a "Content Encoding Error" when you load a cached page as a "known user", aka logged in user.
