### PR TITLE
Removed PHP 5.6 from WordPress latest and added it to previous.

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -74,9 +74,8 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 			'wp'      => $wp,
 			'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
 		);
-		// PHP 8.2+ compatibility only comes in with WP 6.3.
-		// @TODO: Remove this when 6.3 is "previous".
-		$phpver = '8.1';
+		// PHP 8.1+ seems to fail on WordPress 6.2.
+		$phpver = '8.0';
 	}
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP {$phpver} WP $wp",

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -55,7 +55,7 @@ $default_matrix_vars = array(
 $matrix = array();
 
 // Add PHP tests.
-foreach ( array( '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ) as $php ) {
+foreach ( array( '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ) as $php ) {
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP $php WP latest",
 		'script'  => 'test-php',
@@ -65,11 +65,15 @@ foreach ( array( '5.6', '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ) as $ph
 	);
 }
 foreach ( array( 'previous', 'trunk' ) as $wp ) {
-	// PHP 8.1+ compatibility only came in with WP 6.2.
-	// @todo Remove this when 6.2 is "previous".
 	$phpver = $versions['PHP_VERSION'];
 	if ( $wp === 'previous' ) {
-		$phpver = '8.0';
+		$matrix[] = array(
+			'name'    => "PHP tests: PHP {$phpver} WP $wp",
+			'script'  => 'test-php',
+			'php'     => '5.6', // 2023-08-09 now that 5.6 is excluded from latest tests, we test it on 'previous'.
+			'wp'      => $wp,
+			'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
+		);
 	}
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP {$phpver} WP $wp",

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -74,6 +74,9 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 			'wp'      => $wp,
 			'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
 		);
+		// PHP 8.2+ compatibility only comes in with WP 6.3.
+		// @TODO: Remove this when 6.3 is "previous".
+		$phpver = '8.1';
 	}
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP {$phpver} WP $wp",

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -68,7 +68,7 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 	$phpver = $versions['PHP_VERSION'];
 	if ( $wp === 'previous' ) {
 		$matrix[] = array(
-			'name'    => "PHP tests: PHP {$phpver} WP $wp",
+			'name'    => "PHP tests: PHP 5.6 WP $wp",
 			'script'  => 'test-php',
 			'php'     => '5.6', // 2023-08-09 now that 5.6 is excluded from latest tests, we test it on 'previous'.
 			'wp'      => $wp,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,10 +156,10 @@ jobs:
               if [[ "$WP_BRANCH" == 'trunk' && "$TEST_SCRIPT" == "test-php" ]]; then
                 VER=$(composer --format=json --working-dir="$DIR" show | jq -r '.installed[] | select( .name == "roots/wordpress" ) | .version')
                 if [[ -n "$VER" ]]; then
-                  echo 'Supposed to run tests against WordPress trunk, so upgrading roots/wordpress to dev-main'
+                  echo 'Supposed to run tests against WordPress trunk, so upgrading roots/wordpress and roots/wordpress-no-content to dev-main'
                   # Composer seems to sometimes have issues with deleting the wordpress dir on its own, so do it manually first.
                   rm -rf "$DIR/wordpress"
-                  composer --working-dir="$DIR" require --dev roots/wordpress="dev-main as $VER"
+                  composer --working-dir="$DIR" require --dev roots/wordpress="dev-main as $VER" roots/wordpress-no-content="dev-main as $VER"
                 fi
               fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,10 +156,10 @@ jobs:
               if [[ "$WP_BRANCH" == 'trunk' && "$TEST_SCRIPT" == "test-php" ]]; then
                 VER=$(composer --format=json --working-dir="$DIR" show | jq -r '.installed[] | select( .name == "roots/wordpress" ) | .version')
                 if [[ -n "$VER" ]]; then
-                  echo 'Supposed to run tests against WordPress trunk, so upgrading roots/wordpress to dev-nightly'
+                  echo 'Supposed to run tests against WordPress trunk, so upgrading roots/wordpress to dev-main'
                   # Composer seems to sometimes have issues with deleting the wordpress dir on its own, so do it manually first.
                   rm -rf "$DIR/wordpress"
-                  composer --working-dir="$DIR" require --dev roots/wordpress="dev-nightly as $VER"
+                  composer --working-dir="$DIR" require --dev roots/wordpress="dev-main as $VER"
                 fi
               fi
 

--- a/projects/packages/connection/changelog/remove-5.6-from-latest-test-matrix
+++ b/projects/packages/connection/changelog/remove-5.6-from-latest-test-matrix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Tests: remove invalid tests for WP 6.3

--- a/projects/packages/connection/tests/php/test_Signature.php
+++ b/projects/packages/connection/tests/php/test_Signature.php
@@ -368,20 +368,9 @@ class SignatureTest extends TestCase {
 			// Invalid values.
 			array(
 				'',
-				new stdClass(),
-				'',
-			),
-			array(
-				'',
 				'string',
 				'',
 			),
-			array(
-				'',
-				array( 'string' ),
-				'',
-			),
-
 		);
 	}
 

--- a/projects/plugins/boost/changelog/remove-5.6-from-latest-test-matrix
+++ b/projects/plugins/boost/changelog/remove-5.6-from-latest-test-matrix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock to fit the latest version of WP for wordbless on dev.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -2682,7 +2682,7 @@
         },
         {
             "name": "roots/wordpress",
-            "version": "6.2.2",
+            "version": "6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/wordpress.git",
@@ -2713,7 +2713,7 @@
             ],
             "support": {
                 "issues": "https://github.com/roots/wordpress/issues",
-                "source": "https://github.com/roots/wordpress/tree/6.2.2"
+                "source": "https://github.com/roots/wordpress/tree/6.3"
             },
             "funding": [
                 {
@@ -2796,22 +2796,22 @@
         },
         {
             "name": "roots/wordpress-no-content",
-            "version": "6.2.2",
+            "version": "6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "6.2.2"
+                "reference": "6.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/release/wordpress-6.2.2-no-content.zip",
-                "shasum": "df066a16e97dd6ad5c1679d4a575983ea3143117"
+                "url": "https://downloads.wordpress.org/release/wordpress-6.3-no-content.zip",
+                "shasum": "beb2a89525274d08fae06bf4bf5bc0cfdcb5b1f5"
             },
             "require": {
-                "php": ">= 5.6.20"
+                "php": ">= 7.0.0"
             },
             "provide": {
-                "wordpress/core-implementation": "6.2.2"
+                "wordpress/core-implementation": "6.3"
             },
             "suggest": {
                 "ext-curl": "Performs remote request operations.",
@@ -2862,7 +2862,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2023-05-20T04:31:46+00:00"
+            "time": "2023-08-08T19:41:46+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION


This PR removes PHP 5.6 tests from WordPress 6.3 matrix because WordPress 6.3 does not allow 5.6 anymore.

## Proposed changes:
* Removes 5.6 from the `latest` column.
* Adds 5.6 to the `previous` column.
* Adds 8.2 to the `trunk` column.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See #31714

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

