### PR TITLE
Backport mu-wpcom-plugin 1.6.10, jetpack 12.5-a.5 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2023-08-09
+### Added
+- AI Client: Introduce disabled prop in AI Control. [#32326]
+- AI Control: Add guideline message. [#32358]
+
+### Changed
+- AI Client: handle token fetching errors by dispatching an event from the SuggestionsEventSource class. [#32350]
+- AI Client: tweak layout and styles to make AI Control mobile friendly. [#32362]
+- AI Control: clean up props. [#32360]
+- Updated package dependencies. [#32166]
+
+### Fixed
+- AI Client: fix TS type definition issue [#32330]
+
 ## [0.1.2] - 2023-08-07
 ### Added
 - AI Assistant: Add options parameter to request function on useAiSuggestions hook [#32198]
@@ -54,5 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.1.3]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.1.0...v0.1.1

--- a/projects/js-packages/ai-client/changelog/add-ai-control-disabled-prop
+++ b/projects/js-packages/ai-client/changelog/add-ai-control-disabled-prop
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-AI Client: Introduce disabled prop in AI Control

--- a/projects/js-packages/ai-client/changelog/add-ai-control-guidelines
+++ b/projects/js-packages/ai-client/changelog/add-ai-control-guidelines
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-AI Control: Add guideline message

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/changelog/update-ai-assistant-bar-fix-visual-issue-when-switching-viewport-size
+++ b/projects/js-packages/ai-client/changelog/update-ai-assistant-bar-fix-visual-issue-when-switching-viewport-size
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Client: fix TS type definition issue

--- a/projects/js-packages/ai-client/changelog/update-ai-client-handle-internal-errors
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-handle-internal-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Client: Handle token fetching errors by dispatching an event from the SuggestionsEventSource class.

--- a/projects/js-packages/ai-client/changelog/update-ai-control-props
+++ b/projects/js-packages/ai-client/changelog/update-ai-control-props
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Control: Clean up props

--- a/projects/js-packages/ai-client/changelog/update-jetpack-form-ai-assistant-bar-in-mobile
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-form-ai-assistant-bar-in-mobile
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Client: tweak layout and styles to make AI Control mobile friendly

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.1.3-alpha",
+	"version": "0.1.3",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## 0.15.10 - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## 0.15.9 - 2023-07-11
 ### Changed
 - Updated package dependencies. [#31785]

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.15.10-alpha",
+	"version": "0.15.10",
 	"description": "Jetpack Api Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.6.4] - 2023-07-24
 
 ## [0.6.3] - 2023-07-11
@@ -200,6 +204,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.5]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.4...0.6.5
 [0.6.4]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.3...0.6.4
 [0.6.3]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.2...0.6.3
 [0.6.2]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.1...0.6.2

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.5-alpha",
+	"version": "0.6.5",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.1.5] - 2023-07-17
 ### Changed
 - Updated package dependencies. [#31815]
@@ -35,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.6]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.2...v0.1.3

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.6-alpha",
+	"version": "0.1.6",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.41.1] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.41.0] - 2023-07-24
 ### Added
 - Jetpack Footer: added generic links [#31627]
@@ -779,6 +783,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.41.1]: https://github.com/Automattic/jetpack-components/compare/0.41.0...0.41.1
 [0.41.0]: https://github.com/Automattic/jetpack-components/compare/0.40.4...0.41.0
 [0.40.4]: https://github.com/Automattic/jetpack-components/compare/0.40.3...0.40.4
 [0.40.3]: https://github.com/Automattic/jetpack-components/compare/0.40.2...0.40.3

--- a/projects/js-packages/components/changelog/renovate-definitelytyped
+++ b/projects/js-packages/components/changelog/renovate-definitelytyped
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.41.1-alpha",
+	"version": "0.41.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## 0.29.7 - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## 0.29.6 - 2023-07-25
 ### Changed
 - Updated package dependencies. [#31999]

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.29.7-alpha",
+	"version": "0.29.7",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.36] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [2.0.35] - 2023-07-11
 ### Changed
 - Updated package dependencies. [#31785]
@@ -168,6 +172,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.36]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.35...v2.0.36
 [2.0.35]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.34...v2.0.35
 [2.0.34]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.33...v2.0.34
 [2.0.33]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.32...v2.0.33

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.36-alpha",
+	"version": "2.0.36",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.44 - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## 0.10.43 - 2023-07-17
 ### Changed
 - Updated package dependencies. [#31785]

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.44-alpha",
+	"version": "0.10.44",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.11.3 - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## 0.11.2 - 2023-07-17
 ### Changed
 - Updated package dependencies. [#31872]

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.11.3-alpha",
+	"version": "0.11.3",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.53 - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## 0.2.52 - 2023-07-17
 ### Changed
 - Updated package dependencies. [#31785]

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.53-alpha",
+	"version": "0.2.53",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] - 2023-08-09
+### Changed
+- Moved store to publicize-components package [#32317]
+- Updated package dependencies. [#32166]
+
 ## [0.32.0] - 2023-08-07
 ### Added
 - ADded new notice for admin page for Advanced plan upsell [#32128]
@@ -379,6 +384,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.33.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.29.1...v0.30.0

--- a/projects/js-packages/publicize-components/changelog/renovate-definitelytyped
+++ b/projects/js-packages/publicize-components/changelog/renovate-definitelytyped
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/update-move-social-store-to-publicize-components
+++ b/projects/js-packages/publicize-components/changelog/update-move-social-store-to-publicize-components
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Moved store to publicize-components package

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.33.0-alpha",
+	"version": "0.33.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.11.0] - 2023-08-07
 ### Added
 - Add shared block editor logo component. [#32257]
@@ -225,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.11.1]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.11.0...0.11.1
 [0.11.0]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.9...0.11.0
 [0.10.9]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.8...0.10.9
 [0.10.8]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.10.7...0.10.8

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.11.1-alpha",
+	"version": "0.11.1",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.5.8 - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## 1.5.7 - 2023-07-18
 ### Changed
 - Updated package dependencies. [#31922]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "1.5.8-alpha",
+	"version": "1.5.8",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/action-bar/CHANGELOG.md
+++ b/projects/packages/action-bar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.24] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.1.23] - 2023-07-25
 ### Changed
 - Updated package dependencies. [#32040]
@@ -101,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds the Action Bar package and Jetpack plugin module for follows, likes, and comments. Just a scaffold to build on, for now. [#25447]
 
+[0.1.24]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/Automattic/jetpack-action-bar/compare/v0.1.20...v0.1.21

--- a/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/action-bar/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/action-bar/package.json
+++ b/projects/packages/action-bar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-action-bar",
-	"version": "0.1.24-alpha",
+	"version": "0.1.24",
 	"description": "An easy way for visitors to follow, like, and comment on your WordPress site.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/action-bar/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.8] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [1.18.7] - 2023-07-11
 ### Changed
 - Updated package dependencies. [#31785]
@@ -345,6 +349,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[1.18.8]: https://github.com/Automattic/jetpack-assets/compare/v1.18.7...v1.18.8
 [1.18.7]: https://github.com/Automattic/jetpack-assets/compare/v1.18.6...v1.18.7
 [1.18.6]: https://github.com/Automattic/jetpack-assets/compare/v1.18.5...v1.18.6
 [1.18.5]: https://github.com/Automattic/jetpack-assets/compare/v1.18.4...v1.18.5

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.6] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [1.16.5] - 2023-08-01
 ### Changed
 - Minor internal updates.
@@ -453,6 +457,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[1.16.6]: https://github.com/Automattic/jetpack-backup/compare/v1.16.5...v1.16.6
 [1.16.5]: https://github.com/Automattic/jetpack-backup/compare/v1.16.4...v1.16.5
 [1.16.4]: https://github.com/Automattic/jetpack-backup/compare/v1.16.3...v1.16.4
 [1.16.3]: https://github.com/Automattic/jetpack-backup/compare/v1.16.2...v1.16.3

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.16.6-alpha';
+	const PACKAGE_VERSION = '1.16.6';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+- Update wording in the Blaze CTA link appearing in the post list. [#32339]
+
 ## [0.9.1] - 2023-08-07
 ### Fixed
 - Fixes missing controller for DSP /woo/wpcom-payment-methods request [#32267]
@@ -179,6 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.9.2]: https://github.com/automattic/jetpack-blaze/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/automattic/jetpack-blaze/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/automattic/jetpack-blaze/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/automattic/jetpack-blaze/compare/v0.8.0...v0.8.1

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/changelog/update-blaze-wording
+++ b/projects/packages/blaze/changelog/update-blaze-wording
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update wording in the Blaze CTA link appearing in the post list.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.9.2-alpha",
+	"version": "0.9.2",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.9.2-alpha';
+	const PACKAGE_VERSION = '0.9.2';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.56.1] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
+### Removed
+- Tests: remove invalid tests for WP 6.3 [#32353]
+
 ## [1.56.0] - 2023-08-01
 ### Added
 - Add a filter to modify response for the `jetpack.idcUrlValidation` endpoint, add unit test. [#32005]
@@ -853,6 +860,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[1.56.1]: https://github.com/Automattic/jetpack-connection/compare/v1.56.0...v1.56.1
 [1.56.0]: https://github.com/Automattic/jetpack-connection/compare/v1.55.0...v1.56.0
 [1.55.0]: https://github.com/Automattic/jetpack-connection/compare/v1.54.1...v1.55.0
 [1.54.1]: https://github.com/Automattic/jetpack-connection/compare/v1.54.0...v1.54.1

--- a/projects/packages/connection/changelog/remove-5.6-from-latest-test-matrix
+++ b/projects/packages/connection/changelog/remove-5.6-from-latest-test-matrix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Tests: remove invalid tests for WP 6.3

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.56.1-alpha';
+	const PACKAGE_VERSION = '1.56.1';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.10] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.19.9] - 2023-08-07
 ### Added
 - Added SIG modal ui [#31665]
@@ -296,6 +300,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.19.10]: https://github.com/automattic/jetpack-forms/compare/v0.19.9...v0.19.10
 [0.19.9]: https://github.com/automattic/jetpack-forms/compare/v0.19.8...v0.19.9
 [0.19.8]: https://github.com/automattic/jetpack-forms/compare/v0.19.7...v0.19.8
 [0.19.7]: https://github.com/automattic/jetpack-forms/compare/v0.19.6...v0.19.7

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.19.10-alpha",
+	"version": "0.19.10",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.19.10-alpha';
+	const PACKAGE_VERSION = '0.19.10';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.10.0] - 2023-08-07
 ### Changed
 - Make IDC container ID adjustable.
@@ -392,6 +396,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.10.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.52...v0.9.0
 [0.8.52]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.8.51...v0.8.52

--- a/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.10.1-alpha",
+	"version": "0.10.1",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -30,7 +30,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.10.1-alpha';
+	const PACKAGE_VERSION = '0.10.1';
 
 	/**
 	 * Instance of the object.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.1] - 2023-08-09
+### Added
+- Adds the 'Write 3 posts' launchpad task to the 'Write' intent [#32341]
+
+### Changed
+- Update the email verification task copy [#32364]
+
 ## [4.3.0] - 2023-08-07
 ### Added
 - Added add_about_page Launchpad task [#32245]
@@ -287,6 +294,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[4.3.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.3.0...v4.3.1
 [4.3.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.0.0...v4.1.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/80321-update-write-posts
+++ b/projects/packages/jetpack-mu-wpcom/changelog/80321-update-write-posts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Adds the 'Write 3 posts' launchpad task to the 'Write' intent

--- a/projects/packages/jetpack-mu-wpcom/changelog/80340-update-confirm-email-copy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/80340-update-confirm-email-copy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update the email verification task copy

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.3.1-alpha",
+	"version": "4.3.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.3.1-alpha';
+	const PACKAGE_VERSION = '4.3.1';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.15] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [2.3.14] - 2023-07-25
 ### Changed
 - Updated package dependencies. [#32040]
@@ -605,6 +609,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[2.3.15]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.14...v2.3.15
 [2.3.14]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.13...v2.3.14
 [2.3.13]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.12...v2.3.13
 [2.3.12]: https://github.com/Automattic/jetpack-jitm/compare/v2.3.11...v2.3.12

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '2.3.15-alpha';
+	const PACKAGE_VERSION = '2.3.15';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/lazy-images/CHANGELOG.md
+++ b/projects/packages/lazy-images/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.43] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [2.1.42] - 2023-07-11
 ### Changed
 - Updated package dependencies. [#31785]
@@ -336,6 +340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy Images: Move into a package
 
+[2.1.43]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.42...v2.1.43
 [2.1.42]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.41...v2.1.42
 [2.1.41]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.40...v2.1.41
 [2.1.40]: https://github.com/Automattic/jetpack-lazy-images/compare/v2.1.39...v2.1.40

--- a/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/lazy-images/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [3.3.0] - 2023-08-07
 ### Added
 - Add Identity Crisis screen modal. [#32249]
@@ -972,6 +976,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[3.3.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.3.0...3.3.1
 [3.3.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.2.1...3.3.0
 [3.2.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.2.0...3.2.1
 [3.2.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/3.1.3...3.2.0

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.3.1-alpha",
+	"version": "3.3.1",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.3.1-alpha';
+	const PACKAGE_VERSION = '3.3.1';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.1] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.33.0] - 2023-08-07
 ### Added
 - Added admin-page upsell notice [#32128]
@@ -359,6 +363,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.33.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.30.4...v0.31.0

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.33.1-alpha",
+	"version": "0.33.1",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.38.3] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.38.2] - 2023-07-25
 ### Changed
 - Updated package dependencies. [#31923]
@@ -778,6 +782,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.38.3]: https://github.com/Automattic/jetpack-search/compare/v0.38.2...v0.38.3
 [0.38.2]: https://github.com/Automattic/jetpack-search/compare/v0.38.1...v0.38.2
 [0.38.1]: https://github.com/Automattic/jetpack-search/compare/v0.38.0...v0.38.1
 [0.38.0]: https://github.com/Automattic/jetpack-search/compare/v0.37.4...v0.38.0

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.38.3-alpha",
+	"version": "0.38.3",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.38.3-alpha';
+	const VERSION = '0.38.3';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4] - 2023-08-09
+### Added
+- Stats: compatibility for AMP for WP plugin [#32328]
+
 ## [0.6.3] - 2023-05-15
 ### Changed
 - PHP 8.1 compatibility updates [#30517]
@@ -88,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.6.4]: https://github.com/Automattic/jetpack-stats/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/Automattic/jetpack-stats/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/Automattic/jetpack-stats/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/Automattic/jetpack-stats/compare/v0.6.0...v0.6.1

--- a/projects/packages/stats/changelog/fix-stats-compability-ampforwp
+++ b/projects/packages/stats/changelog/fix-stats-compability-ampforwp
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Stats: compatibility for AMP for WP plugin

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.53.0] - 2023-08-09
+### Added
+- Jetpack Sync: Custom table initialization and migration functionality [#32135]
+- Jetpack Sync: Drop custom table on sender uninstall [#32335]
+
 ## [1.52.0] - 2023-08-01
 ### Added
 - Add support for a custom database table for Sync Queue. [#32111]
@@ -890,6 +895,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[1.53.0]: https://github.com/Automattic/jetpack-sync/compare/v1.52.0...v1.53.0
 [1.52.0]: https://github.com/Automattic/jetpack-sync/compare/v1.51.0...v1.52.0
 [1.51.0]: https://github.com/Automattic/jetpack-sync/compare/v1.50.2...v1.51.0
 [1.50.2]: https://github.com/Automattic/jetpack-sync/compare/v1.50.1...v1.50.2

--- a/projects/packages/sync/changelog/add-jetpack-sync-custom-table-initialization-and-migration
+++ b/projects/packages/sync/changelog/add-jetpack-sync-custom-table-initialization-and-migration
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Jetpack Sync: Custom table initialization and migration functionality

--- a/projects/packages/sync/changelog/add-sync-drop-custom-table-on-uninstall
+++ b/projects/packages/sync/changelog/add-sync-drop-custom-table-on-uninstall
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Jetpack Sync: Drop custom table on sender uninstall

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.53.0-alpha';
+	const PACKAGE_VERSION = '1.53.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.13] - 2023-08-09
+### Added
+- Added comment note about IS_WPCOM. [#32136]
+
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.14.12] - 2023-08-01
 ### Added
 - VideoPress: handle uploading video files when dropping in the editor canvas. [#32084]
@@ -1070,6 +1077,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.14.13]: https://github.com/Automattic/jetpack-videopress/compare/v0.14.12...v0.14.13
 [0.14.12]: https://github.com/Automattic/jetpack-videopress/compare/v0.14.11...v0.14.12
 [0.14.11]: https://github.com/Automattic/jetpack-videopress/compare/v0.14.10...v0.14.11
 [0.14.10]: https://github.com/Automattic/jetpack-videopress/compare/v0.14.9...v0.14.10

--- a/projects/packages/videopress/changelog/renovate-definitelytyped
+++ b/projects/packages/videopress/changelog/renovate-definitelytyped
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/update-videopress-ajax-wpcom-note
+++ b/projects/packages/videopress/changelog/update-videopress-ajax-wpcom-note
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added comment note about IS_WPCOM.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.14.13-alpha",
+	"version": "0.14.13",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.14.13-alpha';
+	const PACKAGE_VERSION = '0.14.13';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.48] - 2023-08-09
+### Changed
+- Updated package dependencies. [#32166]
+
 ## [0.2.47] - 2023-07-25
 ### Changed
 - Updated package dependencies. [#31923]
@@ -227,6 +231,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.2.48]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.47...v0.2.48
 [0.2.47]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.46...v0.2.47
 [0.2.46]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.45...v0.2.46
 [0.2.45]: https://github.com/Automattic/jetpack-wordads/compare/v0.2.44...v0.2.45

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.2.48-alpha",
+	"version": "0.2.48",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.2.48-alpha';
+	const VERSION = '0.2.48';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 12.5-a.5 - 2023-08-09
+### Enhancements
+- AI Assistant: change tracked event to English instead of translated value and track language and tone change [#32291]
+- AI Assistant: fix grammar and typos on Proofread feature [#32321]
+- AI Extension: fix visual issue in Assistant bar when switching viewport size. [#32344] [#32330]
+- AI Extension: Introduce AI Assistant bar. [#32359]
+- Paywall block: add transforms for "more" and "nextpage" core blocks. [#32338]
+
+### Bug fixes
+- Add subscribe button on premium content block on self-hosted [#32318]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Blocks: avoid hardcoding the version number when creating a new block via the CLI command [#32110]
+- AI Control: clean up props [#32360]
+- AI Extension: add UpgradePrompt if upgrade is required. [#32326] 
+- AI Plugin: Add upgrade path. [#32327]
+- Move out of api.js [#32273]
+- Updated package dependencies. [#32307]
+
 ## 12.5-a.3 - 2023-08-07
 ### Enhancements
 - Added SIG modal ui [#31665]

--- a/projects/plugins/jetpack/changelog/add-ai-plugin-upgrade
+++ b/projects/plugins/jetpack/changelog/add-ai-plugin-upgrade
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Plugin: Add upgrade path

--- a/projects/plugins/jetpack/changelog/add-ai-upgrade-prompt-form
+++ b/projects/plugins/jetpack/changelog/add-ai-upgrade-prompt-form
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: Add UpgradePrompt if require upgrade

--- a/projects/plugins/jetpack/changelog/add-jetpack-sync-custom-table-initialization-and-migration
+++ b/projects/plugins/jetpack/changelog/add-jetpack-sync-custom-table-initialization-and-migration
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-sync-custom-queua-table-flag#3
+++ b/projects/plugins/jetpack/changelog/add-sync-custom-queua-table-flag#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-jetpack-block-cli-reference
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-block-cli-reference
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blocks: avoid hardcoding the version number when creating a new block via the CLI command

--- a/projects/plugins/jetpack/changelog/fix-missing-subscribe-buttons-on-premium-content
+++ b/projects/plugins/jetpack/changelog/fix-missing-subscribe-buttons-on-premium-content
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Add subscribe button on premium content block on self-hosted

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 12.5-a.6
+
+

--- a/projects/plugins/jetpack/changelog/remove-unused-api-js
+++ b/projects/plugins/jetpack/changelog/remove-unused-api-js
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Move out of api.js

--- a/projects/plugins/jetpack/changelog/renovate-definitelytyped
+++ b/projects/plugins/jetpack/changelog/renovate-definitelytyped
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fix-visual-issue-when-switching-viewport-size
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fix-visual-issue-when-switching-viewport-size
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: fix visual on the AI Assistant bar when switching viewport size

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-position
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-position
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: Introduce AI Assistant bar. Update.

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-fix-tracked-event-content
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-fix-tracked-event-content
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Change tracked event to English instead of translated value and track language and tone change

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-proofread-typos
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-proofread-typos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Fix grammar and typos on Proofread feature

--- a/projects/plugins/jetpack/changelog/update-ai-control-props
+++ b/projects/plugins/jetpack/changelog/update-ai-control-props
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Control: Clean up props

--- a/projects/plugins/jetpack/changelog/update-get_post_access_level
+++ b/projects/plugins/jetpack/changelog/update-get_post_access_level
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Adding an optional parameter to get_post_access_level() does not seem very significant.
-
-

--- a/projects/plugins/jetpack/changelog/update-jetpack-form-swtich-viewport-issue
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-swtich-viewport-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Extension: fix visual issue in Assistant bar when switching viewport size

--- a/projects/plugins/jetpack/changelog/update-paywall-more-transform
+++ b/projects/plugins/jetpack/changelog/update-paywall-more-transform
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Paywall block: add transforms for "more" and "nextpage" core blocks

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_5_a_4",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_5_a_5",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_5_a_5",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ12_5_a_6",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/paywall.php
@@ -2,7 +2,7 @@
 /**
  * Paywall Block.
  *
- * @since $$next-version$$
+ * @since 12.5
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.5-a.4
+ * Version: 12.5-a.5
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.1' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.5-a.4' );
+define( 'JETPACK__VERSION', '12.5-a.5' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 12.5-a.5
+ * Version: 12.5-a.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.1' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
-define( 'JETPACK__VERSION', '12.5-a.5' );
+define( 'JETPACK__VERSION', '12.5-a.6' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.5.0-a.5",
+	"version": "12.5.0-a.6",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "12.5.0-a.4",
+	"version": "12.5.0-a.5",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.10 - 2023-08-09
+### Changed
+- Updated package dependencies. [#32307]
+
 ## 1.6.9 - 2023-08-07
 
 ## 1.6.8 - 2023-08-01

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_10_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_10"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.10-alpha
+ * Version: 1.6.10
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.10-alpha",
+	"version": "1.6.10",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 1.6.10, jetpack 12.5-a.5

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.