### PR TITLE
Paid Content Block: ensure gating works on self-hosted sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-premium-on-self-hosted
+++ b/projects/plugins/jetpack/changelog/fix-premium-on-self-hosted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Ficx issue with Paid-content block on self-hosted env by enabling sub-blocks

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/logged-out-view/logged-out-view.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Extensions\Premium_Content;
 
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
 const LOGGEDOUT_VIEW_NAME = 'premium-content/logged-out-view';
@@ -21,20 +20,17 @@ require_once dirname( __DIR__ ) . '/_inc/access-check.php';
  * registration if we need to.
  */
 function register_loggedout_view_block() {
-	// Only load this block on WordPress.com.
-	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site() ) {
-		// Determine required `context` key based on Gutenberg version.
-		$deprecated = function_exists( 'gutenberg_get_post_from_context' );
-		$uses       = $deprecated ? 'context' : 'uses_context';
+	// Determine required `context` key based on Gutenberg version.
+	$deprecated = function_exists( 'gutenberg_get_post_from_context' );
+	$uses       = $deprecated ? 'context' : 'uses_context';
 
-		Blocks::jetpack_register_block(
-			LOGGEDOUT_VIEW_NAME,
-			array(
-				'render_callback' => __NAMESPACE__ . '\render_loggedout_view_block',
-				$uses             => array( 'premium-content/planId' ),
-			)
-		);
-	}
+	Blocks::jetpack_register_block(
+		LOGGEDOUT_VIEW_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_loggedout_view_block',
+			$uses             => array( 'premium-content/planId' ),
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_loggedout_view_block' );
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
@@ -9,7 +9,6 @@ namespace Automattic\Jetpack\Extensions\Premium_Content;
 
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
-use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
 require_once dirname( __DIR__ ) . '/_inc/subscription-service/include.php';
@@ -22,15 +21,12 @@ const LOGIN_BUTTON_NAME = 'premium-content/login-button';
  * registration if we need to.
  */
 function register_login_button_block() {
-	// Only load this block on WordPress.com.
-	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site() ) {
-		Blocks::jetpack_register_block(
-			LOGIN_BUTTON_NAME,
-			array(
-				'render_callback' => __NAMESPACE__ . '\render_login_button_block',
-			)
-		);
-	}
+	Blocks::jetpack_register_block(
+		LOGIN_BUTTON_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_login_button_block',
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_login_button_block' );
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/subscriber-view.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/subscriber-view/subscriber-view.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Extensions\Premium_Content;
 
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
 const SUBSCRIBER_VIEW_NAME = 'premium-content/subscriber-view';
@@ -21,20 +20,17 @@ require_once dirname( __DIR__ ) . '/_inc/access-check.php';
  * registration if we need to.
  */
 function register_subscriber_view_block() {
-	// Only load this block on WordPress.com.
-	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site() ) {
-		// Determine required `context` key based on Gutenberg version.
-		$deprecated = function_exists( 'gutenberg_get_post_from_context' );
-		$uses       = $deprecated ? 'context' : 'uses_context';
+	// Determine required `context` key based on Gutenberg version.
+	$deprecated = function_exists( 'gutenberg_get_post_from_context' );
+	$uses       = $deprecated ? 'context' : 'uses_context';
 
-		Blocks::jetpack_register_block(
-			SUBSCRIBER_VIEW_NAME,
-			array(
-				'render_callback' => __NAMESPACE__ . '\render_subscriber_view_block',
-				$uses             => array( 'premium-content/planId' ),
-			)
-		);
-	}
+	Blocks::jetpack_register_block(
+		SUBSCRIBER_VIEW_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_subscriber_view_block',
+			$uses             => array( 'premium-content/planId' ),
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_subscriber_view_block' );
 


### PR DESCRIPTION
Follow-up from #30868

## Proposed changes:

Now that the main Premium Content block is available on self-hosted sites, sub-components must be available as well.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1690874836677279-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Connect a brand new site to WordPress.com.
* Go to Posts > Add New and insert a Paid Content block
* Connect your site to Stripe and set up a payment plan
* Add content that will only be visible to logged in users / paid subscribers
* Ensure that content isn't visible in an incognito window.