### PR TITLE
Paywall block: avoid undefined variable warning

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-undefined
+++ b/projects/plugins/jetpack/changelog/update-paywall-undefined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Paywall block: avoid undefined variable warning

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -760,19 +760,17 @@ function add_paywall( $the_content ) {
 		return $the_content;
 	}
 
+	$post_access_level = Jetpack_Memberships::get_post_access_level();
+	if ( jetpack_is_frontend() ) {
+		$paywalled_content = get_paywall_blocks( $post_access_level );
+	} else {
+		// emails
+		$paywalled_content = get_paywall_simple();
+	}
+
 	// Partially free content with paywall
 	if ( has_block( $block_name ) ) {
-		$post_access_level = Jetpack_Memberships::get_post_access_level();
-		if ( jetpack_is_frontend() ) {
-			$paywalled_content = get_paywall_blocks( $post_access_level );
-		} else {
-			// emails
-			$paywalled_content = get_paywall_simple();
-		}
-		$paywalled_content = strstr( $the_content, '<!-- wp:' . $block_name . ' /-->', true ) . $paywalled_content;
-	} else {
-		// Fully paywalled content
-		$paywalled_content = get_paywall_blocks( $post_access_level );
+		return strstr( $the_content, '<!-- wp:' . $block_name . ' /-->', true ) . $paywalled_content;
 	}
 
 	return $paywalled_content;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -760,6 +760,7 @@ function add_paywall( $the_content ) {
 		return $the_content;
 	}
 
+	// Partially free content with paywall
 	if ( has_block( $block_name ) ) {
 		$post_access_level = Jetpack_Memberships::get_post_access_level();
 		if ( jetpack_is_frontend() ) {
@@ -769,6 +770,9 @@ function add_paywall( $the_content ) {
 			$paywalled_content = get_paywall_simple();
 		}
 		$paywalled_content = strstr( $the_content, '<!-- wp:' . $block_name . ' /-->', true ) . $paywalled_content;
+	} else {
+		// Fully paywalled content
+		$paywalled_content = get_paywall_blocks( $post_access_level );
 	}
 
 	return $paywalled_content;


### PR DESCRIPTION
@lezama can you double check the logic here, I'm not entirely sure I followed it right.

We could add some comments between lines to make it easier to follow what happens.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes:
```
PHP Warning:  Undefined variable $paywalled_content in /usr/local/src/jetpack-monorepo/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php on line 774
```
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Post which is free _and_ paid as a free _and_ paid user (so 4 test cases)
* Same as above but with paywall block in the post
* Check both emails and the blog

