### PR TITLE
Social: Fix Advanced upsell siteless checkout

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-advanced-upsell-siteless-checkout
+++ b/projects/js-packages/publicize-components/changelog/fix-advanced-upsell-siteless-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed checkout link so it's not siteless

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -355,7 +355,12 @@ export default function PublicizeForm( {
 								),
 								{
 									upgradeLink: (
-										<ExternalLink href={ getRedirectUrl( 'jetpack-social-pricing-modal' ) } />
+										<ExternalLink
+											href={ getRedirectUrl( 'jetpack-social-advanced-site-checkout', {
+												site: getSiteFragment(),
+												query: 'redirect_to=' + encodeURIComponent( window.location.href ),
+											} ) }
+										/>
 									),
 								}
 							) }

--- a/projects/plugins/social/changelog/fix-advanced-upsell-siteless-checkout
+++ b/projects/plugins/social/changelog/fix-advanced-upsell-siteless-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed checkout link so it's not siteless

--- a/projects/plugins/social/src/js/components/advanced-upsell-notice/index.jsx
+++ b/projects/plugins/social/src/js/components/advanced-upsell-notice/index.jsx
@@ -1,13 +1,16 @@
 import { Button, Container, Notice, Text, getRedirectUrl } from '@automattic/jetpack-components';
 import { useDismissNotice } from '@automattic/jetpack-publicize-components';
+import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { STORE_ID } from '../../store';
 import styles from './styles.module.scss';
 
 const MONTH_IN_SECONDS = 30 * 24 * 60 * 60;
 
 const AdvancedUpsellNotice = () => {
 	const { shouldShowNotice, dismissNotice, NOTICES } = useDismissNotice();
+	const siteSuffix = useSelect( select => select( STORE_ID ).getSiteSuffix() );
 
 	const handleDismiss = useCallback( () => {
 		dismissNotice( NOTICES.advancedUpgradeAdmin, 3 * MONTH_IN_SECONDS );
@@ -26,7 +29,10 @@ const AdvancedUpsellNotice = () => {
 							key="learn-more"
 							variant="link"
 							isExternalLink
-							href={ getRedirectUrl( 'jetpack-social-pricing-modal' ) }
+							href={ getRedirectUrl( 'jetpack-social-advanced-site-checkout', {
+								site: siteSuffix,
+								query: 'redirect_to=' + encodeURIComponent( window.location.href ),
+							} ) }
 						>
 							{ __( 'Learn more', 'jetpack-social' ) }
 						</Button>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This change updates the checkout links, so it's not a siteless checkout anymore, and redirects the user to the current screen after finishing the purchase.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
1205142973434174-as-1205184308987047
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* While having the basic plan mock `show_advanced_plan_upgrade_nudge` on your sandbox so it always returns true. This way you will see the nudge.
* Check the links and if they are working in both the editor and the admin page.