### PR TITLE
get_post_access_level(): Allow $post_id argument

### DIFF
--- a/projects/plugins/jetpack/changelog/update-get_post_access_level
+++ b/projects/plugins/jetpack/changelog/update-get_post_access_level
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Adding an optional parameter to get_post_access_level() does not seem very significant.
+
+

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -437,10 +437,16 @@ class Jetpack_Memberships {
 	/**
 	 * Get the post access level
 	 *
+	 * If no ID is provided, the method tries to get it from the global post object.
+	 *
+	 * @param int|null $post_id The ID of the post. Default is null.
+	 *
 	 * @return string the actual post access level (see projects/plugins/jetpack/extensions/blocks/subscriptions/constants.js for the values).
 	 */
-	public static function get_post_access_level() {
-		$post_id = get_the_ID();
+	public static function get_post_access_level( $post_id = null ) {
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
 		if ( ! $post_id ) {
 			return Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
 		}


### PR DESCRIPTION
While working on the WordPress.com reader, I realized we needed to keep posts tagged as paid content out of the cache. This ensures users won't accidentally see content they aren't supposed to. The challenge? I wanted to leverage `get_post_access_level()`, but our caching logic runs outside the typical post rendering loop. Given that `get_post_access_level()` relies on `get_the_ID()`, this posed a problem.

To handle this, I've introduced an optional `$post_id` parameter to `get_post_access_level()`. This lets me determine the access level of posts, even when the global `$post` isn't set. Additionally, the classic way of just letting it use `get_the_ID()` still works perfectly.

## Proposed changes:

* `get_post_access_level()`: Now accepts an optional `$post_id` argument. If it's left out, it'll stick to the tried-and-true method of using `get_the_ID()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Access control on posts should continue to work.

