### PR TITLE
Super cache - fix 2 null/false warnings

### DIFF
--- a/projects/plugins/super-cache/changelog/super-cache-fix-null-warnings
+++ b/projects/plugins/super-cache/changelog/super-cache-fix-null-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WP Super Cache: fix null/false warning in PHP8.1

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -393,6 +393,11 @@ function wp_cache_postload() {
 		return true;
 	}
 
+	if ( wpsc_is_backend() ) {
+		wp_cache_debug( 'wp_cache_postload: backend detected, not running' );
+		return true;
+	}
+
 	if ( isset( $wp_super_cache_late_init ) && true == $wp_super_cache_late_init ) {
 		wp_cache_debug( 'Supercache Late Init: add wp_cache_serve_cache_file to init', 3 );
 		add_action( 'init', 'wp_cache_late_loader', 9999 );

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3487,6 +3487,11 @@ function wp_cron_preload_cache() {
 				continue;
 			$url = get_permalink( $post_id );
 
+			if ( ! is_string( $url ) ) {
+					wp_cache_debug( "wp_cron_preload_cache: skipped $post_id. Expected a URL, received: " . gettype( $url ) );
+					continue;
+			}
+
 			if ( wp_cache_is_rejected( $url ) ) {
 				wp_cache_debug( "wp_cron_preload_cache: skipped $url per rejected strings setting" );
 				continue;


### PR DESCRIPTION
As reported by @mcaskill in a comment on #29971 the get_permalink() function can return false which we didn't handle in the preload function. They provided a small patch to check which I added to this PR.

It was observed by @dilirity during testing that there was a NULL warning in trunk:
> PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /usr/local/src/jetpack-monorepo/projects/plugins/super-cache/wp-cache-phase2.php on line 54

I noticed this only happens in wp-admin and so, this PR fixes this by disabling caching in "the backend". wp-cache-phase1.php is not loaded in wp-admin, where $wp_cache_request_uri is defined, which caused the problem. This also has the side effect of reducing the amount of extra logging done in the debug log in areas of a site that aren't cached any way.



## Proposed changes:
* Check that the return value from get_permalink() is a string, and handle it if not.
* Disable the caching system if the current URL is in "the backend", which is wp-admin, wp-login.php and other areas.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1692102560916519-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
I'm not sure how to replicate the permalink issue with preloading. It might be caused by deleting a post while preloading, when the preload system has the post_id in the "to check" array in memory.
The issue found by Peter can be replicated by using trunk, going to wp-admin and looking at the debug log.
Apply this patch and the `str_replace` warning disappears because it has not been run.