### PR TITLE
 AI Extension: select Jetpack Form when toggling the AI Assistant

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-focus-form-from-assistant
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-focus-form-from-assistant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: select Form when selecting child block

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -24,7 +24,7 @@ import type React from 'react';
  * @returns {React.Component}          the AI Assistant data context.
  */
 export const AiAssistantPopover = () => {
-	const { toggle, isVisible, popoverProps, inputValue, setInputValue } =
+	const { isVisible, hide, toggle, popoverProps, inputValue, setInputValue } =
 		useContext( AiAssistantUiContext );
 
 	const { requestSuggestion, requestingState } = useAiContext();
@@ -36,7 +36,7 @@ export const AiAssistantPopover = () => {
 	}
 
 	return (
-		<Popover { ...popoverProps } className="jetpack-ai-assistant__popover">
+		<Popover onClose={ hide } { ...popoverProps } className="jetpack-ai-assistant__popover">
 			<KeyboardShortcuts
 				bindGlobal
 				shortcuts={ {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -5,7 +5,7 @@ import { useAiContext } from '@automattic/jetpack-ai-client';
 import { parse } from '@wordpress/blocks';
 import { KeyboardShortcuts } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
@@ -63,6 +63,15 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		const toggle = useCallback( () => {
 			setAssistantVisibility( ! isVisible );
 		}, [ isVisible ] );
+
+		/**
+		 * Select the Jetpack Form block
+		 *
+		 * @returns {void}
+		 */
+		const selectFormBlock = useCallback( () => {
+			dispatch( 'core/block-editor' ).selectBlock( props.clientId );
+		}, [ props.clientId ] );
 
 		/*
 		 * Set the anchor element for the popover.
@@ -158,6 +167,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 					shortcuts={ {
 						'mod+/': () => {
 							toggle();
+							selectFormBlock();
 						},
 					} }
 				>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Even if the selected block is a child of the form, it is still possible to open the AI assistant. However, it is recommended to choose the form as it provides better assistance for now.
Also, it closes the Assistant when click-out outside of it

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: select Jetpack Form when toggling the AI Assistant

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack form instance
* Select a child block
 
<img width="443" alt="Screenshot 2023-08-02 at 09 15 27" src="https://github.com/Automattic/jetpack/assets/77539/0b3434d5-ad27-4be7-84fd-c32ab7e5840a">

* Open the assistant by pressing `CMD` + `/`
* Confirm the assistant shows up
* Confirm that, now, the Jetpack Form (wrapper) block instance is selected
* Also, confirm the assistant hides out once you click outside of it.

before | after
------|-----
<img width="495" alt="Screenshot 2023-08-02 at 09 17 12" src="https://github.com/Automattic/jetpack/assets/77539/84caac35-3392-427a-9989-429597588561"> | <img width="563" alt="Screenshot 2023-08-02 at 09 15 49" src="https://github.com/Automattic/jetpack/assets/77539/b9b04047-de4a-4099-98ca-644a6b12d920">

