### PR TITLE
Launchpad: Re-add the update_about_page task to the intent-build list.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-re-add-update-about-page-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-re-add-update-about-page-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+This re-adds the update_about_page task to the intent-build list

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -139,6 +139,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'drive_traffic',
 				'edit_page',
 				'share_site',
+				'update_about_page',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to #31966 and #31905

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When we renamed the `keep-building` list to `intent-build`, the `update_about_page` task got lost.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Since the `update_about_page` code is still there and hasn't changed, visual inspection should be fine.

Otherwise you can do a simple, English-locale test. Detailed instructions for testing multiple locales can be found in #31966.

* Apply this patch and sandbox the public-api.
* Go to `/start` and create a new Free site and select the "Promote myself or business" goal.
* Select the Barsnbury23 theme.
* Launch the site.
* You should see the "Update your About page" task.
* Click the task and edit the about page. When you return to next steps, the task should be marked complete.

