### PR TITLE
AI Extension: check placeholder before to render AI assistant bar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-check-anchor-before-to-render
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-check-anchor-before-to-render
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI Extension: check placeholder before to render AI assistannt bar
+AI Extension: check placeholder before to render AI assistant bar

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-check-anchor-before-to-render
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-check-anchor-before-to-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: check placeholder before to render AI assistannt bar

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -199,6 +199,11 @@ export default function AiAssistantBar( {
 		</div>
 	);
 
+	// In mobile, do not render until the Assistant anchor is set.
+	if ( isAssistantBarFixed === null ) {
+		return null;
+	}
+
 	// Check if the Assistant bar should be rendered in the Assistant anchor (fixed mode)
 	if ( isAssistantBarFixed ) {
 		return createPortal( AiAssistantBarComponent, assistantAnchor );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
This PR addresses an issue where the AI assistant bar is rendered in the editor canvas under specific conditions:

This PR addresses an issue where the AI assistant bar is rendered in the editor canvas under specific conditions:

* When the Jetpack Form block instance component mounts.
* When the assistant bar is in fixed mode.

To resolve this, the PR introduces a check for the `isAssistantBarFixed` value. If it's `null`, the assistant bar won't be rendered. This null value indicates two scenarios:

* The viewport is set to medium.
* The anchor element for the assistant is not available in the DOM yet.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: check placeholder before to render AI assistant bar

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack From the block instance
* Confirm the assistant bar render in the editor canvas and below the Block toolbar, depending on the viewport size.
* It should work as expected.