### PR TITLE
Google Fonts: Register Google Fonts to theme json default to keep them in the font selection list

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-register-google-fonts-to-theme-json-default
+++ b/projects/plugins/jetpack/changelog/feat-register-google-fonts-to-theme-json-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix the goole fonts are missing if the style variation has its font families

--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -169,4 +169,6 @@ function jetpack_register_google_fonts_to_theme_json_default( $theme_json ) {
 	return new WP_Theme_JSON_Data_Gutenberg( $raw_data, 'default' );
 }
 
-add_filter( 'wp_theme_json_data_default', 'jetpack_register_google_fonts_to_theme_json_default' );
+if ( class_exists( 'WP_Fonts_Utils' ) ) {
+	add_filter( 'wp_theme_json_data_default', 'jetpack_register_google_fonts_to_theme_json_default' );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/3162, https://github.com/Automattic/wp-calypso/issues/78605

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* [Gutenberg adds the missing fonts to the theme json data](https://github.com/WordPress/gutenberg/blob/57d7861eca9a526d896adf717f64d6483bb6cc6f/lib/class-wp-theme-json-resolver-gutenberg.php#L283). However, when it tries to merge the global styles (selected style variation) into the theme json data, the [mergeBaseAndUserConfigs](https://github.com/WordPress/gutenberg/blob/eac3f039b0bd094af35291987390ea1c5cc473d9/packages/edit-site/src/components/global-styles/global-styles-provider.js#L24) will override the old array (no merging) so that the font families from the theme json data will be overridden if the style variation has its own font families set.
* The above behavior seems to be correct as the font family list should be the same as the style variation. However, on Jetpack (or WP.com), we want to display the google fonts that are not included in the theme or its style variation. So, we'd prefer to inject the google fonts into the core data so people can still pick the google fonts even if the current style variation has its font definition.

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/jetpack/assets/13596067/48d1bc88-72b4-47e9-adb2-db620fa39661) | ![image](https://github.com/Automattic/jetpack/assets/13596067/bef961f3-1994-4f92-a32d-3293a7d8afe8) |

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**WP.com**

* Apply this patch to your sandbox
* Go to Theme Showcase
* Activate the Pendant theme with any style variation (non-default one)
* Go to the Site Editor
* Select Styles > Typography > Text > Font
* Ensure you're able to see all Google Fonts in the list instead of just 3

**JN site**

* Create a [Jurassic Ninja sandbox](https://jurassic.ninja/create/?jetpack-beta&branch=feat/register-google-fonts-to-theme-json-default) against this PR.
* Go to Theme Showcase
* Install and activate the Pendant theme via https://public-api.wordpress.com/rest/v1/themes/download/pendant.zip
* Go to the Site Editor
* Select Styles > Typography > Text > Font
* Ensure you're able to see all Google Fonts in the list instead of just 3
* Install the Gutenberg plugin and repeat the above steps
* Ensure everything still works well