### PR TITLE
AI Extension: use assistant to edit Jetpack Form content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-edit-form
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-edit-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: use assistant to edit Jetpack Format content

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import { useAiContext } from '@automattic/jetpack-ai-client';
+import { serialize } from '@wordpress/blocks';
 import { Button, KeyboardShortcuts, Popover, TextControl } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { useContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
@@ -16,18 +18,54 @@ import './style.scss';
  */
 import type React from 'react';
 
+type AiAssistantPopoverProps = {
+	clientId?: string;
+};
+
+/**
+ * Return the serialized content from the childrens block.
+ *
+ * @param {string} clientId - The block client ID.
+ * @returns {string}          The serialized content.
+ */
+function getSerializedContentFromBlock( clientId: string ): string {
+	if ( ! clientId?.length ) {
+		return '';
+	}
+
+	const block = select( 'core/block-editor' ).getBlock( clientId );
+	if ( ! block ) {
+		return '';
+	}
+
+	const { innerBlocks } = block;
+	if ( ! innerBlocks?.length ) {
+		return '';
+	}
+
+	return innerBlocks.reduce( ( acc, innerBlock ) => {
+		return acc + serialize( innerBlock );
+	}, '' );
+}
+
 /**
  * useAiContext hook to provide access to
  * the AI Assistant data (from context),
  * and to subscribe to the request events (onDone, onSuggestion).
  *
- * @returns {React.Component}          the AI Assistant data context.
+ * @param {string} clientId  - The block client ID. Optional.
+ * @returns {React.Component} the AI Assistant data context.
  */
-export const AiAssistantPopover = () => {
+
+export const AiAssistantPopover = ( {
+	clientId = '',
+}: AiAssistantPopoverProps ): React.ReactNode => {
 	const { isVisible, hide, toggle, popoverProps, inputValue, setInputValue } =
 		useContext( AiAssistantUiContext );
 
 	const { requestSuggestion, requestingState } = useAiContext();
+
+	const content = getSerializedContentFromBlock( clientId );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 
@@ -51,7 +89,7 @@ export const AiAssistantPopover = () => {
 						onClick={ () => {
 							const prompt = getPrompt( PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, {
 								request: inputValue,
-								content: '',
+								content,
 							} );
 
 							requestSuggestion( prompt );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -44,7 +44,7 @@ function getSerializedContentFromBlock( clientId: string ): string {
 	}
 
 	return innerBlocks.reduce( ( acc, innerBlock ) => {
-		return acc + serialize( innerBlock );
+		return acc + serialize( innerBlock ) + '\n\n';
 	}, '' );
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -65,8 +65,6 @@ export const AiAssistantPopover = ( {
 
 	const { requestSuggestion, requestingState } = useAiContext();
 
-	const content = getSerializedContentFromBlock( clientId );
-
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 
 	if ( ! isVisible ) {
@@ -89,7 +87,7 @@ export const AiAssistantPopover = ( {
 						onClick={ () => {
 							const prompt = getPrompt( PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, {
 								request: inputValue,
-								content,
+								content: getSerializedContentFromBlock( clientId ),
 							} );
 
 							requestSuggestion( prompt );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -171,7 +171,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 						},
 					} }
 				>
-					<AiAssistantPopover />
+					<AiAssistantPopover clientId={ clientId } />
 					<BlockListBlock { ...props } />
 				</KeyboardShortcuts>
 			</AiAssistantUiContextProvider>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -243,71 +243,55 @@ function getJetpackFormCustomPrompt( {
 	return [
 		{
 			role: 'system',
-			content: `You are an expert developer in Gutenberg, the WordPress block editor, and thoroughly familiar with the Jetpack Form feature. Your content will be used inside a Jetpack Form block that already exists.
-Writing rules:
-- Execute the request without any acknowledgment or explanation to the user.
-- If you cannot generate a meaningful response to a user's request, reply only with “__JETPACK_AI_ERROR__“. This term should only be used in this context, it is used to generate user facing errors.
+			content: `
+- You are an expert developer in Gutenberg, the WordPress block editor, and thoroughly familiar with the Jetpack Form feature.
+- Do not wrap the generated structure with any block, like the \`<!-- wp:jetpack/contact-form -->\` syntax.
+- DO NOT add any addtional feedback to the "user", just generate the requested block structure.
+
+- Use syntax templates for blocks as follows:
+	- \`Name Field\`: <!-- wp:jetpack/field-name {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Email Field\`: <!-- wp:jetpack/field-email {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Text Input Field\`: <!-- wp:jetpack/field-text {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Multi-line Text Field \`: <!-- wp:jetpack/field-textarea {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Checkbox\`: <!-- wp:jetpack/field-checkbox {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT} /-->
+	- \`Date Picker\`: <!-- wp:jetpack/field-date {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Phone Number Field\`: <!-- wp:jetpack/field-telephone {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`URL Field\`: <!-- wp:jetpack/field-url {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Multiple Choice (Checkbox)\`: <!-- wp:jetpack/field-checkbox-multiple {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
+	- \`Single Choice (Radio)\`: <!-- wp:jetpack/field-radio {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
+	- \`Dropdown Field\`: <!-- wp:jetpack/field-select {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE],"toggleLabel":TOGGLE_LABEL} /-->
+	- \`Terms Consent\`:  <!-- wp:jetpack/field-consent {"consentType":"CONSENT_TYPE","implicitConsentMessage":"IMPLICIT_CONSENT_MESSAGE","explicitConsentMessage":"EXPLICIT_CONSENT_MESSAGE", /-->
+	- \`Button\`: <!-- wp:jetpack/button {"label":FIELD_LABEL,"element":"button","text":BUTTON_TEXT,"borderRadius":BORDER_RADIUS,"lock":{"remove":true}} /-->
+- When the user provides instructions, translate them into appropriate Gutenberg blocks and Jetpack form structure.
+- Replace placeholders (like FIELD_LABEL, IS_REQUIRED, etc.) with the user's specifications.
 - Avoid sensitive or controversial topics and ensure your responses are grammatically correct and coherent.
-- Do not add any additional feedback to the user, just generate the requested block structure and nothing else.
-- Do not refer to yourself, the user or the response in any way.`,
+- If you cannot generate a meaningful response to a user's request, reply with “__JETPACK_AI_ERROR__“. This term should only be used in this context, it is used to generate user facing errors.`,
 		},
 		{
 			role,
-			content: `Handle the following request, delimited with ${ delimiter }: ${ getDelimitedContent(
-				request
-			) }
-Strong requirements:
-- When the user provides instructions, translate them into appropriate Gutenberg Jetpack form blocks in the allowed list.
-- Do not wrap the generated structure with any block, element, or delimiters of any kind.
-- Never use the wp:jetpack/contact-form block nor any containing elements. The existing form already has a containing block and appropriate elements.
-- There is no wp:jetpack/form block. Never use it.
-- Crucially, when asked to add or modify something in the form, always respond with the full form including the previous form and the modified or added part in it, not just the new part. This is to ensure no data is lost.
-- Replace placeholders (like FIELD_LABEL, IS_REQUIRED, etc.) with the user's specifications.
-- Use only the allowed blocks with their given syntax.
-- Allowed blocks:
-  Name Field
-    code: wp:jetpack/field-name
-    syntax: <!-- wp:jetpack/field-name {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-  Email Field
-    code: wp:jetpack/field-email
-    syntax: <!-- wp:jetpack/field-email {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-  Text Input Field
-    code: wp:jetpack/field-text
-    syntax: <!-- wp:jetpack/field-text {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-  Multi-line Text Field
-    code: wp:jetpack/field-textarea
-    syntax: <!-- wp:jetpack/field-textarea {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-  Checkbox
-    code: wp:jetpack/field-checkbox
-    syntax: <!-- wp:jetpack/field-checkbox {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT} /-->
-  Date Picker
-    code: wp:jetpack/field-date
-    syntax: <!-- wp:jetpack/field-date {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-  Phone Number Field
-    code: wp:jetpack/field-telephone
-    syntax: <!-- wp:jetpack/field-telephone {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-  URL Field
-    code: wp:jetpack/field-url
-    syntax: <!-- wp:jetpack/field-url {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
-  Multiple Choice (Checkbox)
-    code: wp:jetpack/field-checkbox-multiple
-    syntax: <!-- wp:jetpack/field-checkbox-multiple {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
-  Single Choice (Radio)
-    code: wp:jetpack/field-radio
-    syntax: <!-- wp:jetpack/field-radio {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
-  Dropdown Field
-    code: wp:jetpack/field-select
-    syntax: <!-- wp:jetpack/field-select {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE],"toggleLabel":TOGGLE_LABEL} /-->
-  Terms Consent
-    code: wp:jetpack/field-consent
-    syntax: <!-- wp:jetpack/field-consent {"consentType":"CONSENT_TYPE","implicitConsentMessage":"IMPLICIT_CONSENT_MESSAGE","explicitConsentMessage":"EXPLICIT_CONSENT_MESSAGE", /-->
-  Button
-    code: wp:jetpack/button
-    syntax: <!-- wp:jetpack/button {"label":FIELD_LABEL,"element":"button","text":BUTTON_TEXT,"borderRadius":BORDER_RADIUS,"lock":{"remove":true}} /-->
+			content: `Handle the following request: ${ request }
 
-Jetpack Form to modify or add content to, delimited with ${ delimiter }: ${ getDelimitedContent(
-				content
-			) }`,
+Strong requirements:
+- Do not wrap the generated structure with any block, like the \`<!-- wp:jetpack/contact-form -->\` syntax.
+- DO NOT add any addtional feedback to the "user", just generate the requested block structure.
+- Use syntax templates for blocks as follows:
+	- \`Name Field\`: <!-- wp:jetpack/field-name {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Email Field\`: <!-- wp:jetpack/field-email {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Text Input Field\`: <!-- wp:jetpack/field-text {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Multi-line Text Field \`: <!-- wp:jetpack/field-textarea {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Checkbox\`: <!-- wp:jetpack/field-checkbox {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT} /-->
+	- \`Date Picker\`: <!-- wp:jetpack/field-date {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Phone Number Field\`: <!-- wp:jetpack/field-telephone {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`URL Field\`: <!-- wp:jetpack/field-url {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT,"placeholder":PLACEHOLDER_TEXT} /-->
+	- \`Multiple Choice (Checkbox)\`: <!-- wp:jetpack/field-checkbox-multiple {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
+	- \`Single Choice (Radio)\`: <!-- wp:jetpack/field-radio {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE]} /-->
+	- \`Dropdown Field\`: <!-- wp:jetpack/field-select {"label":FIELD_LABEL,"required":IS_REQUIRED,"requiredText":REQUIRED_TEXT, "options": [OPTION_ONE, OPTION_TWO, OPTION_THREE],"toggleLabel":TOGGLE_LABEL} /-->
+	- \`Terms Consent\`:  <!-- wp:jetpack/field-consent {"consentType":"CONSENT_TYPE","implicitConsentMessage":"IMPLICIT_CONSENT_MESSAGE","explicitConsentMessage":"EXPLICIT_CONSENT_MESSAGE", /-->
+	- \`Button\`: <!-- wp:jetpack/button {"label":FIELD_LABEL,"element":"button","text":BUTTON_TEXT,"borderRadius":BORDER_RADIUS,"lock":{"remove":true}} /-->
+	- When the user provides instructions, translate them into appropriate Gutenberg blocks and Jetpack form structure.
+	- Replace placeholders (like FIELD_LABEL, IS_REQUIRED, etc.) with the user's specifications.
+
+Jetpack Form to modify:\n${ content }`,
 		},
 	];
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This pull request involves transferring the Form content to the AI service for iteration.

Fixes https://github.com/Automattic/jetpack/issues/32213

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: use assistant to edit Jetpack Format content

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Create a form
* Edit the content by using the AI assistant, for instance:
* Confirm you can translate the content:
```
translate to Spanish
```


https://github.com/Automattic/jetpack/assets/77539/d583ccfd-7691-4b77-9888-16afce831f4e


