### PR TITLE
AI Assistant: Register ai-assistant-form-support beta extension

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-assistant-form-beta-flag
+++ b/projects/plugins/jetpack/changelog/add-ai-assistant-form-beta-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Register ai-assistant-form-support beta flag to control the form extension we are working on.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -58,3 +58,13 @@ add_action(
 		\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-support' );
 	}
 );
+
+/**
+ * Register the `ai-assistant-form-support` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-form-support' );
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -64,7 +64,8 @@
 		"recipe",
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
-		"paywall"
+		"paywall",
+		"ai-assistant-form-support"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],
 	"no-post-editor": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32156.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Register `ai-assistant-form-support` as a beta extension

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test in Simple, Atomic, and Simple sites
* Go to the block editor
* Open the dev console
* With the `beta extensions` disabled, confirm that `Jetpack_Editor_Initial_State.available_blocks[ai-assistant-form-support]` is not set:

```
Jetpack_Editor_Initial_State.available_blocks['ai-assistant-form-support']
```

<img width="500" alt="Screen Shot 2023-07-31 at 16 31 30" src="https://github.com/Automattic/jetpack/assets/6760046/d22eeb9a-5f91-4c4b-8f9d-9d2e6c28fd5a">

* With the `beta extensions` enabled, confirm that `Jetpack_Editor_Initial_State.available_blocks['ai-assistant-form-support']` is set to `available: true`:

<img width="500" alt="Screen Shot 2023-07-31 at 16 34 05" src="https://github.com/Automattic/jetpack/assets/6760046/022af9c2-4d21-4f9e-a7fd-b11a537820ee">
