### PR TITLE
Subscriptions: Remove newsletter check for subscribe modal

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-subscribe-modal-check
+++ b/projects/plugins/jetpack/changelog/update-remove-subscribe-modal-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscriptions: Remove newsletter check for subscribe modal.

--- a/projects/plugins/jetpack/changelog/update-remove-subscribe-modal-check
+++ b/projects/plugins/jetpack/changelog/update-remove-subscribe-modal-check
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Subscriptions: Remove newsletter check for subscribe modal.
+Subscriptions: Remove newsletter flow+theme and FSE theme check for the subscribe modal. Leave WP.com check.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -170,9 +170,6 @@ HTML;
 		if ( ! $is_wpcom ) {
 			return false;
 		}
-		if ( 'lettre' !== get_option( 'stylesheet' ) && 'newsletter' !== get_option( 'site_intent' ) ) {
-			return false;
-		}
 		if ( ! wp_is_block_theme() ) {
 			return false;
 		}

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -158,8 +158,6 @@ HTML;
 
 	/**
 	 * Returns true if we should load Newsletter content.
-	 * This is currently limited to lettre theme or newsletter sites.
-	 * We could open it to all themes or site intents.
 	 *
 	 * @return bool
 	 */
@@ -167,13 +165,7 @@ HTML;
 		// Adding extra check/flag to load only on WP.com
 		// When ready for Jetpack release, remove this.
 		$is_wpcom = ( new Host() )->is_wpcom_platform();
-		if ( ! $is_wpcom ) {
-			return false;
-		}
-		if ( ! wp_is_block_theme() ) {
-			return false;
-		}
-		return true;
+		return $is_wpcom;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We currently check for site_intent === newsletter or theme === lettre before loading any code for the subscribe modal. This PR removes this check. Note that: 
   - The modal will still show only WordPress.com sites, not self hosted sites.
   - The modal will not show on the frontend until/unless a user enables it. The option to enable the modal is off by default.
   - We still need to remove a check in Calypso to show the 'Enable subscribe modal' option as well (https://github.com/Automattic/wp-calypso/pull/80703)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

We want to test modal can now be enabled on any WordPress.com simple site (not just those with newsletter site_intent or Lettre theme). To check this, you'll need to remove the extra check in Calypso as well. 

1) Setup
   - Test on any WordPress.com simple site that does _not_ have newsletter / Lettre. 
   - Run the bin command provided by github below to load this branch in your sandbox. Sandbox public API and the domain of your test site. 
   - Checkout and start the trunk branch of calypso. Temporarily commend out this isNewsletterSite check to ensure the option will show in calypso with PR https://github.com/Automattic/wp-calypso/pull/80703
   - The modal should load.
   - Test also using non-FSE theme; the theme should still load.

2) Test
   - Access your site's dashboard via calypso localhost, and go to Settings > Reading > Newsletter. Confirm the 'Enable subscribe modal' option is visible.
   - Enable the modal and save. 
   - In a non-logged in browser (won't see the modal if logged in), go to any single blog post on the front end, scroll, pause, and confirm the modal shows. 

3) As a safety check, load this branch in your Jetpack dev environment, and confirm that the option to show the modal still does not show, and also that the modal does not load on any frontend single post. 

