### PR TITLE
Paywall Block: register only if Subscription module

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-block-restrictions
+++ b/projects/plugins/jetpack/changelog/update-paywall-block-restrictions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: minor change
+
+

--- a/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
@@ -21,6 +21,10 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
+	// check if the subscription module is enabled
+	if ( ! class_exists( '\Jetpack_Memberships' ) ) {
+		return;
+	}
 	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )

--- a/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
@@ -21,7 +21,6 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	// check if the subscription module is enabled
 	if ( ! \Jetpack::is_module_active( 'subscriptions' ) ) {
 		return;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
@@ -22,9 +22,13 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  */
 function register_block() {
 	// check if the subscription module is enabled
+	if ( ! \Jetpack::is_module_active( 'subscriptions' ) ) {
+		return;
+	}
 	if ( ! class_exists( '\Jetpack_Memberships' ) ) {
 		return;
 	}
+
 	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )


### PR DESCRIPTION
Related #32124

## Proposed changes:
Register Paywall block only if Subscription module is activated 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Turn subscription module on/off and check if the block is available. 

