### PR TITLE
AI Extension: make forms ai assistant input receive focus on first mount

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-input-focus
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-input-focus
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: other
 
-Make the AI Assistant input to receive focus on render
+Make the AI Assistant input to receive focus on first render for forms variations

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-input-focus
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-input-focus
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Make the AI Assistant input to receive focus on render

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -154,6 +154,11 @@ export default function AiAssistantBar( {
 		};
 	}, [ isFixed ] );
 
+	// focus input on first render only (for a11y reasons, toggling on/off should not focus the input)
+	useEffect( () => {
+		inputRef.current?.focus();
+	}, [] );
+
 	if ( ! isVisible ) {
 		return null;
 	}


### PR DESCRIPTION
This PR is a wee change to set focus on the assistant input on render. It's a re-do from #32438 since it moved from the JS package to the plugin to address the specific case of forms assistant.

## Proposed changes:
The change is a small one, just adding a useEffect on the input ref to imperatively set focus on it.

While simple in concept, if you're engaging the editor with your keyboard, it is a bit counter intuitive to have to reach the mouse only to focus on the input and start typing what you need from the assistant.

For a11y reasons the focus is set only on first appearance, toggling the assistant off/on won't trigger the focus again.

Before:
![no-focus](https://github.com/Automattic/jetpack/assets/157240/c5f3c8af-7b36-4131-b965-23797c35fab8)

After:
![with-focus](https://github.com/Automattic/jetpack/assets/157240/35da770b-cd10-4133-9f06-97d6f4d68583)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Checkout and `jetpack build plugins/jetpack`. Insert a form block (which, in particular was stealing focus from the variation picker).
Focus should be immediately in the assistant input. Toggle the assistant on/off, the focus should not be set on the input anymore.
