### PR TITLE
AI Assistant: Render response from the AI

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-assistant-form-rendering
+++ b/projects/js-packages/ai-client/changelog/update-ai-assistant-form-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: Export types

--- a/projects/js-packages/ai-client/index.ts
+++ b/projects/js-packages/ai-client/index.ts
@@ -24,3 +24,8 @@ export { default as AIControl } from './src/components/ai-control';
  * Contexts
  */
 export * from './src/data-flow';
+
+/*
+ * Types
+ */
+export * from './src/types';

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.1.1",
+	"version": "0.1.2-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/data-flow/use-ai-context.ts
+++ b/projects/js-packages/ai-client/src/data-flow/use-ai-context.ts
@@ -12,7 +12,7 @@ import { AiDataContext } from '.';
 import type { AiDataContextProps } from './context';
 import type { AskQuestionOptionsArgProps } from '../ask-question';
 
-export type useAiContextOptions = {
+export type UseAiContextOptions = {
 	/*
 	 * Ask question options.
 	 */
@@ -34,13 +34,13 @@ export type useAiContextOptions = {
  * the AI Assistant data (from context),
  * and to subscribe to the request events (onDone, onSuggestion).
  *
- * @param {useAiContextOptions} options - the hook options.
+ * @param {UseAiContextOptions} options - the hook options.
  * @returns {AiDataContextProps}          the AI Assistant data context.
  */
 export default function useAiContext( {
 	onDone,
 	onSuggestion,
-}: useAiContextOptions = {} ): AiDataContextProps {
+}: UseAiContextOptions = {} ): AiDataContextProps {
 	const context = useContext( AiDataContext );
 	const { eventSource } = context;
 

--- a/projects/js-packages/ai-client/src/data-flow/use-ai-context.ts
+++ b/projects/js-packages/ai-client/src/data-flow/use-ai-context.ts
@@ -12,7 +12,7 @@ import { AiDataContext } from '.';
 import type { AiDataContextProps } from './context';
 import type { AskQuestionOptionsArgProps } from '../ask-question';
 
-type useAiContextOptions = {
+export type useAiContextOptions = {
 	/*
 	 * Ask question options.
 	 */

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -22,3 +22,5 @@ export type PromptItemProps = {
 export type PromptMessagesProp = Array< PromptItemProps >;
 
 export type PromptProp = PromptMessagesProp | string;
+
+export type { useAiContextOptions } from './data-flow/use-ai-context';

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -23,4 +23,4 @@ export type PromptMessagesProp = Array< PromptItemProps >;
 
 export type PromptProp = PromptMessagesProp | string;
 
-export type { useAiContextOptions } from './data-flow/use-ai-context';
+export type { UseAiContextOptions } from './data-flow/use-ai-context';

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-form-rendering
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-form-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Render response from the AI

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -14,7 +14,6 @@ import './style.scss';
 /*
  * Types
  */
-import type { UseAiContextOptions } from '@automattic/jetpack-ai-client';
 import type React from 'react';
 
 /**
@@ -22,18 +21,13 @@ import type React from 'react';
  * the AI Assistant data (from context),
  * and to subscribe to the request events (onDone, onSuggestion).
  *
- * @param {UseAiContextOptions} options - the hook options.
  * @returns {React.Component}          the AI Assistant data context.
  */
-export const AiAssistantPopover = ( { onSuggestion, onDone, askQuestionOptions } ) => {
+export const AiAssistantPopover = () => {
 	const { toggle, isVisible, popoverProps, inputValue, setInputValue } =
 		useContext( AiAssistantUiContext );
 
-	const { requestSuggestion, requestingState } = useAiContext( {
-		onDone,
-		onSuggestion,
-		askQuestionOptions,
-	} );
+	const { requestSuggestion, requestingState } = useAiContext();
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -11,12 +11,29 @@ import { __ } from '@wordpress/i18n';
 import { PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, getPrompt } from '../../../../lib/prompt';
 import { AiAssistantUiContext } from '../../ui-handler/context';
 import './style.scss';
+/*
+ * Types
+ */
+import type { useAiContextOptions } from '@automattic/jetpack-ai-client';
+import type React from 'react';
 
-export const AiAssistantPopover = () => {
+/**
+ * useAiContext hook to provide access to
+ * the AI Assistant data (from context),
+ * and to subscribe to the request events (onDone, onSuggestion).
+ *
+ * @param {useAiContextOptions} options - the hook options.
+ * @returns {React.Component}          the AI Assistant data context.
+ */
+export const AiAssistantPopover = ( { onSuggestion, onDone, askQuestionOptions } ) => {
 	const { toggle, isVisible, popoverProps, inputValue, setInputValue } =
 		useContext( AiAssistantUiContext );
 
-	const { requestSuggestion, requestingState } = useAiContext();
+	const { requestSuggestion, requestingState } = useAiContext( {
+		onDone,
+		onSuggestion,
+		askQuestionOptions,
+	} );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -14,7 +14,7 @@ import './style.scss';
 /*
  * Types
  */
-import type { useAiContextOptions } from '@automattic/jetpack-ai-client';
+import type { UseAiContextOptions } from '@automattic/jetpack-ai-client';
 import type React from 'react';
 
 /**
@@ -22,7 +22,7 @@ import type React from 'react';
  * the AI Assistant data (from context),
  * and to subscribe to the request events (onDone, onSuggestion).
  *
- * @param {useAiContextOptions} options - the hook options.
+ * @param {UseAiContextOptions} options - the hook options.
  * @returns {React.Component}          the AI Assistant data context.
  */
 export const AiAssistantPopover = ( { onSuggestion, onDone, askQuestionOptions } ) => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useAiContext } from '@automattic/jetpack-ai-client';
 import { parse } from '@wordpress/blocks';
 import { KeyboardShortcuts } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -96,6 +97,12 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			[ clientId, replaceInnerBlocks ]
 		);
 
+		useAiContext( {
+			onDone: setContent,
+			onSuggestion: setContent,
+			askQuestionOptions: { postId },
+		} );
+
 		/*
 		 * Ensure to provide data context
 		 * only if is't possible to extend the block.
@@ -113,11 +120,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 						},
 					} }
 				>
-					<AiAssistantPopover
-						onDone={ setContent }
-						onSuggestion={ setContent }
-						askQuestionOptions={ postId }
-					/>
+					<AiAssistantPopover />
 					<BlockListBlock { ...props } />
 				</KeyboardShortcuts>
 			</AiAssistantUiContextProvider>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
+import { parse } from '@wordpress/blocks';
 import { KeyboardShortcuts } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useMemo, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
@@ -13,6 +15,7 @@ import { AiAssistantUiContextProps, AiAssistantUiContextProvider } from './conte
 
 const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => {
 	return props => {
+		const { clientId } = props;
 		// AI Assistant input value
 		const [ inputValue, setInputValue ] = useState( '' );
 
@@ -24,6 +27,12 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			anchor: null,
 			placement: 'bottom',
 		} );
+
+		const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+		const coreEditorSelect = useSelect( select => select( 'core/editor' ), [] ) as {
+			getCurrentPostId: () => number;
+		};
+		const postId = coreEditorSelect.getCurrentPostId();
 
 		/**
 		 * Show the AI Assistant
@@ -68,6 +77,25 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			[ inputValue, isVisible, popoverProps, show, hide, toggle ]
 		);
 
+		const setContent = useCallback(
+			( newContent: string ) => {
+				// Remove the Jetpack Form block from the content.
+				const processedContent = newContent.replace(
+					/<!-- (\/)*wp:jetpack\/(contact-)*form ({.*} )*(\/)*-->/g,
+					''
+				);
+				const newContentBlocks = parse( processedContent );
+
+				// Check if the generated blocks are valid.
+				const validBlocks = newContentBlocks.filter( block => {
+					return block.isValid && block.name !== 'core/freeform';
+				} );
+				// Only update the valid blocks
+				replaceInnerBlocks( clientId, validBlocks );
+			},
+			[ clientId, replaceInnerBlocks ]
+		);
+
 		/*
 		 * Ensure to provide data context
 		 * only if is't possible to extend the block.
@@ -85,7 +113,11 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 						},
 					} }
 				>
-					<AiAssistantPopover />
+					<AiAssistantPopover
+						onDone={ setContent }
+						onSuggestion={ setContent }
+						askQuestionOptions={ postId }
+					/>
 					<BlockListBlock { ...props } />
 				</KeyboardShortcuts>
 			</AiAssistantUiContextProvider>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -246,9 +246,10 @@ function getJetpackFormCustomPrompt( {
 			content: `You are an expert developer in Gutenberg, the WordPress block editor, and thoroughly familiar with the Jetpack Form feature. Your content will be used inside a Jetpack Form block that already exists.
 Writing rules:
 - Execute the request without any acknowledgment or explanation to the user.
-- If you cannot generate a meaningful response to a user's request, reply with “__JETPACK_AI_ERROR__“. This term should only be used in this context, it is used to generate user facing errors.
+- If you cannot generate a meaningful response to a user's request, reply only with “__JETPACK_AI_ERROR__“. This term should only be used in this context, it is used to generate user facing errors.
 - Avoid sensitive or controversial topics and ensure your responses are grammatically correct and coherent.
-- DO NOT add any addtional feedback to the user, just generate the requested block structure and nothing else.`,
+- Do not add any additional feedback to the user, just generate the requested block structure and nothing else.
+- Do not refer to yourself, the user or the response in any way.`,
 		},
 		{
 			role,
@@ -256,26 +257,57 @@ Writing rules:
 				request
 			) }
 Strong requirements:
-- When the user provides instructions, translate them into appropriate Gutenberg blocks and Jetpack form structure.
+- When the user provides instructions, translate them into appropriate Gutenberg Jetpack form blocks in the allowed list.
 - Do not wrap the generated structure with any block, element, or delimiters of any kind.
-- Do not use the \`<!-- wp:jetpack/contact-form -->\` block nor any containing elements. The existing form already has a containing block and appropriate elements.
+- Never use the wp:jetpack/contact-form block nor any containing elements. The existing form already has a containing block and appropriate elements.
+- There is no wp:jetpack/form block. Never use it.
+- Crucially, when asked to add or modify something in the form, always respond with the full form including the previous form and the modified or added part in it, not just the new part. This is to ensure no data is lost.
 - Replace placeholders (like FIELD_LABEL, IS_REQUIRED, etc.) with the user's specifications.
-- Use only the following blocks with the following syntax templates:
-	- \`Name Field\`: <!-- wp:jetpack/field-name {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-	- \`Email Field\`: <!-- wp:jetpack/field-email {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-	- \`Text Input Field\`: <!-- wp:jetpack/field-text {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-	- \`Multi-line Text Field \`: <!-- wp:jetpack/field-textarea {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-	- \`Checkbox\`: <!-- wp:jetpack/field-checkbox {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT} /-->
-	- \`Date Picker\`: <!-- wp:jetpack/field-date {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-	- \`Phone Number Field\`: <!-- wp:jetpack/field-telephone {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-	- \`URL Field\`: <!-- wp:jetpack/field-url {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-	- \`Multiple Choice (Checkbox)\`: <!-- wp:jetpack/field-checkbox-multiple {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
-	- \`Single Choice (Radio)\`: <!-- wp:jetpack/field-radio {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
-	- \`Dropdown Field\`: <!-- wp:jetpack/field-select {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE],"toggleLabel":TOGGLE_LABEL} /-->
-	- \`Terms Consent\`:  <!-- wp:jetpack/field-consent {"consentType":"CONSENT_TYPE","implicitConsentMessage":"IMPLICIT_CONSENT_MESSAGE","explicitConsentMessage":"EXPLICIT_CONSENT_MESSAGE", /-->
-	- \`Button\`: <!-- wp:jetpack/button {"label":FIELD_LABEL,"element":"button","text":BUTTON_TEXT,"borderRadius":BORDER_RADIUS,"lock":{"remove":true}} /-->
+- Use only the allowed blocks with their given syntax.
+- Allowed blocks:
+  Name Field
+    code: wp:jetpack/field-name
+    syntax: <!-- wp:jetpack/field-name {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+  Email Field
+    code: wp:jetpack/field-email
+    syntax: <!-- wp:jetpack/field-email {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+  Text Input Field
+    code: wp:jetpack/field-text
+    syntax: <!-- wp:jetpack/field-text {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+  Multi-line Text Field
+    code: wp:jetpack/field-textarea
+    syntax: <!-- wp:jetpack/field-textarea {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+  Checkbox
+    code: wp:jetpack/field-checkbox
+    syntax: <!-- wp:jetpack/field-checkbox {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT} /-->
+  Date Picker
+    code: wp:jetpack/field-date
+    syntax: <!-- wp:jetpack/field-date {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+  Phone Number Field
+    code: wp:jetpack/field-telephone
+    syntax: <!-- wp:jetpack/field-telephone {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+  URL Field
+    code: wp:jetpack/field-url
+    syntax: <!-- wp:jetpack/field-url {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+  Multiple Choice (Checkbox)
+    code: wp:jetpack/field-checkbox-multiple
+    syntax: <!-- wp:jetpack/field-checkbox-multiple {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
+  Single Choice (Radio)
+    code: wp:jetpack/field-radio
+    syntax: <!-- wp:jetpack/field-radio {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
+  Dropdown Field
+    code: wp:jetpack/field-select
+    syntax: <!-- wp:jetpack/field-select {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE],"toggleLabel":TOGGLE_LABEL} /-->
+  Terms Consent
+    code: wp:jetpack/field-consent
+    syntax: <!-- wp:jetpack/field-consent {"consentType":"CONSENT_TYPE","implicitConsentMessage":"IMPLICIT_CONSENT_MESSAGE","explicitConsentMessage":"EXPLICIT_CONSENT_MESSAGE", /-->
+  Button
+    code: wp:jetpack/button
+    syntax: <!-- wp:jetpack/button {"label":FIELD_LABEL,"element":"button","text":BUTTON_TEXT,"borderRadius":BORDER_RADIUS,"lock":{"remove":true}} /-->
 
-Jetpack Form to modify, delimited with ${ delimiter }: ${ getDelimitedContent( content ) }`,
+Jetpack Form to modify or add content to, delimited with ${ delimiter }: ${ getDelimitedContent(
+				content
+			) }`,
 		},
 	];
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32202

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Renders the response from the AI
* Filters out the jetpack form block just in case
* Tweaks the prompt to make it clearer which blocks and syntax are expected as output

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form block
* Use the extension to ask for a form, like "give me a form for hotel reservation"
* Check that the form fields are inserted in the page as the response is sent
