### PR TITLE
Flickr embeds: avoid errors when a request to Flickr fails

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-flickr-fails
+++ b/projects/plugins/jetpack/changelog/fix-flickr-fails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortcode embeds: avoid errors when a request to Flickr fails.

--- a/projects/plugins/jetpack/modules/shortcodes/flickr.php
+++ b/projects/plugins/jetpack/modules/shortcodes/flickr.php
@@ -217,6 +217,11 @@ function flickr_shortcode_video_markup( $atts, $id, $video_param ) {
 
 		$embed_page = wp_remote_get( $embed_url );
 
+		// Bail if the request returns an error.
+		if ( is_wp_error( $embed_page ) ) {
+			return '';
+		}
+
 		// Get the video url from embed html markup.
 
 		preg_match( '/video.+src=\"([^\"]+)\"/', $embed_page['body'], $matches );

--- a/projects/plugins/jetpack/modules/shortcodes/flickr.php
+++ b/projects/plugins/jetpack/modules/shortcodes/flickr.php
@@ -218,7 +218,7 @@ function flickr_shortcode_video_markup( $atts, $id, $video_param ) {
 		$embed_page = wp_remote_get( $embed_url );
 
 		// Bail if the request returns an error.
-		if ( is_wp_error( $embed_page ) ) {
+		if ( ! is_array( $embed_page ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
## Proposed changes:

Let's add an additional safeguard before we try using items from a response we get from Flickr.

See p1692257171912309-slack-CBG1CP4EN

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings and enable Shortcode embeds.
* Embed a Flickr video as explained here: https://wordpress.com/support/images/flickr-photos/
* It should be displayed nicely on the frontend.
