### PR TITLE
Revert "Make "My Jetpack" the default page in Jetpack wp-admin. (#32240)

### DIFF
--- a/projects/packages/my-jetpack/changelog/revert-22655e3
+++ b/projects/packages/my-jetpack/changelog/revert-22655e3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Revert My Jetpack as first menu item

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.3.1",
+	"version": "3.3.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -67,7 +67,7 @@ class Initializer {
 			'manage_options',
 			'my-jetpack',
 			array( __CLASS__, 'admin_page' ),
-			0
+			999
 		);
 
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.3.1';
+	const PACKAGE_VERSION = '3.3.2-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -110,7 +110,6 @@ const recommendationsRoutes = [
 	'/recommendations/vaultpress-for-woocommerce',
 ];
 
-const myJetpackRoutes = [ 'my-jetpack ' ];
 const dashboardRoutes = [ '/', '/dashboard', '/reconnect', '/my-plan', '/plans' ];
 const settingsRoutes = [
 	'/settings',
@@ -946,9 +945,8 @@ export default connect(
  *
  * @param pageOrder
  */
-window.wpNavMenuClassChange = function ( pageOrder = { myJetpack: 1, dashboard: 2, settings: 3 } ) {
+window.wpNavMenuClassChange = function ( pageOrder = { dashboard: 1, settings: 2 } ) {
 	let hash = window.location.hash;
-	let page = new URLSearchParams( window.location.search );
 
 	// Clear currently highlighted sub-nav item
 	jQuery( '.current' ).each( function ( i, obj ) {
@@ -965,11 +963,7 @@ window.wpNavMenuClassChange = function ( pageOrder = { myJetpack: 1, dashboard: 
 
 	// Set the current sub-nav item according to the current hash route
 	hash = hash.split( '?' )[ 0 ].replace( /#/, '' );
-	page = page.get( 'page' );
-
-	if ( myJetpackRoutes.includes( page ) ) {
-		getJetpackSubNavItem( pageOrder.myJetpack ).classList.add( 'current' );
-	} else if (
+	if (
 		dashboardRoutes.includes( hash ) ||
 		recommendationsRoutes.includes( hash ) ||
 		productDescriptionRoutes.includes( hash )

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -77,7 +77,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 */
 	public function jetpack_add_dashboard_sub_nav_item() {
 		if ( ( new Status() )->is_offline_mode() || Jetpack::is_connection_ready() ) {
-			add_submenu_page( 'jetpack', __( 'Dashboard', 'jetpack' ), __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/dashboard', '__return_null', 1 );
+			add_submenu_page( 'jetpack', __( 'Dashboard', 'jetpack' ), __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/dashboard', '__return_null' );
 			remove_submenu_page( 'jetpack', 'jetpack' );
 		}
 	}

--- a/projects/plugins/jetpack/changelog/revert-22655e3
+++ b/projects/plugins/jetpack/changelog/revert-22655e3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: revert
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/connection/connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/connection/connection.test.js
@@ -14,7 +14,7 @@ test.beforeEach( async ( { page } ) => {
 		.withWpComLoggedIn( true )
 		.build();
 	await DashboardPage.visit( page );
-	await ( await Sidebar.init( page ) ).selectJetpackSubMenuItem();
+	await ( await Sidebar.init( page ) ).selectJetpack();
 } );
 
 test( 'Site only connection', async ( { page } ) => {

--- a/projects/plugins/jetpack/tests/e2e/specs/pre-connection/pre-connection.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/pre-connection/pre-connection.test.js
@@ -43,7 +43,7 @@ test( 'Connect button is displayed on dashboard page', async ( { page } ) => {
 } );
 
 test( 'Connect button is displayed  on Jetpack page', async ( { page } ) => {
-	await ( await Sidebar.init( page ) ).selectJetpackSubMenuItem();
+	await ( await Sidebar.init( page ) ).selectJetpack();
 
 	const jetpackPage = await JetpackPage.init( page );
 	expect(

--- a/tools/e2e-commons/pages/wp-admin/sidebar.js
+++ b/tools/e2e-commons/pages/wp-admin/sidebar.js
@@ -7,14 +7,8 @@ export default class Sidebar extends WpPage {
 
 	async selectJetpack() {
 		const jetpackMenuSelector = '#toplevel_page_jetpack';
-		const menuItemSelector = '#toplevel_page_jetpack a[href$="admin.php?page=my-jetpack"]';
-
-		return await this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
-	}
-
-	async selectJetpackSubMenuItem() {
-		const jetpackMenuSelector = '#toplevel_page_jetpack';
-		const menuItemSelector = '#toplevel_page_jetpack .wp-submenu a[href$="admin.php?page=jetpack"]';
+		const menuItemSelector =
+			'#toplevel_page_jetpack a[href$="jetpack#/dashboard"], #toplevel_page_jetpack a[href$="jetpack"]';
 
 		return await this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
 	}


### PR DESCRIPTION
Fixes #32383

This reverts commit 22655e3d40ea6b70e4a7da1446e22c3c0617ce44.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Due to crashing the Jetpack dashboard for non-admins

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

