### PR TITLE
AI Extension: connect data context with components

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-connect-with-ai-data-context
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-connect-with-ai-data-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extesion: connect AI Data context with components

--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-connect-with-ai-data-context
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-connect-with-ai-data-context
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI Extesion: connect AI Data context with components
+AI Extension: Connect AI Data context with components

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -32,22 +32,24 @@ export const AiAssistantPopover = () => {
 					'mod+/': toggle,
 				} }
 			>
-				<TextControl onChange={ setInputValue } value={ inputValue } disabled={ isDisabled } />
+				<div className="jetpack-ai-assistant__popover-container">
+					<TextControl onChange={ setInputValue } value={ inputValue } disabled={ isDisabled } />
 
-				<Button
-					variant="primary"
-					onClick={ () => {
-						const prompt = getPrompt( PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, {
-							request: inputValue,
-							content: '',
-						} );
+					<Button
+						variant="primary"
+						onClick={ () => {
+							const prompt = getPrompt( PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, {
+								request: inputValue,
+								content: '',
+							} );
 
-						requestSuggestion( prompt );
-					} }
-					disabled={ isDisabled }
-				>
-					{ __( 'Ask', 'jetpack' ) }
-				</Button>
+							requestSuggestion( prompt );
+						} }
+						disabled={ isDisabled }
+					>
+						{ __( 'Ask', 'jetpack' ) }
+					</Button>
+				</div>
 			</KeyboardShortcuts>
 		</Popover>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -1,16 +1,24 @@
 /**
  * External dependencies
  */
-import { KeyboardShortcuts, Popover } from '@wordpress/components';
+import { useAiContext } from '@automattic/jetpack-ai-client';
+import { Button, KeyboardShortcuts, Popover, TextControl } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, getPrompt } from '../../../../lib/prompt';
 import { AiAssistantUiContext } from '../../ui-handler/context';
 import './style.scss';
 
 export const AiAssistantPopover = () => {
-	const { toggle, isVisible, popoverProps } = useContext( AiAssistantUiContext );
+	const { toggle, isVisible, popoverProps, inputValue, setInputValue } =
+		useContext( AiAssistantUiContext );
+
+	const { requestSuggestion, requestingState } = useAiContext();
+
+	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 
 	if ( ! isVisible ) {
 		return null;
@@ -24,7 +32,22 @@ export const AiAssistantPopover = () => {
 					'mod+/': toggle,
 				} }
 			>
-				[ AI Client Component here ]
+				<TextControl onChange={ setInputValue } value={ inputValue } disabled={ isDisabled } />
+
+				<Button
+					variant="primary"
+					onClick={ () => {
+						const prompt = getPrompt( PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, {
+							request: inputValue,
+							content: '',
+						} );
+
+						requestSuggestion( prompt );
+					} }
+					disabled={ isDisabled }
+				>
+					{ __( 'Ask', 'jetpack' ) }
+				</Button>
 			</KeyboardShortcuts>
 		</Popover>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
@@ -7,3 +7,17 @@
 		align-items: center;
 	}
 }
+
+/*
+ * temporary styles
+ * @todo removes when integrates the AI Control component
+ */
+ .jetpack-ai-assistant__popover-container {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+
+	.components-text-control__input {
+		min-width: 300px;
+	};
+ }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -1,7 +1,7 @@
 /*
  * External dependencies
  */
-import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
+import { aiAssistantIcon, useAiContext } from '@automattic/jetpack-ai-client';
 import { ToolbarButton } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -13,16 +13,19 @@ import { AiAssistantUiContext } from '../../ui-handler/context';
 
 export default function AiAssistantToolbarButton(): React.ReactElement {
 	const { isVisible, toggle } = useContext( AiAssistantUiContext );
+	const { requestingState } = useAiContext();
+
+	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 
 	return (
 		<ToolbarButton
 			showTooltip
 			onClick={ toggle }
 			aria-haspopup="true"
-			aria-expanded={ true }
-			label={ __( 'AI Assistant', 'jetpack' ) }
+			aria-expanded={ isVisible }
+			label={ __( 'Ask AI Assistant', 'jetpack' ) }
 			icon={ aiAssistantIcon }
-			disabled={ false }
+			disabled={ isDisabled }
 			isActive={ isVisible }
 		/>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -1,6 +1,7 @@
 /*
  * External dependencies
  */
+import { withAiDataProvider } from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -100,3 +101,5 @@ addFilter(
 	withUiHandlerDataProvider,
 	100
 );
+
+addFilter( 'editor.BlockListBlock', 'jetpack/ai-assistant-block-list', withAiDataProvider, 110 );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
@@ -3,7 +3,9 @@
  */
 import { createContext } from '@wordpress/element';
 
-type AiAssistantUiContextProps = {
+export type AiAssistantUiContextProps = {
+	inputValue: string;
+
 	isVisible: boolean;
 
 	popoverProps?: {
@@ -24,6 +26,8 @@ type AiAssistantUiContextProps = {
 			| 'left-end'
 			| 'overlay';
 	};
+
+	setInputValue: ( value: string ) => void;
 
 	show: () => void;
 	hide: () => void;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -13,6 +13,9 @@ import { AiAssistantUiContextProps, AiAssistantUiContextProvider } from './conte
 
 const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => {
 	return props => {
+		// AI Assistant input value
+		const [ inputValue, setInputValue ] = useState( '' );
+
 		// AI Assistant component visibility
 		const [ isVisible, setAssistantVisibility ] = useState( false );
 		const [ popoverProps, setPopoverProps ] = useState<
@@ -52,16 +55,17 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		// Build the context value to pass to the provider.
 		const contextValue = useMemo(
 			() => ( {
+				inputValue,
 				isVisible,
 				popoverProps,
 
+				setInputValue,
 				show,
 				hide,
 				toggle,
-
 				setPopoverProps,
 			} ),
-			[ isVisible, popoverProps, show, hide, toggle ]
+			[ inputValue, isVisible, popoverProps, show, hide, toggle ]
 		);
 
 		/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# Do not merge: branched off from https://github.com/Automattic/jetpack/pull/32189~

This PR adds simple TextArea and Button components into the assistant container component to check the connection between the AI Data context and the UI. In other words, we'll be able to request and gets data to/from the AI service.

Follow-up: Integrate AI Control with the Assistant component
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: connect data context with components

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Open the Assistant
* Perform a request
* Confirm the textarea and button gets disabled for a while (it's requesting)
* Confirm the toolbar button gets disabled, too

https://github.com/Automattic/jetpack/assets/77539/a143f89c-407d-4521-8c6f-2559c053ca17

* Confirm the dev console shows the debug() logs about the request/response

```
localStorage.setItem( 'debug', 'jetpack*' )
```
<img width="792" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/d1c8a2b8-8a17-4033-8dfd-a1bf29ee6c39">
 

