### PR TITLE
Sitemaps: Add WooCommerce product post type to sitemaps if WooCommerce is present

### DIFF
--- a/projects/plugins/jetpack/3rd-party/woocommerce.php
+++ b/projects/plugins/jetpack/3rd-party/woocommerce.php
@@ -57,7 +57,9 @@ function jetpack_woocommerce_add_to_sitemap( $post_types ) {
 function jetpack_woocommerce_skip_hidden_products_in_sitemap( $skip, $post ) {
 	if ( $post !== null && $post->post_type === 'product' ) {
 		$product = wc_get_product( $post->ID );
-		$skip    = ! $product->is_visible();
+		if ( $product ) {
+			$skip = ! $product->is_visible();
+		}
 	}
 	return $skip;
 }

--- a/projects/plugins/jetpack/3rd-party/woocommerce.php
+++ b/projects/plugins/jetpack/3rd-party/woocommerce.php
@@ -23,12 +23,28 @@ function jetpack_woocommerce_integration() {
 	add_action( 'woocommerce_share', 'jetpack_woocommerce_social_share_icons', 10 );
 
 	/**
+	 * Add product post type to Jetpack sitemap present.
+	 */
+	add_filter( 'jetpack_sitemap_post_types', 'jetpack_woocommerce_add_to_sitemap' );
+
+	/**
 	 * Wrap in function exists check since this requires WooCommerce 3.3+.
 	 */
 	if ( function_exists( 'wc_get_default_products_per_row' ) ) {
 		add_filter( 'infinite_scroll_render_callbacks', 'jetpack_woocommerce_infinite_scroll_render_callback', 10 );
 		add_action( 'wp_enqueue_scripts', 'jetpack_woocommerce_infinite_scroll_style', 10 );
 	}
+}
+
+/**
+ * Add product post type to sitemap if Woocommerce is present.
+ *
+ * @param array $post_types Array of post types included in sitemap.
+ */
+function jetpack_woocommerce_add_to_sitemap( $post_types ) {
+	$post_types[] = 'product';
+
+	return $post_types;
 }
 
 /**

--- a/projects/plugins/jetpack/3rd-party/woocommerce.php
+++ b/projects/plugins/jetpack/3rd-party/woocommerce.php
@@ -23,9 +23,10 @@ function jetpack_woocommerce_integration() {
 	add_action( 'woocommerce_share', 'jetpack_woocommerce_social_share_icons', 10 );
 
 	/**
-	 * Add product post type to Jetpack sitemap present.
+	 * Add product post type to Jetpack sitemap while skipping hidden products.
 	 */
 	add_filter( 'jetpack_sitemap_post_types', 'jetpack_woocommerce_add_to_sitemap' );
+	add_filter( 'jetpack_sitemap_skip_post', 'jetpack_woocommerce_skip_hidden_products_in_sitemap', 10, 2 );
 
 	/**
 	 * Wrap in function exists check since this requires WooCommerce 3.3+.
@@ -45,6 +46,20 @@ function jetpack_woocommerce_add_to_sitemap( $post_types ) {
 	$post_types[] = 'product';
 
 	return $post_types;
+}
+
+/**
+ * Skip hidden products when generating the sitemap.
+ *
+ * @param bool    $skip Whether to skip the post.
+ * @param WP_Post $post The post object.
+ */
+function jetpack_woocommerce_skip_hidden_products_in_sitemap( $skip, $post ) {
+	if ( $post !== null && $post->post_type === 'product' ) {
+		$product = wc_get_product( $post->ID );
+		$skip    = ! $product->is_visible();
+	}
+	return $skip;
 }
 
 /**

--- a/projects/plugins/jetpack/changelog/add-sitemap-compatibility-with-woocommerce
+++ b/projects/plugins/jetpack/changelog/add-sitemap-compatibility-with-woocommerce
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Add Woocommerce product post type to sitemaps if WooCommerce is present


### PR DESCRIPTION
Add compatibility with WooCommerce types when generating sitemaps. Non-visible products are skipped when generating the sitemap.

Fixes #32572

<table>
<tr>
<td><img src="https://github.com/Automattic/jetpack/assets/746152/f5120981-b533-49f2-9d32-7f95ac6fbd41" />
 <td><img src="https://github.com/Automattic/jetpack/assets/746152/8b0a63cd-d436-46c3-8354-8480d26571af" />
<tr>
 <td>Before
 <td>After
</table>

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a filter to `jetpack_sitemap_post_types` adding the `product` post type to be mapped.
* * Adds a filter to `jetpack_sitemap_skip_post` skipping `product` if it's not visible

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1692300608136739-slack-C03Q87XT1QF

## Does this pull request change what data or activity we track or use?

No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Install WooCommerce, and Jetpack running this branch (e.g. [Jurassic Ninja + Jetpack (this branch) + WooCommerce]( https://jurassic.ninja/create?jetpack-beta&branches.jetpack=add/sitemap-compatibility-with-woocommerce&wp-debug-log&woocommerce) )
* Connect Jetpack
* Set up your Woo Store.
* Add A product named **Shirt**. Publish it
* Add a second product named **T-shirt**, but this time set its catalog visibility to hidden before publishing.
* Enable Jetpack Settings -> Traffic -> Sitemaps
* Visit [your-site]/sitemap.xml
* Click the first sitemap.
* Confirm the Shirt product you added is listed there.
* Confirm the T-Shirt product you added is **not** listed there.
  <img width="698" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/4ca3e0d0-3928-4446-9592-adb835b94b70">





## Test on WooExpress site

* Install [Jetpack beta plugin](https://github.com/Automattic/jetpack-beta/archive/refs/heads/trunk.zip)
* Make sure your site is published and/or set to be reachable by engines.
* Visit Jetpack -> Jetpack Beta
* Click Jetpack
* In the field **Feature Branch**, type `woocommerce` and from the dropdown select `add / sitemap compatibility with woocommerce
`
  <img width="736" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/4d8e9685-f034-453b-9cfa-5a16208b5b54">
* Add A product named **Shirt**. Publish it
* Add a second product named **T-shirt**, but this time set its catalog visibility to hidden before publishing.
* Enable Sitemaps under Tools -> Marketing -> Traffic (At the bottom)
  <img width="1070" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/453cdbc7-9832-4dad-9e8f-20cc3bae44a2">
* Visit [your-site]/sitemap.xml
* Click the first sitemap.
* Confirm the product you added is listed there.
* Confirm the T-Shirt product you added is **not** listed there.
  <img width="881" alt="image" src="https://github.com/Automattic/jetpack/assets/746152/ddb5340c-164f-462a-8812-8839118d9a46">
