### PR TITLE
Newsletters: Fix Non WPCOM subscribers paywalled emails

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-email-subscribers
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-email-subscribers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Email subscribers now receive full posts

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -505,7 +505,7 @@ class Jetpack_Memberships {
 		}
 
 		$cache_key = sprintf( '%d_%d', $user_id, $post_id );
-		if ( isset( self::$user_can_view_post_cache[ $cache_key ] ) ) {
+		if ( $user_id !== 0 && isset( self::$user_can_view_post_cache[ $cache_key ] ) ) {
 			return self::$user_can_view_post_cache[ $cache_key ];
 		}
 
@@ -513,6 +513,14 @@ class Jetpack_Memberships {
 		if ( Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY === $post_access_level ) {
 			self::$user_can_view_post_cache[ $cache_key ] = true;
 			return true;
+		}
+
+		if ( $user_id === 0 ) {
+			if ( defined( 'WPCOM_SENDING_POST_TO_SUBSCRIBERS' ) && WPCOM_SENDING_POST_TO_SUBSCRIBERS ) {
+				if ( Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS === $post_access_level ) {
+					return true;
+				}
+			}
 		}
 
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix email only (non wpcom users) subscribers receiving a paywalled email when post has a paywall block but access is set to "All subscribers".


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See instructions at D119666-code

