### PR TITLE
Launchpad: Update 'Confirm email...' copy

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/80340-update-confirm-email-copy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/80340-update-confirm-email-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update the email verification task copy

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -106,7 +106,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 		'verify_email'                    => array(
 			'get_title'           => function () {
-				return __( 'Confirm email (check your inbox)', 'jetpack-mu-wpcom' );
+				return __( 'Verify email address', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback' => 'wpcom_launchpad_is_email_unverified',
 			'get_task_url'        => function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/80340

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This changes the task copy from 'Confirm email (check your inbox)' to 'Verify email address'.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox the public-api.
* With an unverified user account (you may want to create a new account), go to `/start`.
* Create a new, free site and choose either "Write & Publish" or "Promote...".
* Launch the site.
* The dashboard should show the 'Verify email address' task (previously 'Confirm email...')
![image](https://github.com/Automattic/jetpack/assets/917632/c693b527-6f9c-4bc6-b6b5-03bef7d62710)


