### PR TITLE
Gravatar profile widget: add srcset

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-srcset-to-gravatar-profile
+++ b/projects/plugins/jetpack/changelog/update-add-srcset-to-gravatar-profile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Gravatar profile widget: add srcset

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
@@ -135,7 +135,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 			?>
 			<img
 				src="<?php echo esc_url( $gravatar_url ); ?>"
-				<?php echo $srcset ? 'srcset="' . esc_attr( $srcset ) . '"' : ''; ?>
+				srcset="<?php echo esc_attr( $srcset ); ?>"
 				class="grofile-thumbnail no-grav"
 				alt="<?php echo esc_attr( $profile['displayName'] ); ?>"
 				loading="lazy" />

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
@@ -115,13 +115,30 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 					'accounts'     => array(),
 				)
 			);
-			$gravatar_url = add_query_arg( 's', 320, $profile['thumbnailUrl'] ); // The default grav returned by grofiles is super small.
+			$base_width   = 320;
+			$gravatar_url = add_query_arg( 's', $base_width, $profile['thumbnailUrl'] ); // The default grav returned by grofiles is super small.
+
+			// Generate a srcset with larger sizes for high DPI screens.
+			$srcset        = '';
+			$multipliers   = array( 1, 1.5, 2, 3, 4 );
+			$srcset_values = array();
+			foreach ( $multipliers as $multiplier ) {
+				$srcset_width    = (int) ( $base_width * $multiplier );
+				$srcset_url      = add_query_arg( 's', $srcset_width, $profile['thumbnailUrl'] );
+				$srcset_values[] = "{$srcset_url} {$multiplier}x";
+			}
+			$srcset = implode( ', ', $srcset_values );
 
 			// Enqueue front end assets.
 			$this->enqueue_scripts();
 
 			?>
-			<img src="<?php echo esc_url( $gravatar_url ); ?>" class="grofile-thumbnail no-grav" alt="<?php echo esc_attr( $profile['displayName'] ); ?>" />
+			<img
+				src="<?php echo esc_url( $gravatar_url ); ?>"
+				<?php echo $srcset ? 'srcset="' . esc_attr( $srcset ) . '"' : ''; ?>
+				class="grofile-thumbnail no-grav"
+				alt="<?php echo esc_attr( $profile['displayName'] ); ?>"
+				loading="lazy" />
 			<div class="grofile-meta">
 				<h4><a href="<?php echo esc_url( $profile['profileUrl'] ); ?>"><?php echo esc_html( $profile['displayName'] ); ?></a></h4>
 				<p><?php echo wp_kses_post( $profile['aboutMe'] ); ?></p>


### PR DESCRIPTION
In an effort to move away from the `devicepx` script towards native functionality, this PR adds a `srcset` to images in the Gravatar Profile widget. The browser will automatically pick the most appropriate image from the options in the `srcset`, depending on the screen pixel ratio and the current zoom value.

For an ancillary performance improvement, this PR also adds `loading="lazy"` to the same images.

## Proposed changes:
* Add `srcset` to the images in the Gravatar Profile widget
* Add `loading="lazy"` to the images in the Gravatar Profile widget

### Other information:

- N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* In the Jetpack settings for your test blog, enable `Make extra widgets available for use on your site including subscription forms and more` under `Writing` -> `Widgets`
* On your test blog, add a Gravatar Profile legacy widget
* Ensure that your avatar is displayed as a large image
* Open any page on your site that includes the widget
* Inspect the `img` tag and ensure it includes a `srcset` with various image sizes, as well as `loading` set to `lazy`

