### PR TITLE
Fix/allow trailing slashes on membership products endpoints

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -31,7 +31,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/status',
+			$this->rest_base . '/status/?',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -73,7 +73,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/product',
+			$this->rest_base . '/product/?',
 			array(
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
@@ -109,7 +109,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/products',
+			$this->rest_base . '/products/?',
 			array(
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
@@ -125,7 +125,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		);
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/product/(?P<product_id>[0-9]+)',
+			$this->rest_base . '/product/(?P<product_id>[0-9]+)/?',
 			array(
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,

--- a/projects/plugins/jetpack/changelog/fix-allow-trailing-slashes-on-membership-products-endpoints
+++ b/projects/plugins/jetpack/changelog/fix-allow-trailing-slashes-on-membership-products-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Allow trailing slashes on membership products endpoints.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to 106-gh-automattic/gold
These changes are included in https://github.com/Automattic/jetpack/pull/32571 (if that PR is merged, this one will contain no changes and can be closed).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allows membership products endpoint paths to work with or without a trailing forward slash (`/`)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test to ensure there isn't a regression with this patch. At time of writing these calls do not have a trailing slash, and this patch should allow these calls to continue working.

1. Sandbox the public API.
2. Download the patched version of Jetpack to your sandbox with `bin/jetpack-downloader test jetpack fix/allow-trailing-slashes-on-membership-products-endpoints`.
3. Visit https://wordpress.com/earn/payment-plans in a browser and choose a site that is setup with Earn payments.
4. Click to add a new payment plan. The plan should add successfully.
5. Click to edit the created payment plan, make some adjustments and click save. The plan should save successfully and your edits should persist if you refresh the page.
6. Click to delete the created payment plan. The plan should delete, and if you refresh the page the plan should not re-appear in the list of payment plans.
7. Return to your Jetpack site and create a new post, this time with a payment button. Click the icon to select the payment plan and you should see a list of payment plans. Click add new payment plan and fill out the form, clicking save when done. The plan should exist when you return to the calypso live page and view your payment plans.