### PR TITLE
Earn/remove/connected account id option

### DIFF
--- a/projects/packages/sync/changelog/earn-remove-connected-account-id-option
+++ b/projects/packages/sync/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+remove jetpack option jetpack-memberships-connected-account-id

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -57,7 +57,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.54.x-dev"
+			"dev-trunk": "1.55.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -63,7 +63,6 @@ class Defaults {
 		'image_default_link_type',
 		'infinite_scroll',
 		'infinite_scroll_google_analytics',
-		'jetpack-memberships-connected-account-id',
 		'jetpack-twitter-cards-site-tag',
 		'jetpack_activated',
 		'jetpack_allowed_xsite_search_ids',

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -63,6 +63,7 @@ class Defaults {
 		'image_default_link_type',
 		'infinite_scroll',
 		'infinite_scroll_google_analytics',
+		'jetpack-memberships-has-connected-account',
 		'jetpack-twitter-cards-site-tag',
 		'jetpack_activated',
 		'jetpack_allowed_xsite_search_ids',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.54.0';
+	const PACKAGE_VERSION = '1.55.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/backup/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/backup/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1299,7 +1299,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "2e043ed46f2a6ba145d282527d4e31d1680a691a"
+                "reference": "9c2ceb892a70d7108a573859f88dcd2d099c4606"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1330,7 +1330,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.54.x-dev"
+                    "dev-trunk": "1.55.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+remove jetpack option jetpack-memberships-connected-account-id

--- a/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option#2
+++ b/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2513,7 +2513,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "2e043ed46f2a6ba145d282527d4e31d1680a691a"
+                "reference": "9c2ceb892a70d7108a573859f88dcd2d099c4606"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2544,7 +2544,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.54.x-dev"
+                    "dev-trunk": "1.55.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -101,7 +101,7 @@ function render_block( $attr, $content ) {
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 
 	// If stripe isn't connected don't show anything to potential donors - they can't actually make a donation.
-	if ( ! \Jetpack_Memberships::get_connected_account_id() ) {
+	if ( ! \Jetpack_Memberships::has_connected_account() ) {
 		return '';
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -22,7 +22,7 @@ function membership_checks() {
 		return false;
 	}
 	// if stripe not connected don't show anything...
-	if ( ! Jetpack_Memberships::has_connected_account() ) {
+	if ( ! \Jetpack_Memberships::has_connected_account() ) {
 		return false;
 	}
 	return true;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -22,7 +22,7 @@ function membership_checks() {
 		return false;
 	}
 	// if stripe not connected don't show anything...
-	if ( empty( \Jetpack_Memberships::get_connected_account_id() ) ) {
+	if ( ! Jetpack_Memberships::has_connected_account() ) {
 		return false;
 	}
 	return true;

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -33,7 +33,7 @@ class Jetpack_Memberships {
 	 *
 	 * @var string
 	 */
-	public static $connected_account_id_option_name = 'jetpack-memberships-connected-account-id';
+	public static $has_connected_account_option_name = 'jetpack-memberships-has-connected-account';
 
 	/**
 	 * Post meta that will store the level of access for newsletters
@@ -282,7 +282,7 @@ class Jetpack_Memberships {
 	 */
 	public function should_render_button_preview( $block ) {
 		$user_can_edit              = static::user_can_edit();
-		$requires_stripe_connection = ! static::get_connected_account_id();
+		$requires_stripe_connection = ! static::has_connected_account();
 
 		$jetpack_ready = ! self::is_enabled_jetpack_recurring_payments();
 
@@ -428,10 +428,10 @@ class Jetpack_Memberships {
 	/**
 	 * Get the id of the connected payment acount (Stripe etc).
 	 *
-	 * @return int|void
+	 * @return bool
 	 */
-	public static function get_connected_account_id() {
-		return get_option( self::$connected_account_id_option_name );
+	public static function has_connected_account() {
+		return get_option( self::$has_connected_account_option_name, false ) ? true : false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -29,7 +29,7 @@ class Jetpack_Memberships {
 	 */
 	public static $post_type_plan = 'jp_mem_plan';
 
-    /**
+	/**
 	 * Option that will store currently set up account (Stripe etc) id for memberships.
 	 *
 	 *  TODO: remove

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -28,8 +28,20 @@ class Jetpack_Memberships {
 	 * @var string
 	 */
 	public static $post_type_plan = 'jp_mem_plan';
-	/**
+
+    /**
 	 * Option that will store currently set up account (Stripe etc) id for memberships.
+	 *
+	 *  TODO: remove
+	 *
+	 * @deprecated
+	 * @var string
+	 */
+	public static $connected_account_id_option_name = 'jetpack-memberships-connected-account-id';
+
+	/**
+	 * Option that will toggle account enabled for memberships (i.e. Stripe is
+	 * configured, etc. ).
 	 *
 	 * @var string
 	 */
@@ -431,7 +443,16 @@ class Jetpack_Memberships {
 	 * @return bool
 	 */
 	public static function has_connected_account() {
-		return get_option( self::$has_connected_account_option_name, false ) ? true : false;
+
+		// This is the primary solution.
+		$has_option = get_option( self::$has_connected_account_option_name, false ) ? true : false;
+		if ( $has_option ) {
+			return true;
+		}
+
+		// This is the fallback solution.
+		// TODO: Remove this once the has_connected_account_option is migrated to all sites.
+		return get_option( 'jetpack-memberships-connected-account-id', false ) ? true : false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
@@ -467,7 +467,7 @@ class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
 		update_post_meta( $this->plan_id, 'jetpack_memberships_site_subscriber', true );
 
 		// Connect the site to Stripe
-		update_option( Jetpack_Memberships::$connected_account_id_option_name, 123 );
+		update_option( Jetpack_Memberships::$has_connected_account_option_name, true );
 
 		// Create a post
 		return $this->factory->post->create();

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -214,7 +214,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'site_segment'                                 => 'pineapple',
 			'site_vertical'                                => 'pineapple',
 			'jetpack_excluded_extensions'                  => 'pineapple',
-			'jetpack-memberships-connected-account-id'     => '340',
 			'jetpack_publicize_options'                    => array(),
 			'jetpack_connection_active_plugins'            => array( 'jetpack' ),
 			'jetpack_sync_non_blocking'                    => false,

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -214,6 +214,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'site_segment'                                 => 'pineapple',
 			'site_vertical'                                => 'pineapple',
 			'jetpack_excluded_extensions'                  => 'pineapple',
+			'jetpack-memberships-has-connected-account'    => true,
 			'jetpack_publicize_options'                    => array(),
 			'jetpack_connection_active_plugins'            => array( 'jetpack' ),
 			'jetpack_sync_non_blocking'                    => false,

--- a/projects/plugins/migration/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/migration/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1299,7 +1299,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "2e043ed46f2a6ba145d282527d4e31d1680a691a"
+                "reference": "9c2ceb892a70d7108a573859f88dcd2d099c4606"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1330,7 +1330,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.54.x-dev"
+                    "dev-trunk": "1.55.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/protect/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1278,7 +1278,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "2e043ed46f2a6ba145d282527d4e31d1680a691a"
+                "reference": "9c2ceb892a70d7108a573859f88dcd2d099c4606"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1309,7 +1309,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.54.x-dev"
+                    "dev-trunk": "1.55.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/search/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1358,7 +1358,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "2e043ed46f2a6ba145d282527d4e31d1680a691a"
+                "reference": "9c2ceb892a70d7108a573859f88dcd2d099c4606"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1389,7 +1389,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.54.x-dev"
+                    "dev-trunk": "1.55.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/social/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1354,7 +1354,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "2e043ed46f2a6ba145d282527d4e31d1680a691a"
+                "reference": "9c2ceb892a70d7108a573859f88dcd2d099c4606"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1385,7 +1385,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.54.x-dev"
+                    "dev-trunk": "1.55.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/starter-plugin/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1214,7 +1214,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "2e043ed46f2a6ba145d282527d4e31d1680a691a"
+                "reference": "9c2ceb892a70d7108a573859f88dcd2d099c4606"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1245,7 +1245,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.54.x-dev"
+                    "dev-trunk": "1.55.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/videopress/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1278,7 +1278,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "2e043ed46f2a6ba145d282527d4e31d1680a691a"
+                "reference": "9c2ceb892a70d7108a573859f88dcd2d099c4606"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1309,7 +1309,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.54.x-dev"
+                    "dev-trunk": "1.55.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Part of https://github.com/Automattic/gold/issues/59. Requires D117364-code to be deployed for WPCOM tests to pass.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See p81Rsd-1q4-p2 (TL;DR - create a jetpack ninja site using this branch and sandbox with the last WPCOM commit (D117364-code) and verify that it all works...