### PR TITLE
AI Extension: fix AI Assistant bar position in the Top toolbar mode

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fixed-toolbar-mode
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fixed-toolbar-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: fix AI Assistant bar position in the Top toolbar mode

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -3,6 +3,7 @@
  */
 import { aiAssistantIcon, useAiContext } from '@automattic/jetpack-ai-client';
 import { KeyboardShortcuts, Popover, ToolbarButton } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { useContext, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect } from 'react';
@@ -19,10 +20,12 @@ export default function AiAssistantToolbarButton( {
 }: {
 	clientId: string;
 } ): React.ReactElement {
-	const { isVisible, toggle, setPopoverProps, setAssistantFixed, isFixed } =
-		useContext( AiAssistantUiContext );
+	const { isVisible, toggle, setAssistantFixed, isFixed } = useContext( AiAssistantUiContext );
 	const { requestingState } = useAiContext();
 
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
+
+	useViewportMatch;
 	const [ barAnchor, setBarAnchor ] = React.useState< HTMLElement | null >( null );
 
 	/*
@@ -44,12 +47,13 @@ export default function AiAssistantToolbarButton( {
 			return;
 		}
 
+		// Set the anxhor where the Assistant Bar will be rendered.
 		setBarAnchor( toolbar );
 
-		const isToolbarBlockFixed = toolbar.classList.contains( 'is-fixed' );
-		setAssistantFixed( isToolbarBlockFixed );
-		handleAiExtensionsBarBodyClass( isToolbarBlockFixed, isVisible );
-	}, [ setAssistantFixed, setPopoverProps, isVisible ] );
+		// Fix the Assistant Bar if the Toolbar Block is fixed and the viewport is mobile.
+		setAssistantFixed( isMobileViewport );
+		handleAiExtensionsBarBodyClass( isMobileViewport, isVisible );
+	}, [ setAssistantFixed, isVisible, isMobileViewport ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/32347

This PR updates how the app switches and fixes the AI Assistant bar on mobile. Here:

* Detects the mobile view with the useViewportMatch() core hook
* Discard the part that looks the CSS class to detect if the Toolbar block is fixes

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: fix AI Assistant bar position in the Top toolbar mode

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Check how the Toolbar looks on mobile
<img width="752" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/b8890797-8a99-4543-b874-ee987919f571">

* Switch to the Top toolbar mode

<img width="702" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/d48161ef-acdc-4044-9849-8adf8fe1242e">


### regular view

**before**

<img width="878" alt="Screenshot 2023-08-09 at 18 09 23" src="https://github.com/Automattic/jetpack/assets/77539/41858e5c-98cd-4fd0-bc01-47e7c8f30bc3">

**after**
<img width="852" alt="Screenshot 2023-08-09 at 18 12 56" src="https://github.com/Automattic/jetpack/assets/77539/27b5c6bd-541e-4343-9a16-220e06faa2d8">

The Assistant bar keeps in the editor canvas context
