### PR TITLE
Use shared component for editor panel icons

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -920,6 +920,9 @@ importers:
       '@automattic/jetpack-analytics':
         specifier: workspace:*
         version: link:../analytics
+      '@automattic/jetpack-components':
+        specifier: workspace:*
+        version: link:../components
       '@automattic/jetpack-connection':
         specifier: workspace:*
         version: link:../connection

--- a/projects/js-packages/shared-extension-utils/changelog/update-jetpack-editor-panel-icon
+++ b/projects/js-packages/shared-extension-utils/changelog/update-jetpack-editor-panel-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add shared block editor logo component.

--- a/projects/js-packages/shared-extension-utils/index.js
+++ b/projects/js-packages/shared-extension-utils/index.js
@@ -16,3 +16,4 @@ export {
 export { default as isCurrentUserConnected } from './src/is-current-user-connected';
 export { default as useAnalytics } from './src/hooks/use-analytics';
 export { default as useModuleStatus } from './src/hooks/use-module-status';
+export { default as JetpackEditorPanelLogo } from './src/components/jetpack-editor-panel-logo';

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.10.9",
+	"version": "0.11.0-alpha",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:*",
+		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@wordpress/api-fetch": "6.34.0",
 		"@wordpress/compose": "6.14.0",

--- a/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/index.jsx
+++ b/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/index.jsx
@@ -1,13 +1,20 @@
 import { JetpackLogo } from '@automattic/jetpack-components';
 import React from 'react';
 
+import './style.scss';
+
 /**
  * The Jetpack logo used for block editor panels
  *
  * @returns {React.Component} Jetpack logo component
  */
 const JetpackEditorPanelLogo = () => (
-	<JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />
+	<JetpackLogo
+		className="jetpack-editor-panel-logo"
+		height={ 16 }
+		logoColor="#1E1E1E"
+		showText={ false }
+	/>
 );
 
 export default JetpackEditorPanelLogo;

--- a/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/index.jsx
+++ b/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/index.jsx
@@ -1,10 +1,10 @@
 import { JetpackLogo } from '@automattic/jetpack-components';
-import type React from 'react';
+import React from 'react';
 
 /**
  * The Jetpack logo used for block editor panels
  *
- * @returns {React.ReactElement} - JSX Element
+ * @returns {React.Component} Jetpack logo component
  */
 const JetpackEditorPanelLogo = () => (
 	<JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />

--- a/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/style.scss
+++ b/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/style.scss
@@ -1,0 +1,3 @@
+.jetpack-editor-panel-logo {
+	margin-left: 0.5em;
+}

--- a/projects/plugins/jetpack/changelog/update-jetpack-editor-panel-icon
+++ b/projects/plugins/jetpack/changelog/update-jetpack-editor-panel-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack editor extensions: use shared component for the logo.

--- a/projects/plugins/jetpack/extensions/blocks/seo/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/seo/index.js
@@ -1,8 +1,8 @@
+import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import SeoDescriptionPanel from './description-panel';
 import SeoNoindexPanel from './noindex-panel';

--- a/projects/plugins/jetpack/extensions/blocks/seo/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/seo/index.js
@@ -1,8 +1,8 @@
-import { JetpackLogo } from '@automattic/jetpack-components';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import SeoDescriptionPanel from './description-panel';
 import SeoNoindexPanel from './noindex-panel';
@@ -19,7 +19,7 @@ export const settings = {
 		};
 
 		const jetpackSeoPrePublishPanelProps = {
-			icon: <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />,
+			icon: <JetpackEditorPanelLogo />,
 			title: __( 'SEO', 'jetpack' ),
 		};
 

--- a/projects/plugins/jetpack/extensions/blocks/social-previews/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/social-previews/index.js
@@ -1,9 +1,9 @@
-import { JetpackLogo } from '@automattic/jetpack-components';
 import { SocialPreviewsModal, SocialPreviewsPanel } from '@automattic/jetpack-publicize-components';
 import { PanelBody } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 
 export const name = 'social-previews';
@@ -25,7 +25,7 @@ export const SocialPreviews = function SocialPreviews() {
 			</JetpackPluginSidebar>
 			<PluginPrePublishPanel
 				title={ __( 'Social Previews', 'jetpack' ) }
-				icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+				icon={ <JetpackEditorPanelLogo /> }
 				initialOpen={ false }
 			>
 				<SocialPreviewsPanel openModal={ () => setIsOpened( true ) } />

--- a/projects/plugins/jetpack/extensions/blocks/social-previews/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/social-previews/index.js
@@ -1,9 +1,9 @@
 import { SocialPreviewsModal, SocialPreviewsPanel } from '@automattic/jetpack-publicize-components';
+import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 
 export const name = 'social-previews';

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -1,4 +1,4 @@
-import { JetpackLogo, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import {
 	isComingSoon,
 	isPrivateSite,
@@ -23,6 +23,7 @@ import {
 	accessOptions,
 	isNewsletterFeatureEnabled,
 } from '../../../extensions/shared/memberships-edit';
+import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import EmailPreview from './email-preview';
 import {
@@ -60,7 +61,7 @@ function NewsletterEditorSettingsPanel( { accessLevel, setPostMeta } ) {
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Newsletter visibility', 'jetpack' ) }
-			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<NewsletterAccessDocumentSettings accessLevel={ accessLevel } setPostMeta={ setPostMeta } />
 		</PluginDocumentSettingPanel>
@@ -78,21 +79,21 @@ const NewsletterDisabledPanels = () => (
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Newsletter visibility', 'jetpack' ) }
-			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<NewsletterDisabledNotice />
 		</PluginDocumentSettingPanel>
 		<PluginPrePublishPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Newsletter visibility', 'jetpack' ) }
-			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<NewsletterDisabledNotice />
 		</PluginPrePublishPanel>
 		<PluginPostPublishPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Newsletter visibility', 'jetpack' ) }
-			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<NewsletterDisabledNotice />
 		</PluginPostPublishPanel>
@@ -133,7 +134,7 @@ function NewsletterPrePublishSettingsPanel( {
 					) }
 				</>
 			}
-			icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+			icon={ <JetpackEditorPanelLogo /> }
 		>
 			{ isModuleActive && (
 				<>
@@ -226,7 +227,7 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 					</>
 				}
 				className="jetpack-subscribe-newsletters-panel jetpack-subscribe-post-publish-panel"
-				icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+				icon={ <JetpackEditorPanelLogo /> }
 			>
 				{ ! showMisconfigurationWarning && (
 					<Notice className="jetpack-subscribe-post-publish-panel__notice" isDismissible={ false }>
@@ -243,7 +244,7 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 					initialOpen
 					className="jetpack-subscribe-newsletters-panel paid-newsletters-post-publish-panel"
 					title={ __( 'Set up a paid newsletter', 'jetpack' ) }
-					icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+					icon={ <JetpackEditorPanelLogo /> }
 				>
 					<PanelRow>
 						<p>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -1,10 +1,11 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import {
+	getSiteFragment,
 	isComingSoon,
 	isPrivateSite,
-	useModuleStatus,
+	JetpackEditorPanelLogo,
 	useAnalytics,
-	getSiteFragment,
+	useModuleStatus,
 } from '@automattic/jetpack-shared-extension-utils';
 import { Button, ExternalLink, Flex, FlexItem, Notice, PanelRow } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
@@ -23,7 +24,6 @@ import {
 	accessOptions,
 	isNewsletterFeatureEnabled,
 } from '../../../extensions/shared/memberships-edit';
-import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import EmailPreview from './email-preview';
 import {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
+import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import JetpackEditorPanelLogo from '../../../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
 import Proofread from '../proofread';
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { JetpackLogo } from '@automattic/jetpack-components';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import JetpackEditorPanelLogo from '../../../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
 import Proofread from '../proofread';
 
@@ -25,7 +25,7 @@ export default function AiAssistantPluginSidebar() {
 			</JetpackPluginSidebar>
 			<PluginPrePublishPanel
 				title={ title }
-				icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+				icon={ <JetpackEditorPanelLogo /> }
 				initialOpen={ false }
 			>
 				<Proofread />

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -1,9 +1,9 @@
-import { JetpackLogo } from '@automattic/jetpack-components';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
+import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar.js';
 import { QRPostButton } from './components/qr-post.js';
 import './editor.scss';
@@ -18,7 +18,6 @@ export const settings = {
 			className: 'post-publish-qr-post-panel',
 			initialOpen: false,
 		};
-		const icon = <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />;
 
 		const isPostPublished = useSelect(
 			select => select( editorStore ).isCurrentPostPublished(),
@@ -43,7 +42,7 @@ export const settings = {
 
 		return (
 			<>
-				<PluginPostPublishPanel { ...panelBodyProps } icon={ icon }>
+				<PluginPostPublishPanel { ...panelBodyProps } icon={ <JetpackEditorPanelLogo /> }>
 					<QRPostPanelBodyContent />
 				</PluginPostPublishPanel>
 

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -1,9 +1,9 @@
+import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody, PanelRow } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar.js';
 import { QRPostButton } from './components/qr-post.js';
 import './editor.scss';

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -16,10 +16,10 @@ import {
 	SocialImageGeneratorPanel,
 	PostPublishReviewPrompt,
 } from '@automattic/jetpack-publicize-components';
+import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PostTypeSupportCheck } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import UpsellNotice from './components/upsell';
 

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -8,7 +8,6 @@
  * displays the Publicize UI there.
  */
 
-import { JetpackLogo } from '@automattic/jetpack-components';
 import {
 	TwitterThreadListener,
 	PublicizePanel,
@@ -20,6 +19,7 @@ import {
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
 import { PostTypeSupportCheck } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
+import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import UpsellNotice from './components/upsell';
 
@@ -50,7 +50,7 @@ const PublicizeSettings = () => {
 						{ __( 'Share this post', 'jetpack' ) }
 					</span>
 				}
-				icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+				icon={ <JetpackEditorPanelLogo /> }
 			>
 				<PublicizePanel prePublish={ true } enableTweetStorm={ true }>
 					<UpsellNotice />
@@ -61,7 +61,7 @@ const PublicizeSettings = () => {
 				<PluginPrePublishPanel
 					initialOpen
 					title={ __( 'Social Image Generator', 'jetpack' ) }
-					icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+					icon={ <JetpackEditorPanelLogo /> }
 				>
 					<SocialImageGeneratorPanel prePublish={ true } />
 				</PluginPrePublishPanel>

--- a/projects/plugins/jetpack/extensions/shared/components/jetpack-editor-panel-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/shared/components/jetpack-editor-panel-logo/index.tsx
@@ -1,0 +1,13 @@
+import { JetpackLogo } from '@automattic/jetpack-components';
+import type React from 'react';
+
+/**
+ * The Jetpack logo used for block editor panels
+ *
+ * @returns {React.ReactElement} - JSX Element
+ */
+const JetpackEditorPanelLogo = () => (
+	<JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" />
+);
+
+export default JetpackEditorPanelLogo;

--- a/projects/plugins/social/changelog/update-jetpack-editor-panel-icon
+++ b/projects/plugins/social/changelog/update-jetpack-editor-panel-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack editor extensions: use shared component for the logo.

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -1,4 +1,4 @@
-import { JetpackLogo, SocialIcon } from '@automattic/jetpack-components';
+import { SocialIcon } from '@automattic/jetpack-components';
 import {
 	SocialPreviewsModal,
 	SocialPreviewsPanel,
@@ -21,6 +21,7 @@ import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { getQueryArg } from '@wordpress/url';
+import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import Description from './components/publicize-panel/description';
 
 import './editor.scss';
@@ -84,7 +85,7 @@ const JetpackSocialSidebar = () => {
 			<PluginPrePublishPanel
 				initialOpen
 				title={ __( 'Share this post', 'jetpack-social' ) }
-				icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+				icon={ <JetpackEditorPanelLogo /> }
 			>
 				<PublicizePanel prePublish={ true }>
 					<PanelDescription />
@@ -95,7 +96,7 @@ const JetpackSocialSidebar = () => {
 				<PluginPrePublishPanel
 					initialOpen
 					title={ __( 'Social Image Generator', 'jetpack-social' ) }
-					icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+					icon={ <JetpackEditorPanelLogo /> }
 				>
 					<SocialImageGeneratorPanel prePublish={ true } />
 				</PluginPrePublishPanel>
@@ -104,7 +105,7 @@ const JetpackSocialSidebar = () => {
 			<PluginPrePublishPanel
 				initialOpen
 				title={ __( 'Social Previews', 'jetpack-social' ) }
-				icon={ <JetpackLogo showText={ false } height={ 16 } logoColor="#1E1E1E" /> }
+				icon={ <JetpackEditorPanelLogo /> }
 			>
 				<SocialPreviewsPanel openModal={ openModal } />
 			</PluginPrePublishPanel>

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -8,6 +8,7 @@ import {
 	PublicizePanel,
 	PostPublishReviewPrompt,
 } from '@automattic/jetpack-publicize-components';
+import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
@@ -21,7 +22,6 @@ import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { getQueryArg } from '@wordpress/url';
-import JetpackEditorPanelLogo from '../../shared/jetpack-editor-panel-logo';
 import Description from './components/publicize-panel/description';
 
 import './editor.scss';


### PR DESCRIPTION
Use a shared component as Jetpack icon for block editor panels.

Pretty minor but seemed like repeating `showText={ false } height={ 16 } logoColor="#1E1E1E"` everywhere was a bit unnecessary.

<img width="303" alt="Screenshot 2023-08-03 at 12 51 53" src="https://github.com/Automattic/jetpack/assets/87168/0026ea65-af7c-4b25-b815-569503315141">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test all affected panels and ensure icons render fine. They seem all to be in post editor's post settings, pre-publish, or post-publish panels.
