### PR TITLE
Social: Fix race condition in mobile app's post request

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mobile-sharing-toggling
+++ b/projects/plugins/jetpack/changelog/fix-mobile-sharing-toggling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+bugfix

--- a/projects/plugins/jetpack/changelog/fix-mobile-sharing-toggling
+++ b/projects/plugins/jetpack/changelog/fix-mobile-sharing-toggling
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-bugfix
+Social: Fix race condition in mobile app's post request

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -196,7 +196,6 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		// unhook publicize, it's hooked again later -- without this, skipping services is impossible.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			remove_action( 'save_post', array( $GLOBALS['publicize_ui']->publicize, 'async_publicize_post' ), 100, 2 );
-			add_action( 'rest_api_inserted_post', array( $GLOBALS['publicize_ui']->publicize, 'async_publicize_post' ) );
 
 			if ( $this->should_load_theme_functions( $post_id ) ) {
 				$this->load_theme_functions();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 1205142973434174-as-1205190774917545

We will rely on the `wp_after_insert_post` instead. When `rest_api_inserted_post` exists with it, there is a race condition which causes posts from being publicized before the metadata is updated.

More information here: p1691156301965779/1691150316.598199-slack-C02JJ910CNL
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the rest_api_inserted_post hook 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1691156301965779/1691150316.598199-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the testing instructions on D118215-code