### PR TITLE
AI Extension: show AI notices 

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-show-notices
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-show-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: show a Notice when AI needs to provide feedback


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# require https://github.com/Automattic/jetpack/pull/32223~

This PR shows a Notice when AI needs to provide feedback to the user.
This is a tentative approach that uses the core Notice implementation.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: show AI notices 

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Try to generate an error when requesting a suggestion
* Confirm the app shows the app Notice 

https://github.com/Automattic/jetpack/assets/77539/d20f68d7-0ba5-4465-9487-819d1c58b56d
