### PR TITLE
Form block: rename "Newsletter" to "CreativeMail" 

### DIFF
--- a/projects/packages/forms/changelog/update-forms-block-rename-creativemail
+++ b/projects/packages/forms/changelog/update-forms-block-rename-creativemail
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Forms block: rename CreativeMail integration from "Newsletter" to "CreativeMail" to avoid confusing with "Jetpack Newsletters" and subscription block.
+Forms block: rename "Newsletter Connection" to "Creative Mail" to avoid confusing with "Jetpack Newsletters" and subscription block. Call the block a "Lead Capture" block (not sign up).

--- a/projects/packages/forms/changelog/update-forms-block-rename-creativemail
+++ b/projects/packages/forms/changelog/update-forms-block-rename-creativemail
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms block: rename CreativeMail integration from "Newsletter" to "CreativeMail" to avoid confusing with "Jetpack Newsletters" and subscription block.

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -61,7 +61,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.19.x-dev"
+			"dev-trunk": "0.20.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.19.11",
+	"version": "0.20.0-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -310,10 +310,7 @@ export const JetpackContactFormEdit = forwardRef(
 									/>
 								</PanelBody>
 							) }
-							<PanelBody
-								title={ __( 'Creative Mail', 'jetpack-forms' ) }
-								initialOpen={ false }
-							>
+							<PanelBody title={ __( 'Creative Mail', 'jetpack-forms' ) } initialOpen={ false }>
 								<NewsletterIntegrationSettings />
 							</PanelBody>
 						</Fragment>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -311,7 +311,7 @@ export const JetpackContactFormEdit = forwardRef(
 								</PanelBody>
 							) }
 							<PanelBody
-								title={ __( 'CreativeMail Connection', 'jetpack-forms' ) }
+								title={ __( 'Creative Mail', 'jetpack-forms' ) }
 								initialOpen={ false }
 							>
 								<NewsletterIntegrationSettings />

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -311,7 +311,7 @@ export const JetpackContactFormEdit = forwardRef(
 								</PanelBody>
 							) }
 							<PanelBody
-								title={ __( 'Newsletter Connection', 'jetpack-forms' ) }
+								title={ __( 'CreativeMail Connection', 'jetpack-forms' ) }
 								initialOpen={ false }
 							>
 								<NewsletterIntegrationSettings />

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -62,15 +62,16 @@ const variations = compact( [
 	},
 	! isSimpleSite() && {
 		name: 'newsletter-form',
-		title: __( 'Sign-up', 'jetpack-forms' ),
+		title: __( 'CreativeMail newsletter', 'jetpack-forms' ),
 		description: __(
-			'A simple way to collect information from folks visiting your site.',
+			'A simple way to collect information from folks visiting your site using CreativeMail plugin.',
 			'jetpack-forms'
 		),
 		keywords: [
 			__( 'subscribe', 'jetpack-forms' ),
 			__( 'email', 'jetpack-forms' ),
 			__( 'signup', 'jetpack-forms' ),
+			'CreativeMail',
 		],
 		icon: renderMaterialIcon(
 			<>

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -1,6 +1,6 @@
 import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Path } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { people } from '@wordpress/icons';
 import { compact } from 'lodash';
 import { salesforceLeadFormVariation } from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
@@ -66,10 +66,10 @@ const variations = compact( [
 		title: __( 'Lead capture', 'jetpack-forms' ),
 		description: __( 'A simple way to collect leads using forms on your site.', 'jetpack-forms' ),
 		keywords: [
-			__( 'subscribe', 'jetpack-forms' ),
-			__( 'email', 'jetpack-forms' ),
-			__( 'signup', 'jetpack-forms' ),
-			__( 'lead capture', 'jetpack-forms' ),
+			_x( 'subscribe', 'block search term', 'jetpack-forms' ),
+			_x( 'email', 'block search term', 'jetpack-forms' ),
+			_x( 'signup', 'block search term', 'jetpack-forms' ),
+			_x( 'lead capture', 'block search term', 'jetpack-forms' ),
 		],
 		icon: people,
 		innerBlocks: [

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -63,10 +63,7 @@ const variations = compact( [
 	! isSimpleSite() && {
 		name: 'newsletter-form',
 		title: __( 'Lead capture', 'jetpack-forms' ),
-		description: __(
-			'A simple way to collect leads using forms on your site.',
-			'jetpack-forms'
-		),
+		description: __( 'A simple way to collect leads using forms on your site.', 'jetpack-forms' ),
 		keywords: [
 			__( 'subscribe', 'jetpack-forms' ),
 			__( 'email', 'jetpack-forms' ),

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -62,7 +62,7 @@ const variations = compact( [
 	},
 	! isSimpleSite() && {
 		name: 'newsletter-form',
-		title: __( 'CreativeMail sign-up', 'jetpack-forms' ),
+		title: __( 'Lead capture', 'jetpack-forms' ),
 		description: __(
 			'A simple way to collect information from folks visiting your site using CreativeMail plugin.',
 			'jetpack-forms'

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -1,6 +1,7 @@
 import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
 import { compact } from 'lodash';
 import { salesforceLeadFormVariation } from './components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings';
 import { getIconColor } from './util/block-icons';
@@ -70,43 +71,7 @@ const variations = compact( [
 			__( 'signup', 'jetpack-forms' ),
 			__( 'lead capture', 'jetpack-forms' ),
 		],
-		icon: renderMaterialIcon(
-			<>
-				<Path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M7 8C7 7.72386 7.22386 7.5 7.5 7.5H19.5C19.7761 7.5 20 7.72386 20 8V16C20 16.2761 19.7761 16.5 19.5 16.5H10.5V18H19.5C20.6046 18 21.5 17.1046 21.5 16V8C21.5 6.89543 20.6046 6 19.5 6H7.5C6.39543 6 5.5 6.89543 5.5 8V9.5H7V8Z"
-					fill={ getIconColor() }
-				/>
-				<Path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M9 15.25H3V13.75H9V15.25Z"
-					fill={ getIconColor() }
-				/>
-				<Path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M9 12.5H4V11H9V12.5Z"
-					fill={ getIconColor() }
-				/>
-				<Path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M9 18H2V16.5H9V18Z"
-					fill={ getIconColor() }
-				/>
-				<Path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M6.01196 7.56955L6.98815 6.43066L13.5001 12.0123L20.012 6.43066L20.9881 7.56955L13.5001 13.9879L6.01196 7.56955Z"
-					fill={ getIconColor() }
-				/>
-			</>,
-			24,
-			24,
-			'0 0 24 24'
-		),
+		icon: people,
 		innerBlocks: [
 			[ 'jetpack/field-name', { required: true, label: __( 'Name', 'jetpack-forms' ) } ],
 			[ 'jetpack/field-email', { required: true, label: __( 'Email', 'jetpack-forms' ) } ],

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -62,7 +62,7 @@ const variations = compact( [
 	},
 	! isSimpleSite() && {
 		name: 'newsletter-form',
-		title: __( 'CreativeMail newsletter', 'jetpack-forms' ),
+		title: __( 'CreativeMail sign-up', 'jetpack-forms' ),
 		description: __(
 			'A simple way to collect information from folks visiting your site using CreativeMail plugin.',
 			'jetpack-forms'

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -64,7 +64,7 @@ const variations = compact( [
 		name: 'newsletter-form',
 		title: __( 'Lead capture', 'jetpack-forms' ),
 		description: __(
-			'A simple way to collect information from folks visiting your site using CreativeMail plugin.',
+			'A simple way to collect leads using forms on your site.',
 			'jetpack-forms'
 		),
 		keywords: [

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -71,7 +71,7 @@ const variations = compact( [
 			__( 'subscribe', 'jetpack-forms' ),
 			__( 'email', 'jetpack-forms' ),
 			__( 'signup', 'jetpack-forms' ),
-			'CreativeMail',
+			__( 'lead capture', 'jetpack-forms' ),
 		],
 		icon: renderMaterialIcon(
 			<>

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -69,7 +69,6 @@ const variations = compact( [
 			_x( 'subscribe', 'block search term', 'jetpack-forms' ),
 			_x( 'email', 'block search term', 'jetpack-forms' ),
 			_x( 'signup', 'block search term', 'jetpack-forms' ),
-			_x( 'lead capture', 'block search term', 'jetpack-forms' ),
 		],
 		icon: people,
 		innerBlocks: [

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.19.11';
+	const PACKAGE_VERSION = '0.20.0-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -60,7 +60,7 @@ class Util {
                     <!-- /wp:jetpack/contact-form -->',
 			),
 			'newsletter-form'   => array(
-				'title'      => __( 'CreativeMail Sign-up Form', 'jetpack-forms' ),
+				'title'      => __( 'Lead Capture Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
 				'content'    => '<!-- wp:jetpack/contact-form {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -47,7 +47,7 @@ class Util {
 
 		$patterns = array(
 			'contact-form'      => array(
-				'title'      => 'Contact Form',
+				'title'      => __( 'Contact Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
 				'content'    => '<!-- wp:jetpack/contact-form {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
@@ -60,7 +60,7 @@ class Util {
                     <!-- /wp:jetpack/contact-form -->',
 			),
 			'newsletter-form'   => array(
-				'title'      => 'Newsletter Subscription Form',
+				'title'      => __( 'CreativeMail Subscription Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
 				'content'    => '<!-- wp:jetpack/contact-form {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
@@ -73,7 +73,7 @@ class Util {
                     <!-- /wp:jetpack/contact-form -->',
 			),
 			'rsvp-form'         => array(
-				'title'      => 'RSVP Form',
+				'title'      => __( 'RSVP Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
 				'content'    => '<!-- wp:jetpack/contact-form {"subject":"A new RSVP from your website","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
@@ -87,7 +87,7 @@ class Util {
                     <!-- /wp:jetpack/contact-form -->',
 			),
 			'registration-form' => array(
-				'title'      => 'Registration Form',
+				'title'      => __( 'Registration Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
 				'content'    => '<!-- wp:jetpack/contact-form {"subject":"A new registration from your website","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
@@ -102,7 +102,7 @@ class Util {
                     <!-- /wp:jetpack/contact-form -->',
 			),
 			'appointment-form'  => array(
-				'title'      => 'Appointment Form',
+				'title'      => __( 'Appointment Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
 				'content'    => '<!-- wp:jetpack/contact-form {"subject":"A new appointment booked from your website","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
@@ -118,7 +118,7 @@ class Util {
                     <!-- /wp:jetpack/contact-form -->',
 			),
 			'feedback-form'     => array(
-				'title'      => 'Feedback Form',
+				'title'      => __( 'Feedback Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
 				'content'    => '<!-- wp:jetpack/contact-form {"subject":"New feedback received from your website","style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -60,7 +60,7 @@ class Util {
                     <!-- /wp:jetpack/contact-form -->',
 			),
 			'newsletter-form'   => array(
-				'title'      => __( 'CreativeMail Subscription Form', 'jetpack-forms' ),
+				'title'      => __( 'CreativeMail Sign-up Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
 				'content'    => '<!-- wp:jetpack/contact-form {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->

--- a/projects/plugins/jetpack/changelog/update-forms-block-rename-creativemail
+++ b/projects/plugins/jetpack/changelog/update-forms-block-rename-creativemail
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1068,7 +1068,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "3cf6312555ea362ba5f49014d028f9e883dc6c3d"
+                "reference": "96690fdc2a9a756a0a21283910a7f6f2af5a3d5c"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1093,7 +1093,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.19.x-dev"
+                    "dev-trunk": "0.20.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Renames "CreativeMail" variation and pattern of the Forms block from "Newsletter" or "Sign-up" to "CreativeMail" or "Lead capture" (depending on UI) to avoid confusing with "Jetpack Newsletters" and subscription block.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Rename "CreativeMail" variation, side panel UIs and pattern of the Forms block from "Newsletter" to "CreativeMail" or "Lead capture".


#### Before

<img width="301" alt="Screenshot 2023-08-15 at 15 55 05" src="https://github.com/Automattic/jetpack/assets/87168/7ed276ab-7614-4ae6-a4ab-8d3de614ca19">
<img width="687" alt="Screenshot 2023-08-15 at 15 53 58" src="https://github.com/Automattic/jetpack/assets/87168/0b6e5d9e-c548-46be-8120-42db0413eb38">


#### After


<img width="674" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/a3c347aa-9e1b-4782-a131-2a10f525f9c7">

<img width="288" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/19acda38-9f83-44cc-a382-e6923f54ecfe">

<img width="342" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/8bfe1380-cfde-424b-acfe-cbb95b278a42">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build forms package
* Add Forms block and pick CreativeMail integration
* Search for "Newsletter" or "signup" or "creativemail" from the forms picker

