### PR TITLE
Launchpad: Fix completion logic for "Customize welcome message" task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-completion-logic-for-custom-welcome
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-completion-logic-for-custom-welcome
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fix completion logic for welcome message on newsletters task.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "4.4.x-dev"
+			"dev-trunk": "4.5.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.4.2-alpha",
+	"version": "4.5.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.4.2-alpha';
+	const PACKAGE_VERSION = '4.5.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1418,7 +1418,7 @@ function wpcom_mark_customize_welcome_message_complete_on_add( $value ) {
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }
-add_action( 'add_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete_on_add', 10, 3 );
+add_action( 'add_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete_on_add', 10, 1 );
 
 /**
  * When a page is updated, check to see if we've already completed the `add_new_page` task and mark the `edit_page` task complete accordingly.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1390,20 +1390,35 @@ function wpcom_is_edit_page_task_visible() {
 /**
  * Mark the customize_welcome_message task complete
  * if the subscription_options['invitation'] value
- * for the welcome message has changed.
+ * for the welcome message has changed on option update.
  *
  * @param string $old_value The old value of the welcome message.
  * @param string $value The new value of the welcome message.
  *
  * @return void
  */
-function wpcom_mark_customize_welcome_message_complete( $old_value, $value ) {
+function wpcom_mark_customize_welcome_message_complete_on_update( $old_value, $value ) {
 	if ( $value['invitation'] !== $old_value['invitation'] ) {
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }
-add_action( 'add_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete', 10, 3 );
-add_action( 'update_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete', 10, 3 );
+add_action( 'update_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete_on_update', 10, 3 );
+
+/**
+ * Mark the customize_welcome_message task complete
+ * if the subscription_options['invitation'] value
+ * for the welcome message has been added.
+ *
+ * @param string $value The value of the welcome message.
+ *
+ * @return void
+ */
+function wpcom_mark_customize_welcome_message_complete_on_add( $value ) {
+	if ( $value['invitation'] ) {
+		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
+	}
+}
+add_action( 'add_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete_on_add', 10, 3 );
 
 /**
  * When a page is updated, check to see if we've already completed the `add_new_page` task and mark the `edit_page` task complete accordingly.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1402,6 +1402,7 @@ function wpcom_mark_customize_welcome_message_complete( $old_value, $value ) {
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }
+add_action( 'add_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete', 10, 3 );
 add_action( 'update_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete', 10, 3 );
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1402,7 +1402,7 @@ function wpcom_mark_customize_welcome_message_complete_on_update( $old_value, $v
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }
-add_action( 'update_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete_on_update', 10, 3 );
+add_action( 'update_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete_on_update', 10, 2 );
 
 /**
  * Mark the customize_welcome_message task complete

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-completion-logic-for-custom-welcome
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-completion-logic-for-custom-welcome
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_13_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_14_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_13"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_13_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "106be62e6f4eb66889fd089a2982f5b92764a87e"
+                "reference": "045d61085194c3b88fe72967ea0598818fae1c37"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.4.x-dev"
+                    "dev-trunk": "4.5.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,11 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
-<<<<<<< HEAD
- * Version: 1.6.13
-=======
- * Version: 1.6.13-alpha
->>>>>>> 99805fa5d7 ([not verified] Update project versions)
+ * Version: 1.6.14-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,11 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
+<<<<<<< HEAD
  * Version: 1.6.13
+=======
+ * Version: 1.6.13-alpha
+>>>>>>> 99805fa5d7 ([not verified] Update project versions)
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.13-alpha",
+	"version": "1.6.14-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.13",
+	"version": "1.6.13-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/80503

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hook into the subscription option's add action in addition to the update action to ensure it completes the task whether adding or updating, not just on update.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox public-api
* Create a new site from `/setup/newsletter` and publish your first post on it
* On the Home screen, click on the "Customize welcome message" task
* Update the welcome message and save changes
* Go back to `/home` and the Customize welcome message task should be marked complete!

