### PR TITLE
AI Extension: make Jetpack Form AI extension mobile friendly

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-anchor-to-toolbar
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-anchor-to-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: handle AI assistant component in mobile

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -5,19 +5,21 @@ import { useAiContext, AIControl } from '@automattic/jetpack-ai-client';
 import { serialize } from '@wordpress/blocks';
 import { KeyboardShortcuts, Popover } from '@wordpress/components';
 import { select } from '@wordpress/data';
-import { useContext, useCallback } from '@wordpress/element';
+import { useContext, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { useEffect } from 'react';
 import { PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, getPrompt } from '../../../../lib/prompt';
 import { AiAssistantUiContext } from '../../ui-handler/context';
 /*
  * Types
  */
 import type React from 'react';
+
+import './style.scss';
 
 type AiAssistantPopoverProps = {
 	clientId?: string;
@@ -63,7 +65,7 @@ function getSerializedContentFromBlock( clientId: string ): string {
 export const AiAssistantPopover = ( {
 	clientId = '',
 }: AiAssistantPopoverProps ): React.ReactNode => {
-	const { isVisible, hide, toggle, popoverProps, inputValue, setInputValue, width } =
+	const { isVisible, isFixed, hide, toggle, popoverProps, inputValue, setInputValue, width } =
 		useContext( AiAssistantUiContext );
 
 	const { requestSuggestion, requestingState, eventSource } = useAiContext();
@@ -110,13 +112,21 @@ export const AiAssistantPopover = ( {
 	}
 
 	return (
-		<Popover onClose={ hide } { ...popoverProps } animate={ false }>
+		<Popover
+			onClose={ hide }
+			{ ...popoverProps }
+			animate={ false }
+			className={ classNames( 'jetpack-ai-assistant__popover', {
+				'is-fixed': isFixed,
+			} ) }
+		>
 			<KeyboardShortcuts
 				bindGlobal
 				shortcuts={ {
 					'mod+/': toggle,
 				} }
 			/>
+
 			<div style={ { width } }>
 				<AIControl
 					loading={ isLoading }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
@@ -4,13 +4,16 @@
 	z-index: 31;
 	border-bottom: 1px solid #e0e0e0;
 	&.is-fixed {
+		width: 100%;
 		.components-popover__content,
 		.jetpack-components-ai-control__container {
+			width: 100%;
 			border-radius: 0;
 			box-shadow: none;
 		}
 		.jetpack-components-ai-control__wrapper {
 			padding: 7px 14px;
+			width: 100%;
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
@@ -1,0 +1,16 @@
+
+
+.jetpack-ai-assistant__popover {
+	z-index: 31;
+	border-bottom: 1px solid #e0e0e0;
+	&.is-fixed {
+		.components-popover__content,
+		.jetpack-components-ai-control__container {
+			border-radius: 0;
+			box-shadow: none;
+		}
+		.jetpack-components-ai-control__wrapper {
+			padding: 7px 14px;
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -28,14 +28,13 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 			return;
 		}
 
-		const toolbar: HTMLElement = anchorRef.current.closest(
-			'.block-editor-block-contextual-toolbar'
-		);
+		const toolbar = anchorRef.current.closest( '.block-editor-block-contextual-toolbar' );
 		if ( ! toolbar ) {
 			return;
 		}
-
 		const isFixed = toolbar.classList.contains( 'is-fixed' );
+		setAssistantFixed( isFixed );
+
 		if ( ! isFixed ) {
 			return;
 		}
@@ -46,8 +45,6 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 			offset: 0,
 			variant: 'toolbar',
 		} ) );
-
-		setAssistantFixed( true );
 	}, [ setAssistantFixed, setPopoverProps ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -3,22 +3,58 @@
  */
 import { aiAssistantIcon, useAiContext } from '@automattic/jetpack-ai-client';
 import { ToolbarButton } from '@wordpress/components';
-import { useContext } from '@wordpress/element';
+import { useContext, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import React, { useEffect } from 'react';
 /*
  * Internal dependencies
  */
 import { AiAssistantUiContext } from '../../ui-handler/context';
 
 export default function AiAssistantToolbarButton(): React.ReactElement {
-	const { isVisible, toggle } = useContext( AiAssistantUiContext );
+	const { isVisible, toggle, setPopoverProps, setAssistantFixed } =
+		useContext( AiAssistantUiContext );
 	const { requestingState } = useAiContext();
+
+	/*
+	 * Let's switch the anchor when the toolbar is fixed
+	 * 1 - Pick the Dom element reference
+	 * 2 - Find the closest block-editor-block-contextual-toolbar
+	 * 3 - Check if the toolbar is fixed, based on `is-fixed` CSS class
+	 */
+	const anchorRef = useRef< HTMLElement | null >( null );
+	useEffect( () => {
+		if ( ! anchorRef.current ) {
+			return;
+		}
+
+		const toolbar: HTMLElement = anchorRef.current.closest(
+			'.block-editor-block-contextual-toolbar'
+		);
+		if ( ! toolbar ) {
+			return;
+		}
+
+		const isFixed = toolbar.classList.contains( 'is-fixed' );
+		if ( ! isFixed ) {
+			return;
+		}
+
+		setPopoverProps( prev => ( {
+			...prev,
+			anchor: toolbar,
+			offset: 0,
+			variant: 'toolbar',
+		} ) );
+
+		setAssistantFixed( true );
+	}, [ setAssistantFixed, setPopoverProps ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 
 	return (
 		<ToolbarButton
+			ref={ anchorRef }
 			showTooltip
 			onClick={ toggle }
 			aria-haspopup="true"

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
@@ -8,11 +8,14 @@ export type AiAssistantUiContextProps = {
 
 	isVisible: boolean;
 
+	isFixed: boolean;
+
 	width?: number;
 
 	popoverProps?: {
 		anchor: HTMLElement | null;
 		offset?: number;
+		variant?: 'toolbar' | 'unstyled';
 		placement?:
 			| 'top'
 			| 'top-start'
@@ -34,6 +37,8 @@ export type AiAssistantUiContextProps = {
 	show: () => void;
 	hide: () => void;
 	toggle: () => void;
+
+	setAssistantFixed: ( isFixed: boolean ) => void;
 
 	setPopoverProps: ( props: AiAssistantUiContextProps[ 'popoverProps' ] ) => void;
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
@@ -13,7 +13,7 @@ export type AiAssistantUiContextProps = {
 	width?: number;
 
 	popoverProps?: {
-		anchor: HTMLElement | null;
+		anchor?: HTMLElement | null;
 		offset?: number;
 		variant?: 'toolbar' | 'unstyled';
 		placement?:

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -157,6 +157,11 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				return;
 			}
 
+			// Do not observe the anchor resize if the toolbar is fixed.
+			if ( isFixed ) {
+				return;
+			}
+
 			const resizeObserver = new ResizeObserver( () => {
 				setWidth( popoverProps.anchor?.getBoundingClientRect?.()?.width );
 			} );
@@ -166,7 +171,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			return () => {
 				resizeObserver.disconnect();
 			};
-		}, [ popoverProps.anchor ] );
+		}, [ popoverProps.anchor, isFixed ] );
 
 		// Build the context value to pass to the provider.
 		const contextValue = useMemo(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -32,6 +32,9 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		// AI Assistant component visibility
 		const [ isVisible, setAssistantVisibility ] = useState( false );
 
+		// AI Assistant component is-fixed state
+		const [ isFixed, setAssistantFixed ] = useState( false );
+
 		// AI Assistant width
 		const [ width, setWidth ] = useState( 400 );
 
@@ -165,6 +168,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			() => ( {
 				inputValue,
 				isVisible,
+				isFixed,
 				popoverProps,
 				width,
 
@@ -172,9 +176,10 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				show,
 				hide,
 				toggle,
+				setAssistantFixed,
 				setPopoverProps,
 			} ),
-			[ inputValue, isVisible, popoverProps, width, show, hide, toggle ]
+			[ inputValue, isVisible, isFixed, popoverProps, width, show, hide, toggle ]
 		);
 
 		const setContent = useCallback(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -36,7 +36,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		const [ isFixed, setAssistantFixed ] = useState( false );
 
 		// AI Assistant width
-		const [ width, setWidth ] = useState( 400 );
+		const [ width, setWidth ] = useState< number | string >( 400 );
 
 		// AI Assistant popover props
 		const [ popoverProps, setPopoverProps ] = useState<
@@ -117,6 +117,11 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				return;
 			}
 
+			// Do not anchor the popover if the toolbar is fixed.
+			if ( isFixed ) {
+				return setWidth( '100%' ); // ensure to use the full width.
+			}
+
 			const idAttribute = `block-${ clientId }`;
 
 			/*
@@ -136,7 +141,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 
 			setPopoverProps( prev => ( { ...prev, anchor: blockDomElement } ) );
 			setWidth( blockDomElement?.getBoundingClientRect?.()?.width );
-		}, [ clientId ] );
+		}, [ clientId, isFixed ] );
 
 		// Show/hide the assistant based on the block selection.
 		useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -139,7 +139,13 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				return;
 			}
 
-			setPopoverProps( prev => ( { ...prev, anchor: blockDomElement } ) );
+			setPopoverProps( prev => ( {
+				...prev,
+				anchor: blockDomElement,
+				placement: 'bottom-start',
+				offset: 12,
+			} ) );
+
 			setWidth( blockDomElement?.getBoundingClientRect?.()?.width );
 		}, [ clientId, isFixed ] );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR aims to begin addressing the AI ExtensionBar for mobile. The plan is to anchor the bar just below the Block toolbar in mobile and have it connect to the block canvas representation when not in mobile mode.

_**Disclaimer: We nee to polish the changes when the viewport resizes, etc.**_ Ideal to do in a follow-up ;-)

Fixes https://github.com/Automattic/jetpack/issues/32226

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: make Jetpack Form AI extension mobile friendly

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Check how the extension bar looks in mobile, and regular viewport.


https://github.com/Automattic/jetpack/assets/77539/5f72662a-7589-4de9-99b5-eb547da99a7d

regular | medium | small | P2
----|----|----|----
<img width="788" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/da752f26-3d53-4614-8a9a-db827a994f8d"> | <img width="715" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/4cf589c4-a7fe-418d-adb7-193ccd6070e0"> | <img width="407" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/e39f351e-5f18-4ef5-8cbf-5379f7428f7b">|<img width="794" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/3802084b-a8f7-47e1-b16b-ae7bee3d7dfb">


