### PR TITLE
AI Client: add onError() response support

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-form-ai-show-notices
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-form-ai-show-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: add onError() response support

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -108,7 +108,7 @@ const debug = debugFactory( 'jetpack-ai-client:use-suggestion' );
  * @param {SuggestionErrorCode} errorCode - The error code.
  * @returns {RequestingErrorProps}          The error data.
  */
-function getErrorData( errorCode: SuggestionErrorCode ): RequestingErrorProps {
+export function getErrorData( errorCode: SuggestionErrorCode ): RequestingErrorProps {
 	switch ( errorCode ) {
 		case ERROR_QUOTA_EXCEEDED:
 			return {

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -6,14 +6,16 @@ import debugFactory from 'debug';
 /*
  * Types & constants
  */
+import { getErrorData } from '../hooks/use-ai-suggestions';
 import {
 	ERROR_MODERATION,
 	ERROR_NETWORK,
 	ERROR_QUOTA_EXCEEDED,
+	ERROR_RESPONSE,
 	ERROR_SERVICE_UNAVAILABLE,
 	ERROR_UNCLEAR_PROMPT,
 } from '../types';
-import type { PromptMessagesProp, PromptProp } from '../types';
+import type { PromptMessagesProp, PromptProp, SuggestionErrorCode } from '../types';
 
 type SuggestionsEventSourceConstructorArgs = {
 	url?: string;
@@ -150,6 +152,9 @@ export default class SuggestionsEventSource extends EventTarget {
 				if ( response.ok ) {
 					return;
 				}
+
+				let errorCode: SuggestionErrorCode;
+
 				if (
 					response.status >= 400 &&
 					response.status <= 500 &&
@@ -163,6 +168,7 @@ export default class SuggestionsEventSource extends EventTarget {
 				 * service unavailable
 				 */
 				if ( response.status === 503 ) {
+					errorCode = ERROR_SERVICE_UNAVAILABLE;
 					this.dispatchEvent( new CustomEvent( ERROR_SERVICE_UNAVAILABLE ) );
 				}
 
@@ -171,6 +177,7 @@ export default class SuggestionsEventSource extends EventTarget {
 				 * you exceeded your current quota please check your plan and billing details
 				 */
 				if ( response.status === 429 ) {
+					errorCode = ERROR_QUOTA_EXCEEDED;
 					this.dispatchEvent( new CustomEvent( ERROR_QUOTA_EXCEEDED ) );
 				}
 
@@ -179,8 +186,16 @@ export default class SuggestionsEventSource extends EventTarget {
 				 * request flagged by moderation system
 				 */
 				if ( response.status === 422 ) {
+					errorCode = ERROR_MODERATION;
 					this.dispatchEvent( new CustomEvent( ERROR_MODERATION ) );
 				}
+
+				// Always dispatch a global responseError event
+				this.dispatchEvent(
+					new CustomEvent( ERROR_RESPONSE, {
+						detail: getErrorData( errorCode ),
+					} )
+				);
 
 				throw new Error();
 			},
@@ -204,6 +219,11 @@ export default class SuggestionsEventSource extends EventTarget {
 		if ( replacedMessage.startsWith( 'JETPACK_AI_ERROR' ) ) {
 			// The unclear prompt marker was found, so we dispatch an error event
 			this.dispatchEvent( new CustomEvent( ERROR_UNCLEAR_PROMPT ) );
+			this.dispatchEvent(
+				new CustomEvent( ERROR_RESPONSE, {
+					detail: getErrorData( ERROR_UNCLEAR_PROMPT ),
+				} )
+			);
 		} else if ( 'JETPACK_AI_ERROR'.startsWith( replacedMessage ) ) {
 			// Partial unclear prompt marker was found, so we wait for more data and print a debug message without dispatching an event
 			debug( this.fullMessage );
@@ -276,6 +296,11 @@ export default class SuggestionsEventSource extends EventTarget {
 	processConnectionError( response ) {
 		debug( 'Connection error: %o', response );
 		this.dispatchEvent( new CustomEvent( ERROR_NETWORK, { detail: response } ) );
+		this.dispatchEvent(
+			new CustomEvent( ERROR_RESPONSE, {
+				detail: getErrorData( ERROR_NETWORK ),
+			} )
+		);
 	}
 
 	processErrorEvent( e ) {
@@ -283,5 +308,10 @@ export default class SuggestionsEventSource extends EventTarget {
 
 		// Dispatch a generic network error event
 		this.dispatchEvent( new CustomEvent( ERROR_NETWORK, { detail: e } ) );
+		this.dispatchEvent(
+			new CustomEvent( ERROR_RESPONSE, {
+				detail: getErrorData( ERROR_NETWORK ),
+			} )
+		);
 	}
 }

--- a/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
+++ b/projects/js-packages/ai-client/src/suggestions-event-source/index.ts
@@ -190,7 +190,7 @@ export default class SuggestionsEventSource extends EventTarget {
 					this.dispatchEvent( new CustomEvent( ERROR_MODERATION ) );
 				}
 
-				// Always dispatch a global responseError event
+				// Always dispatch a global ERROR_RESPONSE event
 				this.dispatchEvent(
 					new CustomEvent( ERROR_RESPONSE, {
 						detail: getErrorData( errorCode ),

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -3,13 +3,15 @@ export const ERROR_QUOTA_EXCEEDED = 'error_quota_exceeded' as const;
 export const ERROR_MODERATION = 'error_moderation' as const;
 export const ERROR_NETWORK = 'error_network' as const;
 export const ERROR_UNCLEAR_PROMPT = 'error_unclear_prompt' as const;
+export const ERROR_RESPONSE = 'error_response' as const;
 
 export type SuggestionErrorCode =
 	| typeof ERROR_SERVICE_UNAVAILABLE
 	| typeof ERROR_QUOTA_EXCEEDED
 	| typeof ERROR_MODERATION
 	| typeof ERROR_NETWORK
-	| typeof ERROR_UNCLEAR_PROMPT;
+	| typeof ERROR_UNCLEAR_PROMPT
+	| typeof ERROR_RESPONSE;
 
 /*
  * Prompt types
@@ -24,3 +26,4 @@ export type PromptMessagesProp = Array< PromptItemProps >;
 export type PromptProp = PromptMessagesProp | string;
 
 export type { UseAiContextOptions } from './data-flow/use-ai-context';
+export type { RequestingErrorProps } from './hooks/use-ai-suggestions';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In this PR:
- Trigger a new generic `error_response`
- Add a `onError` callback to the useAiContext() hook

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: add onError() response support

### Other information:


- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Since the changes here are not being used for now:
* Confirm the dev-env builds the package correctly. (stop, and restart the building process of Jetpack plugin, for instance)
* A visual code review ftw

Additionality, these changes will be required for https://github.com/Automattic/jetpack/pull/32222, so you can merge the branches in your local to test how the app shows the notices based on the emitted error.

