### PR TITLE
Allow more roles to use the video uploader

### DIFF
--- a/projects/plugins/jetpack/changelog/add-author-editor-allow-vp-upload
+++ b/projects/plugins/jetpack/changelog/add-author-editor-allow-vp-upload
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow authors and editors to use the video uploader

--- a/projects/plugins/jetpack/modules/videopress.php
+++ b/projects/plugins/jetpack/modules/videopress.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/videopress/class.jetpack-videopress.php';
 
 require_once __DIR__ . '/videopress/class-videopress-attachment-metadata.php';
 
-if ( current_user_can( 'publish_posts' ) ) {
+if ( is_admin() && current_user_can( 'publish_posts' ) ) {
 	include_once __DIR__ . '/videopress/editor-media-view.php';
 	include_once __DIR__ . '/videopress/class.videopress-edit-attachment.php';
 }

--- a/projects/plugins/jetpack/modules/videopress.php
+++ b/projects/plugins/jetpack/modules/videopress.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/videopress/class.jetpack-videopress.php';
 
 require_once __DIR__ . '/videopress/class-videopress-attachment-metadata.php';
 
-if ( is_admin() ) {
+if ( current_user_can( 'publish_posts' ) ) {
 	include_once __DIR__ . '/videopress/editor-media-view.php';
 	include_once __DIR__ . '/videopress/class.videopress-edit-attachment.php';
 }


### PR DESCRIPTION
Fixes #32511

## Proposed changes:
The PR replaces the admin requirement for using the VideoPress uploader to `user_can( 'publish_posts' )`, effectively allowing `author` and `editor` roles to use the uploader.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Test site setup:
- subscribe to a VideoPress plan
- add a user of each role. Note that, in order to use VideoPress, each user will need to connect to Jetpack.

Verify roles `author` and `editor` (besides `admin`) can upload videos on a VideoPress block:
- log in
- create a post with a VideoPress block
- upload a video

Other roles should remain restricted.