### PR TITLE
AI Extension: improve show/hide assistant bar when fixed

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-auto-switch-mobile-mode
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-auto-switch-mobile-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: tweaks assistant bar in narrow spaces

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -65,6 +65,7 @@ export default function AiAssistantBar( {
 	clientId: string;
 	className?: string;
 } ) {
+	const wrapperRef = useRef< HTMLDivElement >( null );
 	const inputRef = useRef< HTMLInputElement >( null );
 
 	const { requireUpgrade } = useAIFeature();
@@ -113,7 +114,7 @@ export default function AiAssistantBar( {
 
 	useEffect( () => {
 		// Get the Assistant bar DOM element.
-		const barElement = inputRef.current.closest( '.jetpack-ai-assistant__bar' );
+		const barElement = wrapperRef?.current;
 		if ( ! barElement ) {
 			return;
 		}
@@ -150,7 +151,7 @@ export default function AiAssistantBar( {
 	}, [ debounceUpdateIsMobileMode, isFixed ] );
 
 	return (
-		<div className={ classNames( 'jetpack-ai-assistant__bar', className ) }>
+		<div ref={ wrapperRef } className={ classNames( 'jetpack-ai-assistant__bar', className ) }>
 			{ requireUpgrade && <UpgradePrompt /> }
 			<AIControl
 				ref={ inputRef }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -3,9 +3,10 @@
  */
 import { useAiContext, AIControl } from '@automattic/jetpack-ai-client';
 import { serialize } from '@wordpress/blocks';
+import { debounce } from '@wordpress/compose';
 import { select } from '@wordpress/data';
 import { useDispatch } from '@wordpress/data';
-import { useContext, useCallback, useRef } from '@wordpress/element';
+import { useContext, useCallback, useRef, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 /**
@@ -17,6 +18,19 @@ import useAIFeature from '../../../../hooks/use-ai-feature';
 import { PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT, getPrompt } from '../../../../lib/prompt';
 import { AiAssistantUiContext } from '../../ui-handler/context';
 import { AI_ASSISTANT_JETPACK_FORM_NOTICE_ID } from '../../ui-handler/with-ui-handler-data-provider';
+
+/*
+ * Core viewport breakpoints.
+ * @see https://github.com/WordPress/gutenberg/blob/d5d8533cf2cc04bb005bda147114cf00782d6c38/packages/base-styles/_breakpoints.scss#L5-L14
+ */
+const BREAKPOINTS = {
+	huge: 1440,
+	wide: 1280,
+	large: 960,
+	medium: 782,
+	small: 600,
+	mobile: 480,
+};
 
 /**
  * Return the serialized content from the childrens block.
@@ -85,6 +99,44 @@ export default function AiAssistantBar( {
 		requestSuggestion( prompt, { feature: 'jetpack-form-ai-extension' } );
 	}, [ clientId, inputValue, removeNotice, requestSuggestion ] );
 
+	/*
+	 * Auto-resize mode.
+	 * Update the bar layout depending on the component width.
+	 */
+	const [ isMobileMode, setMobileMode ] = useState( isFixed );
+
+	const observerRef = useRef( null );
+
+	// Debounce the resize event.
+	const debounceUpdateIsMobileMode = debounce( setMobileMode, 300 );
+
+	useEffect( () => {
+		// Get the Assistant bar DOM element.
+		const barElement = inputRef.current.closest( '.jetpack-ai-assistant__bar' );
+		if ( ! barElement ) {
+			return;
+		}
+
+		// Only create a new observer if there isn't one already
+		if ( ! observerRef.current ) {
+			observerRef.current = new ResizeObserver( entries => {
+				const barWidth = entries[ 0 ].contentRect.width;
+				debounceUpdateIsMobileMode( barWidth < BREAKPOINTS.mobile );
+			} );
+		}
+
+		// Start observing the Assistant bar element.
+		observerRef.current.observe( barElement );
+
+		return () => {
+			// Disconnect the observer when the component is unmounted.
+			observerRef.current?.disconnect();
+
+			// Also, cancel any pending debounce.
+			debounceUpdateIsMobileMode.cancel();
+		};
+	}, [ debounceUpdateIsMobileMode ] );
+
 	return (
 		<div className={ classNames( 'jetpack-ai-assistant__bar', className ) }>
 			{ requireUpgrade && <UpgradePrompt /> }
@@ -98,7 +150,7 @@ export default function AiAssistantBar( {
 				onStop={ stopSuggestion }
 				state={ requestingState }
 				isOpaque={ requireUpgrade }
-				showButtonsLabel={ ! isFixed }
+				showButtonsLabel={ isMobileMode || isFixed }
 			/>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -3,7 +3,6 @@
  */
 import { useAiContext, AIControl } from '@automattic/jetpack-ai-client';
 import { serialize } from '@wordpress/blocks';
-import { debounce } from '@wordpress/compose';
 import { select } from '@wordpress/data';
 import { useDispatch } from '@wordpress/data';
 import { useContext, useCallback, useRef, useState, useEffect } from '@wordpress/element';
@@ -109,9 +108,6 @@ export default function AiAssistantBar( {
 
 	const observerRef = useRef( null );
 
-	// Debounce the resize event.
-	const debounceUpdateIsMobileMode = debounce( () => ( isMobileModeRef.current = isFixed ), 100 );
-
 	useEffect( () => {
 		// Get the Assistant bar DOM element.
 		const barElement = wrapperRef?.current;
@@ -144,11 +140,8 @@ export default function AiAssistantBar( {
 		return () => {
 			// Disconnect the observer when the component is unmounted.
 			observerRef.current?.disconnect();
-
-			// Also, cancel any pending debounce.
-			debounceUpdateIsMobileMode.cancel();
 		};
-	}, [ debounceUpdateIsMobileMode, isFixed ] );
+	}, [ isFixed ] );
 
 	return (
 		<div ref={ wrapperRef } className={ classNames( 'jetpack-ai-assistant__bar', className ) }>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -4,7 +4,7 @@
 import { useAiContext } from '@automattic/jetpack-ai-client';
 import { parse } from '@wordpress/blocks';
 import { KeyboardShortcuts } from '@wordpress/components';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
@@ -121,6 +121,11 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			}
 			hide();
 		}, [ isSelected, hide ] );
+
+		const isMobileViewport = useViewportMatch( 'medium', '<' );
+		useEffect( () => {
+			handleAiExtensionsBarBodyClass( isMobileViewport, isVisible );
+		}, [ isMobileViewport, isVisible ] );
 
 		// Build the context value to pass to the provider.
 		const contextValue = useMemo(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -4,7 +4,7 @@
 import { useAiContext } from '@automattic/jetpack-ai-client';
 import { parse } from '@wordpress/blocks';
 import { KeyboardShortcuts } from '@wordpress/components';
-import { createHigherOrderComponent, useViewportMatch } from '@wordpress/compose';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
@@ -121,11 +121,6 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			}
 			hide();
 		}, [ isSelected, hide ] );
-
-		const isMobileViewport = useViewportMatch( 'medium', '<' );
-		useEffect( () => {
-			handleAiExtensionsBarBodyClass( isMobileViewport, isVisible );
-		}, [ isMobileViewport, isVisible ] );
 
 		// Build the context value to pass to the provider.
 		const contextValue = useMemo(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This proposal outlines a method for the Assistant bar to switch to the "mobile" mode automatically.
It aims to improve the component representation when placed in narrow places.

Fixes https://github.com/Automattic/jetpack/issues/32415

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: improve show/hide assistant bar when fixed

### Other information:


- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Start to reduce the canvas space by activating the sidebar of the List view bar
* Confirm how the Assistant bar changes its mode to mobile depending on the available space in the canvas

<img width="869" alt="Screenshot 2023-08-11 at 10 55 14" src="https://github.com/Automattic/jetpack/assets/77539/e32b53e1-cb8e-4dff-9384-e04f39012420">

<img width="868" alt="Screenshot 2023-08-11 at 10 55 37" src="https://github.com/Automattic/jetpack/assets/77539/fd4f1fa8-f114-4e1e-b13c-26ffbd725f94">


<img width="1170" alt="Screenshot 2023-08-11 at 10 56 43" src="https://github.com/Automattic/jetpack/assets/77539/2cb9ffbf-641b-43ec-b3f0-d082f147e716">


### 🍿 
https://github.com/Automattic/jetpack/assets/77539/74e21c34-9097-4591-8bed-3f2047050c01


