### PR TITLE
CRM: Automation, rename trigger hooks and classes

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-3266-rename-trigger-hooks-and-classes
+++ b/projects/plugins/crm/changelog/update-crm-3266-rename-trigger-hooks-and-classes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Hook and class rename _new by _created
+
+

--- a/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/companies/class-company-created.php
@@ -1,51 +1,45 @@
 <?php
 /**
- * Jetpack CRM Automation Contact_New trigger.
+ * Jetpack CRM Automation Company_Created trigger.
  *
  * @package automattic/jetpack-crm
  */
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**
- * Adds the Contact_New class.
+ * Adds the Company_Created class.
  */
-class Contact_New extends Base_Trigger {
-
-	/**
-	 * @var Automation_Workflow The Automation workflow object.
-	 */
-	protected $workflow;
+class Company_Created extends Base_Trigger {
 
 	/** Get the slug name of the trigger
 	 * @return string
 	 */
 	public static function get_slug(): string {
-		return 'jpcrm/contact_new';
+		return 'jpcrm/company_created';
 	}
 
 	/** Get the title of the trigger
 	 * @return string
 	 */
 	public static function get_title(): ?string {
-		return __( 'New Contact', 'zero-bs-crm' );
+		return __( 'New Company', 'zero-bs-crm' );
 	}
 
 	/** Get the description of the trigger
 	 * @return string
 	 */
 	public static function get_description(): ?string {
-		return __( 'Triggered when a CRM contact is added', 'zero-bs-crm' );
+		return __( 'Triggered when a CRM company is added', 'zero-bs-crm' );
 	}
 
 	/** Get the category of the trigger
 	 * @return string
 	 */
 	public static function get_category(): ?string {
-		return __( 'contact', 'zero-bs-crm' );
+		return __( 'company', 'zero-bs-crm' );
 	}
 
 	/**
@@ -53,7 +47,7 @@ class Contact_New extends Base_Trigger {
 	 */
 	protected function listen_to_event() {
 		add_action(
-			'jpcrm_automation_contact_new',
+			'jpcrm_automation_company_created',
 			array( $this, 'execute_workflow' )
 		);
 	}

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-created.php
@@ -1,45 +1,51 @@
 <?php
 /**
- * Jetpack CRM Automation Invoice_New trigger.
+ * Jetpack CRM Automation Contact_Created trigger.
  *
  * @package automattic/jetpack-crm
  */
 
 namespace Automattic\Jetpack\CRM\Automation\Triggers;
 
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**
- * Adds the Invoice_New class.
+ * Adds the Contact_Created class.
  */
-class Invoice_New extends Base_Trigger {
+class Contact_Created extends Base_Trigger {
+
+	/**
+	 * @var Automation_Workflow The Automation workflow object.
+	 */
+	protected $workflow;
 
 	/** Get the slug name of the trigger
 	 * @return string
 	 */
 	public static function get_slug(): string {
-		return 'jpcrm/invoice_new';
+		return 'jpcrm/contact_created';
 	}
 
 	/** Get the title of the trigger
 	 * @return string
 	 */
 	public static function get_title(): ?string {
-		return __( 'New Invoice', 'zero-bs-crm' );
+		return __( 'New Contact', 'zero-bs-crm' );
 	}
 
 	/** Get the description of the trigger
 	 * @return string
 	 */
 	public static function get_description(): ?string {
-		return __( 'Triggered when a new invoice status is added', 'zero-bs-crm' );
+		return __( 'Triggered when a CRM contact is added', 'zero-bs-crm' );
 	}
 
 	/** Get the category of the trigger
 	 * @return string
 	 */
 	public static function get_category(): ?string {
-		return __( 'invoice', 'zero-bs-crm' );
+		return __( 'contact', 'zero-bs-crm' );
 	}
 
 	/**
@@ -47,7 +53,7 @@ class Invoice_New extends Base_Trigger {
 	 */
 	protected function listen_to_event() {
 		add_action(
-			'jpcrm_automation_invoice_new',
+			'jpcrm_automation_contact_created',
 			array( $this, 'execute_workflow' )
 		);
 	}

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-created.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack CRM Automation Event_New trigger.
+ * Jetpack CRM Automation Event_Created trigger.
  *
  * @package automattic/jetpack-crm
  */
@@ -10,11 +10,11 @@ namespace Automattic\Jetpack\CRM\Automation\Triggers;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**
- * Adds the Event_New class.
+ * Adds the Event_Created class.
  *
  * @since $$next-version$$
  */
-class Event_New extends Base_Trigger {
+class Event_Created extends Base_Trigger {
 
 	/**
 	 * Get the slug name of the trigger.
@@ -22,7 +22,7 @@ class Event_New extends Base_Trigger {
 	 * @return string
 	 */
 	public static function get_slug(): string {
-		return 'jpcrm/event_new';
+		return 'jpcrm/event_created';
 	}
 
 	/**
@@ -57,7 +57,7 @@ class Event_New extends Base_Trigger {
 	 */
 	protected function listen_to_event(): void {
 		add_action(
-			'jpcrm_event_new',
+			'jpcrm_event_created',
 			array( $this, 'execute_workflow' )
 		);
 	}

--- a/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/invoices/class-invoice-created.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack CRM Automation Quote_New trigger.
+ * Jetpack CRM Automation Invoice_Created trigger.
  *
  * @package automattic/jetpack-crm
  */
@@ -10,48 +10,44 @@ namespace Automattic\Jetpack\CRM\Automation\Triggers;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**
- * Adds the Quote_New class.
+ * Adds the Invoice_Created class.
  */
-class Quote_New extends Base_Trigger {
+class Invoice_Created extends Base_Trigger {
 
-	/**
-	 * Get the slug name of the trigger.
+	/** Get the slug name of the trigger
 	 * @return string
 	 */
 	public static function get_slug(): string {
-		return 'jpcrm/quote_new';
+		return 'jpcrm/invoice_created';
 	}
 
-	/**
-	 * Get the title of the trigger.
+	/** Get the title of the trigger
 	 * @return string
 	 */
 	public static function get_title(): ?string {
-		return __( 'New Quote', 'zero-bs-crm' );
+		return __( 'New Invoice', 'zero-bs-crm' );
 	}
 
-	/**
-	 * Get the description of the trigger.
+	/** Get the description of the trigger
 	 * @return string
 	 */
 	public static function get_description(): ?string {
-		return __( 'Triggered when a new quote status is added', 'zero-bs-crm' );
+		return __( 'Triggered when a new invoice status is added', 'zero-bs-crm' );
 	}
 
-	/**
-	 * Get the category of the trigger.
+	/** Get the category of the trigger
 	 * @return string
 	 */
 	public static function get_category(): ?string {
-		return __( 'quote', 'zero-bs-crm' );
+		return __( 'invoice', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Listen to this trigger's target event.
+	 * Listen to the desired event
 	 */
 	protected function listen_to_event() {
 		add_action(
-			'jpcrm_quote_new',
+			'jpcrm_automation_invoice_created',
 			array( $this, 'execute_workflow' )
 		);
 	}

--- a/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/quotes/class-quote-created.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack CRM Automation Company_New trigger.
+ * Jetpack CRM Automation Quote_Created trigger.
  *
  * @package automattic/jetpack-crm
  */
@@ -10,44 +10,48 @@ namespace Automattic\Jetpack\CRM\Automation\Triggers;
 use Automattic\Jetpack\CRM\Automation\Base_Trigger;
 
 /**
- * Adds the Company_New class.
+ * Adds the Quote_Created class.
  */
-class Company_New extends Base_Trigger {
+class Quote_Created extends Base_Trigger {
 
-	/** Get the slug name of the trigger
+	/**
+	 * Get the slug name of the trigger.
 	 * @return string
 	 */
 	public static function get_slug(): string {
-		return 'jpcrm/company_new';
-	}
-
-	/** Get the title of the trigger
-	 * @return string
-	 */
-	public static function get_title(): ?string {
-		return __( 'New Company', 'zero-bs-crm' );
-	}
-
-	/** Get the description of the trigger
-	 * @return string
-	 */
-	public static function get_description(): ?string {
-		return __( 'Triggered when a CRM company is added', 'zero-bs-crm' );
-	}
-
-	/** Get the category of the trigger
-	 * @return string
-	 */
-	public static function get_category(): ?string {
-		return __( 'company', 'zero-bs-crm' );
+		return 'jpcrm/quote_created';
 	}
 
 	/**
-	 * Listen to the desired event
+	 * Get the title of the trigger.
+	 * @return string
+	 */
+	public static function get_title(): ?string {
+		return __( 'New Quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 * @return string
+	 */
+	public static function get_description(): ?string {
+		return __( 'Triggered when a new quote status is added', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 * @return string
+	 */
+	public static function get_category(): ?string {
+		return __( 'quote', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Listen to this trigger's target event.
 	 */
 	protected function listen_to_event() {
 		add_action(
-			'jpcrm_automation_company_new',
+			'jpcrm_quote_created',
 			array( $this, 'execute_workflow' )
 		);
 	}

--- a/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/companies/class-company-trigger-test.php
@@ -4,8 +4,8 @@ namespace Automattic\Jetpack\CRM\Automation\Tests;
 
 use Automattic\Jetpack\CRM\Automation\Automation_Engine;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Triggers\Company_Created;
 use Automattic\Jetpack\CRM\Automation\Triggers\Company_Deleted;
-use Automattic\Jetpack\CRM\Automation\Triggers\Company_New;
 use Automattic\Jetpack\CRM\Automation\Triggers\Company_Status_Updated;
 use Automattic\Jetpack\CRM\Automation\Triggers\Company_Updated;
 use WorDBless\BaseTestCase;
@@ -95,11 +95,11 @@ class Company_Trigger_Test extends BaseTestCase {
 	/**
 	 * @testdox Test the company new trigger executes the workflow with an action
 	 */
-	public function test_company_new_trigger() {
+	public function test_company_created_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/company_new' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/company_created' );
 
-		$trigger = new Company_New();
+		$trigger = new Company_Created();
 
 		// Build a PHPUnit mock Automation_Workflow
 		$workflow = $this->getMockBuilder( Automation_Workflow::class )
@@ -107,13 +107,13 @@ class Company_Trigger_Test extends BaseTestCase {
 			->onlyMethods( array( 'execute' ) )
 			->getMock();
 
-		// Init the Company_New trigger.
+		// Init the Company_Created trigger.
 		$trigger->init( $workflow );
 
 		// Fake event data.
 		$company_data = $this->automation_faker->company_data();
 
-		// We expect the workflow to be executed on company_new event with the company data
+		// We expect the workflow to be executed on company_created event with the company data
 		$workflow->expects( $this->once() )
 		->method( 'execute' )
 		->with(
@@ -121,8 +121,8 @@ class Company_Trigger_Test extends BaseTestCase {
 			$this->equalTo( $company_data )
 		);
 
-		// Run the company_new action.
-		do_action( 'jpcrm_automation_company_new', $company_data );
+		// Notify the company_created event.
+		do_action( 'jpcrm_automation_company_created', $company_data );
 	}
 
 	/**

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
@@ -5,9 +5,9 @@ namespace Automattic\Jetpack\CRM\Automation\Tests;
 use Automattic\Jetpack\CRM\Automation\Automation_Engine;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Before_Deleted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Created;
 use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Deleted;
 use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Email_Updated;
-use Automattic\Jetpack\CRM\Automation\Triggers\Contact_New;
 use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Status_Updated;
 use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Updated;
 use WorDBless\BaseTestCase;
@@ -98,11 +98,11 @@ class Contact_Trigger_Test extends BaseTestCase {
 	/**
 	 * @testdox Test the contact new trigger executes the workflow with an action
 	 */
-	public function test_contact_new_trigger() {
+	public function test_contact_created_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/contact_new' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/contact_created' );
 
-		$trigger = new Contact_New();
+		$trigger = new Contact_Created();
 
 		// Build a PHPUnit mock Automation_Workflow
 		$workflow = $this->getMockBuilder( Automation_Workflow::class )
@@ -110,13 +110,13 @@ class Contact_Trigger_Test extends BaseTestCase {
 			->onlyMethods( array( 'execute' ) )
 			->getMock();
 
-		// Init the Contact_New trigger.
+		// Init the Contact_Created trigger.
 		$trigger->init( $workflow );
 
 		// Fake event data.
 		$contact_data = $this->automation_faker->contact_data();
 
-		// We expect the workflow to be executed on contact_new event with the contact data
+		// We expect the workflow to be executed on contact_created event with the contact data
 		$workflow->expects( $this->once() )
 		->method( 'execute' )
 		->with(
@@ -124,8 +124,8 @@ class Contact_Trigger_Test extends BaseTestCase {
 			$this->equalTo( $contact_data )
 		);
 
-		// Run the contact_new action.
-		do_action( 'jpcrm_automation_contact_new', $contact_data );
+		// Notify the contact_created event.
+		do_action( 'jpcrm_automation_contact_created', $contact_data );
 	}
 
 	/**

--- a/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
@@ -4,8 +4,8 @@ namespace Automattic\Jetpack\CRM\Automation\Tests;
 
 use Automattic\Jetpack\CRM\Automation\Automation_Engine;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Triggers\Event_Created;
 use Automattic\Jetpack\CRM\Automation\Triggers\Event_Deleted;
-use Automattic\Jetpack\CRM\Automation\Triggers\Event_New;
 use WorDBless\BaseTestCase;
 
 require_once __DIR__ . '../../tools/class-automation-faker.php';
@@ -14,7 +14,7 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
  * Test Automation's event triggers
  *
  * @covers Automattic\Jetpack\CRM\Automation\Triggers\Event_Deleted
- * @covers Automattic\Jetpack\CRM\Automation\Triggers\Event_New
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Event_Created
  */
 class Event_Trigger_Test extends BaseTestCase {
 
@@ -26,10 +26,10 @@ class Event_Trigger_Test extends BaseTestCase {
 	}
 
 	/**
-	 * @testdox Test the event new trigger executes the workflow with an action
+	 * @testdox Test the event created trigger executes the workflow with an action
 	 */
-	public function test_event_new_trigger() {
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/event_new' );
+	public function test_event_created_trigger() {
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/event_created' );
 
 		// Build a PHPUnit mock Automation_Workflow
 		$workflow = $this->getMockBuilder( Automation_Workflow::class )
@@ -37,14 +37,14 @@ class Event_Trigger_Test extends BaseTestCase {
 			->onlyMethods( array( 'execute' ) )
 			->getMock();
 
-		// Init the Event_New trigger.
-		$trigger = new Event_New();
+		// Init the Event_Created trigger.
+		$trigger = new Event_Created();
 		$trigger->init( $workflow );
 
 		// Fake event data.
 		$event_data = $this->automation_faker->event_data();
 
-		// We expect the workflow to be executed on event_new event with the event data.
+		// We expect the workflow to be executed on event_created event with the event data.
 		$workflow->expects( $this->once() )
 		->method( 'execute' )
 		->with(
@@ -52,8 +52,8 @@ class Event_Trigger_Test extends BaseTestCase {
 			$this->equalTo( $event_data )
 		);
 
-		// Run the event_new action.
-		do_action( 'jpcrm_event_new', $event_data );
+		// Run the event_created action.
+		do_action( 'jpcrm_event_created', $event_data );
 	}
 
 	/**

--- a/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/invoices/class-invoice-trigger-test.php
@@ -4,8 +4,8 @@ namespace Automattic\Jetpack\CRM\Automation\Tests;
 
 use Automattic\Jetpack\CRM\Automation\Automation_Engine;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Created;
 use Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Deleted;
-use Automattic\Jetpack\CRM\Automation\Triggers\Invoice_New;
 use Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Status_Updated;
 use Automattic\Jetpack\CRM\Automation\Triggers\Invoice_Updated;
 use WorDBless\BaseTestCase;
@@ -95,11 +95,11 @@ class Invoice_Trigger_Test extends BaseTestCase {
 	/**
 	 * @testdox Test the invoice new trigger executes the workflow with an action
 	 */
-	public function test_invoice_new_trigger() {
+	public function test_invoice_created_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/invoice_new' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/invoice_created' );
 
-		$trigger = new Invoice_New();
+		$trigger = new Invoice_Created();
 
 		// Build a PHPUnit mock Automation_Workflow
 		$workflow = $this->getMockBuilder( Automation_Workflow::class )
@@ -107,13 +107,13 @@ class Invoice_Trigger_Test extends BaseTestCase {
 			->onlyMethods( array( 'execute' ) )
 			->getMock();
 
-		// Init the Invoice_New trigger.
+		// Init the Invoice_Created trigger.
 		$trigger->init( $workflow );
 
 		// Fake event data.
 		$invoice_data = $this->automation_faker->invoice_data();
 
-		// We expect the workflow to be executed on invoice_new event with the invoice data
+		// We expect the workflow to be executed on invoice_created event with the invoice data
 		$workflow->expects( $this->once() )
 		->method( 'execute' )
 		->with(
@@ -121,8 +121,8 @@ class Invoice_Trigger_Test extends BaseTestCase {
 			$this->equalTo( $invoice_data )
 		);
 
-		// Run the invoice_new action.
-		do_action( 'jpcrm_automation_invoice_new', $invoice_data );
+		// Run the invoice_created action.
+		do_action( 'jpcrm_automation_invoice_created', $invoice_data );
 	}
 
 	/**

--- a/projects/plugins/crm/tests/php/automation/quotes/class-quote-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/quotes/class-quote-trigger-test.php
@@ -5,8 +5,8 @@ namespace Automattic\Jetpack\CRM\Automation\Tests;
 use Automattic\Jetpack\CRM\Automation\Automation_Engine;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Triggers\Quote_Accepted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Quote_Created;
 use Automattic\Jetpack\CRM\Automation\Triggers\Quote_Deleted;
-use Automattic\Jetpack\CRM\Automation\Triggers\Quote_New;
 use Automattic\Jetpack\CRM\Automation\Triggers\Quote_Status_Updated;
 use Automattic\Jetpack\CRM\Automation\Triggers\Quote_Updated;
 use WorDBless\BaseTestCase;
@@ -94,13 +94,13 @@ class Quote_Trigger_Test extends BaseTestCase {
 	}
 
 	/**
-	 * @testdox Test the quote new trigger executes the workflow with an action
+	 * @testdox Test the quote created trigger executes the workflow with an action
 	 */
-	public function test_quote_new_trigger() {
+	public function test_quote_created_trigger() {
 
-		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/quote_new' );
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/quote_created' );
 
-		$trigger = new Quote_New();
+		$trigger = new Quote_Created();
 
 		// Build a PHPUnit mock Automation_Workflow
 		$workflow = $this->getMockBuilder( Automation_Workflow::class )
@@ -108,13 +108,13 @@ class Quote_Trigger_Test extends BaseTestCase {
 			->onlyMethods( array( 'execute' ) )
 			->getMock();
 
-		// Init the Quote_New trigger.
+		// Init the Quote_Created trigger.
 		$trigger->init( $workflow );
 
 		// Fake event data.
 		$quote_data = $this->automation_faker->quote_data();
 
-		// We expect the workflow to be executed on quote_new event with the quote data
+		// We expect the workflow to be executed on quote_created event with the quote data
 		$workflow->expects( $this->once() )
 		->method( 'execute' )
 		->with(
@@ -122,8 +122,8 @@ class Quote_Trigger_Test extends BaseTestCase {
 			$this->equalTo( $quote_data )
 		);
 
-		// Run the quote_new action.
-		do_action( 'jpcrm_quote_new', $quote_data );
+		// Run the quote_created action.
+		do_action( 'jpcrm_quote_created', $quote_data );
 	}
 
 	/**
@@ -141,13 +141,13 @@ class Quote_Trigger_Test extends BaseTestCase {
 			->onlyMethods( array( 'execute' ) )
 			->getMock();
 
-		// Init the Quote_New trigger.
+		// Init the Quote_Created trigger.
 		$trigger->init( $workflow );
 
 		// Fake event data.
 		$quote_data = $this->automation_faker->quote_data();
 
-		// We expect the workflow to be executed on quote_new event with the quote data
+		// We expect the workflow to be executed on quote_created event with the quote data
 		$workflow->expects( $this->once() )
 		->method( 'execute' )
 		->with(
@@ -155,7 +155,7 @@ class Quote_Trigger_Test extends BaseTestCase {
 			$this->equalTo( $quote_data )
 		);
 
-		// Run the quote_new action.
+		// Notify the quote_accepted event.
 		do_action( 'jpcrm_quote_accepted', $quote_data );
 	}
 

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -116,7 +116,7 @@ class Automation_Faker {
 	 */
 	public function quote_triggers(): array {
 		return array(
-			'jpcrm/quote_new',
+			'jpcrm/quote_created',
 			'jpcrm/quote_accepted',
 			'jpcrm/quote_updated',
 			'jpcrm/quote_status_updated',
@@ -143,7 +143,7 @@ class Automation_Faker {
 	 */
 	public function event_triggers(): array {
 		return array(
-			'jpcrm/event_new',
+			'jpcrm/event_created',
 			'jpcrm/event_deleted',
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3266

## Proposed changes:

This PR renames the hook and trigger class names. Changing `_new` by the verb `_created`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Check the code
- Run the unit tests and check they all pass. Remember to update the autoloader running `composer dumpautoload`
