### PR TITLE
Add Calypso path to launchpad task data

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-calypso-path-data-to-launchpad-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-calypso-path-data-to-launchpad-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: add calypso_url property to tasks where we know the Calypso page we want to show

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -30,6 +30,13 @@ class Launchpad_Task_Lists {
 	private $task_registry = array();
 
 	/**
+	 * Internal reference for the current site slug.
+	 *
+	 * @var string|null
+	 */
+	private $site_slug = null;
+
+	/**
 	 * Singleton instance
 	 *
 	 * @var Launchpad_Task_List
@@ -302,6 +309,14 @@ class Launchpad_Task_Lists {
 			$built_task['repetition_count']   = $this->load_repetition_count( $task );
 		}
 
+		if ( isset( $task['get_calypso_path'] ) ) {
+			$calypso_path = $this->load_calypso_path( $task );
+
+			if ( ! empty( $calypso_path ) ) {
+				$built_task['calypso_path'] = $calypso_path;
+			}
+		}
+
 		return $built_task;
 	}
 
@@ -311,11 +326,12 @@ class Launchpad_Task_Lists {
 	 * @param array  $item     The task or task list definition.
 	 * @param string $callback The callback to attempt to call.
 	 * @param mixed  $default  The default value, passed to the callback if it exists.
+	 * @param array  $data     Any additional data specific to the callback.
 	 * @return mixed The value returned by the callback, or the default value.
 	 */
-	private function load_value_from_callback( $item, $callback, $default = '' ) {
+	private function load_value_from_callback( $item, $callback, $default = '', $data = array() ) {
 		if ( isset( $item[ $callback ] ) && is_callable( $item[ $callback ] ) ) {
-			return call_user_func_array( $item[ $callback ], array( $item, $default ) );
+			return call_user_func_array( $item[ $callback ], array( $item, $default, $data ) );
 		}
 		return $default;
 	}
@@ -384,6 +400,35 @@ class Launchpad_Task_Lists {
 	 */
 	private function load_repetition_count( $task ) {
 		return $this->load_value_from_callback( $task, 'repetition_count_callback' );
+	}
+
+	/**
+	 * Helper function to load the Calypso path for a task.
+	 *
+	 * @param array $task A task definition.
+	 * @return string|null
+	 */
+	private function load_calypso_path( $task ) {
+		if ( null === $this->site_slug ) {
+			$this->site_slug = wpcom_launchpad_get_site_slug();
+		}
+
+		$data = array(
+			'site_slug' => $this->site_slug,
+		);
+
+		$calypso_path = $this->load_value_from_callback( $task, 'get_calypso_path', null, $data );
+
+		if ( ! is_string( $calypso_path ) ) {
+			return null;
+		}
+
+		// Require that the string start with `/`, but don't allow `//`.
+		if ( '/' !== substr( $calypso_path, 0, 1 ) || '/' === substr( $calypso_path, 1, 1 ) ) {
+			return null;
+		}
+
+		return $calypso_path;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -414,7 +414,8 @@ class Launchpad_Task_Lists {
 		}
 
 		$data = array(
-			'site_slug' => $this->site_slug,
+			'site_slug'         => $this->site_slug,
+			'site_slug_encoded' => rawurlencode( $this->site_slug ),
 		);
 
 		$calypso_path = $this->load_value_from_callback( $task, 'get_calypso_path', null, $data );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -350,6 +350,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_has_goal_import_subscribers',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/subscribers/' . $data['site_slug_encoded'];
+			},
 		),
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -22,7 +22,7 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
-				return '/site-editor/' . rawurlencode( $data['site_slug'] );
+				return '/site-editor/' . $data['site_slug_encoded'];
 			},
 		),
 		// design_completed checks for task completion while design_selected always returns true.
@@ -46,7 +46,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_is_domain_claim_completed',
 			'is_visible_callback'  => 'wpcom_domain_claim_is_visible_callback',
 			'get_task_url'         => function ( $task, $default, $data ) {
-				return '/domains/add/' . rawurlencode( $data['site_slug'] );
+				return '/domains/add/' . $data['site_slug_encoded'];
 			},
 		),
 		'domain_upsell'                   => array(
@@ -58,7 +58,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
 			'is_visible_callback'  => 'wpcom_is_domain_upsell_task_visible',
 			'get_task_url'         => function ( $task, $default, $data ) {
-				return '/domains/add/' . rawurlencode( $data['site_slug'] );
+				return '/domains/add/' . $data['site_slug_encoded'];
 			},
 		),
 		'first_post_published'            => array(
@@ -69,7 +69,7 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
-				return '/post/' . rawurlencode( $data['site_slug'] );
+				return '/post/' . $data['site_slug_encoded'];
 			},
 		),
 		'plan_completed'                  => array(
@@ -101,7 +101,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'isLaunchTask'          => true,
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
 			'get_task_url'          => function ( $task, $default, $data ) {
-				return '/settings/general/' . rawurlencode( $data['site_slug'] ) . '#site-privacy-settings';
+				return '/settings/general/' . $data['site_slug_encoded'] . '#site-privacy-settings';
 			},
 		),
 		'verify_email'                    => array(
@@ -124,7 +124,7 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
-				return '/post/' . rawurlencode( $data['site_slug'] );
+				return '/post/' . $data['site_slug_encoded'];
 			},
 		),
 		'newsletter_plan_created'         => array(
@@ -172,7 +172,7 @@ function wpcom_launchpad_get_task_definitions() {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
-				return '/site-editor/' . rawurlencode( $data['site_slug'] );
+				return '/site-editor/' . $data['site_slug_encoded'];
 			},
 		),
 		'setup_link_in_bio'               => array(
@@ -247,7 +247,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/settings/general/' . rawurlencode( $data['site_slug'] );
+				return '/settings/general/' . $data['site_slug_encoded'];
 			},
 		),
 
@@ -257,7 +257,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/marketing/connections/' . rawurlencode( $data['site_slug'] );
+				return '/marketing/connections/' . $data['site_slug_encoded'];
 			},
 		),
 
@@ -267,7 +267,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/page/' . rawurlencode( $data['site_slug'] );
+				return '/page/' . $data['site_slug_encoded'];
 			},
 		),
 
@@ -283,7 +283,7 @@ function wpcom_launchpad_get_task_definitions() {
 				);
 			},
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/page/' . rawurlencode( $data['site_slug'] ) . '/' . wpcom_get_site_about_page_id();
+				return '/page/' . $data['site_slug_encoded'] . '/' . wpcom_get_site_about_page_id();
 			},
 		),
 
@@ -294,7 +294,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_is_edit_page_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/pages/' . rawurlencode( $data['site_slug'] );
+				return '/pages/' . $data['site_slug_encoded'];
 			},
 		),
 
@@ -306,7 +306,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_is_domain_customize_completed',
 			'is_visible_callback'  => 'wpcom_is_domain_customize_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/domains/add/' . rawurlencode( $data['site_slug'] );
+				return '/domains/add/' . $data['site_slug_encoded'];
 			},
 		),
 
@@ -324,7 +324,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/earn/' . rawurlencode( $data['site_slug'] );
+				return '/earn/' . $data['site_slug_encoded'];
 			},
 		),
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -21,6 +21,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'add_listener_callback' => function () {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
 			},
+			'get_calypso_path'      => function ( $task, $default, $data ) {
+				return '/site-editor/' . rawurlencode( $data['site_slug'] );
+			},
 		),
 		// design_completed checks for task completion while design_selected always returns true.
 		'design_completed'                => array(
@@ -42,6 +45,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_domain_claim_completed',
 			'is_visible_callback'  => 'wpcom_domain_claim_is_visible_callback',
+			'get_task_url'         => function ( $task, $default, $data ) {
+				return '/domains/add/' . rawurlencode( $data['site_slug'] );
+			},
 		),
 		'domain_upsell'                   => array(
 			'id_map'               => 'domain_upsell_deferred',
@@ -51,6 +57,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_is_domain_upsell_completed',
 			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
 			'is_visible_callback'  => 'wpcom_is_domain_upsell_task_visible',
+			'get_task_url'         => function ( $task, $default, $data ) {
+				return '/domains/add/' . rawurlencode( $data['site_slug'] );
+			},
 		),
 		'first_post_published'            => array(
 			'get_title'             => function () {
@@ -58,6 +67,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'add_listener_callback' => function () {
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
+			},
+			'get_calypso_path'      => function ( $task, $default, $data ) {
+				return '/post/' . rawurlencode( $data['site_slug'] );
 			},
 		),
 		'plan_completed'                  => array(
@@ -88,12 +100,18 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'isLaunchTask'          => true,
 			'add_listener_callback' => 'wpcom_add_site_launch_listener',
+			'get_task_url'          => function ( $task, $default, $data ) {
+				return '/settings/general/' . rawurlencode( $data['site_slug'] ) . '#site-privacy-settings';
+			},
 		),
 		'verify_email'                    => array(
 			'get_title'           => function () {
 				return __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback' => 'wpcom_launchpad_is_email_unverified',
+			'get_task_url'        => function () {
+				return '/me/account';
+			},
 		),
 
 		// Newsletter pre-launch tasks.
@@ -104,6 +122,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'add_listener_callback' => function () {
 				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
+			},
+			'get_calypso_path'      => function ( $task, $default, $data ) {
+				return '/post/' . rawurlencode( $data['site_slug'] );
 			},
 		),
 		'newsletter_plan_created'         => array(
@@ -149,6 +170,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'id_map'                => 'links_edited',
 			'add_listener_callback' => function () {
 				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
+			},
+			'get_calypso_path'      => function ( $task, $default, $data ) {
+				return '/site-editor/' . rawurlencode( $data['site_slug'] );
 			},
 		),
 		'setup_link_in_bio'               => array(
@@ -222,6 +246,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Give your site a name', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/settings/general/' . rawurlencode( $data['site_slug'] );
+			},
 		),
 
 		'drive_traffic'                   => array(
@@ -229,6 +256,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Drive traffic to your site', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/marketing/connections/' . rawurlencode( $data['site_slug'] );
+			},
 		),
 
 		'add_new_page'                    => array(
@@ -236,6 +266,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Add a new page', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/page/' . rawurlencode( $data['site_slug'] );
+			},
 		),
 
 		'update_about_page'               => array(
@@ -249,6 +282,9 @@ function wpcom_launchpad_get_task_definitions() {
 					'about_page_id' => wpcom_get_site_about_page_id(),
 				);
 			},
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/page/' . rawurlencode( $data['site_slug'] ) . '/' . wpcom_get_site_about_page_id();
+			},
 		),
 
 		'edit_page'                       => array(
@@ -257,6 +293,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_is_edit_page_task_visible',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/pages/' . rawurlencode( $data['site_slug'] );
+			},
 		),
 
 		'domain_customize'                => array(
@@ -266,6 +305,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_domain_customize_completed',
 			'is_visible_callback'  => 'wpcom_is_domain_customize_task_visible',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/domains/add/' . rawurlencode( $data['site_slug'] );
+			},
 		),
 
 		'share_site'                      => array(
@@ -281,6 +323,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Earn money with your newsletter', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/earn/' . rawurlencode( $data['site_slug'] );
+			},
 		),
 
 		'customize_welcome_message'       => array(
@@ -575,6 +620,36 @@ function wpcom_get_plan_selected_badge_text() {
 	}
 
 	return wpcom_global_styles_in_use() && wpcom_should_limit_global_styles() ? __( 'Upgrade plan', 'jetpack-mu-wpcom' ) : '';
+}
+
+/**
+ * Helper function to return the site slug for Calypso URLs.
+ * The fallback logic here is derived from the following code:
+ *
+ * @see https://github.com/Automattic/wc-calypso-bridge/blob/85664e2c7836b2ddc29e99871ec2c5dc4015bcc8/class-wc-calypso-bridge.php#L227-L251
+ *
+ * @return string
+ */
+function wpcom_launchpad_get_site_slug() {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && class_exists( 'WPCOM_Masterbar' ) && method_exists( 'WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
+		return WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
+	}
+
+	// The Jetpack class should be auto-loaded if Jetpack has been loaded,
+	// but we've seen fatal errors from cases where the class wasn't defined.
+	// So let's make double-sure it exists before calling it.
+	if ( class_exists( '\Automattic\Jetpack\Status' ) ) {
+		$jetpack_status = new \Automattic\Jetpack\Status();
+
+		return $jetpack_status->get_site_suffix();
+	}
+
+	// If the Jetpack Status class doesn't exist, fall back on site_url()
+	// with any trailing '/' characters removed.
+	$site_url = untrailingslashit( site_url( '/', 'https' ) );
+
+	// Remove the leading 'https://' and replace any remaining `/` characters with ::
+	return str_replace( '/', '::', substr( $site_url, 8 ) );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -333,6 +333,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Customize welcome message', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/settings/reading/' . $data['site_slug_encoded'] . ' #newsletter-settings';
+			},
 		),
 		'enable_subscribers_modal'        => array(
 			'get_title'            => function () {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -254,4 +254,86 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 1, $first_task['repetition_count'] );
 		$this->assertEquals( 2, $first_task['target_repetitions'] );
 	}
+
+	/**
+	 * Data provider for {@see test_get_calypso_path_validation()}.
+	 *
+	 * @return array
+	 */
+	public function provide_get_calypso_path_validation_test_cases() {
+		return array(
+			'Full URL is rejected'                       => array(
+				'https://example.com/invalid-full-url',
+				null,
+			),
+			'Same-protocol URL is rejected'              => array(
+				'//example.com/invalid-protocol-url',
+				null,
+			),
+			'Relative URL without leading / is rejected' => array(
+				'test/relative-url-invalid',
+				null,
+			),
+			'Null value is rejected'                     => array(
+				null,
+				null,
+			),
+			'Empty string is rejected'                   => array(
+				'',
+				null,
+			),
+			'Valid absolute path is accepted'            => array(
+				'/test/example',
+				'/test/example',
+			),
+		);
+	}
+
+	/**
+	 * Test that we correctly validate return values from the
+	 * `get_calypso_path` callback for tasks.
+	 *
+	 * @dataProvider provide_get_calypso_path_validation_test_cases()
+	 * @param string|null $calypso_path_to_test The path to test.
+	 * @param string|null $expected_path        The path we expect to be returned.
+	 * @return void
+	 */
+	public function test_get_calypso_path_validation( $calypso_path_to_test, $expected_path ) {
+		wpcom_register_launchpad_task(
+			array(
+				'id'               => 'test-get-calypso-path-validation',
+				'title'            => 'Test get_calypso_path validation',
+				'get_calypso_path' => function () use ( $calypso_path_to_test ) {
+					return $calypso_path_to_test;
+				},
+			)
+		);
+
+		wpcom_launchpad_checklists()->unregister_task_list( 'test-get-calypso-path-validation-task-list' );
+		wpcom_register_launchpad_task_list(
+			array(
+				'id'       => 'test-get-calypso-path-validation-task-list',
+				'title'    => 'Test task list for testing get_calypso_path validation',
+				'task_ids' => array( 'test-get-calypso-path-validation' ),
+			)
+		);
+
+		$tasks = wpcom_get_launchpad_checklist_by_checklist_slug( 'test-get-calypso-path-validation-task-list' );
+
+		$this->assertIsArray( $tasks );
+		$this->assertCount( 1, $tasks );
+
+		$first_task = reset( $tasks );
+
+		$this->assertIsArray( $first_task );
+		$this->assertArrayHasKey( 'id', $first_task );
+		$this->assertSame( 'test-get-calypso-path-validation', $first_task['id'] );
+
+		if ( null === $expected_path ) {
+			$this->assertArrayNotHasKey( 'calypso_path', $first_task );
+		} else {
+			$this->assertArrayHasKey( 'calypso_path', $first_task );
+			$this->assertSame( $expected_path, $first_task['calypso_path'] );
+		}
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

The core change in this PR involves returning a new `calypso_path` string for tasks where we know what Calypso page we want to take users to for that task. The goal of the change is to simplify new task creation by ensuring that we don't need separate Calypso PRs to add specific handling for each new task. Instead, we can simply generate the right path on the server and add generic handling to the client code so that we only have one place to change code for tasks.

The implementation is handled by the following changes:
 * The generic `load_value_from_callback()` helper now takes an additional `$data` argument, which defaults to `array()`, and allows callers to pass in context-specific data, which is then passed to the callback.
 * Tasks can specify a new `get_calypso_path` callback, which accepts three arguments, `$task`, `$default`, and `$data`, where `$data['site_slug']` will contain the site slug and `$data['site_slug_encoded']` will contain the URL-encoded site slug
    - Note that we use `WPCOM_Masterbar::get_calypso_site_slug()` to compute the site slug when that class and function exist, but we fall back on `Automattic\Jetpack\Status->get_site_suffix()`, and then process `site_url()`. The fallbacks here are borrowed from https://github.com/Automattic/wc-calypso-bridge/blob/85664e2c7836b2ddc29e99871ec2c5dc4015bcc8/class-wc-calypso-bridge.php#L227-L251
 * The task list code validates that the returned path is an absolute path of the form `/some/path`

A separate patch in Calypso will update the client-side handling.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No product discussion as this is specifically intended for WordPress.com sites.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to data or tracking.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the changes in this patch to your WordPress.com development system
* Navigate to a site with a launchpad shown in Customer Home
* Verify that the tasks return valid `calypso_path` values where expected