### PR TITLE
Subscribe modal: bump up z-index

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-z-index
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-z-index
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe modal: bump modal Z-index up

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
@@ -1,7 +1,7 @@
 .jetpack-subscribe-modal {
 	visibility: hidden;
 	position: fixed;
-	z-index: 1;
+	z-index: 50000; /* Same as WP.com Action bar */
 	left: 0;
 	top: 0;
 	width: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bump up z-index for the modal+background skrim up to same as WP.com action bar

This will solve potential theme issues with fixed headings:


**Before**
<img width="1069" alt="Screenshot 2023-08-22 at 11 46 07" src="https://github.com/Automattic/jetpack/assets/87168/a4c51408-fff8-47b8-b1ed-c3bce94ccd33">

**After**
<img width="1063" alt="Screenshot 2023-08-22 at 11 45 27" src="https://github.com/Automattic/jetpack/assets/87168/9def5f2b-0f5a-4878-bde4-cc626af96569">

Action bar z-index:
<img width="779" alt="Screenshot 2023-08-22 at 11 47 14" src="https://github.com/Automattic/jetpack/assets/87168/6d6b4117-dd6a-42e7-8d96-26450fd702dc">

The broken button has something to do with theme's styles and is a separate issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You can test on WP.com by sandboxing my site simisonfreetesting2.wordpress.com which has modal enabled, or test on your own site e.g. with Stratford theme.

