### PR TITLE
Stats: Fix compatibility for 'AMP for WP'

### DIFF
--- a/projects/packages/stats/changelog/fix-stats-compability-ampforwp
+++ b/projects/packages/stats/changelog/fix-stats-compability-ampforwp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Stats: compatibility for AMP for WP plugin

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -252,6 +252,7 @@ _stq.push([ "clickTrackerInit", "%2$s", "%3$s" ]);',
 	 */
 	private static function is_amp_request() {
 		$is_amp_request = ( function_exists( 'amp_is_request' ) && amp_is_request() );
+		$is_amp_request = $is_amp_request || ( function_exists( 'ampforwp_is_amp_endpoint' ) && ampforwp_is_amp_endpoint() );
 
 		/**
 		 * Returns true if the current request should return valid AMP content.


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/8386

## Proposed changes:

* Test whether the request is AMP by calling `ampforwp_is_amp_endpoint` if exists to allow the loading of the pixel when AMP is enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Install "AMP for WP" - https://wordpress.org/plugins/accelerated-mobile-pages/
* Turn on AMP for posts `/wp-admin/admin.php?page=amp_options#038;tab=1`
<img width="1051" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/d786751c-23bd-457d-b590-d5261c002409">
* Open a post e.g. `/2012/01/07/template-sticky/amp/` <- please note the appended `amp/`
* Open network requests in dev tools
* Ensure `pixel.wp.com/g.gif` is loading with params added
<img width="557" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/62985357-83c6-4f8d-b1db-3f5ab77d2e0e">



