### PR TITLE
AI Extension: Fix missing language label error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-missing-language-label
+++ b/projects/plugins/jetpack/changelog/fix-missing-language-label
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: fix missing key error
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
@@ -111,11 +111,11 @@ const I18nMenuGroup = ( {
 	value,
 	onChange,
 }: Pick< LanguageDropdownControlProps, 'value' | 'onChange' > ) => {
-	// Move the default language to the top of the list.
-	const languageList = [
-		defaultLanguage,
-		...LANGUAGE_LIST.filter( language => language !== defaultLanguage ),
-	];
+	const languageList = [ ...LANGUAGE_LIST.filter( language => language !== defaultLanguage ) ];
+	// Move the default language to the top of the list if it is included on LANGUAGE_LIST.
+	if ( languageList.includes( defaultLanguage ) ) {
+		languageList.unshift( defaultLanguage );
+	}
 
 	return (
 		<MenuGroup label={ __( 'Select language', 'jetpack' ) }>
@@ -123,12 +123,10 @@ const I18nMenuGroup = ( {
 				return (
 					<MenuItem
 						key={ `key-${ language }` }
-						onClick={ () =>
-							onChange( language + ' (' + ( LANGUAGE_MAP[ language ]?.label || '' ) + ')' )
-						}
+						onClick={ () => onChange( language + ' (' + LANGUAGE_MAP[ language ].label + ')' ) }
 						isSelected={ value === language }
 					>
-						{ LANGUAGE_MAP[ language ]?.label || '' }
+						{ LANGUAGE_MAP[ language ].label }
 					</MenuItem>
 				);
 			} ) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
@@ -123,10 +123,12 @@ const I18nMenuGroup = ( {
 				return (
 					<MenuItem
 						key={ `key-${ language }` }
-						onClick={ () => onChange( language + ' (' + LANGUAGE_MAP[ language ].label + ')' ) }
+						onClick={ () =>
+							onChange( language + ' (' + ( LANGUAGE_MAP[ language ]?.label || '' ) + ')' )
+						}
 						isSelected={ value === language }
 					>
-						{ LANGUAGE_MAP[ language ].label }
+						{ LANGUAGE_MAP[ language ]?.label || '' }
 					</MenuItem>
 				);
 			} ) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
@@ -113,7 +113,7 @@ const I18nMenuGroup = ( {
 }: Pick< LanguageDropdownControlProps, 'value' | 'onChange' > ) => {
 	const languageList = [ ...LANGUAGE_LIST.filter( language => language !== defaultLanguage ) ];
 	// Move the default language to the top of the list if it is included on LANGUAGE_LIST.
-	if ( languageList.includes( defaultLanguage ) ) {
+	if ( LANGUAGE_LIST.includes( defaultLanguage ) ) {
 		languageList.unshift( defaultLanguage );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes bug discussed in p1691176362127099-slack-C054LN8RNVA


https://github.com/Automattic/jetpack/assets/16329583/0273e109-8572-4c0c-b4a9-d5270a833f13



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When a language not mapped in LANGUAGE_MAP is selected for the site, the label key does not exist and therefore the translation menu is erroring. Fix this by checking if it exists and otherwise using an empty string. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*  Set site to language not existing in LANGUAGE_LIST, like catalan
* Add an AI Assistant
* translate text from the paragraph extension
* Confirm it does not break

