### PR TITLE
ci: Move PHP 5.6 rule out of loop in test matrix

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -61,20 +61,21 @@ foreach ( array( '7.0', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ) as $php ) {
 		'script'  => 'test-php',
 		'php'     => $php,
 		'wp'      => 'latest',
-		'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
+		'timeout' => 20, // 2023-08-17: Successful runs seem to take up to ~12 minutes.
 	);
 }
+
+// PHP 5.6 support was dropped in WP 6.3. Remove this (and everything elsewhere related to PHP 5.6) when we drop support for earlier versions.
+$matrix[] = array(
+	'name'    => 'PHP tests: PHP 5.6 WP previous',
+	'script'  => 'test-php',
+	'php'     => '5.6',
+	'wp'      => 'previous',
+	'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
+);
+
 foreach ( array( 'previous', 'trunk', 'special' ) as $wp ) {
 	$phpver = $versions['PHP_VERSION'];
-	if ( $wp === 'previous' ) {
-		$matrix[] = array(
-			'name'    => "PHP tests: PHP 5.6 WP $wp",
-			'script'  => 'test-php',
-			'php'     => '5.6', // 2023-08-09 now that 5.6 is excluded from latest tests, we test it on 'previous'.
-			'wp'      => $wp,
-			'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
-		);
-	}
 	if ( $wp === 'special' ) {
 		$phpver = '8.0'; // WordPress 6.1 is not ready for PHP 8.1+.
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
There's no reason for that to be inside the loop.

Also, clean up the comments a bit.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* All the same tests should run as before.
