### PR TITLE
Social: Prepare for new dismissable notices

### DIFF
--- a/projects/js-packages/publicize-components/changelog/Add hasBasicPLan check
+++ b/projects/js-packages/publicize-components/changelog/Add hasBasicPLan check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+New check for checking is user is on BAsic plan

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -13,7 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Fragment, createInterpolateElement, useMemo, useCallback } from '@wordpress/element';
 import { _n, sprintf, __ } from '@wordpress/i18n';
 import useAttachedMedia from '../../hooks/use-attached-media';
-import useDismissNotice, { INSTAGRAM_NOTICE } from '../../hooks/use-dismiss-notice';
+import useDismissNotice from '../../hooks/use-dismiss-notice';
 import useFeaturedImage from '../../hooks/use-featured-image';
 import useImageGeneratorConfig from '../../hooks/use-image-generator-config';
 import useMediaDetails from '../../hooks/use-media-details';
@@ -58,7 +58,7 @@ export default function PublicizeForm( {
 		useSocialMediaConnections();
 	const { message, updateMessage, maxLength } = useSocialMediaMessage();
 	const { isEnabled: isSocialImageGeneratorEnabledForPost } = useImageGeneratorConfig();
-	const { dismissNotice, shouldShowNotice } = useDismissNotice();
+	const { dismissNotice, shouldShowNotice, NOTICES } = useDismissNotice();
 
 	const { isInstagramConnectionSupported } = useSelect( select => ( {
 		isInstagramConnectionSupported: select( PUBLICIZE_STORE_ID ).isInstagramConnectionSupported(),
@@ -71,11 +71,11 @@ export default function PublicizeForm( {
 	const shouldShowInstagramNotice =
 		! hasInstagramConnection &&
 		isInstagramConnectionSupported &&
-		shouldShowNotice( INSTAGRAM_NOTICE );
+		shouldShowNotice( NOTICES.instagram );
 
 	const onDismissInstagramNotice = useCallback( () => {
-		dismissNotice( INSTAGRAM_NOTICE );
-	}, [ dismissNotice ] );
+		dismissNotice( NOTICES.instagram );
+	}, [ dismissNotice, NOTICES ] );
 	const shouldDisableMediaPicker =
 		isSocialImageGeneratorAvailable && isSocialImageGeneratorEnabledForPost;
 	const Wrapper = isPublicizeDisabledBySitePlan ? Disabled : Fragment;

--- a/projects/js-packages/publicize-components/src/components/panel/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.jsx
@@ -28,6 +28,7 @@ const PublicizePanel = ( { prePublish, enableTweetStorm, children } ) => {
 		isShareLimitEnabled,
 		numberOfSharesRemaining,
 		hasPaidPlan,
+		hasBasicPlan,
 		connectionsAdminUrl,
 		adminUrl,
 		isEnhancedPublishingEnabled,
@@ -84,6 +85,7 @@ const PublicizePanel = ( { prePublish, enableTweetStorm, children } ) => {
 							isShareLimitEnabled && ! hasPaidPlan ? numberOfSharesRemaining : null
 						}
 						isEnhancedPublishingEnabled={ isEnhancedPublishingEnabled }
+						hasBasicPlan={ hasBasicPlan }
 						isSocialImageGeneratorAvailable={ isSocialImageGeneratorAvailable }
 						adminUrl={ adminUrl }
 					/>

--- a/projects/js-packages/publicize-components/src/hooks/use-dismiss-notice/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-dismiss-notice/index.js
@@ -2,7 +2,16 @@ import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useMemo, useState } from 'react';
 
-export const INSTAGRAM_NOTICE = 'instagram';
+/**
+ * @typedef {object} NoticeTypes
+ * @property {string} instagram - The name of the Instagram notice.
+ * @property {string} advancedUpgrade - The name of the advanced upgrade nudge.
+ */
+
+const NOTICES = {
+	instagram: 'instagram',
+	advancedUpgrade: 'advanced-upgrade-nudge',
+};
 
 const calculateReappearanceTime = seconds => {
 	if ( seconds === -1 ) {
@@ -15,6 +24,8 @@ const calculateReappearanceTime = seconds => {
  * @typedef {object} DismissNoticeHook
  * @property {Array} dismissedNotices - Array of names of dismissed notices.
  * @property {Function} dismissNotice - Callback used to dismiss a notice.
+ * @property {Function} shouldShowNotice - Callback used to check if a notice should be shown.
+ * @property {NoticeTypes} NOTICES - Object containing the names of the supported notices.
  */
 
 /**
@@ -70,7 +81,7 @@ export default function useDismissNotice() {
 	);
 
 	return useMemo(
-		() => ( { dismissedNotices, shouldShowNotice, dismissNotice } ),
+		() => ( { dismissedNotices, shouldShowNotice, dismissNotice, NOTICES } ),
 		[ dismissedNotices, shouldShowNotice, dismissNotice ]
 	);
 }

--- a/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
@@ -81,6 +81,25 @@ export default function usePublicizeConfig() {
 	 */
 	const hidePublicizeFeature = isPostPublished && ! isRePublicizeFeatureAvailable;
 
+	/**
+	 * hasPaidPlan:
+	 * Whether the site has a paid plan. This could be either the Basic or the Advanced plan.
+	 */
+	const hasPaidPlan = !! getJetpackData()?.social?.hasPaidPlan;
+
+	/**
+	 * isEnhancedPublishingEnabled:
+	 * Whether the site has the enhanced publishing feature enabled. If true, it means that
+	 * the site has the Advanced plan.
+	 */
+	const isEnhancedPublishingEnabled = !! getJetpackData()?.social?.isEnhancedPublishingEnabled;
+
+	/**
+	 * hasBasicPlan:
+	 * Whether the site has the Basic plan.
+	 */
+	const hasBasicPlan = hasPaidPlan && ! isEnhancedPublishingEnabled;
+
 	return {
 		isPublicizeEnabledMeta,
 		isPublicizeEnabled,
@@ -92,8 +111,9 @@ export default function usePublicizeConfig() {
 		isShareLimitEnabled,
 		isPostAlreadyShared,
 		numberOfSharesRemaining: sharesData.shares_remaining,
-		hasPaidPlan: !! getJetpackData()?.social?.hasPaidPlan,
-		isEnhancedPublishingEnabled: !! getJetpackData()?.social?.isEnhancedPublishingEnabled,
+		hasPaidPlan,
+		hasBasicPlan,
+		isEnhancedPublishingEnabled,
 		isSocialImageGeneratorAvailable: !! getJetpackData()?.social?.isSocialImageGeneratorAvailable,
 		isSocialImageGeneratorEnabled: !! getJetpackData()?.social?.isSocialImageGeneratorEnabled,
 		connectionsAdminUrl: connectionsRootUrl + getSiteFragment(),

--- a/projects/plugins/social/changelog/Add hasBasicPLan check
+++ b/projects/plugins/social/changelog/Add hasBasicPLan check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+New check for checking is user is on BAsic plan

--- a/projects/plugins/social/src/js/components/instagram-notice/index.jsx
+++ b/projects/plugins/social/src/js/components/instagram-notice/index.jsx
@@ -11,8 +11,6 @@ import { __ } from '@wordpress/i18n';
 import { STORE_ID } from '../../store';
 import styles from './styles.module.scss';
 
-const INSTAGRAM_NOTICE = 'instagram';
-
 const freePlanNoticeText = __(
 	'Share featured images directly to your Instagram Business account for free, or share unlimited photos with Jetpack Social Advanced.',
 	'jetpack-social'
@@ -23,7 +21,7 @@ const paidPlanNoticeText = __(
 );
 
 const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
-	const { shouldShowNotice, dismissNotice } = useDismissNotice();
+	const { shouldShowNotice, dismissNotice, NOTICES } = useDismissNotice();
 
 	const { connectionsAdminUrl, isInstagramConnectionSupported, isEnhancedPublishingEnabled } =
 		useSelect( select => {
@@ -36,10 +34,10 @@ const InstagramNotice = ( { onUpgrade = () => {} } = {} ) => {
 		} );
 
 	const handleDismiss = useCallback( () => {
-		dismissNotice( INSTAGRAM_NOTICE );
-	}, [ dismissNotice ] );
+		dismissNotice( NOTICES.instagram );
+	}, [ dismissNotice, NOTICES ] );
 
-	if ( ! shouldShowNotice( INSTAGRAM_NOTICE ) || ! isInstagramConnectionSupported ) {
+	if ( ! shouldShowNotice( NOTICES.instagram ) || ! isInstagramConnectionSupported ) {
 		return null;
 	}
 

--- a/projects/plugins/social/src/js/components/publicize-panel/index.jsx
+++ b/projects/plugins/social/src/js/components/publicize-panel/index.jsx
@@ -26,8 +26,13 @@ const PublicizePanel = ( { prePublish } ) => {
 	);
 	const { togglePublicizeFeature } = useDispatch( 'jetpack/publicize' );
 
-	const { hasPaidPlan, isShareLimitEnabled, numberOfSharesRemaining, connectionsAdminUrl } =
-		usePublicizeConfig();
+	const {
+		hasPaidPlan,
+		hasBasicPlan,
+		isShareLimitEnabled,
+		numberOfSharesRemaining,
+		connectionsAdminUrl,
+	} = usePublicizeConfig();
 
 	// Refresh connections when the post is just published.
 	usePostJustPublished(
@@ -74,6 +79,7 @@ const PublicizePanel = ( { prePublish } ) => {
 				<PublicizeForm
 					isPublicizeEnabled={ isPublicizeEnabled }
 					isRePublicizeFeatureEnabled={ ! isPostPublished }
+					hasBasicPlan={ hasBasicPlan }
 					numberOfSharesRemaining={
 						isShareLimitEnabled && ! hasPaidPlan ? numberOfSharesRemaining : null
 					}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This change makes life easier for the followup tasks on the new notices.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a check to see if user on Basic plan
* Cleaned up `use-dismiss-notice` a bit, so the Notice types are inside the hook

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sanity check the code.
* You could import and `console.log` out the `hasBasicPlan` value, it should only be true if you have the Basic plan.
* Dismissing Instagram notice should work as before

