### PR TITLE
Forms block: allow transforming to a subscribe block

### DIFF
--- a/projects/packages/forms/changelog/update-form-subscribe-block
+++ b/projects/packages/forms/changelog/update-form-subscribe-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms block - allow transforming to a subscribe block.

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -61,7 +61,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.19.x-dev"
+			"dev-trunk": "0.20.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.19.11",
+	"version": "0.20.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/transforms.js
+++ b/projects/packages/forms/src/blocks/contact-form/transforms.js
@@ -137,4 +137,11 @@ export default {
 			},
 		},
 	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'jetpack/subscriptions' ],
+			transform: () => createBlock( 'jetpack/subscriptions' ),
+		},
+	],
 };

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.19.11';
+	const PACKAGE_VERSION = '0.20.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/plugins/jetpack/changelog/update-form-subscribe-block
+++ b/projects/plugins/jetpack/changelog/update-form-subscribe-block
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1068,7 +1068,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "3cf6312555ea362ba5f49014d028f9e883dc6c3d"
+                "reference": "96690fdc2a9a756a0a21283910a7f6f2af5a3d5c"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1093,7 +1093,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.19.x-dev"
+                    "dev-trunk": "0.20.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a simple transform from Forms block to a Subscription block

<img width="736" alt="Screenshot 2023-08-15 at 15 29 06" src="https://github.com/Automattic/jetpack/assets/87168/ab83f97f-cbbe-4158-9e63-c3b7615c8d20">

<img width="715" alt="Screenshot 2023-08-15 at 15 29 20" src="https://github.com/Automattic/jetpack/assets/87168/42965e92-24f6-42c7-8216-c95443b018ea">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build Forms package locally
* Add Forms block
* Try converting it to subscribe block

