### PR TITLE
Add block.json metadata file to beta blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-beta-blocks-metadata-files
+++ b/projects/plugins/jetpack/changelog/add-jetpack-beta-blocks-metadata-files
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add block.json metadata file to beta blocks

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/block.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/ai-chat",
+	"title": "AI Chat (Experimental)",
+	"description": "Provides summarized chat across a site’s content, powered by AI magic.",
+	"keywords": [ "AI", "GPT", "Chat", "Search" ],
+	"version": "12.5.0",
+	"textdomain": "jetpack",
+	"category": "text",
+	"icon": "superhero",
+	"supports": {
+		"align": true,
+		"alignWide": true,
+		"customClassName": true,
+		"className": true,
+		"html": false,
+		"multiple": false,
+		"reusable": false
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/block.json
@@ -17,5 +17,6 @@
 		"html": false,
 		"multiple": false,
 		"reusable": false
-	}
+	},
+	"editorScript": "file:../editor-beta.js"
 }

--- a/projects/plugins/jetpack/extensions/blocks/amazon/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/amazon/block.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/amazon",
+	"title": "Amazon",
+	"description": "Promote Amazon products and earn a commission from sales.",
+	"keywords": [ "amazon", "affiliate" ],
+	"version": "12.5.0",
+	"textdomain": "jetpack",
+	"category": "earn",
+	"icon": "amazon",
+	"supports": {
+		"align": true,
+		"alignWide": false,
+		"html": false
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/amazon/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/amazon/block.json
@@ -13,5 +13,6 @@
 		"align": true,
 		"alignWide": false,
 		"html": false
-	}
+	},
+	"editorScript": "file:../editor-beta.js"
 }

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/block.json
@@ -43,5 +43,6 @@
 			"type": "boolean",
 			"default": false
 		}
-	}
+	},
+	"editorScript": "file:../editor-beta.js"
 }

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/block.json
@@ -1,0 +1,47 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/author-recommendation",
+	"title": "Author Recommendation",
+	"description": "Select the sites you follow and share them with your users.",
+	"keywords": [],
+	"version": "12.5.0",
+	"textdomain": "jetpack",
+	"category": "grow",
+	"icon": "thumbs-up",
+	"supports": {
+		"align": false,
+		"alignWide": true,
+		"anchor": false,
+		"customClassName": true,
+		"className": true,
+		"html": false,
+		"multiple": true,
+		"reusable": true,
+		"color": {
+			"link": true,
+			"gradients": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"attributes": {
+		"recommendations": {
+			"type": "array",
+			"items": {
+				"type": "object"
+			},
+			"default": []
+		},
+		"ignore_user_blogs": {
+			"type": "boolean",
+			"default": false
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
@@ -56,5 +56,6 @@
 			"attributes": { "variation": "google-slides" },
 			"isActive": [ "variation" ]
 		}
-	]
+	],
+	"editorScript": "file:../editor-beta.js"
 }

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
@@ -27,33 +27,33 @@
 	},
 	"variations": [
 		{
-			"name": "google-docs",
+			"name": "jetpack/google-docs",
 			"isDefault": true,
 			"title": "Google Docs",
 			"description": "Embed a Google Document.",
 			"icon": "document",
 			"keywords": [ "document", "gsuite", "doc" ],
-			"attributes": { "variation": "google-docs" },
+			"attributes": { "variation": "jetpack/google-docs" },
 			"isActive": [ "variation" ]
 		},
 		{
-			"name": "google-sheets",
+			"name": "jetpack/google-sheets",
 			"isDefault": true,
 			"title": "Google Sheets",
 			"description": "Embed a Google Sheet.",
 			"icon": "spreadsheet",
 			"keywords": [ "sheet", "spreadsheet" ],
-			"attributes": { "variation": "google-sheets" },
+			"attributes": { "variation": "jetpack/google-sheets" },
 			"isActive": [ "variation" ]
 		},
 		{
-			"name": "google-slides",
+			"name": "jetpack/google-slides",
 			"isDefault": true,
 			"title": "Google Slides",
 			"description": "Embed a Google Slides presentation.",
 			"icon": "interactive",
 			"keywords": [ "slide", "presentation", "deck" ],
-			"attributes": { "variation": "google-slides" },
+			"attributes": { "variation": "jetpack/google-slides" },
 			"isActive": [ "variation" ]
 		}
 	],

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
@@ -1,0 +1,60 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/google-docs-embed",
+	"title": "Google Docs",
+	"description": "Embed a Google Document.",
+	"keywords": [ "document", "gsuite", "doc" ],
+	"version": "12.5.0",
+	"textdomain": "jetpack",
+	"category": "embed",
+	"icon": "document",
+	"supports": {
+		"align": [ "left", "right", "center", "wide", "full" ],
+		"anchor": true
+	},
+	"attributes": {
+		"url": {
+			"type": "string",
+			"default": ""
+		},
+		"aspectRatio": {
+			"type": "string"
+		},
+		"variation": {
+			"type": "string"
+		}
+	},
+	"variations": [
+		{
+			"name": "google-docs",
+			"isDefault": true,
+			"title": "Google Docs",
+			"description": "Embed a Google Document.",
+			"icon": "document",
+			"keywords": [ "document", "gsuite", "doc" ],
+			"attributes": { "variation": "google-docs" },
+			"isActive": [ "variation" ]
+		},
+		{
+			"name": "google-sheets",
+			"isDefault": true,
+			"title": "Google Sheets",
+			"description": "Embed a Google Sheet.",
+			"icon": "spreadsheet",
+			"keywords": [ "sheet", "spreadsheet" ],
+			"attributes": { "variation": "google-sheets" },
+			"isActive": [ "variation" ]
+		},
+		{
+			"name": "google-slides",
+			"isDefault": true,
+			"title": "Google Slides",
+			"description": "Embed a Google Slides presentation.",
+			"icon": "interactive",
+			"keywords": [ "slide", "presentation", "deck" ],
+			"attributes": { "variation": "google-slides" },
+			"isActive": [ "variation" ]
+		}
+	]
+}

--- a/projects/plugins/jetpack/extensions/blocks/paywall/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/block.json
@@ -24,5 +24,6 @@
 		"html": false,
 		"multiple": false
 	},
-	"parent": [ "core/post-content" ]
+	"parent": [ "core/post-content" ],
+	"editorScript": "file:../editor-beta.js"
 }

--- a/projects/plugins/jetpack/extensions/blocks/paywall/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/block.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/paywall",
+	"title": "Paywall",
+	"description": "Paywall",
+	"keywords": [
+		"email",
+		"follow",
+		"gated",
+		"memberships",
+		"newsletter",
+		"signin",
+		"subscribe",
+		"subscription",
+		"subscriptions"
+	],
+	"version": "12.5.0",
+	"textdomain": "jetpack",
+	"category": "earn",
+	"icon": "",
+	"supports": {
+		"customClassName": false,
+		"html": false,
+		"multiple": false
+	},
+	"parent": [ "core/post-content" ]
+}

--- a/projects/plugins/jetpack/extensions/blocks/recipe/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/block.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/recipe",
+	"title": "Recipe",
+	"description": "Add images, ingredients and cooking steps to display an easy to read recipe.",
+	"keywords": [],
+	"version": "12.5.0",
+	"textdomain": "jetpack",
+	"category": "widgets",
+	"icon": "book",
+	"supports": {
+		"align": [ "full", "wide" ],
+		"alignWide": true,
+		"anchor": false,
+		"customClassName": true,
+		"className": true,
+		"html": false,
+		"multiple": true,
+		"reusable": true
+	},
+	"attributes": {
+		"ingredients": {
+			"type": "array",
+			"default": []
+		},
+		"steps": {
+			"type": "array",
+			"default": []
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/recipe/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/block.json
@@ -28,5 +28,6 @@
 			"type": "array",
 			"default": []
 		}
-	}
+	},
+	"editorScript": "file:../editor-beta.js"
 }


### PR DESCRIPTION

See #32408

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add `block.json` metadata files for Jetpack beta blocks.

`v6-video-frame-poster`, `ai-assistant-form-support`, and `videopress/video-chapters` are Jetpack extensions but not blocks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pedMtX-RS-p2

Content is extracted from the metadata found in various files in the block folder.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Review the files content.