### PR TITLE
IS: add conditional to use new method introduced in WP 6.3

### DIFF
--- a/projects/plugins/jetpack/changelog/update-infinite-scripts
+++ b/projects/plugins/jetpack/changelog/update-infinite-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Infinite Scroll: avoid PHP notices when using the latest version of WordPress, 6.3.

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -1162,6 +1162,7 @@ class The_Neverending_Home_Page {
 
 			// If new scripts are needed, extract relevant data from $wp_scripts
 			if ( ! empty( $new_scripts ) ) {
+				global $wp_version;
 				$results['scripts'] = array();
 
 				foreach ( $new_scripts as $handle ) {
@@ -1173,13 +1174,22 @@ class The_Neverending_Home_Page {
 						continue;
 					}
 
+					// Remove conditional once WordPress 6.3 is the minimum required version.
+					if ( version_compare( $wp_version, '6.3', '>=' ) ) {
+						$before_handle = $wp_scripts->get_inline_script_data( $handle, 'before' );
+						$after_handle  = $wp_scripts->get_inline_script_data( $handle, 'after' );
+					} else {
+						$before_handle = $wp_scripts->print_inline_script( $handle, 'before', false );
+						$after_handle  = $wp_scripts->print_inline_script( $handle, 'after', false );
+					}
+
 					// Provide basic script data
 					$script_data = array(
 						'handle'        => $handle,
 						'footer'        => ( is_array( $wp_scripts->in_footer ) && in_array( $handle, $wp_scripts->in_footer, true ) ),
 						'extra_data'    => $wp_scripts->print_extra_script( $handle, false ),
-						'before_handle' => $wp_scripts->print_inline_script( $handle, 'before', false ),
-						'after_handle'  => $wp_scripts->print_inline_script( $handle, 'after', false ),
+						'before_handle' => $before_handle,
+						'after_handle'  => $after_handle,
 					);
 
 					// Base source


### PR DESCRIPTION
## Proposed changes:

`WP_Scripts::print_inline_script` was deprecated in WordPress 6.3, in favor of `WP_Scripts::get_inline_script_data`. Let's start using that to avoid deprecation notices, when we're running WP 6.3 or above.

See https://core.trac.wordpress.org/ticket/12009

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Primary issue: #31638

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Start with a site with more than 10 posts.

* Enable a classic theme that bundles support for Infinite Scroll, such as "Superhero".
* Go to Jetpack > Settings and enable Infinite Scroll (e.g. set it to "Load more posts as the reader scrolls down").
* Load the home page and scroll down
    * You should see more posts appearing as you scroll down the page.

