### PR TITLE
Paywall: add block transforms from/to core's "more" and "nextpage" blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-more-transform
+++ b/projects/plugins/jetpack/changelog/update-paywall-more-transform
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Paywall block: add transforms for "more" and "nextpage" core blocks

--- a/projects/plugins/jetpack/extensions/blocks/paywall/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/index.js
@@ -3,6 +3,7 @@ import { pageBreak as icon } from '@wordpress/icons';
 import { getIconColor } from '../../shared/block-icons';
 import attributes from './attributes';
 import edit from './edit';
+import transforms from './transforms';
 
 /**
  * Style dependencies
@@ -42,4 +43,5 @@ export const settings = {
 	example: {
 		attributes: {},
 	},
+	transforms,
 };

--- a/projects/plugins/jetpack/extensions/blocks/paywall/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/transforms.js
@@ -1,0 +1,26 @@
+import { createBlock } from '@wordpress/blocks';
+import { name } from './';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/more', 'core/nextpage' ],
+			transform: () => createBlock( `jetpack/${ name }` ),
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/more' ],
+			transform: () => createBlock( 'core/more' ),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/nextpage' ],
+			transform: () => createBlock( 'core/nextpage' ),
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
* Add block transforms from/to core's "more" and "nextpage" blocks

**Transform to**

<img width="747" alt="Screenshot 2023-08-08 at 14 04 06" src="https://github.com/Automattic/jetpack/assets/87168/7f97d850-e3b8-4ecb-a984-b7f133ebd2df">

**Transform from**

<img width="725" alt="Screenshot 2023-08-08 at 14 03 44" src="https://github.com/Automattic/jetpack/assets/87168/9153200b-3a93-4417-bb0e-30797b844bdc">
<img width="733" alt="Screenshot 2023-08-08 at 14 03 18" src="https://github.com/Automattic/jetpack/assets/87168/e0690357-cffd-4b07-852d-ffdad633ee36">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta-blocks
* Test that you can transform to/from between paywall, more, and nextpage blocks.

