### PR TITLE
Launchpad: Add calypso path callback for `set_up_payments` task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-path-for-payments
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-path-for-payments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Add calypso path for set_up_payments task.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -485,18 +485,23 @@ class Launchpad_Task_Lists {
 	}
 
 	/**
-	 * Checks if a string is a valid admin URL or an absolute path.
+	 * Checks if a string is a Stripe connection, valid admin URL, or absolute path.
 	 *
 	 * @param string $input The string to check.
 	 * @return boolean
 	 */
 	private function is_valid_admin_url_or_absolute_path( $input ) {
-		// Checks if the string is URL starting with the admin URL
+		// Allow Stripe connection URLs for `set_up_payments` task.
+		if ( strpos( $input, 'https://connect.stripe.com' ) === 0 ) {
+			return true;
+		}
+
+		// Checks if the string is URL starting with the admin URL.
 		if ( strpos( $input, admin_url() ) === 0 ) {
 			return true;
 		}
 
-		// Require that the string start with a slash, but not two slashes
+		// Require that the string start with a slash, but not two slashes.
 		if ( '/' === substr( $input, 0, 1 ) && '/' !== substr( $input, 1, 1 ) ) {
 			return true;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -145,6 +145,15 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Set up payment method', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
+			'get_calypso_path'    => function( $task, $default, $data ) {
+				if ( function_exists( 'get_memberships_connected_account_redirect' ) ) {
+					return get_memberships_connected_account_redirect(
+						get_current_user_id(),
+						get_current_blog_id()
+					);
+				}
+				return '/earn/payments/' . $data['site_slug_encoded'];
+			},
 		),
 		'subscribers_added'               => array(
 			'get_title'            => function () {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -145,7 +145,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Set up payment method', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
-			'get_calypso_path'    => function( $task, $default, $data ) {
+			'get_calypso_path'    => function ( $task, $default, $data ) {
 				if ( function_exists( 'get_memberships_connected_account_redirect' ) ) {
 					return get_memberships_connected_account_redirect(
 						get_current_user_id(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/80714

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a Calypso path callback for the `set_up_payments` task so we can use it in the Customer Home Launchpad for paid newsletters.
* Allow URLs that start with `https://connect.stripe.com` in the `load_calypso_path` URL validation function.
* If we can, get the Stripe connect URL. If not, fall back to the `/earn/payments/siteSlug` URL.
* We wrap the Stripe connect URL in a function_exists check because this function is not available in Jetpack/on Atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your sandbox and sandbox public-api
* Create a new site from `/setup/newsletter`, select the Paid option
* Complete setup by publishing your first post, then go to `/home/siteSlug`
* You should be able to click on the "Set up payments" task and go to either the Stripe connection screen or `/earn/payments/siteSlug`