### PR TITLE
[Boost] Remove dependence on Critical CSS nonce

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/stores/critical-css-state-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/critical-css-state-types.ts
@@ -44,7 +44,6 @@ const ProviderSchema = z.object( {
 export const CriticalCssStateSchema = z
 	.object( {
 		callback_passthrough: z.record( z.unknown() ).optional(),
-		generation_nonce: z.coerce.string().optional(),
 		proxy_nonce: z.coerce.string().optional(),
 		// Source provider information - which URLs to generate CSS for.
 		providers: z.array( ProviderSchema ),

--- a/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
@@ -34,9 +34,10 @@ export default async function generateCriticalCss(
 		// Load Critical CSS gen library if not already loaded.
 		await loadCriticalCssLibrary();
 
-		// Prepare GET parameters to include with each request.
+		// Prepare GET parameters to include with each request. Tell the back end that
+		// Critical CSS is being generated, but use a timestamp to prevent caching.
 		const requestGetParameters = {
-			'jb-generate-critical-css': cssState.generation_nonce,
+			'jb-generate-critical-css': Date.now().toString(),
 		};
 
 		logPreCriticalCSSGeneration();

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Generator.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Generator.php
@@ -23,32 +23,7 @@ class Generator {
 	 * phpcs:disable WordPress.Security.NonceVerification.Recommended
 	 */
 	public static function is_generating_critical_css() {
-		static $is_generating = null;
-		if ( null !== $is_generating ) {
-			return $is_generating;
-		}
-
-		// Accept nonce via HTTP headers or GET parameters.
-		$generate_nonce = null;
-		if ( ! empty( $_GET[ self::GENERATE_QUERY_ACTION ] ) ) {
-			$generate_nonce = sanitize_key(
-				$_GET[ self::GENERATE_QUERY_ACTION ]
-			);
-		} elseif ( ! empty( $_SERVER['HTTP_X_GENERATE_CRITICAL_CSS'] ) ) {
-			$generate_nonce = sanitize_key(
-				$_SERVER['HTTP_X_GENERATE_CRITICAL_CSS']
-			);
-		}
-
-		// If GET parameter or header set, we are trying to generate.
-		$is_generating = ! empty( $generate_nonce );
-
-		// Die if the nonce is invalid.
-		if ( $is_generating && ! Nonce::verify( $generate_nonce, self::GENERATE_QUERY_ACTION ) ) {
-			die();
-		}
-
-		return $is_generating;
+		return ! empty( $_GET[ self::GENERATE_QUERY_ACTION ] ) || ! empty( $_SERVER['HTTP_X_GENERATE_CRITICAL_CSS'] );
 	}
 
 	/**
@@ -77,9 +52,6 @@ class Generator {
 				'height' => 1080,
 			),
 		);
-
-		// Add a userless nonce to use when requesting pages for Critical CSS generation (i.e.: To turn off admin features).
-		$status['generation_nonce'] = Nonce::create( self::GENERATE_QUERY_ACTION );
 
 		// Add a user-bound nonce to use when proxying CSS for Critical CSS generation.
 		$status['proxy_nonce'] = wp_create_nonce( CSS_Proxy::NONCE_ACTION );

--- a/projects/plugins/boost/changelog/fix-css-errors
+++ b/projects/plugins/boost/changelog/fix-css-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Removed dependency on nonces for Critical CSS generation.

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -72,7 +72,6 @@ add_action( 'admin_init', 'jetpack_boost_initialize_datasync' );
 $critical_css_state_schema = Schema::as_assoc_array(
 	array(
 		'callback_passthrough' => Schema::any_json_data()->nullable(),
-		'generation_nonce'     => Schema::as_string()->nullable(),
 		'proxy_nonce'          => Schema::as_string()->nullable(),
 		'providers'            => Schema::as_array(
 			Schema::as_assoc_array(
@@ -115,7 +114,6 @@ $critical_css_state_schema = Schema::as_assoc_array(
 		'status'               => 'not_generated',
 		'providers'            => array(),
 		'callback_passthrough' => null,
-		'generation_nonce'     => null,
 		'proxy_nonce'          => null,
 		'viewports'            => array(),
 		'created'              => null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We've had a number of users report issues generating Critical CSS. It appears their Critical CSS nonce is undefined, causing errors.

This works around the problem - but does not get down to the bottom of how users are in this state. We are investigating further.

## Proposed changes:
* Remove Critical CSS regen nonce requirement - it isn't actually useful for security.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Test critical css regeneration

