### PR TITLE
e2e tests: when a WP site has Jetpack SSO, switch to regular login

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -34,7 +34,7 @@ const projects = [
 		project: 'Jetpack blocks',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/blocks', '--retries=1' ],
-		targets: [ 'plugins/jetpack', 'monorepo' ],
+		targets: [ 'plugins/jetpack' ],
 		suite: '',
 	},
 	{

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -34,7 +34,7 @@ const projects = [
 		project: 'Jetpack blocks',
 		path: 'projects/plugins/jetpack/tests/e2e',
 		testArgs: [ 'specs/blocks', '--retries=1' ],
-		targets: [ 'plugins/jetpack' ],
+		targets: [ 'plugins/jetpack', 'monorepo' ],
 		suite: '',
 	},
 	{

--- a/tools/e2e-commons/pages/wp-admin/login.js
+++ b/tools/e2e-commons/pages/wp-admin/login.js
@@ -12,6 +12,14 @@ export default class WPLoginPage extends WpPage {
 	async login( credentials = getSiteCredentials(), { retry = true } = {} ) {
 		logger.step( 'Log in to wp-admin' );
 
+		// If the SSO login button (a tag with the jetpack-sso class) is present,
+		// click on the link (a tag with the jetpack-sso-toggle class) to log in with the default core WP login form instead.
+		if ( await this.isElementVisible( '.jetpack-sso' ) ) {
+			await this.clickAndWaitForNewPage( '.jetpack-sso-toggle', {
+				expectedSelectors: [ '#loginform' ],
+			} );
+		}
+
 		await this.fill( '#user_login', credentials.username );
 		await this.fill( '#user_pass', credentials.password );
 		await this.click( '#wp-submit' );


### PR DESCRIPTION
## Proposed changes:

This should allow us to log in using the saved site credentials at all times

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Is CI happy on this PR?
* Once merged, will VIP tests pass?
