### PR TITLE
My Jetpack: clarify user connection text

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.jsx
@@ -179,7 +179,7 @@ const ConnectionStatusCard = props => {
 						{ ! isUserConnected && (
 							<ConnectionListItem
 								onClick={ handleConnectUser }
-								text={ __( 'You’re not connected.', 'jetpack-my-jetpack' ) }
+								text={ __( 'User account not connected.', 'jetpack-my-jetpack' ) }
 								actionText={ __( 'Connect', 'jetpack-my-jetpack' ) }
 								status="error"
 							/>

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.jsx
@@ -34,9 +34,9 @@ describe( 'ConnectionStatusCard', () => {
 			expect( screen.queryByRole( 'button', { name: 'Manage' } ) ).not.toBeInTheDocument();
 		} );
 
-		it( 'renders the "You’re not connected" error list item', () => {
+		it( 'renders the "User account not connected" error list item', () => {
 			setup();
-			expect( screen.getByText( 'You’re not connected.' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'User account not connected.' ) ).toBeInTheDocument();
 		} );
 
 		it( 'renders the "Connect your user account" button', () => {
@@ -67,9 +67,9 @@ describe( 'ConnectionStatusCard', () => {
 			expect( screen.queryByRole( 'button', { name: 'Manage' } ) ).not.toBeInTheDocument();
 		} );
 
-		it( 'Render the "You’re not connected" error list item', () => {
+		it( 'Render the "User account not connected" error list item', () => {
 			setup();
-			expect( screen.getByText( 'You’re not connected.' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'User account not connected.' ) ).toBeInTheDocument();
 		} );
 
 		it( 'renders the "Connect" button', () => {

--- a/projects/packages/my-jetpack/changelog/update-connection-copy
+++ b/projects/packages/my-jetpack/changelog/update-connection-copy
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: My Jetpack: clarify user connection text
+
+

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.3.3",
+	"version": "3.3.4-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.3.3';
+	const PACKAGE_VERSION = '3.3.4-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:

Small tweak to user connection text: From `You’re not connected` --> `User account not connected`

To help disambiguate a bit between the site/user connection. From testing:

> “You’re not connected” is confusing to me, especially beneath “Site connected”. I understand it’s talking about the user vs the site but I doubt that’s clear to everyone. Maybe “Your user account is not connected”?

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal: p8oabR-1jo-p2#comment-7506

## Does this pull request change what data or activity we track or use?
n/a

## Testing instructions:

On JN, pull down this patch and observe the updated text in My Jetpack for a site with site connection but not user connection `/wp-admin/admin.php?page=my-jetpack`:

**Before:**

![Screenshot 2023-08-15 at 12 02 02 PM](https://github.com/Automattic/jetpack/assets/15803018/949c794b-78a7-46b1-a366-ad221f5b6bb9)

**After:**

![Screenshot 2023-08-15 at 12 03 06 PM](https://github.com/Automattic/jetpack/assets/15803018/d50b1b43-d13e-4c6f-9d79-56840a7dfeac)