### PR TITLE
AI Extension: fix bug when focusing on the input element when component mount

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fix-on-focus-process
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-fix-on-focus-process
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: fix bug when focusing on the input element when component mount

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -166,8 +166,26 @@ export default function AiAssistantBar( {
 
 	// focus input on first render only (for a11y reasons, toggling on/off should not focus the input)
 	useEffect( () => {
-		inputRef.current?.focus();
-	}, [] );
+		/*
+		 * Only focus the input when the Assistant bar is visible.
+		 * Also, add a small delay to avoid focus when the Assistant bar is toggled off.
+		 */
+		const timeId = setTimeout( () => {
+			if ( ! isVisible ) {
+				return;
+			}
+
+			if ( ! inputRef?.current ) {
+				return;
+			}
+
+			inputRef.current.focus();
+		}, 300 );
+
+		return function () {
+			clearTimeout( timeId );
+		};
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps -- only run on first render
 
 	if ( ! isVisible ) {
 		return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The current approach to show the AI Assistant only when the component mounts the first time is a bit unstable.
The app shows the bar by default by setting [its visibility to true from the local state](https://github.com/Automattic/jetpack/blob/d1b29cf7d5ce950b9b6fd25083fd288e4e1acffa/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx#L46) (UI Context)
On the other hand, the [bar tries to focus its input once it mounts](https://github.com/Automattic/jetpack/blob/b0ba23de16e214bddbc9985265a7807becade496/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx#L168-L170) (only the first time, too).
Based on DOM tree references and local state, this behavior produces a recursion issue (Maximum update depth exceeded). The issue arises when the Block previsualizes, for instance, in the block styles feature.

This PR tackles it by doing the following:
* Check if the bar component is visible before trying to focus its input
* Add a delay (timeout) to mitigate the race condition (rather hacky, but still).

Fixes https://github.com/Automattic/jetpack/issues/32565

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: fix bug when focusing on the input element when component mount

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Fomr block instance
* Confirm that, when it visualizes the first time, the Assistant bat focuses
* Open the block sidebar
* Mouse over the block styles
* Confirm it shows the preview into the popover
* Confirm no error logs


https://github.com/Automattic/jetpack/assets/77539/2c9d88ad-37ea-41bd-a1ff-f02610e97726

