### PR TITLE
AI Client: replace using CSS modules with the regular way

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-dont-use-css-modules
+++ b/projects/js-packages/ai-client/changelog/update-dont-use-css-modules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: replace using CSS modules with the regular way

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { aiAssistantIcon } from '../../icons';
-import styles from './style.module.scss';
+import './style.scss';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
@@ -61,17 +61,17 @@ export default function AIControl( {
 	const promptUserInputRef = useRef( null );
 
 	return (
-		<div className={ styles.container }>
+		<div className="jetpack-components-ai-control__container">
 			<div
-				className={ classNames( styles[ 'input-wrapper' ], {
-					[ styles[ 'is-opaque' ] ]: isOpaque,
+				className={ classNames( 'jetpack-components-ai-control__wrapper', {
+					'is-opaque': isOpaque,
 				} ) }
 			>
-				<div className={ styles[ 'icon-wrapper' ] }>
+				<div className="jetpack-components-ai-controlton__icon">
 					{ loading ? (
-						<Spinner className={ styles[ 'input-spinner' ] } />
+						<Spinner className="input-spinner" />
 					) : (
-						<Icon className={ styles[ 'input-icon' ] } icon={ aiAssistantIcon } size={ 24 } />
+						<Icon className="input-icon" icon={ aiAssistantIcon } size={ 24 } />
 					) }
 				</div>
 
@@ -79,16 +79,16 @@ export default function AIControl( {
 					value={ value }
 					onChange={ onChange }
 					placeholder={ placeholder }
-					className={ styles.input }
+					className="jetpack-components-ai-control__input"
 					disabled={ loading }
 					ref={ promptUserInputRef }
 				/>
 
-				<div className={ styles.controls }>
-					<div className={ styles.prompt_button_wrapper }>
+				<div className="jetpack-components-ai-control__controls">
+					<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
 						{ ! loading ? (
 							<Button
-								className={ styles.prompt_button }
+								className="jetpack-components-ai-control__controls-prompt_button"
 								onClick={ () => onSend( value ) }
 								isSmall={ true }
 								disabled={ value?.length }
@@ -99,7 +99,7 @@ export default function AIControl( {
 							</Button>
 						) : (
 							<Button
-								className={ styles.prompt_button }
+								className="jetpack-components-ai-control__controls-prompt_button"
 								onClick={ onStop }
 								isSmall={ true }
 								label={ __( 'Stop request', 'jetpack-ai-client' ) }
@@ -111,9 +111,9 @@ export default function AIControl( {
 					</div>
 
 					{ showAccept && (
-						<div className={ styles.prompt_button_wrapper }>
+						<div className="jetpack-components-ai-control__controls-prompt_button_wrapper">
 							<Button
-								className={ styles.prompt_button }
+								className="jetpack-components-ai-control__controls-prompt_button"
 								onClick={ onAccept }
 								isSmall={ true }
 								label={ acceptLabel }

--- a/projects/js-packages/ai-client/src/components/ai-control/style.scss
+++ b/projects/js-packages/ai-client/src/components/ai-control/style.scss
@@ -1,11 +1,11 @@
-.container {
+.jetpack-components-ai-control__container {
 	color: var( --jp-gray-80 );
 	background-color: var( --jp-white );
 	box-shadow: var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 0px 1px, var( --wp--preset--color--cyan-bluish-gray ) 0px 0px 8px;
 	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
-.input-wrapper {
+.jetpack-components-ai-control__wrapper {
 	display: flex;
 	padding: 12px 14px;
 	gap: 8px;
@@ -14,7 +14,7 @@
 		opacity: 0.4;
 	}
 
-	textarea.input {
+	textarea.jetpack-components-ai-control__input {
 		width: 100%;
         min-height: 20px;
 		flex-grow: 1;
@@ -49,7 +49,7 @@
 	}
 }
 
-.icon-wrapper {
+.jetpack-components-ai-controlton__icon {
 	flex-shrink: 0;
 	display: flex;
 	align-items: center;
@@ -71,37 +71,37 @@
 	}
 }
 
-.controls {
+.jetpack-components-ai-control__controls {
 	display: flex;
 	align-items: center;
+}
 
-	.prompt_button_wrapper {
-		text-transform: uppercase;
-		font-size: 11px;
-		font-weight: 600;
-		line-height: 16px;
-		user-select: none;
-		white-space: nowrap;
-		display: flex;
-		align-items: center;
+.jetpack-components-ai-control__controls-prompt_button_wrapper {
+	text-transform: uppercase;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 16px;
+	user-select: none;
+	white-space: nowrap;
+	display: flex;
+	align-items: center;
+}
+
+.jetpack-components-ai-control__controls-prompt_button {
+	color: var( --jp-gray-80 );
+	text-transform: uppercase;
+
+	> SVG {
+		margin-right: 4px;
 	}
 
-	.prompt_button {
-		color: var( --jp-gray-80 );
-		text-transform: uppercase;
+	&:hover,
+	&:active {
+		color: var( --wp-components-color-accent, var( --wp-admin-theme-color ) );
+	}
 
-		> SVG {
-			margin-right: 4px;
-		}
-
-		&:hover,
-		&:active {
-			color: var( --wp-components-color-accent, var( --wp-admin-theme-color ) );
-		}
-
-		&:disabled {
-			opacity: 0.6;
-			cursor: not-allowed;
-		}
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: replace using CSS modules with the regular way

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Use storybook

* Go to the storybook folder

```
cd projects/js-packages/storybook/
```

* Run the storybook app

```
pnpm run storybook:dev
```

* Confirm the styles look as before. No changes.

<img width="1079" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/8bdbae38-174d-47a9-8549-6f5c93c63ee8">

