### PR TITLE
 CRM: Automations Contact transitional status condition

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-3190-automations-contact-transitional-status-condition
+++ b/projects/plugins/crm/changelog/add-crm-3190-automations-contact-transitional-status-condition
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Automation:  Added a condition to detect changes in status from a specified initial value to a designated target one

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
@@ -83,6 +83,12 @@ class Contact_Transitional_Status extends Base_Condition {
 		$status_was = $this->get_attributes()['previous_status_was'];
 		$status_is  = $this->get_attributes()['new_status_is'];
 
+		if ( ! $this->is_valid_operator( $operator ) ) {
+			$this->condition_met = false;
+			$this->logger->log( 'Invalid operator: ' . $operator );
+			throw new Automation_Exception( 'Invalid operator: ' . $operator );
+		}
+
 		$this->logger->log( 'Condition: Contact_Transitional_Status ' . $operator . ' ' . $status_was . ' => ' . $status_is );
 		switch ( $operator ) {
 			case 'from_to':
@@ -90,12 +96,10 @@ class Contact_Transitional_Status extends Base_Condition {
 				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
 
 				return;
+			default:
+				$this->condition_met = false;
+				throw new Automation_Exception( 'Valid but unimplemented operator: ' . $operator );
 		}
-
-		$this->condition_met = false;
-		$this->logger->log( 'Invalid operator: ' . $operator );
-
-		throw new Automation_Exception( 'Invalid operator: ' . $operator );
 	}
 
 	/**
@@ -105,10 +109,22 @@ class Contact_Transitional_Status extends Base_Condition {
 	 * @since $$next-version$$
 	 *
 	 * @param array $data The event data.
-	 * @return bool True if the data is valid to detect a transitional status change, false otherwise
+	 * @return bool True if the data is valid to detect a transitional status change, false otherwise.
 	 */
 	private function is_valid_contact_status_transitional_data( array $data ): bool {
 		return isset( $data['contact'] ) && isset( $data['old_status_value'] ) && isset( $data['contact']['data']['status'] );
+	}
+
+	/**
+	 * Checks if this is a valid operator for this condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $operator The operator.
+	 * @return bool True if the operator is valid for this condition, false otherwise.
+	 */
+	private function is_valid_operator( string $operator ): bool {
+		return in_array( $operator, $this->valid_operators, true );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Jetpack CRM Automation Contact_Transitional_Status condition.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Conditions;
+
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Automation_Logger;
+use Automattic\Jetpack\CRM\Automation\Base_Condition;
+
+/**
+ * Contact_Transitional_Status condition class.
+ *
+ * @since $$next-version$$
+ */
+class Contact_Transitional_Status extends Base_Condition {
+
+	/**
+	 * The Automation logger.
+	 *
+	 * @since $$next-version$$
+	 * @var Automation_Logger $logger The Automation logger.
+	 */
+	private $logger;
+
+	/**
+	 * All valid operators for this condition.
+	 *
+	 * @since $$next-version$$
+	 * @var string[] $valid_operators Valid operators.
+	 */
+	private $valid_operators = array(
+		'from_to',
+	);
+
+	/**
+	 * All valid attributes for this condition.
+	 *
+	 * @since $$next-version$$
+	 * @var string[] $valid_operators Valid attributes.
+	 */
+	private $valid_attributes = array(
+		'previous_status_was',
+		'new_status_is',
+	);
+
+	/**
+	 * Contact_Transitional_Status constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $step_data The step data for the condition.
+	 */
+	public function __construct( array $step_data ) {
+		parent::__construct( $step_data );
+
+		$this->logger = Automation_Logger::instance();
+	}
+
+	/**
+	 * Executes the condition. If the condition is met, the value stored in the
+	 * attribute $condition_met is set to true; otherwise, it is set to false.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $data The data this condition has to evaluate.
+	 * @return void
+	 *
+	 * @throws Automation_Exception If an invalid operator is encountered.
+	 */
+	public function execute( array $data ) {
+		if ( ! $this->is_valid_contact_status_transitional_data( $data ) ) {
+			$this->logger->log( 'Invalid contact status transitional data', $data );
+			$this->condition_met = false;
+
+			return;
+		}
+
+		$operator   = $this->get_attributes()['operator'];
+		$status_was = $this->get_attributes()['previous_status_was'];
+		$status_is  = $this->get_attributes()['new_status_is'];
+
+		$this->logger->log( 'Condition: Contact_Transitional_Status ' . $operator . ' ' . $status_was . ' => ' . $status_is );
+		switch ( $operator ) {
+			case 'from_to':
+				$this->condition_met = ( $data['old_status_value'] === $status_was ) && ( $data['contact']['data']['status'] === $status_is );
+				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
+
+				return;
+		}
+
+		$this->condition_met = false;
+		$this->logger->log( 'Invalid operator: ' . $operator );
+
+		throw new Automation_Exception( 'Invalid operator: ' . $operator );
+	}
+
+	/**
+	 * Checks if the contact has at least the necessary keys to detect a transitional
+	 * status condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $data The event data.
+	 * @return bool True if the data is valid to detect a transitional status change, false otherwise
+	 */
+	private function is_valid_contact_status_transitional_data( array $data ): bool {
+		return isset( $data['contact'] ) && isset( $data['old_status_value'] ) && isset( $data['contact']['data']['status'] );
+	}
+
+	/**
+	 * Get the slug for the contact transitional status condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The slug 'contact_status_transitional'.
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/condition/contact_status_transitional';
+	}
+
+	/**
+	 * Get the title for the contact transitional status condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The title 'Contact Transitional Status'.
+	 */
+	public static function get_title(): string {
+		return __( 'Contact Transitional Status', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the description for the contact transitional status condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The description for the condition.
+	 */
+	public static function get_description(): string {
+		return __( 'Checks if a contact status changes from a specified initial value to a designated target one', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the type of the contact transitional status condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The type 'condition'.
+	 */
+	public static function get_type(): string {
+		return 'condition';
+	}
+
+	/**
+	 * Get the category of the contact transitional status condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The category 'contact'.
+	 */
+	public static function get_category(): string {
+		return 'contact';
+	}
+
+	/**
+	 * Get the allowed triggers for the contact transitional status condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string[] An array of allowed triggers:
+	 *               - 'jpcrm/contact_status_updated'
+	 */
+	public static function get_allowed_triggers(): array {
+		return array(
+			'jpcrm/contact_status_updated',
+		);
+	}
+}

--- a/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
+++ b/projects/plugins/crm/src/automation/commons/triggers/contacts/class-contact-status-updated.php
@@ -71,6 +71,25 @@ class Contact_Status_Updated extends Base_Trigger {
 	}
 
 	/**
+	 * Called when the contact status updated event we are listening to is triggered.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array  $contact The array representing the contact that triggered this action.
+	 * @param string $old_status_value The value this contact's status had before being updated.
+	 * @return void
+	 *
+	 * @throws Automation_Exception If an invalid operator is encountered.
+	 */
+	public function on_jpcrm_contact_status_updated( $contact, $old_status_value ) {
+		$data = array(
+			'contact'          => $contact,
+			'old_status_value' => $old_status_value,
+		);
+		$this->execute_workflow( $data );
+	}
+
+	/**
 	 * Listen to the desired event.
 	 *
 	 * @since $$next-version$$
@@ -78,7 +97,9 @@ class Contact_Status_Updated extends Base_Trigger {
 	protected function listen_to_event() {
 		add_action(
 			'jpcrm_contact_status_updated',
-			array( $this, 'execute_workflow' )
+			array( $this, 'on_jpcrm_contact_status_updated' ),
+			10,
+			2
 		);
 	}
 

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack\CRM\Automation\Tests;
 
 use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Field_Changed;
+use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Transitional_Status;
 use WorDBless\BaseTestCase;
 
 require_once __DIR__ . '../../tools/class-automation-faker.php';
@@ -11,7 +12,8 @@ require_once __DIR__ . '../../tools/class-automation-faker.php';
 /**
  * Test Automation Workflow functionalities
  *
- * @covers Automattic\Jetpack\CRM\Automation
+ * @covers Automattic\Jetpack\CRM\Automation\Conditions\Contact_Field_Changed
+ * @covers Automattic\Jetpack\CRM\Automation\Conditions\Contact_Transitional_Status
  */
 class Contact_Condition_Test extends BaseTestCase {
 

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-trigger-test.php
@@ -80,18 +80,23 @@ class Contact_Trigger_Test extends BaseTestCase {
 		$trigger->init( $workflow );
 
 		// Fake event data.
-		$contact_data = $this->automation_faker->contact_data();
+		$contact    = $this->automation_faker->contact_data();
+		$old_status = 'Blacklisted';
+		$expected   = array(
+			'contact'          => $contact,
+			'old_status_value' => $old_status,
+		);
 
 		// We expect the workflow to be executed on contact_status_update event with the contact data
 		$workflow->expects( $this->once() )
 		->method( 'execute' )
 		->with(
 			$this->equalTo( $trigger ),
-			$this->equalTo( $contact_data )
+			$this->equalTo( $expected )
 		);
 
 		// Run the contact_status_update action.
-		do_action( 'jpcrm_contact_status_updated', $contact_data );
+		do_action( 'jpcrm_contact_status_updated', $contact, $old_status );
 	}
 
 	/**

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -344,6 +344,21 @@ class Automation_Faker {
 	}
 
 	/**
+	 * Returns the data for a dummy contact transitional status.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $old_status The value of the old status.
+	 * @return array An array containing a dummy contact and the value of the old status that was passed as a parameter.
+	 */
+	public function contact_transitional_status_data( $old_status ) {
+		return array(
+			'contact'          => $this->contact_data(),
+			'old_status_value' => $old_status,
+		);
+	}
+
+	/**
 	 * Return a empty workflow, without triggers and initial step
 	 *
 	 * @return array


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds the contact transitional status condition and respective tests.
   * Operators:
      * from_to

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3190

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).

