### PR TITLE
CRM: Automations, use the original trigger data during the workflow execution

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-3284-keep-original-trigger-data-in-workflow-execution
+++ b/projects/plugins/crm/changelog/update-crm-3284-keep-original-trigger-data-in-workflow-execution
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Automation Engine, internal change, to keep the original trigger data through the workflow execution
+
+

--- a/projects/plugins/crm/src/automation/class-automation-engine.php
+++ b/projects/plugins/crm/src/automation/class-automation-engine.php
@@ -399,9 +399,7 @@ class Automation_Engine {
 
 		while ( $step_data ) {
 			try {
-				$step_slug = $step_data['slug'];
-
-				$step_class = $step_data['class_name'] ?? $this->get_step_class( $step_slug );
+				$step_class = $step_data['class_name'] ?? $this->get_step_class( $step_data['slug'] );
 
 				if ( ! class_exists( $step_class ) ) {
 					throw new Automation_Exception(
@@ -413,6 +411,8 @@ class Automation_Engine {
 
 				/** @var Step $step */
 				$step = new $step_class( $step_data );
+
+				$step_slug = $step->get_slug();
 
 				if ( isset( $step_data['attributes'] ) && is_array( $step_data['attributes'] ) ) {
 					$step->set_attributes( $step_data['attributes'] );


### PR DESCRIPTION
Fixes: https://github.com/Automattic/zero-bs-crm/issues/3284

## Proposed changes:

This PR updates the Automation Engine, when executing workflows, we have to keep the original data through the workflow execution and transform it before each step execution and pass the data type transformed, if any.

I couldn't add a test because of some dependencies and issues with the Data_Type/Transformer code (it needs to be updated because some data format issues).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:

This change doesn't affect the current behavior, so everything should work as before.

- Check the code.
- Run the tests and check that everything passes.
