### PR TITLE
Social: Fix logic issue in store for enhanced publishig

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-enhanced-publishing-store-issue
+++ b/projects/js-packages/publicize-components/changelog/fix-enhanced-publishing-store-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue with the logic of getting the enchanced publishing feature

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.35.0",
+	"version": "0.35.1-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/social-store/selectors/jetpack-settings.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/jetpack-settings.js
@@ -4,8 +4,7 @@ const jetpackSettingSelectors = {
 	showPricingPage: state => state.jetpackSettings.show_pricing_page,
 	isUpdatingJetpackSettings: state => state.jetpackSettings.is_updating,
 	hasPaidPlan: state => ! ( state.jetpackSettings?.showNudge ?? true ),
-	isEnhancedPublishingEnabled: state =>
-		! ( state.jetpackSettings?.isEnhancedPublishingEnabled ?? false ),
+	isEnhancedPublishingEnabled: state => state.jetpackSettings?.isEnhancedPublishingEnabled ?? false,
 	getDismissedNotices: state => state.jetpackSettings?.dismissedNotices,
 	isInstagramConnectionSupported: state => state.jetpackSettings?.isInstagramConnectionSupported,
 	isMastodonConnectionSupported: state => state.jetpackSettings?.isMastodonConnectionSupported,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1693215729811629-slack-C02JJ910CNL

There was an issue in the Social store, that resulted in the `isEnhancedPublishingEnabled` flag to be flipped. This fixes that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1693215729811629-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new JN site with the Jetpack Complete plan and Jetpack Social
* Connect the page to your account and open the Social admin page
* You should see the Instagram notice, but it should not nudge you for an upgrade:
<img width="1177" alt="CleanShot 2023-08-28 at 12 24 40 png" src="https://github.com/Automattic/jetpack/assets/36671565/248d01f5-d7c0-481b-a5ba-84bfcb93765c">

---

* Check the same without this change, it should have the nudging part in it:
![image](https://github.com/Automattic/jetpack/assets/36671565/bdfdfa45-eabe-4d2c-aba9-2e795ce1fc55)