### PR TITLE
gold :: re-whitelist connected account id option

### DIFF
--- a/projects/packages/sync/changelog/earn-re-whitelist-connected-account-id-option
+++ b/projects/packages/sync/changelog/earn-re-whitelist-connected-account-id-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Re-adds the jetpack-memberships-connected-account-id option to whitelist.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -63,6 +63,7 @@ class Defaults {
 		'image_default_link_type',
 		'infinite_scroll',
 		'infinite_scroll_google_analytics',
+		'jetpack-memberships-connected-account-id',
 		'jetpack-memberships-has-connected-account',
 		'jetpack-twitter-cards-site-tag',
 		'jetpack_activated',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.55.1';
+	const PACKAGE_VERSION = '1.55.2-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/changelog/earn-re-whitelist-connected-account-id-option
+++ b/projects/plugins/jetpack/changelog/earn-re-whitelist-connected-account-id-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+adding test for default whitelist option.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -214,6 +214,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'site_segment'                                 => 'pineapple',
 			'site_vertical'                                => 'pineapple',
 			'jetpack_excluded_extensions'                  => 'pineapple',
+			'jetpack-memberships-connected-account-id'     => '340',
 			'jetpack-memberships-has-connected-account'    => true,
 			'jetpack_publicize_options'                    => array(),
 			'jetpack_connection_active_plugins'            => array( 'jetpack' ),


### PR DESCRIPTION
Part of https://github.com/Automattic/gold/issues/59.  This rolls back a change from #32125.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Create the jurassic ninja site with [this link](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=earn/re-whitelist-connected-account-id-option).
* From sandbox find the jurassic ninja site id: `php ./bin/get-blog-id.php rural-stilt.jurassic.ninja`
* From shell (`wpsh`):

    ```php
    require_once( ABSPATH . "wp-content/lib/mailchimp/0-load.php" );
    print \MailchimpApi::set_jetpack_option( $site_id, 'jetpack-memberships-connected-account-id', '' );
    ```
* This should not return an `WP_Error`

```
var_dump( \MailchimpApi::set_jetpack_option( $site_id, 'jetpack-memberships-connected-account-id', '' ) );
bool(true)
```