### PR TITLE
CRM: Automations Transaction triggers for new and updated

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-3242-3243-automations-transaction-new-and-updated-triggers
+++ b/projects/plugins/crm/changelog/add-crm-3242-3243-automations-transaction-new-and-updated-triggers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Automation: Added transaction triggers for new and updated

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
@@ -21,7 +21,7 @@ class Transaction_Created extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The slug.
 	 */
 	public static function get_slug(): string {
 		return 'jpcrm/transaction_created';
@@ -32,7 +32,7 @@ class Transaction_Created extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The title.
 	 */
 	public static function get_title(): string {
 		return __( 'New Transaction', 'zero-bs-crm' );
@@ -43,7 +43,7 @@ class Transaction_Created extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The description.
 	 */
 	public static function get_description(): string {
 		return __( 'Triggered when a transaction is created', 'zero-bs-crm' );
@@ -54,7 +54,7 @@ class Transaction_Created extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The category.
 	 */
 	public static function get_category(): string {
 		return __( 'transaction', 'zero-bs-crm' );

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
@@ -54,6 +54,8 @@ class Transaction_Created extends Base_Trigger {
 
 	/**
 	 * Listen to this trigger's target event.
+	 *
+	 * @return void
 	 */
 	protected function listen_to_event(): void {
 		add_action(

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
@@ -49,7 +49,7 @@ class Transaction_Created extends Base_Trigger {
 	 * @return string
 	 */
 	public static function get_category(): string {
-		return 'transaction';
+		return __( 'transaction', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Jetpack CRM Automation Transaction_Created trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Transaction_Created class.
+ *
+ * @since $$next-version$$
+ */
+class Transaction_Created extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/transaction_created';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_title(): string {
+		return __( 'New Transaction', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_description(): string {
+		return __( 'Triggered when a transaction is created', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_category(): string {
+		return 'transaction';
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event(): void {
+		add_action(
+			'jpcrm_transaction_created',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-created.php
@@ -19,6 +19,8 @@ class Transaction_Created extends Base_Trigger {
 	/**
 	 * Get the slug name of the trigger.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string
 	 */
 	public static function get_slug(): string {
@@ -27,6 +29,8 @@ class Transaction_Created extends Base_Trigger {
 
 	/**
 	 * Get the title of the trigger.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return string
 	 */
@@ -37,6 +41,8 @@ class Transaction_Created extends Base_Trigger {
 	/**
 	 * Get the description of the trigger.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string
 	 */
 	public static function get_description(): string {
@@ -46,6 +52,8 @@ class Transaction_Created extends Base_Trigger {
 	/**
 	 * Get the category of the trigger.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string
 	 */
 	public static function get_category(): string {
@@ -54,6 +62,8 @@ class Transaction_Created extends Base_Trigger {
 
 	/**
 	 * Listen to this trigger's target event.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return void
 	 */

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
@@ -69,7 +69,7 @@ class Transaction_Updated extends Base_Trigger {
 	 */
 	protected function listen_to_event() {
 		add_action(
-			'jpcrm_transaction_update',
+			'jpcrm_transaction_updated',
 			array( $this, 'execute_workflow' )
 		);
 	}

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
@@ -19,6 +19,8 @@ class Transaction_Updated extends Base_Trigger {
 	/**
 	 * Get the slug name of the trigger.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string
 	 */
 	public static function get_slug(): string {
@@ -27,6 +29,8 @@ class Transaction_Updated extends Base_Trigger {
 
 	/**
 	 * Get the title of the trigger.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return string
 	 */
@@ -37,6 +41,8 @@ class Transaction_Updated extends Base_Trigger {
 	/**
 	 * Get the description of the trigger.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string
 	 */
 	public static function get_description(): string {
@@ -46,6 +52,8 @@ class Transaction_Updated extends Base_Trigger {
 	/**
 	 * Get the category of the trigger.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string
 	 */
 	public static function get_category(): string {
@@ -54,6 +62,8 @@ class Transaction_Updated extends Base_Trigger {
 
 	/**
 	 * Listen to this trigger's target event.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return void
 	 */

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
@@ -21,7 +21,7 @@ class Transaction_Updated extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The slug.
 	 */
 	public static function get_slug(): string {
 		return 'jpcrm/transaction_updated';
@@ -32,7 +32,7 @@ class Transaction_Updated extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The title.
 	 */
 	public static function get_title(): string {
 		return __( 'Transaction Updated', 'zero-bs-crm' );
@@ -43,7 +43,7 @@ class Transaction_Updated extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The description.
 	 */
 	public static function get_description(): string {
 		return __( 'Triggered when a transaction is updated', 'zero-bs-crm' );
@@ -54,7 +54,7 @@ class Transaction_Updated extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The category.
 	 */
 	public static function get_category(): string {
 		return __( 'transaction', 'zero-bs-crm' );

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
@@ -54,6 +54,8 @@ class Transaction_Updated extends Base_Trigger {
 
 	/**
 	 * Listen to this trigger's target event.
+	 *
+	 * @return void
 	 */
 	protected function listen_to_event() {
 		add_action(

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
@@ -49,7 +49,7 @@ class Transaction_Updated extends Base_Trigger {
 	 * @return string
 	 */
 	public static function get_category(): string {
-		return 'transaction';
+		return __( 'transaction', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/transactions/class-transaction-updated.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Jetpack CRM Automation Transaction_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Transaction_Updated class.
+ *
+ * @since $$next-version$$
+ */
+class Transaction_Updated extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/transaction_updated';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_title(): string {
+		return __( 'Transaction Updated', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_description(): string {
+		return __( 'Triggered when a transaction is updated', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_category(): string {
+		return 'transaction';
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_transaction_update',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -149,6 +149,18 @@ class Automation_Faker {
 	}
 
 	/**
+	 * Return dummy transaction triggers name list
+	 *
+	 * @return array
+	 */
+	public function transaction_triggers(): array {
+		return array(
+			'jpcrm/transaction_created',
+			'jpcrm/transaction_updated',
+		);
+	}
+
+	/**
 	 * Return a workflow with a condition and an action
 	 * @return array
 	 */
@@ -303,6 +315,28 @@ class Automation_Faker {
 				'complete'       => false,
 				'show_on_portal' => true,
 				'show_on_cal'    => true,
+				'created'        => 1675000000,
+				'lastupdated'    => 1675000000,
+			),
+		);
+	}
+
+	/**
+	 * Return data for a dummy transaction
+	 *
+	 * @return array
+	 */
+	public function transaction_data() {
+		return array(
+			'id'   => 1,
+			'data' => array(
+				'title'          => 'Some transaction title',
+				'desc'           => 'Some desc',
+				'hash'           => 'mASOpAnf334Pncl1px4',
+				'status'         => 'Completed',
+				'type'           => 'Sale',
+				'date'           => 1676000000,
+				'date_completed' => 1676923766,
 				'created'        => 1675000000,
 				'lastupdated'    => 1675000000,
 			),

--- a/projects/plugins/crm/tests/php/automation/transactions/class-transaction-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/transactions/class-transaction-trigger-test.php
@@ -85,6 +85,6 @@ class Transaction_Trigger_Test extends BaseTestCase {
 		);
 
 		// Run the transaction_updated action.
-		do_action( 'jpcrm_transaction_update', $transaction_data );
+		do_action( 'jpcrm_transaction_updated', $transaction_data );
 	}
 }

--- a/projects/plugins/crm/tests/php/automation/transactions/class-transaction-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/transactions/class-transaction-trigger-test.php
@@ -1,0 +1,90 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+namespace Automattic\Jetpack\CRM\Automation\Tests;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Engine;
+use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
+use Automattic\Jetpack\CRM\Automation\Triggers\Transaction_Created;
+use Automattic\Jetpack\CRM\Automation\Triggers\Transaction_Updated;
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '../../tools/class-automation-faker.php';
+
+/**
+ * Test Automation's transaction triggers
+ *
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Transaction_Updated
+ * @covers Automattic\Jetpack\CRM\Automation\Triggers\Transaction_Created
+ */
+class Transaction_Trigger_Test extends BaseTestCase {
+
+	private $automation_faker;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->automation_faker = Automation_Faker::instance();
+	}
+
+	/**
+	 * @testdox Test the transaction created trigger executes the workflow with an action
+	 */
+	public function test_transaction_created_trigger() {
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/transaction_created' );
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Transaction_Created trigger.
+		$trigger = new Transaction_Created();
+		$trigger->init( $workflow );
+
+		// Fake transaction data.
+		$transaction_data = $this->automation_faker->transaction_data();
+
+		// We expect the workflow to be executed on transaction_created transaction with the transaction data.
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $transaction_data )
+		);
+
+		// Run the transaction_created action.
+		do_action( 'jpcrm_transaction_created', $transaction_data );
+	}
+
+	/**
+	 * @testdox Test the transaction updated trigger executes the workflow with an action
+	 */
+	public function test_transaction_updated_trigger() {
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/transaction_updated' );
+
+		$trigger = new Transaction_Updated();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Transaction_Updated trigger.
+		$trigger->init( $workflow );
+
+		// Fake transaction data.
+		$transaction_data = $this->automation_faker->transaction_data();
+
+		// We expect the workflow to be executed on transaction_updated transaction with the transaction data.
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $transaction_data )
+		);
+
+		// Run the transaction_updated action.
+		do_action( 'jpcrm_transaction_update', $transaction_data );
+	}
+}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds the following triggers to transactions with their respective tests:
  * New transaction
  * Transaction updated

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3242
https://github.com/Automattic/zero-bs-crm/issues/3243

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).
* You can test manually the objects being passed to the actions within each trigger by being creative (e.g. using the error_log).
