### PR TITLE
Subscribe Block: improve copies

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-copies
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-copies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+minor copy change

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -817,15 +817,13 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	$is_paid_post = $newsletter_access_level === 'paid_subscribers'
 		&& ! empty( Jetpack_Memberships::get_connected_account_id() );
 
-	$access_heading = $is_paid_post
-		? esc_html__( 'This post is for paid subscribers', 'jetpack' )
-		: esc_html__( 'This post is for subscribers', 'jetpack' );
+	$access_heading = esc_html__( 'Subscribe to continue reading', 'jetpack' );
 
 	$subscribe_text = $is_paid_post
 		// translators: %s is the name of the site.
-		? sprintf( esc_html__( 'Subscribe to %s to keep reading and receive all new posts in your inbox.', 'jetpack' ), get_bloginfo( 'name' ) )
+		? esc_html__( 'Become a paid subscriber to get access to the rest of this post and other exclusive content.', 'jetpack' )
 		// translators: %s is the name of the site.
-		: sprintf( esc_html__( 'Subscribe to %s to keep reading, receive all new posts in your inbox and have access to the full archives.', 'jetpack' ), get_bloginfo( 'name' ) );
+		: esc_html__( 'Subscribe to get access to the rest of this post and other subscriber-only content.', 'jetpack' );
 
 	$lock_svg = plugins_url( 'images/lock-paywall.svg', JETPACK__PLUGIN_FILE );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/79973#issuecomment-1660139347

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Anyone subscribed
- Heading: `Subscribe to continue reading`
- Body: `Subscribe to get access to the rest of this post and other subscriber-only content.`

Paid-subscribers only
- Heading: `Subscribe to continue reading`
- Body: `Become a paid subscriber to get access to the rest of this post and other exclusive content.`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a subscribe block and check the new copies are there.

