### PR TITLE
Async load business hours and blogging prompt blocks

### DIFF
--- a/projects/packages/blocks/changelog/add-blocks-metadata-file
+++ b/projects/packages/blocks/changelog/add-blocks-metadata-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Allow block registration with path to metadata file

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -36,10 +36,11 @@ class Blocks {
 	 *     @type array $version_requirements Array containing required Gutenberg version and, if known, the WordPress version that was released with this minimum version.
 	 *     @type bool  $plan_check           Should we check for a specific plan before registering the block.
 	 * }
+	 * @param string $metadata_dir Directory where the block's metadata is located.
 	 *
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
-	public static function jetpack_register_block( $slug, $args = array() ) {
+	public static function jetpack_register_block( $slug, $args = array(), $metadata_dir = '' ) {
 		if ( 0 !== strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
 			_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', 'Jetpack 9.0.0' );
 			$slug = 'jetpack/' . $slug;
@@ -94,12 +95,12 @@ class Blocks {
 
 			// Ensure editor styles are registered so that the site editor knows about the
 			// editor style dependency when copying styles to the editor iframe.
-			if ( ! isset( $args['editor_style'] ) ) {
+			if ( ! isset( $args['editor_style'] ) && ! $metadata_dir ) {
 				$args['editor_style'] = 'jetpack-blocks-editor';
 			}
 		}
 
-		return register_block_type( $slug, $args );
+		return register_block_type( $metadata_dir ? $metadata_dir : $slug, $args );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-blocks-metadata-file
+++ b/projects/plugins/jetpack/changelog/add-blocks-metadata-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add metadata file to blogging-prompt and business-hours blocks

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/block.json
@@ -7,5 +7,29 @@
 	"keywords": [ "writing", "blogging" ],
 	"version": "12.5.0",
 	"textdomain": "jetpack",
-	"category": "text"
+	"category": "text",
+	"supports": {
+		"align": false,
+		"alignWide": false,
+		"anchor": false,
+		"className": true,
+		"color": {
+			"background": true,
+			"gradients": true,
+			"link": true,
+			"text": true
+		},
+		"customClassName": true,
+		"html": false,
+		"inserter": true,
+		"multiple": false,
+		"reusable": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": false
+		}
+	},
+	"editorScript": "file:./editor.js",
+	"editorStyle": "file:./editor.css"
 }

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/block.json
@@ -29,7 +29,5 @@
 			"padding": true,
 			"blockGap": false
 		}
-	},
-	"editorScript": "file:./editor.js",
-	"editorStyle": "file:./editor.css"
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/block.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/blogging-prompt",
+	"title": "Writing Prompt",
+	"description": "Answer a new and inspiring writing prompt each day.",
+	"keywords": [ "writing", "blogging" ],
+	"version": "12.5.0",
+	"textdomain": "jetpack",
+	"category": "text"
+}

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/blogging-prompt.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/blogging-prompt.php
@@ -30,7 +30,7 @@ function register_block() {
 			array(
 				'render_callback' => __NAMESPACE__ . '\load_assets',
 			),
-			$json_dir,
+			$json_dir
 		);
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/blogging-prompt.php
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/blogging-prompt.php
@@ -22,9 +22,15 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  */
 function register_block() {
 	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || \Jetpack::is_connection_ready() ) {
+		$dir      = dirname( JETPACK__PLUGIN_FILE );
+		$json_dir = $dir . '/_inc/blocks/' . FEATURE_NAME;
+
 		Blocks::jetpack_register_block(
 			BLOCK_NAME,
-			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+			array(
+				'render_callback' => __NAMESPACE__ . '\load_assets',
+			),
+			$json_dir,
 		);
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
@@ -7,5 +7,22 @@
 	"keywords": [ "opening hours", "closing time", "schedule", "working day" ],
 	"version": "12.5.0",
 	"textdomain": "jetpack",
-	"category": "grow"
+	"category": "grow",
+	"supports": {
+		"html": true,
+		"color": {
+			"gradients": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		},
+		"align": [ "wide", "full" ]
+	},
+	"editorScript": "file:./editor.js",
+	"editorStyle": "file:./editor.css"
 }

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
@@ -22,7 +22,5 @@
 			"lineHeight": true
 		},
 		"align": [ "wide", "full" ]
-	},
-	"editorScript": "file:./editor.js",
-	"editorStyle": "file:./editor.css"
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/block.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/business-hours",
+	"title": "Business Hours",
+	"description": "Display opening hours for your business.",
+	"keywords": [ "opening hours", "closing time", "schedule", "working day" ],
+	"version": "12.5.0",
+	"textdomain": "jetpack",
+	"category": "grow"
+}

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/business-hours.php
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/business-hours.php
@@ -28,22 +28,8 @@ function register_block() {
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\render',
-			'supports'        => array(
-				'color'      => array(
-					'gradients' => true,
-				),
-				'spacing'    => array(
-					'margin'  => true,
-					'padding' => true,
-				),
-				'typography' => array(
-					'fontSize'   => true,
-					'lineHeight' => true,
-				),
-				'align'      => array( 'wide', 'full' ),
-			),
-			$json_dir,
-		)
+		),
+		$json_dir,
 	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/business-hours.php
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/business-hours.php
@@ -29,7 +29,7 @@ function register_block() {
 		array(
 			'render_callback' => __NAMESPACE__ . '\render',
 		),
-		$json_dir,
+		$json_dir
 	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/business-hours.php
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/business-hours.php
@@ -21,6 +21,9 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
+	$dir      = dirname( JETPACK__PLUGIN_FILE );
+	$json_dir = $dir . '/_inc/blocks/' . FEATURE_NAME;
+
 	Blocks::jetpack_register_block(
 		BLOCK_NAME,
 		array(
@@ -39,6 +42,7 @@ function register_block() {
 				),
 				'align'      => array( 'wide', 'full' ),
 			),
+			$json_dir,
 		)
 	);
 }

--- a/projects/plugins/jetpack/extensions/bundles.json
+++ b/projects/plugins/jetpack/extensions/bundles.json
@@ -3,7 +3,8 @@
 		"name": "first-bundle",
 		"title": "First Bundle",
 		"description": "This is a proof of concept",
-		"blocks": [ "blogging-prompt", "business-hours" ],
+		"blocks": [ "blogging-prompt" ],
 		"version": "1.0.0"
-	}
+	},
+	"business-hours"
 ]

--- a/projects/plugins/jetpack/extensions/bundles.json
+++ b/projects/plugins/jetpack/extensions/bundles.json
@@ -1,0 +1,9 @@
+[
+	{
+		"name": "first-bundle",
+		"title": "First Bundle",
+		"description": "This is a proof of concept",
+		"blocks": [ "blogging-prompt", "business-hours" ],
+		"version": "1.0.0"
+	}
+]

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -93,6 +93,5 @@
 		"tock",
 		"videopress",
 		"wordads"
-	],
-	"_bundles": { "test": [ "blogging-prompt", "business-hours" ] }
+	]
 }

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -93,5 +93,6 @@
 		"tock",
 		"videopress",
 		"wordads"
-	]
+	],
+	"_bundles": { "test": [ "blogging-prompt", "business-hours" ] }
 }

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -192,6 +192,15 @@ module.exports = [
 					},
 				],
 			} ),
+			new CopyWebpackPlugin( {
+				patterns: [
+					{
+						from: '**/block.json',
+						to: '[path][name][ext]',
+						context: path.join( __dirname, '../extensions/blocks' ),
+					},
+				],
+			} ),
 			new CopyBlockEditorAssetsPlugin(),
 		],
 	},

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -36,7 +36,11 @@ const bundlesPath = path.join( __dirname, '../extensions', 'bundles.json' );
 const bundlesIndex = require( bundlesPath );
 const bundles = bundlesIndex || [];
 const bundledBlocks = bundles
-	.reduce( ( blocks, bundle ) => [ ...blocks, ...bundle.blocks ], [] )
+	.reduce(
+		( blocks, bundle ) =>
+			'string' === typeof bundle ? [ ...blocks, bundle ] : [ ...blocks, ...bundle.blocks ],
+		[]
+	)
 	.filter( Boolean );
 
 /**
@@ -191,7 +195,10 @@ const sharedWebpackConfig = {
 const bundlesEntry = {};
 const bundlesPlugins = [];
 
-bundles.forEach( ( { name, blocks } ) => {
+bundles.forEach( bundle => {
+	const name = 'string' === typeof bundle ? bundle : bundle.name;
+	const blocks = 'string' === typeof bundle ? [ bundle ] : bundle.blocks;
+
 	// Bundle editor assets
 	bundlesEntry[ name + '/editor' ] = blocks.reduce( ( arr, block ) => {
 		const editorScriptPath = path.join( __dirname, '../extensions/blocks', block, 'editor.js' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Load _Business Hours_ and _Blogging Prompt_ blocks asynchronously. This is a proof-of-concept.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- pedMtX-RS-p2
- #17099

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
- Pull [this Gutenberg PR](https://github.com/WordPress/gutenberg/pull/51778)
- In the `jetpack` repo, link the Gutenberg plugin to your local folder in `tools/docker/jetpack-docker-config-default.yml` by adding `<path to your Gutenberg folder>: /var/www/html/wp-content/plugins/gutenberg` in the `volumeMappings` key

### Testing
TBD