### PR TITLE
Fix a Global Styles UI performance issue

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gs-performance-issue
+++ b/projects/plugins/jetpack/changelog/fix-gs-performance-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed a Global Styles UI performance issue in the Site Editor

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -608,7 +608,12 @@ class Jetpack_Gutenberg {
 	 * @return void
 	 */
 	public static function enqueue_block_editor_assets() {
-		if ( ! self::should_load() ) {
+		/**
+		 * The is_admin condition is needed so that the editor assets are only loaded in the Site Editor.
+		 *
+		 * This was added because we are now using enqueue_block_assets hook instead of the enqueue_block_editor_assets.
+		 */
+		if ( ! self::should_load() || ! is_admin() ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -747,65 +747,6 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Add the Gutenberg editor stylesheet to iframed editors, such as the site editor,
-	 * which don't have access to stylesheets added with `wp_enqueue_style`.
-	 *
-	 * This workaround is currently used by WordPress.com Simple and Atomic sites.
-	 *
-	 * @since 10.7
-	 *
-	 * @return void
-	 */
-	public static function add_iframed_editor_style() {
-		if ( ! self::should_load() ) {
-			return;
-		}
-
-		global $pagenow;
-		if ( ! isset( $pagenow ) ) {
-			return;
-		}
-
-		// Pre 13.7 pages that still need to be supported if < 13.7 is
-		// still installed.
-		$allowed_old_pages       = array( 'admin.php', 'themes.php' );
-		$is_old_site_editor_page = in_array( $pagenow, $allowed_old_pages, true ) && isset( $_GET['page'] ) && 'gutenberg-edit-site' === $_GET['page']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		// For Gutenberg > 13.7, the core `site-editor.php` route is used instead
-		$is_site_editor_page = 'site-editor.php' === $pagenow;
-
-		$should_skip_adding_styles = ! $is_site_editor_page && ! $is_old_site_editor_page;
-		if ( $should_skip_adding_styles ) {
-			return;
-		}
-
-		$blocks_dir       = self::get_blocks_directory();
-		$blocks_variation = self::blocks_variation();
-
-		if ( 'production' !== $blocks_variation ) {
-			$blocks_env = '-' . esc_attr( $blocks_variation );
-		} else {
-			$blocks_env = '';
-		}
-
-		$path = "{$blocks_dir}editor{$blocks_env}.css";
-		$dir  = dirname( JETPACK__PLUGIN_FILE );
-
-		if ( file_exists( "$dir/$path" ) ) {
-			if ( is_rtl() ) {
-				$rtlcsspath = substr( $path, 0, -4 ) . '.rtl.css';
-				if ( file_exists( "$dir/$rtlcsspath" ) ) {
-					$path = $rtlcsspath;
-				}
-			}
-
-			$url = Assets::normalize_path( plugins_url( $path, JETPACK__PLUGIN_FILE ) );
-			$url = add_query_arg( 'minify', 'false', $url );
-
-			add_editor_style( $url );
-		}
-	}
-
-	/**
 	 * Some blocks do not depend on a specific module,
 	 * and can consequently be loaded outside of the usual modules.
 	 * We will look for such modules in the extensions/ directory.
@@ -1331,11 +1272,4 @@ if ( ( new Host() )->is_woa_site() ) {
 	 * More doc: https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/README.md#upgrades-for-blocks
 	 */
 	add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
-
-	/**
-	 * Load block editor styles inline for iframed editors.
-	 *
-	 * @see paYJgx-1Kl-p2
-	 */
-	add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'add_iframed_editor_style' ) );
 }

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -1337,5 +1337,5 @@ if ( ( new Host() )->is_woa_site() ) {
 	 *
 	 * @see paYJgx-1Kl-p2
 	 */
-	add_action( 'admin_init', array( 'Jetpack_Gutenberg', 'add_iframed_editor_style' ) );
+	add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'add_iframed_editor_style' ) );
 }

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -691,6 +691,11 @@ class Jetpack {
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
 		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_independent_blocks' ) );
 		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_block_editor_extensions' ), 9 );
+		/**
+		 * We've switched from enqueue_block_editor_assets to enqueue_block_assets because the assets with the former are loaded on the main site-editor.php.
+		 *
+		 * With the latter, the assets are now loaded in the SE iframe; the implementation is now faster because Gutenberg doesn't need to inject the assets in the iframe on client-side.
+		 */
 		add_action( 'enqueue_block_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 		add_filter( 'render_block', array( 'Jetpack_Gutenberg', 'display_deprecated_block_message' ), 10, 2 );
 

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -691,7 +691,7 @@ class Jetpack {
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
 		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_independent_blocks' ) );
 		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_block_editor_extensions' ), 9 );
-		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
+		add_action( 'enqueue_block_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 		add_filter( 'render_block', array( 'Jetpack_Gutenberg', 'display_deprecated_block_message' ), 10, 2 );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );


### PR DESCRIPTION
Instead of loading the Jetpack blocks CSS for the Site Editor using the admin_init hook, we'll switch to the `enqueue_block_editor_assets` hook. In this manner, the CSS script is loaded in the iframe, instead of the main site-editor.php page.

By doing so, the UI for Global Styles is more responsive.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/3565 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `enqueue_block_editor_assets` hook instead of `admin_init`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Jetpack beta on an Atomic site
* Make sure that your theme is TT3 (for easier testing)
* Go to the site editor and open the Global Styles UI.
* Go to Layout and play with the control. Notice that the feedback is way faster than before.
* To better notice the change, switch to the slider button (the right icon) and slide the margins/padding. The input value will update faster.

**Check for regressions:**

Make sure that the styles for payment blocks are still working fine (e.g. donations block).

