### PR TITLE
Added WordPress 6.1 test suite to the matrix.

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -64,7 +64,7 @@ foreach ( array( '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ) as $php ) {
 		'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
 	);
 }
-foreach ( array( 'previous', 'trunk' ) as $wp ) {
+foreach ( array( 'previous', 'trunk', 'special' ) as $wp ) {
 	$phpver = $versions['PHP_VERSION'];
 	if ( $wp === 'previous' ) {
 		$matrix[] = array(
@@ -74,8 +74,6 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 			'wp'      => $wp,
 			'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
 		);
-		// PHP 8.1+ seems to fail on WordPress 6.2.
-		$phpver = '8.0';
 	}
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP {$phpver} WP $wp",

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -75,6 +75,9 @@ foreach ( array( 'previous', 'trunk', 'special' ) as $wp ) {
 			'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
 		);
 	}
+	if ( $wp === 'special' ) {
+		$phpver = '8.0'; // WordPress 6.1 is not ready for PHP 8.1+.
+	}
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP {$phpver} WP $wp",
 		'script'  => 'test-php',
@@ -202,7 +205,7 @@ foreach ( $matrix as &$m ) {
 	}
 
 	// Only specific values allowed for `wp`.
-	$valid_wp = array( 'latest', 'previous', 'trunk', 'none' );
+	$valid_wp = array( 'latest', 'previous', 'trunk', 'special', 'none' );
 	if ( ! in_array( $m['wp'], $valid_wp, true ) ) {
 		$valid_wp = join_or(
 			array_map(

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -40,7 +40,11 @@ case "$WP_BRANCH" in
 	previous)
 		# We hard-code the version here because there's a time near WP releases where
 		# we've dropped the old 'previous' but WP hasn't actually released the new 'latest'
-		# @todo Update generate-ci-matrix.php as well when this bumps to 6.2.
+		TAG=6.2
+		;;
+	special)
+		# This is a special case for testing WP 6.1 as well as 6.2 in the interim between Jetpack 12.4 and WC US on 25th of August, 2023.
+		# TODO: Remove this after Jetpack 12.5 is released, more here: pdWQjU-r3-p2
 		TAG=6.1
 		;;
 	*)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
We have been setting WordPress "previous" to 6.1 directly, this PR changes that to 6.2. In addition to that, we add a special test suite to continue testing 6.1 in the interim between Jetpack 12.4 and Jetpack 12.5.

## Proposed changes:
* Moves 'previous' to 6.2 instead of 6.1.
* Adds a 'special' test suite that will continue testing in WordPress 6.1.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* CI should be OK

