### PR TITLE
AI Plugin: Add track for get feedback feature

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-get-feedback-track
+++ b/projects/plugins/jetpack/changelog/add-ai-get-feedback-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Plugin: Add track for get feedback feature

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { aiAssistantIcon, useAiSuggestions } from '@automattic/jetpack-ai-client';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { serialize } from '@wordpress/blocks';
 import { Modal, Button, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -44,6 +45,7 @@ const ModalHeader = ( { loading, onClose } ) => {
 export default function Proofread() {
 	const [ isProofreadModalVisible, setIsProofreadModalVisible ] = useState( false );
 	const [ suggestion, setSuggestion ] = useState( null );
+	const { tracks } = useAnalytics();
 
 	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId(), [] );
 	const postContent = usePostContent();
@@ -102,6 +104,9 @@ export default function Proofread() {
 
 		request( messages );
 		toggleProofreadModal();
+		tracks.recordEvent( 'jetpack_ai_get_feedabck', {
+			post_id: postId,
+		} );
 	};
 
 	return (

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
@@ -104,7 +104,7 @@ export default function Proofread() {
 
 		request( messages );
 		toggleProofreadModal();
-		tracks.recordEvent( 'jetpack_ai_get_feedabck', {
+		tracks.recordEvent( 'jetpack_ai_get_feedback', {
 			post_id: postId,
 		} );
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Context: p1691412497121729-slack-C054LN8RNVA

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `jetpack_ai_get_feedback` track.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use `get feedback` feature.
* Check in `Network` panel if the track was sent.

#### Demo

![CleanShot 2023-08-07 at 12 16 12](https://github.com/Automattic/jetpack/assets/1663717/af3d2cad-94f5-437b-97d9-ae39dc1b49b7)