### PR TITLE
Repo Gardening: Accept add_label input for passing custom path/label matching

### DIFF
--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -75,6 +75,7 @@ The action relies on the following parameters.
 
 - (Required) `github_token` is a GitHub Access Token used to access GitHub's API. The user account associated with the token is the one that will be seen as posting the checkDescription comment, adding and removing labels, and so on. If omitted, the standard token for the github-actions bot will be used.
 - (Optional) `tasks` allows for running selected tasks instead of the full suite. The value is a comma-separated list of task identifiers. You can find the list of the different tasks (and what event it's attached to) in `src/index.js`.
+- (Optional) `add_labels`. Pass custom labels to add. Defaults to an empty string. Only applies for the [addLabel](src/tasks/add-labels/readme.md) task.
 - (Optional) `slack_token` is the Auth token of a bot that is installed on your Slack workspace. The token should be stored in a [secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository). See the instructions below to create a bot.
 - (Optional) `slack_design_channel` is the Slack public channel ID where messages for the design team will be posted. Again, the value should be stored in a secret.
 - (Optional) `slack_editorial_channel` is the Slack public channel ID where messages for the Editorial team will be posted. Again, the value should be stored in a secret.

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "GitHub access token"
     required: true
     default: ${{ github.token }}
+  add_labels:
+    description: 'Labels and paths to match from a workflow.'
+    required: false
+    default: ""
   reply_to_customers_threshold:
     description: "Minimum of support references needed to trigger a reminder to batch-reply to customers. Default to 10."
     required: false

--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-add-labels
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-add-labels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Repo Gardening Action: Add add_labels input to addLabels task for setting custom path: label matching directly in the workflow.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -1,3 +1,4 @@
+const { getInput } = require( '@actions/core' );
 const debug = require( '../../utils/debug' );
 const getFiles = require( '../../utils/get-files' );
 
@@ -136,6 +137,19 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft ) {
 			if ( project.groups.ptype === 'js-packages' ) {
 				keywords.add( 'RNA' );
 			}
+		}
+
+		// Custom [{ "path": "label" }] values passed from a workflow.
+		const addLabelsString = getInput( 'add_labels' );
+		if ( addLabelsString ) {
+			debug( `GOT addLabelsString: ${ addLabelsString }` );
+			const addedLabels = JSON.parse( addLabelsString );
+			addedLabels.forEach( passed => {
+				if ( file.startsWith( passed.path ) ) {
+					debug( `passing: ${ passed.label } for ${ passed.path }` );
+					keywords.add( passed.label );
+				}
+			} );
 		}
 
 		// Modules.
@@ -278,7 +292,7 @@ async function addLabels( payload, octokit ) {
 		return;
 	}
 
-	debug( `add-labels: Adding labels to PR #${ number }` );
+	debug( `add-labels: Adding labels ${ labels } to PR #${ number }` );
 
 	await octokit.rest.issues.addLabels( {
 		owner: owner.login,

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/readme.md
@@ -5,3 +5,21 @@ Add labels to PRs that touch specific features.
 ## Rationale
 
 Instead of having to manually add labels for each feature that is touched in a given PR, let's look at the list of changed files in that PR, and automatically apply matching labels.
+
+## Usage
+
+- Set the `task: addLabels` task as part of the workflow. 
+- Optionally pass custom values `[{"path/": "label"}]` to add labels to certain changed paths.  
+
+Example: 
+```
+  ...
+  with:
+    # Required
+    tasks: 'addLabels'
+    # Optional
+    add_labels: '[
+        {"path": "projects/your-project/", "label": "[Project] Your Project"},
+        {"path": "somepath/", "label": "Some label"}
+      ]'
+```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add add_labels input to addLabels task for setting custom path: label matching directly in the workflow like so: 
```
  with:
    tasks: 'addLabels'
    add_labels: '[
        {"path": "projects/your-project/", "label": "[Project] Your Project"},
        {"path": "somepath/", "label": "Some label"}
      ]'
```

This enables folks to not have to update the source in the monorepo for their own matching rules. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You can test this by pointing the build to `uses: automattic/action-repo-gardening@ai-services`, which is [this branch](https://github.com/Automattic/action-repo-gardening/tree/ai-services/src/tasks) I created and hacked on in the action's mirror repo. Doing this allowed me to test it on both the ai-services repo as well as my personal fork. 

Note: the ai-services repo is currently running the ai-services branch and it seems to be fully functional. I plan to point it to trunk/stable again once this functionality is included. 
Check out the diffs that introduced it: 
- 221-gh-Automattic/ai-services
- 224-gh-Automattic/ai-services