### PR TITLE
docker: Add tools/docker/data/ssh.keys/README.txt

### DIFF
--- a/tools/docker/data/ssh.keys/.gitignore
+++ b/tools/docker/data/ssh.keys/.gitignore
@@ -1,3 +1,4 @@
 /*
 !.gitignore
+!README.txt
 

--- a/tools/docker/data/ssh.keys/README.txt
+++ b/tools/docker/data/ssh.keys/README.txt
@@ -1,0 +1,2 @@
+# Add public key files for sftp access in this directory.
+# https://github.com/Automattic/jetpack/blob/trunk/tools/docker/README.md#sftp-keys


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The main purpose of this is to exist to work around #31498 absent an upstream fix.

Note every line in the file needs to begin with `#` or it'll break the container in a different way.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #31498

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without any key files in `tools/docker/data/ssh.keys/`, running `jetpack docker up` should not have the sftp container exit with the error in the linked issue.
  * Note you may need to `docker container rm jetpack_dev_sftp_1` or the like to clean up an old broken version of the sftp container.