### PR TITLE
Boost: Fix not deferring concatenated stylesheets when using Critical CSS

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -194,6 +194,10 @@ class Concatenate_CSS extends WP_Styles {
 
 				$style_tag = apply_filters( 'page_optimize_style_loader_tag', $style_tag, $handles, $href, $media );
 
+				// Allow manipulation of the stylesheet tag.
+				// For example - making it deferred when using with Critical CSS.
+				$style_tag = apply_filters( 'style_loader_tag', $style_tag, implode( ',', $handles ), $href, $media );
+
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo $style_tag . "\n";
 

--- a/projects/plugins/boost/changelog/fix-not-deferring-concatenated-stylesheets
+++ b/projects/plugins/boost/changelog/fix-not-deferring-concatenated-stylesheets
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: fixed
 
 Fixed not being able to defer concatenated stylesheets, causing them to be render-blocking when used with Critical CSS.

--- a/projects/plugins/boost/changelog/fix-not-deferring-concatenated-stylesheets
+++ b/projects/plugins/boost/changelog/fix-not-deferring-concatenated-stylesheets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fixed not being able to defer concatenated stylesheets, causing them to be render-blocking when used with Critical CSS.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/32449

Some background - this got removed in https://github.com/Automattic/jetpack/pull/31058 and that caused concatenated stylesheets to no longer be deferred. This PR adds it back, but changes the handles from an array, to a comma separated string, to prevent plugins using the filter from complaining.

Not sure if this is the best thing to do, but it was the cleanest.

Maybe we shouldn't use the filter, but call https://github.com/Automattic/jetpack/blob/3104e377ae2d45ad2d4ffadfd839cee47aa871df/projects/plugins/boost/app/lib/critical-css/Display_Critical_CSS.php#L34 if Critical/Cloud CSS is enabled, as the concatenated stylesheet shouldn't be modified by anything other than Boost?

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a filter to allow Critical/Cloud CSS logic to hook onto and prepare the concatenated stylesheet tag for deferring.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the steps listed in the "Steps to reproduce" section of https://github.com/Automattic/jetpack/issues/32449