### PR TITLE
Paywall: Add tracks to emails

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-email-tracks
+++ b/projects/plugins/jetpack/changelog/update-paywall-email-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Paywall: Add tracks to emails

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -884,6 +884,7 @@ function get_paywall_simple() {
             <!-- wp:button -->
             <div class="wp-block-button" style="display: inline-block; margin: 10px 0;">
                 <a href="#" class="wp-block-button__link wp-element-button"
+                   data-wpcom-track data-tracks-link-desc="paywall-email-click"
                    style="display: inline-block;
                           padding: 15px 20px;
                           background-color: #0675C4;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -883,7 +883,7 @@ function get_paywall_simple() {
         <div class="wp-block-buttons" style="text-align: center;">
             <!-- wp:button -->
             <div class="wp-block-button" style="display: inline-block; margin: 10px 0;">
-                <a href="#" class="wp-block-button__link wp-element-button"
+                <a href="' . esc_url( get_post_permalink() ) . '" class="wp-block-button__link wp-element-button"
                    data-wpcom-track data-tracks-link-desc="paywall-email-click"
                    style="display: inline-block;
                           padding: 15px 20px;


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds tracks event to the paywall on emails.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, it adds a tracks event to the paywall button click on emails.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ping me for instructions 👀 

