### PR TITLE
AI Extension: Change event parameter name

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-extension-tracks-parameter
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-extension-tracks-parameter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: Change event parameter name

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -96,9 +96,8 @@ export const withAIAssistant = createHigherOrderComponent(
 		const handleChange = useCallback(
 			( promptType: PromptTypeProp, options: AiAssistantDropdownOnChangeOptionsArgProps ) => {
 				tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
-					type: 'suggestion',
 					suggestion: promptType,
-					blockType,
+					block_type: blockType,
 				} );
 
 				requestSuggestion( promptType, options );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to https://github.com/Automattic/jetpack/pull/32489

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the `type` property, as there is only one type in the extension
* Changes `blockType` to `block_type` in order to conform to the standards

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Same instructions as the original PR
* Check that `type` is not sent
* Check that `blockType` is now `block_type`
