### PR TITLE
AI Extension: increase the page height when AI Assistant bar is visible

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-move-page-down-when-bar-shown
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-move-page-down-when-bar-shown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: increase the page height when AI Assistant bar is visible

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
@@ -1,5 +1,3 @@
-
-
 .jetpack-ai-assistant__popover {
 	z-index: 31;
 	border-bottom: 1px solid #e0e0e0;
@@ -16,4 +14,8 @@
 			width: 100%;
 		}
 	}
+}
+
+.jetpack-ai-assistant-bar-is-fixed .block-editor-block-contextual-toolbar {
+	margin-bottom: 46px;
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -10,6 +10,7 @@ import React, { useEffect } from 'react';
  * Internal dependencies
  */
 import { AiAssistantUiContext } from '../../ui-handler/context';
+import { handleAiExtensionsBarBodyClass } from '../../ui-handler/with-ui-handler-data-provider';
 
 export default function AiAssistantToolbarButton(): React.ReactElement {
 	const { isVisible, toggle, setPopoverProps, setAssistantFixed } =
@@ -34,6 +35,7 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 		}
 		const isFixed = toolbar.classList.contains( 'is-fixed' );
 		setAssistantFixed( isFixed );
+		handleAiExtensionsBarBodyClass( isFixed, isVisible );
 
 		if ( ! isFixed ) {
 			return;
@@ -45,7 +47,7 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 			offset: 0,
 			variant: 'toolbar',
 		} ) );
-	}, [ setAssistantFixed, setPopoverProps ] );
+	}, [ setAssistantFixed, setPopoverProps, isVisible ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -41,12 +41,18 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 			return;
 		}
 
-		setPopoverProps( prev => ( {
-			...prev,
-			anchor: toolbar,
-			offset: 0,
-			variant: 'toolbar',
-		} ) );
+		/*
+		 * There is a race condition between the toolbar and component onMount.
+		 * We need to wait a bit to set the popover props.
+		 */
+		setTimeout( () => {
+			setPopoverProps( prev => ( {
+				...prev,
+				anchor: toolbar,
+				offset: 0,
+				variant: 'toolbar',
+			} ) );
+		}, 100 );
 	}, [ setAssistantFixed, setPopoverProps, isVisible ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -117,6 +117,13 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				return;
 			}
 
+			// Add a CSS class to document body when the popover is fixed.
+			if ( isVisible && isFixed ) {
+				document.body.classList.add( 'jetpack-ai-assistant-bar-is-fixed' );
+			} else {
+				document.body.classList.remove( 'jetpack-ai-assistant-bar-is-fixed' );
+			}
+
 			// Do not anchor the popover if the toolbar is fixed.
 			if ( isFixed ) {
 				return setWidth( '100%' ); // ensure to use the full width.
@@ -147,7 +154,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			} ) );
 
 			setWidth( blockDomElement?.getBoundingClientRect?.()?.width );
-		}, [ clientId, isFixed ] );
+		}, [ clientId, isFixed, isVisible ] );
 
 		// Show/hide the assistant based on the block selection.
 		useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -22,6 +22,22 @@ import type { RequestingErrorProps } from '@automattic/jetpack-ai-client';
 // An identifier to use on the extension error notices,
 const AI_ASSISTANT_JETPACK_FORM_NOTICE_ID = 'ai-assistant';
 
+/**
+ * Add the `jetpack-ai-assistant-bar-is-fixed` class to the body
+ * when the toolbar is fixed and the AI Assistant is visible.
+ *
+ * @param {boolean} isFixed - Is the toolbar fixed?
+ * @param {boolean} isVisible - Is the AI Assistant visible?
+ * @returns {void}
+ */
+export function handleAiExtensionsBarBodyClass( isFixed: boolean, isVisible: boolean ) {
+	if ( isFixed && isVisible ) {
+		return document.body.classList.add( 'jetpack-ai-assistant-bar-is-fixed' );
+	}
+
+	document.body.classList.remove( 'jetpack-ai-assistant-bar-is-fixed' );
+}
+
 const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => {
 	return props => {
 		const { clientId, isSelected } = props;
@@ -117,12 +133,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				return;
 			}
 
-			// Add a CSS class to document body when the popover is fixed.
-			if ( isVisible && isFixed ) {
-				document.body.classList.add( 'jetpack-ai-assistant-bar-is-fixed' );
-			} else {
-				document.body.classList.remove( 'jetpack-ai-assistant-bar-is-fixed' );
-			}
+			handleAiExtensionsBarBodyClass( isFixed, isVisible );
 
 			// Do not anchor the popover if the toolbar is fixed.
 			if ( isFixed ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On mobile, when the AiBar is anchored below the toolbar, it takes the vertical space of the page. This PR creates the space to preserve the editor's canvas size.


Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: increase the page height when AI Assistant bar is visible

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Switch to mobile viewport 
* Open and close the Block toolbar and the Assistant bar, and confirm how the page adjusts the vertical space of the canvas:

https://github.com/Automattic/jetpack/assets/77539/506cd64b-d074-4010-8aa9-0cd218bcbf40


https://github.com/Automattic/jetpack/assets/77539/5c30cc3e-09eb-4d46-9c45-05c3e40f51c4


