### PR TITLE
Launchpad: Remove old `keep-building` task list

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-keep-building-task-list
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-keep-building-task-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Remove duplicate task list

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -128,22 +128,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
 		),
-		// @TODO: Remove the following task list once the migration/rename is complete across WP.com and Calypso.
-		'keep-building'          => array(
-			'title'               => 'Keep Building',
-			'task_ids'            => array(
-				'site_title',
-				'domain_claim',
-				'verify_email',
-				'domain_customize',
-				'add_new_page',
-				'drive_traffic',
-				'update_about_page',
-				'edit_page',
-				'share_site',
-			),
-			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
-		),
 		'intent-build'           => array(
 			'title'               => 'Keep Building',
 			'task_ids'            => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/31905

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Now that the keep-building task list has been renamed across WP.com, jetpack-mu-wpcom, and Calypso, we can remove it from the task list definitions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site from `/start` with the "Promote myself or business" intent.
* Launch the site.
* You should see the intent-build task list in Customer Home:

<img width="703" alt="Screenshot 2023-07-27 at 1 22 00 PM" src="https://github.com/Automattic/jetpack/assets/2124984/e3b0818f-f971-45a8-bd97-6e124c034c41">

* Purchase a Business plan and install a plugin to take the site Atomic.
* Install Jetpack Beta and activate this WordPress.com Features branch on the site following the instructions in the FG (Don't forget to add the constant somewhere on the Atomic site via SSH/SFTP so it uses the Jetpack Beta plugin, `wp-content/mu-plugins/index.php` seems to work)
* Go back to `/home/siteSlug` and you should still see the correct task list.

