### PR TITLE
Blocks: add "Beta" suffix to Beta blocks' description

### DIFF
--- a/projects/plugins/jetpack/changelog/update-beta-block-json
+++ b/projects/plugins/jetpack/changelog/update-beta-block-json
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: add "Beta" suffix to Beta blocks' descriptions in block.json file.

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack/ai-chat",
-	"title": "AI Chat (Experimental)",
+	"title": "AI Chat (Beta)",
 	"description": "Provides summarized chat across a site’s content, powered by AI magic.",
 	"keywords": [ "AI", "GPT", "Chat", "Search" ],
 	"version": "12.5.0",

--- a/projects/plugins/jetpack/extensions/blocks/amazon/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/amazon/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack/amazon",
-	"title": "Amazon",
+	"title": "Amazon (Beta)",
 	"description": "Promote Amazon products and earn a commission from sales.",
 	"keywords": [ "amazon", "affiliate" ],
 	"version": "12.5.0",

--- a/projects/plugins/jetpack/extensions/blocks/author-recommendation/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/author-recommendation/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack/author-recommendation",
-	"title": "Author Recommendation",
+	"title": "Author Recommendation (Beta)",
 	"description": "Select the sites you follow and share them with your users.",
 	"keywords": [],
 	"version": "12.5.0",

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack/google-docs-embed",
-	"title": "Google Docs",
+	"title": "Google Docs (Beta)",
 	"description": "Embed a Google Document.",
 	"keywords": [ "document", "gsuite", "doc" ],
 	"version": "12.5.0",

--- a/projects/plugins/jetpack/extensions/blocks/paywall/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack/paywall",
-	"title": "Paywall",
+	"title": "Paywall (Beta)",
 	"description": "Paywall",
 	"keywords": [
 		"email",

--- a/projects/plugins/jetpack/extensions/blocks/recipe/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "jetpack/recipe",
-	"title": "Recipe",
+	"title": "Recipe (Beta)",
 	"description": "Add images, ingredients and cooking steps to display an easy to read recipe.",
 	"keywords": [],
 	"version": "12.5.0",


### PR DESCRIPTION
Follow-up from #32432

## Proposed changes:

As discussed during the team chat, this can be a quick and dirty way to mark our Beta blocks as "Beta" for now.

We could do the same for Experimental blocks, but it just so happens that our Experimental blocks are already marked as experimental in their titles today.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* Primary issue: #32408 

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test here. Make sure all the Beta blocks are covered here.
