### PR TITLE
Make "My Jetpack" the default page in Jetpack wp-admin.

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-is-default-nav-item
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-is-default-nav-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move 'My Jetpack' sub-menu item to first position.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -62,7 +62,7 @@ class Initializer {
 			'manage_options',
 			'my-jetpack',
 			array( __CLASS__, 'admin_page' ),
-			999
+			0
 		);
 
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -110,6 +110,7 @@ const recommendationsRoutes = [
 	'/recommendations/vaultpress-for-woocommerce',
 ];
 
+const myJetpackRoutes = [ 'my-jetpack ' ];
 const dashboardRoutes = [ '/', '/dashboard', '/reconnect', '/my-plan', '/plans' ];
 const settingsRoutes = [
 	'/settings',
@@ -945,8 +946,9 @@ export default connect(
  *
  * @param pageOrder
  */
-window.wpNavMenuClassChange = function ( pageOrder = { dashboard: 1, settings: 2 } ) {
+window.wpNavMenuClassChange = function ( pageOrder = { myJetpack: 1, dashboard: 2, settings: 3 } ) {
 	let hash = window.location.hash;
+	let page = new URLSearchParams( window.location.search );
 
 	// Clear currently highlighted sub-nav item
 	jQuery( '.current' ).each( function ( i, obj ) {
@@ -963,7 +965,11 @@ window.wpNavMenuClassChange = function ( pageOrder = { dashboard: 1, settings: 2
 
 	// Set the current sub-nav item according to the current hash route
 	hash = hash.split( '?' )[ 0 ].replace( /#/, '' );
-	if (
+	page = page.get( 'page' );
+
+	if ( myJetpackRoutes.includes( page ) ) {
+		getJetpackSubNavItem( pageOrder.myJetpack ).classList.add( 'current' );
+	} else if (
 		dashboardRoutes.includes( hash ) ||
 		recommendationsRoutes.includes( hash ) ||
 		productDescriptionRoutes.includes( hash )

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -77,7 +77,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 */
 	public function jetpack_add_dashboard_sub_nav_item() {
 		if ( ( new Status() )->is_offline_mode() || Jetpack::is_connection_ready() ) {
-			add_submenu_page( 'jetpack', __( 'Dashboard', 'jetpack' ), __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/dashboard', '__return_null' );
+			add_submenu_page( 'jetpack', __( 'Dashboard', 'jetpack' ), __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/dashboard', '__return_null', 1 );
 			remove_submenu_page( 'jetpack', 'jetpack' );
 		}
 	}

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-is-default-nav-item
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-is-default-nav-item
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Make 'My Jetpack' the first sub-menu item, above 'Dashboard'.

--- a/projects/plugins/jetpack/tests/e2e/specs/connection/connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/connection/connection.test.js
@@ -14,7 +14,7 @@ test.beforeEach( async ( { page } ) => {
 		.withWpComLoggedIn( true )
 		.build();
 	await DashboardPage.visit( page );
-	await ( await Sidebar.init( page ) ).selectJetpack();
+	await ( await Sidebar.init( page ) ).selectJetpackSubMenuItem();
 } );
 
 test( 'Site only connection', async ( { page } ) => {

--- a/projects/plugins/jetpack/tests/e2e/specs/pre-connection/pre-connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/pre-connection/pre-connection.test.js
@@ -43,7 +43,7 @@ test( 'Connect button is displayed on dashboard page', async ( { page } ) => {
 } );
 
 test( 'Connect button is displayed  on Jetpack page', async ( { page } ) => {
-	await ( await Sidebar.init( page ) ).selectJetpack();
+	await ( await Sidebar.init( page ) ).selectJetpackSubMenuItem();
 
 	const jetpackPage = await JetpackPage.init( page );
 	expect(

--- a/tools/e2e-commons/pages/wp-admin/sidebar.js
+++ b/tools/e2e-commons/pages/wp-admin/sidebar.js
@@ -7,8 +7,14 @@ export default class Sidebar extends WpPage {
 
 	async selectJetpack() {
 		const jetpackMenuSelector = '#toplevel_page_jetpack';
-		const menuItemSelector =
-			'#toplevel_page_jetpack a[href$="jetpack#/dashboard"], #toplevel_page_jetpack a[href$="jetpack"]';
+		const menuItemSelector = '#toplevel_page_jetpack a[href$="admin.php?page=my-jetpack"]';
+
+		return await this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
+	}
+
+	async selectJetpackSubMenuItem() {
+		const jetpackMenuSelector = '#toplevel_page_jetpack';
+		const menuItemSelector = '#toplevel_page_jetpack .wp-submenu a[href$="admin.php?page=jetpack"]';
 
 		return await this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
 	}


### PR DESCRIPTION
This diff makes **My Jetpack** the default page that shows when the top-level "**Jetpack**" menu item is clicked in the left sidebar in WP Admin. Also make "My Jetpack" the first sub-menu nav item.

It was agreed to split this change into two pieces:
1. First we just make My Jetpack the default with no other changes. (This PR).
2. Then, we will bring more dynamic data into My Jetpack, and over time at some point we get rid of At a Glance.

We're hoping to get this in before the _Aug 16th code freeze_. Please see: p1690031014020359/1690029940.688399-slack-CDLH4C1UZ

Per _James Grierson_ in: **Unleashing Our Potential: A Roadmap to Flourish in the Upcoming Months**: p1HpG7-mMC-p2

> **My Jetpack as the default in August** –  My Jetpack is the page that allows users to see and explore our other products. Now that we have unified the experience of our plugins, we need to make My Jetpack the top level starting point when someone clicks on Jetpack in the WP-Admin. Doing so will increase exploration and the flow of new users to our individual plugins.


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Project Thread: pbNhbs-7IV-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Makes the "Jetpack" menu item link to `?page=my-jetpack` instead of `?page=jetpack#/dashboard`
- Moves the "My Jetpack" sub-menu item to first position, followed by each activated standalone plugin (if disconnected), or followed by "Dashboard", "Settings", and each activated plugin (if connected). 
- Updates the jQuery that controls which sub-menu item is currently active/highlighted to account for the re-positioned "My Jetpack" sub-menu link.
- Updates connection e2e tests to account for the top-level "Jetpack" menu item now pointing to the My Jetpack page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1HpG7-mMC-p2#comment-63646

p1690029940688399-slack-CDLH4C1UZ


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Do one of these:
    - Checkout this PR and spin up a local development build of Jetpack, OR
    - Spin up a Jurassic.ninja or Ephemeral site with the Jetpack Beta plugin running this PR.
- Jetpack plugin activated, Not connected:
    - Click the top-level "Jetpack" menu item and verify it takes you to the "My Jetpack" page.
    - Verify "My Jetpack" is the first sub-item in the Jetpack menu, with any activated plugins following suit.
    - Verify the currently active menu-item is highlighted correctly. ie.- When on My Jetpack page, the My Jetpack menu item is highlighted.
- Connect Jetpack.
    - Click the top-level "Jetpack" menu item and verify it takes you to the "My Jetpack" page.
    - View the Jetpack side menu. Verify "My Jetpack" is the first menu item, with "Dashboard" below it, "Settings" below that, and with any activated plugins following suit.
    - Verify the "My Jetpack" sub-menu item takes you to the "My Jetpack" page, and the "Dashboard" sub-menu item takes you to the Jetpack "Dashboard" page.
    - Verify the currently active menu-item is highlighted correctly. ie.- When on the "My Jetpack" page, the "My Jetpack" sub-menu item is active/highlighted, and when on the "Dashboard" page, the "Dashboard" sub-menu item is highlighted.

Jetpack **disconnected**:
**BEFORE PR** | **AFTER PR**
--- | ---
![Markup 2023-08-02 at 14 18 50](https://github.com/Automattic/jetpack/assets/11078128/9461b192-d47e-430f-8a2c-e0cb7d9f9ebc) | ![Markup 2023-08-02 at 14 22 28](https://github.com/Automattic/jetpack/assets/11078128/6d9f6e15-04b3-410d-9a17-9476fc4c6bba)

Jetpack **connected**:
**BEFORE PR** | **AFTER PR**
--- | ---
![Markup 2023-08-02 at 14 25 57 (1)](https://github.com/Automattic/jetpack/assets/11078128/0381a89d-5e2b-49e2-b86b-d5aecc4bce51) | ![Markup 2023-08-02 at 14 28 11](https://github.com/Automattic/jetpack/assets/11078128/49711ed8-596e-4954-bdad-093de5ccae96)









