### PR TITLE
AI Extension: set role and aria-label for the assistant bar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-set-role
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-set-role
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: set role and aria-label for the assistant bar

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -58,6 +58,10 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 
 		// Slot not found - create it.
 		slot = document.createElement( 'div' );
+
+		// Set role="toolbar" and Aria label
+		slot.setAttribute( 'role', 'toolbar' );
+		slot.setAttribute( 'aria-label', __( 'AI Assistant', 'jetpack' ) );
 		slot.className = AI_ASSISTANT_BAR_SLOT_CLASS;
 		toolbar.after( slot );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -62,6 +62,7 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 		// Set role="toolbar" and Aria label
 		slot.setAttribute( 'role', 'toolbar' );
 		slot.setAttribute( 'aria-label', __( 'AI Assistant', 'jetpack' ) );
+		slot.setAttribute( 'aria-orientation', 'horizontal' );
 		slot.className = AI_ASSISTANT_BAR_SLOT_CLASS;
 		toolbar.after( slot );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR sets the role `toolbar` to the Assistant bar and defines the `aria-label` and `aria-orientation`.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: set role and aria-label for the assistant bar

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack From the block instance
* Test on mobile breakpoint 
* Inspect the anchor element of the Assistant bar
* Confirm you see the `role` and `aria-label` attributes there

<img width="501" alt="Screenshot 2023-08-14 at 13 12 24" src="https://github.com/Automattic/jetpack/assets/77539/f059b413-c5f6-41bb-b752-fef2c1aa0cad">
