### PR TITLE
AI Client: introduce useAiContext() hook

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-client-ai-add-use-ai-data-context-hook
+++ b/projects/js-packages/ai-client/changelog/update-client-ai-add-use-ai-data-context-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: add useAiData() react hook

--- a/projects/js-packages/ai-client/changelog/update-client-ai-add-use-ai-data-context-hook
+++ b/projects/js-packages/ai-client/changelog/update-client-ai-add-use-ai-data-context-hook
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-AI Client: add useAiData() react hook
+AI Client: add useAiContext() react hook

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -88,7 +88,7 @@ A function to request a suggestion from the AI. The function takes a prompt para
 
 Higher Order Component (HOC) that wraps a given component and provides it with the AI Assistant Data context. This HOC is instrumental in the data flow of the AI Assistant functionality and helps manage the interaction with the AI Assistant's communication layer.
 
-<h2 id="use-ai-data">useAiContext Hook</h2>
+<h2 id="use-ai-context">useAiContext Hook</h2>
 
 The `useAiContext` hook provides a convenient way to access the 
 Ai Data Context and subscribe to the `done` and `suggestion` events emitted by SuggestionsEventSource.

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -2,10 +2,10 @@
 # AI Assistant Data Flow
 
 ```jsx
-import { withAiAssistantData, useAiDataContext } from '@automattic/jetpack-ai-client';
+import { withAiAssistantData, useAiData } from '@automattic/jetpack-ai-client';
 
 const MyComponent = () => {
-  const { suggestion, requestingState, requestSuggestion } = useAiDataContext( {
+  const { suggestion, requestingState, requestSuggestion } = useAiData( {
     onDone: content => console.log( `Content is done: ${ content }.` );
   } );
 
@@ -31,7 +31,7 @@ export default withAiAssistantData( MyComponent );
 
 * [AI Data Context](#ai-assistant-content)
 * [withAiDataProvider HOC](#with-ai-data-provider)
-* [useAiDataContext Hook](#use-ai-data-context)
+* [useAiData Hook](#use-ai-data)
 
 <h2 id="ai-assistant-content">Ai Data Context</h2>
 
@@ -88,13 +88,13 @@ A function to request a suggestion from the AI. The function takes a prompt para
 
 Higher Order Component (HOC) that wraps a given component and provides it with the AI Assistant Data context. This HOC is instrumental in the data flow of the AI Assistant functionality and helps manage the interaction with the AI Assistant's communication layer.
 
-<h2 id="use-ai-data-context">useAiDataContext Hook</h2>
+<h2 id="use-ai-data">useAiData Hook</h2>
 
-The `useAiDataContext` hook provides a convenient way to access the 
+The `useAiData` hook provides a convenient way to access the 
 Ai Data Context and subscribe to the `done` and `suggestion` events emitted by SuggestionsEventSource.
 
 ```es6
-const { suggestion } = useAiDataContext( {
+const { suggestion } = useAiData( {
   onDone: content => console.log( content ),
   onSuggestion: suggestion => console.log( suggestion ),
 } );

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -2,10 +2,10 @@
 # AI Assistant Data Flow
 
 ```jsx
-import { withAiAssistantData, useAiData } from '@automattic/jetpack-ai-client';
+import { withAiAssistantData, useAiContext } from '@automattic/jetpack-ai-client';
 
 const MyComponent = () => {
-  const { suggestion, requestingState, requestSuggestion } = useAiData( {
+  const { suggestion, requestingState, requestSuggestion } = useAiContext( {
     onDone: content => console.log( `Content is done: ${ content }.` );
   } );
 
@@ -31,7 +31,7 @@ export default withAiAssistantData( MyComponent );
 
 * [AI Data Context](#ai-assistant-content)
 * [withAiDataProvider HOC](#with-ai-data-provider)
-* [useAiData Hook](#use-ai-data)
+* [useAiContext Hook](#use-ai-context)
 
 <h2 id="ai-assistant-content">Ai Data Context</h2>
 
@@ -88,13 +88,13 @@ A function to request a suggestion from the AI. The function takes a prompt para
 
 Higher Order Component (HOC) that wraps a given component and provides it with the AI Assistant Data context. This HOC is instrumental in the data flow of the AI Assistant functionality and helps manage the interaction with the AI Assistant's communication layer.
 
-<h2 id="use-ai-data">useAiData Hook</h2>
+<h2 id="use-ai-data">useAiContext Hook</h2>
 
-The `useAiData` hook provides a convenient way to access the 
+The `useAiContext` hook provides a convenient way to access the 
 Ai Data Context and subscribe to the `done` and `suggestion` events emitted by SuggestionsEventSource.
 
 ```es6
-const { suggestion } = useAiData( {
+const { suggestion } = useAiContext( {
   onDone: content => console.log( content ),
   onSuggestion: suggestion => console.log( suggestion ),
 } );

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -1,10 +1,37 @@
 
 # AI Assistant Data Flow
 
+```jsx
+import { withAiAssistantData, useAiDataContext } from '@automattic/jetpack-ai-client';
+
+const MyComponent = () => {
+  const { suggestion, requestingState, requestSuggestion } = useAiDataContext( {
+    onDone: content => console.log( `Content is done: ${ content }.` );
+  } );
+
+  return (
+    <>
+      <div>{ suggestions }</div>
+      <button
+        onClick={ () => requestSuggestion( 'How to make a cake' ) }
+        disabled={ requestingState === 'suggesting' }
+      >
+        Request
+      </button>
+    <>
+  )
+};
+
+// Ensure to provide the data context to `MyComponent`.
+export default withAiAssistantData( MyComponent );
+
+```
+
 ## In-depth Analysis
 
-* [Ai Data Context](#ai-assistant-content)
+* [AI Data Context](#ai-assistant-content)
 * [withAiDataProvider HOC](#with-ai-data-provider)
+* [useAiDataContext Hook](#use-ai-data-context)
 
 <h2 id="ai-assistant-content">Ai Data Context</h2>
 
@@ -60,3 +87,27 @@ A function to request a suggestion from the AI. The function takes a prompt para
 <h2 id="with-ai-data-provider">withAiDataProvider HOC</h2>
 
 Higher Order Component (HOC) that wraps a given component and provides it with the AI Assistant Data context. This HOC is instrumental in the data flow of the AI Assistant functionality and helps manage the interaction with the AI Assistant's communication layer.
+
+<h2 id="use-ai-data-context">useAiDataContext Hook</h2>
+
+The `useAiDataContext` hook provides a convenient way to access the 
+Ai Data Context and subscribe to the `done` and `suggestion` events emitted by SuggestionsEventSource.
+
+```es6
+const { suggestion } = useAiDataContext( {
+  onDone: content => console.log( content ),
+  onSuggestion: suggestion => console.log( suggestion ),
+} );
+
+```
+
+_Before using the hook, ensure the data is provided by the [Ai Data Context](#ai-assistant-content). [withAiDataProvider HOC](#with-ai-data-provider) is usually the best option_
+
+Optional options object:
+
+- `onDone`: A callback function to be called when a request completes. The callback receives the request result as a parameter.
+- `onSuggestion`: A callback function to be called when a new suggestion is received. The callback receives the suggestion as a parameter.
+
+These callbacks will be invoked with the detail of the corresponding event emitted by SuggestionsEventSource.
+
+When called, the hook returns the Ai Data Context.

--- a/projects/js-packages/ai-client/src/data-flow/index.ts
+++ b/projects/js-packages/ai-client/src/data-flow/index.ts
@@ -1,3 +1,3 @@
 export { AiDataContext, AiDataContextProvider } from './context';
 export { default as withAiDataProvider } from './with-ai-assistant-data';
-export { default as useAiData } from './use-ai-assistant-context';
+export { default as useAiContext } from './use-ai-context';

--- a/projects/js-packages/ai-client/src/data-flow/index.ts
+++ b/projects/js-packages/ai-client/src/data-flow/index.ts
@@ -1,3 +1,3 @@
 export { AiDataContext, AiDataContextProvider } from './context';
 export { default as withAiDataProvider } from './with-ai-assistant-data';
-export { default as useAiDataContext } from './use-ai-assistant-context';
+export { default as useAiData } from './use-ai-assistant-context';

--- a/projects/js-packages/ai-client/src/data-flow/index.ts
+++ b/projects/js-packages/ai-client/src/data-flow/index.ts
@@ -1,2 +1,3 @@
 export { AiDataContext, AiDataContextProvider } from './context';
 export { default as withAiDataProvider } from './with-ai-assistant-data';
+export { default as useAiDataContext } from './use-ai-assistant-context';

--- a/projects/js-packages/ai-client/src/data-flow/use-ai-assistant-context.ts
+++ b/projects/js-packages/ai-client/src/data-flow/use-ai-assistant-context.ts
@@ -12,11 +12,12 @@ import { AiDataContext } from '.';
 import type { AiDataContextProps } from './context';
 import type { AskQuestionOptionsArgProps } from '../ask-question';
 
-type UseAiAssistantContextOptions = {
+type UseAiDataOptions = {
 	/*
 	 * Ask question options.
 	 */
 	askQuestionOptions?: AskQuestionOptionsArgProps;
+
 	/*
 	 * onDone callback.
 	 */
@@ -29,17 +30,17 @@ type UseAiAssistantContextOptions = {
 };
 
 /**
- * useAiDataContext hook to provide access to
+ * useAiData hook to provide access to
  * the AI Assistant data (from context),
  * and to subscribe to the request events (onDone, onSuggestion).
  *
- * @param {UseAiAssistantContextOptions} options - the hook options.
+ * @param {UseAiDataOptions} options - the hook options.
  * @returns {AiDataContextProps}          the AI Assistant data context.
  */
-export default function useAiDataContext( {
+export default function useAiData( {
 	onDone,
 	onSuggestion,
-}: UseAiAssistantContextOptions = {} ): AiDataContextProps {
+}: UseAiDataOptions = {} ): AiDataContextProps {
 	const context = useContext( AiDataContext );
 	const { eventSource } = context;
 

--- a/projects/js-packages/ai-client/src/data-flow/use-ai-assistant-context.ts
+++ b/projects/js-packages/ai-client/src/data-flow/use-ai-assistant-context.ts
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useContext, useEffect } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { AiDataContext } from '.';
+/**
+ * Types & constants
+ */
+import type { AiDataContextProps } from './context';
+import type { AskQuestionOptionsArgProps } from '../ask-question';
+
+type UseAiAssistantContextOptions = {
+	/*
+	 * Ask question options.
+	 */
+	askQuestionOptions?: AskQuestionOptionsArgProps;
+	/*
+	 * onDone callback.
+	 */
+	onDone?: ( content: string ) => void;
+
+	/*
+	 * onSuggestion callback.
+	 */
+	onSuggestion?: ( suggestion: string ) => void;
+};
+
+/**
+ * useAiDataContext hook to provide access to
+ * the AI Assistant data (from context),
+ * and to subscribe to the request events (onDone, onSuggestion).
+ *
+ * @param {UseAiAssistantContextOptions} options - the hook options.
+ * @returns {AiDataContextProps}          the AI Assistant data context.
+ */
+export default function useAiDataContext( {
+	onDone,
+	onSuggestion,
+}: UseAiAssistantContextOptions = {} ): AiDataContextProps {
+	const context = useContext( AiDataContext );
+	const { eventSource } = context;
+
+	const done = useCallback( ( event: CustomEvent ) => onDone?.( event?.detail ), [ onDone ] );
+	const suggestion = useCallback(
+		( event: CustomEvent ) => onSuggestion?.( event?.detail ),
+		[ onSuggestion ]
+	);
+
+	useEffect( () => {
+		if ( ! eventSource ) {
+			return;
+		}
+
+		if ( onDone ) {
+			eventSource.addEventListener( 'done', done );
+		}
+
+		if ( onSuggestion ) {
+			eventSource.addEventListener( 'suggestion', suggestion );
+		}
+
+		return () => {
+			eventSource.removeEventListener( 'done', done );
+			eventSource.removeEventListener( 'suggestion', suggestion );
+		};
+	}, [ eventSource ] );
+
+	return context;
+}

--- a/projects/js-packages/ai-client/src/data-flow/use-ai-context.ts
+++ b/projects/js-packages/ai-client/src/data-flow/use-ai-context.ts
@@ -12,7 +12,7 @@ import { AiDataContext } from '.';
 import type { AiDataContextProps } from './context';
 import type { AskQuestionOptionsArgProps } from '../ask-question';
 
-type UseAiDataOptions = {
+type useAiContextOptions = {
 	/*
 	 * Ask question options.
 	 */
@@ -30,17 +30,17 @@ type UseAiDataOptions = {
 };
 
 /**
- * useAiData hook to provide access to
+ * useAiContext hook to provide access to
  * the AI Assistant data (from context),
  * and to subscribe to the request events (onDone, onSuggestion).
  *
- * @param {UseAiDataOptions} options - the hook options.
+ * @param {useAiContextOptions} options - the hook options.
  * @returns {AiDataContextProps}          the AI Assistant data context.
  */
-export default function useAiData( {
+export default function useAiContext( {
 	onDone,
 	onSuggestion,
-}: UseAiDataOptions = {} ): AiDataContextProps {
+}: useAiContextOptions = {} ): AiDataContextProps {
 	const context = useContext( AiDataContext );
 	const { eventSource } = context;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR introduces a new hook, `useAiContext()`, that provides an intuitive way to access AI data from the context within components. The hook is designed to be used with the `withAiDataProvider()` Higher Order Component (HOC), ensuring that the AI data context is readily available for children components.


```jsx
const MyComponent = () => {
  const { suggestion, requestingState, requestSuggestion } = useAiContext( {
    onDone: content => console.log( `Content is done: ${ content }.` );
  } );

  return (
    <>
      <div>{ suggestions }</div>
      <button
        onClick={ () => requestSuggestion( 'How to make a cake' ) }
        disabled={ requestingState === 'suggesting' }
      >
        Request
      </button>
    <>
  )
};

export default withAiDataProvider( MyComponent );
```

### Differences with `useAiSuggestions()` Hook

The `useAiSuggestions()` hook is independent of the context. It's practical when you don't need to propagate the AI data across all child components. However, `useAiContext()` is preferred for deeper data context integration.

### Data Handler Independence

One of the core advantages of the `useAiContext()` hook is that it's agnostic to the underlying data handler. While the current implementation uses a context instance, it can be readily refactored to use other state management libraries, like Redux, if required.

### [useAiContext](https://github.com/Automattic/jetpack/blob/aa9444109ffcebab61d27fae7239700cadde090e/projects/js-packages/ai-client/src/data-flow/Readme.md#use-ai-context) documentation

Fixes https://github.com/Automattic/jetpack/issues/32143

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: introduce useAiContext() hook

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To test the approach, let's use the [PoC branch](https://github.com/Automattic/jetpack/pull/32053).

* Go to the block editor
* Create a Jetpack Form block instance
* Confirm with the see provider in the React components tree (React dev tool):
<img width="894" alt="Screenshot 2023-07-31 at 11 19 06" src="https://github.com/Automattic/jetpack/assets/77539/00d99190-4e1c-49d4-ad76-a030262567da">
The image below shows the `withAiDataProvider` HOC component in the tree and what are the variables it provides.
* Ask for a Jetpack From composition:

```
Create a form for scheduling a veterinary appointment for pets in French, please.
```

<img width="677" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/bd793c92-ce50-40f5-afee-ba18fd0aebfc">

* Pay attention to the Icon status since it gets the [requestingState](https://github.com/Automattic/jetpack/pull/32053/files#diff-ac6eaf693e2283fcf5388decaec76064ca8c0eddc423ca039779c80525c6f971R126) by using the hook (the link points to the PoC PR)

<img width="210" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/6b594592-c491-4e6f-8511-261679e6a43b">

* Confirm the form is created properly


https://github.com/Automattic/jetpack/assets/77539/d3da7fbd-0e16-420d-bbd7-10ef26315199


