### PR TITLE
Launchpad: fullscreen method refactor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/launchpad-fullscreen-method-refactor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/launchpad-fullscreen-method-refactor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: simple refactor
+
+

--- a/projects/packages/jetpack-mu-wpcom/changelog/launchpad-fullscreen-method-refactor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/launchpad-fullscreen-method-refactor
@@ -1,5 +1,3 @@
 Significance: patch
 Type: changed
-Comment: simple refactor
-
-
+Comment: Rename 'wpcom_get_launchpad_is_enabled()' to 'wpcom_launchpad_get_fullscreen_enabled()'

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -34,7 +34,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'design_edited',
 				'site_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'free'                   => array(
 			'title'               => 'Free',
@@ -47,7 +47,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'design_edited',
 				'site_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'link-in-bio'            => array(
 			'title'               => 'Link In Bio',
@@ -58,7 +58,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'links_added',
 				'link_in_bio_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'link-in-bio-tld'        => array(
 			'title'               => 'Link In Bio',
@@ -69,7 +69,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'links_added',
 				'link_in_bio_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'newsletter'             => array(
 			'title'               => 'Newsletter',
@@ -82,7 +82,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'newsletter_plan_created',
 				'first_post_published_newsletter',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'videopress'             => array(
 			'title'               => 'Videopress',
@@ -92,7 +92,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'videopress_upload',
 				'videopress_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'write'                  => array(
 			'title'               => 'Write',
@@ -103,7 +103,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'first_post_published',
 				'site_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'start-writing'          => array(
 			'title'               => 'Start Writing',
@@ -114,7 +114,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'plan_completed',
 				'blog_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'design-first'           => array(
 			'title'               => 'Pick a Design',
@@ -126,7 +126,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'first_post_published',
 				'blog_launched',
 			),
-			'is_enabled_callback' => 'wpcom_get_launchpad_is_enabled',
+			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
 		'intent-build'           => array(
 			'title'               => 'Keep Building',
@@ -584,7 +584,7 @@ function wpcom_log_launchpad_being_enabled_for_test_sites( $option, $value ) {
  *
  * @return bool True if the launchpad is enabled, false otherwise.
  */
-function wpcom_get_launchpad_is_enabled() {
+function wpcom_launchpad_get_fullscreen_enabled() {
 	return wpcom_launchpad_checklists()->is_fullscreen_launchpad_enabled();
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/80140

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Rename `wpcom_get_launchpad_is_enabled` to `wpcom_launchpad_get_fullscreen_enabled`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify tests pass correctly
* Verify there's no other usages where the function needs to be replaced. I opengroked in all projects, but a double check wont hurt

