### PR TITLE
Repo Gardening: label issues with support references

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-happiness-request-labelling
+++ b/projects/github-actions/repo-gardening/changelog/add-happiness-request-labelling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gather Support References task: automatically label issues that include support references.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -389,6 +389,35 @@ async function createOrUpdateComment( payload, octokit, issueReferences, issueCo
 }
 
 /**
+ * Add a label to the issue, if it does not exist yet.
+ *
+ * @param {GitHub} octokit       - Initialized Octokit REST client.
+ * @param {string} ownerLogin    - Repository owner login.
+ * @param {string} repo          - Repository name.
+ * @param {number} number        - Issue number.
+ * @returns {Promise<void>}
+ */
+async function addHappinessLabel( octokit, ownerLogin, repo, number ) {
+	const happinessLabel = '[Type] Happiness Request';
+
+	const labels = await getLabels( octokit, ownerLogin, repo, number );
+	if ( labels.includes( happinessLabel ) ) {
+		debug(
+			`gather-support-references: Issue #${ number } already has the "${ happinessLabel }" label.`
+		);
+		return;
+	}
+
+	debug( `gather-support-references: Adding ${ happinessLabel } label to issue #${ number }` );
+	await octokit.rest.issues.addLabels( {
+		owner: ownerLogin,
+		repo,
+		issue_number: number,
+		labels: [ happinessLabel ],
+	} );
+}
+
+/**
  * Post or update a comment with a to-do list of all support references on that issue.
  *
  * @param {WebhookPayloadIssue} payload - Issue or issue comment event payload.
@@ -404,6 +433,7 @@ async function gatherSupportReferences( payload, octokit ) {
 	if ( issueReferences.length > 0 ) {
 		debug( `gather-support-references: Found ${ issueReferences.length } references.` );
 		await createOrUpdateComment( payload, octokit, issueReferences, issueComments );
+		await addHappinessLabel( octokit, owner.login, repo, number );
 	}
 }
 

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
@@ -2,7 +2,7 @@
 
 Happiness Engineers can comment on issues to add references to support interactions with customers that would like to be updated whenever the problem is solved.
 
-This task creates a new comment that lists all support references found in all comments on the issue.
+This task creates a new comment that lists all support references found in all comments on the issue. If it finds a support reference, it will also add a label to the issue, "[Type] Happiness Request".
 
 The tasks also monitors the number of support references it has gathered:
 


### PR DESCRIPTION
## Proposed changes:

This is something that has happened via a GitHub webhook for the past few years.
However, since we now have a task that does look for support references in issues, we may as well add the label through that task and retire the webhook imo.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* Internal reference: p1691543440826329-slack-CQD1HH4MA
* Once this is merged, I will remove the logic that achieved the same result via a webhook, in D118593-code and D118594-code.

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This is hard to test in this repo before this gets merged, but we can check in another repo. In the issue below, the label was automatically added by the task after a comment with a support reference was added:
https://github.com/jeherve/jetpack/issues/93
