### PR TITLE
AI Extension: consolidate Block Toolbar button style

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-toolbar-button-styles
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-toolbar-button-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: consolidate Block Toolbar button style

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -128,7 +128,6 @@ export default function AiAssistantToolbarButton( {
 				label={ __( 'Ask AI Assistant', 'jetpack' ) }
 				icon={ aiAssistantIcon }
 				disabled={ isDisabled }
-				isActive={ isVisible }
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Pretty simple PR that tries to consolidate how the the toolbar button looks compared with core.

Fixes https://github.com/Automattic/jetpack/issues/32225

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: consolidate Block Toolbar button style

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance 
* Take a look at both buttons: `Align` and `AI assistant`

**Before**
In the video below, the toolbar buttons look pretty different

https://github.com/Automattic/jetpack/assets/77539/d1b1f874-a8ce-45d2-a95a-005fd8a43d9d

**After**
They look pretty similar. No ideal in terms of a11y.

https://github.com/Automattic/jetpack/assets/77539/2a3570cc-9385-4520-9d40-2053782460ab
