### PR TITLE
Make AI assistant input receive focus

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-assistant-input-focus
+++ b/projects/js-packages/ai-client/changelog/update-ai-assistant-input-focus
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Make the AI Assistant input to receive focus on render

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -4,7 +4,7 @@
 import { PlainText } from '@wordpress/block-editor';
 import { Button } from '@wordpress/components';
 import { useKeyboardShortcut } from '@wordpress/compose';
-import { forwardRef, useImperativeHandle, useRef } from '@wordpress/element';
+import { forwardRef, useImperativeHandle, useRef, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, closeSmall, check, arrowUp } from '@wordpress/icons';
 import classNames from 'classnames';
@@ -101,6 +101,10 @@ export function AIControl(
 			target: promptUserInputRef,
 		}
 	);
+
+	useEffect( () => {
+		promptUserInputRef.current?.focus();
+	} );
 
 	const actionButtonClasses = classNames( 'jetpack-components-ai-control__controls-prompt_button', {
 		'has-label': showButtonsLabel,


### PR DESCRIPTION
This PR is a wee change to set focus on the assistant input on render.

## Proposed changes:
The change is a small one, just adding a useEffect on the input ref to imperatively set focus on it.

While simple in concept, if you're engaging the editor with your keyboard, it is a bit counter intuitive to have to reach the mouse only to focus on the input and start typing what you need from the assistant.

Before:
![no-focus](https://github.com/Automattic/jetpack/assets/157240/c5f3c8af-7b36-4131-b965-23797c35fab8)

After:
![with-focus](https://github.com/Automattic/jetpack/assets/157240/35da770b-cd10-4133-9f06-97d6f4d68583)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Checkout and `jetpack build plugins/jetpack`. Insert a form block (which, in particular was stealing focus from the variation picker) or any other block and enable the assistant.
Focus should be immediately in the assistant input.
