### PR TITLE
Subscriber block: present large subscriber numbers more elegantly

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribers-number-format
+++ b/projects/plugins/jetpack/changelog/update-subscribers-number-format
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Nicer subscribers number

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -712,7 +712,7 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 					<div class="wp-block-jetpack-subscriptions__subscount">
 						<?php
 						/* translators: %s: number of folks following the blog */
-						echo esc_html( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $data['subscribers_total'], 'jetpack' ), number_format_i18n( $data['subscribers_total'] ) ) );
+						echo esc_html( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $data['subscribers_total'], 'jetpack' ), human_readable_number( $data['subscribers_total'] ) ) );
 						?>
 					</div>
 				<?php endif; ?>
@@ -722,6 +722,23 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 	<?php
 
 	return ob_get_clean();
+}
+
+/**
+ * Transforms a number into it's short human-readable version.
+ *
+ * @param int $num The extrapolated excerpt string.
+ *
+ * @return string Human-readable version of the number. ie. ~1.9M.
+ */
+function human_readable_number( $num ) {
+	if ( $num >= 1000000 ) {
+		return number_format_i18n( $num / 1000000, 1 ) . __( 'M', 'jetpack' );
+	} elseif ( $num >= 1000 ) {
+		return number_format_i18n( $num / 1000, 1 ) . __( 'K', 'jetpack' );
+	} else {
+		return number_format_i18n( $num );
+	}
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -711,8 +711,7 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 				<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>
 					<div class="wp-block-jetpack-subscriptions__subscount">
 						<?php
-						/* translators: %s: number of folks following the blog */
-						echo esc_html( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $data['subscribers_total'], 'jetpack' ), human_readable_number( $data['subscribers_total'] ) ) );
+						echo esc_html( Jetpack_Memberships::get_join_others_text( $data['subscribers_total'] ) );
 						?>
 					</div>
 				<?php endif; ?>
@@ -722,23 +721,6 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 	<?php
 
 	return ob_get_clean();
-}
-
-/**
- * Transforms a number into it's short human-readable version.
- *
- * @param int $num The extrapolated excerpt string.
- *
- * @return string Human-readable version of the number. ie. ~1.9M.
- */
-function human_readable_number( $num ) {
-	if ( $num >= 1000000 ) {
-		return number_format_i18n( $num / 1000000, 1 ) . __( 'M', 'jetpack' );
-	} elseif ( $num >= 1000 ) {
-		return number_format_i18n( $num / 1000, 1 ) . __( 'K', 'jetpack' );
-	} else {
-		return number_format_i18n( $num );
-	}
 }
 
 /**

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -625,5 +625,26 @@ class Jetpack_Memberships {
 
 		self::$has_registered_block = true;
 	}
+
+	/**
+	 * Transforms a number into it's short human-readable version.
+	 *
+	 * @param int $subscribers_total The extrapolated excerpt string.
+	 *
+	 * @return string Human-readable version of the number. ie. 1.9 M.
+	 */
+	public static function get_join_others_text( $subscribers_total ) {
+		if ( $subscribers_total >= 1000000 ) {
+			/* translators: %s: number of folks following the blog, millions(M) with one decimal. i.e. 1.1 */
+			return sprintf( __( 'Join %sM other subscribers', 'jetpack' ), number_format_i18n( $subscribers_total / 1000000, 1 ) );
+		}
+		if ( $subscribers_total >= 10000 ) {
+			/* translators: %s: number of folks following the blog, thousands(K) with one decimal. i.e. 1.1 */
+			return sprintf( __( 'Join %sK other subscribers', 'jetpack' ), number_format_i18n( $subscribers_total / 1000, 1 ) );
+		}
+
+		/* translators: %s: number of folks following the blog */
+		return sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $subscribers_total, 'jetpack' ), number_format_i18n( $subscribers_total ) );
+	}
 }
 Jetpack_Memberships::get_instance();

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -443,11 +443,10 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 					</button>
 				</p>
 			</form>
-			<?php if ( $show_subscribers_total && $subscribers_total ) { ?>
+			<?php if ( $show_subscribers_total && $subscribers_total > 0 ) { ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
 					<?php
-					/* translators: %s: number of folks following the blog */
-					echo esc_html( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $subscribers_total, 'jetpack' ), number_format_i18n( $subscribers_total ) ) );
+					echo esc_html( Jetpack_Memberships::get_join_others_text( $subscribers_total ) );
 					?>
 				</div>
 			<?php } ?>
@@ -538,8 +537,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 			<?php if ( $show_subscribers_total && 0 < $subscribers_total ) { ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
 					<?php
-					/* translators: %s: number of folks following the blog */
-					echo esc_html( sprintf( _n( 'Join %s other subscriber', 'Join %s other subscribers', $subscribers_total, 'jetpack' ), number_format_i18n( $subscribers_total ) ) );
+					echo esc_html( Jetpack_Memberships::get_join_others_text( $subscribers_total ) );
 					?>
 				</div>
 			<?php } ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #32373

## Proposed changes:

Present large numbers more elegantly in subscriber block.

#### Before

<img width="324" alt="Screenshot 2023-08-23 at 19 17 21" src="https://github.com/Automattic/jetpack/assets/104869/b3ba0ea5-1d66-47d5-8a34-294136eddbfe">

#### After

<img width="348" alt="Screenshot 2023-08-23 at 19 16 46" src="https://github.com/Automattic/jetpack/assets/104869/46ba96dc-817c-4ce9-8af2-eacd806b6047">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that Subscribe widget and Subscribe blocks still work and look ok with the new format :)
* Sandbox sites with different amount of subscribers
* A site with millions: https://wordpress.com/blog/2009/11/25/blog-subscriptions/
* A site with thousands: https://jetpack.com/blog/
* A site with less than a thousand: <your test site> 

