### PR TITLE
CI: Lint that published packages' deps are published too

### DIFF
--- a/projects/js-packages/analytics/.gitattributes
+++ b/projects/js-packages/analytics/.gitattributes
@@ -5,3 +5,4 @@ node_modules      export-ignore
 # Files to exclude from the mirror repo
 /changelog/**     production-exclude
 /jest.config.cjs  production-exclude
+/test/**          production-exclude

--- a/projects/js-packages/analytics/changelog/add-lint-published-packages-deps-are-published-too
+++ b/projects/js-packages/analytics/changelog/add-lint-published-packages-deps-are-published-too
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Publish package to npmjs.com.

--- a/projects/js-packages/analytics/composer.json
+++ b/projects/js-packages/analytics/composer.json
@@ -23,5 +23,13 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-analytics",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-analytics/compare/v${old}...v${new}"
+		},
+		"autotagger": true,
+		"npmjs-autopublish": true
+	}
 }

--- a/projects/js-packages/analytics/package.json
+++ b/projects/js-packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-analytics",
-	"version": "0.1.25",
+	"version": "0.1.26-alpha",
 	"description": "Jetpack Analytics Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/analytics/package.json
+++ b/projects/js-packages/analytics/package.json
@@ -2,6 +2,15 @@
 	"name": "@automattic/jetpack-analytics",
 	"version": "0.1.26-alpha",
 	"description": "Jetpack Analytics Package",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/analytics/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[JS Package] Analytics"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/js-packages/analytics"
+	},
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {},

--- a/projects/js-packages/api/.gitattributes
+++ b/projects/js-packages/api/.gitattributes
@@ -7,3 +7,4 @@ node_modules      export-ignore
 /.eslintrc.cjs    production-exclude
 /.gitignore       production-exclude
 /jest.config.cjs  production-exclude
+/test/**          production-exclude

--- a/projects/js-packages/api/changelog/add-lint-published-packages-deps-are-published-too
+++ b/projects/js-packages/api/changelog/add-lint-published-packages-deps-are-published-too
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Publish package to npmjs.com.

--- a/projects/js-packages/api/composer.json
+++ b/projects/js-packages/api/composer.json
@@ -19,5 +19,13 @@
 				"monorepo": true
 			}
 		}
-	]
+	],
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-api",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-api/compare/v${old}...v${new}"
+		},
+		"autotagger": true,
+		"npmjs-autopublish": true
+	}
 }

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,7 +1,16 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.16.0",
+	"version": "0.16.1-alpha",
 	"description": "Jetpack Api Package",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[JS Package] Api"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/js-packages/api"
+	},
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {

--- a/projects/js-packages/config/.gitattributes
+++ b/projects/js-packages/config/.gitattributes
@@ -3,6 +3,7 @@
 node_modules      export-ignore
 
 # Files to exclude from the mirror repo
+/.gitignore       production-exclude
 /**/test/**       production-exclude
 /changelog/**     production-exclude
 /jest.config.js   production-exclude

--- a/projects/js-packages/config/changelog/add-lint-published-packages-deps-are-published-too
+++ b/projects/js-packages/config/changelog/add-lint-published-packages-deps-are-published-too
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Publish package to npmjs.com.

--- a/projects/js-packages/config/composer.json
+++ b/projects/js-packages/config/composer.json
@@ -27,5 +27,13 @@
 		}
 	],
 	"minimum-stability": "dev",
-	"prefer-stable": true
+	"prefer-stable": true,
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-config-js",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-config-js/compare/v${old}...v${new}"
+		},
+		"autotagger": true,
+		"npmjs-autopublish": true
+	}
 }

--- a/projects/js-packages/config/package.json
+++ b/projects/js-packages/config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-config",
-	"version": "0.1.20",
+	"version": "0.1.21-alpha",
 	"description": "Handles Jetpack global configuration shared across all packages",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/config/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/.gitattributes
+++ b/projects/js-packages/connection/.gitattributes
@@ -5,5 +5,8 @@ node_modules      export-ignore
 # Files to exclude from the mirror repo
 /changelog/**     production-exclude
 /.eslintrc.cjs    production-exclude
+/.gitignore       production-exclude
 /jest.config.cjs  production-exclude
-/jest.setup.cjs   production-exclude
+/jest.setup.js    production-exclude
+**/stories/**     production-exclude
+**/test/**        production-exclude

--- a/projects/js-packages/connection/changelog/add-lint-published-packages-deps-are-published-too
+++ b/projects/js-packages/connection/changelog/add-lint-published-packages-deps-are-published-too
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Publish package to npmjs.com.

--- a/projects/js-packages/connection/composer.json
+++ b/projects/js-packages/connection/composer.json
@@ -19,5 +19,13 @@
 				"monorepo": true
 			}
 		}
-	]
+	],
+	"extra": {
+		"mirror-repo": "Automattic/jetpack-connection-js",
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-connection-js/compare/v${old}...v${new}"
+		},
+		"autotagger": true,
+		"npmjs-autopublish": true
+	}
 }

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -2,6 +2,15 @@
 	"name": "@automattic/jetpack-connection",
 	"version": "0.29.8-alpha",
 	"description": "Jetpack Connection Component",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[JS Package] Connection"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/js-packages/connection"
+	},
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
js-packages/ai-client depends on js-packages/connection, but the latter isn't published. That makes the published version of ai-client unusable. We should lint for that.

Then, of course, we have to actually publish the necessary packages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1691484579161569/1690493398.174649-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The initial commit on this PR should fail the linting.
  * [x] https://github.com/Automattic/jetpack/actions/runs/5881910741/job/15951321022?pr=32515#step:5:21
* Subsequent commits that set up the necessary packages for release should pass the linting.
* Also check that things look right for those releases.