### PR TITLE
VideoPress: fix false values being removed from shortcodes

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-shortcode-false-values
+++ b/projects/packages/videopress/changelog/fix-videopress-shortcode-false-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix false values not working on shortcodes

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -80,7 +80,7 @@ class Block_Editor_Content {
 		// Make sure "false" will be actually false.
 		foreach ( $atts as $key => $value ) {
 			if ( is_string( $value ) && 'false' === strtolower( $value ) ) {
-				$atts[ $key ] = false;
+				$atts[ $key ] = 0;
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes  1822-gh-Automattic/GreenHouse

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use 0 as the false value for attributes set as "attribute=false" in the shortcode so the value is not empty.

Video attributes when setting controls as false, before this change:
```
(
    [w] => 1280
    [h] => 720
    [at] => 0
    [loop] =>
    [autoplay] => 1
    [cover] => 1
    [muted] =>
    [controls] =>
    [playsinline] =>
    [useaveragecolor] =>
    [preloadcontent] => metadata
)
```
After this change:
```
(
    [w] => 1280
    [h] => 720
    [at] => 0
    [loop] =>
    [autoplay] => 1
    [cover] => 1
    [muted] =>
    [controls] => 0
    [playsinline] =>
    [useaveragecolor] =>
    [preloadcontent] => metadata
)
```
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site using Jetpack VideoPress
* Upload one video and get its shortcode
* Add the video to a post using the shortcode and set controls=false
* Confirm that controls are not visible