### PR TITLE
CRM: Fix placeholders for contacts and companies in the task reminder email

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3275-placeholders-on-tasks-quickfix
+++ b/projects/plugins/crm/changelog/fix-crm-3275-placeholders-on-tasks-quickfix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tasks: Corrected placeholders for contacts and companies in the task reminder email

--- a/projects/plugins/crm/includes/jpcrm-mail-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-mail-templating.php
@@ -878,7 +878,21 @@ function zeroBSCRM_Event_generateNotificationHTML( $return = true, $email = fals
 		$replacements['task-link-button'] = '<div style="text-align:center;margin:1em;margin-top:2em">' . __( 'You can view your task at the following URL: ', 'zero-bs-crm' ) . '<br />' . zeroBSCRM_mailTemplate_emailSafeButton( $eventURL, __( 'View Task', 'zero-bs-crm' ) ) . '</div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		// replacements
-		$html = $placeholder_templating->replace_placeholders( array( 'global', 'event', 'contact', 'company' ), $html, $replacements, array( ZBS_TYPE_EVENT => $event ) );
+		$html = $placeholder_templating->replace_placeholders(
+			array(
+				'global',
+				'event',
+				'contact',
+				'company',
+			),
+			$html,
+			$replacements,
+			array(
+				ZBS_TYPE_EVENT   => $event,
+				ZBS_TYPE_CONTACT => isset( $event['contact'] ) ? $event['contact'][0] : null,
+				ZBS_TYPE_COMPANY => isset( $event['company'] ) ? $event['company'][0] : null,
+			)
+		);
 
 		// return
 		if ( !$return ) {

--- a/projects/plugins/crm/includes/jpcrm-mail-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-mail-templating.php
@@ -213,8 +213,11 @@ function zeroBSCRM_mailTemplate_emailPreview($templateID=-1){
 		// event
 		if ( $templateID == 5 ){
 
-			$replacements['task-title'] = __( 'Example Task #101', 'zero-bs-crm' );
-			$replacements['task-link']  = '<div style="text-align:center;margin:1em;margin-top:2em">' . zeroBSCRM_mailTemplate_emailSafeButton( admin_url(), __( 'View Task', 'zero-bs-crm' ) ) . '</div>';
+			$replacements['task-title']       = __( 'Example Task #101', 'zero-bs-crm' );
+			$replacements['task-link']        = '<div style="text-align:center;margin:1em;margin-top:2em">' . zeroBSCRM_mailTemplate_emailSafeButton( admin_url(), __( 'View Task', 'zero-bs-crm' ) ) . '</div>';
+			$replacements['contact-fname']    = __( 'First-Name', 'zero-bs-crm' );
+			$replacements['contact-lname']    = __( 'Last-Name', 'zero-bs-crm' );
+			$replacements['contact-fullname'] = __( 'Full-Name', 'zero-bs-crm' );
 
 	        // replace vars
 	        $html = $placeholder_templating->replace_placeholders( array( 'global', 'event' ), $html, $replacements );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes  placeholders for contacts and companies in the task reminder email.
It also adds hardcoded ``##CONTACT-FNAME##``, ``##CONTACT-LNAME##``, ``##CONTACT-FULLNAME##`` to the sample e-mail. Since the user opening the ticket only complains about fname this should be enough for now, and a more complete solution to fill the sample e-mail with all the possible placeholders should be developed later.

## Proposed changes:
This is a bugfix.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3275

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the steps in https://github.com/Automattic/zero-bs-crm/issues/3275 to send a sample task reminder email
* Make sure the sample task reminder e-mail fills the placeholders: ``##CONTACT-FNAME##``, ``##CONTACT-LNAME##``, ``##CONTACT-FULLNAME##``
* Add a new task ( `/wp-admin/admin.php?page=manage-events` ), with an assigned contact for 20 hours from your current time. Make sure `Remind CRM member 24 hours before` is checked
* Check if the e-mail correctly replaces all the contact's placeholders
* Do the same with a company assigned to the task

