### PR TITLE
Launchpad: Update the Enable Subscribers Modal task redirect

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-enable-subscriber-modal-redirect
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-enable-subscriber-modal-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove the initial slash to match the pattern used throughout the project

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -352,7 +352,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_visible_callback'  => 'wpcom_is_enable_subscribers_modal_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				if ( ( new Automattic\Jetpack\Status\Host() )->is_atomic_platform() ) {
-					return admin_url( '/admin.php?page=jetpack#/discussion' );
+					return admin_url( 'admin.php?page=jetpack#/discussion' );
 				}
 				return '/settings/reading/' . $data['site_slug_encoded'] . '#newsletter-settings';
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/80276

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the initial slash in the Enable Subscribers Modal task redirect to match the pattern used throughout the project. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To test this PR, you'll need an Atomic Newsletter. Follow the testing instructions on the link below
  * https://github.com/Automattic/jetpack/pull/32233
* Apply this PR in your Atomic Newsletter.
* Click on the  "Enable Subscriber Modal" to ensure you still get redirected to `admin.php?page=jetpack#/discussion`.

