### PR TITLE
Newsletter: visibility settings – remove notice

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-remove-notice
+++ b/projects/plugins/jetpack/changelog/update-newsletter-remove-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Newsletter: remove notice

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/settings.js
@@ -4,7 +4,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
 	accessOptions,
@@ -35,15 +35,6 @@ export function getReachForAccessLevelKey( accessLevelKey, emailSubscribers, pai
 }
 
 export function NewsletterNotice( { accessLevel } ) {
-	const { hasPostBeenPublished, hasPostBeenScheduled } = useSelect( select => {
-		const { isCurrentPostPublished, isCurrentPostScheduled } = select( editorStore );
-
-		return {
-			hasPostBeenPublished: isCurrentPostPublished(),
-			hasPostBeenScheduled: isCurrentPostScheduled(),
-		};
-	} );
-
 	const { emailSubscribers, paidSubscribers } = useSelect( select =>
 		select( membershipProductsStore ).getSubscriberCounts()
 	);
@@ -81,38 +72,6 @@ export function NewsletterNotice( { accessLevel } ) {
 			</FlexBlock>
 		);
 	}
-
-	let subscriberType = __( 'subscribers', 'jetpack' );
-	if ( accessLevel === accessOptions.paid_subscribers.key ) {
-		subscriberType = __( 'paid subscribers', 'jetpack' );
-	}
-
-	let numberOfSubscribersText = sprintf(
-		/* translators: %1s is the number of subscribers in numerical format, %2s options are paid subscribers or subscribers */
-		__( 'This will also be sent to <br/><strong>%1$s %2$s</strong>.', 'jetpack' ),
-		reachCount,
-		subscriberType
-	);
-
-	if ( hasPostBeenPublished && ! hasPostBeenScheduled ) {
-		numberOfSubscribersText = sprintf(
-			/* translators: %1s is the number of subscribers in numerical format, %2s options are paid subscribers or subscribers */
-			__( 'This was sent to <strong>%1$s %2$s</strong>.', 'jetpack' ),
-			reachCount,
-			subscriberType
-		);
-	}
-
-	return (
-		<FlexBlock>
-			<Notice status="info" isDismissible={ false } className="edit-post-post-visibility__notice">
-				{ createInterpolateElement( numberOfSubscribersText, {
-					br: <br />,
-					strong: <strong />,
-				} ) }
-			</Notice>
-		</FlexBlock>
-	);
 }
 
 function NewsletterAccessSetupNudge( { stripeConnectUrl, isStripeConnected, hasNewsletterPlans } ) {


### PR DESCRIPTION
Opened this PR for further discussion. Didn't even test.

Discussed with @crisbusquets that this notice makes little sense 🤔,
![image](https://github.com/Automattic/jetpack/assets/104869/ab85fd84-5e65-4178-b44c-d7a1d28b686a)

What do you all think?

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

