### PR TITLE
AI Extension: fix visual issue in Assistant bar when switching viewport size

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-swtich-viewport-issue
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-swtich-viewport-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: fix visual issue in Assistant bar when switching viewport size

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -114,9 +114,9 @@ export const AiAssistantPopover = ( {
 	const [ anchor, setAnchor ] = useState< HTMLElement | null >( null );
 
 	/*
-	 * Hack to deal with a reac condition
-	 * where the popover anchor changes.
-	 * - Keeps the anchor reference in a local state of the component.
+	 * Hack to deal with a race condition
+	 * that happens where the popover anchor changes:
+	 * - Keeps the anchor reference in the local state of the component.
 	 * - When the popoverProps.anchor changes, it updates the local state.
 	 */
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-popover/index.tsx
@@ -5,7 +5,7 @@ import { useAiContext, AIControl } from '@automattic/jetpack-ai-client';
 import { serialize } from '@wordpress/blocks';
 import { KeyboardShortcuts, Popover } from '@wordpress/components';
 import { select } from '@wordpress/data';
-import { useContext, useCallback, useEffect } from '@wordpress/element';
+import { useContext, useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import debugFactory from 'debug';
@@ -67,7 +67,7 @@ function getSerializedContentFromBlock( clientId: string ): string {
 export const AiAssistantPopover = ( {
 	clientId = '',
 }: AiAssistantPopoverProps ): React.ReactNode => {
-	const { isVisible, isFixed, toggle, popoverProps, inputValue, setInputValue, width } =
+	const { isVisible, isFixed, toggle, show, hide, popoverProps, inputValue, setInputValue, width } =
 		useContext( AiAssistantUiContext );
 
 	const { requestSuggestion, requestingState, eventSource } = useAiContext();
@@ -111,6 +111,20 @@ export const AiAssistantPopover = ( {
 		requestSuggestion( prompt, { feature: 'jetpack-form-ai-extension' } );
 	}, [ clientId, inputValue, requestSuggestion ] );
 
+	const [ anchor, setAnchor ] = useState< HTMLElement | null >( null );
+
+	/*
+	 * Hack to deal with a reac condition
+	 * where the popover anchor changes.
+	 * - Keeps the anchor reference in a local state of the component.
+	 * - When the popoverProps.anchor changes, it updates the local state.
+	 */
+	useEffect( () => {
+		setTimeout( () => {
+			setAnchor( popoverProps.anchor );
+		}, 0 );
+	}, [ popoverProps.anchor, show, hide ] );
+
 	if ( ! isVisible ) {
 		return null;
 	}
@@ -118,6 +132,7 @@ export const AiAssistantPopover = ( {
 	return (
 		<Popover
 			{ ...popoverProps }
+			anchor={ anchor }
 			animate={ false }
 			className={ classNames( 'jetpack-ai-assistant__popover', {
 				'is-fixed': isFixed,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -43,18 +43,12 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 			return;
 		}
 
-		/*
-		 * There is a race condition between the toolbar and component onMount.
-		 * We need to wait a bit to set the popover props.
-		 */
-		setTimeout( () => {
-			setPopoverProps( prev => ( {
-				...prev,
-				anchor: toolbar,
-				offset: 0,
-				variant: 'toolbar',
-			} ) );
-		}, 100 );
+		setPopoverProps( prev => ( {
+			...prev,
+			anchor: toolbar,
+			offset: 0,
+			variant: 'toolbar',
+		} ) );
 	}, [ setAssistantFixed, setPopoverProps, isVisible ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR stores the anchor element to anchor the assistant in a local state of the Popover instance.
There is a race condition that doesn't place the Popover properly when the viewport size switches from/to mobile.
Storing the reference locally fixes the issue.
Probably we'll have to iterate over it in follow-ups. 

Fixes https://github.com/Automattic/jetpack/issues/32313

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: fix visual issue in Assistant bar when switching viewport size

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form
* Take a look at the assistant bar


**BEFORE**

https://github.com/Automattic/jetpack/assets/77539/147d21eb-5858-4708-a115-60fe21df13cd

**AFTER**

https://github.com/Automattic/jetpack/assets/77539/90b41f19-2b8b-4d15-8b12-aea9f515393b


