### PR TITLE
AI Extension: do not extend Jetpack Form when it's inside of a query loop

### DIFF
--- a/projects/plugins/jetpack/changelog/update-extending-blocks-into-the-loop
+++ b/projects/plugins/jetpack/changelog/update-extending-blocks-into-the-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: do not extend Jetpack Form when it's inside of a query loop

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -48,7 +48,7 @@ export function isPossibleToExtendJetpackFormBlock(
 		return false;
 	}
 
-	// ClientId gets required
+	// clientId is required
 	if ( ! clientId?.length ) {
 		return false;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -19,6 +19,11 @@ import { isJetpackFromBlockAiCompositionAvailable } from './constants';
 import { JETPACK_FORM_CHILDREN_BLOCKS } from './constants';
 import withUiHandlerDataProvider from './ui-handler/with-ui-handler-data-provider';
 
+type IsPossibleToExtendJetpackFormBlockProps = {
+	checkChildrenBlocks?: boolean;
+	clientId?: string;
+};
+
 /**
  * Check if it is possible to extend the block.
  *
@@ -28,7 +33,7 @@ import withUiHandlerDataProvider from './ui-handler/with-ui-handler-data-provide
  */
 export function isPossibleToExtendJetpackFormBlock(
 	blockName: string | undefined,
-	checkChildrenBlocks?: boolean
+	{ checkChildrenBlocks = false }: IsPossibleToExtendJetpackFormBlockProps = {}
 ): boolean {
 	// Check if the AI Assistant block is registered.
 	const isBlockRegistered = getBlockType( 'jetpack/ai-assistant' );
@@ -128,7 +133,7 @@ addFilter( 'editor.BlockEdit', 'jetpack/jetpack-form-block-edit', withAiAssistan
  */
 const withAiToolbarButton = createHigherOrderComponent( BlockEdit => {
 	return props => {
-		if ( ! isPossibleToExtendJetpackFormBlock( props?.name, true ) ) {
+		if ( ! isPossibleToExtendJetpackFormBlock( props?.name, { checkChildrenBlocks: true } ) ) {
 			return <BlockEdit { ...props } />;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -192,7 +192,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		 * and the AI Assistant component (popover)
 		 * only if is't possible to extend the block.
 		 */
-		if ( ! isPossibleToExtendJetpackFormBlock( props.name ) ) {
+		if ( ! isPossibleToExtendJetpackFormBlock( props.name, { clientId: props.clientId } ) ) {
 			return <BlockListBlock { ...props } />;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR is the first attempt to avoid extending the Jetpack Form block when it's inside of a query loop instance. Let's keep researching to see if we can get an approach more solid.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: do not extend Jetpack Form when it's inside of a query loop

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance inside of a Query Loop instance
* Confirm the Jetpack Form block instance is not extended
* Create a new Jetpack Form block but outside of the Query Loop
* Confirm that the Jetpack Form block instance now gets extended

Inside the loop | Outside the loop
-------|--------
<img width="715" alt="Screenshot 2023-08-17 at 17 40 40" src="https://github.com/Automattic/jetpack/assets/77539/77cc3f94-b2c6-4329-b891-cdb88f5adc13"> | <img width="364" alt="Screenshot 2023-08-17 at 17 41 15" src="https://github.com/Automattic/jetpack/assets/77539/82c225ce-9b3d-467e-ba88-f536bf353726">
