### PR TITLE
Ensure Initial_State::render() always returns a string

### DIFF
--- a/projects/packages/connection/changelog/php-81-null-inline-script-deprecation
+++ b/projects/packages/connection/changelog/php-81-null-inline-script-deprecation
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Ensure Initial_State::render() always returns a string

--- a/projects/packages/connection/src/class-initial-state.php
+++ b/projects/packages/connection/src/class-initial-state.php
@@ -53,7 +53,7 @@ class Initial_State {
 	 */
 	public static function render() {
 		if ( self::$rendered ) {
-			return null;
+			return '';
 		}
 		self::$rendered = true;
 		return 'var JP_CONNECTION_INITIAL_STATE=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( self::get_data() ) ) . '"));';


### PR DESCRIPTION
## Proposed changes:

Updates `Initial_State::render()` to return an empty string instead of `null` when is it called a second time.

This is necessary because passing `null` to `wp_add_inline_script()` will result in a PHP deprecation notice, as WordPress blindly expects a string to be passed in.

This also brings the function into compliance with its PHPDoc return type, which is `string`.

## Testing instructions:

No special instructions. Just run unit tests and verify no PHP Deprecated notices are thrown.

## Does this pull request change what data or activity we track or use?

No.