### PR TITLE
Super Cache: fix PHP warning about NULL used in str_replace

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super_cache_wp_cache_request_uri_defined
+++ b/projects/plugins/super-cache/changelog/fix-super_cache_wp_cache_request_uri_defined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Caching: make sure $wp_cache_request_uri is defined to avoid warnings about "NULL" parameters.

--- a/projects/plugins/super-cache/wp-cache-phase1.php
+++ b/projects/plugins/super-cache/wp-cache-phase1.php
@@ -95,6 +95,18 @@ if (
 // for timing purposes for the html comments
 $wp_start_time = microtime();
 
+if ( isset( $_SERVER['REQUEST_URI'] ) ) { // Cache this in case any plugin modifies it and filter out tracking parameters.
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- none available before WordPress is loaded. Sanitized in wp_cache_postload().
+	$wp_cache_request_uri = wpsc_remove_tracking_params_from_uri( $_SERVER['REQUEST_URI'] ); // phpcs:ignore
+
+	// $wp_cache_request_uri is expected to be a string. If running from wp-cli it will be null.
+	if ( $wp_cache_request_uri === null ) {
+		$wp_cache_request_uri = '';
+	}
+} else {
+	$wp_cache_request_uri = '';
+}
+
 // don't cache in wp-admin
 if ( wpsc_is_backend() ) {
 	return true;
@@ -142,13 +154,6 @@ if ( $cache_compression ) {
 add_cacheaction( 'supercache_filename_str', 'wp_cache_check_mobile' );
 if ( function_exists( 'add_filter' ) ) { // loaded since WordPress 4.6
 	add_filter( 'supercache_filename_str', 'wp_cache_check_mobile' );
-}
-
-$wp_cache_request_uri = wpsc_remove_tracking_params_from_uri( $_SERVER['REQUEST_URI'] ); // Cache this in case any plugin modifies it and filter out tracking parameters.
-
-// $wp_cache_request_uri is expected to be a string. If running from wp-cli it will be null.
-if ( $wp_cache_request_uri === null ) {
-	$wp_cache_request_uri = '';
 }
 
 if ( defined( 'DOING_CRON' ) ) {

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -388,6 +388,10 @@ function wp_cache_get_legacy_cache( $cache_file ) {
 
 function wp_cache_postload() {
 	global $cache_enabled, $wp_super_cache_late_init;
+	global $wp_cache_request_uri;
+
+	// have to sanitize here because formatting.php is loaded after wp_cache_request_uri is set
+	$wp_cache_request_uri = esc_url_raw( wp_unslash( $wp_cache_request_uri ) );
 
 	if ( ! $cache_enabled ) {
 		return true;


### PR DESCRIPTION
If you disabled caching for logged in users then a warning about about using NULL showed in the PHP error log:

> PHP Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in .../plugins/wp-super-cache/wp-cache-phase2.php on line 54

In this PR the code that defines $wp_cache_request_uri is moved up in wp-cache-phase1.php so it always runs. It wouldn't run if caching was disabled for logged in users due to the way checks were done.
Later on when that variable was used, functions received the value "NULL" and in the latest versions of PHP8 that caused a warning to show.

The linter complained the value was unsanitized but this code executes before WordPress is entirely loaded. It is eventually unslashed and sanitized in wp_cache_postload().

Related thread: https://wordpress.org/support/topic/php-deprecated-str_replace-passing-null/

## Proposed changes:
* Move code that defines $wp_cache_request_uri up so it runs all the time.
* Sanitize that variable in wp_cache_postload()

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Using a host with PHP8.2* apply this patch.
* Disable caching for logged in users.
* Visit your site and you shouldn't see that warning notice.

