### PR TITLE
Boost: Integrate performance history graph

### DIFF
--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.5",
+	"version": "0.1.6-alpha",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/packages/boost-speed-score/changelog/add-performance-history-graph
+++ b/projects/packages/boost-speed-score/changelog/add-performance-history-graph
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package version

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.2.0';
+	const PACKAGE_VERSION = '0.2.1-alpha';
 
 	/**
 	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor

--- a/projects/plugins/boost/app/assets/src/css/admin-style.scss
+++ b/projects/plugins/boost/app/assets/src/css/admin-style.scss
@@ -10,6 +10,7 @@
 @import 'components/feature-toggle';
 @import 'components/benchmarks';
 @import 'components/score';
+@import 'components/performance-history';
 @import 'components/error-message';
 @import 'components/critical-css';
 @import 'components/close-button';

--- a/projects/plugins/boost/app/assets/src/css/components/performance-history.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/performance-history.scss
@@ -1,0 +1,3 @@
+.jb-performance-history {
+    margin-top: 3em;
+}

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/Settings.svelte
@@ -7,7 +7,6 @@
 	import { connection } from '../../stores/connection';
 	import { Router, Route } from '../../utils/router';
 	import AdvancedCriticalCss from './sections/AdvancedCriticalCss.svelte';
-	import History from './sections/History.svelte';
 	import Modules from './sections/Modules.svelte';
 	import Score from './sections/Score.svelte';
 	import Support from './sections/Support.svelte';
@@ -24,10 +23,6 @@
 
 		<div class="jb-section jb-section--alt jb-section--scores">
 			<Score />
-		</div>
-
-		<div class="jb-section">
-			<History />
 		</div>
 
 		<Router>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/History.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/History.svelte
@@ -4,28 +4,23 @@
 	import { __ } from '@wordpress/i18n';
 	import ErrorNotice from '../../../elements/ErrorNotice.svelte';
 	import ReactComponent from '../../../elements/ReactComponent.svelte';
-	import RefreshIcon from '../../../svg/refresh.svg';
 	import { recordBoostEvent } from '../../../utils/analytics';
 	import { castToString } from '../../../utils/cast-to-string';
-	import ScoreContext from '../elements/ScoreContext.svelte';
 
 	const siteIsOnline = Jetpack_Boost.site.online;
 
 	let loadError;
-	const scoreLetter = '';
-
 	let isLoading = false;
-
 	let periods = [];
 
-	// Load the speed score. Will be cached in the plugin.
-	loadScore();
+	// Load the history
+	refresh();
 
 	/**
 	 * Load the speed history from the API
 	 *
 	 */
-	async function loadScore() {
+	export async function refresh() {
 		// Don't run in offline mode.
 		if ( ! siteIsOnline ) {
 			return;
@@ -54,52 +49,13 @@
 </script>
 
 <div class="jb-container">
-	<div id="jp-admin-notices" class="jetpack-boost-jitm-card" />
 	<div class="jb-site-score" class:loading={isLoading}>
-		{#if siteIsOnline}
-			<div class="jb-site-score__top">
-				<h2>
-					{#if isLoading}
-						{__( 'Loading…', 'jetpack-boost' )}
-					{:else if loadError}
-						{__( 'Whoops, something went wrong', 'jetpack-boost' )}
-					{:else}
-						{__( 'Overall Score', 'jetpack-boost' )}: {scoreLetter}
-					{/if}
-				</h2>
-				{#if ! isLoading && ! loadError}
-					<ScoreContext />
-				{/if}
-				<button
-					type="button"
-					class="components-button is-link"
-					disabled={isLoading}
-					on:click={() => loadScore()}
-				>
-					<RefreshIcon />
-					{__( 'Refresh', 'jetpack-boost' )}
-				</button>
-			</div>
-		{:else}
-			<div class="jb-site-score__offline">
-				<h2>
-					{__( 'Website Offline', 'jetpack-boost' )}
-				</h2>
-				<p>
-					{__(
-						'All Jetpack Boost features are still available, but to get a performance score you would first have to make your website available online.',
-						'jetpack-boost'
-					)}
-				</p>
-			</div>
-		{/if}
-
 		{#if loadError}
 			<ErrorNotice
-				title={__( 'Failed to load Speed Scores', 'jetpack-boost' )}
+				title={__( 'Failed to load performance history', 'jetpack-boost' )}
 				error={loadError}
 				suggestion={__( '<action name="retry">Try again</action>', 'jetpack-boost' )}
-				on:retry={() => loadScore()}
+				on:retry={() => refresh()}
 			/>
 		{/if}
 		<ReactComponent

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/History.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/History.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { requestSpeedScoresHistory } from '@automattic/jetpack-boost-score-api';
-	import { BoostScoreGraph } from '@automattic/jetpack-components';
 	import { __ } from '@wordpress/i18n';
 	import ErrorNotice from '../../../elements/ErrorNotice.svelte';
 	import ReactComponent from '../../../elements/ReactComponent.svelte';
+	import { PerformanceHistory } from '../../../react-components/PerformanceHistory';
+	import { performanceHistoryPanelDS } from '../../../stores/data-sync-client';
 	import { recordBoostEvent } from '../../../utils/analytics';
 	import { castToString } from '../../../utils/cast-to-string';
 
@@ -46,10 +47,15 @@
 			isLoading = false;
 		}
 	}
+
+	const panelStore = performanceHistoryPanelDS.store;
+	const onToggleHistory = status => {
+		panelStore.set( status );
+	};
 </script>
 
 <div class="jb-container">
-	<div class="jb-site-score" class:loading={isLoading}>
+	<div class="jb-performance-history" class:loading={isLoading}>
 		{#if loadError}
 			<ErrorNotice
 				title={__( 'Failed to load performance history', 'jetpack-boost' )}
@@ -59,9 +65,10 @@
 			/>
 		{/if}
 		<ReactComponent
-			this={BoostScoreGraph}
+			this={PerformanceHistory}
+			onToggle={onToggleHistory}
+			isOpen={$panelStore}
 			{periods}
-			title={__( 'Performance history', 'jetpack-boost' )}
 		/>
 	</div>
 </div>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Score.svelte
@@ -17,6 +17,7 @@
 	import debounce from '../../../utils/debounce';
 	import PopOut from '../elements/PopOut.svelte';
 	import ScoreContext from '../elements/ScoreContext.svelte';
+	import History from './History.svelte';
 
 	const siteIsOnline = Jetpack_Boost.site.online;
 
@@ -34,6 +35,8 @@
 		noBoost: null,
 		isStale: false,
 	};
+
+	let refreshHistory;
 
 	// Load the speed score. Will be cached in the plugin.
 	loadScore();
@@ -89,6 +92,9 @@
 			);
 			scoreLetter = getScoreLetter( scores.current.mobile, scores.current.desktop );
 			showPrevScores = didScoresChange( scores ) && ! scores.isStale;
+
+			// Trigger a refresh of the performance history.
+			refreshHistory();
 		} catch ( err ) {
 			recordBoostEvent( 'speed_score_request_error', {
 				error_message: castToString( err.message ),
@@ -180,6 +186,8 @@
 			noBoostScoreTooltip={__( 'Your desktop score without Boost', 'jetpack-boost' )}
 		/>
 	</div>
+
+	<History bind:refresh={refreshHistory} />
 </div>
 
 {#if modalData}

--- a/projects/plugins/boost/app/assets/src/js/react-components/PerformanceHistory.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/PerformanceHistory.tsx
@@ -1,0 +1,21 @@
+import { BoostScoreGraph } from '@automattic/jetpack-components';
+import { Panel, PanelBody, PanelRow } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export const PerformanceHistory = ( { periods, onToggle, isOpen } ) => {
+	return (
+		<Panel>
+			<PanelBody
+				title={ __( 'Historical Performance', 'jetpack-boost' ) }
+				initialOpen={ isOpen }
+				onToggle={ onToggle }
+			>
+				<PanelRow>
+					<div style={ { flexGrow: 1, minHeight: '300px' } }>
+						<BoostScoreGraph periods={ periods } />
+					</div>
+				</PanelRow>
+			</PanelBody>
+		</Panel>
+	);
+};

--- a/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/data-sync-client.ts
@@ -34,3 +34,8 @@ export const suggestRegenerateDS = jetpack_boost_ds.createAsyncStore(
 	'critical_css_suggest_regenerate',
 	z.enum( allowedSuggestions ).nullable()
 );
+
+export const performanceHistoryPanelDS = jetpack_boost_ds.createAsyncStore(
+	'performance_history_toggle',
+	z.boolean()
+);

--- a/projects/plugins/boost/changelog/add-performance-history-graph
+++ b/projects/plugins/boost/changelog/add-performance-history-graph
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Refactoring and improvements
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -160,3 +160,5 @@ $js_excludes_entry  = new Minify_Excludes_State_Entry( 'minify_js_excludes' );
 $css_excludes_entry = new Minify_Excludes_State_Entry( 'minify_css_excludes' );
 jetpack_boost_register_option( 'minify_js_excludes', Schema::as_array( Schema::as_string() )->fallback( Minify_JS::$default_excludes ), $js_excludes_entry );
 jetpack_boost_register_option( 'minify_css_excludes', Schema::as_array( Schema::as_string() )->fallback( Minify_CSS::$default_excludes ), $css_excludes_entry );
+
+jetpack_boost_register_option( 'performance_history_toggle', Schema::as_boolean()->fallback( true ) );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add performance history graph to a panel
* Cleanup and refactor the svelte component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
Collapse/expand the panel and refresh the page to ensure the status sticks across browser reloads

