### PR TITLE
Blaze: update wording in post list CTA

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-wording
+++ b/projects/packages/blaze/changelog/update-blaze-wording
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update wording in the Blaze CTA link appearing in the post list.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -300,7 +300,7 @@ class Blaze {
 		}
 
 		$blaze_url = self::get_campaign_management_url( $post_id );
-		$text      = _x( 'Blaze', 'Verb', 'jetpack-blaze' );
+		$text      = __( 'Promote with Blaze', 'jetpack-blaze' );
 		$title     = get_the_title( $post );
 		$label     = sprintf(
 			/* translators: post title */


### PR DESCRIPTION
## Proposed changes:

Let's update the wording used in the Blaze CTA, as it can be a bit obscure today.

> We could use a clearer button label like “Promote” or “Promote with Blaze” to make it more recognizable and easier to understand. When Blaze becomes a household name, we could consider using “Blaze” as a verb, like how we use “Google” today.

<img width="448" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/e93851db-b31b-4d1f-b2e2-e26dd998e82b">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal reference: pbIy4N-3lP-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a **public** site, connected to WordPress.com.
* Go to Jetpack > Settings > Traffic, and ensure that the Blaze feature is turned on. **Note**: if you are testing on a WoA site, the feature will already be on and you will not see any UI there.
* Go to Posts > All Posts, or Products > All Products, and move your mouse over one of the items.
    * You should see a "Promote with Blaze" link appear.
