### PR TITLE
AI Extension: Add `UpgradePrompt` if requires upgrade

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-ai-control-disabled-prop
+++ b/projects/js-packages/ai-client/changelog/add-ai-control-disabled-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: Introduce disabled prop in AI Control

--- a/projects/js-packages/ai-client/src/components/ai-control/Readme.md
+++ b/projects/js-packages/ai-client/src/components/ai-control/Readme.md
@@ -3,6 +3,7 @@
 #### Properties
 
 - `loading` (**boolean**) (Optional): Determines the loading state. Default value is `false`.
+- `disabled` (**boolean**) (Optional): Disables the ai control. Default value is `false`.
 - `value` (**string**): Current input value. Default value is `''`.
 - `placeholder` (**string**) (Optional): Placeholder text for the input field. Default value is `''`.
 - `showAccept` (**boolean**) (Optional): Determines if the accept button is shown. Default value is `false`.

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -26,6 +26,7 @@ const noop = () => {};
  *
  * @param {object} props - component props
  * @param {boolean} props.loading - loading state
+ * @param {boolean} props.disabled - is disabled
  * @param {string} props.value - input value
  * @param {string} props.placeholder - input placeholder
  * @param {boolean} props.showAccept - show accept button
@@ -41,6 +42,7 @@ const noop = () => {};
  */
 export default function AIControl( {
 	loading = false,
+	disabled = false,
 	value = '',
 	placeholder = '',
 	showAccept = false,
@@ -54,6 +56,7 @@ export default function AIControl( {
 	onAccept = noop,
 }: {
 	loading?: boolean;
+	disabled?: boolean;
 	value: string;
 	placeholder?: string;
 	showAccept?: boolean;
@@ -106,7 +109,7 @@ export default function AIControl( {
 						onChange={ onChange }
 						placeholder={ placeholder }
 						className="jetpack-components-ai-control__input"
-						disabled={ loading }
+						disabled={ loading || disabled }
 						ref={ promptUserInputRef }
 					/>
 
@@ -126,7 +129,7 @@ export default function AIControl( {
 								className="jetpack-components-ai-control__controls-prompt_button"
 								onClick={ () => onSend( value ) }
 								isSmall={ true }
-								disabled={ ! value?.length }
+								disabled={ ! value?.length || disabled }
 								label={ __( 'Send request', 'jetpack-ai-client' ) }
 							>
 								<Icon icon={ arrowUp } />

--- a/projects/plugins/jetpack/changelog/add-ai-upgrade-prompt-form
+++ b/projects/plugins/jetpack/changelog/add-ai-upgrade-prompt-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: Add UpgradePrompt if require upgrade

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -12,6 +12,8 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import UpgradePrompt from '../../../../components/upgrade-prompt';
+import useAIFeature from '../../../../hooks/use-ai-feature';
 import { PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, getPrompt } from '../../../../lib/prompt';
 import { AiAssistantUiContext } from '../../ui-handler/context';
 /*
@@ -70,6 +72,8 @@ export const AiAssistantPopover = ( {
 
 	const { requestSuggestion, requestingState, eventSource } = useAiContext();
 
+	const { requireUpgrade } = useAIFeature();
+
 	const stopSuggestion = useCallback( () => {
 		if ( ! eventSource ) {
 			return;
@@ -127,14 +131,17 @@ export const AiAssistantPopover = ( {
 			/>
 
 			<div style={ { width } }>
+				{ requireUpgrade && <UpgradePrompt /> }
 				<AIControl
 					loading={ isLoading }
+					disabled={ requireUpgrade }
 					value={ isLoading ? undefined : inputValue }
 					placeholder={ isLoading ? loadingPlaceholder : placeholder }
 					onChange={ setInputValue }
 					onSend={ onSend }
 					onStop={ onStop }
 					requestingState={ requestingState }
+					isOpaque={ requireUpgrade }
 				/>
 			</div>
 		</Popover>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related with #32216 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `UpgradePromp` in `AiAssistantPopover`.
* Introduce `disabled` prop in `AIControl`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spawn a new JN site.
* Use free `Jetpack AI` and achieve the free limit.
* You should see the upgrade banner.

#### Demo

| Desktop | Mobile |
|---------|---------|
| ![CleanShot 2023-08-07 at 20 28 24](https://github.com/Automattic/jetpack/assets/1663717/c5945e91-d2e9-4837-bdb9-16ff77c5d2de) | ![CleanShot 2023-08-07 at 20 30 37](https://github.com/Automattic/jetpack/assets/1663717/d0e7ddf3-1d13-4948-aec8-8b81e18b0964)


