### PR TITLE
Add number formatting to subscribers count in newsletter block

### DIFF
--- a/projects/plugins/jetpack/changelog/add-number-formatting-to-subscribers-in-newsletter-block
+++ b/projects/plugins/jetpack/changelog/add-number-formatting-to-subscribers-in-newsletter-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add number formatting for subscriber count in newsletter module

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -188,7 +188,11 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 
 	const postVisibility = useSelect( select => select( editorStore ).getEditedPostVisibility() );
 
-	const reachCount = getReachForAccessLevelKey( accessLevel, emailSubscribers, paidSubscribers );
+	const reachCount = getReachForAccessLevelKey(
+		accessLevel,
+		emailSubscribers,
+		paidSubscribers
+	).toLocaleString();
 
 	let subscriberType = __( 'subscribers', 'jetpack' );
 	if ( accessLevel === accessOptions.paid_subscribers.key ) {


### PR DESCRIPTION
## Proposed changes:

1. Convert number to locale string to display a friendlier looking number in the subscriber count

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Get your local environment set up and running on docker
2. Go to the file `projects/plugins/jetpack/extensions/shared/memberships/settings.js` and update line 23 to
```js
return 4487;
```
3. Go to `/wp-admin/admin.php?page=jetpack#/newsletter` and make sure newsletter is enabled
4. Now go to https://wordpress.com/posts/{your-site} and create a new post
5. In the right sidebar, you should see this (with the number formatted)
![image](https://github.com/Automattic/jetpack/assets/65001528/bc7fa3f7-0281-42c3-8d2c-cd37360417b1)

