### PR TITLE
Launchpad: refactor disable_launchpad & maybe_disable_launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/launchpad-refactor-fullscreen-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/launchpad-refactor-fullscreen-launchpad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Refactors refactor disable_launchpad & maybe_disable_launchpad to make it clear they are related to the fullscreen launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -659,15 +659,15 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
-	 * Disables Launchpad if all tasks are complete.
+	 * Disables fullscreen Launchpad if all tasks are complete.
 	 *
 	 * @return void
 	 */
-	public function maybe_disable_launchpad() {
+	public function maybe_disable_fullscreen_launchpad() {
 		if ( $this->has_active_tasks() ) {
 			return;
 		}
-		$this->disable_launchpad();
+		$this->disable_fullscreen_launchpad();
 	}
 
 	/**
@@ -729,7 +729,7 @@ class Launchpad_Task_Lists {
 	 *
 	 * @return bool True if successful, false if not.
 	 */
-	private function disable_launchpad() {
+	private function disable_fullscreen_launchpad() {
 		return update_option( 'launchpad_screen', 'off' );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -636,7 +636,7 @@ class Launchpad_Task_Lists {
 		$statuses[ $key ] = true;
 		$result           = update_option( 'launchpad_checklist_tasks_statuses', $statuses );
 
-		$this->maybe_disable_launchpad();
+		$this->maybe_disable_fullscreen_launchpad();
 
 		return $result;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -153,7 +153,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 						$updated[ $key ] = $value;
 					}
 					// This will check if we have completed all the tasks and disable Launchpad if so.
-					wpcom_launchpad_checklists()->maybe_disable_launchpad();
+					wpcom_launchpad_checklists()->maybe_disable_fullscreen_launchpad();
 					break;
 
 				default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/80140

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Refactors disable_launchpad & maybe_disable_launchpad to make it clear they are related to the fullscreen launchpad

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify tests pass correctly
* Verify there's no other usages where the function needs to be replaced. I opengroked in all projects, but a double check wont hurt

