### PR TITLE
AI Assistant: Set default feature value as ai-assistant [DO NOT MERGE]

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-assistant-set-feature-value
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-set-feature-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: Start sending ai-assistant as the default feature name for the AI Assistant on the completion request

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -219,7 +219,7 @@ const useSuggestionsFromOpenAI = ( {
 			source.current = await askQuestion( prompt, {
 				postId,
 				requireUpgrade,
-				feature: attributes?.useGpt4 ? 'ai-assistant-experimental' : undefined,
+				feature: attributes?.useGpt4 ? 'ai-assistant-experimental' : 'ai-assistant',
 				functions: options?.functions,
 			} );
 		} catch ( err ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We are doing it to be able to differentiate the AI Assistant requests on the `jetpack-ai-query` endpoint, to set different default values for the model, for example.

This needs to be merged after the backend change: D119377-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Start sending `feature=ai-assistant` on the AI Assistant completion requests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and open the browser's dev console
* Add an AI Assistant block and ask for some completion (example: a haiku about sun light)
* Notice the `jetpack-ai-client:ask-question` debug message; it should contain the `feature=ai-assistant` parameter:

<img width="800" alt="Screenshot 2023-08-18 at 16 43 46" src="https://github.com/Automattic/jetpack/assets/6760046/9e53416c-ab76-4e4e-862c-5f61468fd829">