### PR TITLE
Fix/subscriber call when module not available

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriber-call-when-module-not-available
+++ b/projects/plugins/jetpack/changelog/fix-subscriber-call-when-module-not-available
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Fix small regression on Newsletter panels

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -302,8 +302,9 @@ export default function SubscribePanels() {
 
 	return (
 		<>
-			( isModuleActive &&{ ' ' }
-			<NewsletterEditorSettingsPanel accessLevel={ accessLevel } setPostMeta={ setPostMeta } /> )
+			{ isModuleActive && (
+				<NewsletterEditorSettingsPanel accessLevel={ accessLevel } setPostMeta={ setPostMeta } />
+			) }
 			<NewsletterPrePublishSettingsPanel
 				accessLevel={ accessLevel }
 				setPostMeta={ setPostMeta }
@@ -313,9 +314,12 @@ export default function SubscribePanels() {
 					setIsModalOpen( true );
 				} }
 			/>
-			( isModuleActive &&{ ' ' }
-			<NewsletterPostPublishSettingsPanel accessLevel={ accessLevel } setPostMeta={ setPostMeta } />{ ' ' }
-			)
+			{ isModuleActive && (
+				<NewsletterPostPublishSettingsPanel
+					accessLevel={ accessLevel }
+					setPostMeta={ setPostMeta }
+				/>
+			) }
 			<EmailPreview isModalOpen={ isModalOpen } closeModal={ () => setIsModalOpen( false ) } />
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -15,7 +15,7 @@ import {
 	PluginPostPublishPanel,
 } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
-import { useEffect, useState, createInterpolateElement } from '@wordpress/element';
+import { useState, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
 import {
@@ -55,11 +55,7 @@ const SubscriptionsPanelPlaceholder = ( { children } ) => {
 	);
 };
 
-function NewsletterEditorSettingsPanel( { accessLevel, setPostMeta, isModuleActive } ) {
-	if ( ! isModuleActive ) {
-		return null;
-	}
-
+function NewsletterEditorSettingsPanel( { accessLevel, setPostMeta } ) {
 	return (
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletters-panel"
@@ -173,7 +169,7 @@ function NewsletterPrePublishSettingsPanel( {
 	);
 }
 
-function NewsletterPostPublishSettingsPanel( { accessLevel, isModuleActive } ) {
+function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 	const { emailSubscribers, paidSubscribers } = useSelect( select =>
 		select( membershipProductsStore ).getSubscriberCounts()
 	);
@@ -194,10 +190,6 @@ function NewsletterPostPublishSettingsPanel( { accessLevel, isModuleActive } ) {
 	} );
 
 	const postVisibility = useSelect( select => select( editorStore ).getEditedPostVisibility() );
-
-	if ( ! isModuleActive ) {
-		return null;
-	}
 
 	const reachCount = getReachForAccessLevelKey( accessLevel, emailSubscribers, paidSubscribers );
 
@@ -291,12 +283,6 @@ export default function SubscribePanels() {
 	const { tracks } = useAnalytics();
 	const accessLevel = useAccessLevel( postType );
 
-	useEffect( () => {
-		if ( ! isModuleActive ) {
-			return;
-		}
-	}, [ isModuleActive ] );
-
 	// Subscriptions are only available for posts. Additionally, we will allow access level selector for pages.
 	// TODO: Make it available for pages later.
 	if ( postType !== 'post' ) {
@@ -316,11 +302,8 @@ export default function SubscribePanels() {
 
 	return (
 		<>
-			<NewsletterEditorSettingsPanel
-				accessLevel={ accessLevel }
-				setPostMeta={ setPostMeta }
-				isModuleActive={ isModuleActive }
-			/>
+			( isModuleActive &&{ ' ' }
+			<NewsletterEditorSettingsPanel accessLevel={ accessLevel } setPostMeta={ setPostMeta } /> )
 			<NewsletterPrePublishSettingsPanel
 				accessLevel={ accessLevel }
 				setPostMeta={ setPostMeta }
@@ -330,11 +313,9 @@ export default function SubscribePanels() {
 					setIsModalOpen( true );
 				} }
 			/>
-			<NewsletterPostPublishSettingsPanel
-				accessLevel={ accessLevel }
-				setPostMeta={ setPostMeta }
-				isModuleActive={ isModuleActive }
-			/>
+			( isModuleActive &&{ ' ' }
+			<NewsletterPostPublishSettingsPanel accessLevel={ accessLevel } setPostMeta={ setPostMeta } />{ ' ' }
+			)
 			<EmailPreview isModalOpen={ isModalOpen } closeModal={ () => setIsModalOpen( false ) } />
 		</>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes regression in https://github.com/Automattic/jetpack/pull/32095#issuecomment-1663901576

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Instead of passing isModuleActive and render null in the component, I render the component only if isModuleActive   
* Remove unecessary useEffect

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See in https://github.com/Automattic/jetpack/pull/32095
OR
* Create a new JN instance
* Connect Jetpack, but do not enable the NL module
* Create a post
* Notice there is no calls to the "subscribers" endpoint and no errors in the editor
<img width="1446" alt="Screenshot 2023-08-04 at 12 51 40" src="https://github.com/Automattic/jetpack/assets/790558/957c606d-a198-4112-9d79-cec7fa1220c1">


