### PR TITLE
Newsletters: Add Paywall block functionality

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscription-paywall
+++ b/projects/plugins/jetpack/changelog/update-subscription-paywall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add paywall logic to newsletters


### PR DESCRIPTION
## Proposed changes:
* On gated newsletters; display the content before jetpack/paywall block

Editor:
<img width="600" alt="Screenshot 2023-07-27 at 14 21 51" src="https://github.com/Automattic/jetpack/assets/104869/9e485ba4-c9ac-4319-a759-55dc65b6e21c">

Non subscribers:
<img width="600" alt="Screenshot 2023-07-27 at 14 21 21" src="https://github.com/Automattic/jetpack/assets/104869/089b30d8-c0e6-49cf-985c-a87c54d4c6e8">

Subscribers:
<img width="600" alt="Screenshot 2023-07-27 at 14 21 28" src="https://github.com/Automattic/jetpack/assets/104869/f62cb7be-3cf4-4dcb-8463-c3f169116df6">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p2-peKye1-fd
## Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add define( 'JETPACK_BLOCKS_VARIATION', 'beta' ); to your setup
* Create or Edit a post and add the paywall block
* Test different combinations Newsletter Visibility and different types of users 😱