### PR TITLE
Launchpad: Add manage newsletter task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-manage-newsletter-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-manage-newsletter-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added new Launchpad task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -382,6 +382,16 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/marketing/connections/' . $data['site_slug_encoded'];
 			},
 		),
+		'manage_paid_newsletter_plan'     => array(
+			'get_title'            => function () {
+				return __( 'Manage your paid Newsletter plan', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_has_goal_paid_subscribers',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/earn/payments-plans/' . $data['site_slug_encoded'];
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -183,6 +183,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'manage_subscribers',
 				'write_3_posts',
 				'connect_social_media',
+				'manage_paid_newsletter_plan',
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_paid_newsletter_enabled',
 		),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes https://github.com/Automattic/wp-calypso/issues/80032

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds a new task to Launchpad. It;s a simple task that is completed when `/earn/payments-plans/{site}` is visited.
* It doesn't require an action definition on Calypso because it can take advantage of the `calypso_path` feature.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the newsletter launchpad (possibly with D117910-code)
* Apply this PR
* Create a new site with paid `newsletter` intent
* Check that there is a new `Manage your paid Newsletter plan` task
* Clicking the task should take you to `/earn/payments-plans/{site}`
* Task completion will be handled in a separate calypso PR
![image](https://github.com/Automattic/jetpack/assets/3801502/e8cff679-2f11-4515-8bf0-92dc743587df)
