### PR TITLE
My Jetpack: fix IDC modal height issue

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/idc-modal/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/idc-modal/styles.module.scss
@@ -3,7 +3,7 @@
 		border-left: 4px solid #E68B28;
 		border-top-left-radius: 4px;
 		border-bottom-left-radius: 4px;
-		max-height: 90%;
+		max-height: 100%;
 	}
 
 	:global( .components-modal__content ) {

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-idc-height
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-idc-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix IDC modal height issue.


### PR DESCRIPTION
Related to #32249

## Proposed changes:
* Increase the modal height to 100% to display more of a modal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
1204764935849250-as-1204764935849254

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack, install the [Jetpack Debug Helper plugin](https://github.com/Automattic/jetpack-debug-helper/archive/refs/heads/trunk.zip).
2. Go to "Jetpack Debug -> IDC Simulator", enter the "Spoof URL" and enable "IDC Simulation". Then click on "Send Remote Request" to trigger IDC.
3. Go to "Jetpack -> My Jetpack", confirm that the modal shows up.
4. Use the browser tools to switch to a mobile screen size, and confirm that the modal takes 100% height of the screen with no gaps on top/bottom.