### PR TITLE
 CRM: Automations Invoice condition for status changed

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-3191-automations-invoice-condition-status-changed
+++ b/projects/plugins/crm/changelog/add-crm-3191-automations-invoice-condition-status-changed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Automation: Added condition for invoice status changed

--- a/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Jetpack CRM Automation Invoice_Status_Changed condition.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Conditions;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Logger;
+use Automattic\Jetpack\CRM\Automation\Base_Condition;
+
+/**
+ * Invoice_Status_Changed condition class.
+ *
+ * @since $$next-version$$
+ */
+class Invoice_Status_Changed extends Base_Condition {
+
+	/**
+	 * The Automation logger.
+	 *
+	 * @var Automation_Logger $logger The Automation logger.
+	 */
+	private $logger;
+
+	/**
+	 * All valid operators for this condition.
+	 *
+	 * @var string[] $valid_operators Valid operators.
+	 */
+	private $valid_operators = array(
+		'is',
+		'is_not',
+	);
+
+	/**
+	 * All valid attributes for this condition.
+	 *
+	 * @var string[] $valid_operators Valid attributes.
+	 */
+	private $valid_attributes = array(
+		'field',
+		'operator',
+		'value',
+	);
+
+	/**
+	 * Invoice_Status_Changed constructor.
+	 *
+	 * @param array $step_data The step data for the condition.
+	 */
+	public function __construct( array $step_data ) {
+		parent::__construct( $step_data );
+
+		$this->logger = Automation_Logger::instance();
+	}
+
+	/**
+	 * Executes the condition. If the condition is met, the value stored in the
+	 * attribute $condition_met is set to true; otherwise, it is set to false.
+	 *
+	 * @param array $data The data this condition has to evaluate.
+	 * @return void
+	 * @throws Automation_Exception If an invalid operator is encountered.
+	 */
+	public function execute( array $data ) {
+		if ( ! $this->is_valid_invoice_status_changed_data( $data ) ) {
+			$this->logger->log( 'Invalid invoice status changed data', $data );
+			$this->condition_met = false;
+			return;
+		}
+
+		$field    = $this->get_attributes()['field'];
+		$operator = $this->get_attributes()['operator'];
+		$value    = $this->get_attributes()['value'];
+
+		$this->logger->log( 'Condition: ' . $field . ' ' . $operator . ' ' . $value . ' => ' . $data['data'][ $field ] );
+
+		switch ( $operator ) {
+			case 'is':
+				$this->condition_met = ( $data['data'][ $field ] === $value );
+				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
+
+				return;
+			case 'is_not':
+				$this->condition_met = ( $data['data'][ $field ] !== $value );
+				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
+
+				return;
+		}
+		$this->condition_met = false;
+		$this->logger->log( 'Invalid operator: ' . $operator );
+
+		throw new Automation_Exception( 'Invalid operator: ' . $operator );
+	}
+
+	/**
+	 * Checks if the invoice has at least the necessary keys to detect a status
+	 * change.
+	 *
+	 * @param array $invoice_data The invoice data.
+	 * @return bool True if the data is valid to detect a status change, false otherwise
+	 */
+	private function is_valid_invoice_status_changed_data( array $invoice_data ): bool {
+		return isset( $invoice_data['id'] ) && isset( $invoice_data['data'] ) && isset( $invoice_data['data']['status'] );
+	}
+
+	/**
+	 * Get the slug for the invoice status changed condition.
+	 *
+	 * @return string The slug 'invoice_status_changed'.
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/condition/invoice_status_changed';
+	}
+
+	/**
+	 * Get the title for the invoice status changed condition.
+	 *
+	 * @return string The title 'Invoice Status Changed'.
+	 */
+	public static function get_title(): string {
+		return 'Invoice Status Changed';
+	}
+
+	/**
+	 * Get the description for the invoice status changed condition.
+	 *
+	 * @return string The description for the condition.
+	 */
+	public static function get_description(): string {
+		return __( 'Checks if a invoice status change matches an expected value', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the type of the invoice status changed condition.
+	 *
+	 * @return string The type 'condition'.
+	 */
+	public static function get_type(): string {
+		return 'condition';
+	}
+
+	/**
+	 * Get the category of the invoice status changed condition.
+	 *
+	 * @return string The category 'jpcrm/invoice_condition'.
+	 */
+	public static function get_category(): string {
+		return 'jpcrm/invoice_condition';
+	}
+
+	/**
+	 * Get the allowed triggers for the invoice status changed condition.
+	 *
+	 * @return array An array of allowed triggers:
+	 *               - 'jpcrm/invoice_status_updated'
+	 *               - 'jpcrm/invoice_updated'
+	 */
+	public static function get_allowed_triggers(): array {
+		return array(
+			'jpcrm/invoice_status_updated',
+			'jpcrm/invoice_updated',
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
@@ -21,6 +21,7 @@ class Invoice_Status_Changed extends Base_Condition {
 	/**
 	 * The Automation logger.
 	 *
+	 * @since $$next-version$$
 	 * @var Automation_Logger $logger The Automation logger.
 	 */
 	private $logger;
@@ -28,6 +29,7 @@ class Invoice_Status_Changed extends Base_Condition {
 	/**
 	 * All valid operators for this condition.
 	 *
+	 * @since $$next-version$$
 	 * @var string[] $valid_operators Valid operators.
 	 */
 	private $valid_operators = array(
@@ -38,6 +40,7 @@ class Invoice_Status_Changed extends Base_Condition {
 	/**
 	 * All valid attributes for this condition.
 	 *
+	 * @since $$next-version$$
 	 * @var string[] $valid_operators Valid attributes.
 	 */
 	private $valid_attributes = array(
@@ -48,6 +51,8 @@ class Invoice_Status_Changed extends Base_Condition {
 
 	/**
 	 * Invoice_Status_Changed constructor.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array $step_data The step data for the condition.
 	 */
@@ -60,6 +65,8 @@ class Invoice_Status_Changed extends Base_Condition {
 	/**
 	 * Executes the condition. If the condition is met, the value stored in the
 	 * attribute $condition_met is set to true; otherwise, it is set to false.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array $data The data this condition has to evaluate.
 	 * @return void
@@ -100,6 +107,8 @@ class Invoice_Status_Changed extends Base_Condition {
 	 * Checks if the invoice has at least the necessary keys to detect a status
 	 * change.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param array $invoice_data The invoice data.
 	 * @return bool True if the data is valid to detect a status change, false otherwise
 	 */
@@ -110,6 +119,8 @@ class Invoice_Status_Changed extends Base_Condition {
 	/**
 	 * Get the slug for the invoice status changed condition.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string The slug 'invoice_status_changed'.
 	 */
 	public static function get_slug(): string {
@@ -118,6 +129,8 @@ class Invoice_Status_Changed extends Base_Condition {
 
 	/**
 	 * Get the title for the invoice status changed condition.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return string The title 'Invoice Status Changed'.
 	 */
@@ -128,6 +141,8 @@ class Invoice_Status_Changed extends Base_Condition {
 	/**
 	 * Get the description for the invoice status changed condition.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string The description for the condition.
 	 */
 	public static function get_description(): string {
@@ -136,6 +151,8 @@ class Invoice_Status_Changed extends Base_Condition {
 
 	/**
 	 * Get the type of the invoice status changed condition.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return string The type 'condition'.
 	 */
@@ -146,6 +163,8 @@ class Invoice_Status_Changed extends Base_Condition {
 	/**
 	 * Get the category of the invoice status changed condition.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string The category 'jpcrm/invoice_condition'.
 	 */
 	public static function get_category(): string {
@@ -155,7 +174,9 @@ class Invoice_Status_Changed extends Base_Condition {
 	/**
 	 * Get the allowed triggers for the invoice status changed condition.
 	 *
-	 * @return array An array of allowed triggers:
+	 * @since $$next-version$$
+	 *
+	 * @return string[] An array of allowed triggers:
 	 *               - 'jpcrm/invoice_status_updated'
 	 *               - 'jpcrm/invoice_updated'
 	 */

--- a/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
@@ -122,7 +122,7 @@ class Invoice_Status_Changed extends Base_Condition {
 	 * @return string The title 'Invoice Status Changed'.
 	 */
 	public static function get_title(): string {
-		return 'Invoice Status Changed';
+		return __( 'Invoice Status Changed', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
@@ -149,7 +149,7 @@ class Invoice_Status_Changed extends Base_Condition {
 	 * @return string The category 'jpcrm/invoice_condition'.
 	 */
 	public static function get_category(): string {
-		return 'jpcrm/invoice_condition';
+		return __( 'invoice', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/class-invoice-status-changed.php
@@ -44,7 +44,6 @@ class Invoice_Status_Changed extends Base_Condition {
 	 * @var string[] $valid_operators Valid attributes.
 	 */
 	private $valid_attributes = array(
-		'field',
 		'operator',
 		'value',
 	);
@@ -79,7 +78,7 @@ class Invoice_Status_Changed extends Base_Condition {
 			return;
 		}
 
-		$field    = $this->get_attributes()['field'];
+		$field    = 'status';
 		$operator = $this->get_attributes()['operator'];
 		$value    = $this->get_attributes()['value'];
 

--- a/projects/plugins/crm/tests/php/automation/invoices/class-invoice-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/invoices/class-invoice-condition-test.php
@@ -1,0 +1,87 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\CRM\Automation\Tests;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Conditions\Invoice_Status_Changed;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '../../tools/class-automation-faker.php';
+
+/**
+ * Test Automation Invoice Conditions.
+ *
+ * @covers Automattic\Jetpack\CRM\Automation\Conditions\Invoice_Status_Changed
+ */
+class Invoice_Condition_Test extends BaseTestCase {
+
+	private $automation_faker;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->automation_faker = Automation_Faker::instance();
+		$this->automation_faker->reset_all();
+	}
+
+	private function get_invoice_status_changed_condition( $operator, $expected_value ) {
+		$condition_data = array(
+			'slug'       => 'jpcrm/condition/invoice_status_changed',
+			'attributes' => array(
+				'field'    => 'status',
+				'operator' => $operator,
+				'value'    => $expected_value,
+			),
+		);
+		return new Invoice_Status_Changed( $condition_data );
+	}
+
+	/**
+	 * @testdox Test the update invoice status condition for the is operator.
+	 */
+	public function test_status_changed_is_operator() {
+		$invoice_status_changed_condition = $this->get_invoice_status_changed_condition( 'is', 'paid' );
+		$invoice_data                     = $this->automation_faker->invoice_data();
+
+		// Testing when the condition has been met.
+		$invoice_data['data']['status'] = 'paid';
+		$invoice_status_changed_condition->execute( $invoice_data );
+		$this->assertTrue( $invoice_status_changed_condition->condition_met() );
+
+		// Testing when the condition has not been met.
+		$invoice_data['data']['status'] = 'unpaid';
+		$invoice_status_changed_condition->execute( $invoice_data );
+		$this->assertFalse( $invoice_status_changed_condition->condition_met() );
+	}
+
+	/**
+	 * @testdox Test the update invoice status condition for the is_not operator.
+	 */
+	public function test_status_changed_is_not_operator() {
+		$invoice_status_changed_condition = $this->get_invoice_status_changed_condition( 'is_not', 'paid' );
+		$invoice_data                     = $this->automation_faker->invoice_data();
+
+		// Testing when the condition has been met.
+		$invoice_data['data']['status'] = 'unpaid';
+		$invoice_status_changed_condition->execute( $invoice_data );
+		$this->assertTrue( $invoice_status_changed_condition->condition_met() );
+
+		// Testing when the condition has not been met.
+		$invoice_data['data']['status'] = 'paid';
+		$invoice_status_changed_condition->execute( $invoice_data );
+		$this->assertFalse( $invoice_status_changed_condition->condition_met() );
+	}
+
+	/**
+	 * @testdox Test if an exception is being correctly thrown for wrong operators.
+	 */
+	public function test_status_changed_invalid_operator_throws_exception() {
+		$invoice_status_changed_condition = $this->get_invoice_status_changed_condition( 'wrong_operator', 'paid' );
+		$invoice_data                     = $this->automation_faker->invoice_data();
+
+		$this->expectException( Automation_Exception::class );
+		$this->expectExceptionMessage( 'Invalid operator: wrong_operator' );
+
+		$invoice_status_changed_condition->execute( $invoice_data );
+	}
+
+}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds the invoice condition 'Status Changed' and respective tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3191

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).

