### PR TITLE
Fixes missing controller for DSP /woo/wpcom-payment-methods request

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-dashboard-woo-payment-endpoint
+++ b/projects/packages/blaze/changelog/fix-blaze-dashboard-woo-payment-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes missing controller for DSP /woo/wpcom-payment-methods request

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.9.0",
+	"version": "0.9.1-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -191,13 +191,13 @@ class Dashboard_REST_Controller {
 			)
 		);
 
-		// WordAds DSP API Woo countries routes
+		// WordAds DSP API Woo routes
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/sites/%d/wordads/dsp/api/v1/woo/countries(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
+			sprintf( '/sites/%d/wordads/dsp/api/v1/woo(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_dsp_countries' ),
+				'callback'            => array( $this, 'get_dsp_woo' ),
 				'permission_callback' => array( $this, 'can_user_view_dsp_callback' ),
 			)
 		);
@@ -405,13 +405,13 @@ class Dashboard_REST_Controller {
 	}
 
 	/**
-	 * Redirect GET requests to WordAds DSP Countries endpoint for the site.
+	 * Redirect GET requests to WordAds DSP Woo endpoint for the site.
 	 *
 	 * @param WP_REST_Request $req The request object.
 	 * @return array|WP_Error
 	 */
-	public function get_dsp_countries( $req ) {
-		return $this->get_dsp_generic( 'v1/woo/countries', $req );
+	public function get_dsp_woo( $req ) {
+		return $this->get_dsp_generic( 'v1/woo', $req );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.9.0';
+	const PACKAGE_VERSION = '0.9.1-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.


### PR DESCRIPTION
THis PR fixes a 404 error we get when accessing the DSP Create campaign widget in the Jetpack Blaze Dashbaord.
The problem is happening because the `/woo/wpcom-payment-methods` requests aren't being redirected to WPCOM.

## Proposed changes:
* Changed the Blaze package to redirect all the `/woo/xxx` requests to the DSP. This way, we can take care of future requests under the same root controller.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1691071539223329/1691059525.379029-slack-C050L75TXA5

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The Blaze Dashboard can be tested on self-hosted and pressable sites. You can also test this on atomic, but you will need to manually execute a filter: `add_filter( 'jetpack_blaze_dashboard_enable', '__return_true' );`.

* Go to Tools->Advertising
* Open your Network console tab and filter requests with the `/woo` path
* Click on the Promote button (in the header or in one of your posts)
* Verify that the Create campaign widget loads correctly, and that in the network tab, you see a successfully completed request to `woo/wpcom-payment-methods`