### PR TITLE
Revert "Subscribe modal: release newsletter modal to non lettre sites"

### DIFF
--- a/projects/plugins/jetpack/changelog/update-release-newsletter-modal-non-lettre
+++ b/projects/plugins/jetpack/changelog/update-release-newsletter-modal-non-lettre
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscribe modal: allow non-Lettre themed sites on WP.com use the modal.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -183,7 +183,9 @@ HTML;
 	}
 
 	/**
-	 * Returns true if we should load Subscriber modal
+	 * Returns true if we should load Newsletter content.
+	 * This is currently limited to lettre theme or newsletter sites.
+	 * We could open it to all themes or site intents.
 	 *
 	 * @return bool
 	 */
@@ -192,6 +194,9 @@ HTML;
 		// When ready for Jetpack release, remove this.
 		$is_wpcom = ( new Host() )->is_wpcom_platform();
 		if ( ! $is_wpcom ) {
+			return false;
+		}
+		if ( 'lettre' !== get_option( 'stylesheet' ) && 'newsletter' !== get_option( 'site_intent' ) ) {
 			return false;
 		}
 		if ( ! wp_is_block_theme() ) {


### PR DESCRIPTION
We have the suspicion that it breaks some sites that don't use the letter theme, let's revert until we are sure.

Reverts Automattic/jetpack#32429