### PR TITLE
Subscribe modal toggle: adjust copy slightly

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -142,7 +142,7 @@ function SubscriptionsSettings( props ) {
 									}
 									toggling={ isSavingAnyOption( [ 'sm_enabled' ] ) }
 									onChange={ handleSubscribeModalToggleChange }
-									label={ __( 'Enable subscriber modal', 'jetpack' ) }
+									label={ __( 'Enable subscriber pop-up', 'jetpack' ) }
 								/>
 								<p className="jp-form-setting-explanation">
 									{ __(

--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-toggle-copy
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-toggle-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe modal: update toggle copy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Calypso version https://github.com/Automattic/wp-calypso/pull/80701

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update subscribe modal toggle copy

We got feedback that "pop-up" is better known among customers than "modal".

<img width="1093" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/895a3333-bb59-4f66-bc71-29892819b579">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Newsletter settings
* See toggle label