### PR TITLE
Newsletters: Render subscriptions block on emails

### DIFF
--- a/projects/plugins/jetpack/changelog/update-emails-render-subscriptions-block
+++ b/projects/plugins/jetpack/changelog/update-emails-render-subscriptions-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Render Subscriptions block on emails

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -407,11 +407,90 @@ function get_element_styles_from_attributes( $attributes ) {
 		$email_field_styles   .= $style;
 	}
 
+	if ( ! jetpack_is_frontend() ) {
+		$background_color_style = get_attribute_color( 'buttonBackgroundColor', $attributes, '#113AF5' /* default lettre theme color */ );
+		$text_color_style       = get_attribute_color( 'textColor', $attributes, '#FFFFFF' );
+		$submit_button_styles  .= sprintf( ' background-color: %s; color: %s;', $background_color_style, $text_color_style );
+	}
+
 	return array(
 		'email_field'           => $email_field_styles,
 		'submit_button'         => $submit_button_styles,
 		'submit_button_wrapper' => $submit_button_wrapper_styles,
 	);
+}
+
+/**
+ * Retrieve the resolved color for a given attribute.
+ *
+ * @param string $attribute_name The name of the attribute to resolve.
+ * @param array  $attributes     An array of all attributes.
+ * @param string $default_color  A fallback color in case no color can be resolved.
+ *
+ * @return string Returns the resolved color or the default color if no color is found.
+ */
+function get_attribute_color( $attribute_name, $attributes, $default_color ) {
+	if ( has_attribute( $attributes, $attribute_name ) ) {
+		$color_slug     = get_attribute( $attributes, $attribute_name );
+		$resolved_color = get_color_from_slug( $color_slug );
+
+		if ( $resolved_color ) {
+			return $resolved_color;
+		}
+	}
+
+	return get_global_style_color( $attribute_name, $default_color );
+}
+
+/**
+ * Retrieve the global style color based on a provided style key.
+ *
+ * @param string $style_key     The key for the desired style.
+ * @param string $default_color A fallback color in case the global style is not set.
+ *
+ * @return string Returns the color defined in global styles or the default color if not defined.
+ */
+function get_global_style_color( $style_key, $default_color ) {
+	$global_styles = wp_get_global_styles(
+		array( 'color' ),
+		array(
+			'block_name' => 'core/button',
+			'transforms' => array( 'resolve-variables' ),
+		)
+	);
+
+	if ( isset( $global_styles[ $style_key ] ) ) {
+		return $global_styles[ $style_key ];
+	}
+
+	return $default_color;
+}
+
+/**
+ * Convert a color slug into its corresponding color value.
+ *
+ * @param string $slug The slug representation of the color.
+ *
+ * @return string|null Returns the color value if found, or null otherwise.
+ */
+function get_color_from_slug( $slug ) {
+	$color_palettes = wp_get_global_settings( array( 'color', 'palette' ) );
+
+	if ( ! is_array( $color_palettes ) ) {
+		return null;
+	}
+
+	foreach ( $color_palettes as $palette ) {
+		if ( is_array( $palette ) ) {
+			foreach ( $palette as $color ) {
+				if ( isset( $color['slug'] ) && $color['slug'] === $slug && isset( $color['color'] ) ) {
+					return $color['color'];
+				}
+			}
+		}
+	}
+
+	return null;
 }
 
 /**
@@ -448,8 +527,9 @@ function render_block( $attributes ) {
 	// The block is using the Jetpack_Subscriptions_Widget backend, hence the need to increase the instance count.
 	++Jetpack_Subscriptions_Widget::$instance_count;
 
-	$classes                  = get_element_class_names_from_attributes( $attributes );
-	$styles                   = get_element_styles_from_attributes( $attributes );
+	$classes = get_element_class_names_from_attributes( $attributes );
+	$styles  = get_element_styles_from_attributes( $attributes );
+
 	$include_social_followers = isset( $attributes['includeSocialFollowers'] ) ? (bool) get_attribute( $attributes, 'includeSocialFollowers' ) : true;
 
 	$data = array(
@@ -477,6 +557,9 @@ function render_block( $attributes ) {
 		'source'                 => 'subscribe-block',
 	);
 
+	if ( ! jetpack_is_frontend() ) {
+		return render_for_email( $data, $styles );
+	}
 	if ( is_wpcom() ) {
 		return render_wpcom_subscribe_form( $data, $classes, $styles );
 	}
@@ -721,6 +804,36 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 	<?php
 
 	return ob_get_clean();
+}
+
+/**
+ * Renders the email version of the subscriptions block.
+ *
+ * @param array $data    Array containing block view data.
+ * @param array $styles  Array containing the styles for different block elements.
+ *
+ * @return string
+ */
+function render_for_email( $data, $styles ) {
+	$submit_button_wrapper_style = ! empty( $styles['submit_button_wrapper'] ) ? 'style="' . esc_attr( $styles['submit_button_wrapper'] ) . '"' : '';
+	$button_text                 = wp_kses(
+		html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+		Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+	);
+
+	$html = '<div ' . wp_kses_data( $data['wrapper_attributes'] ) . '>
+		<div>
+			<div>
+				<div>
+					<p ' . $submit_button_wrapper_style . '>
+						<a href="' . esc_url( get_post_permalink() ) . '" style="text-decoration: none; ' . esc_attr( $styles['submit_button'] ) . '">' . $button_text . '</a>
+					</p>
+				</div>
+			</div>
+		</div>
+	</div>';
+
+	return $html;
 }
 
 /**


### PR DESCRIPTION
## Proposed changes:

Improve how the Subscriptions block renders on emails.

*  Add a specific rendering method tailored for email display.
*  Use block attributes or global styles if defined.

POST:
<img width="1151" alt="Screenshot 2023-08-10 at 18 22 12" src="https://github.com/Automattic/jetpack/assets/104869/d7e45116-be4d-4a08-83df-4c6e698c4731">

EMAIL:
<img width="1046" alt="Screenshot 2023-08-10 at 18 22 57" src="https://github.com/Automattic/jetpack/assets/104869/c92eaa10-6db9-40e7-b083-4f85b328f1c5">

(Pardon my French, that's a separate bug :))

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

* Follow the instructions in D118655-code
* Try updating the block attributes. These should reflect on the emails.

