### PR TITLE
AI Extension: improve AI toolbar button a11y

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-bar-imoprove-accessibility-from-toolbar-button
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-bar-imoprove-accessibility-from-toolbar-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: improve AI toolbar button a11y

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -6,6 +6,7 @@ import { serialize } from '@wordpress/blocks';
 import { useViewportMatch } from '@wordpress/compose';
 import { select } from '@wordpress/data';
 import { useDispatch } from '@wordpress/data';
+import { forwardRef } from '@wordpress/element';
 import {
 	useContext,
 	useCallback,
@@ -66,15 +67,17 @@ function getSerializedContentFromBlock( clientId: string ): string {
 	}, '' );
 }
 
-export default function AiAssistantBar( {
-	clientId,
-	className = '',
-}: {
-	clientId: string;
-	className?: string;
-} ) {
+export default forwardRef( function AiAssistantBar(
+	{
+		clientId,
+		className = '',
+	}: {
+		clientId: string;
+		className?: string;
+	},
+	inputRef: React.RefObject< HTMLInputElement >
+) {
 	const wrapperRef = useRef< HTMLDivElement >( null );
-	const inputRef = useRef< HTMLInputElement >( null );
 
 	const { inputValue, setInputValue, isVisible, assistantAnchor } =
 		useContext( AiAssistantUiContext );
@@ -224,4 +227,4 @@ export default function AiAssistantBar( {
 
 	// Render in the editor canvas.
 	return AiAssistantBarComponent;
-}
+} );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -22,12 +22,15 @@ const AI_ASSISTANT_BAR_SLOT_CLASS = 'jetpack-ai-assistant-bar__slot';
  *
  * @param {object} props - The component props.
  * @param {string} props.jetpackFormClientId - The Jetpack Form block client ID.
+ * @param {React.RefObject} props.assistantBarInputRef - The Assistant Bar input ref.
  * @returns {React.ReactElement}               The toolbar button.
  */
 export default function AiAssistantToolbarButton( {
 	jetpackFormClientId,
+	assistantBarInputRef,
 }: {
 	jetpackFormClientId?: string;
+	assistantBarInputRef?: React.RefObject< HTMLInputElement >;
 } ): React.ReactElement {
 	const { isVisible, toggle, setAnchor, assistantAnchor } = useContext( AiAssistantUiContext );
 	const { requestingState } = useAiContext();
@@ -101,12 +104,13 @@ export default function AiAssistantToolbarButton( {
 	}, [ isMobileViewport, assistantAnchor ] );
 
 	const toggleFromToolbar = useCallback( () => {
+		toggle();
 		if ( ! jetpackFormClientId ) {
-			return toggle();
+			return setTimeout( () => assistantBarInputRef?.current?.focus(), 0 );
 		}
 
-		selectFormBlock( jetpackFormClientId, toggle );
-	}, [ jetpackFormClientId, toggle ] );
+		selectFormBlock( jetpackFormClientId );
+	}, [ jetpackFormClientId, toggle, assistantBarInputRef ] );
 
 	const isDisabled = requestingState === 'requesting' || requestingState === 'suggesting';
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -6,7 +6,7 @@ import { BlockControls } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { select, useSelect } from '@wordpress/data';
-import { useEffect, useCallback } from '@wordpress/element';
+import { useEffect, useCallback, useRef } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 /*
  * Internal dependencies
@@ -125,14 +125,16 @@ const withAiAssistantComponents = createHigherOrderComponent( BlockEdit => {
 			group: 'block',
 		};
 
+		const inputRef = useRef< HTMLInputElement >( null );
+
 		return (
 			<>
 				<BlockEdit { ...props } />
 
-				<AiAssistantBar clientId={ props.clientId } />
+				<AiAssistantBar ref={ inputRef } clientId={ props.clientId } />
 
 				<BlockControls { ...blockControlsProps }>
-					<AiAssistantToolbarButton />
+					<AiAssistantToolbarButton assistantBarInputRef={ inputRef } />
 				</BlockControls>
 			</>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -31,7 +31,7 @@ export const AI_ASSISTANT_JETPACK_FORM_NOTICE_ID = 'ai-assistant';
  * @param {Function} fn     - The function to run after selecting the block.
  * @returns {void}
  */
-export function selectFormBlock( clientId: string, fn: () => void ): void {
+export function selectFormBlock( clientId: string, fn?: () => void ): void {
 	dispatch( 'core/block-editor' ).selectBlock( clientId ).then( fn );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR improves the accessibility when showing the Assistant bar by clicking on the AI toolbar button, trying to follow the behavior implemented by the core. For this:

* Forward the ref for the Assistant bar input
* Pass down this reference to the Toolbar button
* With the reference there, the toolbar button will try to focus the input element

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: improve AI toolbar button a11y

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* Click on the AI Toolbar button again and again.
* Confirm when the Assistant bar is visible, the input element get focused 

**Mobile** and **regular** view

https://github.com/Automattic/jetpack/assets/77539/aae9cb62-764d-4bbd-a16c-7d35ebb918f6

https://github.com/Automattic/jetpack/assets/77539/e5d1ee3a-3b5d-4aa3-9767-082344408c05



