### PR TITLE
Newsletter Categories: Add feature flag helper

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter_categories_feature_flag_helper
+++ b/projects/plugins/jetpack/changelog/add-newsletter_categories_feature_flag_helper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add helper function for newsletter categories blog sticker & feature flag

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1070,18 +1070,3 @@ function get_paywall_simple() {
 <!-- /wp:columns -->
 ';
 }
-
-/**
- * Determine if the newsletter categories are enabled for the site.
- *
- * This function checks whether the blog has the 'newsletter_categories' sticker enabled.
- * If the sticker is enabled, the function will return true.
- * If not, it applies the 'jetpack_newsletter_categories' filter and returns the result (default is false).
- */
-function newsletter_categories_enabled_for_site() {
-	if ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'newsletter_categories' ) ) {
-		return true;
-	}
-
-	return apply_filters( 'jetpack_newsletter_categories', false );
-}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1079,7 +1079,7 @@ function get_paywall_simple() {
  * If not, it applies the 'jetpack_newsletter_categories' filter and returns the result (default is false).
  */
 function newsletter_categories_enabled_for_site() {
-	if ( function_exists( 'has_blog_sticker' ) && has_block_sticker( 'newsletter_categories' ) ) {
+	if ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'newsletter_categories' ) ) {
 		return true;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1070,3 +1070,18 @@ function get_paywall_simple() {
 <!-- /wp:columns -->
 ';
 }
+
+/**
+ * Determine if the newsletter categories are enabled for the site.
+ *
+ * This function checks whether the blog has the 'newsletter_categories' sticker enabled.
+ * If the sticker is enabled, the function will return true.
+ * If not, it applies the 'jetpack_newsletter_categories' filter and returns the result (default is false).
+ */
+function newsletter_categories_enabled_for_site() {
+	if ( function_exists( 'has_blog_sticker' ) && has_block_sticker( 'newsletter_categories' ) ) {
+		return true;
+	}
+
+	return apply_filters( 'jetpack_newsletter_categories', false );
+}

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -132,6 +132,10 @@ class Jetpack_Subscriptions {
 
 		// Add Subscribers menu to Jetpack navigation.
 		add_action( 'jetpack_admin_menu', array( $this, 'add_subscribers_menu' ) );
+
+		// Enable/disable newsletter categories
+		add_filter( 'jetpack_newsletter_categories_enabled', array( $this, 'newsletter_categories_check_site_option', 8 ) );
+		add_filter( 'jetpack_newsletter_categories_enabled', array( $this, 'newsletter_categories_check_blog_sticker', 7 ) );
 	}
 
 	/**
@@ -311,6 +315,51 @@ class Jetpack_Subscriptions {
 		return $flags;
 	}
 
+	/**
+	 * Determines if Jetpack's Newsletter Categories feature is enabled.
+	 *
+	 * Uses a filter to allow external control over the enabled state. By default, this feature is disabled.
+	 *
+	 * @return bool True if the feature is enabled, false otherwise.
+	 */
+	public function newsletter_categories_enabled() {
+		/**
+		 * Force enable or disable Jetpack's Newsletter Categories feature.
+		 *
+		 * @module subscriptions
+		 * @since $$next-version$$
+		 *
+		 * @param bool $jetpack_newsletter_categories Should Jetpack's Newsletter Categories be enabled. Default to false.
+		 */
+		return apply_filters( 'jetpack_newsletter_categories_enabled', false );
+	}
+
+	/**
+	 * Checks the site option to determine if Jetpack's Newsletter Categories feature is enabled.
+	 *
+	 * If a value is already provided, it returns that value. Otherwise, it fetches the option from the database.
+	 *
+	 * @param mixed $value The current value.
+	 * @return bool True if the feature is enabled based on site option, the provided value otherwise.
+	 */
+	public function newsletter_categories_check_site_option( $value ) {
+		return $value ? $value : get_option( 'wpcom_newsletter_categories_enabled', false );
+	}
+
+	/**
+	 * Checks the blog sticker to determine if Jetpack's Newsletter Categories feature is enabled.
+	 *
+	 * If a value is provided and is true, or if the blog has the specific sticker, it returns true. Otherwise, it returns false.
+	 *
+	 * @param bool $value The current value.
+	 * @return bool True if the feature is enabled based on blog sticker or provided value, false otherwise.
+	 */
+	public function newsletter_categories_check_blog_sticker( $value ) {
+		if ( $value || ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'newsletter_categories' ) ) ) {
+			return true;
+		}
+		return false;
+	}
 	/**
 	 * Jetpack_Subscriptions::configure()
 	 *


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80916

## Proposed changes:
This PR adds a helper function that checks if either a blog sticker is present (on Simple/Atomic), or a feature flag is set.

To enable this, we can add a filter called jetpack_newsletter_categories in jetpack-mu-wpcom.

We'll also need something similar for inside Gutenberg (client-side).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Build the Jetpack plugin & test on Docker
- Add a Newsletter Sign up block
- Verify that there's no regressions & the block is rendered correctly on the frontend

