### PR TITLE
Subscriptions: Add check before showing subscribe modal

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-check-on-subscribe-modal
+++ b/projects/plugins/jetpack/changelog/update-add-check-on-subscribe-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Add check when showing subscribe modal

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -219,6 +219,7 @@ HTML;
 
 		// Don't show if one of subscribe query params is set.
 		// They are set when user submits the subscribe form.
+		// The nonce is checked elsewhere before redirect back to this page with query params.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['subscribe'] ) || isset( $_GET['blogsub'] ) ) {
 			return false;

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -217,10 +217,10 @@ HTML;
 			return false;
 		}
 
-		// Don't show if subscribe query param is set.
-		// It is set when user submits the subscribe form.
+		// Don't show if one of subscribe query params is set.
+		// They are set when user submits the subscribe form.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['subscribe'] ) ) {
+		if ( isset( $_GET['subscribe'] ) || isset( $_GET['blogsub'] ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds another check before displaying the Subscribe Modal. We were checking for the 'subscribe' query parameter. It is set when a user submits the subscribe form, and we don't want to show the modal again in that case. But in the WordPress.com environment, we set a 'blogsub' query param instead of a 'subscribe'. We weren't checking for that one. With this PR, we are.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Setup: 
   - You will need a WordPress.com simple site that has newsletter as the site_intent, or has the Lettre theme active. If you need one, you can set up a new site at https://wordpress.com/setup/newsletter/intro.
   - This site will also need a blog post, so be sure to publish one.
   - On your test site, go to Settings > Reading > Newsletter and enable the subscribe modal.
   - Run the bin command provide by Github below to load this branch in your sandbox. Sandbox public-api.wordpress.com and the domain of your test site.

2) Test: 
   - Go to a browser where you are not logged in to WordPress.com and open up a single blog post on your test site.
   - Scroll and pause. You should see the subscribe modal appear.
   - Enter any email and submit. When you do, the page will refresh/reload.
   - Scroll and pause - this time confirm the modal does not appear. 

