### PR TITLE
[NL tiers] gate access for newsletter tiers

### DIFF
--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
@@ -539,14 +539,14 @@ class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
 	/**
 	 * Create a tier
 	 *
-	 * @param int        $newsletter_plan_id Plan id.
-	 * @param int        $newsletter_annual_plan_id Annual plan ID.
+	 * @param int        $newsletter_product_id Plan id.
+	 * @param int        $newsletter_annual_product_id Annual plan ID.
 	 * @param float      $price plan price.
 	 * @param float|null $annual_price annual plan price.
 	 * @param string     $currency currency.
 	 * @return int post tier ID
 	 */
-	private function setup_jetpack_tier( $newsletter_plan_id, $newsletter_annual_plan_id, $price, $annual_price = null, $currency = 'EUR' ) {
+	private function setup_jetpack_tier( $newsletter_product_id, $newsletter_annual_product_id, $price, $annual_price = null, $currency = 'EUR' ) {
 		/**
 		 * Create a newsletter plan
 		 */
@@ -555,7 +555,7 @@ class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
 				'post_type' => Jetpack_Memberships::$post_type_plan,
 			)
 		);
-		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_product_id', $newsletter_plan_id );
+		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_product_id', $newsletter_product_id );
 		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_site_subscriber', true );
 		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_price', $price );
 		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_currency', $currency );
@@ -569,12 +569,12 @@ class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
 					'post_type' => Jetpack_Memberships::$post_type_plan,
 				)
 			);
-			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_product_id', $newsletter_annual_plan_id );
+			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_product_id', $newsletter_annual_product_id );
 			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_site_subscriber', true );
 			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_price', $annual_price );
 			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_currency', $currency );
 			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_interval', '1 year' );
-			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_tier', $newsletter_plan_id );
+			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_tier', $newsletter_product_id );
 
 			$this->factory->post->create();
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/118

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Gate access when post is getaed by tiers 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Unit tests
* Go to '..'
* start docker `jetpack docker up -d`
* `jetpack docker phpunit -- -c tests/php.multisite.xml --testsuite=subscriptions --filter=test_newsletter_tiers`

#### Live tests
* Apply https://github.com/Automattic/gold/issues/140 to your sandbox
* Create a 3 tier plans on a site (Gold, SIlver and Bronze)
* Apply this diff to your sandbox
* Subscribe to a a Silver tier
* Send a gated post for Gold -> you should not receive any email
* Send a gated post for Bronze -> you should receive the email
* Send a gated post for Silver -> you should receive the email
