### PR TITLE
AI Extension: move isFixed logic to AI Assistant bar component

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-extension-move-mobile-logic
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-extension-move-mobile-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: move isFixed logic to AI Assistant bar component

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -3,7 +3,6 @@
  */
 import { aiAssistantIcon, useAiContext } from '@automattic/jetpack-ai-client';
 import { KeyboardShortcuts, ToolbarButton } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { useContext, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect } from 'react';
@@ -12,14 +11,26 @@ import React, { useEffect } from 'react';
  */
 import { AiAssistantUiContext } from '../../ui-handler/context';
 
-export default function AiAssistantToolbarButton(): React.ReactElement {
-	const { isVisible, toggle, setAssistantFixed, setAnchor } = useContext( AiAssistantUiContext );
-	const { requestingState } = useAiContext();
+const AI_ASSISTANT_BAR_SLOT_CLASS = 'jetpack-ai-assistant-bar__slot';
 
-	const isMobileViewport = useViewportMatch( 'medium', '<' );
+/**
+ * The toolbar button that toggles the Assistant Bar.
+ * Also, it creates a slot just after the contextual toolbar
+ * to be used as the anchor for the Assistant Bar.
+ *
+ * @returns {React.ReactElement} The toolbar button.
+ */
+export default function AiAssistantToolbarButton(): React.ReactElement {
+	const { isVisible, toggle, setAnchor } = useContext( AiAssistantUiContext );
+	const { requestingState } = useAiContext();
 
 	const toolbarButtonRef = useRef< HTMLElement | null >( null );
 
+	/*
+	 * When the toolbar button is rendered, we need to find the
+	 * contextual toolbar and create a slot just after it.
+	 * This slot will be used as the anchor for the Assistant Bar.
+	 */
 	useEffect( () => {
 		if ( ! toolbarButtonRef.current ) {
 			return;
@@ -36,20 +47,17 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 		 * Let's create a slot just after the toolbar,
 		 * in case it was not created yet.
 		 */
-		if ( toolbar?.nextElementSibling?.classList.contains( 'jetpack-ai-assistant-bar__slot' ) ) {
+		if ( toolbar?.nextElementSibling?.classList.contains( AI_ASSISTANT_BAR_SLOT_CLASS ) ) {
 			return;
 		}
 
 		const slot = document.createElement( 'div' );
-		slot.className = 'jetpack-ai-assistant-bar__slot';
+		slot.className = AI_ASSISTANT_BAR_SLOT_CLASS;
 		toolbar.after( slot );
 
 		// Set the anchor where the Assistant Bar will be rendered.
 		setAnchor( slot );
-
-		// Fix the assistant toolbar in mobile
-		setAssistantFixed( isMobileViewport );
-	}, [ setAssistantFixed, isMobileViewport, setAnchor ] );
+	}, [ setAnchor ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -44,14 +44,20 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 		}
 
 		/*
-		 * Let's create a slot just after the toolbar,
-		 * in case it was not created yet.
+		 * AI Assistant bar slot element.
+		 * When the viewport is in mobile mode,
+		 * create an element just after the contextual toolbar
+		 * to be used as the anchor for the Assistant Bar.
 		 */
-		if ( toolbar?.nextElementSibling?.classList.contains( AI_ASSISTANT_BAR_SLOT_CLASS ) ) {
-			return;
+
+		// Check if the slot already exists.
+		let slot = toolbar?.nextElementSibling as HTMLElement;
+		if ( slot?.classList.contains( AI_ASSISTANT_BAR_SLOT_CLASS ) ) {
+			return setAnchor( slot );
 		}
 
-		const slot = document.createElement( 'div' );
+		// Slot not found - create it.
+		slot = document.createElement( 'div' );
 		slot.className = AI_ASSISTANT_BAR_SLOT_CLASS;
 		toolbar.after( slot );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up of https://github.com/Automattic/jetpack/pull/32425

This pull request focuses on updating the code that determines whether the Assistant Bar should be fixed at the top next to the Block toolbar or not, after merging https://github.com/Automattic/jetpack/pull/32425. It also adjusts the handling of the isMobileMode.
In the end, it's a janitorial/, reorganizing, and performance enhancement.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: move isFixed logic to AI Assistant bar component

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Test how the Navigation bar acts when it's fixed and when the width of the space it's placed in changes.
* The following video shows these cases. Pay attention to the cursor:

https://github.com/Automattic/jetpack/assets/77539/96481ed1-0938-4343-a550-ad54076fd270

