### PR TITLE
AI Assistant: show/hide assistant container for Jetpack Form block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-add-extension-component
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-add-extension-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: show/hide assistant container for Jetpack Form block

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { KeyboardShortcuts, Popover } from '@wordpress/components';
+import { useContext } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { AiAssistantUiContext } from '../../ui-handler/context';
+import './style.scss';
+
+export const AiAssistantPopover = () => {
+	const { toggle, isVisible } = useContext( AiAssistantUiContext );
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	return (
+		<Popover className="jetpack-ai-assistant__popover">
+			<KeyboardShortcuts
+				bindGlobal
+				shortcuts={ {
+					'mod+/': toggle,
+				} }
+			>
+				[ AI Client Component here ]
+			</KeyboardShortcuts>
+		</Popover>
+	);
+};

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -10,14 +10,14 @@ import { AiAssistantUiContext } from '../../ui-handler/context';
 import './style.scss';
 
 export const AiAssistantPopover = () => {
-	const { toggle, isVisible } = useContext( AiAssistantUiContext );
+	const { toggle, isVisible, popoverProps } = useContext( AiAssistantUiContext );
 
 	if ( ! isVisible ) {
 		return null;
 	}
 
 	return (
-		<Popover className="jetpack-ai-assistant__popover">
+		<Popover { ...popoverProps } className="jetpack-ai-assistant__popover">
 			<KeyboardShortcuts
 				bindGlobal
 				shortcuts={ {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
@@ -1,0 +1,9 @@
+.jetpack-ai-assistant__popover {
+	.components-popover__content {
+		display: flex;
+		min-width: 400px;
+		padding: 6px;
+		min-height: 40px;
+		align-items: center;
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
@@ -5,9 +5,31 @@ import { createContext } from '@wordpress/element';
 
 type AiAssistantUiContextProps = {
 	isVisible: boolean;
+
+	popoverProps?: {
+		anchor: HTMLElement | null;
+		offset?: number;
+		placement?:
+			| 'top'
+			| 'top-start'
+			| 'top-end'
+			| 'right'
+			| 'right-start'
+			| 'right-end'
+			| 'bottom'
+			| 'bottom-start'
+			| 'bottom-end'
+			| 'left'
+			| 'left-start'
+			| 'left-end'
+			| 'overlay';
+	};
+
 	show: () => void;
 	hide: () => void;
 	toggle: () => void;
+
+	setPopoverProps: ( props: AiAssistantUiContextProps[ 'popoverProps' ] ) => void;
 };
 
 type AiAssistantUiContextProviderProps = {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -8,6 +8,7 @@ import { useState, useMemo, useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { isPossibleToExtendJetpackFormBlock } from '..';
+import { AiAssistantPopover } from '../components/ai-assistant-popover';
 import { AiAssistantUiContextProps, AiAssistantUiContextProvider } from './context';
 
 const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => {
@@ -80,6 +81,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 						},
 					} }
 				>
+					<AiAssistantPopover />
 					<BlockListBlock { ...props } />
 				</KeyboardShortcuts>
 			</AiAssistantUiContextProvider>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -8,12 +8,18 @@ import { useState, useMemo, useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { isPossibleToExtendJetpackFormBlock } from '..';
-import { AiAssistantUiContextProvider } from './context';
+import { AiAssistantUiContextProps, AiAssistantUiContextProvider } from './context';
 
 const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => {
 	return props => {
 		// AI Assistant component visibility
 		const [ isVisible, setAssistantVisibility ] = useState( false );
+		const [ popoverProps, setPopoverProps ] = useState<
+			AiAssistantUiContextProps[ 'popoverProps' ]
+		>( {
+			anchor: null,
+			placement: 'bottom',
+		} );
 
 		/**
 		 * Show the AI Assistant
@@ -46,11 +52,15 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		const contextValue = useMemo(
 			() => ( {
 				isVisible,
+				popoverProps,
+
 				show,
 				hide,
 				toggle,
+
+				setPopoverProps,
 			} ),
-			[ isVisible, show, hide, toggle ]
+			[ isVisible, popoverProps, show, hide, toggle ]
 		);
 
 		/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a container component (a Popover under the hood) to place the [AI Control component](https://github.com/Automattic/jetpack/blob/trunk/projects/js-packages/ai-client/src/components/ai-control/index.tsx).

On this PR:

* Create the AiAssistantPopover component
* populates the UI context to be able to set Popover properties
* Show/Hide the popover from the toolbar button 
* Show/Hide the popover by keypressing `CMD + /`

Follow-up tasks:

* Add the AI Control
* Anchor the popover in a better place

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Assistant: show/hide assistant container for Jetpack Form block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to 'the block editor
* Ensure `beta` extensions are enabled
* Create a Jetpack From Block instance
* Click on the AI button toolbar
* Confirm it shows/hides the component
* Type `CMD + /`. Confirm same behavior the above

https://github.com/Automattic/jetpack/assets/77539/83c545b2-24ca-4780-9708-bc31f9f4ceb2

