### PR TITLE
Subscriptions: disable option toggles  when user isn't connected

### DIFF
--- a/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
+++ b/projects/plugins/jetpack/_inc/client/discussion/subscriptions.jsx
@@ -124,7 +124,7 @@ class SubscriptionsComponent extends React.Component {
 				>
 					<ModuleToggle
 						slug="subscriptions"
-						disabled={ unavailableInOfflineMode }
+						disabled={ unavailableInOfflineMode || ! this.props.isLinked }
 						activated={ isSubscriptionsActive }
 						toggling={ this.props.isSavingAnyOption( 'subscriptions' ) }
 						toggleModule={ this.props.toggleModuleNow }
@@ -138,7 +138,8 @@ class SubscriptionsComponent extends React.Component {
 								disabled={
 									! isSubscriptionsActive ||
 									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'subscriptions' ] )
+									this.props.isSavingAnyOption( [ 'subscriptions' ] ) ||
+									! this.props.isLinked
 								}
 								toggling={ this.props.isSavingAnyOption( [ 'stb_enabled' ] ) }
 								onChange={ this.handleSubscribeToBlogToggleChange }
@@ -152,7 +153,8 @@ class SubscriptionsComponent extends React.Component {
 								disabled={
 									! isSubscriptionsActive ||
 									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'subscriptions' ] )
+									this.props.isSavingAnyOption( [ 'subscriptions' ] ) ||
+									! this.props.isLinked
 								}
 								toggling={ this.props.isSavingAnyOption( [ 'stc_enabled' ] ) }
 								onChange={ this.handleSubscribeToCommentToggleChange }
@@ -168,7 +170,8 @@ class SubscriptionsComponent extends React.Component {
 										disabled={
 											! isSubscriptionsActive ||
 											unavailableInOfflineMode ||
-											this.props.isSavingAnyOption( [ 'subscriptions' ] )
+											this.props.isSavingAnyOption( [ 'subscriptions' ] ) ||
+											! this.props.isLinked
 										}
 										toggling={ this.props.isSavingAnyOption( [ 'sm_enabled' ] ) }
 										onChange={ this.handleSubscribeModalToggleChange }

--- a/projects/plugins/jetpack/changelog/update-subscriptions-disabled-user-connection
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-disabled-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: do not allow toggling the Subscriptions feature on or off when the user is not connected.


### PR DESCRIPTION
## Proposed changes:

When the site is only site-connected, subscriptions should not be available.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1690883318178689-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a blank site.
* Connect it to WordPress.com, but do not connect the user.
* Go to Jetpack > Settings > Discussion
* You should not be able to toggle Subscriptions options on or off.
