### PR TITLE
Hovercards: switch to new URL

### DIFF
--- a/projects/plugins/jetpack/changelog/update-gravatar-hovercards
+++ b/projects/plugins/jetpack/changelog/update-gravatar-hovercards
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Switch to the new hovercard library.

--- a/projects/plugins/jetpack/modules/gravatar-hovercards.php
+++ b/projects/plugins/jetpack/modules/gravatar-hovercards.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Gravatar Hovercards
- * Module Description: Enable pop-up business cards over commenters’ Gravatars.
+ * Module Description: Enable profile hovercards on comment avatars.
  * Sort Order: 11
  * Recommendation Order: 13
  * First Introduced: 1.1
@@ -263,7 +263,7 @@ function grofiles_attach_cards() {
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		wp_enqueue_style( 'gravatar-hovercard-style', plugins_url( '/gravatar/gravatar-hovercards-amp.css', __FILE__ ), array(), JETPACK__VERSION );
 	} else {
-		wp_enqueue_script( 'grofiles-cards', 'https://secure.gravatar.com/js/gprofiles.js', array(), GROFILES__CACHE_BUSTER, true );
+		wp_enqueue_script( 'grofiles-cards', 'https://secure.gravatar.com/js/hovercards/hovercards.min.js', array(), GROFILES__CACHE_BUSTER, true );
 		wp_enqueue_script( 'wpgroho', plugins_url( 'wpgroho.js', __FILE__ ), array( 'grofiles-cards' ), JETPACK__VERSION, true );
 		if ( is_user_logged_in() ) {
 			$cu      = wp_get_current_user();
@@ -274,6 +274,16 @@ function grofiles_attach_cards() {
 			$my_hash = '';
 		}
 		wp_localize_script( 'wpgroho', 'WPGroHo', compact( 'my_hash' ) );
+		wp_localize_script(
+			'grofiles-cards',
+			'GravatarHovercardsi18n',
+			array(
+				'Edit your profile' => __( 'Edit your profile', 'jetpack' ),
+				'View profile'      => __( 'View profile', 'jetpack' ),
+				'Sorry, we are unable to load this Gravatar profile.' => __( 'Sorry, we are unable to load this Gravatar profile.', 'jetpack' ),
+				'Sorry, we are unable to load this Gravatar profile. Please check your internet connection.' => __( 'Sorry, we are unable to load this Gravatar profile. Please check your internet connection.', 'jetpack' ),
+			)
+		);
 	}
 }
 /**

--- a/projects/plugins/jetpack/modules/wpgroho.js
+++ b/projects/plugins/jetpack/modules/wpgroho.js
@@ -1,4 +1,4 @@
-/* global WPGroHo:true, Gravatar */
+/* global WPGroHo:true, Gravatar, GravatarHovercardsi18n */
 ( function () {
 	var extend = function ( out ) {
 		out = out || {};
@@ -65,7 +65,7 @@
 		};
 
 		Gravatar.my_hash = WPGroHo.my_hash;
-		Gravatar.init( 'body', '#wpadminbar' );
+		Gravatar.init( 'body', '#wpadminbar', { i18n: GravatarHovercardsi18n } );
 	};
 
 	if ( document.readyState === 'interactive' || document.readyState === 'complete' ) {

--- a/projects/plugins/jetpack/tests/php/_inc/lib/fixtures/https---publicizetests.wpsandbox.me-2015-03-26-hello-world-.html
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/fixtures/https---publicizetests.wpsandbox.me-2015-03-26-hello-world-.html
@@ -262,7 +262,7 @@ To delete a comment, just log in and view the post&#039;s comments. There you wi
 		window.WPCOM_sharing_counts = {"https:\/\/publicizetests.wpsandbox.me\/2015\/03\/26\/hello-world\/":1};
 	</script>
 				<script src='https://publicizetests.wpsandbox.me/wp-content/plugins/jetpack/_inc/build/photon/photon.min.js?ver=20191001' id='jetpack-photon-js'></script>
-<script src='https://secure.gravatar.com/js/gprofiles.js?ver=202040' id='grofiles-cards-js'></script>
+<script src='https://secure.gravatar.com/js/hovercards/hovercards.min.js?ver=202040' id='grofiles-cards-js'></script>
 <script id='wpgroho-js-extra'>
 var WPGroHo = {"my_hash":""};
 </script>


### PR DESCRIPTION
Updates the Gravatar hovercard URL to use the updated location. Some i18n strings are also supplied, which are used by the new hovercard library.

The option description has been updated.

![image](https://github.com/Automattic/jetpack/assets/1277682/7f17b9cc-49d8-4819-a6d4-7cd62d155981)

## Proposed changes:
* Update a URL
* Add some i18n strings
* Change option description

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Enable hovercards from settings > discussion
* Visit a post with comments, hover over an avatar, and confirm a popup is shown
