### PR TITLE
Blaze: always display menu in Calypso for Jetpack sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-missing-advertising-menu-jetpack-calypso
+++ b/projects/plugins/jetpack/changelog/fix-missing-advertising-menu-jetpack-calypso
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blaze: add missing Advertising menu in Calypso, for self-hosted sites.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
+use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 
 require_once __DIR__ . '/class-admin-menu.php';
@@ -242,6 +243,11 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		add_menu_page( esc_attr__( 'Tools', 'jetpack' ), __( 'Tools', 'jetpack' ), 'publish_posts', 'tools.php', null, 'dashicons-admin-tools', 75 );
 
 		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain );
+
+		if ( Blaze::should_initialize() ) {
+			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack' ), __( 'Advertising', 'jetpack' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
+		}
+
 		add_submenu_page( 'tools.php', esc_attr__( 'Earn', 'jetpack' ), __( 'Earn', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain );
 
 		// Import/Export on Jetpack sites is always handled on WP Admin.


### PR DESCRIPTION
## Proposed changes:

This is a follow-up to #31617 and #31750.

We now have `Blaze::enable_blaze_menu()` to add the Blaze menu to wp-admin whenever necessary. However, Jetpack sites still rely on the admin-menu endpoint to display a list of custom menu items in Calypso. There, we'll want to always display the Tools > Advertising menu item, as long as the site is eligible for Blaze.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

This was reported in p1690392457355839-slack-C0351BKR0M6

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

You will want to test this in all environments (simple, WoA, Pressable, self-hosted) to ensure this works well, and that **no environment includes a duplicate Advertising menu**.

1. Go to https://wordpress.com/stats/day/yoursite.com
2. You should see a Tools > Advertising if your site is public.
