### PR TITLE
CRM: Automations Contact condition for field changed

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-3189-automations-contact-backend-condition-was-changed
+++ b/projects/plugins/crm/changelog/add-crm-3189-automations-contact-backend-condition-was-changed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Automation: Added condition for contact status changed

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-field-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-field-changed.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack CRM Automation Contact_Status_Changed condition.
+ * Jetpack CRM Automation Contact_Field_Changed condition.
  *
  * @package automattic/jetpack-crm
  */
@@ -12,11 +12,11 @@ use Automattic\Jetpack\CRM\Automation\Automation_Logger;
 use Automattic\Jetpack\CRM\Automation\Base_Condition;
 
 /**
- * Contact_Status_Changed condition class.
+ * Contact_Field_Changed condition class.
  *
  * @since $$next-version$$
  */
-class Contact_Status_Changed extends Base_Condition {
+class Contact_Field_Changed extends Base_Condition {
 
 	/**
 	 * The Automation logger.
@@ -44,13 +44,12 @@ class Contact_Status_Changed extends Base_Condition {
 	 * @var string[] $valid_operators Valid attributes.
 	 */
 	private $valid_attributes = array(
-		'field',
 		'operator',
 		'value',
 	);
 
 	/**
-	 * Contact_Status_Changed constructor.
+	 * Contact_Field_Changed constructor.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -74,9 +73,10 @@ class Contact_Status_Changed extends Base_Condition {
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
 	public function execute( array $data ) {
-		if ( ! $this->is_valid_contact_status_changed_data( $data ) ) {
-			$this->logger->log( 'Invalid contact status changed data', $data );
+		if ( ! $this->is_valid_contact_field_changed_data( $data ) ) {
+			$this->logger->log( 'Invalid contact field changed data', $data );
 			$this->condition_met = false;
+
 			return;
 		}
 
@@ -85,7 +85,6 @@ class Contact_Status_Changed extends Base_Condition {
 		$value    = $this->get_attributes()['value'];
 
 		$this->logger->log( 'Condition: ' . $field . ' ' . $operator . ' ' . $value . ' => ' . $data['data'][ $field ] );
-
 		switch ( $operator ) {
 			case 'is':
 				$this->condition_met = ( $data['data'][ $field ] === $value );
@@ -105,53 +104,53 @@ class Contact_Status_Changed extends Base_Condition {
 	}
 
 	/**
-	 * Checks if the contact has at least the necessary keys to detect a status
+	 * Checks if the contact has at least the necessary keys to detect a field
 	 * change.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @param array $contact_data The contact data.
-	 * @return bool True if the data is valid to detect a status change, false otherwise
+	 * @return bool True if the data is valid to detect a field change, false otherwise
 	 */
-	private function is_valid_contact_status_changed_data( array $contact_data ): bool {
-		return isset( $contact_data['id'] ) && isset( $contact_data['data'] ) && isset( $contact_data['data']['status'] );
+	private function is_valid_contact_field_changed_data( array $contact_data ): bool {
+		return isset( $contact_data['id'] ) && isset( $contact_data['data'] ) && isset( $contact_data['data'][ $this->get_attributes()['field'] ] );
 	}
 
 	/**
-	 * Get the slug for the contact status changed condition.
+	 * Get the slug for the contact field changed condition.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string The slug 'contact_status_changed'.
+	 * @return string The slug 'contact_field_changed'.
 	 */
 	public static function get_slug(): string {
-		return 'jpcrm/condition/contact_status_changed';
+		return 'jpcrm/condition/contact_field_changed';
 	}
 
 	/**
-	 * Get the title for the contact status changed condition.
+	 * Get the title for the contact field changed condition.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string The title 'Contact Status Changed'.
+	 * @return string The title 'Contact Field Changed'.
 	 */
 	public static function get_title(): string {
-		return __( 'Contact Status Changed', 'zero-bs-crm' );
+		return __( 'Contact Field Changed', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Get the description for the contact status changed condition.
+	 * Get the description for the contact field changed condition.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @return string The description for the condition.
 	 */
 	public static function get_description(): string {
-		return __( 'Checks if a contact status change matches an expected value', 'zero-bs-crm' );
+		return __( 'Checks if a contact field change matches an expected value', 'zero-bs-crm' );
 	}
 
 	/**
-	 * Get the type of the contact status changed condition.
+	 * Get the type of the contact field changed condition.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -162,7 +161,7 @@ class Contact_Status_Changed extends Base_Condition {
 	}
 
 	/**
-	 * Get the category of the contact status changed condition.
+	 * Get the category of the contact field changed condition.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -173,7 +172,7 @@ class Contact_Status_Changed extends Base_Condition {
 	}
 
 	/**
-	 * Get the allowed triggers for the contact status changed condition.
+	 * Get the allowed triggers for the contact field changed condition.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Jetpack CRM Automation Contact_Status_Changed condition.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Conditions;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Logger;
+use Automattic\Jetpack\CRM\Automation\Base_Condition;
+
+/**
+ * Contact_Status_Changed condition class.
+ *
+ * @since $$next-version$$
+ */
+class Contact_Status_Changed extends Base_Condition {
+
+	/**
+	 * The Automation logger.
+	 *
+	 * @var Automation_Logger $logger The Automation logger.
+	 */
+	private $logger;
+
+	/**
+	 * All valid operators for this condition.
+	 *
+	 * @var string[] $valid_operators Valid operators.
+	 */
+	private $valid_operators = array(
+		'is',
+		'is_not',
+	);
+
+	/**
+	 * All valid attributes for this condition.
+	 *
+	 * @var string[] $valid_operators Valid attributes.
+	 */
+	private $valid_attributes = array(
+		'field',
+		'operator',
+		'value',
+	);
+
+	/**
+	 * Contact_Status_Changed constructor.
+	 *
+	 * @param array $step_data The step data for the condition.
+	 */
+	public function __construct( array $step_data ) {
+		parent::__construct( $step_data );
+
+		$this->logger = Automation_Logger::instance();
+	}
+
+	/**
+	 * Executes the condition. If the condition is met, the value stored in the
+	 * attribute $condition_met is set to true; otherwise, it is set to false.
+	 *
+	 * @param array $data The data this condition has to evaluate.
+	 * @return void
+	 * @throws Automation_Exception If an invalid operator is encountered.
+	 */
+	public function execute( array $data ) {
+		if ( ! $this->is_valid_contact_status_changed_data( $data ) ) {
+			$this->logger->log( 'Invalid contact status changed data', $data );
+			$this->condition_met = false;
+			return;
+		}
+
+		$field    = $this->get_attributes()['field'];
+		$operator = $this->get_attributes()['operator'];
+		$value    = $this->get_attributes()['value'];
+
+		$this->logger->log( 'Condition: ' . $field . ' ' . $operator . ' ' . $value . ' => ' . $data['data'][ $field ] );
+
+		switch ( $operator ) {
+			case 'is':
+				$this->condition_met = ( $data['data'][ $field ] === $value );
+				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
+
+				return;
+			case 'is_not':
+				$this->condition_met = ( $data['data'][ $field ] !== $value );
+				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
+
+				return;
+		}
+		$this->condition_met = false;
+		$this->logger->log( 'Invalid operator: ' . $operator );
+
+		throw new Automation_Exception( 'Invalid operator: ' . $operator );
+	}
+
+	/**
+	 * Checks if the contact has at least the necessary keys to detect a status
+	 * change.
+	 *
+	 * @param array $contact_data The contact data.
+	 * @return bool True if the data is valid to detect a status change, false otherwise
+	 */
+	private function is_valid_contact_status_changed_data( array $contact_data ): bool {
+		return isset( $contact_data['id'] ) && isset( $contact_data['data'] ) && isset( $contact_data['data']['status'] );
+	}
+
+	/**
+	 * Get the slug for the contact status changed condition.
+	 *
+	 * @return string The slug 'contact_status_changed'.
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/condition/contact_status_changed';
+	}
+
+	/**
+	 * Get the title for the contact status changed condition.
+	 *
+	 * @return string The title 'Contact Status Changed'.
+	 */
+	public static function get_title(): string {
+		return 'Contact Status Changed';
+	}
+
+	/**
+	 * Get the description for the contact status changed condition.
+	 *
+	 * @return string The description for the condition.
+	 */
+	public static function get_description(): string {
+		return __( 'Checks if a contact status change matches an expected value', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the type of the contact status changed condition.
+	 *
+	 * @return string The type 'condition'.
+	 */
+	public static function get_type(): string {
+		return 'condition';
+	}
+
+	/**
+	 * Get the category of the contact status changed condition.
+	 *
+	 * @return string The category 'jpcrm/contact_condition'.
+	 */
+	public static function get_category(): string {
+		return 'jpcrm/contact_condition';
+	}
+
+	/**
+	 * Get the allowed triggers for the contact status changed condition.
+	 *
+	 * @return array An array of allowed triggers:
+	 *               - 'jpcrm/contact_status_updated'
+	 *               - 'jpcrm/contact_updated'
+	 */
+	public static function get_allowed_triggers(): array {
+		return array(
+			'jpcrm/contact_status_updated',
+			'jpcrm/contact_updated',
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
@@ -70,6 +70,7 @@ class Contact_Status_Changed extends Base_Condition {
 	 *
 	 * @param array $data The data this condition has to evaluate.
 	 * @return void
+	 *
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
 	public function execute( array $data ) {

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
@@ -177,7 +177,7 @@ class Contact_Status_Changed extends Base_Condition {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return array An array of allowed triggers:
+	 * @return string[] An array of allowed triggers:
 	 *               - 'jpcrm/contact_status_updated'
 	 *               - 'jpcrm/contact_updated'
 	 */

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
@@ -149,7 +149,7 @@ class Contact_Status_Changed extends Base_Condition {
 	 * @return string The category 'jpcrm/contact_condition'.
 	 */
 	public static function get_category(): string {
-		return 'jpcrm/contact_condition';
+		return __( 'contact', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
@@ -21,6 +21,7 @@ class Contact_Status_Changed extends Base_Condition {
 	/**
 	 * The Automation logger.
 	 *
+	 * @since $$next-version$$
 	 * @var Automation_Logger $logger The Automation logger.
 	 */
 	private $logger;
@@ -28,6 +29,7 @@ class Contact_Status_Changed extends Base_Condition {
 	/**
 	 * All valid operators for this condition.
 	 *
+	 * @since $$next-version$$
 	 * @var string[] $valid_operators Valid operators.
 	 */
 	private $valid_operators = array(
@@ -38,6 +40,7 @@ class Contact_Status_Changed extends Base_Condition {
 	/**
 	 * All valid attributes for this condition.
 	 *
+	 * @since $$next-version$$
 	 * @var string[] $valid_operators Valid attributes.
 	 */
 	private $valid_attributes = array(
@@ -48,6 +51,8 @@ class Contact_Status_Changed extends Base_Condition {
 
 	/**
 	 * Contact_Status_Changed constructor.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array $step_data The step data for the condition.
 	 */
@@ -60,6 +65,8 @@ class Contact_Status_Changed extends Base_Condition {
 	/**
 	 * Executes the condition. If the condition is met, the value stored in the
 	 * attribute $condition_met is set to true; otherwise, it is set to false.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array $data The data this condition has to evaluate.
 	 * @return void
@@ -100,6 +107,8 @@ class Contact_Status_Changed extends Base_Condition {
 	 * Checks if the contact has at least the necessary keys to detect a status
 	 * change.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param array $contact_data The contact data.
 	 * @return bool True if the data is valid to detect a status change, false otherwise
 	 */
@@ -110,6 +119,8 @@ class Contact_Status_Changed extends Base_Condition {
 	/**
 	 * Get the slug for the contact status changed condition.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string The slug 'contact_status_changed'.
 	 */
 	public static function get_slug(): string {
@@ -118,6 +129,8 @@ class Contact_Status_Changed extends Base_Condition {
 
 	/**
 	 * Get the title for the contact status changed condition.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return string The title 'Contact Status Changed'.
 	 */
@@ -128,6 +141,8 @@ class Contact_Status_Changed extends Base_Condition {
 	/**
 	 * Get the description for the contact status changed condition.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string The description for the condition.
 	 */
 	public static function get_description(): string {
@@ -136,6 +151,8 @@ class Contact_Status_Changed extends Base_Condition {
 
 	/**
 	 * Get the type of the contact status changed condition.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return string The type 'condition'.
 	 */
@@ -146,6 +163,8 @@ class Contact_Status_Changed extends Base_Condition {
 	/**
 	 * Get the category of the contact status changed condition.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string The category 'jpcrm/contact_condition'.
 	 */
 	public static function get_category(): string {
@@ -154,6 +173,8 @@ class Contact_Status_Changed extends Base_Condition {
 
 	/**
 	 * Get the allowed triggers for the contact status changed condition.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return array An array of allowed triggers:
 	 *               - 'jpcrm/contact_status_updated'

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-status-changed.php
@@ -122,7 +122,7 @@ class Contact_Status_Changed extends Base_Condition {
 	 * @return string The title 'Contact Status Changed'.
 	 */
 	public static function get_title(): string {
-		return 'Contact Status Changed';
+		return __( 'Contact Status Changed', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
@@ -1,0 +1,87 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\CRM\Automation\Tests;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Status_Changed;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '../../tools/class-automation-faker.php';
+
+/**
+ * Test Automation Workflow functionalities
+ *
+ * @covers Automattic\Jetpack\CRM\Automation
+ */
+class Contact_Condition_Test extends BaseTestCase {
+
+	private $automation_faker;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->automation_faker = Automation_Faker::instance();
+		$this->automation_faker->reset_all();
+	}
+
+	private function get_contact_status_changed_condition( $operator, $expected_value ) {
+		$condition_data = array(
+			'slug'       => 'jpcrm/condition/contact_status_changed',
+			'attributes' => array(
+				'field'    => 'status',
+				'operator' => $operator,
+				'value'    => $expected_value,
+			),
+		);
+		return new Contact_Status_Changed( $condition_data );
+	}
+
+	/**
+	 * @testdox Test the update contact status condition for the is operator.
+	 */
+	public function test_status_changed_is_operator() {
+		$contact_status_changed_condition = $this->get_contact_status_changed_condition( 'is', 'customer' );
+		$contact_data                     = $this->automation_faker->contact_data();
+
+		// Testing when the condition has been met.
+		$contact_data['data']['status'] = 'customer';
+		$contact_status_changed_condition->execute( $contact_data );
+		$this->assertTrue( $contact_status_changed_condition->condition_met() );
+
+		// Testing when the condition has not been met.
+		$contact_data['data']['status'] = 'lead';
+		$contact_status_changed_condition->execute( $contact_data );
+		$this->assertFalse( $contact_status_changed_condition->condition_met() );
+	}
+
+	/**
+	 * @testdox Test the update contact status condition for the is_not operator.
+	 */
+	public function test_status_changed_is_not_operator() {
+		$contact_status_changed_condition = $this->get_contact_status_changed_condition( 'is_not', 'customer' );
+		$contact_data                     = $this->automation_faker->contact_data();
+
+		// Testing when the condition has been met.
+		$contact_data['data']['status'] = 'lead';
+		$contact_status_changed_condition->execute( $contact_data );
+		$this->assertTrue( $contact_status_changed_condition->condition_met() );
+
+		// Testing when the condition has not been met.
+		$contact_data['data']['status'] = 'customer';
+		$contact_status_changed_condition->execute( $contact_data );
+		$this->assertFalse( $contact_status_changed_condition->condition_met() );
+	}
+
+	/**
+	 * @testdox Test if an exception is being correctly thrown for wrong operators.
+	 */
+	public function test_status_changed_invalid_operator_throws_exception() {
+		$contact_status_changed_condition = $this->get_contact_status_changed_condition( 'wrong_operator', 'customer' );
+		$contact_data                     = $this->automation_faker->contact_data();
+
+		$this->expectException( Automation_Exception::class );
+		$this->expectExceptionMessage( 'Invalid operator: wrong_operator' );
+
+		$contact_status_changed_condition->execute( $contact_data );
+	}
+
+}

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
@@ -3,7 +3,7 @@
 namespace Automattic\Jetpack\CRM\Automation\Tests;
 
 use Automattic\Jetpack\CRM\Automation\Automation_Exception;
-use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Status_Changed;
+use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Field_Changed;
 use WorDBless\BaseTestCase;
 
 require_once __DIR__ . '../../tools/class-automation-faker.php';
@@ -23,65 +23,65 @@ class Contact_Condition_Test extends BaseTestCase {
 		$this->automation_faker->reset_all();
 	}
 
-	private function get_contact_status_changed_condition( $operator, $expected_value ) {
+	private function get_contact_field_changed_condition( $operator, $expected_value ) {
 		$condition_data = array(
-			'slug'       => 'jpcrm/condition/contact_status_changed',
+			'slug'       => 'jpcrm/condition/contact_field_changed',
 			'attributes' => array(
 				'field'    => 'status',
 				'operator' => $operator,
 				'value'    => $expected_value,
 			),
 		);
-		return new Contact_Status_Changed( $condition_data );
+		return new Contact_Field_Changed( $condition_data );
 	}
 
 	/**
-	 * @testdox Test the update contact status condition for the is operator.
+	 * @testdox Test the update contact field condition for the is operator.
 	 */
-	public function test_status_changed_is_operator() {
-		$contact_status_changed_condition = $this->get_contact_status_changed_condition( 'is', 'customer' );
-		$contact_data                     = $this->automation_faker->contact_data();
+	public function test_field_changed_is_operator() {
+		$contact_field_changed_condition = $this->get_contact_field_changed_condition( 'is', 'customer' );
+		$contact_data                    = $this->automation_faker->contact_data();
 
 		// Testing when the condition has been met.
 		$contact_data['data']['status'] = 'customer';
-		$contact_status_changed_condition->execute( $contact_data );
-		$this->assertTrue( $contact_status_changed_condition->condition_met() );
+		$contact_field_changed_condition->execute( $contact_data );
+		$this->assertTrue( $contact_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$contact_data['data']['status'] = 'lead';
-		$contact_status_changed_condition->execute( $contact_data );
-		$this->assertFalse( $contact_status_changed_condition->condition_met() );
+		$contact_field_changed_condition->execute( $contact_data );
+		$this->assertFalse( $contact_field_changed_condition->condition_met() );
 	}
 
 	/**
-	 * @testdox Test the update contact status condition for the is_not operator.
+	 * @testdox Test the update contact field condition for the is_not operator.
 	 */
-	public function test_status_changed_is_not_operator() {
-		$contact_status_changed_condition = $this->get_contact_status_changed_condition( 'is_not', 'customer' );
-		$contact_data                     = $this->automation_faker->contact_data();
+	public function test_field_changed_is_not_operator() {
+		$contact_field_changed_condition = $this->get_contact_field_changed_condition( 'is_not', 'customer' );
+		$contact_data                    = $this->automation_faker->contact_data();
 
 		// Testing when the condition has been met.
 		$contact_data['data']['status'] = 'lead';
-		$contact_status_changed_condition->execute( $contact_data );
-		$this->assertTrue( $contact_status_changed_condition->condition_met() );
+		$contact_field_changed_condition->execute( $contact_data );
+		$this->assertTrue( $contact_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
 		$contact_data['data']['status'] = 'customer';
-		$contact_status_changed_condition->execute( $contact_data );
-		$this->assertFalse( $contact_status_changed_condition->condition_met() );
+		$contact_field_changed_condition->execute( $contact_data );
+		$this->assertFalse( $contact_field_changed_condition->condition_met() );
 	}
 
 	/**
 	 * @testdox Test if an exception is being correctly thrown for wrong operators.
 	 */
-	public function test_status_changed_invalid_operator_throws_exception() {
-		$contact_status_changed_condition = $this->get_contact_status_changed_condition( 'wrong_operator', 'customer' );
-		$contact_data                     = $this->automation_faker->contact_data();
+	public function test_field_changed_invalid_operator_throws_exception() {
+		$contact_field_changed_condition = $this->get_contact_field_changed_condition( 'wrong_operator', 'customer' );
+		$contact_data                    = $this->automation_faker->contact_data();
 
 		$this->expectException( Automation_Exception::class );
 		$this->expectExceptionMessage( 'Invalid operator: wrong_operator' );
 
-		$contact_status_changed_condition->execute( $contact_data );
+		$contact_field_changed_condition->execute( $contact_data );
 	}
 
 }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds the contact condition 'Field Changed' and respective tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3189

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).

