### PR TITLE
AI Extension: iterate over the AI Assistant bar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-ai-bar-when-editing
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-ai-bar-when-editing
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Jetpack AI: POC - AI Assistant bar:wq
+AI Extension: iterate over the AI Assistant bar

--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-ai-bar-when-editing
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-ai-bar-when-editing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: POC - AI Assistant bar:wq

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -33,7 +33,7 @@ const debug = debugFactory( 'jetpack-ai-assistant:form-assistant' );
  * @param {string} clientId - The block client ID.
  * @returns {string}          The serialized content.
  */
-function getSerializedContentFromBlock( clientId: string ): string {
+export function getSerializedContentFromBlock( clientId: string ): string {
 	if ( ! clientId?.length ) {
 		return '';
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -14,6 +14,7 @@ import debugFactory from 'debug';
  */
 import { PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, getPrompt } from '../../../../lib/prompt';
 import { AiAssistantUiContext } from '../../ui-handler/context';
+import { hasFormContent } from '../ai-assistant-toolbar-button';
 /*
  * Types
  */
@@ -33,7 +34,7 @@ const debug = debugFactory( 'jetpack-ai-assistant:form-assistant' );
  * @param {string} clientId - The block client ID.
  * @returns {string}          The serialized content.
  */
-export function getSerializedContentFromBlock( clientId: string ): string {
+function getSerializedContentFromBlock( clientId: string ): string {
 	if ( ! clientId?.length ) {
 		return '';
 	}
@@ -69,6 +70,7 @@ export const AiAssistantPopover = ( {
 		useContext( AiAssistantUiContext );
 
 	const { requestSuggestion, requestingState, eventSource } = useAiContext();
+	const hasContent = hasFormContent( clientId );
 
 	const stopSuggestion = useCallback( () => {
 		if ( ! eventSource ) {
@@ -117,6 +119,7 @@ export const AiAssistantPopover = ( {
 			animate={ false }
 			className={ classNames( 'jetpack-ai-assistant__popover', {
 				'is-fixed': isFixed,
+				'has-form-content': hasContent,
 			} ) }
 		>
 			<KeyboardShortcuts

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/style.scss
@@ -1,6 +1,7 @@
 .jetpack-ai-assistant__popover {
 	z-index: 31;
 	border-bottom: 1px solid #e0e0e0;
+
 	&.is-fixed {
 		width: 100%;
 		.components-popover__content,
@@ -12,6 +13,20 @@
 		.jetpack-components-ai-control__wrapper {
 			padding: 7px 14px;
 			width: 100%;
+		}
+	}
+
+	&.has-form-content:not(.is-fixed) {
+		border: 1px solid #1e1e1e;
+		min-width: 480px;
+		.components-popover__content,
+		.jetpack-components-ai-control__container {
+			width: 100%;
+			border-radius: 0;
+			box-shadow: none;
+		}
+		.jetpack-components-ai-control__wrapper {
+			padding: 7px 14px;
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -40,10 +40,18 @@ export default function AiAssistantToolbarButton( {
 	const hasContent = hasFormContent( clientId );
 
 	/*
-	 * Let's switch the anchor when the toolbar is fixed
-	 * 1 - Pick the Dom element reference
-	 * 2 - Find the closest block-editor-block-contextual-toolbar
-	 * 3 - Check if the toolbar is fixed, based on `is-fixed` CSS class
+	 * *** AI Assistant bar anchor ***
+	 *
+	 * On this component onMount event:
+	 * 1 - Pick the Dom toolbar-button DOM element reference.
+	 * 2 - Find the Block Toolbar DOM element, based on a CSS class.
+	 * 3 - Check if the toolbar is fixed, based on `is-fixed` CSS class.
+	 * 4 - Anchot the AI Assistant Bar to it when:
+	 *  - The toolbar is fixed.
+	 *  - The toolbar is not fixed, but the block has content.
+	 *
+	 * Also, it set the isFixed UI context state
+	 * Add/remove the `jetpack-ai-assistant-bar-is-fixed` class to the body.
 	 */
 	const anchorRef = useRef< HTMLElement | null >( null );
 	useEffect( () => {
@@ -65,18 +73,12 @@ export default function AiAssistantToolbarButton( {
 			return;
 		}
 
-		/*
-		 * There is a race condition between the toolbar and component onMount.
-		 * We need to wait a bit to set the popover props.
-		 */
-		setTimeout( () => {
-			setPopoverProps( prev => ( {
-				...prev,
-				anchor: toolbar,
-				offset: hasContent && ! isFixed ? 6 : 0,
-				variant: 'toolbar',
-			} ) );
-		}, 100 );
+		setPopoverProps( prev => ( {
+			...prev,
+			anchor: toolbar,
+			offset: hasContent && ! isFixed ? 6 : 0,
+			variant: 'toolbar',
+		} ) );
 	}, [ setAssistantFixed, setPopoverProps, isVisible, hasContent ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -17,7 +17,7 @@ type AiAssistantToolbarButtonProps = {
 	clientId?: string;
 };
 
-function hasFormContent( clientId: string ): boolean {
+export function hasFormContent( clientId: string ): boolean {
 	if ( ! clientId?.length ) {
 		return false;
 	}
@@ -73,7 +73,7 @@ export default function AiAssistantToolbarButton( {
 			setPopoverProps( prev => ( {
 				...prev,
 				anchor: toolbar,
-				offset: hasContent ? 8 : 0,
+				offset: hasContent && ! isFixed ? 6 : 0,
 				variant: 'toolbar',
 			} ) );
 		}, 100 );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -3,6 +3,7 @@
  */
 import { aiAssistantIcon, useAiContext } from '@automattic/jetpack-ai-client';
 import { ToolbarButton } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { useContext, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect } from 'react';
@@ -12,10 +13,31 @@ import React, { useEffect } from 'react';
 import { AiAssistantUiContext } from '../../ui-handler/context';
 import { handleAiExtensionsBarBodyClass } from '../../ui-handler/with-ui-handler-data-provider';
 
-export default function AiAssistantToolbarButton(): React.ReactElement {
+type AiAssistantToolbarButtonProps = {
+	clientId?: string;
+};
+
+function hasFormContent( clientId: string ): boolean {
+	if ( ! clientId?.length ) {
+		return false;
+	}
+
+	const block = select( 'core/block-editor' ).getBlock( clientId );
+	if ( ! block ) {
+		return false;
+	}
+
+	return !! block?.innerBlocks?.length;
+}
+
+export default function AiAssistantToolbarButton( {
+	clientId,
+}: AiAssistantToolbarButtonProps ): React.ReactElement {
 	const { isVisible, toggle, setPopoverProps, setAssistantFixed } =
 		useContext( AiAssistantUiContext );
 	const { requestingState } = useAiContext();
+
+	const hasContent = hasFormContent( clientId );
 
 	/*
 	 * Let's switch the anchor when the toolbar is fixed
@@ -39,7 +61,7 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 		setAssistantFixed( isFixed );
 		handleAiExtensionsBarBodyClass( isFixed, isVisible );
 
-		if ( ! isFixed ) {
+		if ( ! isFixed && ! hasContent ) {
 			return;
 		}
 
@@ -51,11 +73,11 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 			setPopoverProps( prev => ( {
 				...prev,
 				anchor: toolbar,
-				offset: 0,
+				offset: hasContent ? 8 : 0,
 				variant: 'toolbar',
 			} ) );
 		}, 100 );
-	}, [ setAssistantFixed, setPopoverProps, isVisible ] );
+	}, [ setAssistantFixed, setPopoverProps, isVisible, hasContent ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -80,7 +80,7 @@ const withAiAssistantToolbarButton = createHigherOrderComponent( BlockEdit => {
 				<BlockEdit { ...props } />
 
 				<BlockControls { ...blockControlsProps }>
-					<AiAssistantToolbarButton />
+					<AiAssistantToolbarButton clientId={ props.clientId } />
 				</BlockControls>
 			</>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -126,25 +126,22 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 
 		const hasContent = hasFormContent( clientId );
 
-		/*
-		 * Set the anchor element for the popover.
-		 * For now, let's use the block representation in the canvas,
-		 * but we can change it in the future.
-		 */
+		// *** AI Assistant bar anchor ***
 		useEffect( () => {
 			if ( ! clientId ) {
 				return;
 			}
 
+			// Add/remove the `jetpack-ai-assistant-bar-is-fixed` class to the body.
 			handleAiExtensionsBarBodyClass( isFixed, isVisible );
 
 			if ( hasContent ) {
-				return;
+				return; // Bail out if the block has content.
 			}
 
 			// Do not anchor the popover if the toolbar is fixed.
 			if ( isFixed ) {
-				return setWidth( '100%' ); // ensure to use the full width.
+				return setWidth( '100%' ); // ensure to use the full width, and bail out.
 			}
 
 			const idAttribute = `block-${ clientId }`;
@@ -158,11 +155,11 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			const iframeDocument = iFrame && iFrame.contentWindow.document;
 
 			const blockDomElement = ( iframeDocument ?? document ).getElementById( idAttribute );
-
 			if ( ! blockDomElement ) {
-				return;
+				return; // Bail out if the block DOM element is not available.
 			}
 
+			// Set the popover props.
 			setPopoverProps( prev => ( {
 				...prev,
 				anchor: blockDomElement,
@@ -170,6 +167,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				offset: 12,
 			} ) );
 
+			// Set the popover width.
 			setWidth( blockDomElement?.getBoundingClientRect?.()?.width );
 		}, [ clientId, isFixed, isVisible, hasContent ] );
 
@@ -187,7 +185,10 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				return;
 			}
 
-			// Do not observe the anchor resize if the toolbar is fixed.
+			/*
+			 * Do not observe the anchor resize if
+			 * the toolbar is fixed or the block has content.
+			 */
 			if ( isFixed || hasContent ) {
 				setWidth( '100%' );
 				return;
@@ -263,6 +264,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				<KeyboardShortcuts
 					shortcuts={ {
 						'mod+/': () => {
+							// Select the block. Then toggle().
 							selectFormBlock().then( () => {
 								setTimeout( () => {
 									toggle();

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -102,7 +102,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		 *
 		 * @returns {void}
 		 */
-		const selectFormBlock = useCallback( async () => {
+		const selectFormBlock = useCallback( () => {
 			return dispatch( 'core/block-editor' ).selectBlock( props.clientId );
 		}, [ props.clientId ] );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR suggests an approach to handle how and where anchoring the AIAssistantBar.
The toolbar will be anchored to:
* The block representation in the canvas if it's empty
* Just below the Button Toolbar button when the block has content

Fixes https://github.com/Automattic/jetpack/issues/32255

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: iterate over the AI Assistant bar

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test how the Ai Assistant bar is positioned, depending on the viewport size.

https://github.com/Automattic/jetpack/assets/77539/7dc631ae-68db-47e9-974c-074eba954235

