### PR TITLE
Remove the last traces of jetpack-memberships-connected-account-id

### DIFF
--- a/projects/packages/sync/changelog/earn-remove-connected-account-id-option
+++ b/projects/packages/sync/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+remove jetpack option jetpack-memberships-connected-account-id

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -57,7 +57,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.59.x-dev"
+			"dev-trunk": "1.60.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -63,7 +63,6 @@ class Defaults {
 		'image_default_link_type',
 		'infinite_scroll',
 		'infinite_scroll_google_analytics',
-		'jetpack-memberships-connected-account-id',
 		'jetpack-memberships-has-connected-account',
 		'jetpack-twitter-cards-site-tag',
 		'jetpack_activated',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.59.1-alpha';
+	const PACKAGE_VERSION = '1.60.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/backup/changelog/earn-remove-connected-account-id-option-2
+++ b/projects/plugins/backup/changelog/earn-remove-connected-account-id-option-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1367,7 +1367,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dab5b4eca59882dfd90a3a0c74d705f84e7f026f"
+                "reference": "421bbdeb621e9370537399dbfe037cd12bf07d6f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1398,7 +1398,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option
+++ b/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+remove jetpack option jetpack-memberships-connected-account-id

--- a/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option-2
+++ b/projects/plugins/jetpack/changelog/earn-remove-connected-account-id-option-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2521,7 +2521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dab5b4eca59882dfd90a3a0c74d705f84e7f026f"
+                "reference": "421bbdeb621e9370537399dbfe037cd12bf07d6f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2552,7 +2552,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -447,7 +447,16 @@ class Jetpack_Memberships {
 	 * @return bool
 	 */
 	public static function has_connected_account() {
-		return get_option( self::$has_connected_account_option_name, false ) ? true : false;
+
+		// This is the primary solution.
+		$has_option = get_option( self::$has_connected_account_option_name, false ) ? true : false;
+		if ( $has_option ) {
+			return true;
+		}
+
+		// This is the fallback solution.
+		// TODO: Remove this once the has_connected_account_option is migrated to all sites.
+		return get_option( 'jetpack-memberships-connected-account-id', false ) ? true : false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -454,9 +454,7 @@ class Jetpack_Memberships {
 			return true;
 		}
 
-		// This is the fallback solution.
-		// TODO: Remove this once the has_connected_account_option is migrated to all sites.
-		return get_option( 'jetpack-memberships-connected-account-id', false ) ? true : false;
+		return false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -31,18 +31,7 @@ class Jetpack_Memberships {
 	public static $post_type_plan = 'jp_mem_plan';
 
 	/**
-	 * Option that will store currently set up account (Stripe etc) id for memberships.
-	 *
-	 *  TODO: remove
-	 *
-	 * @deprecated
-	 * @var string
-	 */
-	public static $connected_account_id_option_name = 'jetpack-memberships-connected-account-id';
-
-	/**
-	 * Option that will toggle account enabled for memberships (i.e. Stripe is
-	 * configured, etc. ).
+	 * Option stores status for memberships (Stripe, etc.).
 	 *
 	 * @var string
 	 */
@@ -458,16 +447,7 @@ class Jetpack_Memberships {
 	 * @return bool
 	 */
 	public static function has_connected_account() {
-
-		// This is the primary solution.
-		$has_option = get_option( self::$has_connected_account_option_name, false ) ? true : false;
-		if ( $has_option ) {
-			return true;
-		}
-
-		// This is the fallback solution.
-		// TODO: Remove this once the has_connected_account_option is migrated to all sites.
-		return get_option( 'jetpack-memberships-connected-account-id', false ) ? true : false;
+		return get_option( self::$has_connected_account_option_name, false ) ? true : false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -215,7 +215,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'site_segment'                                 => 'pineapple',
 			'site_vertical'                                => 'pineapple',
 			'jetpack_excluded_extensions'                  => 'pineapple',
-			'jetpack-memberships-connected-account-id'     => '340',
 			'jetpack-memberships-has-connected-account'    => true,
 			'jetpack_publicize_options'                    => array(),
 			'jetpack_connection_active_plugins'            => array( 'jetpack' ),

--- a/projects/plugins/migration/changelog/earn-remove-connected-account-id-option-2
+++ b/projects/plugins/migration/changelog/earn-remove-connected-account-id-option-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1367,7 +1367,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dab5b4eca59882dfd90a3a0c74d705f84e7f026f"
+                "reference": "421bbdeb621e9370537399dbfe037cd12bf07d6f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1398,7 +1398,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/earn-remove-connected-account-id-option-2
+++ b/projects/plugins/protect/changelog/earn-remove-connected-account-id-option-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1282,7 +1282,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dab5b4eca59882dfd90a3a0c74d705f84e7f026f"
+                "reference": "421bbdeb621e9370537399dbfe037cd12bf07d6f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1313,7 +1313,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/earn-remove-connected-account-id-option-2
+++ b/projects/plugins/search/changelog/earn-remove-connected-account-id-option-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1426,7 +1426,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dab5b4eca59882dfd90a3a0c74d705f84e7f026f"
+                "reference": "421bbdeb621e9370537399dbfe037cd12bf07d6f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1457,7 +1457,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/earn-remove-connected-account-id-option-2
+++ b/projects/plugins/social/changelog/earn-remove-connected-account-id-option-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1358,7 +1358,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dab5b4eca59882dfd90a3a0c74d705f84e7f026f"
+                "reference": "421bbdeb621e9370537399dbfe037cd12bf07d6f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1389,7 +1389,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/earn-remove-connected-account-id-option-2
+++ b/projects/plugins/starter-plugin/changelog/earn-remove-connected-account-id-option-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1282,7 +1282,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dab5b4eca59882dfd90a3a0c74d705f84e7f026f"
+                "reference": "421bbdeb621e9370537399dbfe037cd12bf07d6f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1313,7 +1313,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/earn-remove-connected-account-id-option-2
+++ b/projects/plugins/videopress/changelog/earn-remove-connected-account-id-option-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1282,7 +1282,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "dab5b4eca59882dfd90a3a0c74d705f84e7f026f"
+                "reference": "421bbdeb621e9370537399dbfe037cd12bf07d6f"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1313,7 +1313,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.59.x-dev"
+                    "dev-trunk": "1.60.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Part of https://github.com/Automattic/gold/issues/59. This finally removes the option.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* All earn features should continue to work after applying this PR.  Check donations, recurring payment buttons, paid content and subscriptions.