### PR TITLE
AI Assistant: Disable `Get feedback` if post is empty

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-feedback-disable-empty-post
+++ b/projects/plugins/jetpack/changelog/update-ai-feedback-disable-empty-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Disable feedback button if empty post


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #32094 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add new `usePostContent` hook.
* Check for `postContent` and disable button.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to editor.
* Check if `Get feedback` button is disabled.
* Write a post, and check if is enabled.

#### Demo

https://github.com/Automattic/jetpack/assets/1663717/7332019d-69d7-4af4-be8f-293a1d03e10f




