### PR TITLE
AI Assistant: Move from origami to arrowUp icon

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-send-icon
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-send-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Move to arrowUp icon at send button

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-control/index.js
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { aiAssistantIcon, origamiPlaneIcon } from '@automattic/jetpack-ai-client';
+import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import { PlainText } from '@wordpress/block-editor';
 import { Button, Icon, Spinner } from '@wordpress/components';
 import { useKeyboardShortcut } from '@wordpress/compose';
 import { forwardRef, useImperativeHandle, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { closeSmall, check } from '@wordpress/icons';
+import { closeSmall, check, arrowUp } from '@wordpress/icons';
 /*
  * Internal dependencies
  */
@@ -186,7 +186,7 @@ const AIControl = forwardRef(
 										disabled={ ! userPrompt?.length || ! connected || requireUpgrade }
 										label={ __( 'Send request', 'jetpack' ) }
 									>
-										<Icon icon={ origamiPlaneIcon } />
+										<Icon icon={ arrowUp } />
 										{ ! isSm && __( 'Send', 'jetpack' ) }
 									</Button>
 								) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Reference: p1691754780642529/1691686037.451339-slack-C054LN8RNVA

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move from `origami` to `arrowUp` icon, to keep consistency.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add `AI Assistant` block.
* Check if `Send` icon is `arrowUp`.

#### Demo

![CleanShot 2023-08-11 at 09 13 48](https://github.com/Automattic/jetpack/assets/1663717/941c0e06-db4a-4cee-97b4-55ca5746696a)
