### PR TITLE
 AI Extension: do not send request when AI assistant input is empty

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-extension-do-not-send-empty-request
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-extension-do-not-send-empty-request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: do not send request when AI assistant input is empty

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -100,6 +100,11 @@ export default function AiAssistantBar( {
 	const { removeNotice } = useDispatch( noticesStore );
 
 	const onSend = useCallback( () => {
+		// Do not send the request if the input value is empty.
+		if ( ! inputValue?.length ) {
+			return;
+		}
+
 		// Remove previous error notice.
 		removeNotice( AI_ASSISTANT_JETPACK_FORM_NOTICE_ID );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR checks if the AI Assistant bar input is empty when the user presses the enter key. If so, it won't call the send() function, avoiding showing an error in the dev console./

Fixes https://github.com/Automattic/jetpack/issues/32589

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: do not send request when AI assistant input is empty

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Jetpack Form block instance
* **Before**: Confirm that typing the enter key in the input when it's empty triggers an error in the dev-console
![image](https://github.com/Automattic/jetpack/assets/77539/6917b939-64c2-430c-9289-fd0f8d6b16db)

* **After**: dev console does not show any error.