### PR TITLE
Add permanent dismissal of launchpad save modal

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-permanent-dismissal-of-launchpad-save-modal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-permanent-dismissal-of-launchpad-save-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Launchpad: persist user option to hide the post-save modal

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-permanent-dismissal-of-launchpad-save-modal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-permanent-dismissal-of-launchpad-save-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Launchpad: persist user option to hide the post-save modal

--- a/projects/plugins/jetpack/changelog/add-permanent-dismissal-of-launchpad-save-modal
+++ b/projects/plugins/jetpack/changelog/add-permanent-dismissal-of-launchpad-save-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Launchpad save modal: persist the user option when they opt to hide the modal

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -19,6 +19,24 @@ const updateHideFSENextStepsModal = async hideFSENextStepsModal => {
 	} );
 };
 
+const LAUNCHPAD_SAVE_MODAL_EDITABLE_PROPS = [ 'hideFSENextStepsModal' ];
+
+const updateLaunchpadSaveModalBrowserConfig = config => {
+	if ( ! config || typeof config !== 'object' ) {
+		return;
+	}
+
+	if ( ! window.Jetpack_LaunchpadSaveModal ) {
+		window.Jetpack_LaunchpadSaveModal = {};
+	}
+
+	for ( const editableProp of LAUNCHPAD_SAVE_MODAL_EDITABLE_PROPS ) {
+		if ( config.hasOwnProperty( editableProp ) ) {
+			window.Jetpack_LaunchpadSaveModal[ editableProp ] = config[ editableProp ];
+		}
+	}
+};
+
 export const settings = {
 	render: function LaunchpadSaveModal() {
 		const {
@@ -158,6 +176,7 @@ export const settings = {
 
 		const handleDontShowAgainSetting = shouldHide => {
 			setDontShowAgain( shouldHide );
+			updateLaunchpadSaveModalBrowserConfig( { hideFSENextStepsModal: shouldHide } );
 			updateHideFSENextStepsModal( shouldHide );
 		};
 

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -186,13 +186,13 @@ export const settings = {
 					isDismissible={ true }
 					className="launchpad__save-modal"
 					onRequestClose={ () => {
+						handleDontShowAgainSetting( isChecked );
 						// bypass the onRequestClose function the first time it's called when you publish a post because it closes the modal immediately
 						if ( isInitialPostPublish ) {
 							setIsInitialPostPublish( false );
 							return;
 						}
 						setIsModalOpen( false );
-						handleDontShowAgainSetting( isChecked );
 						recordTracksEvent( 'jetpack_launchpad_save_modal_close' );
 					} }
 				>
@@ -221,8 +221,11 @@ export const settings = {
 								<Button
 									variant="primary"
 									href={ actionButtonHref }
-									onClick={ () => recordTracksEvent( actionButtonTracksEvent ) }
 									target="_top"
+									onClick={ () => {
+										handleDontShowAgainSetting( isChecked );
+										recordTracksEvent( actionButtonTracksEvent );
+									} }
 								>
 									{ actionButtonText }
 								</Button>

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/launchpad-save-modal.php
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/launchpad-save-modal.php
@@ -34,6 +34,11 @@ function add_launchpad_options() {
 		'siteIntentOption'            => get_option( 'site_intent' ),
 		'hasNeverPublishedPostOption' => get_option( 'has_never_published_post' ),
 	);
+
+	if ( function_exists( 'wpcom_launchpad_is_fse_next_steps_modal_hidden' ) && wpcom_launchpad_is_fse_next_steps_modal_hidden() ) {
+		$launchpad_options['hideFSENextStepsModal'] = true;
+	}
+
 	wp_add_inline_script(
 		'jetpack-blocks-editor',
 		'var Jetpack_LaunchpadSaveModal = ' . wp_json_encode( $launchpad_options, JSON_HEX_TAG | JSON_HEX_AMP ) . ';',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/76880

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the launchpad modal to be permanently dismissable by three distinct pieces:
   1.  Implement `wpcom_launchpad_is_fse_next_steps_modal_hidden()` and `wpcom_launchpad_set_fse_next_steps_modal_hidden()` functions for the launchpad, which store the flag as the `hide_fse_next_steps_modal` sub-option of `wpcom_launchpad_config`.
   2. Add `hide_fse_next_steps_modal` as a modifiable option to the `POST` launchpad API.
   3. Update the launchpad save modal to hide the modal when `wpcom_launchpad_is_fse_next_steps_modal_hidden()` returns true, and to correctly update the option via the REST API above

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This is a WordPress.com-specific feature.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply both parts of this PR to your WordPress.com development sandbox as per the instructions in [this comment](https://github.com/Automattic/jetpack/pull/32567#issuecomment-1682981605)
* Create a new WordPress.com site with the Write intent and get to the fullscreen launchpad for your site
* Ensure that both `public-api.wordpress.com` and your site's `*.wordpress.com` subdomain are both pointing at your development sandbox
* From the fullscreen launchpad, click on the task to write a post
* Write some content and publish the post
* You should see the "Great progress" prompt appear (possibly after another prompt)
* Select the "Don't show again" checkbox
* Click on the "Back to Edit" button
* Refresh the page
* Open the developer tools, and open the Console tab
* Ensure you're running in the context of `post-new.php` or `post.php`
* Type `window.Jetpack_LaunchpadSaveModal`, and verify that the `hideFSENextStepsModal` value is present and set to `true`
* Go back to the full-screen launchpad
* Click on the task to create a new post
* Edit and then publish the new post
* Verify that you don't see the "Great progress" modal - this means the update went through from the "Back to Edit" button and took effect correctly on loading the post editor
* On the back end, delete the `wpcom_launchpad_config` option for this blog via `switch_to_blog( $your_blog_id ); delete_option( 'wpcom_launchpad_config' );`
* Go back to the fullscreen launchpad
* Click on the task to create a new post
* Edit and then publish the new post
* Verify that you see the "Great progress" modal
* Check the "Don't show this again" checkbox, and click on the "Next steps" CTA
* You can either work through another publish cycle, or simply check the status of the option on the back end to verify that the update occurred for this code path.
* 

#### Open questions/concerns

- The API calls may fail for users who don't have sufficient permissions, though the site should generally only have one user while we're showing the full-screen launchpad
- I haven't implemented checks to prevent unnecessary API calls when we're not actually making a change - we may need a `useRef()` call to help with that, and maybe make the update to `window.Jetpack_LaunchpadSaveModal` conditional on the return from the POST call (at least for the "Back to Edit" button -- we're navigating away for the primary CTA).
