### PR TITLE
AI Extension: clean up unusable remnant code

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-clean
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: clean up unusable remnant code

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -102,7 +102,7 @@ const withAiAssistantComponents = createHigherOrderComponent( BlockEdit => {
 				<AiAssistantAnchor clientId={ props.clientId } />
 
 				<BlockControls { ...blockControlsProps }>
-					<AiAssistantToolbarButton />
+					<AiAssistantToolbarButton clientId={ props.clientId } />
 				</BlockControls>
 			</>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/context.tsx
@@ -10,26 +10,6 @@ export type AiAssistantUiContextProps = {
 
 	isFixed: boolean;
 
-	popoverProps?: {
-		anchor?: HTMLElement | null;
-		offset?: number;
-		variant?: 'toolbar' | 'unstyled';
-		placement?:
-			| 'top'
-			| 'top-start'
-			| 'top-end'
-			| 'right'
-			| 'right-start'
-			| 'right-end'
-			| 'bottom'
-			| 'bottom-start'
-			| 'bottom-end'
-			| 'left'
-			| 'left-start'
-			| 'left-end'
-			| 'overlay';
-	};
-
 	setInputValue: ( value: string ) => void;
 
 	show: () => void;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -13,7 +13,7 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { isPossibleToExtendJetpackFormBlock } from '..';
 import { fixIncompleteHTML } from '../../../lib/utils/fix-incomplete-html';
-import { AiAssistantUiContextProps, AiAssistantUiContextProvider } from './context';
+import { AiAssistantUiContextProvider } from './context';
 /**
  * Types
  */
@@ -30,7 +30,7 @@ const AI_ASSISTANT_JETPACK_FORM_NOTICE_ID = 'ai-assistant';
  * @param {boolean} isVisible - Is the AI Assistant visible?
  * @returns {void}
  */
-export function handleAiExtensionsBarBodyClass( isFixed: boolean, isVisible: boolean ) {
+export function handleAiExtensionsBarBodyClass( isFixed: boolean, isVisible: boolean ): void {
 	if ( isFixed && isVisible ) {
 		return document.body.classList.add( 'jetpack-ai-assistant-bar-is-fixed' );
 	}
@@ -50,13 +50,6 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 
 		// AI Assistant component is-fixed state
 		const [ isFixed, setAssistantFixed ] = useState( false );
-
-		// AI Assistant popover props
-		const [ popoverProps ] = useState< AiAssistantUiContextProps[ 'popoverProps' ] >( {
-			anchor: null,
-			placement: 'bottom-start',
-			offset: 12,
-		} );
 
 		// Keep track of the current list of valid blocks between renders.
 		const currentListOfValidBlocks = useRef( [] );
@@ -144,20 +137,9 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 
 				// Assistant bar position and size.
 				isFixed,
-				popoverProps,
 				setAssistantFixed,
 			} ),
-			[
-				inputValue,
-				setInputValue,
-				isVisible,
-				show,
-				hide,
-				toggle,
-				isFixed,
-				popoverProps,
-				setAssistantFixed,
-			]
+			[ inputValue, setInputValue, isVisible, show, hide, toggle, isFixed, setAssistantFixed ]
 		);
 
 		const setContent = useCallback(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR cleans up unusable remnant code.
Also, it adds the missed `clientId` in the `AiAssistantToolbarButton` instance.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: clean up unusable remnant code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test the app. It should work as usual,.

