### PR TITLE
AI Extension: check missing blocks when parsing Jetpack Form blocks in the AI generation process

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-ai-check-valid-blocks
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-ai-check-valid-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: check missing blocks when parsing Jetpack Form blocks in the AI generation process

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -162,7 +162,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 
 				// Check if the generated blocks are valid.
 				const validBlocks = newContentBlocks.filter( block => {
-					return block.isValid && block.name !== 'core/freeform';
+					return block.isValid && block.name !== 'core/freeform' && block.name !== 'core/missing';
 				} );
 
 				// Only update the blocks when the valid list changed, meaning a new block arrived.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This pull request verifies the blocks generated during the parsing process and identifies any `core/missing` blocks. If any are found, they are excluded. This ensures that only registered blocks are added to the app.nly registered blocks are added to the app.


Fixes https://github.com/Automattic/jetpack/issues/32560

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: check missing blocks when parsing Jetpack Form blocks in the AI generation process

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Open the AI Assistant bar
* Ask for some block that is not supported, for instance:

```
create a simple contact form with "jetpack/field-message" field
```

* **Before**: Confirm that, usually, the app shows a block that doesn't exists
* **After**: Confirm the unexciting block is not part of the generated form

Before | After
-------|------
<img width="675" alt="Screenshot 2023-08-18 at 10 25 35" src="https://github.com/Automattic/jetpack/assets/77539/fd4b0bf3-20d3-4b8f-a25b-84a850632c96"> | <img width="677" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/d06387ac-0b1c-46b6-bb3c-b1a876ec7106">
