### PR TITLE
Connection: adjust the way we render initial state

### DIFF
--- a/projects/js-packages/connection/README.md
+++ b/projects/js-packages/connection/README.md
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 function my_app_enqueue_script() {
 	// ...
 	wp_enqueue_script( 'my-app-script' );
-	wp_add_inline_script( 'my-app-script', Connection_Initial_State::render(), 'before' );
+	Connection_Initial_State::render_script( 'my-app-script' );
 }
 ```
 

--- a/projects/js-packages/connection/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/js-packages/connection/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Better way to render initial state.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.29.7",
+	"version": "0.29.8-alpha",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/shared-extension-utils/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/js-packages/shared-extension-utils/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.11.1",
+	"version": "0.11.2-alpha",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/src/hooks/readme.md
+++ b/projects/js-packages/shared-extension-utils/src/hooks/readme.md
@@ -7,7 +7,7 @@ This library is only useful when the logged in user is connected to WordPress.co
 ```php
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 // Adds Connection package initial state.
-wp_add_inline_script( 'your-app-script-handle-in-editor', Connection_Initial_State::render(), 'before' );
+Connection_Initial_State::render_script( 'your-app-script-handle-in-editor' );
 ```
 
 Adding Tracks related class and including the check function in your admin ui page:

--- a/projects/packages/backup/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/packages/backup/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -184,7 +184,7 @@ class Jetpack_Backup {
 		Assets::enqueue_script( 'jetpack-backup' );
 		// Initial JS state including JP Connection data.
 		wp_add_inline_script( 'jetpack-backup', self::get_initial_state(), 'before' );
-		wp_add_inline_script( 'jetpack-backup', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'jetpack-backup' );
 
 		// Load script for analytics.
 		if ( self::can_use_analytics() ) {

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.17.0';
+	const PACKAGE_VERSION = '1.17.1-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/packages/blaze/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.9.2",
+	"version": "0.9.3-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -357,7 +357,7 @@ class Blaze {
 		);
 
 		// Adds Connection package initial state.
-		wp_add_inline_script( self::SCRIPT_HANDLE, Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( self::SCRIPT_HANDLE );
 
 		// Pass additional data to our script.
 		wp_localize_script(

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.9.2';
+	const PACKAGE_VERSION = '0.9.3-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/connection/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/packages/connection/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Better way to render initial state.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -65,7 +65,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.56.x-dev"
+			"dev-trunk": "1.57.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/connection/src/class-initial-state.php
+++ b/projects/packages/connection/src/class-initial-state.php
@@ -59,4 +59,17 @@ class Initial_State {
 		return 'var JP_CONNECTION_INITIAL_STATE=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( self::get_data() ) ) . '"));';
 	}
 
+	/**
+	 * Render the initial state using an inline script.
+	 *
+	 * @param string $handle The JS script handle.
+	 *
+	 * @return void
+	 */
+	public static function render_script( $handle ) {
+		if ( ! static::$rendered ) {
+			wp_add_inline_script( $handle, static::render(), 'before' );
+		}
+	}
+
 }

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.56.1';
+	const PACKAGE_VERSION = '1.57.0-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/my-jetpack/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/packages/my-jetpack/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.3.3",
+	"version": "3.3.4-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.3.3';
+	const PACKAGE_VERSION = '3.3.4-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -191,7 +191,7 @@ class Initializer {
 		);
 
 		// Connection Initial State.
-		wp_add_inline_script( 'my_jetpack_main_app', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'my_jetpack_main_app' );
 
 		// Required for Analytics.
 		if ( self::can_use_analytics() ) {

--- a/projects/packages/search/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/packages/search/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.38.3",
+	"version": "0.38.4-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.38.3';
+	const VERSION = '0.38.4-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -192,11 +192,7 @@ class Dashboard {
 		);
 
 		// Connection initial state.
-		wp_add_inline_script(
-			'jp-search-dashboard',
-			Connection_Initial_State::render(),
-			'before'
-		);
+		Connection_Initial_State::render_script( 'jp-search-dashboard' );
 	}
 
 	/**

--- a/projects/packages/videopress/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/packages/videopress/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.14.13",
+	"version": "0.14.14-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -149,7 +149,7 @@ class Admin_UI {
 		}
 
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE, Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE );
 		wp_add_inline_script( self::JETPACK_VIDEOPRESS_PKG_NAMESPACE, self::render_initial_state(), 'before' );
 	}
 

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -163,10 +163,10 @@ class Block_Editor_Extensions {
 			'playerBridgeUrl'             => plugins_url( '../build/lib/player-bridge.js', __FILE__ ),
 		);
 
-		// Expose initital state of site connection
-		wp_add_inline_script( self::$script_handle, Connection_Initial_State::render(), 'before' );
+		// Expose initial state of site connection
+		Connection_Initial_State::render_script( self::$script_handle );
 
-		// Expose initital state of videoPress editor
+		// Expose initial state of videoPress editor
 		wp_localize_script( self::$script_handle, 'videoPressEditorState', $videopress_editor_state );
 	}
 }

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.14.13';
+	const PACKAGE_VERSION = '0.14.14-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/backup/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/backup/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -422,7 +422,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -453,7 +453,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/boost/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -470,7 +470,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -501,7 +501,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/inspect/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/inspect/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -337,7 +337,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -368,7 +368,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -296,6 +296,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		wp_add_inline_script( 'react-plugin', 'var jetpack_redirects = { currentSiteRawUrl: "' . $site_suffix . '" };', 'before' );
 
 		// Adds Connection package initial state.
-		wp_add_inline_script( 'react-plugin', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'react-plugin' );
 	}
 }

--- a/projects/plugins/jetpack/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/jetpack/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use the new method to render Connection initial state.

--- a/projects/plugins/jetpack/changelog/fix-connection-initial-state-render-repeat#2
+++ b/projects/plugins/jetpack/changelog/fix-connection-initial-state-render-repeat#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -743,7 +743,7 @@ class Jetpack_Gutenberg {
 		);
 
 		// Adds Connection package initial state.
-		wp_add_inline_script( 'jetpack-blocks-editor', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'jetpack-blocks-editor' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3799,7 +3799,7 @@ p {
 		wp_add_inline_script( 'jetpack-full-activation-modal-js', 'var Initial_State=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( Jetpack_Redux_State_Helper::get_minimal_state() ) ) . '"));', 'before' );
 
 		// Adds Connection package initial state.
-		wp_add_inline_script( 'jetpack-full-activation-modal-js', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'jetpack-full-activation-modal-js' );
 
 		add_action( 'admin_notices', array( $this, 'jetpack_plugin_portal_containers' ) );
 	}

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -851,7 +851,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -882,7 +882,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/migration/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/migration/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/plugins/migration/changelog/fix-connection-initial-state-render-repeat#2
+++ b/projects/plugins/migration/changelog/fix-connection-initial-state-render-repeat#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -422,7 +422,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -453,7 +453,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/migration/src/class-wpcom-migration.php
+++ b/projects/plugins/migration/src/class-wpcom-migration.php
@@ -121,7 +121,7 @@ class WPCOM_Migration {
 			Tracking::register_tracks_functions_scripts( true );
 		}
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( 'wpcom-migration', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'wpcom-migration' );
 		wp_add_inline_script( 'wpcom-migration', $this->render_initial_state(), 'before' );
 	}
 

--- a/projects/plugins/protect/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/protect/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/plugins/protect/changelog/fix-connection-initial-state-render-repeat#2
+++ b/projects/plugins/protect/changelog/fix-connection-initial-state-render-repeat#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -337,7 +337,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -368,7 +368,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -184,7 +184,7 @@ class Jetpack_Protect {
 		// Required for Analytics.
 		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( 'jetpack-protect', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'jetpack-protect' );
 		wp_add_inline_script( 'jetpack-protect', $this->render_initial_state(), 'before' );
 	}
 

--- a/projects/plugins/search/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/search/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -337,7 +337,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -368,7 +368,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/social/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/plugins/social/changelog/fix-connection-initial-state-render-repeat#2
+++ b/projects/plugins/social/changelog/fix-connection-initial-state-render-repeat#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -337,7 +337,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -368,7 +368,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -175,7 +175,7 @@ class Jetpack_Social {
 
 		Assets::enqueue_script( 'jetpack-social' );
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( 'jetpack-social', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'jetpack-social' );
 		wp_add_inline_script( 'jetpack-social', $this->render_initial_state(), 'before' );
 	}
 
@@ -302,7 +302,6 @@ class Jetpack_Social {
 	 */
 	public function enqueue_block_editor_scripts() {
 		global $publicize;
-
 		if (
 			class_exists( 'Jetpack' ) ||
 			! $this->should_enqueue_block_editor_scripts()
@@ -349,7 +348,7 @@ class Jetpack_Social {
 		);
 
 		// Connection initial state is expected when the connection JS package is in the bundle
-		wp_add_inline_script( 'jetpack-social-editor', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'jetpack-social-editor' );
 		// Conditionally load analytics scripts
 		// The only component using analytics in the editor at the moment is the review request
 		if ( ! in_array( get_post_status(), array( 'publish', 'private', 'trash' ), true ) && self::can_use_analytics() && ! self::is_review_request_dismissed() ) {

--- a/projects/plugins/starter-plugin/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/starter-plugin/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use the new method to render Connection initial state.

--- a/projects/plugins/starter-plugin/changelog/fix-connection-initial-state-render-repeat#2
+++ b/projects/plugins/starter-plugin/changelog/fix-connection-initial-state-render-repeat#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -337,7 +337,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -368,7 +368,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/src/class-jetpack-starter-plugin.php
+++ b/projects/plugins/starter-plugin/src/class-jetpack-starter-plugin.php
@@ -88,7 +88,7 @@ class Jetpack_Starter_Plugin {
 		);
 		Assets::enqueue_script( 'jetpack-starter-plugin' );
 		// Initial JS state including JP Connection data.
-		wp_add_inline_script( 'jetpack-starter-plugin', Connection_Initial_State::render(), 'before' );
+		Connection_Initial_State::render_script( 'jetpack-starter-plugin' );
 		wp_add_inline_script( 'jetpack-starter-plugin', $this->render_initial_state(), 'before' );
 	}
 

--- a/projects/plugins/videopress/changelog/fix-connection-initial-state-render-repeat
+++ b/projects/plugins/videopress/changelog/fix-connection-initial-state-render-repeat
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -337,7 +337,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "d20feb5a09eec141ca3a4b347da899e073a0557e"
+                "reference": "53778ab847d8271bbecebd2725029996e9c6c1db"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -368,7 +368,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Fixes #32499

## Proposed changes:
Currently, trying to render connection initial state multiple times on the same page will lead to `null` returned instead of the valid JavaScript code. That `null` will be passed to `wp_add_inline_script()` and subsequently to `stripos()`, which does not support non-string values for the `$haystack` argument.

This PR changes the way we render connection initial state to prevent re-render attempts, and simplifies it for consuming plugins/packages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1690838332688659-slack-CDLH4C1UZ
1191179647901802-as-1205228449251052

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Open the browser console and confirm the global variable `JP_CONNECTION_INITIAL_STATE` exists:

1. Jetpack Dashboard
2. Edit a post
3. Jetpack Social
4. Activate Jetpack Social (free is enough), disable Jetpack, and go to the post editor
5. Jetpack Search
6. Jetpack Starter Plugin
7. “Move to WordPress.com”
8. VideoPress
9. My Jetpack
10. Jetpack Protect
11. Disconnect and deactivate Jetpack, activate it again and see the huge “Set up Jetpack” modal.