### PR TITLE
AI Assistant: Fix AI Control toggle behavior

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-control-toggle
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-control-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Extension: Stop handling popover close event to prevent the AI Control from hiding when it loses focus.

--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-control-toggle
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-control-toggle
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 AI Extension: Stop handling popover close event to prevent the AI Control from hiding when it loses focus.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -65,7 +65,7 @@ function getSerializedContentFromBlock( clientId: string ): string {
 export const AiAssistantPopover = ( {
 	clientId = '',
 }: AiAssistantPopoverProps ): React.ReactNode => {
-	const { isVisible, isFixed, hide, toggle, popoverProps, inputValue, setInputValue, width } =
+	const { isVisible, isFixed, toggle, popoverProps, inputValue, setInputValue, width } =
 		useContext( AiAssistantUiContext );
 
 	const { requestSuggestion, requestingState, eventSource } = useAiContext();
@@ -113,7 +113,7 @@ export const AiAssistantPopover = ( {
 
 	return (
 		<Popover
-			onClose={ hide }
+			onClose={ null }
 			{ ...popoverProps }
 			animate={ false }
 			className={ classNames( 'jetpack-ai-assistant__popover', {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -113,7 +113,6 @@ export const AiAssistantPopover = ( {
 
 	return (
 		<Popover
-			onClose={ null }
 			{ ...popoverProps }
 			animate={ false }
 			className={ classNames( 'jetpack-ai-assistant__popover', {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32243.

The bug was happening because the click to toggle the component off was generating two events, and the handling of the two events was generating conflicting results:

* when you clicked the toolbar button to close the popover, the popover would lose it's focus and fire the `close` event, hidding the component
* after it, we would handle the toolbar button click, changing the component back to visible again

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Stop handling the `close` event from the popover that contains the AI Control, so it stops hiding when it loses focus
* Let the extension toolbar button be in charge of toggling the popover, as the only way to show and hide it
* Do not change the behavior when the whole Jetpack Form block is unselected; in this cases we still hide the popover, as before

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to block editor
* Insert a Jetpack Form block
* Click the AI Assistant extension button to show the AI Control component:

<img width="600" alt="Screen Shot 2023-08-02 at 14 49 32" src="https://github.com/Automattic/jetpack/assets/6760046/98161017-b825-42e3-83e4-dd9cc44d0706">

* Click the button again and observe the behavior:
   * before this change, this would not hide the component (see issue report)
   * after this change, the AI Control will be hidden
* Test multiple clicks to toggle the component:
   * it should show/hide it as expected
* With the AI Control visible, click on the Jetpack Form block itself:
   * before this change, this would hide the popover
   * after this change, the popover will still be there; it will only disapear when the toolbar extension button is clicked again
   * this was part of the solution for the bug, and I think it actually improves the experience while using the extension
* With the component visible, click outside the Jetpack Form block so it gets unselected
   * before this change, this would hide the popover
   * after this change, this will also hide the popover (no change on the behavior)