### PR TITLE
WP.com sidebar: update performance settings link position

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wpcom-sidebar-performance-position
+++ b/projects/plugins/jetpack/changelog/update-wpcom-sidebar-performance-position
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Performance settings: update position in wpcom menu

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -396,7 +396,7 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		$this->update_submenus( 'options-general.php', $submenus_to_update );
 
-		add_submenu_page( 'options-general.php', esc_attr__( 'Performance', 'jetpack' ), __( 'Performance', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain, null, 1 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Performance', 'jetpack' ), __( 'Performance', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain, null, 9 );
 	}
 
 	/**


### PR DESCRIPTION
While working on adding Newsletter and Podcasting setting sections (https://github.com/Automattic/jetpack/pull/32146), I noticed "performance" weirdly high (2nd) in the settings list although it feels pretty advanced stuff. More common Writing/Reading were down in the list.

<img width="1807" alt="Screenshot 2023-07-31 at 15 22 38" src="https://github.com/Automattic/jetpack/assets/87168/3852eb9f-d8c3-4b78-afb1-c992801f4e15">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Define position for perfomrance not as `1` (which placed it always on top) but as `9` which will place it before "Hosting configuration", going forward.

<img width="287" alt="Screenshot 2023-07-31 at 15 23 32" src="https://github.com/Automattic/jetpack/assets/87168/5b2ac71d-f0b2-4633-9b97-e123b99032a7">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply patch to the sandbox (See instructions below)
* Sandobox public api and open settings in Calypso

