### PR TITLE
Launchpad: Update function prefixes in task definitions

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-function-prefixes
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-function-prefixes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update function prefixes for task list definitions

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -19,7 +19,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'id_map'                => 'site_edited',
 			'add_listener_callback' => function () {
-				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
+				add_action( 'load-site-editor.php', 'wpcom_launchpad_track_edit_site_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
 				return '/site-editor/' . $data['site_slug_encoded'];
@@ -30,21 +30,21 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 		),
 		'design_selected'                 => array(
 			'get_title'            => function () {
 				return __( 'Select a design', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
-			'is_disabled_callback' => 'wpcom_is_design_step_enabled',
+			'is_disabled_callback' => 'wpcom_launchpad_is_design_step_enabled',
 		),
 		'domain_claim'                    => array(
 			'get_title'            => function () {
 				return __( 'Claim your free one-year domain', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_domain_claim_completed',
-			'is_visible_callback'  => 'wpcom_domain_claim_is_visible_callback',
+			'is_complete_callback' => 'wpcom_launchpad_is_domain_claim_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_domain_claim_is_visible_callback',
 			'get_task_url'         => function ( $task, $default, $data ) {
 				return '/domains/add/' . $data['site_slug_encoded'];
 			},
@@ -54,9 +54,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Choose a domain', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_domain_upsell_completed',
-			'badge_text_callback'  => 'wpcom_get_domain_upsell_badge_text',
-			'is_visible_callback'  => 'wpcom_is_domain_upsell_task_visible',
+			'is_complete_callback' => 'wpcom_launchpad_is_domain_upsell_completed',
+			'badge_text_callback'  => 'wpcom_launchpad_get_domain_upsell_badge_text',
+			'is_visible_callback'  => 'wpcom_launchpad_is_domain_upsell_task_visible',
 			'get_task_url'         => function ( $task, $default, $data ) {
 				return '/domains/add/' . $data['site_slug_encoded'];
 			},
@@ -66,7 +66,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Write your first post', 'jetpack-mu-wpcom' );
 			},
 			'add_listener_callback' => function () {
-				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
+				add_action( 'publish_post', 'wpcom_launchpad_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
 				return '/post/' . $data['site_slug_encoded'];
@@ -76,16 +76,15 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
 			},
-			'subtitle'             => 'wpcom_get_plan_completed_subtitle', // This callback doesn't seem to exist.
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 		),
 		'plan_selected'                   => array(
 			'get_title'            => function () {
 				return __( 'Choose a plan', 'jetpack-mu-wpcom' );
 			},
-			'subtitle'             => 'wpcom_get_plan_selected_subtitle',
+			'subtitle'             => 'wpcom_launchpad_get_plan_selected_subtitle',
 			'is_complete_callback' => '__return_true',
-			'badge_text_callback'  => 'wpcom_get_plan_selected_badge_text',
+			'badge_text_callback'  => 'wpcom_launchpad_get_plan_selected_badge_text',
 		),
 		'setup_general'                   => array(
 			'get_title'            => function () {
@@ -99,7 +98,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Launch your site', 'jetpack-mu-wpcom' );
 			},
 			'isLaunchTask'          => true,
-			'add_listener_callback' => 'wpcom_add_site_launch_listener',
+			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 			'get_task_url'          => function ( $task, $default, $data ) {
 				return '/settings/general/' . $data['site_slug_encoded'] . '#site-privacy-settings';
 			},
@@ -121,7 +120,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Start writing', 'jetpack-mu-wpcom' );
 			},
 			'add_listener_callback' => function () {
-				add_action( 'publish_post', 'wpcom_track_publish_first_post_task' );
+				add_action( 'publish_post', 'wpcom_launchpad_track_publish_first_post_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
 				return '/post/' . $data['site_slug_encoded'];
@@ -131,7 +130,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'           => function () {
 				return __( 'Create paid Newsletter', 'jetpack-mu-wpcom' );
 			},
-			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
+			'is_visible_callback' => 'wpcom_launchpad_has_goal_paid_subscribers',
 		),
 		'setup_newsletter'                => array(
 			'id'                   => 'setup_newsletter',
@@ -144,7 +143,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'           => function () {
 				return __( 'Set up payment method', 'jetpack-mu-wpcom' );
 			},
-			'is_visible_callback' => 'wpcom_has_goal_paid_subscribers',
+			'is_visible_callback' => 'wpcom_launchpad_has_goal_paid_subscribers',
 			'get_calypso_path'    => function ( $task, $default, $data ) {
 				if ( function_exists( 'get_memberships_connected_account_redirect' ) ) {
 					return get_memberships_connected_account_redirect(
@@ -159,15 +158,15 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add subscribers', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
-			'is_visible_callback'  => 'wpcom_has_goal_import_subscribers',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 		),
 		'migrate_content'                 => array(
 			'get_title'            => function () {
 				return __( 'Migrate content', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
-			'is_visible_callback'  => 'wpcom_has_goal_import_subscribers',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 		),
 
 		// Link in bio tasks.
@@ -176,8 +175,8 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Launch your site', 'jetpack-mu-wpcom' );
 			},
 			'id_map'                => 'site_launched',
-			'is_disabled_callback'  => 'wpcom_is_link_in_bio_launch_disabled',
-			'add_listener_callback' => 'wpcom_add_site_launch_listener',
+			'is_disabled_callback'  => 'wpcom_launchpad_is_link_in_bio_launch_disabled',
+			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
 		'links_added'                     => array(
 			'get_title'             => function () {
@@ -185,7 +184,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'id_map'                => 'links_edited',
 			'add_listener_callback' => function () {
-				add_action( 'load-site-editor.php', 'wpcom_track_edit_site_task' );
+				add_action( 'load-site-editor.php', 'wpcom_launchpad_track_edit_site_task' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
 				return '/site-editor/' . $data['site_slug_encoded'];
@@ -204,8 +203,8 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'             => function () {
 				return __( 'Launch site', 'jetpack-mu-wpcom' );
 			},
-			'is_disabled_callback'  => 'wpcom_is_videopress_launch_disabled',
-			'add_listener_callback' => 'wpcom_add_site_launch_listener',
+			'is_disabled_callback'  => 'wpcom_launchpad_is_videopress_launch_disabled',
+			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
 		'videopress_setup'                => array(
 			'get_title'            => function () {
@@ -218,9 +217,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'             => function () {
 				return __( 'Upload your first video', 'jetpack-mu-wpcom' );
 			},
-			'is_disabled_callback'  => 'wpcom_is_videopress_upload_disabled',
+			'is_disabled_callback'  => 'wpcom_launchpad_is_videopress_upload_disabled',
 			'add_listener_callback' => function () {
-				add_action( 'add_attachment', 'wpcom_track_video_uploaded_task' );
+				add_action( 'add_attachment', 'wpcom_launchpad_track_video_uploaded_task' );
 			},
 		),
 
@@ -230,13 +229,13 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Launch your blog', 'jetpack-mu-wpcom' );
 			},
 			'isLaunchTask'          => true,
-			'add_listener_callback' => 'wpcom_add_site_launch_listener',
+			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
 		'setup_blog'                      => array(
 			'get_title'            => function () {
 				return __( 'Name your blog', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 		),
 
 		// Free plan tasks.
@@ -261,7 +260,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Give your site a name', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
@@ -271,7 +270,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Drive traffic to your site', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/marketing/connections/' . $data['site_slug_encoded'];
 			},
@@ -281,7 +280,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add a new page', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/page/' . $data['site_slug_encoded'];
 			},
@@ -291,15 +290,15 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Update your About page', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
-			'is_visible_callback'  => 'wpcom_is_update_about_page_task_visible',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_update_about_page_task_visible',
 			'extra_data_callback'  => function () {
 				return array(
-					'about_page_id' => wpcom_get_site_about_page_id(),
+					'about_page_id' => wpcom_launchpad_get_site_about_page_id(),
 				);
 			},
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/page/' . $data['site_slug_encoded'] . '/' . wpcom_get_site_about_page_id();
+				return '/page/' . $data['site_slug_encoded'] . '/' . wpcom_launchpad_get_site_about_page_id();
 			},
 		),
 
@@ -307,8 +306,8 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Edit a page', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
-			'is_visible_callback'  => 'wpcom_is_edit_page_task_visible',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_edit_page_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/pages/' . $data['site_slug_encoded'];
 			},
@@ -319,8 +318,8 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Customize your domain', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_domain_customize_completed',
-			'is_visible_callback'  => 'wpcom_is_domain_customize_task_visible',
+			'is_complete_callback' => 'wpcom_launchpad_is_domain_customize_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_domain_customize_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/domains/add/' . $data['site_slug_encoded'];
 			},
@@ -330,7 +329,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Share your site', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 		),
 
 		// Newsletter post-launch tasks.
@@ -338,7 +337,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Earn money with your newsletter', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/earn/' . $data['site_slug_encoded'];
 			},
@@ -348,7 +347,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Customize welcome message', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/settings/newsletter/' . $data['site_slug_encoded'];
 			},
@@ -357,8 +356,8 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Enable subscribers modal', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
-			'is_visible_callback'  => 'wpcom_is_enable_subscribers_modal_visible',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_enable_subscribers_modal_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/settings/newsletter/' . $data['site_slug_encoded'];
 			},
@@ -389,8 +388,8 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Manage your subscribers', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
-			'is_visible_callback'  => 'wpcom_has_goal_import_subscribers',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/subscribers/' . $data['site_slug_encoded'];
 			},
@@ -408,8 +407,8 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Manage your paid Newsletter plan', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
-			'is_visible_callback'  => 'wpcom_has_goal_paid_subscribers',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_has_goal_paid_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/earn/payments-plans/' . $data['site_slug_encoded'];
 			},
@@ -418,7 +417,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add your About page', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_add_about_page_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/page/' . $data['site_slug_encoded'];
@@ -477,7 +476,11 @@ function wpcom_launchpad_get_reverse_id_mappings() {
 /**
  * Mark a task as complete.
  *
+ * Also included wp-content/lib/memberships/connected-accounts.php#36
+ * and wp-content/lib/memberships/class.membership-product.php#497
+ *
  * @param string $task_id The task ID that should be marked as complete.
+ *
  * @return bool True if the task was marked as complete, false otherwise.
  */
 function wpcom_mark_launchpad_task_complete( $task_id ) {
@@ -648,7 +651,7 @@ add_action( 'init', 'wpcom_launchpad_init_task_definitions', 11 );
  * @param string $task_id The task ID.
  * @return bool True if successful, false if not.
  */
-function wpcom_mark_launchpad_task_complete_if_active( $task_id ) {
+function wpcom_launchpad_mark_launchpad_task_complete_if_active( $task_id ) {
 	if ( wpcom_launchpad_checklists()->mark_task_complete_if_active( $task_id ) ) {
 		wpcom_launchpad_track_completed_task( $task_id );
 		return true;
@@ -662,9 +665,9 @@ function wpcom_mark_launchpad_task_complete_if_active( $task_id ) {
  *
  * @return void
  */
-function wpcom_track_edit_site_task() {
-	wpcom_mark_launchpad_task_complete_if_active( 'links_added' );
-	wpcom_mark_launchpad_task_complete_if_active( 'design_edited' );
+function wpcom_launchpad_track_edit_site_task() {
+	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'links_added' );
+	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'design_edited' );
 }
 
 /**
@@ -672,7 +675,7 @@ function wpcom_track_edit_site_task() {
  *
  * @return boolean
  */
-function wpcom_is_design_step_enabled() {
+function wpcom_launchpad_is_design_step_enabled() {
 	return ! wpcom_can_update_design_selected_task();
 }
 
@@ -683,7 +686,7 @@ function wpcom_is_design_step_enabled() {
  * @param mixed $default The default value.
  * @return bool True if domain upsell task is completed.
  */
-function wpcom_is_domain_upsell_completed( $task, $default ) {
+function wpcom_launchpad_is_domain_upsell_completed( $task, $default ) {
 	if ( wpcom_site_has_feature( 'custom-domain' ) ) {
 		return true;
 	}
@@ -712,7 +715,7 @@ function wpcom_is_domain_upsell_completed( $task, $default ) {
  *
  * @return string Badge text
  */
-function wpcom_get_domain_upsell_badge_text() {
+function wpcom_launchpad_get_domain_upsell_badge_text() {
 	// Never run `wpcom_is_checklist_task_complete` within a is_complete_callback unless you are fond of infinite loops.
 	return wpcom_is_checklist_task_complete( 'domain_upsell' ) ? '' : __( 'Upgrade plan', 'jetpack-mu-wpcom' );
 }
@@ -722,7 +725,7 @@ function wpcom_get_domain_upsell_badge_text() {
  *
  * @return bool True if user is on a free plan.
  */
-function wpcom_is_domain_upsell_task_visible() {
+function wpcom_launchpad_is_domain_upsell_task_visible() {
 	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 		return false;
 	}
@@ -794,14 +797,14 @@ function wpcom_launchpad_get_newsletter_subscriber_count() {
  *
  * @return void
  */
-function wpcom_track_publish_first_post_task() {
-	// Ensure that Headstart posts don't mark this as complete
+function wpcom_launchpad_track_publish_first_post_task() {
+	// Ensure that Headstart posts don't mark this as complete.
 	if ( defined( 'HEADSTART' ) && HEADSTART ) {
 		return;
 	}
 	// Since we share the same callback for generic first post and newsletter-specific, we mark both.
-	wpcom_mark_launchpad_task_complete_if_active( 'first_post_published' );
-	wpcom_mark_launchpad_task_complete_if_active( 'first_post_published_newsletter' );
+	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'first_post_published' );
+	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'first_post_published_newsletter' );
 }
 
 /**
@@ -810,7 +813,7 @@ function wpcom_track_publish_first_post_task() {
  * @return int
  */
 function wpcom_launchpad_get_published_non_headstart_posts_count() {
-	// Ensure that Headstart posts don't affect the count
+	// Ensure that Headstart posts don't affect the count.
 	if ( defined( 'HEADSTART' ) && HEADSTART ) {
 		return 0;
 	}
@@ -837,7 +840,7 @@ function wpcom_launchpad_get_published_non_headstart_posts_count() {
  */
 function wpcom_launchpad_track_write_3_posts_task() {
 	// If the task is already completed, don't do anything.
-	if ( wpcom_is_task_option_completed( array( 'id' => 'write_3_posts' ) ) ) {
+	if ( wpcom_launchpad_is_task_option_completed( array( 'id' => 'write_3_posts' ) ) ) {
 		return;
 	}
 
@@ -867,7 +870,7 @@ function wpcom_launchpad_get_write_3_posts_repetition_count( $task ) {
  * @param array $task The task data.
  * @return bool True if the option for the task is marked as complete, false otherwise.
  */
-function wpcom_is_task_option_completed( $task ) {
+function wpcom_launchpad_is_task_option_completed( $task ) {
 	$checklist = get_option( 'launchpad_checklist_tasks_statuses', array() );
 	if ( ! empty( $checklist[ $task['id'] ] ) ) {
 		return true;
@@ -925,7 +928,7 @@ function wpcom_launchpad_is_repeated_task_complete( $task, $is_option_complete )
  *
  * @return string Subtitle text
  */
-function wpcom_get_plan_selected_subtitle() {
+function wpcom_launchpad_get_plan_selected_subtitle() {
 	if ( ! function_exists( 'wpcom_global_styles_in_use' ) || ! function_exists( 'wpcom_should_limit_global_styles' ) ) {
 		return '';
 	}
@@ -942,7 +945,7 @@ function wpcom_get_plan_selected_subtitle() {
  *
  * @return string Badge text
  */
-function wpcom_get_plan_selected_badge_text() {
+function wpcom_launchpad_get_plan_selected_badge_text() {
 	if ( ! function_exists( 'wpcom_global_styles_in_use' ) || ! function_exists( 'wpcom_should_limit_global_styles' ) ) {
 		return '';
 	}
@@ -983,15 +986,17 @@ function wpcom_launchpad_get_site_slug() {
 /**
  * Callback for completing site launched task.
  *
+ * Also included in bin/tests/isolated/suites/Guides/observer-modules/OnboardingUseCaseBlogTest.php
+ *
  * @return void
  */
 function wpcom_track_site_launch_task() {
 	// it would be ideal if the registry was smart enough to map based on id_map but it isn't.
 	// So we mark them all. We'd avoid this if we had dedicated callbacks for each task.
-	wpcom_mark_launchpad_task_complete_if_active( 'site_launched' );
-	wpcom_mark_launchpad_task_complete_if_active( 'link_in_bio_launched' );
-	wpcom_mark_launchpad_task_complete_if_active( 'videopress_launched' );
-	wpcom_mark_launchpad_task_complete_if_active( 'blog_launched' );
+	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'site_launched' );
+	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'link_in_bio_launched' );
+	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'videopress_launched' );
+	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'blog_launched' );
 
 	// Remove site intent for blog onboarding flows and disable launchpad.
 	$site_intent = get_option( 'site_intent' );
@@ -1016,11 +1021,11 @@ function wpcom_track_site_launch_task() {
  *
  * @return void
  */
-function wpcom_add_site_launch_listener() {
+function wpcom_launchpad_add_site_launch_listener() {
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		add_action( 'wpcom_site_launched', 'wpcom_track_site_launch_task' );
 	} else {
-		add_action( 'update_option_blog_public', 'wpcom_launch_task_listener_atomic', 10, 2 );
+		add_action( 'update_option_blog_public', 'wpcom_launchpad_launch_task_listener_atomic', 10, 2 );
 	}
 }
 
@@ -1031,7 +1036,7 @@ function wpcom_add_site_launch_listener() {
  * @param string $new_value The previous option value.
  * @return void
  */
-function wpcom_launch_task_listener_atomic( $old_value, $new_value ) {
+function wpcom_launchpad_launch_task_listener_atomic( $old_value, $new_value ) {
 	$blog_public = (int) $new_value;
 	// 'blog_public' is set to '1' when a site is launched.
 	if ( $blog_public === 1 ) {
@@ -1058,7 +1063,7 @@ function wpcom_launchpad_is_email_unverified() {
  *
  * @return bool True if the site has a paid-subscriber goal, false otherwise.
  */
-function wpcom_has_goal_paid_subscribers() {
+function wpcom_launchpad_has_goal_paid_subscribers() {
 	return in_array( 'paid-subscribers', get_option( 'site_goals', array() ), true );
 }
 
@@ -1067,7 +1072,7 @@ function wpcom_has_goal_paid_subscribers() {
  *
  * @return bool True if the site has a import-subscriber goal, false otherwise.
  */
-function wpcom_has_goal_import_subscribers() {
+function wpcom_launchpad_has_goal_import_subscribers() {
 	return in_array( 'import-subscribers', get_option( 'site_goals', array() ), true );
 }
 
@@ -1076,7 +1081,7 @@ function wpcom_has_goal_import_subscribers() {
  *
  * @return boolean True if link-in-bio launch task is enabled
  */
-function wpcom_is_link_in_bio_launch_disabled() {
+function wpcom_launchpad_is_link_in_bio_launch_disabled() {
 	return ! wpcom_is_checklist_task_complete( 'links_added' );
 }
 
@@ -1085,7 +1090,7 @@ function wpcom_is_link_in_bio_launch_disabled() {
  *
  * @return boolean True if videopress launch task is enabled
  */
-function wpcom_is_videopress_launch_disabled() {
+function wpcom_launchpad_is_videopress_launch_disabled() {
 	return ! wpcom_is_checklist_task_complete( 'videopress_upload' );
 }
 
@@ -1094,7 +1099,7 @@ function wpcom_is_videopress_launch_disabled() {
  *
  * @return boolean True if videopress upload task is enabled
  */
-function wpcom_is_videopress_upload_disabled() {
+function wpcom_launchpad_is_videopress_upload_disabled() {
 	return wpcom_is_checklist_task_complete( 'videopress_upload' );
 }
 
@@ -1106,7 +1111,7 @@ function wpcom_is_videopress_upload_disabled() {
  * @param string $post_id The id of the post being udpated.
  * @return void
  */
-function wpcom_track_video_uploaded_task( $post_id ) {
+function wpcom_launchpad_track_video_uploaded_task( $post_id ) {
 	// Not using `wp_attachment_is` because it requires the actual file
 	// which is not the case for Atomic VideoPress.
 	if ( 0 !== strpos( get_post_mime_type( $post_id ), 'video/' ) ) {
@@ -1123,12 +1128,12 @@ function wpcom_track_video_uploaded_task( $post_id ) {
  *
  * @return void
  */
-function wpcom_mark_site_title_complete( $old_value, $value ) {
+function wpcom_launchpad_mark_site_title_complete( $old_value, $value ) {
 	if ( $value !== $old_value ) {
 		wpcom_mark_launchpad_task_complete( 'site_title' );
 	}
 }
-add_action( 'update_option_blogname', 'wpcom_mark_site_title_complete', 10, 3 );
+add_action( 'update_option_blogname', 'wpcom_launchpad_mark_site_title_complete', 10, 3 );
 
 /**
  * Mark the enable_subscribers_modal task complete
@@ -1139,20 +1144,20 @@ add_action( 'update_option_blogname', 'wpcom_mark_site_title_complete', 10, 3 );
  *
  * @return void
  */
-function wpcom_mark_enable_subscribers_modal_complete( $old_value, $value ) {
+function wpcom_launchpad_mark_enable_subscribers_modal_complete( $old_value, $value ) {
 	if ( $value ) {
 		wpcom_mark_launchpad_task_complete( 'enable_subscribers_modal' );
 	}
 }
-add_action( 'update_option_sm_enabled', 'wpcom_mark_enable_subscribers_modal_complete', 10, 3 );
-add_action( 'add_option_sm_enabled', 'wpcom_mark_enable_subscribers_modal_complete', 10, 3 );
+add_action( 'update_option_sm_enabled', 'wpcom_launchpad_mark_enable_subscribers_modal_complete', 10, 3 );
+add_action( 'add_option_sm_enabled', 'wpcom_launchpad_mark_enable_subscribers_modal_complete', 10, 3 );
 
 /**
  * Determines whether the enable_subscribers_modal task should show.
  *
  * @return bool True if the task should show, false otherwise.
  */
-function wpcom_is_enable_subscribers_modal_visible() {
+function wpcom_launchpad_is_enable_subscribers_modal_visible() {
 	return apply_filters( 'jetpack_subscriptions_modal_enabled', false );
 }
 
@@ -1161,7 +1166,7 @@ function wpcom_is_enable_subscribers_modal_visible() {
  *
  * @return bool True if we should show the task, false otherwise.
  */
-function wpcom_domain_claim_is_visible_callback() {
+function wpcom_launchpad_domain_claim_is_visible_callback() {
 	if ( ! function_exists( 'wpcom_site_has_feature' ) ) {
 		return false;
 	}
@@ -1174,7 +1179,7 @@ function wpcom_domain_claim_is_visible_callback() {
  *
  * @return bool True if domain claim task is completed.
  */
-function wpcom_is_domain_claim_completed() {
+function wpcom_launchpad_is_domain_claim_completed() {
 	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 		return false;
 	}
@@ -1198,9 +1203,9 @@ function wpcom_is_domain_claim_completed() {
  * @param int    $post_id The ID of the post being updated.
  * @param object $post    The post object.
  */
-function wpcom_add_new_page_check( $post_id, $post ) {
+function wpcom_launchpad_add_new_page_check( $post_id, $post ) {
 	// Don't do anything if the task is already complete.
-	if ( wpcom_is_task_option_completed( array( 'id' => 'add_new_page' ) ) ) {
+	if ( wpcom_launchpad_is_task_option_completed( array( 'id' => 'add_new_page' ) ) ) {
 		return;
 	}
 
@@ -1220,13 +1225,13 @@ function wpcom_add_new_page_check( $post_id, $post ) {
 	}
 
 	// This is necessary to avoid marking the task as complete when the about page is updated.
-	if ( $post_id === wpcom_get_site_about_page_id() ) {
+	if ( $post_id === wpcom_launchpad_get_site_about_page_id() ) {
 		return;
 	}
 
 	wpcom_mark_launchpad_task_complete( 'add_new_page' );
 }
-add_action( 'wp_insert_post', 'wpcom_add_new_page_check', 10, 3 );
+add_action( 'wp_insert_post', 'wpcom_launchpad_add_new_page_check', 10, 3 );
 
 /**
  * Return the about page id, if any.
@@ -1235,7 +1240,7 @@ add_action( 'wp_insert_post', 'wpcom_add_new_page_check', 10, 3 );
  *
  * @return int|null The page ID of the 'About' page if it exists, null otherwise.
  */
-function wpcom_get_site_about_page_id() {
+function wpcom_launchpad_get_site_about_page_id() {
 	// First, attempt to get the page ID from the cache.
 	$about_page_id_cache_key = 'wpcom_about_page_id';
 	$about_page_id           = wp_cache_get( $about_page_id_cache_key, 'jetpack_mu_wpcom' );
@@ -1250,7 +1255,7 @@ function wpcom_get_site_about_page_id() {
 	}
 
 	// Call the current function implementation without any caching logic.
-	$about_page_id = wpcom_find_site_about_page_id();
+	$about_page_id = wpcom_launchpad_find_site_about_page_id();
 
 	if ( null === $about_page_id ) {
 		// In the event that we don't have a page id, cache -1 to avoid caching null
@@ -1272,7 +1277,7 @@ function wpcom_get_site_about_page_id() {
  *
  * @return int|null The page ID of the 'About' page if it exists, null otherwise.
  */
-function wpcom_find_site_about_page_id() {
+function wpcom_launchpad_find_site_about_page_id() {
 	if ( ! function_exists( 'wpcom_get_theme_annotation' ) ) {
 		return null;
 	}
@@ -1365,7 +1370,7 @@ function wpcom_launchpad_has_translation( $string, $domain = 'jetpack-mu-wpcom' 
  * @return bool True if we should show the task, false otherwise.
  */
 function wpcom_launchpad_is_add_about_page_visible() {
-	return ! wpcom_is_update_about_page_task_visible() && registered_meta_key_exists( 'post', '_wpcom_template_layout_category', 'page' );
+	return ! wpcom_launchpad_is_update_about_page_task_visible() && registered_meta_key_exists( 'post', '_wpcom_template_layout_category', 'page' );
 }
 
 /**
@@ -1396,12 +1401,12 @@ function wpcom_launchpad_add_about_page_check( $post_id, $post ) {
 	}
 
 	// Don't do anything if the task is already complete.
-	if ( wpcom_is_task_option_completed( array( 'id' => 'add_about_page' ) ) ) {
+	if ( wpcom_launchpad_is_task_option_completed( array( 'id' => 'add_about_page' ) ) ) {
 		return;
 	}
 
 	// If the page is the previously located About page, ignore it.
-	$about_page_id = wpcom_get_site_about_page_id();
+	$about_page_id = wpcom_launchpad_get_site_about_page_id();
 	if ( null !== $about_page_id && $post->ID === $about_page_id ) {
 		return;
 	}
@@ -1420,13 +1425,13 @@ add_action( 'wp_insert_post', 'wpcom_launchpad_add_about_page_check', 10, 3 );
  *
  * @return bool True if we should show the task, false otherwise.
  */
-function wpcom_is_update_about_page_task_visible() {
+function wpcom_launchpad_is_update_about_page_task_visible() {
 	// The task isn't visible if the task title hasn't been translated into the current locale.
 	if ( ! wpcom_launchpad_has_translation( 'Update your About page', 'jetpack-mu-wpcom' ) ) {
 		return false;
 	}
 
-	return wpcom_get_site_about_page_id() !== null;
+	return wpcom_launchpad_get_site_about_page_id() !== null;
 }
 
 /**
@@ -1435,7 +1440,7 @@ function wpcom_is_update_about_page_task_visible() {
  * @param int     $post_id The ID of the post being updated.
  * @param WP_Post $post The post object.
  */
-function wpcom_update_about_page_check( $post_id, $post ) {
+function wpcom_launchpad_update_about_page_check( $post_id, $post ) {
 	// Ensure that Headstart posts don't mark this as complete
 	if ( defined( 'HEADSTART' ) && HEADSTART ) {
 		return;
@@ -1452,33 +1457,33 @@ function wpcom_update_about_page_check( $post_id, $post ) {
 	}
 
 	// Don't do anything if the task is already complete.
-	if ( wpcom_is_task_option_completed( array( 'id' => 'update_about_page' ) ) ) {
+	if ( wpcom_launchpad_is_task_option_completed( array( 'id' => 'update_about_page' ) ) ) {
 		return;
 	}
 
 	// If the page is not the previously located About page, ignore it.
-	$about_page_id = wpcom_get_site_about_page_id();
+	$about_page_id = wpcom_launchpad_get_site_about_page_id();
 	if ( null === $about_page_id || $post->ID !== $about_page_id ) {
 		return;
 	}
 
 	wpcom_mark_launchpad_task_complete( 'update_about_page' );
 }
-add_action( 'post_updated', 'wpcom_update_about_page_check', 10, 3 );
+add_action( 'post_updated', 'wpcom_launchpad_update_about_page_check', 10, 3 );
 
 /**
  * Determine `edit_page` task visibility. The task is visible if there is at least one page and the add_new_page task is complete.
  *
  * @return bool True if we should show the task, false otherwise.
  */
-function wpcom_is_edit_page_task_visible() {
+function wpcom_launchpad_is_edit_page_task_visible() {
 	// Don't show the task if the update_about_page task is visible.
-	if ( wpcom_is_update_about_page_task_visible() ) {
+	if ( wpcom_launchpad_is_update_about_page_task_visible() ) {
 		return false;
 	}
 
 	// Otherwise, don't show the task until after a page has been added.
-	if ( ! wpcom_is_task_option_completed( array( 'id' => 'add_new_page' ) ) ) {
+	if ( ! wpcom_launchpad_is_task_option_completed( array( 'id' => 'add_new_page' ) ) ) {
 		return false;
 	}
 
@@ -1503,12 +1508,12 @@ function wpcom_is_edit_page_task_visible() {
  *
  * @return void
  */
-function wpcom_mark_customize_welcome_message_complete_on_update( $old_value, $value ) {
+function wpcom_launchpad_mark_customize_welcome_message_complete_on_update( $old_value, $value ) {
 	if ( $value['invitation'] !== $old_value['invitation'] ) {
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }
-add_action( 'update_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete_on_update', 10, 2 );
+add_action( 'update_option_subscription_options', 'wpcom_launchpad_mark_customize_welcome_message_complete_on_update', 10, 2 );
 
 /**
  * Mark the customize_welcome_message task complete
@@ -1519,12 +1524,12 @@ add_action( 'update_option_subscription_options', 'wpcom_mark_customize_welcome_
  *
  * @return void
  */
-function wpcom_mark_customize_welcome_message_complete_on_add( $value ) {
+function wpcom_launchpad_mark_customize_welcome_message_complete_on_add( $value ) {
 	if ( $value['invitation'] ) {
 		wpcom_mark_launchpad_task_complete( 'customize_welcome_message' );
 	}
 }
-add_action( 'add_option_subscription_options', 'wpcom_mark_customize_welcome_message_complete_on_add', 10, 1 );
+add_action( 'add_option_subscription_options', 'wpcom_launchpad_mark_customize_welcome_message_complete_on_add', 10, 1 );
 
 /**
  * When a page is updated, check to see if we've already completed the `add_new_page` task and mark the `edit_page` task complete accordingly.
@@ -1532,14 +1537,14 @@ add_action( 'add_option_subscription_options', 'wpcom_mark_customize_welcome_mes
  * @param int     $post_id The ID of the post being updated.
  * @param WP_Post $post The post object.
  */
-function wpcom_edit_page_check( $post_id, $post ) {
+function wpcom_launchpad_edit_page_check( $post_id, $post ) {
 	// Don't do anything if the task is already complete.
-	if ( wpcom_is_task_option_completed( array( 'id' => 'edit_page' ) ) ) {
+	if ( wpcom_launchpad_is_task_option_completed( array( 'id' => 'edit_page' ) ) ) {
 		return;
 	}
 
 	// Don't do anything if the add_new_page task is incomplete.
-	if ( ! wpcom_is_task_option_completed( array( 'id' => 'add_new_page' ) ) ) {
+	if ( ! wpcom_launchpad_is_task_option_completed( array( 'id' => 'add_new_page' ) ) ) {
 		return false;
 	}
 
@@ -1560,14 +1565,14 @@ function wpcom_edit_page_check( $post_id, $post ) {
 
 	wpcom_mark_launchpad_task_complete( 'edit_page' );
 }
-add_action( 'post_updated', 'wpcom_edit_page_check', 10, 3 );
+add_action( 'post_updated', 'wpcom_launchpad_edit_page_check', 10, 3 );
 
 /**
  * Returns if the site has domain or bundle purchases.
  *
  * @return array Array of booleans, first value is if the site has a bundle, second is if the site has a domain.
  */
-function wpcom_domain_customize_check_purchases() {
+function wpcom_launchpad_domain_customize_check_purchases() {
 	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 		return false;
 	}
@@ -1596,10 +1601,10 @@ function wpcom_domain_customize_check_purchases() {
  * @param mixed $default The default value.
  * @return bool True if domain customize task is complete.
  */
-function wpcom_is_domain_customize_completed( $task, $default ) {
-	$result = wpcom_domain_customize_check_purchases();
+function wpcom_launchpad_is_domain_customize_completed( $task, $default ) {
+	$result = wpcom_launchpad_domain_customize_check_purchases();
 
-	if ( $result === false ) {
+	if ( false === $result ) {
 		return false;
 	}
 
@@ -1619,10 +1624,10 @@ function wpcom_is_domain_customize_completed( $task, $default ) {
  *
  * @return bool True if user is on a free plan and didn't purchase domain or if user is on a paid plan and did purchase a domain.
  */
-function wpcom_is_domain_customize_task_visible() {
-	$result = wpcom_domain_customize_check_purchases();
+function wpcom_launchpad_is_domain_customize_task_visible() {
+	$result = wpcom_launchpad_domain_customize_check_purchases();
 
-	if ( $result === false ) {
+	if ( false === $result ) {
 		return false;
 	}
 
@@ -1651,7 +1656,7 @@ function wpcom_is_domain_customize_task_visible() {
  *
  * @return void
  */
-function wpcom_mark_domain_tasks_complete( $blog_id, $user_id, $product_id ) {
+function wpcom_launchpad_mark_domain_tasks_complete( $blog_id, $user_id, $product_id ) {
 	if ( ! class_exists( 'domains' ) ) {
 		return;
 	}
@@ -1664,10 +1669,14 @@ function wpcom_mark_domain_tasks_complete( $blog_id, $user_id, $product_id ) {
 	wpcom_mark_launchpad_task_complete( 'domain_upsell' );
 	wpcom_mark_launchpad_task_complete( 'domain_upsell_deferred' );
 }
-add_action( 'activate_product', 'wpcom_mark_domain_tasks_complete', 10, 6 );
+add_action( 'activate_product', 'wpcom_launchpad_mark_domain_tasks_complete', 10, 6 );
 
 /**
  * Re-trigger email campaigns for blog onboarding after user edit one of the fields in the launchpad.
+ *
+ * Also included bin/tests/isolated/suites/Guides/observer-modules/OnboardingUseCaseBlogTest.php#601
+ *
+ * @return void
  */
 function wpcom_trigger_email_campaign() {
 	$site_intent = get_option( 'site_intent' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -479,11 +479,11 @@ function wpcom_hacky_track_video_uploaded_task( $post_id ) {
 	if ( get_option( 'launchpad_screen' ) !== 'full' ) {
 		return;
 	}
-	if ( has_action( 'add_attachment', 'wpcom_track_video_uploaded_task' ) ) {
+	if ( has_action( 'add_attachment', 'wpcom_launchpad_track_video_uploaded_task' ) ) {
 		return;
 	}
 
-	wpcom_track_video_uploaded_task( $post_id );
+	wpcom_launchpad_track_video_uploaded_task( $post_id );
 }
 add_action( 'add_attachment', 'wpcom_hacky_track_video_uploaded_task' );
 
@@ -720,7 +720,7 @@ function wpcom_launchpad_is_free_newsletter_enabled() {
 		return false;
 	}
 
-	return ! wpcom_has_goal_paid_subscribers() && apply_filters( 'wpcom_launchpad_intent_free_newsletter_enabled', false );
+	return ! wpcom_launchpad_has_goal_paid_subscribers() && apply_filters( 'wpcom_launchpad_intent_free_newsletter_enabled', false );
 }
 
 /**
@@ -734,7 +734,7 @@ function wpcom_launchpad_is_paid_newsletter_enabled() {
 		return false;
 	}
 
-	return wpcom_has_goal_paid_subscribers() && apply_filters( 'wpcom_launchpad_intent_paid_newsletter_enabled', false );
+	return wpcom_launchpad_has_goal_paid_subscribers() && apply_filters( 'wpcom_launchpad_intent_paid_newsletter_enabled', false );
 }
 
 // Unhook our old mu-plugin - this current file is being loaded on 0 priority for `plugins_loaded`.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/class-launchpad-task-lists-test.php
@@ -424,7 +424,7 @@ class Launchpad_Task_Lists_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( $expected_completion_status, $first_task['completed'] );
 
 		// Verify that the task option has the right value.
-		$this->assertSame( $expected_completion_status, wpcom_is_task_option_completed( $task ) );
+		$this->assertSame( $expected_completion_status, wpcom_launchpad_is_task_option_completed( $task ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the majority of functions in `launchpad-task-definitions.php` to use the same standard prefix, `wpcom_launchpad_`, to avoid potential conflicts down the road.
* The majority of these callbacks are self-contained in this file; a couple have instances in `launchpad.php`.
* This PR does *not* update functions that are also called outside `jetpack-mu-wpcom` to avoid breakage. I've noted instances of these functions and their locations in the doc blocks. These will need to be handled differently:

`wpcom_mark_launchpad_task_complete`
`wpcom_track_site_launch_task`
`wpcom_trigger_email_campaign`


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox and sandbox public-api
* Create new sites for each of the types of Launchpads, both pre- and post-launch, from `/setup` unless otherwise specified:

o Free (Choose a free plan during onboarding)
o Build (Choose "Promote myself or business" during onboarding)
o Write (Choose "Write and publish" during onboarding)
o Free Newsletter (Start from `/setup/newsletter`, choose free)
o Paid Newsletter (Start from `/setup/newsletter`, choose paid)
o Newsletter with subscribers (Start from `/setup/newsletter`, choose import existing subscribers)
o Link in bio (Start from `/link-in-bio`)
o VideoPress (Start from `/setup/videopress`)

* Ensure you can still complete all tasks for each list.
