### PR TITLE
Fix/selfserve 705/fix dsp experiments endpoint

### DIFF
--- a/projects/packages/blaze/changelog/fix-DSP-experiments-endpoint
+++ b/projects/packages/blaze/changelog/fix-DSP-experiments-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a rest route for the DSP experiments api endpoint

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -85,6 +85,17 @@ class Dashboard_REST_Controller {
 			)
 		);
 
+		// WordAds DSP API Experiment route
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/wordads/dsp/api/v1/experiments(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_dsp_experiments' ),
+				'permission_callback' => array( $this, 'can_user_view_dsp_callback' ),
+			)
+		);
+
 		// WordAds DSP API Campaigns routes
 		register_rest_route(
 			static::$namespace,
@@ -317,6 +328,17 @@ class Dashboard_REST_Controller {
 	 */
 	public function get_dsp_credits( $req ) {
 		return $this->get_dsp_generic( 'v1/credits', $req );
+	}
+
+	/**
+	 * Redirect GET requests to WordAds DSP Experiments endpoint for the site.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array|WP_Error
+	 */
+	public function get_dsp_experiments( $req ) {
+
+		return $this->get_dsp_generic( 'v1/experiments', $req );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
please check SELFSERVE-705

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Fire up your local jetpack installation (and tunnel it - so that advertising page is working properly)
navigate to tools->advertising and click to promote a post (or page)
open up your network inspector and verify that the call to /experiments is going through without an error

the full path should be something like the one below (with different ids)

wp-json/jetpack/v4/blaze-app/sites/221890190/wordads/dsp/api/v1/experiments/assignments/29032023

(in trunk this call should be failing)

