### PR TITLE
CRM: Automations Event triggers for update

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-3241-automations-event-updated-trigger
+++ b/projects/plugins/crm/changelog/add-crm-3241-automations-event-updated-trigger
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Automation: Added event trigger for updated

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
@@ -69,7 +69,7 @@ class Event_Updated extends Base_Trigger {
 	 */
 	protected function listen_to_event() {
 		add_action(
-			'jpcrm_event_update',
+			'jpcrm_event_updated',
 			array( $this, 'execute_workflow' )
 		);
 	}

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
@@ -19,6 +19,8 @@ class Event_Updated extends Base_Trigger {
 	/**
 	 * Get the slug name of the trigger.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string
 	 */
 	public static function get_slug(): string {
@@ -27,6 +29,8 @@ class Event_Updated extends Base_Trigger {
 
 	/**
 	 * Get the title of the trigger.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return string
 	 */
@@ -37,6 +41,8 @@ class Event_Updated extends Base_Trigger {
 	/**
 	 * Get the description of the trigger.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string
 	 */
 	public static function get_description(): string {
@@ -46,6 +52,8 @@ class Event_Updated extends Base_Trigger {
 	/**
 	 * Get the category of the trigger.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return string
 	 */
 	public static function get_category(): string {
@@ -54,6 +62,10 @@ class Event_Updated extends Base_Trigger {
 
 	/**
 	 * Listen to this trigger's target event.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return void
 	 */
 	protected function listen_to_event() {
 		add_action(

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
@@ -49,7 +49,7 @@ class Event_Updated extends Base_Trigger {
 	 * @return string
 	 */
 	public static function get_category(): string {
-		return 'event';
+		return __( 'event', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
@@ -21,7 +21,7 @@ class Event_Updated extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The trigger slug.
 	 */
 	public static function get_slug(): string {
 		return 'jpcrm/event_updated';
@@ -32,7 +32,7 @@ class Event_Updated extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The title.
 	 */
 	public static function get_title(): string {
 		return __( 'Event Updated', 'zero-bs-crm' );
@@ -43,7 +43,7 @@ class Event_Updated extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The description.
 	 */
 	public static function get_description(): string {
 		return __( 'Triggered when an event is updated', 'zero-bs-crm' );
@@ -54,7 +54,7 @@ class Event_Updated extends Base_Trigger {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string
+	 * @return string The category.
 	 */
 	public static function get_category(): string {
 		return __( 'event', 'zero-bs-crm' );

--- a/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/events/class-event-updated.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Jetpack CRM Automation Event_Updated trigger.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Triggers;
+
+use Automattic\Jetpack\CRM\Automation\Base_Trigger;
+
+/**
+ * Adds the Event_Updated class.
+ *
+ * @since $$next-version$$
+ */
+class Event_Updated extends Base_Trigger {
+
+	/**
+	 * Get the slug name of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/event_updated';
+	}
+
+	/**
+	 * Get the title of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_title(): string {
+		return __( 'Event Updated', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_description(): string {
+		return __( 'Triggered when an event is updated', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the trigger.
+	 *
+	 * @return string
+	 */
+	public static function get_category(): string {
+		return 'event';
+	}
+
+	/**
+	 * Listen to this trigger's target event.
+	 */
+	protected function listen_to_event() {
+		add_action(
+			'jpcrm_event_update',
+			array( $this, 'execute_workflow' )
+		);
+	}
+}

--- a/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
@@ -6,6 +6,7 @@ use Automattic\Jetpack\CRM\Automation\Automation_Engine;
 use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Triggers\Event_Created;
 use Automattic\Jetpack\CRM\Automation\Triggers\Event_Deleted;
+use Automattic\Jetpack\CRM\Automation\Triggers\Event_Updated;
 use WorDBless\BaseTestCase;
 
 require_once __DIR__ . '../../tools/class-automation-faker.php';
@@ -86,5 +87,37 @@ class Event_Trigger_Test extends BaseTestCase {
 
 		// Run the event_deleted action.
 		do_action( 'jpcrm_event_delete', $event_data );
+	}
+
+	/**
+	 * @testdox Test the event updated trigger executes the workflow with an action
+	 */
+	public function test_event_updated_trigger() {
+		$workflow_data = $this->automation_faker->workflow_without_initial_step_customize_trigger( 'jpcrm/event_updated' );
+
+		$trigger = new Event_Updated();
+
+		// Build a PHPUnit mock Automation_Workflow
+		$workflow = $this->getMockBuilder( Automation_Workflow::class )
+			->setConstructorArgs( array( $workflow_data, new Automation_Engine() ) )
+			->onlyMethods( array( 'execute' ) )
+			->getMock();
+
+		// Init the Event_Updated trigger.
+		$trigger->init( $workflow );
+
+		// Fake event data.
+		$event_data = $this->automation_faker->event_data();
+
+		// We expect the workflow to be executed on event_updated event with the event data.
+		$workflow->expects( $this->once() )
+		->method( 'execute' )
+		->with(
+			$this->equalTo( $trigger ),
+			$this->equalTo( $event_data )
+		);
+
+		// Run the event_updated action.
+		do_action( 'jpcrm_event_update', $event_data );
 	}
 }

--- a/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/events/class-event-trigger-test.php
@@ -118,6 +118,6 @@ class Event_Trigger_Test extends BaseTestCase {
 		);
 
 		// Run the event_updated action.
-		do_action( 'jpcrm_event_update', $event_data );
+		do_action( 'jpcrm_event_updated', $event_data );
 	}
 }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds the updated trigger to events with respective tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3241

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).
* You can test manually the objects being passed to the actions within each trigger by being creative (e.g. using the error_log).
