### PR TITLE
AI Extension: clean the AI Assistant bar input once the suggestion is done

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-clean-prev-user-request
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-clean-prev-user-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: clean the AI Assistant bar input once the suggestion is done

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -175,7 +175,10 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 
 		useAiContext( {
 			askQuestionOptions: { postId },
-			onDone: setContent,
+			onDone: finalContent => {
+				setContent( finalContent );
+				setInputValue( '' );
+			},
 			onSuggestion: setContent,
 			onError: showSuggestionError,
 		} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The user input text is not removed after clicking "Send", making it necessary to manually remove it for every request.
This PR removes the input once the suggestion is done.

Fixes https://github.com/Automattic/jetpack/issues/32520

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: clean the AI Assistant bar input once the suggestion is done


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Request a form
* Confirm that, once it's done, the input clears


https://github.com/Automattic/jetpack/assets/77539/5a66547a-8f8d-47de-b68a-1db1cfc19c10

