### PR TITLE
fix: Avoid importing incompatible web modules

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/fix-avoid-importing-incompatible-web-modules
+++ b/projects/js-packages/shared-extension-utils/changelog/fix-avoid-importing-incompatible-web-modules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add a stub module to avoid the native mobile editor importing incompatible web modules.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.11.1",
+	"version": "0.11.2-alpha",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/index.native.js
+++ b/projects/js-packages/shared-extension-utils/src/components/jetpack-editor-panel-logo/index.native.js
@@ -1,0 +1,4 @@
+// The native mobile editor does not implement or use this module, but importing
+// the web module results in critical errors due to web-specific dependencies.
+// Thus, we provide a stub module here to avoid those errors.
+export default () => null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a native mobile editor breaking change introduced in 9041972d0a30b3d5c5ee6e54c294665ce0a83d79. 
The refactor there resulted in the native mobile editor importing 
additional web-specific dependencies. The incompatibilities threw 
errors, e.g.:

```
 ERROR  [Error: undefined Unable to resolve module react-slider from /Users/davidcalhoun/Sites/a8c/gutenberg-mobile/jetpack/projects/js-packages/components/components/pricing-slider/index.tsx: react-slider could not be found within the project or in these directories:
  jetpack/projects/js-packages/components/node_modules
  jetpack/node_modules
  node_modules
  1 | import classNames from 'classnames';
  2 | import React from 'react';
> 3 | import ReactSlider from 'react-slider';
    |                          ^
  4 | import { PricingSliderProps } from './types';
  5 | import './style.scss';
  6 |]
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at Server._symbolicate (/Users/davidcalhoun/Sites/a8c/gutenberg-mobile/node_modules/metro/src/Server.js:1050:31)
    at async Server._processRequest (/Users/davidcalhoun/Sites/a8c/gutenberg-mobile/node_modules/metro/src/Server.js:444:7)
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at Server._symbolicate (/Users/davidcalhoun/Sites/a8c/gutenberg-mobile/node_modules/metro/src/Server.js:1050:31)
    at async Server._processRequest (/Users/davidcalhoun/Sites/a8c/gutenberg-mobile/node_modules/metro/src/Server.js:444:7)
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add a native mobile editor stub module to avoid importing the incompatible web
modules.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
  - There is a known failure on the post-connection E2E test. 
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load the Demo editor found within the `gutenberg-mobile` project repository.
* Verify the app does not crash or throw errors.