### PR TITLE
[Super Cache] Fix banner on zoom out

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-banner-zoom
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-banner-zoom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed boost banner getting oversized when zoomed out

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -1075,14 +1075,13 @@ table.wpsc-settings-table {
 			min-width: 40%;
 			max-width: 40%;
 			overflow: hidden;
+			text-align: right;
 		}
 
 		.wpsc-boost-banner-image-container img {
 			position: relative;
-			left: 50%;
 			top: 50%;
-			transform: translate(-50%, -50%);
-			width: 100%;
+			transform: translateY(-50%);
 		}
 
 		.wpsc-boost-banner h3 {


### PR DESCRIPTION
When you zoom out (ctrl/cmd minus), the "boost banner" can end up looking kind of big: 
![image](https://github.com/Automattic/jetpack/assets/1369626/2acc0312-2e40-40c4-b7d9-522a4cf3d7e3)

This PR tweaks its CSS to prevent it from growing weirdly.

## Proposed changes:
* Tweak CSS rules to prevent the boost banner from growing strangely when zoomed out.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Reset the boost banner by deleting the user option `wpsc_dismissed_boost_banner`
* View the Super Cache easy dashboard
* Zoom out (cmd-minus)
* Make sure the boost banner doesn't end up weirdly sized.

