### PR TITLE
Launchpad: Use task ID to validate status update request

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/Use the task id to validate the task update request
+++ b/projects/packages/jetpack-mu-wpcom/changelog/Use the task id to validate the task update request
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Use the task id to validate the task update request

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -103,7 +103,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 		$tasks            = wpcom_launchpad_checklists()->get_all_tasks();
 		$allowed_task_ids = array();
 		foreach ( $tasks as $task ) {
-			$allowed_task_ids[] = wpcom_launchpad_checklists()->get_task_key( $task );
+			$allowed_task_ids[] = $task['id'];
 		}
 		$allowed_task_ids = array_unique( $allowed_task_ids );
 		$properties       = array();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -104,6 +104,9 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 		$allowed_task_ids = array();
 		foreach ( $tasks as $task ) {
 			$allowed_task_ids[] = $task['id'];
+			if ( isset( $task['id_map'] ) ) {
+				$allowed_task_ids[] = $task['id_map'];
+			}
 		}
 		$allowed_task_ids = array_unique( $allowed_task_ids );
 		$properties       = array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* With the changes introduced on https://github.com/Automattic/jetpack/pull/31471 we should be able to update a task with it's task ID and not the ID map prop. However, the request to update the task status used the method `get_task_key` to validate whether the incoming task was valid. This would make it impossible to update tasks by their ID if it contains the id_map prop.
* Instead of using the id_map to check if the incoming task is valid, we check by the ID.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your Sandbox
* Create a new site
* Navigate to the Developer Console
* Make a PUT request to `WP REST API` -> `wpcom/v2` -> `/sites/:siteId/launchpad`, with the following body:
```
checklist_statuses = { "connect_social_media": true }
```
* The request should be completed without errors

