### PR TITLE
VideoPress: Check if module is active before initializing

### DIFF
--- a/projects/packages/videopress/changelog/change-videopress-block-registration-check
+++ b/projects/packages/videopress/changelog/change-videopress-block-registration-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Defer assets enqueuing for non block themes as those seem to be loading the assets on every page

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.15.x-dev"
+			"dev-trunk": "0.16.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.15.3",
+	"version": "0.16.0-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -356,7 +356,7 @@ class Initializer {
 			add_action(
 				'wp_enqueue_scripts',
 				function () use ( $videopress_video_metadata_file ) {
-					if ( ! has_block( 'videopress/video', get_the_content() ) && ! has_block( 'jetpack-videopress/video', get_the_content() ) ) {
+					if ( ! has_block( 'videopress/video', get_the_content() ) ) {
 						return;
 					}
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -356,16 +356,16 @@ class Initializer {
 			add_action(
 				'wp_enqueue_scripts',
 				function () use ( $videopress_video_metadata_file ) {
-					if ( ! has_block( 'videopress/video', get_the_content() ) ) {
+					$post_content = get_the_content();
+					// TODO: we need to also parse the site content for FSE cases (block/shortcode could be on footer, header, etc)
+					if ( ! has_block( 'videopress/video', $post_content ) && ! has_shortcode( $post_content, 'videopress' ) ) {
 						return;
 					}
-
 					self::enqueue_block_assets( $videopress_video_metadata_file );
 				}
 			);
 			return;
 		}
-
 		self::enqueue_block_assets( $videopress_video_metadata_file );
 	}
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -353,7 +353,7 @@ class Initializer {
 
 		// for non block themes, we defer the enqueuing to the frontend, so we're able to tell if we need the assets
 		// TODO: this is draft code, shall we go this path I'll clean up and split code to its own method
-		if ( ! $is_block_theme ) {
+		if ( ! $is_block_theme && ! is_admin() ) {
 			add_action(
 				'wp_enqueue_scripts',
 				function () use ( $videopress_video_metadata_file ) {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -348,6 +348,60 @@ class Initializer {
 			return;
 		}
 
+		// check current theme
+		$is_block_theme = wp_get_theme()->is_block_theme();
+
+		// for non block themes, we defer the enqueuing to the frontend, so we're able to tell if we need the assets
+		// TODO: this is draft code, shall we go this path I'll clean up and split code to its own method
+		if ( ! $is_block_theme ) {
+			add_action(
+				'wp_enqueue_scripts',
+				function () use ( $videopress_video_metadata_file ) {
+					$blocks               = parse_blocks( get_the_content() );
+					$has_videopress_block = false;
+					foreach ( $blocks as $block ) {
+						if ( $block['blockName'] === 'videopress/video' ) {
+							$has_videopress_block = true;
+							break;
+						}
+					}
+					if ( ! $has_videopress_block ) {
+						return;
+					}
+					// Register script used by the VideoPress video block in the editor.
+					Assets::register_script(
+						self::JETPACK_VIDEOPRESS_VIDEO_HANDLER,
+						'../build/block-editor/blocks/video/index.js',
+						__FILE__,
+						array(
+							'in_footer'  => false,
+							'textdomain' => 'jetpack-videopress-pkg',
+						)
+					);
+
+					// Register script used by the VideoPress video block in the front-end.
+					Assets::register_script(
+						self::JETPACK_VIDEOPRESS_VIDEO_VIEW_HANDLER,
+						'../build/block-editor/blocks/video/view.js',
+						__FILE__,
+						array(
+							'in_footer'  => true,
+							'textdomain' => 'jetpack-videopress-pkg',
+						)
+					);
+
+					// Register VideoPress video block.
+					register_block_type(
+						$videopress_video_metadata_file,
+						array(
+							'render_callback' => array( __CLASS__, 'render_videopress_video_block' ),
+						)
+					);
+				}
+			);
+			return;
+		}
+
 		// Register script used by the VideoPress video block in the editor.
 		Assets::register_script(
 			self::JETPACK_VIDEOPRESS_VIDEO_HANDLER,

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -357,7 +357,7 @@ class Initializer {
 				'wp_enqueue_scripts',
 				function () use ( $videopress_video_metadata_file ) {
 					$post_content = get_the_content();
-					// TODO: we need to also parse the site content for FSE cases (block/shortcode could be on footer, header, etc)
+
 					if ( ! has_block( 'videopress/video', $post_content ) && ! has_shortcode( $post_content, 'videopress' ) ) {
 						return;
 					}

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.15.3';
+	const PACKAGE_VERSION = '0.16.0-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/changelog/change-videopress-block-registration-check
+++ b/projects/plugins/jetpack/changelog/change-videopress-block-registration-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Check if VideoPress module is active in order to register the VideoPress video block

--- a/projects/plugins/jetpack/changelog/change-videopress-block-registration-check#2
+++ b/projects/plugins/jetpack/changelog/change-videopress-block-registration-check#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2580,7 +2580,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "5f37a24f44baeeb237537d9b899007d8014b42c3"
+                "reference": "083fb7a5c30886d3858d9f7a9854052f2fe785c1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2605,7 +2605,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.15.x-dev"
+                    "dev-trunk": "0.16.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -23,9 +23,11 @@ add_action(
 	function () {
 		$extensions                            = \Jetpack_Gutenberg::get_extensions();
 		$is_videopress_video_extension_enabled = in_array( 'videopress/video', $extensions, true );
+		$is_videopress_module_active           = \Jetpack::is_module_active( 'videopress' );
 
 		if (
 			$is_videopress_video_extension_enabled &&
+			$is_videopress_module_active &&
 			method_exists( 'Automattic\Jetpack\VideoPress\Initializer', 'register_videopress_video_block' )
 		) {
 			VideoPress_Pkg_Initializer::register_videopress_video_block();

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -23,11 +23,9 @@ add_action(
 	function () {
 		$extensions                            = \Jetpack_Gutenberg::get_extensions();
 		$is_videopress_video_extension_enabled = in_array( 'videopress/video', $extensions, true );
-		$is_videopress_module_active           = \Jetpack::is_module_active( 'videopress' );
 
 		if (
 			$is_videopress_video_extension_enabled &&
-			$is_videopress_module_active &&
 			method_exists( 'Automattic\Jetpack\VideoPress\Initializer', 'register_videopress_video_block' )
 		) {
 			VideoPress_Pkg_Initializer::register_videopress_video_block();

--- a/projects/plugins/videopress/changelog/change-videopress-block-registration-check
+++ b/projects/plugins/videopress/changelog/change-videopress-block-registration-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1345,7 +1345,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "5f37a24f44baeeb237537d9b899007d8014b42c3"
+                "reference": "083fb7a5c30886d3858d9f7a9854052f2fe785c1"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1370,7 +1370,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.15.x-dev"
+                    "dev-trunk": "0.16.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"


### PR DESCRIPTION
VideoPress initializer takes place even without the module being active, leading to load unneeded resources.

Fixes #32235

## Proposed changes:
This PR adds an extra check to see if the module is active before continuing with the registration. When the theme is NOT a block theme, the enqueuing process is deferred to `wp_enqueue_scripts` hook, where the content of the post can be parsed and checked for a VP block and, only then, enqueue the needed assets.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a site and connect it to Jetpack. Don't enable VideoPress yet. Visit the site's homepage (or any page), check on the sources to verify `jetpack_vendor/automattic/jetpack-videopress/build/block-editor/blocks/video/view.css` is NOT being loaded.

Change theme to a classic theme, like 2020. Visit a page/post on frontend where NO video blocks are present. See that the mentioned file above is not being loaded. Then visit a page WITH a video block to see the file is being loaded properly.

