### PR TITLE
Launchpad: Refactor is launchpad enabled

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/launchpad-refactor-is-launchpad-enabled
+++ b/projects/packages/jetpack-mu-wpcom/changelog/launchpad-refactor-is-launchpad-enabled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Refactors is_launchpad_enabled method  to make it clear they are related to the fullscreen launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -591,7 +591,7 @@ class Launchpad_Task_Lists {
 	 */
 	public function add_hooks_for_active_tasks( $task_list_id = null ) {
 		// leave things alone if Launchpad is not enabled.
-		if ( ! $this->is_launchpad_enabled() ) {
+		if ( ! $this->is_fullscreen_launchpad_enabled() ) {
 			return;
 		}
 
@@ -716,7 +716,7 @@ class Launchpad_Task_Lists {
 	 *
 	 * @return boolean
 	 */
-	public function is_launchpad_enabled() {
+	public function is_fullscreen_launchpad_enabled() {
 		$launchpad_screen = get_option( 'launchpad_screen' );
 		if ( 'full' !== $launchpad_screen ) {
 			return false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -585,7 +585,7 @@ function wpcom_log_launchpad_being_enabled_for_test_sites( $option, $value ) {
  * @return bool True if the launchpad is enabled, false otherwise.
  */
 function wpcom_get_launchpad_is_enabled() {
-	return wpcom_launchpad_checklists()->is_launchpad_enabled();
+	return wpcom_launchpad_checklists()->is_fullscreen_launchpad_enabled();
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/80140

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Refactors `is_launchpad_enabled` to make it clear it's related to the fullscreen launchpad.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify tests pass correctly
* Verify there's no other usages where the function needs to be replaced. I opengroked in all projects, but a double check wont hurt
