### PR TITLE
Boost: Prevent SEO plugins from breaking Critical CSS generation

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
@@ -138,4 +138,18 @@ class Critical_CSS implements Pluggable, Has_Endpoints {
 	public function update_total_problem_count( $count ) {
 		return ( new Critical_CSS_State() )->has_errors() ? ++$count : $count;
 	}
+
+	/**
+	 * Add the critical css generation flag to a list.
+	 * This is mainly used by filters for compatibility.
+	 *
+	 * @var $query_args    array The list to add the arg to.
+	 *
+	 * @return $query_args array The updatest list with query args.
+	 */
+	public static function add_critical_css_query_arg_to_list( $query_args ) {
+		$query_args[] = 'jb-generate-critical-css';
+
+		return $query_args;
+	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
@@ -50,7 +50,7 @@ class Critical_CSS implements Pluggable, Has_Endpoints {
 	public function setup() {
 		add_action( 'wp', array( $this, 'display_critical_css' ) );
 		add_filter( 'jetpack_boost_total_problem_count', array( $this, 'update_total_problem_count' ) );
-		add_filter( 'query_vars', array( __CLASS__, 'add_critical_css_query_arg_to_list' ) );
+		add_filter( 'query_vars', array( '\Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );
 
 		if ( Generator::is_generating_critical_css() ) {
 			add_action( 'wp_head', array( $this, 'display_generate_meta' ), 0 );
@@ -138,22 +138,5 @@ class Critical_CSS implements Pluggable, Has_Endpoints {
 
 	public function update_total_problem_count( $count ) {
 		return ( new Critical_CSS_State() )->has_errors() ? ++$count : $count;
-	}
-
-	/**
-	 * Add the critical css generation flag to a list if it's present in the URL.
-	 * This is mainly used by filters for compatibility.
-	 *
-	 * @var $query_args    array The list to add the arg to.
-	 *
-	 * @return $query_args array The updatest list with query args.
-	 */
-	public static function add_critical_css_query_arg_to_list( $query_args ) {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET[ Generator::GENERATE_QUERY_ACTION ] ) ) {
-			$query_args[] = Generator::GENERATE_QUERY_ACTION;
-		}
-
-		return $query_args;
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Critical_CSS.php
@@ -50,6 +50,7 @@ class Critical_CSS implements Pluggable, Has_Endpoints {
 	public function setup() {
 		add_action( 'wp', array( $this, 'display_critical_css' ) );
 		add_filter( 'jetpack_boost_total_problem_count', array( $this, 'update_total_problem_count' ) );
+		add_filter( 'query_vars', array( __CLASS__, 'add_critical_css_query_arg_to_list' ) );
 
 		if ( Generator::is_generating_critical_css() ) {
 			add_action( 'wp_head', array( $this, 'display_generate_meta' ), 0 );
@@ -74,7 +75,7 @@ class Critical_CSS implements Pluggable, Has_Endpoints {
 	 */
 	public function display_generate_meta() {
 		?>
-		<meta name="jb-generate-critical-css" content="true"/>
+		<meta name="<?php echo esc_attr( Generator::GENERATE_QUERY_ACTION ); ?>" content="true"/>
 		<?php
 	}
 
@@ -140,7 +141,7 @@ class Critical_CSS implements Pluggable, Has_Endpoints {
 	}
 
 	/**
-	 * Add the critical css generation flag to a list.
+	 * Add the critical css generation flag to a list if it's present in the URL.
 	 * This is mainly used by filters for compatibility.
 	 *
 	 * @var $query_args    array The list to add the arg to.
@@ -148,7 +149,10 @@ class Critical_CSS implements Pluggable, Has_Endpoints {
 	 * @return $query_args array The updatest list with query args.
 	 */
 	public static function add_critical_css_query_arg_to_list( $query_args ) {
-		$query_args[] = 'jb-generate-critical-css';
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET[ Generator::GENERATE_QUERY_ACTION ] ) ) {
+			$query_args[] = Generator::GENERATE_QUERY_ACTION;
+		}
 
 		return $query_args;
 	}

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/Generator.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/Generator.php
@@ -63,4 +63,20 @@ class Generator {
 		return $status;
 	}
 
+	/**
+	 * Add the critical css generation flag to a list if it's present in the URL.
+	 * This is mainly used by filters for compatibility.
+	 *
+	 * @var $query_args    array The list to add the arg to.
+	 *
+	 * @return $query_args array The updatest list with query args.
+	 */
+	public static function add_generate_query_action_to_list( $query_args ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET[ self::GENERATE_QUERY_ACTION ] ) ) {
+			$query_args[] = self::GENERATE_QUERY_ACTION;
+		}
+
+		return $query_args;
+	}
 }

--- a/projects/plugins/boost/changelog/add-seo-plugins-compatibility
+++ b/projects/plugins/boost/changelog/add-seo-plugins-compatibility
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Adds the Critical CSS generation token (jb-generate-critical-css), to the allowed query args lists of Yoast SEO and All in One SEO. This prevents them from removing it and breaking Critical CSS generation.
+Critical CSS: Improved compatibility with Yoast SEO and All in One SEO to ensure smooth Critical CSS generation.

--- a/projects/plugins/boost/changelog/add-seo-plugins-compatibility
+++ b/projects/plugins/boost/changelog/add-seo-plugins-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adds the Critical CSS generation token (jb-generate-critical-css), to the allowed query args lists of Yoast SEO and All in One SEO. This prevents them from removing it and breaking Critical CSS generation.

--- a/projects/plugins/boost/compatibility/aioseo.php
+++ b/projects/plugins/boost/compatibility/aioseo.php
@@ -7,10 +7,6 @@
 
 namespace Automattic\Jetpack_Boost\Compatibility\AIOSEO;
 
-function prevent_c_css_query_arg_removal( $query_args ) {
-	$query_args[] = 'jb-generate-critical-css';
-
-	return $query_args;
-}
-
-add_filter( 'aioseo_unrecognized_allowed_query_args', __NAMESPACE__ . '\prevent_c_css_query_arg_removal' );
+// Add the Critical CSS generation query arg to the list of allowed query args of All in One SEO.
+// This prevents All in One SEO from removing the query arg, which breaks Critical CSS generation.
+add_filter( 'aioseo_unrecognized_allowed_query_args', array( '\Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Critical_CSS', 'add_critical_css_query_arg_to_list' ) );

--- a/projects/plugins/boost/compatibility/aioseo.php
+++ b/projects/plugins/boost/compatibility/aioseo.php
@@ -9,4 +9,4 @@ namespace Automattic\Jetpack_Boost\Compatibility\AIOSEO;
 
 // Add the Critical CSS generation query arg to the list of allowed query args of All in One SEO.
 // This prevents All in One SEO from removing the query arg, which breaks Critical CSS generation.
-add_filter( 'aioseo_unrecognized_allowed_query_args', array( '\Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Critical_CSS', 'add_critical_css_query_arg_to_list' ) );
+add_filter( 'aioseo_unrecognized_allowed_query_args', array( '\Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );

--- a/projects/plugins/boost/compatibility/aioseo.php
+++ b/projects/plugins/boost/compatibility/aioseo.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * All in One SEO compatibility for Boost
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Compatibility\AIOSEO;
+
+function prevent_c_css_query_arg_removal( $query_args ) {
+	$query_args[] = 'jb-generate-critical-css';
+
+	return $query_args;
+}
+
+add_filter( 'aioseo_unrecognized_allowed_query_args', __NAMESPACE__ . '\prevent_c_css_query_arg_removal' );

--- a/projects/plugins/boost/compatibility/yoast.php
+++ b/projects/plugins/boost/compatibility/yoast.php
@@ -9,4 +9,4 @@ namespace Automattic\Jetpack_Boost\Compatibility\Yoast;
 
 // Add the Critical CSS generation query arg to Yoast's allowed query args list.
 // This prevents Yoast from removing the query arg, which breaks Critical CSS generation.
-add_filter( 'Yoast\WP\SEO\allowlist_permalink_vars', array( '\Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Critical_CSS', 'add_critical_css_query_arg_to_list' ) );
+add_filter( 'Yoast\WP\SEO\allowlist_permalink_vars', array( '\Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Generator', 'add_generate_query_action_to_list' ) );

--- a/projects/plugins/boost/compatibility/yoast.php
+++ b/projects/plugins/boost/compatibility/yoast.php
@@ -7,10 +7,6 @@
 
 namespace Automattic\Jetpack_Boost\Compatibility\Yoast;
 
-function prevent_c_css_query_arg_removal( $default_allowed_extravars ) {
-	$default_allowed_extravars[] = 'jb-generate-critical-css';
-
-	return $default_allowed_extravars;
-}
-
-add_filter( 'Yoast\WP\SEO\allowlist_permalink_vars', __NAMESPACE__ . '\prevent_c_css_query_arg_removal' );
+// Add the Critical CSS generation query arg to Yoast's allowed query args list.
+// This prevents Yoast from removing the query arg, which breaks Critical CSS generation.
+add_filter( 'Yoast\WP\SEO\allowlist_permalink_vars', array( '\Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\Critical_CSS', 'add_critical_css_query_arg_to_list' ) );

--- a/projects/plugins/boost/compatibility/yoast.php
+++ b/projects/plugins/boost/compatibility/yoast.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Yoast SEO compatibility for Boost
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Compatibility\Yoast;
+
+function prevent_c_css_query_arg_removal( $default_allowed_extravars ) {
+	$default_allowed_extravars[] = 'jb-generate-critical-css';
+
+	return $default_allowed_extravars;
+}
+
+add_filter( 'Yoast\WP\SEO\allowlist_permalink_vars', __NAMESPACE__ . '\prevent_c_css_query_arg_removal' );

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -209,6 +209,10 @@ function include_compatibility_files() {
 	if ( function_exists( 'wp_cache_is_enabled' ) ) {
 		require_once __DIR__ . '/compatibility/wp-super-cache.php';
 	}
+
+	if ( class_exists( '\Yoast\WP\SEO\Main' ) ) {
+		require_once __DIR__ . '/compatibility/yoast.php';
+	}
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\include_compatibility_files' );

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -213,6 +213,10 @@ function include_compatibility_files() {
 	if ( class_exists( '\Yoast\WP\SEO\Main' ) ) {
 		require_once __DIR__ . '/compatibility/yoast.php';
 	}
+
+	if ( function_exists( 'aioseo' ) ) {
+		require_once __DIR__ . '/compatibility/aioseo.php';
+	}
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\include_compatibility_files' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/32596

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add compatibility files for `Yoast SEO` and `All in One SEO` plugins.
* Compatibility prevents plugins from stripping `jb-generate-critical-css` from URLs, by using their filters.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test that Critical CSS generation does not work

* Setup latest stable Boost (free);
* Add and activate Yoast SEO;
* Go to **Yoast SEO > Settings > Advanced > Crawl Optimization > Advanced: URL cleanup** and enable `Remove unregistered URL parameters`;
   ![CleanShot 2023-08-22 at 17 16 27](https://github.com/Automattic/jetpack/assets/11799079/ebce2d9f-cb08-4f16-8286-a5f9eef8a8da)
* Go to the Boost dashboard and regenerate Critical CSS;
* Generation should fail (you could also check the network tab, and there should be 301 redirects).

You can repeat the above, but instead of Yoast SEO, you can install All in One SEO, and enable the `Crawl Cleanup` from **All in on SEO > Search Appearance > Advanced** (make sure `Remove Query Args` is set to `Yes`).

![CleanShot 2023-08-22 at 17 17 21](https://github.com/Automattic/jetpack/assets/11799079/c70d0181-3df3-443b-a1ca-4f8924ce4985)


### Test that Critical CSS generation works

* Setup Boost (free) via Jetpack Beta;
* Checkout the `add/boost/seo-plugins-compatibility` branch;
* Follow the steps from the previous section, to enable the "query cleanup" feature of either Yoast SEO or All in One SEO;
* Go to the Boost dashboard and regenerate Critical CSS;
* Generation should work without a problem.