### PR TITLE
Docker: add user switching

### DIFF
--- a/tools/docker/bin/install.sh
+++ b/tools/docker/bin/install.sh
@@ -22,15 +22,15 @@ wp --allow-root core install \
 wp --allow-root option update blog_public 0
 
 if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
-		# Add editor, author, contributor, and subscriber users
-  	roles=("author" "editor" "subscriber" "contributor")
+	# Add editor, author, contributor, and subscriber users
+	roles=("author" "editor" "subscriber" "contributor")
 
-    # Loop through the array and run the command for each role
-    for role in "${roles[@]}"; do
-    		echo "Creating user: $role"
-    		# Silence output to avoid extra noise in the terminal. It would only output the user ID at the quietest level.
-        wp --allow-root user create "$role" "$role"@example.com --role="$role" >> /dev/null 2>&1
-    done
+	# Loop through the array and run the command for each role
+	for role in "${roles[@]}"; do
+		echo "Creating user: $role"
+		# Silence output to avoid extra noise in the terminal. It would only output the user ID at the quietest level.
+		wp --allow-root user create "$role" "$role"@example.com --role="$role" >> /dev/null 2>&1
+	done
 
 	# Install Query Monitor plugin
 	# https://wordpress.org/plugins/query-monitor/

--- a/tools/docker/bin/install.sh
+++ b/tools/docker/bin/install.sh
@@ -22,6 +22,16 @@ wp --allow-root core install \
 wp --allow-root option update blog_public 0
 
 if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
+		# Add editor, author, contributor, and subscriber users
+  	roles=("author" "editor" "subscriber" "contributor")
+
+    # Loop through the array and run the command for each role
+    for role in "${roles[@]}"; do
+    		echo "Creating user: $role"
+    		# Silence output to avoid extra noise in the terminal. It would only output the user ID at the quietest level.
+        wp --allow-root user create "$role" "$role"@example.com --role="$role" >> /dev/null 2>&1
+    done
+
 	# Install Query Monitor plugin
 	# https://wordpress.org/plugins/query-monitor/
 	wp --allow-root plugin install query-monitor --activate
@@ -34,8 +44,12 @@ if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	# https://wordpress.org/plugins/gutenberg/
 	wp --allow-root plugin install gutenberg --activate
 
+	# Install User Switching
+	# https://wordpress.org/plugins/user-switching/
+	wp --allow-root plugin install user-switching --activate
+
 	# Intentionally not auto-updating Akismet since we may be wanting to test that with a specific version.
-	wp --allow-root plugin auto-updates enable query-monitor wp-crontrol gutenberg
+	wp --allow-root plugin auto-updates enable query-monitor wp-crontrol gutenberg user-switching
 fi
 
 # Activate Jetpack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds John Blackbourn's User Switching plugin as a default plugin for our Docker instance. He's the author of Query Monitor and WP Control, which we already use, an active Core contributor, and former Automattician.

Additionally, automatically generate an user at each of the default WordPress roles (editor, author, subscriber, contributor). 

This combination will allow for easier testing of different user roles (or logged out, a feature of User Switching) while developing locally.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Inspired by pdWQjU-tq-p2


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Assuming you have the Jetpack monorepo setup as usual and Docker installed.
* jetpack docker up -d # if docker is not yet up.
* jetpack docker uninstall # this will delete your existing Docker site.
* jetpack docker install # this will run the install.sh script with the changes.
* jetpack docker user list
* See five users: wordpress (the existing default admin), author, contributor, editor, subscriber.
* Verify that "Switch to" is an option when hovering over their line item on the wp-admin user list.

