### PR TITLE
actions: Close stale PRs after an additional month of no activity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,12 +16,16 @@ jobs:
           ascending: false
           # Operations (roughly API calls) per run. Adjust to avoid using up the rate limit (1000/hr shared across all jobs in the repo for the token used here).
           operations-per-run: 50
-          # Do not auto-close issues/PRs marked as stale.
-          days-before-close: -1
           # After 6 months, mark issue as stale.
           days-before-issue-stale: 180
+          # Do not auto-close issues marked as stale.
+          days-before-issue-close: -1
           # After 3 months, mark PR as stale.
           days-before-pr-stale: 90
+          # Auto-close PRs marked as stale a month later.
+          days-before-pr-close: 31
+          # Delete the branch when closing PRs. GitHub's "restore branch" function works indefinitely, so no reason not to.
+          delete-branch: true
           # Issues and PRs with these labels will never be considered stale.
           exempt-issue-labels: '[Pri] High,[Pri] BLOCKER,[Type] Feature Request,[Type] Enhancement,Good For Community,[Type] Good First Bug,FixTheFlows'
           exempt-pr-labels: '[Pri] High,[Pri] BLOCKER,FixTheFlows'
@@ -33,7 +37,7 @@ jobs:
             <p>This issue has been marked as stale. This happened because:</p>
 
             <ul>
-              <li>It has been inactive in the past 6 months.</li>
+              <li>It has been inactive for the past 6 months.</li>
               <li>It hasn’t been labeled `[Pri] BLOCKER`, `[Pri] High`, `[Type] Feature Request`, `[Type] Enhancement`, `Good For Community`, `[Type] Good First Bug`, etc.</li>
             </ul>
 
@@ -45,11 +49,17 @@ jobs:
             <p>This PR has been marked as stale. This happened because:</p>
 
             <ul>
-              <li>It has been inactive in the past 3 months.</li>
+              <li>It has been inactive for the past 3 months.</li>
               <li>It hasn’t been labeled `[Pri] BLOCKER`, `[Pri] High`, etc.</li>
             </ul>
 
-            <p>No further action is needed. But it's worth checking if this PR has clear
-            testing instructions, is it up to date with trunk, and it is still valid.
-            Feel free to close this PR if you think it's not valid anymore — if you
+            <p>If this PR is still useful, please do a [trunk merge or rebase](https://github.com/Automattic/jetpack/blob/trunk/docs/git-workflow.md#keeping-your-branch-up-to-date)
+            and otherwise make sure it's up to date and has clear testing instructions.
+            You may also want to ping possible reviewers in case they've forgotten about it.
+            Please close this PR if you think it's not valid anymore — if you
             do, please add a brief explanation.</p>
+
+            <p>If the PR is not updated (or at least commented on) in another month, it will be automatically closed.</p>
+          close-pr-message: |
+            <p>This PR has been automatically closed as it has not been updated in some time.
+            If you want to resume work on the PR, feel free to restore the branch and reopen the PR.</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If no one cares enough about the PR to at least to a trunk merge, we may as well close it. Chances are we'd have been doing about the same manually anyway.

The message posted when marking a PR as stale is adjusted to explicitly request the trunk merge, and to warn that automatic closure will happen in a month.

When closing, a message is posted inviting people to restore the branch and reopen the PR if they want to resume work on it.

Draft announcement: pdWQjU-pm-p2


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-7Fh-p2#comment-9922

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge and observe is probably the only option. Unless you have a fork laying around that already has a bunch of stale PRs to copy this to, I guess.