### PR TITLE
AI Extension: fix visual on the AI Assistant bar when switching viewport size

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-assistant-bar-fix-visual-issue-when-switching-viewport-size
+++ b/projects/js-packages/ai-client/changelog/update-ai-assistant-bar-fix-visual-issue-when-switching-viewport-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Client: fix TS type definition issue

--- a/projects/js-packages/ai-client/src/data-flow/use-ai-context.ts
+++ b/projects/js-packages/ai-client/src/data-flow/use-ai-context.ts
@@ -5,7 +5,7 @@ import { useCallback, useContext, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { ERROR_RESPONSE } from '../types';
+import { ERROR_RESPONSE, RequestingErrorProps } from '../types';
 import { AiDataContext } from '.';
 /**
  * Types & constants
@@ -32,7 +32,7 @@ export type UseAiContextOptions = {
 	/*
 	 * onError callback.
 	 */
-	onError?: ( error: Error ) => void;
+	onError?: ( error: RequestingErrorProps ) => void;
 };
 
 /**

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fix-visual-issue-when-switching-viewport-size
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fix-visual-issue-when-switching-viewport-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: fix visual on the AI Assistant bar when switching viewport size

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -83,7 +83,7 @@ export const AiAssistantPopover = ( {
 	}, [ eventSource ] );
 
 	useEffect( () => {
-		/**
+		/*
 		 * Cleanup function to remove the event listeners
 		 * and close the event source.
 		 */

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
@@ -10,7 +10,7 @@ export type AiAssistantUiContextProps = {
 
 	isFixed: boolean;
 
-	width?: number;
+	width?: number | string;
 
 	popoverProps?: {
 		anchor?: HTMLElement | null;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -203,20 +203,36 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		// Build the context value to pass to the provider.
 		const contextValue = useMemo(
 			() => ( {
+				// Value of the input element.
 				inputValue,
-				isVisible,
-				isFixed,
-				popoverProps,
-				width,
-
 				setInputValue,
+
+				// Assistant bar visibility.
+				isVisible,
 				show,
 				hide,
 				toggle,
+
+				// Assistant bar position and size.
+				isFixed,
+				popoverProps,
+				width,
 				setAssistantFixed,
 				setPopoverProps,
 			} ),
-			[ inputValue, isVisible, isFixed, popoverProps, width, show, hide, toggle ]
+			[
+				inputValue,
+				setInputValue,
+				isVisible,
+				show,
+				hide,
+				toggle,
+				isFixed,
+				popoverProps,
+				width,
+				setAssistantFixed,
+				setPopoverProps,
+			]
 		);
 
 		const setContent = useCallback(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -164,6 +164,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 				...prev,
 				anchor: blockDomElement,
 				placement: 'bottom-start',
+				variant: null,
 				offset: 12,
 			} ) );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This update resolves an issue when the user switches to mobile view and back to regular size. The Assistant bar fails to display correctly upon returning to the standard view. For more information, please refer to the provided instructions.

Also:

* Fix a TS issue in the AI Client package
* Minor code improvement

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* AI Extension: fix visual on the AI Assistant bar when switching viewport size

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This update resolves an issue when the user switches to mobile view and back to regular size. The Assistant bar fails to display correctly upon returning to the standard view. For more information, please refer to the provided instructions.


* Go to the block editor
* Start with the regular view of the viewport
* Create a Jetpack Form block instance
* Confirm the bar styles are okay

<img width="693" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/92bd6b69-3a25-4ec8-91d9-f514d3fef621">

* Switch to mobile
* Go back to the standard view

**before** (border color black, no shadow...)
<img width="680" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/7bbaa322-0fc1-4403-aa38-a43f9e1d2c34">

**after**
<img width="693" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/92bd6b69-3a25-4ec8-91d9-f514d3fef621">


