### PR TITLE
Subscriptions: Ensure subscribe modal shows in site editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-in-editor
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-in-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Ensure subscribe modal shows in editor.


### PR DESCRIPTION
**For now, this is a trial PR intended to spur discussion.**

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The Subscribe Modal recently stopped showing in the site editor. We believe this is related to changes in Gutenberg around the release of 16.3.0.

I haven't been able to figure out quite what broke with the prior approach we were using. 

For now, this PR trials and demos a fix based onhow the template part is added: using `wp_insert_post()` to add the template part to the database, vs using the `get_block_template` and `get_block_templates` filters. This may not be the best approach, so feedback is welcome. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Test on self hosted site.
   - You'll need jurassic tube connected test site.
   - Add add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 ); to tools/docker/mu-plugins/0-sandbox.php. Without this, the modal won't show or load outside of WordPress.com. I don't think it's needed, but you may need to re-install WordPress in your jetpack dev environment.
   - Go to Jetpack > Settings > Newsletters, and enable the subscription module and the subscriber modal.
   - Go to the Site Editor and look under Template Parts > General. Confirm you see the Subscribe Modal template part.
   - In a non-logged-in browser, go to a single post on the front end of your test site, scroll, pause, and confirm the modal shows.
   
2) Test on simple sites.
   - You will need a simple site that has site_intent of newsletter or Lettre theme active. If you need one, you can create one via the newsletter onboarding flow at https://wordpress.com/setup/newsletter/intro.
   - Go to Settings > Reading > Newsletters and enable the subcriber modal. 
   - Go to the Site Editor and look under Template Parts > General. Confirm you see the Subscribe Modal template part.
   - In a non-logged-in browser, go to a single post on the front end of your test site, scroll, pause, and confirm the modal shows.
  