### PR TITLE
Launchpad: Add ID map to the launchpad response

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-id-map-to-launchpad-response
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-id-map-to-launchpad-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the ID map to the Launchpad response

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -370,6 +370,10 @@ class Launchpad_Task_Lists {
 			}
 		}
 
+		if ( isset( $task['id_map'] ) ) {
+			$built_task['id_map'] = $task['id_map'];
+		}
+
 		return $built_task;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  Adds the ID map to the Launchpad response, so we can identify which task we should mark as complete when clicking on the task.
* This is related to: https://github.com/Automattic/wp-calypso/pull/80636

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this diff to your sandbox using the code in the comment below
* Create a new Newsletter 
* Add the `connect_social_media` task to the appropriate task list in your sandbox:
```
nano wp-content/mu-plugins/jetpack-mu-wpcom-plugin/production/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
```
* Navigate to the Developer Console https://developer.wordpress.com/docs/api/console/
* Make a `GET` request to `WP REST API` `wpcom/v2` `/sites/:siteSlug/launchpad`
* The task `connect_social_media` should contain the `id_map`.

