### PR TITLE
Social: Redistribute icon and toggle in social sharing controls

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-sidebar-controls
+++ b/projects/js-packages/publicize-components/changelog/update-social-sidebar-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Redistribute icon and toggle in social sharing controls

--- a/projects/js-packages/publicize-components/src/components/connection-icon/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/connection-icon/index.jsx
@@ -5,28 +5,24 @@ import PropTypes from 'prop-types';
 import './style.scss';
 
 const ConnectionIcon = props => {
-	const { id, serviceName, label, profilePicture } = props;
+	const { serviceName, label, profilePicture } = props;
 	const [ hasDisplayPicture, setHasDisplayPicture ] = useState( !! profilePicture );
 
 	const onError = useCallback( () => setHasDisplayPicture( false ), [] );
 
 	return (
-		<label htmlFor={ id } className="jetpack-publicize-connection-label">
-			<div className={ hasDisplayPicture ? 'components-connection-icon__picture' : '' }>
-				{ hasDisplayPicture && <img src={ profilePicture } alt={ label } onError={ onError } /> }
-				<SocialServiceIcon
-					serviceName={ 'instagram-business' === serviceName ? 'instagram' : serviceName }
-					className="jetpack-publicize-gutenberg-social-icon"
-					invert={ 'tumblr' === serviceName }
-				/>
-			</div>
-			<span className="jetpack-publicize-connection-label-copy">{ label }</span>
-		</label>
+		<div className={ hasDisplayPicture ? 'components-connection-icon__picture' : '' }>
+			{ hasDisplayPicture && <img src={ profilePicture } alt={ label } onError={ onError } /> }
+			<SocialServiceIcon
+				serviceName={ 'instagram-business' === serviceName ? 'instagram' : serviceName }
+				className="jetpack-publicize-gutenberg-social-icon"
+				invert={ 'tumblr' === serviceName }
+			/>
+		</div>
 	);
 };
 
 ConnectionIcon.propTypes = {
-	id: PropTypes.string.isRequired,
 	serviceName: PropTypes.string,
 	label: PropTypes.string,
 	profilePicture: PropTypes.string,

--- a/projects/js-packages/publicize-components/src/components/connection-icon/style.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-icon/style.scss
@@ -11,42 +11,44 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 
-	// Icon and picture.
-	.components-connection-icon__picture {
-		display: grid;
 
-		img,
-		.placeholder {
-			border-radius: 2px;
-			width: 24px;
-			height: 24px;
-			grid-area: 1 / 1 / 2 / 2;
-		}
-
-		.placeholder {
-			display: block;
-			background-color: #a8bece;
-		}
-
-		.jetpack-publicize-gutenberg-social-icon {
-			width: 15px;
-			height: 15px;
-			grid-area: 1 / 1 / 2 / 2;
-			margin-top: 14px;
-			margin-left: 14px;
-			margin-right: 5px;
-			border-radius: 2px;
-			background-color: white;
-
-			&.is-facebook {
-				border-radius: 50%;
-			}
-		}
-	}
 
 	.jetpack-publicize-gutenberg-social-icon,
 	.jetpack-publicize-connection-label-copy {
 		display: inline-block;
 		vertical-align: middle;
+	}
+}
+
+// Icon and picture.
+.components-connection-icon__picture {
+	display: grid;
+
+	img,
+	.placeholder {
+		border-radius: 2px;
+		width: 24px;
+		height: 24px;
+		grid-area: 1 / 1 / 2 / 2;
+	}
+
+	.placeholder {
+		display: block;
+		background-color: #a8bece;
+	}
+
+	.jetpack-publicize-gutenberg-social-icon {
+		width: 15px;
+		height: 15px;
+		grid-area: 1 / 1 / 2 / 2;
+		margin-top: 14px;
+		margin-left: 14px;
+		margin-right: 5px;
+		border-radius: 2px;
+		background-color: white;
+
+		&.is-facebook {
+			border-radius: 50%;
+		}
 	}
 }

--- a/projects/js-packages/publicize-components/src/components/connection-toggle/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/connection-toggle/index.jsx
@@ -1,4 +1,4 @@
-import { FormToggle } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import ConnectionIcon from '../connection-icon';
@@ -16,15 +16,16 @@ const ConnectionToggle = props => {
 	return (
 		<div className={ wrapperClasses }>
 			<ConnectionIcon
-				id={ id }
 				serviceName={ serviceName }
 				label={ label }
 				profilePicture={ profilePicture }
 			/>
-			<FormToggle
+			<ToggleControl
+				style={ { margin: 'auto' } }
 				id={ id }
 				className={ className }
 				checked={ checked }
+				label={ label }
 				onChange={ onChange }
 				disabled={ disabled }
 			/>

--- a/projects/js-packages/publicize-components/src/components/connection-toggle/style.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-toggle/style.scss
@@ -16,4 +16,8 @@
 		width: 100%;
 		opacity: 0.5;
 	}
+	.components-toggle-control {
+		margin-top: auto;
+		margin-bottom: auto;
+	}
 }


### PR DESCRIPTION
Positions the social icon to the left of the toggle and ensures the label appears to its right
<table>
<tr>
 <td><img width="292" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/623ea80c-21fb-4313-98df-41bdb8697686">

 <td>
<img width="293" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/c1ca4b2c-45f1-4158-9e58-acbac1f110a2">


<tr>
 <td>Before
 <td>After
</table>

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

