### PR TITLE
AI Form Extension: Remove error notice on new request

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-assistant-close-notice
+++ b/projects/js-packages/ai-client/changelog/update-ai-assistant-close-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+AI Client: Remove redundant switch case

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -145,14 +145,6 @@ export function getErrorData( errorCode: SuggestionErrorCode ): RequestingErrorP
 				severity: 'info',
 			};
 		case ERROR_NETWORK:
-			return {
-				code: ERROR_NETWORK,
-				message: __(
-					'It was not possible to process your request. Mind trying again?',
-					'jetpack-ai-client'
-				),
-				severity: 'info',
-			};
 		default:
 			return {
 				code: ERROR_NETWORK,

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-close-notice
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-close-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Form Extension: Remove error notice on new request

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -4,8 +4,10 @@
 import { useAiContext, AIControl } from '@automattic/jetpack-ai-client';
 import { serialize } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useContext, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
@@ -14,6 +16,7 @@ import UpgradePrompt from '../../../../components/upgrade-prompt';
 import useAIFeature from '../../../../hooks/use-ai-feature';
 import { PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, getPrompt } from '../../../../lib/prompt';
 import { AiAssistantUiContext } from '../../ui-handler/context';
+import { AI_ASSISTANT_JETPACK_FORM_NOTICE_ID } from '../../ui-handler/with-ui-handler-data-provider';
 
 /**
  * Return the serialized content from the childrens block.
@@ -60,14 +63,19 @@ export default function AiAssistantBar( {
 
 	const loadingPlaceholder = __( 'Creating your form. Please wait a few moments.', 'jetpack' );
 
+	const { removeNotice } = useDispatch( noticesStore );
+
 	const onSend = useCallback( () => {
+		// Remove previous error notice.
+		removeNotice( AI_ASSISTANT_JETPACK_FORM_NOTICE_ID );
+
 		const prompt = getPrompt( PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, {
 			request: inputValue,
 			content: getSerializedContentFromBlock( clientId ),
 		} );
 
 		requestSuggestion( prompt, { feature: 'jetpack-form-ai-extension' } );
-	}, [ clientId, inputValue, requestSuggestion ] );
+	}, [ clientId, inputValue, removeNotice, requestSuggestion ] );
 
 	return (
 		<div className={ classNames( 'jetpack-ai-assistant__bar', className ) }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -20,7 +20,7 @@ import { AiAssistantUiContextProps, AiAssistantUiContextProvider } from './conte
 import type { RequestingErrorProps } from '@automattic/jetpack-ai-client';
 
 // An identifier to use on the extension error notices,
-const AI_ASSISTANT_JETPACK_FORM_NOTICE_ID = 'ai-assistant';
+export const AI_ASSISTANT_JETPACK_FORM_NOTICE_ID = 'ai-assistant';
 
 /**
  * Add the `jetpack-ai-assistant-bar-is-fixed` class to the body


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32381

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes any notice with the `ai_assistant` id when sending a new request

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form
* Cause an error (like forcing it on code or turning off network temporarily)
* Check that the error notice is displayed
* Sendo another request
* Check that the error notice is removed
