### PR TITLE
Add caching for zendesk auth token

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-caching-for-zendesk-auth-token
+++ b/projects/packages/my-jetpack/changelog/add-caching-for-zendesk-auth-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add transient caching for zendesk jwt auth token


### PR DESCRIPTION
Add a transient to cache the value of the `jwt` auth token for Zendesk chat authentication

## Proposed changes:

 * Adds a new transient to cache Zendesk chat auth for 1 week

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p7pQDF-8rT-p2#comment-23449

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Check out this branch locally or using the Jetpack Beta Plugin
2. Make sure you have the Network tab open and recording network requests
3. Go to `/wp-admin/admin.php?page=my-jetpack`
4. In your network tab, search for the `index.php?rest_route=%2Fmy-jetpack%2Fv1%2Fchat%2Fauthentication&_locale=user` request (I found it by just searching "authentication")
5. Take note of the `jwt` token in the request body (copy it into notes or something)
![Screenshot 2023-07-28 at 2 03 30 PM](https://github.com/Automattic/jetpack/assets/65001528/24c3e33b-68b1-47ec-b810-3bf98826958e)
6. Reload the page, find the request again, and make sure the `jwt` token is the same as last time