### PR TITLE
Mailchimp block: allow transforming to a Subscribe block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-mailchim-block-transform-subscribe-block
+++ b/projects/plugins/jetpack/changelog/update-mailchim-block-transform-subscribe-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Mailchimp block: allow transforming to subscribe block

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/index.js
@@ -4,6 +4,7 @@ import { __, _x } from '@wordpress/i18n';
 import { getIconColor } from '../../shared/block-icons';
 import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
+import transforms from './transforms';
 import './editor.scss';
 
 export const name = 'mailchimp';
@@ -107,4 +108,5 @@ export const settings = {
 		innerBlocks: [ innerButtonBlock ],
 	},
 	deprecated: [ deprecatedV1 ],
+	transforms,
 };

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/transforms.js
@@ -1,0 +1,11 @@
+import { createBlock } from '@wordpress/blocks';
+
+export default {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'jetpack/subscriptions' ],
+			transform: () => createBlock( 'jetpack/subscriptions' ),
+		},
+	],
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow transforming Mailchimp block to subscribe block

<img width="686" alt="Screenshot 2023-08-15 at 16 07 41" src="https://github.com/Automattic/jetpack/assets/87168/6c0d3263-b874-44d2-afd9-01d118f9b7c7">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert Mailchimp block and transform it to subscribe block

