### PR TITLE
AI Assistant: Stop suggestion when form block is deleted

### DIFF
--- a/projects/plugins/jetpack/changelog/update-form-ai-assistant-stop-request-when-unmount
+++ b/projects/plugins/jetpack/changelog/update-form-ai-assistant-stop-request-when-unmount
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: stop suggestion when form block is deleted

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -70,7 +70,7 @@ export const AiAssistantPopover = ( {
 
 	const stopSuggestion = useCallback( () => {
 		if ( eventSource ) {
-			debug( 'Stoping suggestion' );
+			debug( 'Stopping suggestion' );
 			eventSource?.close();
 		}
 	}, [ eventSource ] );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -69,10 +69,11 @@ export const AiAssistantPopover = ( {
 	const { requestSuggestion, requestingState, eventSource } = useAiContext();
 
 	const stopSuggestion = useCallback( () => {
-		if ( eventSource ) {
-			debug( 'Stopping suggestion' );
-			eventSource?.close();
+		if ( ! eventSource ) {
+			return;
 		}
+		debug( 'Stopping suggestion' );
+		eventSource?.close();
 	}, [ eventSource ] );
 
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -7,9 +7,11 @@ import { KeyboardShortcuts, Popover } from '@wordpress/components';
 import { select } from '@wordpress/data';
 import { useContext, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import { useEffect } from 'react';
 import { PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, getPrompt } from '../../../../lib/prompt';
 import { AiAssistantUiContext } from '../../ui-handler/context';
 /*
@@ -20,6 +22,8 @@ import type React from 'react';
 type AiAssistantPopoverProps = {
 	clientId?: string;
 };
+
+const debug = debugFactory( 'jetpack-ai-assistant:form-assistant' );
 
 /**
  * Return the serialized content from the childrens block.
@@ -62,7 +66,24 @@ export const AiAssistantPopover = ( {
 	const { isVisible, hide, toggle, popoverProps, inputValue, setInputValue, width } =
 		useContext( AiAssistantUiContext );
 
-	const { requestSuggestion, requestingState } = useAiContext();
+	const { requestSuggestion, requestingState, eventSource } = useAiContext();
+
+	const stopSuggestion = useCallback( () => {
+		if ( eventSource ) {
+			debug( 'Stoping suggestion' );
+			eventSource?.close();
+		}
+	}, [ eventSource ] );
+
+	useEffect( () => {
+		/**
+		 * Cleanup function to remove the event listeners
+		 * and close the event source.
+		 */
+		return () => {
+			stopSuggestion();
+		};
+	}, [ stopSuggestion ] );
 
 	const isLoading = requestingState === 'requesting' || requestingState === 'suggesting';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32153.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add clean-up function to stop suggestion when the form block is removed
* Add `stopSuggestion` helper function to abstract the details of stopping the suggestion

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open your browser developer console and enable debug messsages with `localStorage.setItem( 'debug', '*' )`
* Add a Jetpack Form block
* Click the `AI Assistant` extension icon to show the popover with the prompt field:

<img width="600" alt="Screen Shot 2023-08-02 at 14 49 32" src="https://github.com/Automattic/jetpack/assets/6760046/ff56e7ed-5d47-42fc-a072-762b97bda2c2">

* Type some Form request that is long and may take a few seconds to process (example: "pizza, soda and dessert ordering form")
* Send the request
* When the suggestion begins, delete the Jetpack Form block
* Before this PR, the suggestion would keep going
* After this change, the suggestion will stop and you will spot a `jetpack-ai-assistant:form-assistant Stopping suggestion` debug message on the console:

<img width="600" alt="Screen Shot 2023-08-02 at 14 53 18" src="https://github.com/Automattic/jetpack/assets/6760046/1f4eb8a9-9098-4cab-9db3-0cb5045b34b6">
