### PR TITLE
feat: Redesign mobile editor Jetpack Paywall block visuals

### DIFF
--- a/projects/js-packages/components/changelog/add-mock-boost-score-graph-module
+++ b/projects/js-packages/components/changelog/add-mock-boost-score-graph-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+BoostScoreGraph: add mock module to avoid the mobile editor importing incompatible web dependencies.

--- a/projects/js-packages/components/components/boost-score-graph/index.native.js
+++ b/projects/js-packages/components/components/boost-score-graph/index.native.js
@@ -1,0 +1,1 @@
+export default () => null;

--- a/projects/plugins/jetpack/changelog/feat-redesign-paywall-block
+++ b/projects/plugins/jetpack/changelog/feat-redesign-paywall-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Paywall block: redesign visuals for the mobile editor.

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.native.js
@@ -1,14 +1,11 @@
-import { View, Text } from 'react-native';
 import { HorizontalRule } from '@wordpress/components';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { View, Text } from 'react-native';
 import styles from './editor.scss';
 
 export default function PaywallEdit() {
-	const paywallStyle = usePreferredColorSchemeStyle(
-		styles[ 'paywall' ],
-		styles[ 'paywall__dark' ]
-	);
+	const paywallStyle = usePreferredColorSchemeStyle( styles.paywall, styles.paywall__dark );
 	const textStyle = usePreferredColorSchemeStyle(
 		styles[ 'paywall--text' ],
 		styles[ 'paywall--text__dark' ]

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.native.js
@@ -1,12 +1,21 @@
+import { View, Text } from 'react-native';
 import { HorizontalRule } from '@wordpress/components';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import styles from './editor.scss';
 
 export default function PaywallEdit() {
+	const paywallStyle = usePreferredColorSchemeStyle(
+		styles[ 'paywall' ],
+		styles[ 'paywall__dark' ]
+	);
 	const textStyle = usePreferredColorSchemeStyle(
 		styles[ 'paywall--text' ],
 		styles[ 'paywall--text__dark' ]
+	);
+	const subtextStyle = usePreferredColorSchemeStyle(
+		styles[ 'paywall--subtext' ],
+		styles[ 'paywall--subtext__dark' ]
 	);
 	const lineStyle = usePreferredColorSchemeStyle(
 		styles[ 'paywall--line' ],
@@ -14,10 +23,16 @@ export default function PaywallEdit() {
 	);
 
 	return (
-		<HorizontalRule
-			text={ __( 'Exclusive content below this line', 'jetpack' ) }
-			textStyle={ textStyle }
-			lineStyle={ lineStyle }
-		/>
+		<View style={ paywallStyle }>
+			<HorizontalRule
+				lineStyle={ lineStyle }
+				style={ styles[ 'paywall--horizontalRule' ] }
+				text={ __( 'Subscriber-only content below', 'jetpack' ) }
+				textStyle={ textStyle }
+			/>
+			<Text style={ subtextStyle }>
+				{ __( 'Access this Paywall block on your web browser for advanced settings.', 'jetpack' ) }
+			</Text>
+		</View>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/paywall/editor.native.scss
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/editor.native.scss
@@ -1,11 +1,11 @@
 .paywall {
-	background-color: rgba( 0, 0, 0, 0.06 );
+	background-color: $light-ultra-dim;
 	border-radius: 10px;
-	padding: 12px 16px;
+	padding: $block-edge-to-content;
 }
 
 .paywall__dark {
-	background-color: rgba( 255, 255, 255, 0.15 );
+	background-color: $dark-dim;
 }
 
 .paywall--horizontalRule {
@@ -13,16 +13,16 @@
 }
 
 .paywall--line {
-	background-color: $black;
+	background-color: $light-quaternary;
 	height: 1;
 }
 
 .paywall--line__dark {
-	background-color: $white;
+	background-color: $dark-quaternary;
 }
 
 .paywall--text {
-	color: $black;
+	color: $light-primary;
 	font-size: 13px;
 	line-height: 18px;
 	letter-spacing: -0.078px;
@@ -31,11 +31,11 @@
 }
 
 .paywall--text__dark {
-	color: $white;
+	color: $dark-primary;
 }
 
 .paywall--subtext {
-	color: rgba( 60, 60, 67, 0.6 );
+	color: $light-secondary;
 	font-size: 13px;
 	line-height: 18px;
 	letter-spacing: -0.078px;
@@ -43,5 +43,5 @@
 }
 
 .paywall--subtext__dark {
-	color: $gray-20;
+	color: $dark-secondary;
 }

--- a/projects/plugins/jetpack/extensions/blocks/paywall/editor.native.scss
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/editor.native.scss
@@ -1,18 +1,47 @@
+.paywall {
+	background-color: rgba( 0, 0, 0, 0.06 );
+	border-radius: 10px;
+	padding: 12px 16px;
+}
+
+.paywall__dark {
+	background-color: rgba( 255, 255, 255, 0.15 );
+}
+
+.paywall--horizontalRule {
+	margin-bottom: 4px;
+}
+
 .paywall--line {
-	background-color: $gray-lighten-20;
-	height: 2;
+	background-color: $black;
+	height: 1;
 }
 
 .paywall--line__dark {
-	background-color: $gray-50;
+	background-color: $white;
 }
 
 .paywall--text {
-	color: $gray;
+	color: $black;
+	font-size: 13px;
+	line-height: 18px;
+	letter-spacing: -0.078px;
 	text-decoration-style: solid;
 	text-transform: uppercase;
 }
 
 .paywall--text__dark {
+	color: $white;
+}
+
+.paywall--subtext {
+	color: rgba( 60, 60, 67, 0.6 );
+	font-size: 13px;
+	line-height: 18px;
+	letter-spacing: -0.078px;
+	text-align: center;
+}
+
+.paywall--subtext__dark {
 	color: $gray-20;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Redesign Paywall block visuals in the mobile editor. Provide additional context
via visual separation and label text.

## Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/6107

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Update block label text.
- Update block visuals.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1692883629188639/1692709886.268299-slack-C05M033KRFC

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See the latest instructions in https://github.com/wordpress-mobile/gutenberg-mobile/pull/6107.