### PR TITLE
AI Extension: improve show/hide assistant bar when fixed

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fixed-and-visible-mode-fix
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fixed-and-visible-mode-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: improve show/hide assistant bar when fixed

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -12,7 +12,6 @@ import React, { useEffect } from 'react';
  * Internal dependencies
  */
 import { AiAssistantUiContext } from '../../ui-handler/context';
-import { handleAiExtensionsBarBodyClass } from '../../ui-handler/with-ui-handler-data-provider';
 import AiAssistantBar from '../ai-assistant-bar';
 import './style.scss';
 
@@ -55,9 +54,8 @@ export default function AiAssistantToolbarButton( {
 		// Set the anxhor where the Assistant Bar will be rendered.
 		setBarAnchor( toolbar );
 
-		// Fix the Assistant Bar if the Toolbar Block is fixed and the viewport is mobile.
+		// Fix the assistant toolbar in mobile
 		setAssistantFixed( isMobileViewport );
-		handleAiExtensionsBarBodyClass( isMobileViewport, isVisible );
 	}, [ setAssistantFixed, isVisible, isMobileViewport ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -24,9 +24,10 @@ export default function AiAssistantToolbarButton( {
 	const { requestingState } = useAiContext();
 
 	// Check if the sidebar is Opened
-	const isSidebarOpened = useSelect( select => {
-		return select( 'core/edit-post' ).isEditorSidebarOpened();
-	}, [] );
+	const isSidebarOpened = useSelect(
+		select => select( 'core/edit-post' )?.isEditorSidebarOpened(), // 'core/edit-post' could not exist in some cases (P2s, full site editing)
+		[]
+	);
 
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -4,9 +4,9 @@
 import { useAiContext, withAiDataProvider } from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, useViewportMatch } from '@wordpress/compose';
 import { select } from '@wordpress/data';
-import { useEffect, useCallback } from '@wordpress/element';
+import { useEffect, useCallback, useContext } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 /*
  * Internal dependencies
@@ -16,7 +16,10 @@ import { isUserConnected } from '../../lib/connection';
 import AiAssistantAnchor from './components/ai-assistant-anchor';
 import AiAssistantToolbarButton from './components/ai-assistant-toolbar-button';
 import { isJetpackFromBlockAiCompositionAvailable } from './constants';
-import withUiHandlerDataProvider from './ui-handler/with-ui-handler-data-provider';
+import { AiAssistantUiContext } from './ui-handler/context';
+import withUiHandlerDataProvider, {
+	handleAiExtensionsBarBodyClass,
+} from './ui-handler/with-ui-handler-data-provider';
 
 /**
  * Check if it is possible to extend the block.
@@ -73,6 +76,7 @@ const withAiAssistantComponents = createHigherOrderComponent( BlockEdit => {
 			return <BlockEdit { ...props } />;
 		}
 		const { eventSource } = useAiContext();
+		const { isVisible } = useContext( AiAssistantUiContext );
 
 		const stopSuggestion = useCallback( () => {
 			if ( ! eventSource ) {
@@ -94,6 +98,11 @@ const withAiAssistantComponents = createHigherOrderComponent( BlockEdit => {
 		const blockControlsProps = {
 			group: 'block',
 		};
+
+		const isMobileViewport = useViewportMatch( 'medium', '<' );
+		useEffect( () => {
+			handleAiExtensionsBarBodyClass( isMobileViewport, isVisible );
+		}, [ isMobileViewport, isVisible ] );
 
 		return (
 			<>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -4,7 +4,7 @@
 import { useAiContext } from '@automattic/jetpack-ai-client';
 import { parse } from '@wordpress/blocks';
 import { KeyboardShortcuts } from '@wordpress/components';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
@@ -121,6 +121,11 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			}
 			hide();
 		}, [ isSelected, hide ] );
+
+		const isMobileViewport = useViewportMatch( 'medium', '<' );
+		useEffect( () => {
+			handleAiExtensionsBarBodyClass( isMobileViewport, isVisible );
+		}, [ isMobileViewport, isVisible ] );
 
 		// Build the context value to pass to the provider.
 		const contextValue = useMemo(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -4,7 +4,7 @@
 import { useAiContext } from '@automattic/jetpack-ai-client';
 import { parse } from '@wordpress/blocks';
 import { KeyboardShortcuts } from '@wordpress/components';
-import { createHigherOrderComponent, useViewportMatch } from '@wordpress/compose';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
@@ -121,11 +121,6 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			}
 			hide();
 		}, [ isSelected, hide ] );
-
-		const isMobileViewport = useViewportMatch( 'medium', '<' );
-		useEffect( () => {
-			handleAiExtensionsBarBodyClass( isMobileViewport, isVisible );
-		}, [ isMobileViewport, isVisible ] );
 
 		// Build the context value to pass to the provider.
 		const contextValue = useMemo(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This pull request addresses a visual issue that occurs when displaying or hiding the assistant bar in fixed mode. Essentially, it moves the code responsible for adding or removing a CSS class to the body element to the Block Edit component level, which eliminates unnecessary calls to it.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: improve show/hide assistant bar when fixed

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form assistant block instance
* Test o mobile 

1) Select the form
2) Show the assistant toolbar 
3) Click out of either the toolbar or the block representation:

<img width="721" alt="Screenshot 2023-08-11 at 08 10 16" src="https://github.com/Automattic/jetpack/assets/77539/648d3ba0-993d-4e66-ac7d-3e441e37cee0">

4) **BEFORE**: Confirm the canvas shows an undesired space at the top of it
<img width="747" alt="Screenshot 2023-08-11 at 08 12 01" src="https://github.com/Automattic/jetpack/assets/77539/e938fac9-57b9-4306-956f-2d52448bc487">

5) **AFTER**: no extra space there
