### PR TITLE
Remove logic that prevents site admins being tracked and add store_admin property to WooCommerce analytics events

### DIFF
--- a/projects/plugins/jetpack/changelog/add-store-admin-property
+++ b/projects/plugins/jetpack/changelog/add-store-admin-property
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Track store admin actions in WooCommerce analytics. Add a store_admin property to all WooCommerce analytics events.

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php
@@ -50,10 +50,6 @@ class Jetpack_WooCommerce_Analytics {
 		if ( is_admin() ) {
 			return false;
 		}
-		// Don't track site admins.
-		if ( is_user_logged_in() && in_array( 'administrator', wp_get_current_user()->roles, true ) ) {
-			return false;
-		}
 		// Make sure Jetpack is installed and connected.
 		if ( ! Jetpack::is_connection_ready() ) {
 			return false;

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -90,6 +90,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			'ui'          => $this->get_user_id(),
 			'url'         => home_url(),
 			'woo_version' => WC()->version,
+			'store_admin' => in_array( 'administrator', wp_get_current_user()->roles, true ),
 		);
 		$cart_checkout_info = self::get_cart_checkout_info();
 		return array_merge( $site_info, $cart_checkout_info );

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php
@@ -90,7 +90,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			'ui'          => $this->get_user_id(),
 			'url'         => home_url(),
 			'woo_version' => WC()->version,
-			'store_admin' => in_array( 'administrator', wp_get_current_user()->roles, true ),
+			'store_admin' => in_array( 'administrator', wp_get_current_user()->roles, true ) ? 1 : 0,
 		);
 		$cart_checkout_info = self::get_cart_checkout_info();
 		return array_merge( $site_info, $cart_checkout_info );

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -5,6 +5,17 @@
 - **At any point during your testing, remember to [check your browser's JavaScript console](https://wordpress.org/support/article/using-your-browser-to-diagnose-javascript-errors/#step-3-diagnosis) and see if there are any errors reported by Jetpack there.**
 - Use the "Debug Bar" or "Query Monitor" WordPress plugins to help make PHP notices and warnings more noticeable and report anything of note you see.
 
+### WooCommerce Analytics
+
+Remove logic that prevents site admins being tracked and add store_admin property to WooCommerce analytics events
+- Ensure site is connected, WooCommerce is installed, products, payment methods, and shipping methods are available. (Cash on Delivery and Free shipping will be fine).
+- Ensure WooCommerce analytics is running.
+- As an admin user: add an item to your cart and go to the checkout.
+- Check out and then visit Tracks and find your event. (I spoofed my user agent so I could find the event easily)
+- Check the event for the `store_admin` property, which should be `1`
+- Repeat as a logged _out_ (e.g. guest) user, the event should be logged, and should have the `store_admin` property but it should be `0`
+- Repeat as a logged in, but _not_ admin user, (e.g. a customer), the event should be logged, and should have the `store_admin` property but it should be `0`
+
 ### Enabling beta blocks
 
 Testing most features on this list requires enabling Jetpack beta blocks. You can be the one of the first to test upcoming features by adding this constant as a snippet, or directly into your configuration file:
@@ -34,7 +45,7 @@ To properly test this ensure that beta blocks are enabled.
 - Confirm the Excerpt panel is there when:
   -	beta extensions are enabled;
   - AI Assistant block is enabled.
- 
+
 - Go to the block editor, open the block sidebar.
 - Look at the AI Excerpt panel.
 - Confirm that the Accept button is initially disabled.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10427

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change `should_track_store` function so it no longer checks whether the user is an administrator, admins will now be tracked.
* Add a `store_admin` property when sending events, true if the user is an admin, false otherwise.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

A previous discussion about this tracking can be found here pb0Spc-ou-p2#comment-701 however it is very old.

We also have pca54o-6dR-p2 where the effort is listed as a cycle goal (point 3). 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes, we now track store admins, as well as regular store users. We also track whether the user is logged in as a store admin on every WooCommerce analytics event.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure site is connected, WooCommerce is installed, products, payment methods, and shipping methods are available. (Cash on Delivery and Free shipping will be fine).
* Ensure WooCommerce analytics is running.
* As an admin user: add an item to your cart and go to the checkout.
* Check out and then visit Tracks and find your event. (I spoofed my user agent so I could find the event easily)
* Check the event for the `store_admin` property, which should be `1`
* Repeat as a logged _out_ (e.g. guest) user, the event should be logged, and should have the `store_admin` property but it should be `0`
* Repeat as a logged in, but _not_ admin user, (e.g. a customer), the event should be logged, and should have the `store_admin` property but it should be `0`