### PR TITLE
Launchpad: Add path for newsletter tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-path-for-newsletter-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-path-for-newsletter-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the path for the Write 3 posts and Enable subscriber modal tasks

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -424,12 +424,32 @@ class Launchpad_Task_Lists {
 			return null;
 		}
 
-		// Require that the string start with `/`, but don't allow `//`.
-		if ( '/' !== substr( $calypso_path, 0, 1 ) || '/' === substr( $calypso_path, 1, 1 ) ) {
+		if ( ! $this->is_valid_url_or_path( $calypso_path ) ) {
 			return null;
 		}
 
 		return $calypso_path;
+	}
+
+	/**
+	 * Checks if a string is a valid URL or path.
+	 *
+	 * @param string $input The string to check.
+	 * @return boolean
+	 */
+	private function is_valid_url_or_path( $input ) {
+		// Validate as a full URL
+		$url_info = wp_parse_url( $input );
+		if ( $url_info !== false && isset( $url_info['scheme'] ) ) {
+			return true;
+		}
+
+		// Require that the string start with a slash, but not two slashes
+		if ( '/' === substr( $input, 0, 1 ) && '/' !== substr( $input, 1, 1 ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -424,7 +424,7 @@ class Launchpad_Task_Lists {
 			return null;
 		}
 
-		if ( ! $this->is_valid_url_or_path( $calypso_path ) ) {
+		if ( ! $this->is_valid_admin_url_or_absolute_path( $calypso_path ) ) {
 			return null;
 		}
 
@@ -432,12 +432,12 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
-	 * Checks if a string is a valid URL or path.
+	 * Checks if a string is a valid admin URL or an absolute path.
 	 *
 	 * @param string $input The string to check.
 	 * @return boolean
 	 */
-	private function is_valid_url_or_path( $input ) {
+	private function is_valid_admin_url_or_absolute_path( $input ) {
 		// Checks if the string is URL starting with the admin URL
 		if ( strpos( $input, admin_url() ) === 0 ) {
 			return true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -438,9 +438,8 @@ class Launchpad_Task_Lists {
 	 * @return boolean
 	 */
 	private function is_valid_url_or_path( $input ) {
-		// Validate as a full URL
-		$url_info = wp_parse_url( $input );
-		if ( $url_info !== false && isset( $url_info['scheme'] ) ) {
+		// Checks if the string is URL starting with the admin URL
+		if ( strpos( $input, admin_url() ) === 0 ) {
 			return true;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -343,6 +343,12 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_is_enable_subscribers_modal_visible',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( ( new Automattic\Jetpack\Status\Host() )->is_atomic_platform() ) {
+					return 'https://' . $data['site_slug_encoded'] . '/wp-admin/admin.php?page=jetpack#/discussion';
+				}
+				return '/settings/reading/' . $data['site_slug_encoded'] . '#newsletter-settings';
+			},
 		),
 		'add_10_email_subscribers'        => array(
 			'get_title'                 => function () {
@@ -362,6 +368,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'repetition_count_callback' => 'wpcom_launchpad_get_write_3_posts_repetition_count',
 			'target_repetitions'        => 3,
+			'get_calypso_path'          => function ( $task, $default, $data ) {
+				return '/post/' . $data['site_slug_encoded'];
+			},
 		),
 		'manage_subscribers'              => array(
 			'get_title'            => function () {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -345,7 +345,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_visible_callback'  => 'wpcom_is_enable_subscribers_modal_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				if ( ( new Automattic\Jetpack\Status\Host() )->is_atomic_platform() ) {
-					return admin_url( '/wp-admin/admin.php?page=jetpack#/discussion' );
+					return admin_url( '/admin.php?page=jetpack#/discussion' );
 				}
 				return '/settings/reading/' . $data['site_slug_encoded'] . '#newsletter-settings';
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -345,7 +345,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_visible_callback'  => 'wpcom_is_enable_subscribers_modal_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				if ( ( new Automattic\Jetpack\Status\Host() )->is_atomic_platform() ) {
-					return 'https://' . $data['site_slug_encoded'] . '/wp-admin/admin.php?page=jetpack#/discussion';
+					return admin_url( '/wp-admin/admin.php?page=jetpack#/discussion' );
 				}
 				return '/settings/reading/' . $data['site_slug_encoded'] . '#newsletter-settings';
 			},

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -434,7 +434,11 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function provide_get_calypso_path_validation_test_cases() {
 		return array(
-			'Full URL should be valid'                   => array(
+			'External absolute URL should be invalid'    => array(
+				'https://example.com/invalid-full-url',
+				null,
+			),
+			'Admin URL should be valid'                  => array(
 				'http://example.org/wp-admin/admin.php?page=jetpack#/discussion',
 				'http://example.org/wp-admin/admin.php?page=jetpack#/discussion',
 			),

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -434,9 +434,9 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function provide_get_calypso_path_validation_test_cases() {
 		return array(
-			'Full URL is rejected'                       => array(
-				'https://example.com/invalid-full-url',
-				null,
+			'Full URL should be valid'                   => array(
+				'https://example.com/valid-full-url',
+				'https://example.com/valid-full-url',
 			),
 			'Same-protocol URL is rejected'              => array(
 				'//example.com/invalid-protocol-url',

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -435,8 +435,8 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 	public function provide_get_calypso_path_validation_test_cases() {
 		return array(
 			'Full URL should be valid'                   => array(
-				'https://example.com/valid-full-url',
-				'https://example.com/valid-full-url',
+				'http://example.org/wp-admin/admin.php?page=jetpack#/discussion',
+				'http://example.org/wp-admin/admin.php?page=jetpack#/discussion',
 			),
 			'Same-protocol URL is rejected'              => array(
 				'//example.com/invalid-protocol-url',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
After we changed how to redirect the user when clicking on the tasks, some tasks were missing the `get_calypso_path` prop introduced on https://github.com/Automattic/jetpack/pull/32177.

* Adds the `get_calypso_path` props with the appropriate path to the "Write 3 posts" and "Enable subscribers modal" tasks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Testing on Simple
* Apply this patch to your sandbox using the command in the comment below
* Create a new Newsletter site and go through the flow until you land on the Customer Home page
* Click on the task "Write 3 posts". You should be redirected to the `/post/:siteSlug`
* Click on the task "Enable subscribers modal". You should be redirected to `/settings/reading/:siteSlug#newsletter-settings`

#### Testing on Atomic
* Create a newsletter site from `/setup/newsletter/intro`; you'll need to publish at least one test post to "launch" the site.
* Upgrade the site to a Business plan
* Install and activate the Jetpack Beta plugin (this should move the site to the Atomic infrastructure)
* Go to Manage under the WordPress.com Features part of the beta plugin
* Activate the `add/path-for-newsletter-tasks` feature branch
* SSH into your Atomic site and add the `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` constant to your wp-config.php
* While you're in there, add the filter to enable the subscriptions modal: `add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 );` I put it in `wp-content/mu-plugins/index.php`
* Go to `/home/siteSlug` to see the Newsletter task list.
* You should see the "Enable subscribers modal" task, and clicking on it should take you to `https://YOUR-SITE/wp-admin/admin.php?page=jetpack#/discussion`

