### PR TITLE
Update Release Script to handle Backporting

### DIFF
--- a/.github/BACKPORT_RELEASE_CHANGES.md
+++ b/.github/BACKPORT_RELEASE_CHANGES.md
@@ -1,0 +1,29 @@
+<!--- This template is used for backporting changes made during a plugin release back to trunk. -->
+
+## Proposed changes:
+<!--- Explain what functional changes your PR includes -->
+Backports changes from PLUGIN_RELEASE X.Y
+
+### Other information:
+
+- [ ] Have you written new tests for your changes, if applicable?
+- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
+- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
+
+## Jetpack product discussion
+<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
+<!-- Make sure any changes to existing products have been discussed and agreed upon -->
+N/a
+## Does this pull request change what data or activity we track or use?
+<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
+<!--- Check existing Jetpack support documents for a preview of the information we need. -->
+No
+## Testing instructions:
+<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
+<!-- Please include detailed testing steps, explaining how to test your change. -->
+<!-- Bear in mind that context you working on is not obvious for everyone.  -->
+<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
+<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
+
+Proofread changes.
+

--- a/.github/files/BACKPORT_RELEASE_CHANGES.md
+++ b/.github/files/BACKPORT_RELEASE_CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Proposed changes:
 <!--- Explain what functional changes your PR includes -->
-Backports changes from PLUGIN_RELEASE X.Y
+Backports changes for %RELEASED_PLUGINS%
 
 ### Other information:
 

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -275,3 +275,10 @@ for PLUGIN in "${!PROJECTS[@]}"; do
 done
 
 gh pr create --title "Backport $PR_TITLE Changes" --body "$(cat .github/BACKPORT_RELEASE_CHANGES.md)" --label "[Status] Needs Review" --repo "Automattic/jetpack" --head "$(git rev-parse --abbrev-ref HEAD)"
+
+yellow "Release script complete! Next steps: "
+echo -e "\t1. Merge the above PR into trunk."
+echo -e "\t2. On trunk, start a new branch and make any changes you want to CHANGELOG.md."
+echo -e "\t3. After merging the changelog edit PR, cherry pick that to the release branch."
+echo -e "\t4. After the changes make it to the mirror repo, conduct a GitHub release."
+echo -e "\t5. Then run ./tools/deploy-to-svn.sh <plugin-name> <tag> to deploy to SVN."

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -269,12 +269,15 @@ git fetch
 git merge origin/trunk
 tools/fixup-project-versions.sh
 git push
-PR_TITLE=
+PLUGINS_CHANGED=
 for PLUGIN in "${!PROJECTS[@]}"; do
-	PR_TITLE+="$(basename "$PLUGIN") ${PROJECTS[$PLUGIN]}, "
+	PLUGINS_CHANGED+="$(basename "$PLUGIN") ${PROJECTS[$PLUGIN]}, "
 done
-
-gh pr create --title "Backport $PR_TITLE Changes" --body "$(cat .github/BACKPORT_RELEASE_CHANGES.md)" --label "[Status] Needs Review" --repo "Automattic/jetpack" --head "$(git rev-parse --abbrev-ref HEAD)"
+# Remove the trailing comma and space
+PLUGINS_CHANGED=${PLUGINS_CHANGED%, }
+sed "s/%RELEASED_PLUGINS%/$PLUGINS_CHANGED/g" .github/files/BACKPORT_RELEASE_CHANGES.md > .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md
+gh pr create --title "Backport $PLUGINS_CHANGED Changes" --body "$(cat .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md)" --label "[Status] Needs Review" --repo "Automattic/jetpack" --head "$(git rev-parse --abbrev-ref HEAD)"
+rm .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md
 
 yellow "Release script complete! Next steps: "
 echo -e "\t1. Merge the above PR into trunk."

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -274,4 +274,4 @@ for PLUGIN in "${!PROJECTS[@]}"; do
 	PR_TITLE+="$(basename "$PLUGIN") ${PROJECTS[$PLUGIN]}, "
 done
 
-gh pr create --title "Backport $PR_TITLE Changes" --body "$(cat .github/BACKPORT_RELEASE_CHANGES.md)" --label "Needs Review"
+gh pr create --title "Backport $PR_TITLE Changes" --body "$(cat .github/BACKPORT_RELEASE_CHANGES.md)" --label "Needs Review" --repo "Automattic/jetpack"

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -274,4 +274,4 @@ for PLUGIN in "${!PROJECTS[@]}"; do
 	PR_TITLE+="$(basename "$PLUGIN") ${PROJECTS[$PLUGIN]}, "
 done
 
-gh pr create --title "Backport $PR_TITLE Changes" --body "$(cat .github/BACKPORT_RELEASE_CHANGES.md)" --label "Needs Review" --repo "Automattic/jetpack"
+gh pr create --title "Backport $PR_TITLE Changes" --body "$(cat .github/BACKPORT_RELEASE_CHANGES.md)" --label "[Status] Needs Review" --repo "Automattic/jetpack" --head "$(git rev-parse --abbrev-ref HEAD)"


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Updates the release script to handle backporting and starting a new cycle.

I don't know if other teams start new cycles, or just Jetpack (I don't think we even do a new cycle for the wpcom-mu-plugin right?)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Changes make sense? Can test it out next week for the weekly release.