### PR TITLE
Earn/tier selector

### DIFF
--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -98,13 +98,15 @@ function TierSelector( { onChange } ) {
 
 	// Find the current tier meta
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
+	// Destructure the tierId from the meta (set tierId using the META_NAME_FOR_POST_TIER_ID_SETTINGS constant)
 	const [ { [ META_NAME_FOR_POST_TIER_ID_SETTINGS ]: tierId } ] = useEntityProp(
 		'postType',
 		postType,
 		'meta'
 	);
 
-	// Tiers don't apply if less than 2 products
+	// Tiers don't apply if less than 2 products (this is called here because
+	// the hooks have to run before any early returns)
 	if ( products.length < 2 ) {
 		return;
 	}
@@ -198,8 +200,7 @@ export function NewsletterAccessRadioButtons( {
 						{ key === accessOptions.paid_subscribers.key &&
 							key === accessLevel &&
 							isStripeConnected &&
-							hasNewsletterPlans &&
-							! postHasPaywallBlock && <TierSelector onChange={ onChange }></TierSelector> }
+							hasNewsletterPlans && <TierSelector onChange={ onChange }></TierSelector> }
 					</div>
 				);
 			} ) }

--- a/projects/plugins/jetpack/sal/class.json-api-metadata.php
+++ b/projects/plugins/jetpack/sal/class.json-api-metadata.php
@@ -4,6 +4,9 @@
  *
  * @package automattic/jetpack
  */
+
+use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
+
 /**
  * Base class for WPCOM_JSON_API_Metadata
  */
@@ -57,7 +60,7 @@ class WPCOM_JSON_API_Metadata {
 		// display the correct newsletter access in Calypso.
 		$whitelist = array(
 			'_jetpack_newsletter_access',
-			'_jetpack_newsletter_tier_id',
+			META_NAME_FOR_POST_TIER_ID_SETTINGS,
 		);
 
 		if ( in_array( $key, $whitelist, true ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/119. (Adds tier selector under the paid subscribers access).

<img src="https://github.com/Automattic/jetpack/assets/6354169/abac41c7-d329-4ee9-ad3d-dde3a5bf2baf" width=300>

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create a TierSelector component and add to post paid newsletter access selector.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the diff to WPCOM (e.g. `bin/jetpack-downloader test jetpack earn/tier-selector`) (this is required by an API change used on public-api.wordpress.com, alternately you could use with jurassic ninja, but make sure you push this change to sandbox and you global-http enable to properly sandbox your site).
* Get a test site working on your sandbox.
* Connect stripe and create a couple plans (they need to be monthly paid newsletter plans)(This PR should work for cases with 2 or more "tiers" defined.
* Enable paid newsletters
* Create a post and set the access to "Paid subscribers only". You should then see your tiers defined and be able to select them.
* Set the tier and save the post.
* Ensure reloading the post selects the same tier.

