### PR TITLE
AI Extension: Add extension toolbar click event

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-ai-assistant-extension-tracks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-ai-assistant-extension-tracks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Version bump after trunk merge
+
+

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.4.1",
+	"version": "4.4.2-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.4.1';
+	const PACKAGE_VERSION = '4.4.2-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-extension-tracks
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-extension-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: Add extension toolbar click event

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -98,11 +98,12 @@ export const withAIAssistant = createHigherOrderComponent(
 				tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
 					type: 'suggestion',
 					suggestion: promptType,
+					blockType,
 				} );
 
 				requestSuggestion( promptType, options );
 			},
-			[ tracks, requestSuggestion ]
+			[ tracks, requestSuggestion, blockType ]
 		);
 
 		const replaceWithAiAssistantBlock = useCallback( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -93,7 +93,7 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ blocks, clientIds, content, blockType, replaceBlock, removeBlocks ]
 		);
 
-		const onChange = useCallback(
+		const handleChange = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
 					type: 'suggestion',
@@ -135,7 +135,7 @@ export const withAIAssistant = createHigherOrderComponent(
 				<BlockControls { ...blockControlProps }>
 					<AiAssistantDropdown
 						disabled={ ! rawContent?.length }
-						onChange={ onChange }
+						onChange={ handleChange }
 						onReplace={ replaceWithAiAssistantBlock }
 						exclude={ exclude }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
@@ -34,6 +35,7 @@ export const withAIAssistant = createHigherOrderComponent(
 		const { name: blockType } = props;
 		const { removeBlocks, replaceBlock } = useDispatch( 'core/block-editor' );
 		const { content, clientIds, blocks } = useTextContentFromSelectedBlocks();
+		const { tracks } = useAnalytics();
 
 		/*
 		 * Set exclude dropdown options.
@@ -43,6 +45,7 @@ export const withAIAssistant = createHigherOrderComponent(
 		if ( blockType === 'core/list-item' ) {
 			exclude.push( KEY_ASK_AI_ASSISTANT );
 		}
+
 		const requestSuggestion = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				const [ firstBlock ] = blocks;
@@ -90,6 +93,18 @@ export const withAIAssistant = createHigherOrderComponent(
 			[ blocks, clientIds, content, blockType, replaceBlock, removeBlocks ]
 		);
 
+		const onChange = useCallback(
+			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
+				tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
+					type: 'suggestion',
+					suggestion: promptType,
+				} );
+
+				requestSuggestion( promptType, options );
+			},
+			[ tracks, requestSuggestion ]
+		);
+
 		const replaceWithAiAssistantBlock = useCallback( () => {
 			const [ firstClientId, ...otherBlocksIds ] = clientIds;
 			const [ firstBlock ] = blocks;
@@ -119,7 +134,7 @@ export const withAIAssistant = createHigherOrderComponent(
 				<BlockControls { ...blockControlProps }>
 					<AiAssistantDropdown
 						disabled={ ! rawContent?.length }
-						onChange={ requestSuggestion }
+						onChange={ onChange }
 						onReplace={ replaceWithAiAssistantBlock }
 						exclude={ exclude }
 					/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32286

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the `jetpack_editor_ai_assistant_extension_toolbar_button_click` event, mirroring the `jetpack_editor_ai_assistant_block_toolbar_button_click`, but in the assistant extension

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a paragraph or any extended block
* Use any toolbar action, like translation
* Check that an event is logged in the console via `debug`

![2023-08-15_13-15-06](https://github.com/Automattic/jetpack/assets/8486249/9dca76bd-bc3e-4f79-82cb-99e71c5ff62e)
