### PR TITLE
Paywall: restrict to posts only

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-restrict-to-posts
+++ b/projects/plugins/jetpack/changelog/update-paywall-restrict-to-posts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: minor
+
+

--- a/projects/plugins/jetpack/extensions/blocks/paywall/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/editor.js
@@ -1,9 +1,10 @@
+import { unregisterBlockType } from '@wordpress/blocks';
+import { subscribe, select } from '@wordpress/data';
 import registerJetpackBlock from '../../shared/register-jetpack-block';
 import { name, settings } from '.';
 
-/* global wp */
-const unsubscribe = wp.data.subscribe( () => {
-	const postType = wp.data.select( 'core/editor' ).getCurrentPostType();
+const unsubscribe = subscribe( () => {
+	const postType = select( 'core/editor' ).getCurrentPostType();
 
 	// If postType is still not available, simply return and wait for the next call.
 	if ( postType === null ) {
@@ -12,7 +13,7 @@ const unsubscribe = wp.data.subscribe( () => {
 	unsubscribe();
 	// If postType is defined and not 'post', unregister the block.
 	if ( postType && postType !== 'post' ) {
-		wp.blocks.unregisterBlockType( 'jetpack/' + name );
+		unregisterBlockType( 'jetpack/' + name );
 	}
 } );
 

--- a/projects/plugins/jetpack/extensions/blocks/paywall/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/editor.js
@@ -1,4 +1,19 @@
 import registerJetpackBlock from '../../shared/register-jetpack-block';
 import { name, settings } from '.';
 
+/* global wp */
+const unsubscribe = wp.data.subscribe( () => {
+	const postType = wp.data.select( 'core/editor' ).getCurrentPostType();
+
+	// If postType is still not available, simply return and wait for the next call.
+	if ( postType === null ) {
+		return;
+	}
+	unsubscribe();
+	// If postType is defined and not 'post', unregister the block.
+	if ( postType && postType !== 'post' ) {
+		wp.blocks.unregisterBlockType( 'jetpack/' + name );
+	}
+} );
+
 registerJetpackBlock( name, settings );


### PR DESCRIPTION
Related https://github.com/Automattic/jetpack/issues/32124

## Proposed changes:
* Unregister the Paywall block from non `post` editors as the subscription module only works with posts right now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that only when editing posts you can pick the Paywall block

