### PR TITLE
Social: Scope the CSS for the preview image

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-image-preview-css-scoping
+++ b/projects/js-packages/publicize-components/changelog/fix-social-image-preview-css-scoping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Scope the preview image CSS to its container

--- a/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
+++ b/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
@@ -120,7 +120,7 @@ export default function GeneratedImagePreview( {
 						src={ generatedImageUrl }
 						alt={ __( 'Generated preview', 'jetpack' ) }
 						onLoad={ onImageLoad }
-					></img>
+					/>
 					{ isLoading && <Spinner data-testid="spinner" /> }
 				</div>
 			</BaseControl>

--- a/projects/js-packages/publicize-components/src/components/generated-image-preview/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/generated-image-preview/styles.module.scss
@@ -18,16 +18,17 @@
 		align-self: center;
 		margin: 0;
 	}
+
+	img {
+		max-height: 100%;
+		max-width: 100%;
+		width: auto;
+		height: auto;
+		object-fit: contain;
+	}
 }
 
 .hidden {
 	display: none;
 }
 
-img {
-	max-height: 100%;
-	max-width: 100%;
-	width: auto;
-    height: auto; 
-    object-fit: contain;
-}


### PR DESCRIPTION
Fixes Automattic/wp-calypso#80347

## Proposed changes:
This moves the `img` CSS rules to inside the container, in order to stop it polluting the CSS of other image tags in the editor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Follow the reproduction steps in Automattic/wp-calypso#80347

