### PR TITLE
[WIP] Fix/missing subscribe buttons on premium content

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-missing-subscribe-buttons-on-premium-content
+++ b/projects/plugins/jetpack/changelog/fix-missing-subscribe-buttons-on-premium-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add subscribe button on premium content block on self-hosted

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/buttons.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Extensions\Premium_Content;
 
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
 const BUTTONS_NAME = 'premium-content/buttons';
@@ -19,15 +18,12 @@ const BUTTONS_NAME = 'premium-content/buttons';
  * registration if we need to.
  */
 function register_buttons_block() {
-	// Only load this block on WordPress.com.
-	if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Host() )->is_woa_site() ) {
-		Blocks::jetpack_register_block(
-			BUTTONS_NAME,
-			array(
-				'render_callback' => __NAMESPACE__ . '\render_buttons_block',
-			)
-		);
-	}
+	Blocks::jetpack_register_block(
+		BUTTONS_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_buttons_block',
+		)
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_buttons_block' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up from https://github.com/Automattic/jetpack/pull/32180

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* I was missing a WPCOM gating for the subscribe button...

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN instance with this branch
* Connect Jetpack and create a post with a Premium-content block
* Test that once connected with a not-yet connected account it displays the subscribe button and the rest works

