### PR TITLE
Fix: Exclude images with broken URL from galleries

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-verify-gallery-images
+++ b/projects/plugins/jetpack/changelog/fix-verify-gallery-images
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Shortcodes: exclude images with broken URL from galleries.

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -130,7 +130,7 @@ class Jetpack_PostImages {
 				$this_gallery['ids'] = implode( ',', $ids );
 			}
 			// Remove any holes we introduced.
-			$this_gallery['src'] = array_values( $this_gallery['src'] );
+			$this_gallery['src']  = array_values( $this_gallery['src'] );
 			$filtered_galleries[] = $this_gallery;
 		}
 

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -120,7 +120,7 @@ class Jetpack_PostImages {
 			$images_to_exclude = array();
 			$image_index       = 0;
 			foreach ( $this_gallery['src'] as $src_url ) {
-				if ( filter_var( $src_url, FILTER_VALIDATE_URL ) === false ) {
+				if ( filter_var( $src_url, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED ) === false ) {
 					$images_to_exclude[] = $image_index;
 				}
 				++$image_index;

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -117,24 +117,20 @@ class Jetpack_PostImages {
 			if ( ! isset( $this_gallery['src'] ) ) {
 				continue;
 			}
-			$images_to_exclude = array();
-			$image_index       = 0;
-			foreach ( $this_gallery['src'] as $src_url ) {
+			$ids = isset( $this_gallery['ids'] ) ? explode( ',', $this_gallery['ids'] ) : array();
+			// Make sure 'src' array isn't associative and has no holes.
+			$this_gallery['src'] = array_values( $this_gallery['src'] );
+			foreach ( $this_gallery['src'] as $idx => $src_url ) {
 				if ( filter_var( $src_url, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED ) === false ) {
-					$images_to_exclude[] = $image_index;
+					unset( $this_gallery['src'][ $idx ] );
+					unset( $ids[ $idx ] );
 				}
-				++$image_index;
-			}
-			foreach ( $images_to_exclude as $key ) {
-				unset( $this_gallery['src'][ $key ] );
 			}
 			if ( isset( $this_gallery['ids'] ) ) {
-				$ids = explode( ',', $this_gallery['ids'] );
-				foreach ( $images_to_exclude as $key ) {
-					unset( $ids[ $key ] );
-				}
 				$this_gallery['ids'] = implode( ',', $ids );
 			}
+			// Remove any holes we introduced.
+			$this_gallery['src'] = array_values( $this_gallery['src'] );
 			$filtered_galleries[] = $this_gallery;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Porting changes from D119165-code to monorepo.
Please check discussion in p1692264542232419-slack-C02NENKA4GN

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adding a filter for excluding images with broken URL

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Testing this is difficult since issues from original site were fixed. I wasn't able to reproduce the error on a standalone Jetpack site.