### PR TITLE
Enable block registration by specifying the path to block.json

### DIFF
--- a/projects/packages/blocks/changelog/add-enable-block-registration-by-path
+++ b/projects/packages/blocks/changelog/add-enable-block-registration-by-path
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enable block registration by specifying block.json path

--- a/projects/packages/blocks/composer.json
+++ b/projects/packages/blocks/composer.json
@@ -46,7 +46,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-blocks/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.4.x-dev"
+			"dev-trunk": "1.5.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -135,7 +135,7 @@ class Blocks {
 		if ( file_exists( $filename ) ) {
 			try {
 				$metadata = wp_json_file_decode( $filename, array( 'associative' => true ) );
-			} catch ( Exception $e ) {
+			} catch ( \Exception $e ) {
 				$metadata = array();
 			}
 		}

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -27,7 +27,7 @@ class Blocks {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param string $slug Slug of the block.
+	 * @param string $slug Slug of the block or absolute path to the directory containing the block.json file.
 	 * @param array  $args {
 	 *     Arguments that are passed into register_block_type.
 	 *     See register_block_type for full list of arguments.
@@ -40,6 +40,22 @@ class Blocks {
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
 	public static function jetpack_register_block( $slug, $args = array() ) {
+		$block_type = null;
+
+		// If the path to block.json is passed, find the slug in the file then create a block type
+		// object to register the block.
+		// Note: passing the path directly to register_block_type seems to loose the interactivity of
+		// the block once in the editor once it's out of focus.
+		if ( '/' === substr( $slug, 0, 1 ) ) {
+			$metadata = self::get_block_metadata_from_file( $slug );
+			$name     = self::get_block_name_from_metadata( $metadata );
+
+			if ( ! empty( $name ) ) {
+				$slug       = $name;
+				$block_type = new \WP_Block_Type( $slug, array_merge( $metadata, $args ) );
+			}
+		}
+
 		if ( 0 !== strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
 			_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', 'Jetpack 9.0.0' );
 			$slug = 'jetpack/' . $slug;
@@ -99,7 +115,53 @@ class Blocks {
 			}
 		}
 
-		return register_block_type( $slug, $args );
+		return register_block_type( isset( $block_type ) ? $block_type : $slug, $args );
+	}
+
+	/**
+	 * Read block metadata from a block.json file.
+	 *
+	 * @param string $filename The path to the block.json file or its directory.
+	 *
+	 * @return array The block metadata.
+	 */
+	public static function get_block_metadata_from_file( $filename ) {
+		$metadata = array();
+		$needle   = '/block.json';
+		$filename = $needle === substr( $filename, -strlen( $needle ) ) ? $filename : $filename . $needle;
+
+		if ( file_exists( $filename ) ) {
+			try {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				$metadata = json_decode( file_get_contents( $filename ), true );
+			} catch ( Exception $e ) {
+				$metadata = array();
+			}
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Get the block name from the its metadata.
+	 *
+	 * @param array $metadata The block metadata.
+	 *
+	 * @return string The block name.
+	 */
+	public static function get_block_name_from_metadata( $metadata ) {
+		return ! isset( $metadata['name'] ) || empty( $metadata['name'] ) ? '' : $metadata['name'];
+	}
+
+	/**
+	 * Get the block feature name (i.e. the name without the `jetpack` prefix) from its metadata.
+	 *
+	 * @param array $metadata The block metadata.
+	 *
+	 * @return string The block feature name.
+	 */
+	public static function get_block_feature_from_metadata( $metadata ) {
+		return str_replace( 'jetpack/', '', self::get_block_name_from_metadata( $metadata ) );
 	}
 
 	/**

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -40,7 +40,7 @@ class Blocks {
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
 	public static function jetpack_register_block( $slug, $args = array() ) {
-		$block_type = null;
+		$block_type = $slug;
 
 		// If the path to block.json is passed, find the slug in the file then create a block type
 		// object to register the block.
@@ -115,7 +115,7 @@ class Blocks {
 			}
 		}
 
-		return register_block_type( isset( $block_type ) ? $block_type : $slug, $args );
+		return register_block_type( $block_type, $args );
 	}
 
 	/**

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -40,7 +40,7 @@ class Blocks {
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
 	public static function jetpack_register_block( $slug, $args = array() ) {
-		if ( 0 !== strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
+		if ( 0 !== strpos( $slug, 'jetpack/' ) && 0 !== strpos( $slug, '/' ) ) {
 			_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', 'Jetpack 9.0.0' );
 			$slug = 'jetpack/' . $slug;
 		}

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -40,7 +40,9 @@ class Blocks {
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
 	public static function jetpack_register_block( $slug, $args = array() ) {
-		if ( 0 !== strpos( $slug, 'jetpack/' ) && 0 !== strpos( $slug, '/' ) ) {
+		// Slug doesn't start with `jetpack/`, isn't an absolute path, or doesn't contain a slash
+		// (synonym of a namespace) at all.
+		if ( 0 !== strpos( $slug, 'jetpack/' ) && 0 !== strpos( $slug, '/' ) && ! strpos( $slug, '/' ) ) {
 			_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', 'Jetpack 9.0.0' );
 			$slug = 'jetpack/' . $slug;
 		}

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -132,7 +132,7 @@ class Blocks {
 
 		if ( file_exists( $filename ) ) {
 			try {
-				$metadata = wp_json_file_decode( $filename, true );
+				$metadata = wp_json_file_decode( $filename, array( 'associative' => true ) );
 			} catch ( Exception $e ) {
 				$metadata = array();
 			}

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -132,8 +132,7 @@ class Blocks {
 
 		if ( file_exists( $filename ) ) {
 			try {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-				$metadata = json_decode( file_get_contents( $filename ), true );
+				$metadata = wp_json_file_decode( $filename, true );
 			} catch ( Exception $e ) {
 				$metadata = array();
 			}

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -128,7 +128,7 @@ class Blocks {
 	public static function get_block_metadata_from_file( $filename ) {
 		$metadata = array();
 		$needle   = '/block.json';
-		$filename = $needle === substr( $filename, -strlen( $needle ) ) ? $filename : $filename . $needle;
+		$filename = $needle === substr( $filename, -strlen( $needle ) ) ? $filename : realpath( $filename . $needle );
 
 		if ( file_exists( $filename ) ) {
 			try {

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -40,6 +40,11 @@ class Blocks {
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
 	public static function jetpack_register_block( $slug, $args = array() ) {
+		if ( 0 !== strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
+			_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', 'Jetpack 9.0.0' );
+			$slug = 'jetpack/' . $slug;
+		}
+
 		$block_type = $slug;
 
 		// If the path to block.json is passed, find the slug in the file then create a block type
@@ -54,11 +59,6 @@ class Blocks {
 				$slug       = $name;
 				$block_type = new \WP_Block_Type( $slug, array_merge( $metadata, $args ) );
 			}
-		}
-
-		if ( 0 !== strpos( $slug, 'jetpack/' ) && ! strpos( $slug, '/' ) ) {
-			_doing_it_wrong( 'jetpack_register_block', 'Prefix the block with jetpack/ ', 'Jetpack 9.0.0' );
-			$slug = 'jetpack/' . $slug;
 		}
 
 		if (

--- a/projects/packages/blocks/tests/php/fixtures/block.json
+++ b/projects/packages/blocks/tests/php/fixtures/block.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/test-block",
+	"title": "Test Block",
+	"description": "",
+	"keywords": [],
+	"version": "",
+	"textdomain": "jetpack",
+	"category": "",
+	"icon": "",
+	"supports": {},
+	"editorScript": ""
+}

--- a/projects/packages/blocks/tests/php/test-blocks.php
+++ b/projects/packages/blocks/tests/php/test-blocks.php
@@ -354,7 +354,8 @@ class Test_Blocks extends TestCase {
 	public function test_get_block_metadata_from_file() {
 		$result = Blocks::get_block_metadata_from_file( __DIR__ . '/fixtures/block.json' );
 
-		$this->assertIsArray( $result );
+		// phpcs:ignore MediaWiki.PHPUnit.SpecificAssertions.assertIsArray -- assertIsArray not supported by all PHP versions we support.
+		$this->assertTrue( is_array( $result ) );
 		$this->assertNotEmpty( $result );
 	}
 
@@ -368,7 +369,8 @@ class Test_Blocks extends TestCase {
 	public function test_get_block_metadata_from_folder() {
 		$result = Blocks::get_block_metadata_from_file( __DIR__ . '/fixtures/' );
 
-		$this->assertIsArray( $result );
+		// phpcs:ignore MediaWiki.PHPUnit.SpecificAssertions.assertIsArray -- assertIsArray not supported by all PHP versions we support.
+		$this->assertTrue( is_array( $result ) );
 		$this->assertNotEmpty( $result );
 	}
 
@@ -382,7 +384,8 @@ class Test_Blocks extends TestCase {
 	public function test_get_block_metadata_from_wrong_file() {
 		$result = Blocks::get_block_metadata_from_file( __DIR__ . '/fixtures/ghost-folder/block.json' );
 
-		$this->assertIsArray( $result );
+		// phpcs:ignore MediaWiki.PHPUnit.SpecificAssertions.assertIsArray -- assertIsArray not supported by all PHP versions we support.
+		$this->assertTrue( is_array( $result ) );
 		$this->assertEmpty( $result );
 	}
 

--- a/projects/packages/blocks/tests/php/test-blocks.php
+++ b/projects/packages/blocks/tests/php/test-blocks.php
@@ -334,7 +334,7 @@ class Test_Blocks extends TestCase {
 	/**
 	 * Test registering a block by specifying the path to its metadata file.
 	 *
-	 * @since 1.4.23
+	 * @since $$next-version$$
 	 *
 	 * @covers Automattic\Jetpack\Blocks::get_block_metadata_from_file
 	 */
@@ -347,7 +347,7 @@ class Test_Blocks extends TestCase {
 	/**
 	 * Test reading metadata from a block.json file by specifying its path.
 	 *
-	 * @since 1.4.23
+	 * @since $$next-version$$
 	 *
 	 * @covers Automattic\Jetpack\Blocks::get_block_metadata_from_file
 	 */
@@ -362,7 +362,7 @@ class Test_Blocks extends TestCase {
 	/**
 	 * Test reading metadata from a block.json file by specifying its folder.
 	 *
-	 * @since 1.4.23
+	 * @since $$next-version$$
 	 *
 	 * @covers Automattic\Jetpack\Blocks::get_block_metadata_from_file
 	 */
@@ -377,7 +377,7 @@ class Test_Blocks extends TestCase {
 	/**
 	 * Test reading metadata from a file that doesn't exist.
 	 *
-	 * @since 1.4.23
+	 * @since $$next-version$$
 	 *
 	 * @covers Automattic\Jetpack\Blocks::get_block_metadata_from_file
 	 */
@@ -392,7 +392,7 @@ class Test_Blocks extends TestCase {
 	/**
 	 * Test reading the name of a block from its metadata.
 	 *
-	 * @since 1.4.23
+	 * @since $$next-version$$
 	 *
 	 * @covers Automattic\Jetpack\Blocks::get_block_name_from_metadata
 	 */
@@ -410,7 +410,7 @@ class Test_Blocks extends TestCase {
 	/**
 	 * Test reading the feature name of a block from its metadata.
 	 *
-	 * @since 1.4.23
+	 * @since $$next-version$$
 	 *
 	 * @covers Automattic\Jetpack\Blocks::get_block_name_from_metadata
 	 */

--- a/projects/packages/blocks/tests/php/test-blocks.php
+++ b/projects/packages/blocks/tests/php/test-blocks.php
@@ -330,4 +330,83 @@ class Test_Blocks extends TestCase {
 			remove_filter( 'jetpack_is_standalone_block', '__return_false' );
 		}
 	}
+
+	/**
+	 * Test reading metadata from a block.json file by specifying its path.
+	 *
+	 * @since 1.4.23
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_block_metadata_from_file
+	 */
+	public function test_get_block_metadata_from_file() {
+		$result = Blocks::get_block_metadata_from_file( __DIR__ . '/fixtures/block.json' );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+	}
+
+	/**
+	 * Test reading metadata from a block.json file by specifying its folder.
+	 *
+	 * @since 1.4.23
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_block_metadata_from_file
+	 */
+	public function test_get_block_metadata_from_folder() {
+		$result = Blocks::get_block_metadata_from_file( __DIR__ . '/fixtures/' );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
+	}
+
+	/**
+	 * Test reading metadata from a file that doesn't exist.
+	 *
+	 * @since 1.4.23
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_block_metadata_from_file
+	 */
+	public function test_get_block_metadata_from_wrong_file() {
+		$result = Blocks::get_block_metadata_from_file( __DIR__ . '/fixtures/ghost-folder/block.json' );
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test reading the name of a block from its metadata.
+	 *
+	 * @since 1.4.23
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_block_name_from_metadata
+	 */
+	public function test_get_block_name_from_metadata() {
+		$name   = 'jetpack/test-block';
+		$result = Blocks::get_block_name_from_metadata( array() );
+
+		$this->assertSame( '', $result );
+
+		$result = Blocks::get_block_name_from_metadata( array( 'name' => $name ) );
+
+		$this->assertEquals( $result, $name );
+	}
+
+	/**
+	 * Test reading the feature name of a block from its metadata.
+	 *
+	 * @since 1.4.23
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_block_name_from_metadata
+	 */
+	public function test_get_block_feature_from_metadata() {
+		$feature = 'test-block';
+		$name    = 'jetpack/' . $feature;
+		$result  = Blocks::get_block_feature_from_metadata( array() );
+
+		$this->assertSame( '', $result );
+
+		$result = Blocks::get_block_feature_from_metadata( array( 'name' => $name ) );
+
+		$this->assertEquals( $result, $feature );
+	}
 }

--- a/projects/packages/blocks/tests/php/test-blocks.php
+++ b/projects/packages/blocks/tests/php/test-blocks.php
@@ -332,6 +332,19 @@ class Test_Blocks extends TestCase {
 	}
 
 	/**
+	 * Test registering a block by specifying the path to its metadata file.
+	 *
+	 * @since 1.4.23
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_block_metadata_from_file
+	 */
+	public function test_jetpack_register_block_from_metadata_file() {
+		$result = Blocks::jetpack_register_block( __DIR__ . '/fixtures/block.json' );
+
+		$this->assertInstanceOf( 'WP_Block_Type', $result );
+	}
+
+	/**
 	 * Test reading metadata from a block.json file by specifying its path.
 	 *
 	 * @since 1.4.23

--- a/projects/plugins/jetpack/changelog/add-enable-block-registration-by-path
+++ b/projects/plugins/jetpack/changelog/add-enable-block-registration-by-path
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enable block registration by specifying block.json path

--- a/projects/plugins/jetpack/changelog/add-enable-block-registration-by-path#2
+++ b/projects/plugins/jetpack/changelog/add-enable-block-registration-by-path#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -478,6 +478,15 @@ class Jetpack_Gutenberg {
 			return;
 		}
 
+		// Retrieve the feature from block.json if its path is passed.
+		if ( '/' === substr( $type, 0, 1 ) ) {
+			$feature = Blocks::get_block_feature_from_metadata( Blocks::get_block_metadata_from_file( $type ) );
+
+			if ( ! empty( $feature ) ) {
+				$type = $feature;
+			}
+		}
+
 		$type = sanitize_title_with_dashes( $type );
 		self::load_styles_as_required( $type );
 		self::load_scripts_as_required( $type, $script_dependencies );

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -466,7 +466,7 @@ class Jetpack_Gutenberg {
 	/**
 	 * Only enqueue block assets when needed.
 	 *
-	 * @param string $type Slug of the block.
+	 * @param string $type Slug of the block or absolute path to the directory containing the block.json file.
 	 * @param array  $script_dependencies Script dependencies. Will be merged with automatically
 	 *                                    detected script dependencies from the webpack build.
 	 *

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -526,7 +526,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "21025b86c1837680dae628cb68c66299dcfaa8d6"
+                "reference": "aa5b7af0bd7d9ae4b54ed9c4664ddc6927ce0c7d"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -545,7 +545,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-blocks/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
+                    "dev-trunk": "1.5.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -78,10 +78,16 @@ function setBetaBlockTitle( settings, name ) {
 		return settings;
 	}
 
+	const { title, keywords } = settings;
+	const titleSuffix = '(beta)';
+	const betaKeyword = 'beta';
+
 	return {
 		...settings,
-		title: `${ settings.title } (beta)`,
-		kewords: [ ...settings.keywords, 'beta' ],
+		title: title.toLowerCase().endsWith( titleSuffix )
+			? title
+			: `${ settings.title } ${ titleSuffix }`,
+		kewords: keywords.includes( betaKeyword ) ? keywords : [ ...keywords, betaKeyword ],
 	};
 }
 

--- a/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
+++ b/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
@@ -11,7 +11,9 @@ const JETPACK_PREFIX = 'jetpack/';
 /**
  * Registers a gutenberg block if the availability requirements are met.
  *
- * @param {string} name - The block's name.
+ * @param {string} name - The block's name. Jetpack blocks must be registered with a name prefixed
+ * with `jetpack/`. This function accepts an unprefixed name too, though (it'd handle both
+ * `business-hours` and `jetpack/business-hours` similarly, for instance).
  * @param {object} settings - The block's settings.
  * @param {object} childBlocks - The block's child blocks.
  * @param {boolean} prefix - Should this block be prefixed with `jetpack/`?


### PR DESCRIPTION
See https://github.com/Automattic/jetpack/issues/32602

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Allows the registration of blocks by passing the path to the `block.json` metadata file to `Blocks::jetpack_register_block`.

In more details:
- In PHP
  - Update `Blocks::jetpack_register_block` and `Jetpack_Gutenberg::load_assets_as_required` to accept a path as first argument
  - Add helper methods
  - Add unit tests
- In JS
  - Make sure the `beta` mention is only rendered once
  - Make `registerJetpackBlock` accept both prefixed and unprefixed names

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pedMtX-RS-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Regression testing:
- Check that Jetpack blocks are still working as expected

Functional testing:
- Test in coordination with https://github.com/Automattic/jetpack/pull/32698