### PR TITLE
Copy block.json files in Jetpack extensions build

### DIFF
--- a/projects/plugins/jetpack/changelog/add-extensions-build-block-json
+++ b/projects/plugins/jetpack/changelog/add-extensions-build-block-json
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Copy block.json files in Jetpack extensions build

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -192,6 +192,16 @@ module.exports = [
 					},
 				],
 			} ),
+			new CopyWebpackPlugin( {
+				patterns: [
+					{
+						from: '**/block.json',
+						to: '[path][name][ext]',
+						context: path.join( __dirname, '../extensions/blocks' ),
+						noErrorOnMissing: true,
+					},
+				],
+			} ),
 			new CopyBlockEditorAssetsPlugin(),
 		],
 	},


### PR DESCRIPTION

See #32408

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Update the Jetpack extensions build to copy `block.json` metatada files to their matching folders in `jetpack/_inc/blocks`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pedMtX-RS-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Add an empty `block.json` file in any folder in `/projects/plugins/jetpack/extensions/blocks/`
- From `projects/plugins/jetpack`, run `rm -rf _inc/blocks && pnpm build-extensions`
- Notice the `block.json` file was copied in `jetpack/_inc/blocks`