### PR TITLE
VIP e2e tests: click and do not wait for a new page to load

### DIFF
--- a/tools/e2e-commons/pages/wp-admin/login.js
+++ b/tools/e2e-commons/pages/wp-admin/login.js
@@ -15,9 +15,7 @@ export default class WPLoginPage extends WpPage {
 		// If the SSO login button (a tag with the jetpack-sso class) is present,
 		// click on the link (a tag with the jetpack-sso-toggle class) to log in with the default core WP login form instead.
 		if ( await this.isElementVisible( '.jetpack-sso' ) ) {
-			await this.clickAndWaitForNewPage( '.jetpack-sso-toggle', {
-				expectedSelectors: [ '#loginform' ],
-			} );
+			await this.click( '.jetpack-sso-toggle' );
 		}
 
 		await this.fill( '#user_login', credentials.username );


### PR DESCRIPTION
Follow-up from #32514

## Proposed changes:

I made a mistake in the last PR; The default core login form appears as soon as you click on the link, no page needs to load.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test in this PR, this will need to be merged first, before we can see results here:
https://a8c-jetpack-e2e-reports.s3.amazonaws.com/reports/vip/report/index.html#

