### PR TITLE
Dashboard: update subscribers link to always point to Calypso

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -13,7 +13,7 @@ import SubscriptionsSettings from './subscriptions-settings';
  * @returns {React.Component} Newsletter settings component.
  */
 function Subscriptions( props ) {
-	const { active, isModuleFound, searchTerm, siteAdminUrl, siteRawUrl } = props;
+	const { active, isModuleFound, searchTerm, siteRawUrl } = props;
 
 	const foundSubscriptions = isModuleFound( 'subscriptions' );
 
@@ -38,9 +38,7 @@ function Subscriptions( props ) {
 							/* dummy arg to avoid bad minification */ 0
 					  ) }
 			</h2>
-			{ foundSubscriptions && (
-				<SubscriptionsSettings siteAdminUrl={ siteAdminUrl } siteRawUrl={ siteRawUrl } />
-			) }
+			{ foundSubscriptions && <SubscriptionsSettings siteRawUrl={ siteRawUrl } /> }
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -11,19 +11,11 @@ import analytics from 'lib/analytics';
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import { isCurrentUserLinked, isUnavailableInOfflineMode, isOfflineMode } from 'state/connection';
-import {
-	isSubscriptionModalEnabled,
-	isWoASite as getIsWoASite,
-	isOdysseyStatsEnabled,
-} from 'state/initial-state';
+import { isSubscriptionModalEnabled } from 'state/initial-state';
 import { getModule } from 'state/modules';
 
 const trackViewSubsClick = () => {
 	analytics.tracks.recordJetpackClick( 'manage-subscribers' );
-};
-
-const trackViewSubsStatsClick = () => {
-	analytics.tracks.recordJetpackClick( 'subscribers-stats' );
 };
 
 /**
@@ -39,14 +31,10 @@ function SubscriptionsSettings( props ) {
 		isLinked,
 		isOffline,
 		isSavingAnyOption,
-		isStatsActive,
 		isStbEnabled,
 		isStcEnabled,
 		isSmEnabled,
 		isSubscriptionsActive,
-		isWoASite,
-		odysseyStatsEnabled,
-		siteAdminUrl,
 		siteRawUrl,
 		subscriptions,
 		toggleModuleNow,
@@ -68,19 +56,6 @@ function SubscriptionsSettings( props ) {
 	const getSubClickableCard = () => {
 		if ( unavailableInOfflineMode || ! isSubscriptionsActive || ! isLinked ) {
 			return '';
-		}
-
-		if ( isStatsActive && odysseyStatsEnabled && ! isWoASite ) {
-			return (
-				<Card
-					compact
-					className="jp-settings-card__configure-link"
-					onClick={ trackViewSubsStatsClick }
-					href={ `${ siteAdminUrl }admin.php?page=stats#!/stats/subscribers/${ siteRawUrl }` }
-				>
-					{ __( 'View your Subscribers', 'jetpack' ) }
-				</Card>
-			);
 		}
 
 		return (
@@ -199,12 +174,9 @@ export default withModuleSettingsFormHelpers(
 			isLinked: isCurrentUserLinked( state ),
 			isOffline: isOfflineMode( state ),
 			isSubscriptionsActive: ownProps.getOptionValue( 'subscriptions' ),
-			isStatsActive: ownProps.getOptionValue( 'stats' ),
-			odysseyStatsEnabled: isOdysseyStatsEnabled( state ),
 			hasSubscriptionModal: isSubscriptionModalEnabled( state ),
 			unavailableInOfflineMode: isUnavailableInOfflineMode( state, 'subscriptions' ),
 			subscriptions: getModule( state, 'subscriptions' ),
-			isWoASite: getIsWoASite( state ),
 			isStbEnabled: ownProps.getOptionValue( 'stb_enabled' ),
 			isStcEnabled: ownProps.getOptionValue( 'stc_enabled' ),
 			isSmEnabled: ownProps.getOptionValue( 'sm_enabled' ),

--- a/projects/plugins/jetpack/_inc/client/settings/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/settings/index.jsx
@@ -61,7 +61,6 @@ class Settings extends React.Component {
 					/>
 					<Subscriptions
 						siteRawUrl={ siteRawUrl }
-						siteAdminUrl={ siteAdminUrl }
 						active={ '/newsletter' === pathname }
 						{ ...commonProps }
 					/>

--- a/projects/plugins/jetpack/changelog/update-subs-link-card
+++ b/projects/plugins/jetpack/changelog/update-subs-link-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: update link to Subscribers to always point to WordPress.com.


### PR DESCRIPTION
## Proposed changes:

Let's always point folks towards the Calypso page when they need to have more information about their subscribers. We previously pointed to the Subscriber Stats page in wp-admin when the Stats module was active, but that page does not include as much information as the Calypso page for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See https://github.com/Automattic/jetpack/pull/31718#issuecomment-1671992894

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Newsletter
* Check the link at the bottom the Subscriptions card when the feature is active; it should point to Calypso.
