### PR TITLE
AI Extension: be able to show AI Assistant from children Jetpack Form blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-assistant-bar-accessibility
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-assistant-bar-accessibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: be able to show AI Assistant from children Jetpack Form blocks

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/style.scss
@@ -24,5 +24,9 @@
 }
 
 .jetpack-ai-assistant-bar__slot {
-    position: sticky;
+	border: none;
+	border-radius: 0;
+	display: block;
+	position: sticky;
+	z-index: 31;
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -57,9 +57,15 @@ export default function AiAssistantToolbarButton( {
 		 * to be used as the anchor for the Assistant Bar.
 		 */
 
-		// Check if the slot already exists.
-		let slot = toolbar?.nextElementSibling as HTMLElement;
-		if ( slot?.classList.contains( AI_ASSISTANT_BAR_SLOT_CLASS ) ) {
+		/*
+		 * Check if the slot already exists,
+		 * quering from the block-toolbar parent element.
+		 */
+		let slot = toolbar.parentElement?.querySelector(
+			`.${ AI_ASSISTANT_BAR_SLOT_CLASS }`
+		) as HTMLElement;
+
+		if ( slot ) {
 			return setAnchor( slot );
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -3,13 +3,14 @@
  */
 import { aiAssistantIcon, useAiContext } from '@automattic/jetpack-ai-client';
 import { KeyboardShortcuts, ToolbarButton } from '@wordpress/components';
-import { useContext, useRef } from '@wordpress/element';
+import { useContext, useRef, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect } from 'react';
 /*
  * Internal dependencies
  */
 import { AiAssistantUiContext } from '../../ui-handler/context';
+import { selectFormBlock } from '../../ui-handler/with-ui-handler-data-provider';
 
 const AI_ASSISTANT_BAR_SLOT_CLASS = 'jetpack-ai-assistant-bar__slot';
 
@@ -18,9 +19,15 @@ const AI_ASSISTANT_BAR_SLOT_CLASS = 'jetpack-ai-assistant-bar__slot';
  * Also, it creates a slot just after the contextual toolbar
  * to be used as the anchor for the Assistant Bar.
  *
- * @returns {React.ReactElement} The toolbar button.
+ * @param {object} props - The component props.
+ * @param {string} props.jetpackFormClientId - The Jetpack Form block client ID.
+ * @returns {React.ReactElement}               The toolbar button.
  */
-export default function AiAssistantToolbarButton(): React.ReactElement {
+export default function AiAssistantToolbarButton( {
+	jetpackFormClientId,
+}: {
+	jetpackFormClientId?: string;
+} ): React.ReactElement {
 	const { isVisible, toggle, setAnchor } = useContext( AiAssistantUiContext );
 	const { requestingState } = useAiContext();
 
@@ -70,6 +77,14 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 		setAnchor( slot );
 	}, [ setAnchor ] );
 
+	const toggleFromToolbar = useCallback( () => {
+		if ( ! jetpackFormClientId ) {
+			return toggle();
+		}
+
+		selectFormBlock( jetpackFormClientId, toggle );
+	}, [ jetpackFormClientId, toggle ] );
+
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 
 	return (
@@ -84,7 +99,7 @@ export default function AiAssistantToolbarButton(): React.ReactElement {
 			<ToolbarButton
 				ref={ toolbarButtonRef }
 				showTooltip
-				onClick={ toggle }
+				onClick={ toggleFromToolbar }
 				aria-haspopup="true"
 				aria-expanded={ isVisible }
 				label={ __( 'Ask AI Assistant', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -3,6 +3,7 @@
  */
 import { aiAssistantIcon, useAiContext } from '@automattic/jetpack-ai-client';
 import { KeyboardShortcuts, ToolbarButton } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { useContext, useRef, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect } from 'react';
@@ -28,10 +29,12 @@ export default function AiAssistantToolbarButton( {
 }: {
 	jetpackFormClientId?: string;
 } ): React.ReactElement {
-	const { isVisible, toggle, setAnchor } = useContext( AiAssistantUiContext );
+	const { isVisible, toggle, setAnchor, assistantAnchor } = useContext( AiAssistantUiContext );
 	const { requestingState } = useAiContext();
 
 	const toolbarButtonRef = useRef< HTMLElement | null >( null );
+
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
 	/*
 	 * When the toolbar button is rendered, we need to find the
@@ -60,11 +63,12 @@ export default function AiAssistantToolbarButton( {
 		/*
 		 * Check if the slot already exists,
 		 * quering from the block-toolbar parent element.
+		 * It should not happend, since the slot removes
+		 * when the viewport is not mobile.
 		 */
 		let slot = toolbar.parentElement?.querySelector(
 			`.${ AI_ASSISTANT_BAR_SLOT_CLASS }`
 		) as HTMLElement;
-
 		if ( slot ) {
 			return setAnchor( slot );
 		}
@@ -86,6 +90,15 @@ export default function AiAssistantToolbarButton( {
 		// Set the anchor where the Assistant Bar will be rendered.
 		setAnchor( slot );
 	}, [ setAnchor ] );
+
+	// Remove the slot when the view is not mobile.
+	useEffect( () => {
+		if ( isMobileViewport ) {
+			return;
+		}
+
+		assistantAnchor?.remove();
+	}, [ isMobileViewport, assistantAnchor ] );
 
 	const toggleFromToolbar = useCallback( () => {
 		if ( ! jetpackFormClientId ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -79,6 +79,10 @@ export default function AiAssistantToolbarButton( {
 		slot.className = AI_ASSISTANT_BAR_SLOT_CLASS;
 		toolbar.after( slot );
 
+		// Set the top position based on the toolbar height.
+		const toolbarHeight = toolbar.offsetHeight;
+		slot.style.top = `${ toolbarHeight }px`;
+
 		// Set the anchor where the Assistant Bar will be rendered.
 		setAnchor( slot );
 	}, [ setAnchor ] );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/constants.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/constants.ts
@@ -3,3 +3,20 @@ export const JETPACK_FORM_AI_COMPOSITION_EXTENSION = 'ai-assistant-form-support'
 export const isJetpackFromBlockAiCompositionAvailable =
 	window?.Jetpack_Editor_Initial_State.available_blocks?.[ JETPACK_FORM_AI_COMPOSITION_EXTENSION ]
 		?.available;
+
+// All blocks to extend
+export const JETPACK_FORM_CHILDREN_BLOCKS = [
+	'jetpack/field-name',
+	'jetpack/field-email',
+	'jetpack/field-text',
+	'jetpack/field-textarea',
+	'jetpack/field-checkbox',
+	'jetpack/field-date',
+	'jetpack/field-telephone',
+	'jetpack/field-url',
+	'jetpack/field-checkbox-multiple',
+	'jetpack/field-radio',
+	'jetpack/field-select',
+	'jetpack/field-consent',
+	'jetpack/button',
+];

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -16,15 +16,20 @@ import { isUserConnected } from '../../lib/connection';
 import AiAssistantBar from './components/ai-assistant-bar';
 import AiAssistantToolbarButton from './components/ai-assistant-toolbar-button';
 import { isJetpackFromBlockAiCompositionAvailable } from './constants';
+import { JETPACK_FORM_CHILDREN_BLOCKS } from './constants';
 import withUiHandlerDataProvider from './ui-handler/with-ui-handler-data-provider';
 
 /**
  * Check if it is possible to extend the block.
  *
- * @param {string} blockName - The block name.
- * @returns {boolean}          True if it is possible to extend the block.
+ * @param {string} blockName            - The block name.
+ * @param {boolean} checkChildrenBlocks - Check if the block is a child of a Jetpack Form block.
+ * @returns {boolean}                     True if it is possible to extend the block.
  */
-export function isPossibleToExtendJetpackFormBlock( blockName: string | undefined ): boolean {
+export function isPossibleToExtendJetpackFormBlock(
+	blockName: string | undefined,
+	checkChildrenBlocks?: boolean
+): boolean {
 	// Check if the AI Assistant block is registered.
 	const isBlockRegistered = getBlockType( 'jetpack/ai-assistant' );
 	if ( ! isBlockRegistered ) {
@@ -36,8 +41,14 @@ export function isPossibleToExtendJetpackFormBlock( blockName: string | undefine
 		return false;
 	}
 
-	// Only extend Jetpack Form block.
-	if ( blockName !== 'jetpack/contact-form' ) {
+	// Only extend allowed blocks.
+	if ( checkChildrenBlocks ) {
+		// First, check if it should check for children blocks. (false by default)
+		if ( ! JETPACK_FORM_CHILDREN_BLOCKS.includes( blockName ) ) {
+			return false;
+		}
+	} else if ( blockName !== 'jetpack/contact-form' ) {
+		// If it is not a child block, check if it is the Jetpack Form block.
 		return false;
 	}
 
@@ -110,6 +121,34 @@ const withAiAssistantComponents = createHigherOrderComponent( BlockEdit => {
 }, 'withAiAssistantComponents' );
 
 addFilter( 'editor.BlockEdit', 'jetpack/jetpack-form-block-edit', withAiAssistantComponents, 100 );
+
+/**
+ * Add the AI Assistant button to the toolbar.
+ * This HOC should be used only for children blocks of the Jetpack Form block.
+ */
+const withAiToolbarButton = createHigherOrderComponent( BlockEdit => {
+	return props => {
+		if ( ! isPossibleToExtendJetpackFormBlock( props?.name, true ) ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const blockControlsProps = {
+			group: 'parent',
+		};
+
+		return (
+			<>
+				<BlockEdit { ...props } />
+
+				<BlockControls { ...blockControlsProps }>
+					<AiAssistantToolbarButton />
+				</BlockControls>
+			</>
+		);
+	};
+}, 'withAiAssistantComponents' );
+
+addFilter( 'editor.BlockEdit', 'jetpack/jetpack-form-block-edit', withAiToolbarButton );
 
 // Provide the UI Handler data context to the block.
 addFilter(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -154,7 +154,7 @@ const withAiToolbarButton = createHigherOrderComponent( BlockEdit => {
 			</>
 		);
 	};
-}, 'withAiAssistantComponents' );
+}, 'withAiToolbarButton' );
 
 addFilter( 'editor.BlockEdit', 'jetpack/jetpack-form-block-edit', withAiToolbarButton );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -5,7 +5,7 @@ import { useAiContext, withAiDataProvider } from '@automattic/jetpack-ai-client'
 import { BlockControls } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { select } from '@wordpress/data';
+import { select, useSelect } from '@wordpress/data';
 import { useEffect, useCallback } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 /*
@@ -132,6 +132,14 @@ const withAiToolbarButton = createHigherOrderComponent( BlockEdit => {
 			return <BlockEdit { ...props } />;
 		}
 
+		// Get clientId of the parent block.
+		const parentClientId = useSelect(
+			selectData => {
+				const { getBlockParentsByBlockName } = selectData( 'core/block-editor' );
+				return getBlockParentsByBlockName( props.clientId, 'jetpack/contact-form' )?.[ 0 ];
+			},
+			[ props.clientId ]
+		);
 		const blockControlsProps = {
 			group: 'parent',
 		};
@@ -141,7 +149,7 @@ const withAiToolbarButton = createHigherOrderComponent( BlockEdit => {
 				<BlockEdit { ...props } />
 
 				<BlockControls { ...blockControlsProps }>
-					<AiAssistantToolbarButton />
+					<AiAssistantToolbarButton jetpackFormClientId={ parentClientId } />
 				</BlockControls>
 			</>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -22,6 +22,19 @@ import type { RequestingErrorProps } from '@automattic/jetpack-ai-client';
 // An identifier to use on the extension error notices,
 export const AI_ASSISTANT_JETPACK_FORM_NOTICE_ID = 'ai-assistant';
 
+/**
+ * Select the Jetpack Form block,
+ * based on the block client ID.
+ * Then, run the function passed as parameter (optional).
+ *
+ * @param {string} clientId - The block client ID.
+ * @param {Function} fn     - The function to run after selecting the block.
+ * @returns {void}
+ */
+export function selectFormBlock( clientId: string, fn: () => void ): void {
+	dispatch( 'core/block-editor' ).selectBlock( clientId ).then( fn );
+}
+
 const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => {
 	return props => {
 		const { clientId, isSelected } = props;
@@ -81,15 +94,6 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		const setAnchor = useCallback( ( anchor: HTMLElement | null ) => {
 			setAssistantAnchor( anchor );
 		}, [] );
-
-		/**
-		 * Select the Jetpack Form block
-		 *
-		 * @returns {void}
-		 */
-		const selectFormBlock = useCallback( () => {
-			dispatch( 'core/block-editor' ).selectBlock( clientId ).then( toggle );
-		}, [ clientId, toggle ] );
 
 		const { createNotice } = useDispatch( noticesStore );
 
@@ -196,7 +200,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			<AiAssistantUiContextProvider value={ contextValue }>
 				<KeyboardShortcuts
 					shortcuts={ {
-						'mod+/': selectFormBlock,
+						'mod+/': () => selectFormBlock( clientId, show ),
 					} }
 				>
 					<BlockListBlock { ...props } />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32524

This PR is the first step to address accessibility issues in implementing the Jetpack Form AI Assistant feature.
In short, the assistant bar gets invisible to the users in different situations:

1 - When the Jetpack block instance is unselected: The assistant bar disappears, and it does not reappear when the user selects a Form (child) block instance. 

2 - When the form is too long (regular view): the assistant bar is always placed at the bottom of the form, becoming invisible for the user, at least until they realize the need to scroll down. 

The changes introduced try to mitigate the issues described in (1) by extending child blocks to add an AI Toolbar button, which: 

* Shows or hides the AI Assistant bar 
* It will select the Jetpack Form block instance, to make it evident that the changes will happen (at least for now) at the Jetpack Form block instance level. 

The AI Toolbar button will be places in the `parent` section fo the Block toolbar component

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: be able to show AI Assistant from children Jetpack Form blocks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Generate a form
* Confirm, it's possible to show/hide the assistant bar from the Jetpack Form block instance
* Confirm, it's possible to show/hide the assistant bar from any Jetpack Form block-child instance
* Confirm that when selecting from the child instance:
  * It shows/hides the assistant bar
  * The Jetpack Form block instance is selected


https://github.com/Automattic/jetpack/assets/77539/5445d835-7171-4820-bead-0e7211b13bac



