### PR TITLE
AI Client: introduce withAiDataProvider HOC

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-client-add-with-ai-data-assistant
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-add-with-ai-data-assistant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: introduce withAiDataProvider HOC

--- a/projects/js-packages/ai-client/index.ts
+++ b/projects/js-packages/ai-client/index.ts
@@ -18,6 +18,6 @@ export * from './src/icons';
 /*
  * Contexts
  */
-export * from './src/contexts';
+export * from './src/data-flow';
 
 export * from './src/index.js';

--- a/projects/js-packages/ai-client/src/contexts/index.ts
+++ b/projects/js-packages/ai-client/src/contexts/index.ts
@@ -1,1 +1,0 @@
-export { AiAssistantDataContext, AiAssistantDataContextProvider } from './ai-assistant-data';

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -1,10 +1,12 @@
 
-# AI Assistant Context
+# Data Flow
+
+## AI Assistant Context
 
 The AI Assistant Context is a React context implementation for managing the state and functionality of an AI Assistant. It manages the suggestion values, error states, and request functionality for the AI Assistant.
 
 
-## Usage
+### Usage
 
 Import the AI Assistant Context and Provider into your component:
 
@@ -26,20 +28,20 @@ You can access the context values in your child components using the `useContext
 const aiContext = React.useContext( AiAssistantDataContext );
 ```
 
-## Context Values
+### Context Values
 
 The AI Assistant Context has the following values:
 
-### `suggestion`
+#### `suggestion`
 The suggestion value from the AI.
 
-### `requestingError`
+#### `requestingError`
 The error object returned from the AI suggestion request. It contains the following properties:
 - `code`: A code referring to the type of error. The possible error codes are `ERROR_SERVICE_UNAVAILABLE`, `ERROR_QUOTA_EXCEEDED`, `ERROR_MODERATION`, `ERROR_NETWORK`, `ERROR_UNCLEAR_PROMPT`.
 - `message`: A user-friendly error message.
 - `severity`: The severity of the error. It can either be 'info' or 'error'.
 
-### `requestingState`
+#### `requestingState`
 The current state of the suggestion request. It can be one of the following:
 - `init`: The initial state before a request is made.
 - `requesting`: The state when a request is being made.
@@ -47,5 +49,5 @@ The current state of the suggestion request. It can be one of the following:
 - `done`: The state when a suggestion has been received.
 - `error`: The state when an error has occurred during the request.
 
-### `requestSuggestion`
+#### `requestSuggestion`
 A function to request a suggestion from the AI. The function takes a prompt parameter which can be an object of `PromptMessagesProp` or a string.

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -16,21 +16,21 @@ The AI Assistant Context is a React context implementation for managing the stat
 Import the AI Assistant Context and Provider into your component:
 
 ```javascript
-import { AiAssistantDataContext, AiAssistantDataContextProvider } from '@automattic/jetpack-ai-client';
+import { AiDataContext, AiDataContextProvider } from '@automattic/jetpack-ai-client';
 ```
 
 Use the Provider in your component's render method to wrap the children components:
 
 ```es6
-<AiAssistantDataContextProvider value={ value }>
+<AiDataContextProvider value={ value }>
   { children }
-</AiAssistantDataContextProvider>
+</AiDataContextProvider>
 ```
 
 You can access the context values in your child components using the `useContext` hook:
 
 ```javascript
-const aiContext = React.useContext( AiAssistantDataContext );
+const aiContext = React.useContext( AiDataContext );
 ```
 
 ### Context Values

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -3,17 +3,17 @@
 
 ## In-depth Analysis
 
-* [AI Assistant Context](#ai-assistant-content)
+* [Ai Data Context](#ai-assistant-content)
 * [withAiDataProvider HOC](#with-ai-data-provider)
 
-<h2 id="ai-assistant-content">AI Assistant Context</h2>
+<h2 id="ai-assistant-content">Ai Data Context</h2>
 
-The AI Assistant Context is a React context implementation for managing the state and functionality of an AI Assistant. It manages the suggestion values, error states, and request functionality for the AI Assistant.
+The Ai Data Context is a React context implementation for managing the state and functionality of an AI Assistant. It manages the suggestion values, error states, and request functionality.
 
 
 ### Usage
 
-Import the AI Assistant Context and Provider into your component:
+Import the Ai Data Context and Provider into your component:
 
 ```javascript
 import { AiDataContext, AiDataContextProvider } from '@automattic/jetpack-ai-client';
@@ -35,7 +35,7 @@ const aiContext = React.useContext( AiDataContext );
 
 ### Context Values
 
-The AI Assistant Context has the following values:
+The Ai Data Context has the following values:
 
 #### `suggestion`
 The suggestion value from the AI.

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -1,7 +1,12 @@
 
-# Data Flow
+# AI Assistant Data Flow
 
-## AI Assistant Context
+## In-depth Analysis
+
+* [AI Assistant Context](#ai-assistant-content)
+* [withAiDataProvider HOC](#with-ai-data-provider)
+
+<h2 id="ai-assistant-content">AI Assistant Context</h2>
 
 The AI Assistant Context is a React context implementation for managing the state and functionality of an AI Assistant. It manages the suggestion values, error states, and request functionality for the AI Assistant.
 
@@ -51,3 +56,7 @@ The current state of the suggestion request. It can be one of the following:
 
 #### `requestSuggestion`
 A function to request a suggestion from the AI. The function takes a prompt parameter which can be an object of `PromptMessagesProp` or a string.
+
+<h2 id="with-ai-data-provider">withAiDataProvider HOC</h2>
+
+Higher Order Component (HOC) that wraps a given component and provides it with the AI Assistant Data context. This HOC is instrumental in the data flow of the AI Assistant functionality and helps manage the interaction with the AI Assistant's communication layer.

--- a/projects/js-packages/ai-client/src/data-flow/context.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/context.tsx
@@ -10,7 +10,7 @@ import SuggestionsEventSource from '../suggestions-event-source';
 import type { RequestingStateProp, RequestingErrorProps } from '../hooks/use-ai-suggestions';
 import type { PromptProp } from '../types';
 
-export type AiAssistantDataContextProps = {
+export type AiDataContextProps = {
 	/*
 	 * Suggestion value
 	 */
@@ -37,11 +37,11 @@ export type AiAssistantDataContextProps = {
 	eventSource: SuggestionsEventSource | null;
 };
 
-type AiAssistantDataContextProviderProps = {
+type AiDataContextProviderProps = {
 	/*
 	 * Open the AI Assistant
 	 */
-	value: AiAssistantDataContextProps;
+	value: AiDataContextProps;
 
 	/*
 	 * Children
@@ -52,23 +52,23 @@ type AiAssistantDataContextProviderProps = {
 /**
  * Ai Assistant Context
  *
- * @returns {AiAssistantDataContextProps} Context.
+ * @returns {AiDataContextProps} Context.
  */
-export const AiAssistantDataContext = createContext( {} as AiAssistantDataContextProps );
+export const AiDataContext = createContext( {} as AiDataContextProps );
 
 /**
  * Ai Assistant Context Provider
  *
- * @param {AiAssistantDataContextProviderProps} props - Component props.
+ * @param {AiDataContextProviderProps} props - Component props.
  * @returns {React.ReactNode}                           Context provider.
  * @example
- * <AiAssistantDataContextProvider value={ value }>
+ * <AiDataContextProvider value={ value }>
  * 	{ children }
- * </AiAssistantDataContextProvider>
+ * </AiDataContextProvider>
  */
-export const AiAssistantDataContextProvider = ( {
+export const AiDataContextProvider = ( {
 	value,
 	children,
-}: AiAssistantDataContextProviderProps ): React.ReactNode => (
-	<AiAssistantDataContext.Provider value={ value } children={ children } />
+}: AiDataContextProviderProps ): React.ReactNode => (
+	<AiDataContext.Provider value={ value } children={ children } />
 );

--- a/projects/js-packages/ai-client/src/data-flow/context.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/context.tsx
@@ -6,10 +6,11 @@ import React from 'react';
 /**
  * Types & Constants
  */
+import SuggestionsEventSource from '../suggestions-event-source';
 import type { RequestingStateProp, RequestingErrorProps } from '../hooks/use-ai-suggestions';
 import type { PromptProp } from '../types';
 
-type AiAssistantDataContextProps = {
+export type AiAssistantDataContextProps = {
 	/*
 	 * Suggestion value
 	 */
@@ -29,6 +30,11 @@ type AiAssistantDataContextProps = {
 	 * Request suggestion function
 	 */
 	requestSuggestion: ( prompt: PromptProp ) => void;
+
+	/*
+	 * The Suggestions Event Source instance
+	 */
+	eventSource: SuggestionsEventSource | null;
 };
 
 type AiAssistantDataContextProviderProps = {

--- a/projects/js-packages/ai-client/src/data-flow/context.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/context.tsx
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Types & Constants
  */
-import type { RequestingStateProp, RequestingErrorProps } from '../../hooks/use-ai-suggestions';
-import type { PromptProp } from '../../types';
+import type { RequestingStateProp, RequestingErrorProps } from '../hooks/use-ai-suggestions';
+import type { PromptProp } from '../types';
 
 type AiAssistantDataContextProps = {
 	/*

--- a/projects/js-packages/ai-client/src/data-flow/context.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/context.tsx
@@ -39,7 +39,7 @@ export type AiDataContextProps = {
 
 type AiDataContextProviderProps = {
 	/*
-	 * Open the AI Assistant
+	 * Data to provide to the context
 	 */
 	value: AiDataContextProps;
 
@@ -50,14 +50,14 @@ type AiDataContextProviderProps = {
 };
 
 /**
- * Ai Assistant Context
+ * AI Data Context
  *
  * @returns {AiDataContextProps} Context.
  */
 export const AiDataContext = createContext( {} as AiDataContextProps );
 
 /**
- * Ai Assistant Context Provider
+ * AI Data Context Provider
  *
  * @param {AiDataContextProviderProps} props - Component props.
  * @returns {React.ReactNode}                           Context provider.

--- a/projects/js-packages/ai-client/src/data-flow/index.ts
+++ b/projects/js-packages/ai-client/src/data-flow/index.ts
@@ -1,2 +1,2 @@
-export { AiAssistantDataContext, AiAssistantDataContextProvider } from './context';
+export { AiDataContext, AiDataContextProvider } from './context';
 export { default as withAiDataProvider } from './with-ai-assistant-data';

--- a/projects/js-packages/ai-client/src/data-flow/index.ts
+++ b/projects/js-packages/ai-client/src/data-flow/index.ts
@@ -1,0 +1,2 @@
+export { AiAssistantDataContext, AiAssistantDataContextProvider } from './context';
+export { default as withAiDataProvider } from './with-ai-assistant-data';

--- a/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { useMemo } from '@wordpress/element';
 import React, { ReactNode } from 'react';
 /**
@@ -16,7 +17,7 @@ import { AiDataContextProvider } from '.';
  * @param {ReactNode} WrappedComponent - component to wrap.
  * @returns {ReactNode}          		 Wrapped component, with the AI Assistant Data context.
  */
-const withAiDataProvider = ( WrappedComponent: ReactNode ): ReactNode => {
+const withAiDataProvider = createHigherOrderComponent( ( WrappedComponent: ReactNode ) => {
 	return props => {
 		// Connect with the AI Assistant communication layer.
 		const {
@@ -46,6 +47,6 @@ const withAiDataProvider = ( WrappedComponent: ReactNode ): ReactNode => {
 			</AiDataContextProvider>
 		);
 	};
-};
+}, 'withAiDataProvider' );
 
 export default withAiDataProvider;

--- a/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
@@ -1,0 +1,51 @@
+/**
+ * External Dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import React, { ReactNode } from 'react';
+/**
+ * Internal Dependencies
+ */
+import { useAiSuggestions } from '../../';
+import { AiAssistantDataContextProvider } from '.';
+
+/**
+ * High Order Component that provides the
+ * AI Assistant Data context to the wrapped component.
+ *
+ * @param {ReactNode} WrappedComponent - component to wrap.
+ * @returns {ReactNode}          		 Wrapped component, with the AI Assistant Data context.
+ */
+const withAiDataProvider = ( WrappedComponent: ReactNode ): ReactNode => {
+	return props => {
+		// Connect with the AI Assistant communication layer.
+		const {
+			suggestion,
+			error: requestingError,
+			requestingState,
+			request: requestSuggestion,
+			eventSource,
+		} = useAiSuggestions();
+
+		// Build the context value to pass to the ai assistant data provider.
+		const dataContextValue = useMemo(
+			() => ( {
+				suggestion,
+				requestingError,
+				requestingState,
+				eventSource,
+
+				requestSuggestion,
+			} ),
+			[ suggestion, requestingError, requestingState, eventSource, requestSuggestion ]
+		);
+
+		return (
+			<AiAssistantDataContextProvider value={ dataContextValue }>
+				<WrappedComponent { ...props } />
+			</AiAssistantDataContextProvider>
+		);
+	};
+};
+
+export default withAiDataProvider;

--- a/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
@@ -7,7 +7,7 @@ import React, { ReactNode } from 'react';
  * Internal Dependencies
  */
 import { useAiSuggestions } from '../../';
-import { AiAssistantDataContextProvider } from '.';
+import { AiDataContextProvider } from '.';
 
 /**
  * High Order Component that provides the
@@ -41,9 +41,9 @@ const withAiDataProvider = ( WrappedComponent: ReactNode ): ReactNode => {
 		);
 
 		return (
-			<AiAssistantDataContextProvider value={ dataContextValue }>
+			<AiDataContextProvider value={ dataContextValue }>
 				<WrappedComponent { ...props } />
-			</AiAssistantDataContextProvider>
+			</AiDataContextProvider>
 		);
 	};
 };

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -217,6 +217,7 @@ export default class SuggestionsEventSource extends EventTarget {
 				// Dispatch an event with the chunk
 				this.dispatchEvent( new CustomEvent( 'chunk', { detail: chunk } ) );
 				// Dispatch an event with the full message
+				debug( 'suggestion: %o', this.fullMessage );
 				this.dispatchEvent( new CustomEvent( 'suggestion', { detail: this.fullMessage } ) );
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/32131

This pull request adds the `withAiDataProvider` higher-order component (HOC), which enables data transfer from the AiDataContext. Furthermore, the pull request modifies the variable names and adjusts the context folder in accordance with the Data Flow approach.

[withAiDataProvider doc](https://github.com/Automattic/jetpack/blob/9b975998c6122d63a8b8871ba869c5514da9c8e2/projects/js-packages/ai-client/src/data-flow/Readme.md#with-ai-data-provider)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: introduce withAiAssistantData HOC

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

These changes have not been implemented yet, so a visual review is sufficient for now. Further updates will be provided later.
