### PR TITLE
[Newsletter] Introduction to tiers for paid-subscribers

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -103,6 +103,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 						'buyer_can_change_amount' => array(
 							'type' => 'boolean',
 						),
+						'tier'                    => array(
+							'type'     => 'integer',
+							'required' => false,
+						),
 					),
 				),
 			)
@@ -154,6 +158,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 						),
 						'buyer_can_change_amount' => array(
 							'type' => 'boolean',
+						),
+						'tier'                    => array(
+							'type'     => 'integer',
+							'required' => false,
 						),
 					),
 				),
@@ -554,6 +562,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 			'welcome_email_content'        => $request['welcome_email_content'],
 			'subscribe_as_site_subscriber' => $request['subscribe_as_site_subscriber'],
 			'multiple_per_user'            => $request['multiple_per_user'],
+			'tier'                         => $request['tier'],
 		);
 
 		// If we pass directly the value "null", it will break the argument validation.

--- a/projects/plugins/jetpack/changelog/add-detect-tier-upgrade
+++ b/projects/plugins/jetpack/changelog/add-detect-tier-upgrade
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adds newsletter tier upgrade detection

--- a/projects/plugins/jetpack/changelog/add-gate-access-for-newsletter-tiers
+++ b/projects/plugins/jetpack/changelog/add-gate-access-for-newsletter-tiers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: major
+
+New feature: gate access depending on Newsletter tier

--- a/projects/plugins/jetpack/changelog/add-membership_tier_endpoints
+++ b/projects/plugins/jetpack/changelog/add-membership_tier_endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add tier parameter for Membership product endpoints

--- a/projects/plugins/jetpack/changelog/add-newsletter-tiers-feature
+++ b/projects/plugins/jetpack/changelog/add-newsletter-tiers-feature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter tiers are added

--- a/projects/plugins/jetpack/changelog/add-tier-logic-for-premium-content
+++ b/projects/plugins/jetpack/changelog/add-tier-logic-for-premium-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use tier logic to get premium content block

--- a/projects/plugins/jetpack/changelog/earn-tier-selector
+++ b/projects/plugins/jetpack/changelog/earn-tier-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Create a TierSelector component and add to post paid newsletter access selector

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -217,7 +217,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 				'fields'         => 'ids',
 				'post_type'      => \Jetpack_Memberships::$post_type_plan,
 				'meta_key'       => 'jetpack_memberships_tier',
-				'meta_value'     => $tier_product_id,
+				'meta_value'     => $tier_id,
 			)
 		);
 
@@ -232,7 +232,8 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 		}
 
 		foreach ( $user_abbreviated_subscriptions as $subscription_plan_id => $details ) {
-			$end = is_int( $details->end_date ) ? $details->end_date : strtotime( $details->end_date );
+			$details = (array) $details;
+			$end = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
 			if ( $end < time() ) {
 				// subscription not active anymore
 				continue;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -219,7 +219,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 				)
 			);
 
-			if ( empty( $subscription_post_id ) === 0 ) {
+			if ( empty( $subscription_post_id ) ) {
 				// No post linked to this plan
 				continue;
 			}

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -176,10 +176,15 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 
 		// We now need the tier price and currency, and the same for the annual price (if available)
 		$tier_meta         = get_post_meta( $tier_id );
-		$tier_price        = $tier_meta['jetpack_memberships_price'][0];
-		$tier_currency     = $tier_meta['jetpack_memberships_currency'][0];
-		$tier_product_id   = $tier_meta['jetpack_memberships_product_id'][0];
+		$tier_price        = isset( $tier_meta['jetpack_memberships_price'] ) ? $tier_meta['jetpack_memberships_price'][0] : null;
+		$tier_currency     = isset( $tier_meta['jetpack_memberships_currency'] ) ? $tier_meta['jetpack_memberships_currency'][0] : null;
+		$tier_product_id   = isset( $tier_meta['jetpack_memberships_product_id'] ) ? $tier_meta['jetpack_memberships_product_id'][0] : null;
 		$annual_tier_price = $tier_price * 12;
+
+		if ( $tier_price === null || $tier_currency === null || $tier_product_id === null ) {
+			// There is an issue with the meta
+			return false;
+		}
 
 		// At this point we know the post is
 		$linked_post_tier = get_posts(
@@ -231,9 +236,14 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 			}
 
 			$metas                 = get_post_meta( $subscription_post_id );
-			$subscription_price    = $metas['jetpack_memberships_price'][0];
-			$subscription_currency = $metas['jetpack_memberships_currency'][0];
-			$subscription_interval = $metas['jetpack_memberships_interval'][0];
+			$subscription_price    = isset( $metas['jetpack_memberships_price'] ) ? $metas['jetpack_memberships_price'][0] : null;
+			$subscription_currency = isset( $metas['jetpack_memberships_currency'] ) ? $metas['jetpack_memberships_currency'][0] : null;
+			$subscription_interval = isset( $metas['jetpack_memberships_interval'] ) ? $metas['jetpack_memberships_interval'][0] : null;
+
+			if ( $subscription_price === null || $subscription_currency === null || $subscription_interval === null ) {
+				// There is an issue with the meta
+				continue;
+			}
 
 			if ( $tier_currency !== $subscription_currency ) {
 				// For now, we don't count if there are different currency (not sure how to convert price in a pure JP env)

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -9,6 +9,7 @@
 namespace Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service;
 
 use Automattic\Jetpack\Extensions\Premium_Content\JWT;
+use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
 
 /**
  * Class Token_Subscription_Service
@@ -103,9 +104,12 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 			);
 			$subscriptions      = (array) $payload['subscriptions'];
 			$is_paid_subscriber = $this->validate_subscriptions( $valid_plan_ids, $subscriptions );
+		} else {
+			// Token not valid. We bail even unless the post can be accessed publicly.
+			return $this->user_has_access( $access_level, false, false, get_the_ID(), array() );
 		}
 
-		$has_access = $this->user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, get_the_ID() );
+		$has_access = $this->user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, get_the_ID(), $subscriptions );
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$current_user = $old_user;
 		return $has_access;
@@ -118,10 +122,11 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	 * @param bool   $is_blog_subscriber Is user a subscriber of the blog.
 	 * @param bool   $is_paid_subscriber Is user a paid subscriber of the blog.
 	 * @param int    $post_id Post ID.
+	 * @param array  $user_abbreviated_subscriptions User subscription abbreviated.
 	 *
 	 * @return bool Whether the user has access to the content.
 	 */
-	protected function user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, $post_id ) {
+	protected function user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, $post_id, $user_abbreviated_subscriptions ) {
 		$has_access = false;
 		if ( is_user_logged_in() && current_user_can( 'edit_post', $post_id ) ) {
 			// Admin has access
@@ -138,11 +143,117 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 		}
 
 		if ( empty( $has_access ) && ( $access_level === self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS ) ) {
-			$has_access = $is_paid_subscriber;
+			$has_access =  $is_paid_subscriber && ! $this->maybe_gate_access_for_user_if_tier( $post_id, $user_abbreviated_subscriptions );
 		}
 
 		do_action( 'earn_user_has_access', $access_level, $has_access, $is_blog_subscriber, $is_paid_subscriber, $post_id );
 		return $has_access;
+	}
+
+	/**
+	 * Check post access for tiers.
+	 *
+	 * @param int   $post_id Current post id.
+	 * @param array $user_abbreviated_subscriptions User subscription abbreviated.
+	 *
+	 * @return bool
+	 */
+	private function maybe_gate_access_for_user_if_tier( $post_id, $user_abbreviated_subscriptions ) {
+		$tier_id = intval(
+			get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true )
+		);
+
+		if ( ! $tier_id ) {
+			return false;
+		}
+
+		$plan_ids = \Jetpack_Memberships::get_all_newsletter_plan_ids();
+
+		if ( ! in_array( $tier_id, $plan_ids, true ) ) {
+			// If the tier is not in the plans, we bail
+			return false;
+		}
+
+		// We now need the tier price and currency, and the same for the annual price (if available)
+		$tier_meta         = get_post_meta( $tier_id );
+		$tier_price        = $tier_meta['jetpack_memberships_price'][0];
+		$tier_currency     = $tier_meta['jetpack_memberships_currency'][0];
+		$tier_product_id   = $tier_meta['jetpack_memberships_product_id'][0];
+		$annual_tier_price = $tier_price * 12;
+
+		// At this point we know the post is
+		$linked_post_tier = get_posts(
+			array(
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'post_type'      => \Jetpack_Memberships::$post_type_plan,
+				'meta_key'       => 'jetpack_memberships_tier',
+				'meta_value'     => $tier_product_id,
+			)
+		);
+
+		$annual_tier_id = false;
+		if ( count( $linked_post_tier ) !== 0 ) {
+			$annual_tier_id = (int) reset(
+				$linked_post_tier
+			);
+
+			$annual_tier_meta  = get_post_meta( $annual_tier_id );
+			$annual_tier_price = isset( $annual_tier_meta['jetpack_memberships_price'][0] ) ? $annual_tier_meta['jetpack_memberships_price'][0] : $annual_tier_price;
+		}
+
+		foreach ( $user_abbreviated_subscriptions as $subscription_plan_id => $details ) {
+			$end = is_int( $details->end_date ) ? $details->end_date : strtotime( $details->end_date );
+			if ( $end < time() ) {
+				// subscription not active anymore
+				continue;
+			}
+
+			if ( $details->status !== 'active' ) {
+				// subscription not active anymore
+				continue;
+			}
+
+			$subscription_post_id = get_posts(
+				array(
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+					'post_type'      => \Jetpack_Memberships::$post_type_plan,
+					'meta_key'       => 'jetpack_memberships_product_id',
+					'meta_value'     => $subscription_plan_id,
+				)
+			);
+
+			if ( empty( $subscription_post_id ) === 0 ) {
+				// No post linked to this plan
+				continue;
+			}
+			$subscription_post_id = $subscription_post_id[0];
+
+			if ( $subscription_post_id === $tier_id || $subscription_post_id === $annual_tier_id ) {
+				// User is subscribed to the right tier
+				return false;
+			}
+
+			$metas                 = get_post_meta( $subscription_post_id );
+			$subscription_price    = $metas['jetpack_memberships_price'][0];
+			$subscription_currency = $metas['jetpack_memberships_currency'][0];
+			$subscription_interval = $metas['jetpack_memberships_interval'][0];
+
+			if ( $tier_currency !== $subscription_currency ) {
+				// For now, we don't count if there are different currency (not sure how to convert price in a pure JP env)
+				continue;
+			}
+
+			if ( ( $subscription_interval === '1 month' && $subscription_price >= $tier_price ) ||
+					( $subscription_interval === '1 year' && $subscription_price >= $annual_tier_price )
+			) {
+				// One subscription is more expensive than the minimum set by the post' selected tier
+				return false;
+			}
+		}
+
+		return true; // No user subscription is more expensive than the post's tier price...
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -175,7 +175,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 		}
 
 		// We now need the tier price and currency, and the same for the annual price (if available)
-		$tier_meta         = get_post_meta( $tier_id );
+		$tier_meta         = get_post_meta( $post_id, $tier_id );
 		$tier_price        = $tier_meta['jetpack_memberships_price'][0];
 		$tier_currency     = $tier_meta['jetpack_memberships_currency'][0];
 		$tier_product_id   = $tier_meta['jetpack_memberships_product_id'][0];
@@ -198,7 +198,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 				$linked_post_tier
 			);
 
-			$annual_tier_meta  = get_post_meta( $annual_tier_id );
+			$annual_tier_meta  = get_post_meta( $post_id, $annual_tier_id );
 			$annual_tier_price = isset( $annual_tier_meta['jetpack_memberships_price'][0] ) ? $annual_tier_meta['jetpack_memberships_price'][0] : $annual_tier_price;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -97,6 +97,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 
 		$is_blog_subscriber = false;
 		$is_paid_subscriber = false;
+		$subscriptions	    = array();
 
 		if ( $is_valid_token ) {
 			/**
@@ -113,9 +114,6 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 			);
 			$subscriptions      = (array) $payload['subscriptions'];
 			$is_paid_subscriber = $this->validate_subscriptions( $valid_plan_ids, $subscriptions );
-		} else {
-			// Token not valid. We bail even unless the post can be accessed publicly.
-			return $this->user_has_access( $access_level, false, false, get_the_ID(), array() );
 		}
 
 		$has_access = $this->user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, get_the_ID(), $subscriptions );
@@ -137,6 +135,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	 */
 	protected function user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, $post_id, $user_abbreviated_subscriptions ) {
 		$has_access = false;
+
 		if ( is_user_logged_in() && current_user_can( 'edit_post', $post_id ) ) {
 			// Admin has access
 			$has_access = true;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -175,7 +175,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 		}
 
 		// We now need the tier price and currency, and the same for the annual price (if available)
-		$tier_meta         = get_post_meta( $post_id, $tier_id );
+		$tier_meta         = get_post_meta( $tier_id );
 		$tier_price        = $tier_meta['jetpack_memberships_price'][0];
 		$tier_currency     = $tier_meta['jetpack_memberships_currency'][0];
 		$tier_product_id   = $tier_meta['jetpack_memberships_product_id'][0];
@@ -198,7 +198,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 				$linked_post_tier
 			);
 
-			$annual_tier_meta  = get_post_meta( $post_id, $annual_tier_id );
+			$annual_tier_meta  = get_post_meta( $annual_tier_id );
 			$annual_tier_price = isset( $annual_tier_meta['jetpack_memberships_price'][0] ) ? $annual_tier_meta['jetpack_memberships_price'][0] : $annual_tier_price;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -155,7 +155,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 		}
 
 		if ( empty( $has_access ) && ( $access_level === self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS ) ) {
-			$has_access =  $is_paid_subscriber && ! $this->maybe_gate_access_for_user_if_tier( $post_id, $user_abbreviated_subscriptions );
+			$has_access =  $is_paid_subscriber && ! $this->maybe_gate_access_for_user_if_post_tier( $post_id, $user_abbreviated_subscriptions );
 		}
 
 		do_action( 'earn_user_has_access', $access_level, $has_access, $is_blog_subscriber, $is_paid_subscriber, $post_id );

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -209,11 +209,6 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 				continue;
 			}
 
-			if ( $details->status !== 'active' ) {
-				// subscription not active anymore
-				continue;
-			}
-
 			$subscription_post_id = get_posts(
 				array(
 					'posts_per_page' => 1,

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -72,7 +72,7 @@ class WPCOM_Online_Subscription_Service extends WPCOM_Token_Subscription_Service
 		$subscriptions      = self::abbreviate_subscriptions( $subscriptions );
 		$is_paid_subscriber = $this->validate_subscriptions( $valid_plan_ids, $subscriptions );
 
-		return $this->user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, $post_id );
+		return $this->user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, $post_id, $subscriptions );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -80,7 +80,7 @@ class WPCOM_Online_Subscription_Service extends WPCOM_Token_Subscription_Service
 	 *
 	 * @param array $subscriptions_from_bd .
 	 *
-	 * @return array<int, array>
+	 * @return array<int, object>
 	 */
 	public static function abbreviate_subscriptions( $subscriptions_from_bd ) {
 		$subscriptions = array();

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -803,43 +803,44 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 						?>
 					</p>
 
-				<p id="subscribe-submit"
-					<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-						style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
-					<?php endif; ?>
-				>
-					<input type="hidden" name="action" value="subscribe"/>
-					<input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
-					<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
-					<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
-					<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
-					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-					<?php
-					if ( ! empty( $post_id ) ) {
-						echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
-					}
-					?>
-					<?php
-					if ( ! empty( $tier_id ) ) {
-						echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
-					}
-					?>
-					<button type="submit"
-						<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-							class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
-						<?php endif; ?>
-						<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-							style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
+					<p id="subscribe-submit"
+						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
 						<?php endif; ?>
 					>
+						<input type="hidden" name="action" value="subscribe"/>
+						<input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
+						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
+						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
+						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+						<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
 						<?php
-						echo wp_kses(
-							html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-							Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
-						);
+						if ( ! empty( $post_id ) ) {
+							echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
+						}
 						?>
-					</button>
-				</p>
+						<?php
+						if ( ! empty( $tier_id ) ) {
+							echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
+						}
+						?>
+						<button type="submit"
+							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
+							<?php endif; ?>
+							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
+							<?php endif; ?>
+						>
+							<?php
+							echo wp_kses(
+								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+							);
+							?>
+						</button>
+					</p>
+				</div>
 			</form>
 			<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
@@ -918,49 +919,49 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 							/>
 						</p>
 
-
-					<p id="subscribe-submit"
-						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
-						<?php endif; ?>
-					>
-						<input type="hidden" name="action" value="subscribe"/>
-						<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
-						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
-						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
-						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
-						<?php
-						if ( ! empty( $post_id ) ) {
-							echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
-						}
-						?>
-						<?php
-						if ( ! empty( $tier_id ) ) {
-							echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
-						}
-						?>
-						<?php
-						if ( is_user_logged_in() ) {
-							wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
-						}
-						?>
-						<button type="submit"
-							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
+						<p id="subscribe-submit"
+							<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+								style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
 							<?php endif; ?>
-							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
-							<?php endif; ?>
-							name="jetpack_subscriptions_widget"
 						>
+							<input type="hidden" name="action" value="subscribe"/>
+							<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
+							<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
+							<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
+							<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 							<?php
-							echo wp_kses(
-								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
-							);
+							if ( ! empty( $post_id ) ) {
+								echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
+							}
 							?>
-						</button>
-					</p>
+							<?php
+							if ( ! empty( $tier_id ) ) {
+								echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
+							}
+							?>
+							<?php
+							if ( is_user_logged_in() ) {
+								wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
+							}
+							?>
+							<button type="submit"
+								<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+									class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
+								<?php endif; ?>
+								<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+									style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
+								<?php endif; ?>
+								name="jetpack_subscriptions_widget"
+							>
+								<?php
+								echo wp_kses(
+									html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+									Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+								);
+								?>
+							</button>
+						</p>
+					</div>
 				</form>
 
 				<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -93,6 +93,19 @@ function register_block() {
 		)
 	);
 
+	register_post_meta(
+		'post',
+		META_NAME_FOR_POST_TIER_ID_SETTINGS,
+		array(
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'string',
+			'auth_callback' => function () {
+				return wp_get_current_user()->has_cap( 'edit_posts' );
+			},
+		)
+	);
+
 	// This ensures Jetpack will sync this post meta to WPCOM.
 	add_filter(
 		'jetpack_sync_post_meta_whitelist',

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -737,7 +737,10 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 		)
 	);
 
-	$post_access_level     = get_post_access_level_for_current_post();
+	$post_access_level = get_post_access_level_for_current_post();
+	$post_id           = get_the_ID();
+	$tier_id           = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
+
 	$newsletter_categories = $data['newsletter_categories'];
 
 	?>
@@ -810,6 +813,12 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
 						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 						<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
+						<?php if ( ! empty( $post_id ) ) {
+							echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
+						}?>
+						<?php if ( ! empty( $tier_id ) ) {
+							echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
+						}?>
 						<button type="submit"
 							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
 								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
@@ -855,6 +864,7 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 	$form_id            = sprintf( 'subscribe-blog-%s', $data['widget_id'] );
 	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field', $data['widget_id'] );
+
 	ob_start();
 
 	Jetpack_Subscriptions_Widget::render_widget_status_messages(
@@ -865,6 +875,8 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 
 	$blog_id           = \Jetpack_Options::get_option( 'id' );
 	$post_access_level = get_post_access_level_for_current_post();
+	$post_id           = get_the_ID();
+	$tier_id           = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
 
 	$newsletter_categories = $data['newsletter_categories'];
 
@@ -913,6 +925,12 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 							<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
 							<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
 							<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+							<?php if ( ! empty( $post_id ) ) {
+								echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
+							}?>
+							<?php if ( ! empty( $tier_id ) ) {
+								echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
+							}?>
 							<?php
 							if ( is_user_logged_in() ) {
 								wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -802,40 +802,43 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 						?>
 					</p>
 
-					<p id="subscribe-submit"
-						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+				<p id="subscribe-submit"
+					<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+						style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+					<?php endif; ?>
+				>
+					<input type="hidden" name="action" value="subscribe"/>
+					<input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
+					<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
+					<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
+					<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
+					<?php
+					if ( ! empty( $post_id ) ) {
+						echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
+					}
+					?>
+					<?php
+					if ( ! empty( $tier_id ) ) {
+						echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
+					}
+					?>
+					<button type="submit"
+						<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+							class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
+						<?php endif; ?>
+						<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+							style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
 						<?php endif; ?>
 					>
-						<input type="hidden" name="action" value="subscribe"/>
-						<input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
-						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
-						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
-						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
-						<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-						<?php if ( ! empty( $post_id ) ) {
-							echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
-						}?>
-						<?php if ( ! empty( $tier_id ) ) {
-							echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
-						}?>
-						<button type="submit"
-							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
-							<?php endif; ?>
-							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
-							<?php endif; ?>
-						>
-							<?php
-							echo wp_kses(
-								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
-							);
-							?>
-						</button>
-					</p>
-				</div>
+						<?php
+						echo wp_kses(
+							html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+							Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+						);
+						?>
+					</button>
+				</p>
 			</form>
 			<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
@@ -915,45 +918,48 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 						</p>
 
 
-						<p id="subscribe-submit"
-							<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-								style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+					<p id="subscribe-submit"
+						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+						<?php endif; ?>
+					>
+						<input type="hidden" name="action" value="subscribe"/>
+						<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
+						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
+						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
+						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+						<?php
+						if ( ! empty( $post_id ) ) {
+							echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
+						}
+						?>
+						<?php
+						if ( ! empty( $tier_id ) ) {
+							echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
+						}
+						?>
+						<?php
+						if ( is_user_logged_in() ) {
+							wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
+						}
+						?>
+						<button type="submit"
+							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
 							<?php endif; ?>
+							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
+							<?php endif; ?>
+							name="jetpack_subscriptions_widget"
 						>
-							<input type="hidden" name="action" value="subscribe"/>
-							<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
-							<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
-							<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
-							<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
-							<?php if ( ! empty( $post_id ) ) {
-								echo '<input type="hidden" name="post_id" value="' . esc_attr( $post_id ) . '"/>';
-							}?>
-							<?php if ( ! empty( $tier_id ) ) {
-								echo '<input type="hidden" name="tier_id" value="' . esc_attr( $tier_id ) . '"/>';
-							}?>
 							<?php
-							if ( is_user_logged_in() ) {
-								wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
-							}
+							echo wp_kses(
+								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+							);
 							?>
-							<button type="submit"
-								<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-									class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
-								<?php endif; ?>
-								<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-									style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
-								<?php endif; ?>
-								name="jetpack_subscriptions_widget"
-							>
-								<?php
-								echo wp_kses(
-									html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-									Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
-								);
-								?>
-							</button>
-						</p>
-					</div>
+						</button>
+					</p>
 				</form>
 
 				<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -628,6 +628,7 @@ function render_block( $attributes ) {
 	$styles  = get_element_styles_from_attributes( $attributes );
 
 	$include_social_followers = isset( $attributes['includeSocialFollowers'] ) ? (bool) get_attribute( $attributes, 'includeSocialFollowers' ) : true;
+	$is_paid_subscriber       = get_attribute( $attributes, 'isPaidSubscriber', false );
 
 	$data = array(
 		'widget_id'              => Jetpack_Subscriptions_Widget::$instance_count,
@@ -639,7 +640,7 @@ function render_block( $attributes ) {
 			)
 		),
 		'subscribe_placeholder'  => get_attribute( $attributes, 'subscribePlaceholder', esc_html__( 'Type your email…', 'jetpack' ) ),
-		'submit_button_text'     => get_attribute( $attributes, 'submitButtonText', esc_html__( 'Subscribe', 'jetpack' ) ),
+		'submit_button_text'     => get_attribute( $attributes, 'submitButtonText', $is_paid_subscriber ? esc_html__( 'Upgrade', 'jetpack' ) : esc_html__( 'Subscribe', 'jetpack' ) ),
 		'success_message'        => get_attribute(
 			$attributes,
 			'successMessage',
@@ -1167,13 +1168,18 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	}
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	// Only display paid texts when Stripe is connected and the post is marked for paid subscribers
-	$is_paid_post = $newsletter_access_level === 'paid_subscribers' && Jetpack_Memberships::has_connected_account();
+	$is_paid_post       = $newsletter_access_level === 'paid_subscribers' && Jetpack_Memberships::has_connected_account();
+	$is_paid_subscriber = Jetpack_Memberships::user_is_paid_subscriber();
 
-	$access_heading = esc_html__( 'Subscribe to continue reading', 'jetpack' );
+	$access_heading = $is_paid_subscriber
+		? esc_html__( 'Upgrade to continue reading', 'jetpack' )
+		: esc_html__( 'Subscribe to continue reading', 'jetpack' );
 
 	$subscribe_text = $is_paid_post
 		// translators: %s is the name of the site.
-		? esc_html__( 'Become a paid subscriber to get access to the rest of this post and other exclusive content.', 'jetpack' )
+		? $is_paid_subscriber
+		? esc_html__( 'Upgrade to get access to the rest of this post and other exclusive content.', 'jetpack' )
+		: esc_html__( 'Become a paid subscriber to get access to the rest of this post and other exclusive content.', 'jetpack' )
 		// translators: %s is the name of the site.
 		: esc_html__( 'Subscribe to get access to the rest of this post and other subscriber-only content.', 'jetpack' );
 
@@ -1206,7 +1212,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 <p class="has-text-align-center" style="margin-top:10px;margin-bottom:10px;font-size:14px">' . $subscribe_text . '</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->
+<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact","isPaidSubscriber":' . ( $is_paid_subscriber ? 'true' : 'false' ) . '} /-->
 ' . $sign_in . '
 </div>
 <!-- /wp:group -->

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -41,13 +41,12 @@ domReady( function () {
 				.filter( checkbox => ! checkbox.checked )
 				.map( checkbox => checkbox.value );
 
+			// If all are unchecked, we treat it as if no exclusions were made.
 			const has_excluded_newsletter_categories =
 				unchecked_newsletter_categories.length > 0 &&
 				unchecked_newsletter_categories.length !== newsletter_category_checkboxes.length; // If all are unchecked, we treat it as if no exclusions were made.
 
-			const excluded_newsletter_categories_clause = has_excluded_newsletter_categories ? `&excluded_newsletter_categories=${unchecked_newsletter_categories.join( ',' )}` : '';
-
-			const url =
+			let url =
 				'https://subscribe.wordpress.com/memberships/?' +
 				'blog=' +
 				form.dataset.blog +
@@ -58,8 +57,12 @@ domReady( function () {
 				'&display=alternate' +
 				post_id_clause +
 				tier_id_clause +
-				email_clause +
-				excluded_newsletter_categories_clause;
+				email_clause;
+
+			if ( has_excluded_newsletter_categories ) {
+				url += '&excluded_newsletter_categories=' + unchecked_newsletter_categories.join( ',' );
+			}
+
 			window.scrollTo( 0, 0 );
 			tb_show( null, url + '&TB_iframe=true', null );
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -19,11 +19,18 @@ domReady( function () {
 		form.payments_attached = true;
 		form.addEventListener( 'submit', function ( event ) {
 			const email = form.querySelector( 'input[type=email]' ).value;
+			const email_clause = email ? `&email=${ encodeURIComponent( email ) }` : '';
+			const post_id = form.querySelector( 'input[name=post_id]' )?.value;
+			const post_id_clause = post_id ? `&post_id=${ post_id }` : '';
+			const tier_id = form.querySelector( 'input[name=tier_id]' )?.value;
+			const tier_id_clause = tier_id ? `&tier_id=${ tier_id }` : '';
+
 			if ( form.resubmitted || ! email ) {
 				return;
 			}
 			event.preventDefault();
 
+			// get all unchecked categories
 			const newsletter_category_checkboxes = Array.from(
 				form.querySelectorAll(
 					'.wp-block-jetpack-subscriptions__newsletter-category input[type=checkbox]'
@@ -38,7 +45,9 @@ domReady( function () {
 				unchecked_newsletter_categories.length > 0 &&
 				unchecked_newsletter_categories.length !== newsletter_category_checkboxes.length; // If all are unchecked, we treat it as if no exclusions were made.
 
-			let url =
+			const excluded_newsletter_categories_clause = has_excluded_newsletter_categories ? `&excluded_newsletter_categories=${unchecked_newsletter_categories.join( ',' )}` : '';
+
+			const url =
 				'https://subscribe.wordpress.com/memberships/?' +
 				'blog=' +
 				form.dataset.blog +
@@ -47,13 +56,10 @@ domReady( function () {
 				'&post_access_level=' +
 				form.dataset.post_access_level +
 				'&display=alternate' +
-				'&email=' +
-				encodeURIComponent( email );
-
-			if ( has_excluded_newsletter_categories ) {
-				url += '&excluded_newsletter_categories=' + unchecked_newsletter_categories.join( ',' );
-			}
-
+				post_id_clause +
+				tier_id_clause +
+				email_clause +
+				excluded_newsletter_categories_clause;
 			window.scrollTo( 0, 0 );
 			tb_show( null, url + '&TB_iframe=true', null );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/constants.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/constants.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 
 export const META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS = '_jetpack_newsletter_access';
+export const META_NAME_FOR_POST_TIER_ID_SETTINGS = '_jetpack_newsletter_tier_id';
 export const accessOptions = {
 	everybody: {
 		key: 'everybody',

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -1,4 +1,12 @@
-import { Flex, FlexBlock, PanelRow, VisuallyHidden, Spinner, Button } from '@wordpress/components';
+import {
+	Flex,
+	FlexBlock,
+	PanelRow,
+	VisuallyHidden,
+	Spinner,
+	Button,
+	RadioControl,
+} from '@wordpress/components';
 import { useInstanceId, useViewportMatch } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -113,28 +121,22 @@ function TierSelector( { onChange } ) {
 
 	return (
 		<div className="jetpack-editor-post-tiers">
-			{ products.map( product => (
-				<div key={ product.id }>
-					<input
-						type="radio"
-						name="tier"
-						checked={ Number( tierId ) === product.id }
-						value={ product.id }
-						onChange={ event => {
-							const obj = {};
-							obj[ META_NAME_FOR_POST_TIER_ID_SETTINGS ] = event?.target?.value;
-							return onChange && onChange( obj );
-						} }
-						id={ `editor-post-tier-${ product.id }` }
-					/>
-					<label htmlFor={ `editor-post-tier-${ product.id }` }>
-						{
-							/* Translators: Tier title (example: "Gold tier"). */
-							sprintf( __( '%s subscribers', 'jetpack' ), product.title )
-						}
-					</label>
-				</div>
-			) ) }
+			<RadioControl
+				label={ __( 'Choose Newsletter Tier', 'jetpack' ) }
+				hideLabelFromVision={ true }
+				selected={ Number( tierId ) }
+				options={ products.map( product => {
+					/* Translators: %s is the tier label created by site user */
+					const label = sprintf( __( '%s subscribers', 'jetpack' ), product.title );
+					const value = Number( product.id );
+					return { label, value };
+				} ) }
+				onChange={ newValue => {
+					const obj = {};
+					obj[ META_NAME_FOR_POST_TIER_ID_SETTINGS ] = newValue;
+					return onChange && onChange( obj );
+				} }
+			/>
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -126,8 +126,11 @@ function TierSelector( { onChange } ) {
 				hideLabelFromVision={ true }
 				selected={ Number( tierId ) }
 				options={ products.map( product => {
-					/* Translators: %s is the tier label created by site user */
-					const label = sprintf( __( '%s subscribers', 'jetpack' ), product.title );
+					const label = sprintf(
+						/* Translators: %s is the tier label created by site user */
+						__( '%s subscribers', 'jetpack' ),
+						product.title
+					);
 					const value = Number( product.id );
 					return { label, value };
 				} ) }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -121,7 +121,7 @@ function TierSelector( { onChange } ) {
 
 	// if no tier are selected, we select the lowest one
 	if ( ! tierId ) {
-		tierId = products[ products.length - 1 ];
+		tierId = products[ products.length - 1 ].id;
 		const obj = {};
 		obj[ META_NAME_FOR_POST_TIER_ID_SETTINGS ] = tierId;
 		// Call the callback

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -4,7 +4,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import { icon as paywallIcon, blockName as paywallBlockName } from '../../blocks/paywall';
 import { store as membershipProductsStore } from '../../store/membership-products';
@@ -128,7 +128,10 @@ function TierSelector( { onChange } ) {
 						id={ `editor-post-tier-${ product.id }` }
 					/>
 					<label htmlFor={ `editor-post-tier-${ product.id }` }>
-						{ product.title } subscribers
+						{
+							/* Translators: Tier title (example: "Gold tier"). */
+							sprintf( __( '%s subscribers', 'jetpack' ), product.title )
+						}
 					</label>
 				</div>
 			) ) }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -107,7 +107,7 @@ function TierSelector( { onChange } ) {
 	// Find the current tier meta
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	// Destructure the tierId from the meta (set tierId using the META_NAME_FOR_POST_TIER_ID_SETTINGS constant)
-	const [ { [ META_NAME_FOR_POST_TIER_ID_SETTINGS ]: tierId } ] = useEntityProp(
+	let [ { [ META_NAME_FOR_POST_TIER_ID_SETTINGS ]: tierId } ] = useEntityProp(
 		'postType',
 		postType,
 		'meta'
@@ -117,6 +117,15 @@ function TierSelector( { onChange } ) {
 	// the hooks have to run before any early returns)
 	if ( products.length < 2 ) {
 		return;
+	}
+
+	// if no tier are selected, we select the lowest one
+	if ( tierId === null ) {
+		tierId = products[ products.length - 1 ];
+		const obj = {};
+		obj[ META_NAME_FOR_POST_TIER_ID_SETTINGS ] = tierId;
+		// Call the callback
+		onChange && setTimeout( () => onChange( obj ) );
 	}
 
 	return (

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -112,7 +112,7 @@ function TierSelector( { onChange } ) {
 	}
 
 	return (
-		<div className="editor-post-tiers">
+		<div className="jetpack-editor-post-tiers">
 			{ products.map( product => (
 				<div key={ product.id }>
 					<input

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -120,7 +120,7 @@ function TierSelector( { onChange } ) {
 	}
 
 	// if no tier are selected, we select the lowest one
-	if ( tierId === null ) {
+	if ( ! tierId ) {
 		tierId = products[ products.length - 1 ];
 		const obj = {};
 		obj[ META_NAME_FOR_POST_TIER_ID_SETTINGS ] = tierId;

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
@@ -75,3 +75,12 @@
 	}
 
 }
+
+.editor-post-tiers {
+	padding-left: 35px;
+	padding-top: 5px;
+
+	div {
+		margin-top: 10px;
+	}
+}

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
@@ -76,7 +76,7 @@
 
 }
 
-.editor-post-tiers {
+.jetpack-editor-post-tiers {
 	padding-left: 35px;
 	padding-top: 5px;
 

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -172,6 +172,9 @@ class Jetpack_Memberships {
 			'product_id'      => array(
 				'meta' => $meta_prefix . 'product_id',
 			),
+			'tier'            => array(
+				'meta' => $meta_prefix . 'tier',
+			),
 		);
 		return $properties;
 	}

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -97,6 +97,13 @@ class Jetpack_Memberships {
 	private static $user_can_view_post_cache = array();
 
 	/**
+	 * Cached results of user_is_paid_subscriber() method.
+	 *
+	 * @var array
+	 */
+	private static $user_is_paid_subscriber_cache = array();
+
+	/**
 	 * Currencies we support and Stripe's minimum amount for a transaction in that currency.
 	 *
 	 * @link https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
@@ -489,6 +496,23 @@ class Jetpack_Memberships {
 		$user = wp_get_current_user();
 		// phpcs:ignore ImportDetection.Imports.RequireImports.Symbol
 		return 0 !== $user->ID && current_user_can( 'edit_post', get_the_ID() );
+	}
+
+	/**
+	 * Determines whether the current user can view the post based on the newsletter access level
+	 * and caches the result.
+	 *
+	 * @return bool Whether the post can be viewed
+	 */
+	public static function user_is_paid_subscriber() {
+		$user_id = get_current_user_id();
+
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+		$paywall            = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+		$is_paid_subscriber = $paywall->visitor_can_view_content( self::get_all_newsletter_plan_ids(), Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS );
+
+		self::$user_is_paid_subscriber_cache[ $user_id ] = $is_paid_subscriber;
+		return $is_paid_subscriber;
 	}
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-metadata.php
+++ b/projects/plugins/jetpack/sal/class.json-api-metadata.php
@@ -4,6 +4,9 @@
  *
  * @package automattic/jetpack
  */
+
+use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
+
 /**
  * Base class for WPCOM_JSON_API_Metadata
  */
@@ -53,8 +56,14 @@ class WPCOM_JSON_API_Metadata {
 			return false;
 		}
 
-		// We want to always return the `_jetpack_newsletter_access` key to display the correct newsletter access in Calypso.
-		if ( $key === '_jetpack_newsletter_access' ) {
+		// We want to always return the `_jetpack_newsletter_access` key to
+		// display the correct newsletter access in Calypso.
+		$whitelist = array(
+			'_jetpack_newsletter_access',
+			META_NAME_FOR_POST_TIER_ID_SETTINGS,
+		);
+
+		if ( in_array( $key, $whitelist, true ) ) {
 			return false;
 		}
 

--- a/projects/plugins/jetpack/sal/class.json-api-metadata.php
+++ b/projects/plugins/jetpack/sal/class.json-api-metadata.php
@@ -5,8 +5,6 @@
  * @package automattic/jetpack
  */
 
-use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
-
 /**
  * Base class for WPCOM_JSON_API_Metadata
  */
@@ -60,7 +58,7 @@ class WPCOM_JSON_API_Metadata {
 		// display the correct newsletter access in Calypso.
 		$whitelist = array(
 			'_jetpack_newsletter_access',
-			META_NAME_FOR_POST_TIER_ID_SETTINGS,
+			'_jetpack_newsletter_tier_id',
 		);
 
 		if ( in_array( $key, $whitelist, true ) ) {

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
@@ -649,11 +649,13 @@ class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
 		);
 		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 
+		// This was removed because subscriptions in JWT_token does not provide the subscription status
+		// See https://github.com/Automattic/jetpack/pull/32710/commits/7e874089416d4d0f6b27d03420055f4b55d3c1e2
 		// Let's make sure inactive subscriptions do not count
-		$subscription_service = $this->set_returned_token(
-			$this->get_payload( true, true, null, 'inactive', $gold_tier_annual_plan_id )
-		);
-		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+		// $subscription_service = $this->set_returned_token(
+		// $this->get_payload( true, true, null, 'inactive', $gold_tier_annual_plan_id )
+		// );
+		// $this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 
 		// Let's make sure non-paid subscribers do not count
 		$subscription_service = $this->set_returned_token(

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
@@ -11,7 +11,8 @@ use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Off
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Online_Subscription_Service;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Token_Subscription_Service;
 use function Automattic\Jetpack\Extensions\Subscriptions\register_block as register_subscription_block;
-use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
+use const \Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
+use const \Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
 
 define( 'EARN_JWT_SIGNING_KEY', 'whatever=' );
 
@@ -531,6 +532,133 @@ class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
 		update_post_meta( $newsletter_paid_post_id, '_jetpack_newsletter_access', $post_access_level );
 
 		$GLOBALS['post'] = get_post( $newsletter_paid_post_id );
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+	}
+
+	/**
+	 * Create a tier
+	 *
+	 * @param int        $newsletter_product_id Plan id.
+	 * @param int        $newsletter_annual_product_id Annual plan ID.
+	 * @param float      $price plan price.
+	 * @param float|null $annual_price annual plan price.
+	 * @param string     $currency currency.
+	 * @return int post tier ID
+	 */
+	private function setup_jetpack_tier( $newsletter_product_id, $newsletter_annual_product_id, $price, $annual_price = null, $currency = 'EUR' ) {
+		/**
+		 * Create a newsletter plan
+		 */
+		$newsletter_plan_id = $this->factory->post->create(
+			array(
+				'post_type' => Jetpack_Memberships::$post_type_plan,
+			)
+		);
+		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_product_id', $newsletter_product_id );
+		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_site_subscriber', true );
+		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_price', $price );
+		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_currency', $currency );
+		update_post_meta( $newsletter_plan_id, 'jetpack_memberships_interval', '1 month' );
+
+		$this->factory->post->create();
+
+		if ( $annual_price !== null ) {
+			$newsletter_annual_plan_id = $this->factory->post->create(
+				array(
+					'post_type' => Jetpack_Memberships::$post_type_plan,
+				)
+			);
+			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_product_id', $newsletter_annual_product_id );
+			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_site_subscriber', true );
+			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_price', $annual_price );
+			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_currency', $currency );
+			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_interval', '1 year' );
+			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_tier', $newsletter_product_id );
+
+			$this->factory->post->create();
+		}
+
+		return $newsletter_plan_id;
+	}
+
+	public function test_newsletter_tiers() {
+		$bronze_tier_plan_id        = 1000;
+		$bronze_tier_annual_plan_id = 2000;
+		$silver_tier_plan_id        = 3000;
+		$silver_tier_annual_plan_id = 5000;
+		$gold_tier_plan_id          = 6000;
+		$gold_tier_annual_plan_id   = 7000;
+
+		$this->setup_jetpack_tier( $bronze_tier_plan_id, $bronze_tier_annual_plan_id, 10, 100 );
+		$silver_tier_id = $this->setup_jetpack_tier( $silver_tier_plan_id, $silver_tier_annual_plan_id, 20, 200 );
+		$this->setup_jetpack_tier( $gold_tier_plan_id, $gold_tier_annual_plan_id, 30, 300 );
+
+		/**
+		 * Setup a paid newsletter plan and post then verify a premium content customer cannot access a newsletter paid post
+		 */
+		$post_access_level       = 'paid_subscribers';
+		$newsletter_paid_post_id = $this->setup_jetpack_paid_newsletters();
+		update_post_meta( $newsletter_paid_post_id, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, $post_access_level );
+
+		$GLOBALS['post'] = get_post( $newsletter_paid_post_id );
+
+		// No subscription
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, false, null, null, 0 )
+		);
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// We now set the "middle" tier in price
+		update_post_meta( $newsletter_paid_post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, $silver_tier_id );
+
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// Let's subscribe the user to the Bronze, monthly or annual
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, null, $bronze_tier_plan_id )
+		);
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, null, $bronze_tier_annual_plan_id )
+		);
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// Let subscribe to the silver, monthly and annual
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, null, $silver_tier_plan_id )
+		);
+		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, null, $silver_tier_annual_plan_id )
+		);
+		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// Let subscribe to the gold, monthly and annual
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, null, $gold_tier_plan_id )
+		);
+		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, null, $gold_tier_annual_plan_id )
+		);
+		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// Let's make sure date is taken into account
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, time() - HOUR_IN_SECONDS, null, $gold_tier_annual_plan_id )
+		);
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// Let's make sure inactive subscriptions do not count
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, 'inactive', $gold_tier_annual_plan_id )
+		);
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// Let's make sure non-paid subscribers do not count
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, false, null, null, $gold_tier_annual_plan_id )
+		);
 		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/test_class.jetpack-subscriptions.php
@@ -11,8 +11,8 @@ use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Off
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Online_Subscription_Service;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Token_Subscription_Service;
 use function Automattic\Jetpack\Extensions\Subscriptions\register_block as register_subscription_block;
-use const \Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
-use const \Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
+use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
+use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
 
 define( 'EARN_JWT_SIGNING_KEY', 'whatever=' );
 
@@ -573,7 +573,7 @@ class WP_Test_Jetpack_Subscriptions extends WP_UnitTestCase {
 			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_price', $annual_price );
 			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_currency', $currency );
 			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_interval', '1 year' );
-			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_tier', $newsletter_product_id );
+			update_post_meta( $newsletter_annual_plan_id, 'jetpack_memberships_tier', $newsletter_plan_id );
 
 			$this->factory->post->create();
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/118
Fixes https://github.com/Automattic/gold/issues/119
Fixes https://github.com/Automattic/gold/issues/140

Needs those related PRs:
 - ~WPCOM: D120952-code~ (merged)
 - ~WPCOM: D121198-code~ (merged)
- ~Calypso: https://github.com/Automattic/wp-calypso/pull/81014~ [OLD]
- Calypso: https://github.com/Automattic/wp-calypso/pull/82728

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds tiers to Newsletters
* This branch merges all those PRs into a feature branch:
  - https://github.com/Automattic/jetpack/pull/32683
  - https://github.com/Automattic/jetpack/pull/32658
  - https://github.com/Automattic/jetpack/pull/32681
  
### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

### Unit tests

- start docker `jetpack docker up -d`
- `jetpack docker phpunit -- -c tests/php.multisite.xml --testsuite=subscriptions --filter=test_newsletter_tiers`

### Live tests

This needs to be tested on both WPCOM simple, and JN/Atomic/self-hosted sites:

### on Jurassic Ninja or self-hosted: make sure to 
 - make sure  to enable the newsletter options in the jetpack settings.
 - make sure to set `JETPACK__SANDBOX_DOMAIN` to your sandbox address (see `wp-admin/options-general.php?page=companion_settings` in JN) and enable global http in your sandbox.

### Common tests for WPCOM Simple sites and self-hosted
- ~Apply D119740-code on your sandbox~ (merged)
- Patch this PR on your sandbox
```
bin/jetpack-downloader test jetpack add/newsletter-tiers-feature
```

- Run this https://github.com/Automattic/wp-calypso/pull/81014 via `yarn start` or [the "live" link](https://calypso.live/?image=registry.a8c.com/calypso/app:build-78948) in https://github.com/Automattic/wp-calypso/pull/81014
- Use `define( 'USE_STORE_SANDBOX', true );`
- Sandbox `public-api.wordpress.com`, `subscribe.wordpress.com` and the test site (if testing on a simple site).
- on Jurrassic-Ninja , link the instance to call your sandbox 

On a Simple site or a JN site:
- From the Earn dashboard, connect Stripe if needed
- Create a 3 tier plans on a site (Gold, SIlver and Bronze for example) via Calypso
<img width="300" alt="Screenshot 2023-08-28 at 16 58 13" src="https://github.com/Automattic/jetpack/assets/790558/246248bb-6165-4d29-b5c7-da0e99921898">


- Create a new post with a Silver tier (example this post: https://bestmemberships.wordpress.com/2023/08/28/silver-tier-content/) 
<img width="300" alt="Screenshot 2023-08-28 at 17 29 53" src="https://github.com/Automattic/jetpack/assets/790558/d2e56e28-39a9-4c13-8a79-e347ff38137c">

- Open a new incognito and go to the test page
- You should NOT be able to see the post
<img width="300" alt="Screenshot 2023-08-28 at 17 32 56" src="https://github.com/Automattic/jetpack/assets/790558/79df5e91-8ac0-4783-98df-88cd309e4c65">


- Open a new incognito and Subscribe to a a Silver tier
<img width="300" alt="Screenshot 2023-08-28 at 17 52 07" src="https://github.com/Automattic/jetpack/assets/790558/2685d7d5-5280-4832-a363-8ae036cd209c">

- You should be able to see the post
<img width="300" alt="Screenshot 2023-08-28 at 18 51 08" src="https://github.com/Automattic/jetpack/assets/790558/92637a71-88fe-4452-876d-1763fb78755d">


- Open a new incognito and Subscribe to a a Bronze tier with a new user (use `EMAIL+%SOME_RANDOM_NB%@YOUR_EMAIL.COM`
- You should be NOT able to see the post
- Open a new incognito and Subscribe to a Gold tier with a new user (use `EMAIL+%SOME_RANDOM_NB%@YOUR_EMAIL.COM`
- You SHOULD be able to see the post


#### Use cases that cannot be tested
It looks like emails are sent from a global async job and therefore is very hard to test (might run into weird issues). So this will need to be tested once it is on production... 
- Send a gated post for Gold -> you should receive an email only on your "Gold" email
- Send a gated post for Bronze -> you should receive the email on your "Gold" and "Silver" email
- Send a gated post for Silver -> you should receive the email  on all the emails