### PR TITLE
Launchpad: dismiss api endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/launchpad-dismiss-api-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/launchpad-dismiss-api-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: add a way to query and set checklist visibility status

--- a/projects/packages/jetpack-mu-wpcom/changelog/launchpad-dismiss-api-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/launchpad-dismiss-api-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Launchpad: add a way to query and set checklist visibility status
+Launchpad: add a way to query and set checklist dismissed status

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -159,10 +159,10 @@ class Launchpad_Task_Lists {
 	 * @return bool|null True if visible, false if not.
 	 */
 	public function is_task_list_visible( $id ) {
-		$task_list_status = get_option( 'wpcom_launchpad_task_list_visibility', array() );
+		$task_list_visibility = $this->get_task_list_visibility_status();
 
 		// Return true if the task list is not in the visibility option or if it is and the value is true.
-		return ! isset( $task_list_status[ $id ] ) || $task_list_status[ $id ];
+		return ! isset( $task_list_visibility[ $id ] ) || $task_list_visibility[ $id ];
 	}
 
 	/**
@@ -172,9 +172,22 @@ class Launchpad_Task_Lists {
 	 * @param bool   $is_visible True if visible, false if not.
 	 */
 	public function set_task_list_visibility( $id, $is_visible ) {
-		$task_list_status        = get_option( 'wpcom_launchpad_task_list_visibility', array() );
-		$task_list_status[ $id ] = $is_visible;
-		update_option( 'wpcom_launchpad_task_list_visibility', $task_list_status );
+		$task_list_visibility        = $this->get_task_list_visibility_status();
+		$task_list_visibility[ $id ] = $is_visible;
+
+		$launchpad_config                         = get_option( 'wpcom_launchpad_config', array() );
+		$launchpad_config['task_list_visibility'] = $task_list_visibility;
+		update_option( 'wpcom_launchpad_config', $launchpad_config );
+	}
+
+	/**
+	 * Get the task list visibility status for a site.
+	 *
+	 * @return array
+	 */
+	protected function get_task_list_visibility_status() {
+		$launchpad_config = get_option( 'wpcom_launchpad_config', array() );
+		return isset( $launchpad_config['task_list_visibility'] ) ? $launchpad_config['task_list_visibility'] : array();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -172,8 +172,14 @@ class Launchpad_Task_Lists {
 	 * @param bool   $is_dismissed True if dismissed, false if not.
 	 */
 	public function set_task_list_dismissed( $id, $is_dismissed ) {
-		$task_list_dismissed_status        = $this->get_task_list_dismissed_status();
-		$task_list_dismissed_status[ $id ] = $is_dismissed;
+		$task_list_dismissed_status = $this->get_task_list_dismissed_status();
+		$is_dismissed               = (bool) $is_dismissed;
+
+		if ( $is_dismissed ) {
+			$task_list_dismissed_status[ $id ] = true;
+		} else {
+			unset( $task_list_dismissed_status[ $id ] );
+		}
 
 		$launchpad_config                               = get_option( 'wpcom_launchpad_config', array() );
 		$launchpad_config['task_list_dismissed_status'] = $task_list_dismissed_status;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -172,6 +172,11 @@ class Launchpad_Task_Lists {
 	 * @param bool   $is_dismissed True if dismissed, false if not.
 	 */
 	public function set_task_list_dismissed( $id, $is_dismissed ) {
+		$task_list = $this->get_task_list( $id );
+		if ( empty( $id ) || empty( $task_list ) ) {
+			return;
+		}
+
 		$task_list_dismissed_status = $this->get_task_list_dismissed_status();
 		$is_dismissed               = (bool) $is_dismissed;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -162,7 +162,7 @@ class Launchpad_Task_Lists {
 		$task_list_dismissed_status = $this->get_task_list_dismissed_status();
 
 		// Return true if the task list is on the dismissed status array and its value is true.
-		return isset( $task_list_dismissed_status[ $id ] ) && $task_list_dismissed_status[ $id ];
+		return isset( $task_list_dismissed_status[ $id ] ) && true === $task_list_dismissed_status[ $id ];
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -153,30 +153,30 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
-	 * Check if a task list is enabled by checking its is_enabled_callback callback.
+	 * Check if a task list was dismissed by the user.
 	 *
 	 * @param string $id Task List id.
-	 * @return bool|null True if visible, false if not.
+	 * @return bool|null True if dismissed, false if not.
 	 */
-	public function is_task_list_visible( $id ) {
-		$task_list_visibility = $this->get_task_list_visibility_status();
+	public function is_task_list_dismissed( $id ) {
+		$task_list_dismissed_status = $this->get_task_list_dismissed_status();
 
-		// Return true if the task list is not in the visibility option or if it is and the value is true.
-		return ! isset( $task_list_visibility[ $id ] ) || $task_list_visibility[ $id ];
+		// Return true if the task list is on the dismissed status array and its value is true.
+		return isset( $task_list_dismissed_status[ $id ] ) && $task_list_dismissed_status[ $id ];
 	}
 
 	/**
-	 * Set wether a task list is visible or not for a site.
+	 * Set wether a task list is dismissed or not for a site.
 	 *
 	 * @param string $id Task List id.
-	 * @param bool   $is_visible True if visible, false if not.
+	 * @param bool   $is_dismissed True if dismissed, false if not.
 	 */
-	public function set_task_list_visibility( $id, $is_visible ) {
-		$task_list_visibility        = $this->get_task_list_visibility_status();
-		$task_list_visibility[ $id ] = $is_visible;
+	public function set_task_list_dismissed( $id, $is_dismissed ) {
+		$task_list_dismissed_status        = $this->get_task_list_dismissed_status();
+		$task_list_dismissed_status[ $id ] = $is_dismissed;
 
-		$launchpad_config                         = get_option( 'wpcom_launchpad_config', array() );
-		$launchpad_config['task_list_visibility'] = $task_list_visibility;
+		$launchpad_config                               = get_option( 'wpcom_launchpad_config', array() );
+		$launchpad_config['task_list_dismissed_status'] = $task_list_dismissed_status;
 		update_option( 'wpcom_launchpad_config', $launchpad_config );
 	}
 
@@ -185,9 +185,9 @@ class Launchpad_Task_Lists {
 	 *
 	 * @return array
 	 */
-	protected function get_task_list_visibility_status() {
+	protected function get_task_list_dismissed_status() {
 		$launchpad_config = get_option( 'wpcom_launchpad_config', array() );
-		return isset( $launchpad_config['task_list_visibility'] ) ? $launchpad_config['task_list_visibility'] : array();
+		return isset( $launchpad_config['task_list_dismissed_status'] ) ? $launchpad_config['task_list_dismissed_status'] : array();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -187,7 +187,11 @@ class Launchpad_Task_Lists {
 	 */
 	protected function get_task_list_dismissed_status() {
 		$launchpad_config = get_option( 'wpcom_launchpad_config', array() );
-		return isset( $launchpad_config['task_list_dismissed_status'] ) ? $launchpad_config['task_list_dismissed_status'] : array();
+		if ( ! isset( $launchpad_config['task_list_dismissed_status'] ) || ! is_array( $launchpad_config['task_list_dismissed_status'] ) ) {
+			return array();
+		}
+
+		return $launchpad_config['task_list_dismissed_status'];
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -153,6 +153,31 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
+	 * Check if a task list is enabled by checking its is_enabled_callback callback.
+	 *
+	 * @param string $id Task List id.
+	 * @return bool|null True if visible, false if not.
+	 */
+	public function is_task_list_visible( $id ) {
+		$task_list_status = get_option( 'wpcom_launchpad_task_list_visibility', array() );
+
+		// Return true if the task list is not in the visibility option or if it is and the value is true.
+		return ! isset( $task_list_status[ $id ] ) || $task_list_status[ $id ];
+	}
+
+	/**
+	 * Set wether a task list is visible or not for a site.
+	 *
+	 * @param string $id Task List id.
+	 * @param bool   $is_visible True if visible, false if not.
+	 */
+	public function set_task_list_visibility( $id, $is_visible ) {
+		$task_list_status        = get_option( 'wpcom_launchpad_task_list_visibility', array() );
+		$task_list_status[ $id ] = $is_visible;
+		update_option( 'wpcom_launchpad_task_list_visibility', $task_list_status );
+	}
+
+	/**
 	 * See if the task list registry has any task lists.
 	 *
 	 * @return bool True if there are task lists, false if not.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -603,6 +603,26 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
 }
 
 /**
+ * Checks if a specific task list is visible.
+ *
+ * @param string $checklist_slug The slug of the launchpad task list to check.
+ * @return bool True if the task list is visible, false otherwise.
+ */
+function wpcom_launchpad_is_task_list_visible( $checklist_slug ) {
+	return wpcom_launchpad_checklists()->is_task_list_visible( $checklist_slug );
+}
+
+/**
+ * Sets a specific task list visibility.
+ *
+ * @param string $checklist_slug The slug of the launchpad task list to check.
+ * @param bool   $is_visible True if the task list is visible, false otherwise.
+ */
+function wpcom_launchpad_set_task_list_visibility( $checklist_slug, $is_visible ) {
+	wpcom_launchpad_checklists()->set_task_list_visibility( $checklist_slug, $is_visible );
+}
+
+/**
  * Checks if the Keep building task list is enabled.
  *
  * @return bool True if the task list is enabled, false otherwise.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -603,23 +603,23 @@ function wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ) {
 }
 
 /**
- * Checks if a specific task list is visible.
+ * Checks if a specific task list is dismissed.
  *
  * @param string $checklist_slug The slug of the launchpad task list to check.
- * @return bool True if the task list is visible, false otherwise.
+ * @return bool True if the task list is dismissed, false otherwise.
  */
-function wpcom_launchpad_is_task_list_visible( $checklist_slug ) {
-	return wpcom_launchpad_checklists()->is_task_list_visible( $checklist_slug );
+function wpcom_launchpad_is_task_list_dismissed( $checklist_slug ) {
+	return wpcom_launchpad_checklists()->is_task_list_dismissed( $checklist_slug );
 }
 
 /**
- * Sets a specific task list visibility.
+ * Sets a specific task list dismissed state.
  *
  * @param string $checklist_slug The slug of the launchpad task list to check.
- * @param bool   $is_visible True if the task list is visible, false otherwise.
+ * @param bool   $is_dismissed True if the task list is dismissed, false otherwise.
  */
-function wpcom_launchpad_set_task_list_visibility( $checklist_slug, $is_visible ) {
-	wpcom_launchpad_checklists()->set_task_list_visibility( $checklist_slug, $is_visible );
+function wpcom_launchpad_set_task_list_dismissed( $checklist_slug, $is_dismissed ) {
+	wpcom_launchpad_checklists()->set_task_list_dismissed( $checklist_slug, $is_dismissed );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -48,27 +48,27 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					'callback'            => array( $this, 'update_site_options' ),
 					'permission_callback' => array( $this, 'can_access' ),
 					'args'                => array(
-						'checklist_statuses'   => array(
+						'checklist_statuses'     => array(
 							'description'          => 'Launchpad statuses',
 							'type'                 => 'object',
 							'properties'           => $this->get_checklist_statuses_properties(),
 							'additionalProperties' => false,
 						),
-						'launchpad_screen'     => array(
+						'launchpad_screen'       => array(
 							'description' => 'Launchpad screen',
 							'type'        => 'string',
 							'enum'        => array( 'off', 'minimized', 'full' ),
 						),
-						'is_checklist_visible' => array(
-							'description'          => 'Toggle checklist visibility',
+						'is_checklist_dismissed' => array(
+							'description'          => 'Marks a checklist as dismissed by the user',
 							'type'                 => 'object',
 							'properties'           => array(
-								'slug'       => array(
+								'slug'         => array(
 									'description' => 'Checklist slug',
 									'type'        => 'string',
 									'enum'        => $this->get_checklist_slug_enums(),
 								),
-								'is_visible' => array(
+								'is_dismissed' => array(
 									'type' => 'boolean',
 								),
 							),
@@ -138,7 +138,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
 			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
 			'is_enabled'         => wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ),
-			'is_visible'         => wpcom_launchpad_is_task_list_visible( $checklist_slug ),
+			'is_dismissed'       => wpcom_launchpad_is_task_list_dismissed( $checklist_slug ),
 		);
 	}
 
@@ -172,11 +172,11 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					wpcom_launchpad_checklists()->maybe_disable_fullscreen_launchpad();
 					break;
 
-				case 'is_checklist_visible':
+				case 'is_checklist_dismissed':
 					$checklist_slug = $value['slug'];
-					$is_visible     = $value['is_visible'];
+					$is_dismissed   = $value['is_dismissed'];
 
-					wpcom_launchpad_set_task_list_visibility( $checklist_slug, $is_visible );
+					wpcom_launchpad_set_task_list_dismissed( $checklist_slug, $is_dismissed );
 					break;
 				default:
 					if ( update_option( $key, $value ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -48,16 +48,31 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					'callback'            => array( $this, 'update_site_options' ),
 					'permission_callback' => array( $this, 'can_access' ),
 					'args'                => array(
-						'checklist_statuses' => array(
+						'checklist_statuses'   => array(
 							'description'          => 'Launchpad statuses',
 							'type'                 => 'object',
 							'properties'           => $this->get_checklist_statuses_properties(),
 							'additionalProperties' => false,
 						),
-						'launchpad_screen'   => array(
+						'launchpad_screen'     => array(
 							'description' => 'Launchpad screen',
 							'type'        => 'string',
 							'enum'        => array( 'off', 'minimized', 'full' ),
+						),
+						'is_checklist_visible' => array(
+							'description'          => 'Toggle checklist visibility',
+							'type'                 => 'object',
+							'properties'           => array(
+								'slug'  => array(
+									'description' => 'Checklist slug',
+									'type'        => 'string',
+									'enum'        => $this->get_checklist_slug_enums(),
+								),
+								'value' => array(
+									'type' => 'boolean',
+								),
+							),
+							'additionalProperties' => false,
 						),
 					),
 				),
@@ -123,6 +138,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
 			'checklist'          => wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug ),
 			'is_enabled'         => wpcom_get_launchpad_task_list_is_enabled( $checklist_slug ),
+			'is_visible'         => wpcom_launchpad_is_task_list_visible( $checklist_slug ),
 		);
 	}
 
@@ -156,6 +172,12 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 					wpcom_launchpad_checklists()->maybe_disable_fullscreen_launchpad();
 					break;
 
+				case 'is_checklist_visible':
+					$checklist_slug = $value['slug'];
+					$is_enabled     = $value['value'];
+
+					wpcom_launchpad_set_task_list_visibility( $checklist_slug, $is_enabled );
+					break;
 				default:
 					if ( update_option( $key, $value ) ) {
 						$updated[ $key ] = $value;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -63,12 +63,12 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 							'description'          => 'Toggle checklist visibility',
 							'type'                 => 'object',
 							'properties'           => array(
-								'slug'  => array(
+								'slug'       => array(
 									'description' => 'Checklist slug',
 									'type'        => 'string',
 									'enum'        => $this->get_checklist_slug_enums(),
 								),
-								'value' => array(
+								'is_visible' => array(
 									'type' => 'boolean',
 								),
 							),
@@ -174,9 +174,9 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 
 				case 'is_checklist_visible':
 					$checklist_slug = $value['slug'];
-					$is_enabled     = $value['value'];
+					$is_visible     = $value['is_visible'];
 
-					wpcom_launchpad_set_task_list_visibility( $checklist_slug, $is_enabled );
+					wpcom_launchpad_set_task_list_visibility( $checklist_slug, $is_visible );
 					break;
 				default:
 					if ( update_option( $key, $value ) ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
@@ -87,8 +87,8 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 		wp_set_current_user( $this->admin_id );
 
 		$values = array(
-			'slug'  => 'intent-build',
-			'value' => false,
+			'slug'       => 'intent-build',
+			'is_visible' => false,
 		);
 		$data   = array( 'is_checklist_visible' => $values );
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
@@ -58,6 +58,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 		$this->assertFalse( $result->get_data()['launchpad_screen'] );
 		$this->assertEmpty( $result->get_data()['checklist_statuses'] );
 		$this->assertIsArray( $result->get_data()['checklist_statuses'] );
+		$this->assertTrue( $result->get_data()['is_visible'] );
 	}
 
 	/**
@@ -77,6 +78,31 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 		$result  = rest_do_request( $request );
 
 		$this->assertSame( 401, $result->get_status() );
+	}
+
+	/**
+	 * Test updating checklist visibility.
+	 */
+	public function test_update_checklist_visibility() {
+		wp_set_current_user( $this->admin_id );
+
+		$values = array(
+			'slug'  => 'intent-build',
+			'value' => false,
+		);
+		$data   = array( 'is_checklist_visible' => $values );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/launchpad' );
+		$request->set_header( 'content_type', 'application/json' );
+		$request->set_body( wp_json_encode( $data ) );
+
+		$this->assertTrue( wpcom_launchpad_is_task_list_visible( 'intent-build' ) );
+
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( array( 'updated' => array() ), $result->get_data() );
+		$this->assertFalse( wpcom_launchpad_is_task_list_visible( 'intent-build' ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-test.php
@@ -58,7 +58,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 		$this->assertFalse( $result->get_data()['launchpad_screen'] );
 		$this->assertEmpty( $result->get_data()['checklist_statuses'] );
 		$this->assertIsArray( $result->get_data()['checklist_statuses'] );
-		$this->assertTrue( $result->get_data()['is_visible'] );
+		$this->assertFalse( $result->get_data()['is_dismissed'] );
 	}
 
 	/**
@@ -81,28 +81,28 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 	}
 
 	/**
-	 * Test updating checklist visibility.
+	 * Test updating checklist dismissed state.
 	 */
-	public function test_update_checklist_visibility() {
+	public function test_update_checklist_dismissed_state() {
 		wp_set_current_user( $this->admin_id );
 
 		$values = array(
-			'slug'       => 'intent-build',
-			'is_visible' => false,
+			'slug'         => 'intent-build',
+			'is_dismissed' => true,
 		);
-		$data   = array( 'is_checklist_visible' => $values );
+		$data   = array( 'is_checklist_dismissed' => $values );
 
 		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/launchpad' );
 		$request->set_header( 'content_type', 'application/json' );
 		$request->set_body( wp_json_encode( $data ) );
 
-		$this->assertTrue( wpcom_launchpad_is_task_list_visible( 'intent-build' ) );
+		$this->assertFalse( wpcom_launchpad_is_task_list_dismissed( 'intent-build' ) );
 
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( array( 'updated' => array() ), $result->get_data() );
-		$this->assertFalse( wpcom_launchpad_is_task_list_visible( 'intent-build' ) );
+		$this->assertTrue( wpcom_launchpad_is_task_list_dismissed( 'intent-build' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Context: paYKcK-3hW-p2#comment-2358 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Updates the `/sites/[YOUR_SITE]/launchpad` API endpoint to query and update the visibility of a task list.

An option called `wpcom_launchpad_config` was added to track general config values for the launchpad in general. This PR handles the launchpad visibility using the `task_list_dismissed_status` key inside that option. All entries in this array follow the form `list-id => true|false` indicating whether the task list with id `list-id` is dismissed.
If the list id is not present in the array stored in `task_list_dismissed_status` then it's assumed to not be dismissed to maintain backward compatibility.

This new option isn't being added to JP sync right now because it's not needed for the dismiss endpoint, but it can be easily added on [this method](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php#L669) when necessity arises.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9Jlb4-7CP-p2#comment-8725
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the changes in this PR to your sandbox
* Go to dev API console and prepare it to run queries on `WP Rest API > wpcom/v2`
* Make a GET to `/sites/[YOUR_SITE]/launchpad?checklist_slug=intent-build`
* Verify that there's an `is_dismissed` key in the result and that it's set to `false`
* Make a POST to `/sites/[YOUR_SITE]/launchpad` with the following value in the `is_checklist_dismissed` param: `{"slug":"intent-build","is_dismissed":true}` (you can check this out to see how to do this from the dev console: p1690917561303459-slack-C0Q664T29)
* Make a GET to `/sites/[YOUR_SITE]/launchpad?checklist_slug=intent-build`
* Verify that there's an `is_dismissed` key in the result and that it's set to `true`