### PR TITLE
AI Assistant: Improve undo support on form AI Assistant

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-improve-undo-support
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-improve-undo-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: Improve undo action behavior by controlling the way received valid blocks are rendered.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -6,7 +6,7 @@ import { parse } from '@wordpress/blocks';
 import { KeyboardShortcuts } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
-import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
+import { useState, useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
@@ -62,6 +62,9 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			placement: 'bottom-start',
 			offset: 12,
 		} );
+
+		// Keep track of the current list of valid blocks between renders.
+		const currentListOfValidBlocks = useRef( [] );
 
 		const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 		const coreEditorSelect = useSelect( select => select( 'core/editor' ), [] ) as {
@@ -228,8 +231,15 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				const validBlocks = newContentBlocks.filter( block => {
 					return block.isValid && block.name !== 'core/freeform';
 				} );
-				// Only update the valid blocks
-				replaceInnerBlocks( clientId, validBlocks );
+
+				// Only update the blocks when the valid list changed, meaning a new block arrived.
+				if ( validBlocks.length !== currentListOfValidBlocks.current.length ) {
+					// Only update the valid blocks
+					replaceInnerBlocks( clientId, validBlocks );
+
+					// Update the list of current valid blocks
+					currentListOfValidBlocks.current = validBlocks;
+				}
 			},
 			[ clientId, replaceInnerBlocks ]
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR considerably improves the undo/redo process when the Jetpack Form populates its content from an AI response, inserting blocks only when are valid.

Part of #32259.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Control the rendering of the received blocks, only updating the editor when the list of valid received blocks changes

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Request a form
* Confirm the app creates the format as usual
* Test the undo/redo
* Confirm it improves 

