### PR TITLE
repo-gardening: Don't crash on null milestone descriptions

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-null-description
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-null-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't crash on milestones with null description.

--- a/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
+++ b/projects/github-actions/repo-gardening/src/utils/get-next-valid-milestone.js
@@ -58,7 +58,7 @@ async function getNextValidMilestone( octokit, owner, repo, plugin = 'jetpack' )
 			 * and that date has elapsed, then filter out the milestone. This prevents merged PRs from being
 			 * automatically added to milestones that have entered a code freeze.
 			 */
-			const match = m.description.match( /(?:Code Freeze|Branch Cut): (\d{4}-\d{2}-\d{2})/ );
+			const match = m.description?.match( /(?:Code Freeze|Branch Cut): (\d{4}-\d{2}-\d{2})/ );
 			return ! ( match && moment( match[ 1 ] ) < moment() );
 		} )
 		.sort( ( m1, m2 ) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Somehow it's possible to create a milestone with a `null` description, so we need to account for this when trying to parse the description.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1692389821759339-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this, then merge something touching Jetpack-the-plugin.