### PR TITLE
AI Extension: fix visual issue of AI toolbar when editor sidebar is opened

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-ai-assistant-visual-issue-sidebar
+++ b/projects/plugins/jetpack/changelog/update-fix-ai-assistant-visual-issue-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: fix visual issue of AI toolbar when editor sidebar is opened

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -4,6 +4,7 @@
 import { aiAssistantIcon, useAiContext } from '@automattic/jetpack-ai-client';
 import { KeyboardShortcuts, Popover, ToolbarButton } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { useContext, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect } from 'react';
@@ -23,9 +24,13 @@ export default function AiAssistantToolbarButton( {
 	const { isVisible, toggle, setAssistantFixed, isFixed } = useContext( AiAssistantUiContext );
 	const { requestingState } = useAiContext();
 
+	// Check if the sidebar is Opened
+	const isSidebarOpened = useSelect( select => {
+		return select( 'core/edit-post' ).isEditorSidebarOpened();
+	}, [] );
+
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
-	useViewportMatch;
 	const [ barAnchor, setBarAnchor ] = React.useState< HTMLElement | null >( null );
 
 	/*
@@ -56,9 +61,10 @@ export default function AiAssistantToolbarButton( {
 	}, [ setAssistantFixed, isVisible, isMobileViewport ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
+	const showAiToolbar = isVisible && isFixed && barAnchor && ! isSidebarOpened;
 	return (
 		<>
-			{ isVisible && isFixed && barAnchor && (
+			{ showAiToolbar && (
 				<Popover
 					anchor={ barAnchor }
 					variant="toolbar"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR hides the assistant toolbar when the editor sidebar is opened.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: fix visual issue of AI toolbar when editor sidebar is opened

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* create a Jetpack Form block instance
* Set mobile view
* Open the AI Assistant bar
* Open the editor sidebar

Before | After
------|-------
<img width="386" alt="Screenshot 2023-08-10 at 10 57 00" src="https://github.com/Automattic/jetpack/assets/77539/4bf9907a-c1a7-4774-be31-1b500bc39529"> | <img width="379" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/7aae5449-0ab6-419c-aeda-cb66e8942437">


