### PR TITLE
Cookie Consent Block: avoid PHP warning when array key isn't set

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-cookie-consent-notice
+++ b/projects/plugins/jetpack/changelog/fix-cookie-consent-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Cookie Consent Block: avoid PHP notice

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
@@ -82,7 +82,7 @@ function load_assets( $attr, $content ) {
 	}
 
 	$option = get_option( 'cookie_consent_template' );
-	if ( ! empty( $option ) && ! $attr['render_from_template'] ) {
+	if ( ! empty( $option ) && empty( $attr['render_from_template'] ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
## Proposed changes:

This should avoid such warnings:

```
PHP Warning:  Undefined array key "render_from_template" in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php on line 85
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Apearance > Site Editor
* Add a Cookie consent block to Patterns > Footer.
* Check your logs, you should see no notice.
