### PR TITLE
AI Assistant: Handle stop action

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-form-ai-extension-handle-stop-action
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-form-ai-extension-handle-stop-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: Expose stopSuggestion function on useAiSuggestions hook so the consumer can stop a suggestion in the middle.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.1.3",
+	"version": "0.1.4-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/data-flow/context.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/context.tsx
@@ -34,6 +34,11 @@ export type AiDataContextProps = {
 	requestSuggestion: ( prompt: PromptProp, options?: AskQuestionOptionsArgProps ) => void;
 
 	/*
+	 * Stop suggestion function
+	 */
+	stopSuggestion: () => void;
+
+	/*
 	 * The Suggestions Event Source instance
 	 */
 	eventSource: SuggestionsEventSource | null;

--- a/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
@@ -25,6 +25,7 @@ const withAiDataProvider = createHigherOrderComponent( ( WrappedComponent: React
 			error: requestingError,
 			requestingState,
 			request: requestSuggestion,
+			stopSuggestion,
 			eventSource,
 		} = useAiSuggestions();
 
@@ -37,8 +38,16 @@ const withAiDataProvider = createHigherOrderComponent( ( WrappedComponent: React
 				eventSource,
 
 				requestSuggestion,
+				stopSuggestion,
 			} ),
-			[ suggestion, requestingError, requestingState, eventSource, requestSuggestion ]
+			[
+				suggestion,
+				requestingError,
+				requestingState,
+				eventSource,
+				requestSuggestion,
+				stopSuggestion,
+			]
 		);
 
 		return (

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -355,39 +355,10 @@ export default function useAiSuggestions( {
 		}
 
 		return () => {
-			if ( ! eventSourceRef?.current ) {
-				return;
-			}
-
-			// Alias
-			const eventSource = eventSourceRef.current;
-
-			// Close the connection.
-			eventSource.close();
-
-			// Clean up the event listeners.
-			eventSource.removeEventListener( 'suggestion', handleSuggestion );
-
-			eventSource.removeEventListener( ERROR_QUOTA_EXCEEDED, handleErrorQuotaExceededError );
-			eventSource.removeEventListener( ERROR_UNCLEAR_PROMPT, handleUnclearPromptError );
-			eventSource.removeEventListener( ERROR_SERVICE_UNAVAILABLE, handleServiceUnavailableError );
-			eventSource.removeEventListener( ERROR_MODERATION, handleModerationError );
-			eventSource.removeEventListener( ERROR_NETWORK, handleNetworkError );
-
-			eventSource.removeEventListener( 'done', handleDone );
+			// Stop the suggestion if the component unmounts.
+			stopSuggestion();
 		};
-	}, [
-		autoRequest,
-		handleDone,
-		handleErrorQuotaExceededError,
-		handleModerationError,
-		handleServiceUnavailableError,
-		handleSuggestion,
-		handleUnclearPromptError,
-		prompt,
-		request,
-		stopSuggestion,
-	] );
+	}, [ autoRequest, prompt, request, stopSuggestion ] );
 
 	return {
 		// Data

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -97,6 +97,11 @@ type useAiSuggestionsProps = {
 	 * The request handler.
 	 */
 	request: ( prompt: PromptProp, options?: AskQuestionOptionsArgProps ) => Promise< void >;
+
+	/*
+	 * The handler to stop a suggestion.
+	 */
+	stopSuggestion: () => void;
 };
 
 const debug = debugFactory( 'jetpack-ai-client:use-suggestion' );
@@ -297,6 +302,46 @@ export default function useAiSuggestions( {
 		]
 	);
 
+	/**
+	 * Stop suggestion handler.
+	 *
+	 * @returns {void}
+	 */
+	const stopSuggestion = useCallback( () => {
+		if ( ! eventSourceRef?.current ) {
+			return;
+		}
+
+		// Alias
+		const eventSource = eventSourceRef?.current;
+
+		// Close the connection.
+		eventSource.close();
+
+		// Clean up the event listeners.
+		eventSource.removeEventListener( 'suggestion', handleSuggestion );
+
+		eventSource.removeEventListener( ERROR_QUOTA_EXCEEDED, handleErrorQuotaExceededError );
+		eventSource.removeEventListener( ERROR_UNCLEAR_PROMPT, handleUnclearPromptError );
+		eventSource.removeEventListener( ERROR_SERVICE_UNAVAILABLE, handleServiceUnavailableError );
+		eventSource.removeEventListener( ERROR_MODERATION, handleModerationError );
+		eventSource.removeEventListener( ERROR_NETWORK, handleNetworkError );
+
+		eventSource.removeEventListener( 'done', handleDone );
+
+		// Set requesting state to done since the suggestion stopped.
+		setRequestingState( 'done' );
+	}, [
+		eventSourceRef,
+		handleSuggestion,
+		handleErrorQuotaExceededError,
+		handleUnclearPromptError,
+		handleServiceUnavailableError,
+		handleModerationError,
+		handleNetworkError,
+		handleDone,
+	] );
+
 	// Request suggestions automatically when ready.
 	useEffect( () => {
 		// Check if there is a prompt to request.
@@ -341,6 +386,7 @@ export default function useAiSuggestions( {
 		handleUnclearPromptError,
 		prompt,
 		request,
+		stopSuggestion,
 	] );
 
 	return {
@@ -349,8 +395,9 @@ export default function useAiSuggestions( {
 		error,
 		requestingState,
 
-		// Request handler
+		// Request/stop handlers
 		request,
+		stopSuggestion,
 
 		// SuggestionsEventSource
 		eventSource: eventSourceRef.current,

--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-extension-handle-stop-action
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-extension-handle-stop-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: Handle stop action on the AI Control component.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -46,7 +46,7 @@ export default function AiAssistantBar( { clientId } ) {
 
 	const { inputValue, setInputValue } = useContext( AiAssistantUiContext );
 
-	const { requestSuggestion, requestingState } = useAiContext();
+	const { requestSuggestion, requestingState, stopSuggestion } = useAiContext();
 
 	const isLoading = requestingState === 'requesting' || requestingState === 'suggesting';
 
@@ -55,7 +55,7 @@ export default function AiAssistantBar( { clientId } ) {
 	const loadingPlaceholder = __( 'Creating your form. Please wait a few moments.', 'jetpack' );
 
 	const onStop = () => {
-		// TODO: Implement onStop
+		stopSuggestion();
 	};
 
 	const onSend = useCallback( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -54,10 +54,6 @@ export default function AiAssistantBar( { clientId } ) {
 
 	const loadingPlaceholder = __( 'Creating your form. Please wait a few moments.', 'jetpack' );
 
-	const onStop = () => {
-		stopSuggestion();
-	};
-
 	const onSend = useCallback( () => {
 		const prompt = getPrompt( PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, {
 			request: inputValue,
@@ -76,7 +72,7 @@ export default function AiAssistantBar( { clientId } ) {
 				placeholder={ isLoading ? loadingPlaceholder : placeholder }
 				onChange={ setInputValue }
 				onSend={ onSend }
-				onStop={ onStop }
+				onStop={ stopSuggestion }
 				state={ requestingState }
 				isOpaque={ requireUpgrade }
 			/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32369.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Expose a `stopSuggestion` function on `useAiSuggestions` hook so the consumer can call it to stop a suggestion
* Connect the JP Form AI Extension AI Contol to the `stopSuggestion` function

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open your browser development console
* Insert a form block and ask the AI for some form (for example, "TV repair support form")
* When the generation starts, click the Stop button on the assistant:

<img width="600" alt="Screenshot 2023-08-09 at 17 53 54" src="https://github.com/Automattic/jetpack/assets/6760046/784e7b83-b765-4ebc-ae87-7b8c0112fec4">

* Notice that the generation stops on the editor
* Notice that the debug log of the suggestion stops on the console as well, meaning the suggestion as a whole stopped
* Send the same request again and when it starts the generation, delete the block
* Notice that the debug log of the suggestion stops on the console, as it was doing before this change, confirming this change didn't break the prior handling of the component unmounting process