### PR TITLE
CRM: Automation - Update the data type to avoid data inconsistencies using entities

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3291-data-inconsistencies-transformers-unify-data
+++ b/projects/plugins/crm/changelog/fix-crm-3291-data-inconsistencies-transformers-unify-data
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update the Data_Type system for using entities for unifying data with a common entity
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -3022,12 +3022,12 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 									'prev_contact' => $previous_contact_obj,
                                     ));
 
-	                            // Generate the old Contact object from the old contact data
-	                            $old_contact_obj = new Contact( $previous_contact_obj );
-								
+								// Generate the old Contact object from the old contact data.
+								$old_contact_obj = new Contact( $previous_contact_obj );
+
 								// Generate the new contact object getting the data from the previous one.
 								$contact_obj = new Contact( $previous_contact_obj );
-								
+
 								// Overwrite the new one with the updated data.
 								$contact_obj->set_db_contact_data( $dataArr );
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -17,6 +17,7 @@
   / Breaking Checks
    ====================================================== */
 
+use Automattic\Jetpack\CRM\Entities\Contact;
 use Automattic\Jetpack\CRM\Event_Manager\Events_Manager;
 
 /**
@@ -3021,12 +3022,19 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 									'prev_contact' => $previous_contact_obj,
                                     ));
 
-								$dataArr['id'] = $id;
-								$this->events_manager->contact()->updated( $dataArr, $previous_contact_obj );
+	                            // Generate the old Contact object from the old contact data
+	                            $old_contact_obj = new Contact( $previous_contact_obj );
+								
+								// Generate the new contact object getting the data from the previous one.
+								$contact_obj = new Contact( $previous_contact_obj );
+								
+								// Overwrite the new one with the updated data.
+								$contact_obj->set_db_contact_data( $dataArr );
 
+								// Notify the contact (tidied) was updated
+								$this->events_manager->contact()->updated( $contact_obj, $old_contact_obj );
                             }
 
-                                
                             // Successfully updated - Return id
                             return $id;
 

--- a/projects/plugins/crm/src/automation/class-automation-engine.php
+++ b/projects/plugins/crm/src/automation/class-automation-engine.php
@@ -376,12 +376,12 @@ class Automation_Engine {
 	 *
 	 * @param Automation_Workflow $workflow The workflow to be executed.
 	 * @param Trigger             $trigger The trigger that started the execution process.
-	 * @param array               $trigger_data The data that was passed along by the trigger.
+	 * @param mixed               $trigger_data The data that was passed along by the trigger.
 	 * @return bool
 	 *
 	 * @throws Automation_Exception Throws exception if an error executing the workflow.
 	 */
-	public function execute_workflow( Automation_Workflow $workflow, Trigger $trigger, array $trigger_data ): bool {
+	public function execute_workflow( Automation_Workflow $workflow, Trigger $trigger, $trigger_data ): bool {
 		$this->get_logger()->log( sprintf( 'Trigger activated: %s', $trigger->get_slug() ) );
 		$this->get_logger()->log( sprintf( 'Executing workflow: %s', $workflow->name ) );
 

--- a/projects/plugins/crm/src/automation/class-automation-workflow.php
+++ b/projects/plugins/crm/src/automation/class-automation-workflow.php
@@ -225,12 +225,12 @@ class Automation_Workflow {
 	 * @since $$next-version$$
 	 *
 	 * @param Trigger $trigger An instance of the Trigger class.
-	 * @param array   $data All relevant object data to be passed through the workflow.
+	 * @param mixed   $data All relevant object data to be passed through the workflow.
 	 * @return bool Whether the workflow was executed successfully.
 	 *
 	 * @throws Workflow_Exception Throws an exception if there is an issue executing the workflow.
 	 */
-	public function execute( Trigger $trigger, array $data ): bool {
+	public function execute( Trigger $trigger, $data ): bool {
 		return $this->get_engine()->execute_workflow( $this, $trigger, $data );
 	}
 

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact-status.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact-status.php
@@ -10,6 +10,8 @@ namespace Automattic\Jetpack\CRM\Automation\Actions;
 
 use Automattic\Jetpack\CRM\Automation\Base_Action;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
+use Automattic\Jetpack\CRM\Automation\Step_Exception;
+use Automattic\Jetpack\CRM\Entities\Contact;
 
 /**
  * Adds the Update_Contact_Status class.
@@ -87,21 +89,24 @@ class Update_Contact_Status extends Base_Action {
 	/**
 	 * Update the DAL with the new contact status.
 	 *
-	 * @since $$next-version$$
-	 *
 	 * @param mixed  $data Data passed from the trigger.
 	 * @param ?mixed $previous_data (Optional) The data before being changed.
+	 * @throws Step_Exception If the data passed is not a Contact object.
+	 * @since $$next-version$$
+	 *
 	 */
 	public function execute( $data, $previous_data = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $zbs;
 
-		$data['status'] = $this->attributes['new_status'];
-		$zbs->DAL->contacts->addUpdateContact( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			array(
-				'id'   => $data['id'],
-				'data' => $data,
-			)
-		);
-	}
+		/** @var Contact $data */
+		// Check if the data is a Contact object.
+		if ( ! $data instanceof Contact ) {
+			throw new Step_Exception( 'The data passed to the Update_Contact action is not a Contact object.', Step_Exception::STEP_TYPE_NOT_ALLOWED );
+		}
 
+		$data->status = $this->attributes['new_status'];
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$zbs->DAL->contacts->addUpdateContact( $data->get_contact_array_for_db() );
+	}
 }

--- a/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact.php
+++ b/projects/plugins/crm/src/automation/commons/actions/contacts/class-update-contact.php
@@ -10,6 +10,8 @@ namespace Automattic\Jetpack\CRM\Automation\Actions;
 
 use Automattic\Jetpack\CRM\Automation\Base_Action;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
+use Automattic\Jetpack\CRM\Automation\Step_Exception;
+use Automattic\Jetpack\CRM\Entities\Contact;
 
 /**
  * Adds the Update_Contact class.
@@ -91,16 +93,21 @@ class Update_Contact extends Base_Action {
 	 *
 	 * @param mixed  $data Data passed from the trigger.
 	 * @param ?mixed $previous_data (Optional) The data before being changed.
+	 *
+	 * @throws Step_Exception If the data passed is not a Contact object.
 	 */
 	public function execute( $data, $previous_data = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $zbs;
 
-		$zbs->DAL->contacts->addUpdateContact( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			array(
-				'id'   => $data['id'],
-				'data' => array_replace( $data, $this->attributes['data'] ),
-			)
-		);
-	}
+		// Check if the data is a Contact object.
+		if ( ! $data instanceof Contact ) {
+			throw new Step_Exception( 'The data passed to the Update_Contact action is not a Contact object.', Step_Exception::STEP_TYPE_NOT_ALLOWED );
+		}
 
+		$contact         = $data->get_contact_array_for_db();
+		$contact['data'] = array_replace( $contact['data'], $this->attributes['data'] );
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$zbs->DAL->contacts->addUpdateContact( $contact );
+	}
 }

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-field-changed.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-field-changed.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\CRM\Automation\Attribute_Definition;
 use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Base_Condition;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
+use Automattic\Jetpack\CRM\Entities\Contact;
 
 /**
  * Contact_Field_Changed condition class.
@@ -106,11 +107,11 @@ class Contact_Field_Changed extends Base_Condition {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $contact_data The contact data.
+	 * @param Contact $contact_data The contact data.
 	 * @return bool True if the data is valid to detect a field change, false otherwise
 	 */
-	private function is_valid_contact_field_changed_data( array $contact_data ): bool {
-		return isset( $contact_data[ $this->get_attributes()['field'] ] );
+	private function is_valid_contact_field_changed_data( Contact $contact_data ): bool {
+		return isset( $contact_data->{$this->get_attributes()['field']} );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-transitional-status.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\CRM\Automation\Attribute_Definition;
 use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Base_Condition;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
+use Automattic\Jetpack\CRM\Entities\Contact;
 
 /**
  * Contact_Transitional_Status condition class.
@@ -77,7 +78,7 @@ class Contact_Transitional_Status extends Base_Condition {
 
 		switch ( $operator ) {
 			case 'from_to':
-				$this->condition_met = ( $previous_data['status'] === $status_was ) && ( $data['status'] === $status_is );
+				$this->condition_met = ( $previous_data->status === $status_was ) && ( $data->status === $status_is );
 				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
 
 				return;
@@ -97,11 +98,11 @@ class Contact_Transitional_Status extends Base_Condition {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $data The event data.
+	 * @param Contact $data The event data.
 	 * @return bool True if the data is valid to detect a transitional status change, false otherwise.
 	 */
-	private function is_valid_contact_status_transitional_data( array $data ): bool {
-		return is_array( $data ) && isset( $data['status'] );
+	private function is_valid_contact_status_transitional_data( Contact $data ): bool {
+		return isset( $data->status );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/data-transformers/class-data-transformer-base.php
+++ b/projects/plugins/crm/src/automation/data-transformers/class-data-transformer-base.php
@@ -56,8 +56,8 @@ abstract class Data_Transformer_Base {
 	 * @since $$next-version$$
 	 *
 	 * @param Data_Type_Base $data The data type we want to transform.
-	 * @return Data_Type_Base Return a transformed data type.
+	 * @return mixed Return a transformed data type.
 	 */
-	abstract public function transform( Data_Type_Base $data ): Data_Type_Base;
+	abstract public function transform( Data_Type_Base $data );
 
 }

--- a/projects/plugins/crm/src/automation/data-transformers/class-data-transformer-invoice-to-contact.php
+++ b/projects/plugins/crm/src/automation/data-transformers/class-data-transformer-invoice-to-contact.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\CRM\Automation\Data_Transformer_Exception;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Base;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Invoice;
+use Automattic\Jetpack\CRM\Entities\Contact;
 
 /**
  * CRM Invoice to CRM Contact Transformer class.
@@ -46,11 +47,11 @@ class Data_Transformer_Invoice_To_Contact extends Data_Transformer_Base {
 	 * @since $$next-version$$
 	 *
 	 * @param Data_Type_Base $data The invoice data type we want to transform.
-	 * @return Data_Type_Base Return the Data_Type_Contact of the invoice owner.
+	 * @return mixed Return the Data_Type_Contact of the invoice owner.
 	 *
 	 * @throws Data_Transformer_Exception If the invoice is not linked to a contact.
 	 */
-	public function transform( Data_Type_Base $data ): Data_Type_Base {
+	public function transform( Data_Type_Base $data ) {
 		global $zbs;
 
 		/* @todo We should really be using getInvoiceContact() but it's broken. */
@@ -64,7 +65,7 @@ class Data_Transformer_Invoice_To_Contact extends Data_Transformer_Base {
 			);
 		}
 
-		return new Data_Type_Contact( $contact );
+		return new Contact( $contact );
 	}
 
 }

--- a/projects/plugins/crm/src/automation/data-types/class-data-type-contact.php
+++ b/projects/plugins/crm/src/automation/data-types/class-data-type-contact.php
@@ -8,6 +8,8 @@
 
 namespace Automattic\Jetpack\CRM\Automation\Data_Types;
 
+use Automattic\Jetpack\CRM\Entities\Contact;
+
 /**
  * Contact Data Type.
  *
@@ -19,7 +21,7 @@ class Data_Type_Contact extends Data_Type_Base {
 	 * {@inheritDoc}
 	 */
 	public static function get_slug(): string {
-		return 'contact';
+		return Contact::class;
 	}
 
 	/**
@@ -36,8 +38,10 @@ class Data_Type_Contact extends Data_Type_Base {
 	 * @throws \Automattic\Jetpack\CRM\Automation\Data_Type_Exception If the entity is not valid.
 	 */
 	public function __construct( $entity ) {
-		$entity = $this->unify_data( $entity );
 
+		if ( ! $entity instanceof Contact ) {
+			$entity = new Contact( $entity );
+		}
 		parent::__construct( $entity );
 	}
 
@@ -57,57 +61,11 @@ class Data_Type_Contact extends Data_Type_Base {
 	 * @return bool Whether the entity is valid or not.
 	 */
 	public function validate_entity( $entity ): bool {
-		// We do not have a model/object class for contacts, so as the very
-		// minimum we need to make sure we received an array since that's
-		// the response the CRM DAL returns.
-		if ( ! is_array( $entity ) ) {
-			return false;
+
+		if ( $entity instanceof Contact ) {
+			return true;
 		}
 
-		// We could look for even more fields, but this should ensure we have
-		// received a data array that looks valid enough.
-		$required_fields = array(
-			'id',
-			'email',
-			'status',
-			'fname',
-			'lname',
-		);
-
-		foreach ( $required_fields as $field ) {
-			if ( ! isset( $entity[ $field ] ) ) {
-				return false;
-			}
-		}
-
-		return true;
+		return false;
 	}
-
-	/**
-	 * Unify how CRM contact data is formatted.
-	 *
-	 * zbsDAL_contacts::getContact() formats the data when it returns results
-	 * but some hooks like "contact.new" passes an older, raw, formatting which
-	 * means we have two different types of formats being passed around.
-	 * This method attempts to unify the formatting, so we only have to work
-	 * with a single version of the formatting (the most recent one).
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param mixed $entity The data we want to potentially prepare.
-	 * @return array|mixed The unified data.
-	 */
-	public function unify_data( $entity ) {
-		if ( ! is_array( $entity ) ) {
-			return $entity;
-		}
-
-		if ( ! isset( $entity['zbsc_status'] ) ) {
-			return $entity;
-		}
-
-		$contacts_dal = new \zbsDAL_contacts();
-		return $contacts_dal->tidy_contact( (object) $entity );
-	}
-
 }

--- a/projects/plugins/crm/src/entities/class-contact.php
+++ b/projects/plugins/crm/src/entities/class-contact.php
@@ -1,0 +1,427 @@
+<?php
+
+/**
+ * Contact Entity.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Entities;
+
+use ArrayAccess;
+
+/**
+ * Contact Entity class.
+ *
+ * @since $$next-version$$
+ */
+class Contact implements ArrayAccess {
+
+	/**
+	 * This is the DB ID of the object.
+	 *
+	 * @var int
+	 */
+	public $id = -1;
+
+	/**
+	 * The owner of the object.
+	 *
+	 * @var int
+	 */
+	public $owner = -1;
+
+	/**
+	 * The contact status.
+	 *
+	 * @var string
+	 */
+	public $status = 'Lead';
+
+	/**
+	 * The contact email.
+	 *
+	 * @var string
+	 */
+	public $email = '';
+
+	/**
+	 * The contact prefix.
+	 *
+	 * @var string
+	 */
+	public $prefix = '';
+
+	/**
+	 * The contact first name.
+	 *
+	 * @var string
+	 */
+	public $fname = '';
+
+	/**
+	 * The contact last name.
+	 *
+	 * @var string
+	 */
+	public $lname = '';
+
+	/**
+	 * The contact address line 1.
+	 *
+	 * @var string
+	 */
+	public $addr1 = '';
+
+	/**
+	 * The contact address line 2.
+	 *
+	 * @var string
+	 */
+	public $addr2 = '';
+
+	/**
+	 * The contact city.
+	 *
+	 * @var string
+	 */
+	public $city = '';
+
+	/**
+	 * The contact county.
+	 *
+	 * @var string
+	 */
+	public $county = '';
+
+	/**
+	 * The contact postcode.
+	 *
+	 * @var string
+	 */
+	public $postcode = '';
+
+	/**
+	 * The contact country.
+	 *
+	 * @var string
+	 */
+	public $country = '';
+
+	/**
+	 * The contact second address line 1.
+	 *
+	 * @var string
+	 */
+	public $secaddr_addr1 = '';
+
+	/**
+	 * The contact second address line 2.
+	 *
+	 * @var string
+	 */
+	public $secaddr_addr2 = '';
+
+	/**
+	 * The contact second city.
+	 *
+	 * @var string
+	 */
+	public $secaddr_city = '';
+
+	/**
+	 * The contact second county.
+	 *
+	 * @var string
+	 */
+	public $secaddr_county = '';
+
+	/**
+	 * The contact second postcode.
+	 *
+	 * @var string
+	 */
+	public $secaddr_postcode = '';
+
+	/**
+	 * The contact second country.
+	 *
+	 * @var string
+	 */
+	public $secaddr_country = '';
+
+	/**
+	 * The contact home telephone.
+	 *
+	 * @var string
+	 */
+	public $hometel = '';
+
+	/**
+	 * The contact work telephone.
+	 *
+	 * @var string
+	 */
+	public $worktel = '';
+
+	/**
+	 * The contact mobile telephone.
+	 *
+	 * @var string
+	 */
+	public $mobtel = '';
+
+	/**
+	 * The contact wordpress ID.
+	 *
+	 * @var int
+	 */
+	public $wpid = -1;
+
+	/**
+	 * The contact avatar.
+	 *
+	 * @var string
+	 */
+	public $avatar = '';
+
+	/**
+	 * The contact twitter.
+	 *
+	 * @var string
+	 */
+	public $tw = '';
+
+	/**
+	 * The contact linkedin.
+	 *
+	 * @var string
+	 */
+	public $li = '';
+
+	/**
+	 * The contact facebook.
+	 *
+	 * @var string
+	 */
+	public $fb = '';
+
+	/**
+	 * The contact created timestamp.
+	 *
+	 * @var int
+	 */
+	public $created = -1;
+
+	/**
+	 * The contact last updated timestamp.
+	 *
+	 * @var int
+	 */
+	public $lastupdated = -1;
+
+	/**
+	 * The contact last contacted timestamp.
+	 *
+	 * @var int
+	 */
+	public $lastcontacted = -1;
+
+	/**
+	 * The contact meta.
+	 *
+	 * @var array
+	 */
+	public $meta = array();
+
+	/**
+	 * The contact tags.
+	 *
+	 * @var array
+	 */
+	public $tags = array();
+
+	/**
+	 * The contact companies.
+	 *
+	 * @var array
+	 */
+	public $companies = array();
+
+	/**
+	 * The contact quotes.
+	 *
+	 * @var array
+	 */
+	public $quotes = array();
+
+	/**
+	 * The contact invoices.
+	 *
+	 * @var array
+	 */
+	public $invoices = array();
+
+	/**
+	 * The contact transactions.
+	 *
+	 * @var array
+	 */
+	public $transactions = array();
+
+	/**
+	 * The contact events.
+	 *
+	 * @var array
+	 */
+	public $events = array();
+
+	/**
+	 * The contact files.
+	 *
+	 * @var array
+	 */
+	public $files = array();
+
+	/**
+	 * The contact notes.
+	 *
+	 * @var array
+	 */
+	public $notes = array();
+
+	/**
+	 * DB field name mapping. db_field => model_field.
+	 *
+	 * @var array
+	 */
+	private $field_map = array(
+		'ID'                 => 'id',
+		'zbs_owner'          => 'owner',
+		'zbsc_status'        => 'status',
+		'zbsc_email'         => 'email',
+		'zbsc_prefix'        => 'prefix',
+		'zbsc_fname'         => 'fname',
+		'zbsc_lname'         => 'lname',
+		'zbsc_addr1'         => 'addr1',
+		'zbsc_addr2'         => 'addr2',
+		'zbsc_city'          => 'city',
+		'zbsc_county'        => 'county',
+		'zbsc_postcode'      => 'postcode',
+		'zbsc_country'       => 'country',
+		'zbsc_secaddr1'      => 'secaddr_addr1',
+		'zbsc_secaddr2'      => 'secaddr_addr2',
+		'zbsc_seccity'       => 'secaddr_city',
+		'zbsc_seccounty'     => 'secaddr_county',
+		'zbsc_secpostcode'   => 'secaddr_postcode',
+		'zbsc_seccountry'    => 'secaddr_country',
+		'zbsc_hometel'       => 'hometel',
+		'zbsc_worktel'       => 'worktel',
+		'zbsc_mobtel'        => 'mobtel',
+		'zbsc_wpid'          => 'wpid',
+		'zbsc_avatar'        => 'avatar',
+		'zbsc_tw'            => 'tw',
+		'zbsc_li'            => 'li',
+		'zbsc_fb'            => 'fb',
+		'zbsc_created'       => 'created',
+		'zbsc_lastupdated'   => 'lastupdated',
+		'zbsc_lastcontacted' => 'lastcontacted',
+	);
+
+	private $custom_fields = array();
+
+	/**
+	 * Contact constructor.
+	 *
+	 * @param ?array $contact_data Associative array of contact data. From DB or generic.
+	 */
+	public function __construct( ?array $contact_data = array() ) {
+
+		// Detect if this is a db contact or a generic contact
+		if ( array_key_exists( 'zbsc_status', $contact_data ) ) {
+			$this->set_db_contact_data( $contact_data );
+		} else {
+			$this->set_generic_contact_data( $contact_data );
+		}
+	}
+	// Set the contact data from a generic/tidy contact array. The fields from $tidy_contact are not prefixed by zbsc_ or zbs_ so it doesn't need the mapping
+	public function set_generic_contact_data( array $tidy_contact ) {
+		foreach ( $tidy_contact as $key => $value ) {
+			if ( in_array( $key, $this->field_map ) ) {
+				$this->{ $key } = $value;
+			}
+		}
+	}
+
+	/**
+	 * Set the contact data with including the database column prefix.
+	 *
+	 * @param array $db_contact Associative array of contact data from the database
+	 */
+	public function set_db_contact_data( array $db_contact ) {
+		foreach ( $db_contact as $key => $value ) {
+			if ( array_key_exists( $key, $this->field_map ) ) {
+				$this->{ $this->field_map[ $key ] } = $value;
+			}
+		}
+	}
+
+	/**
+	 * Get the contact data (tidy) as an array.
+	 *
+	 * @return array
+	 */
+	public function get_contact_array() {
+		$contact_data = array();
+		foreach ( $this->field_map as $value ) {
+			$contact_data[ $value ] = $this->{ $value };
+		}
+		return $contact_data;
+	}
+
+	public function get_contact_array_for_db() {
+		$contact_data = array(
+			'id'    => $this->id,
+			'owner' => $this->owner,
+			'data'  => array(),
+		);
+
+		$skip_fields = array( 'id', 'owner' );
+
+		foreach ( $this->field_map as $db_field => $model_field ) {
+			if ( in_array( $model_field, $skip_fields ) ) {
+				continue;
+			}
+			$contact_data['data'][ $db_field ] = $this->{ $model_field };
+		}
+		return $contact_data;
+	}
+
+	public function get_custom_fields(): array {
+		return $this->custom_fields;
+	}
+
+	public function set_custom_fields( $custom_fields ) {
+		$this->custom_fields = $custom_fields;
+	}
+
+	public function offsetExists( $offset ): bool {
+		return in_array( $offset, $this->field_map );
+	}
+
+	public function offsetGet( $offset ): mixed {
+		return in_array( $offset, $this->field_map ) ? $this->{ $offset } : null;
+	}
+
+	public function offsetSet( $offset, $value ): void {
+		if ( in_array( $offset, $this->field_map ) ) {
+			$this->{ $offset } = $value;
+		}
+	}
+
+	public function offsetUnset( $offset ): void {
+		if ( in_array( $offset, $this->field_map ) ) {
+			$this->{ $offset } = null;
+		}
+	}
+}

--- a/projects/plugins/crm/src/entities/class-contact.php
+++ b/projects/plugins/crm/src/entities/class-contact.php
@@ -392,7 +392,7 @@ class Contact implements ArrayAccess {
 			if ( in_array( $model_field, $skip_fields ) ) {
 				continue;
 			}
-			$contact_data['data'][ $db_field ] = $this->{ $model_field };
+			$contact_data['data'][ $model_field ] = $this->{ $model_field };
 		}
 		return $contact_data;
 	}

--- a/projects/plugins/crm/src/entities/class-contact.php
+++ b/projects/plugins/crm/src/entities/class-contact.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Contact Entity.
  *
@@ -8,14 +7,12 @@
 
 namespace Automattic\Jetpack\CRM\Entities;
 
-use ArrayAccess;
-
 /**
  * Contact Entity class.
  *
  * @since $$next-version$$
  */
-class Contact implements ArrayAccess {
+class Contact extends Entity {
 
 	/**
 	 * This is the DB ID of the object.
@@ -172,7 +169,7 @@ class Contact implements ArrayAccess {
 	public $mobtel = '';
 
 	/**
-	 * The contact wordpress ID.
+	 * The contact WordPress ID.
 	 *
 	 * @var int
 	 */
@@ -328,6 +325,11 @@ class Contact implements ArrayAccess {
 		'zbsc_lastcontacted' => 'lastcontacted',
 	);
 
+	/**
+	 * Custom fields.
+	 *
+	 * @var array Custom fields.
+	 */
 	private $custom_fields = array();
 
 	/**
@@ -344,10 +346,15 @@ class Contact implements ArrayAccess {
 			$this->set_generic_contact_data( $contact_data );
 		}
 	}
-	// Set the contact data from a generic/tidy contact array. The fields from $tidy_contact are not prefixed by zbsc_ or zbs_ so it doesn't need the mapping
+
+	/**
+	 * Set the contact data from a generic/tidy contact array.
+	 *
+	 * @param array $tidy_contact Associative array of contact data.
+	 */
 	public function set_generic_contact_data( array $tidy_contact ) {
 		foreach ( $tidy_contact as $key => $value ) {
-			if ( in_array( $key, $this->field_map ) ) {
+			if ( in_array( $key, $this->field_map, true ) ) {
 				$this->{ $key } = $value;
 			}
 		}
@@ -356,7 +363,7 @@ class Contact implements ArrayAccess {
 	/**
 	 * Set the contact data with including the database column prefix.
 	 *
-	 * @param array $db_contact Associative array of contact data from the database
+	 * @param array $db_contact Associative array of contact data from the database.
 	 */
 	public function set_db_contact_data( array $db_contact ) {
 		foreach ( $db_contact as $key => $value ) {
@@ -369,7 +376,7 @@ class Contact implements ArrayAccess {
 	/**
 	 * Get the contact data (tidy) as an array.
 	 *
-	 * @return array
+	 * @return array The contact data array.
 	 */
 	public function get_contact_array() {
 		$contact_data = array();
@@ -379,6 +386,11 @@ class Contact implements ArrayAccess {
 		return $contact_data;
 	}
 
+	/**
+	 * Get the contact data as an array ready for the database.
+	 *
+	 * @return array The contact data array.
+	 */
 	public function get_contact_array_for_db() {
 		$contact_data = array(
 			'id'    => $this->id,
@@ -388,8 +400,8 @@ class Contact implements ArrayAccess {
 
 		$skip_fields = array( 'id', 'owner' );
 
-		foreach ( $this->field_map as $db_field => $model_field ) {
-			if ( in_array( $model_field, $skip_fields ) ) {
+		foreach ( $this->field_map as $model_field ) {
+			if ( in_array( $model_field, $skip_fields, true ) ) {
 				continue;
 			}
 			$contact_data['data'][ $model_field ] = $this->{ $model_field };
@@ -397,31 +409,10 @@ class Contact implements ArrayAccess {
 		return $contact_data;
 	}
 
-	public function get_custom_fields(): array {
-		return $this->custom_fields;
-	}
-
-	public function set_custom_fields( $custom_fields ) {
-		$this->custom_fields = $custom_fields;
-	}
-
-	public function offsetExists( $offset ): bool {
-		return in_array( $offset, $this->field_map );
-	}
-
-	public function offsetGet( $offset ): mixed {
-		return in_array( $offset, $this->field_map ) ? $this->{ $offset } : null;
-	}
-
-	public function offsetSet( $offset, $value ): void {
-		if ( in_array( $offset, $this->field_map ) ) {
-			$this->{ $offset } = $value;
-		}
-	}
-
-	public function offsetUnset( $offset ): void {
-		if ( in_array( $offset, $this->field_map ) ) {
-			$this->{ $offset } = null;
-		}
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function get_field_map(): array {
+		return $this->field_map;
 	}
 }

--- a/projects/plugins/crm/src/entities/class-entity.php
+++ b/projects/plugins/crm/src/entities/class-entity.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Jetpack CRM Entity base class.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Entities;
+
+use ArrayAccess;
+
+/**
+ * Entity base class.
+ *
+ * @since $$next-version$$
+ */
+abstract class Entity implements ArrayAccess {
+
+	/**
+	 * The field map.
+	 *
+	 * @return array The field map.
+	 */
+	abstract protected function get_field_map(): array;
+
+	/**
+	 * offsetExists implementation
+	 *
+	 * @param mixed $offset The offset.
+	 * @return bool Whether the offset exists.
+	 */
+	public function offsetExists( $offset ): bool {
+		return in_array( $offset, $this->get_field_map(), true );
+	}
+
+	/**
+	 * offsetGet implementation
+	 *
+	 * @param mixed $offset The offset.
+	 * @return mixed The value.
+	 */
+	public function offsetGet( $offset ): mixed {
+		return in_array( $offset, $this->get_field_map(), true ) ? $this->{ $offset } : null;
+	}
+
+	/**
+	 * offsetSet implementation
+	 *
+	 * @param mixed $offset The offset.
+	 * @param mixed $value The value.
+	 * @return void
+	 */
+	public function offsetSet( $offset, $value ): void {
+		if ( in_array( $offset, $this->get_field_map(), true ) ) {
+			$this->{ $offset } = $value;
+		}
+	}
+
+	/**
+	 * offsetUnset implementation
+	 *
+	 * @param mixed $offset The offset.
+	 * @return void
+	 */
+	public function offsetUnset( $offset ): void {
+		if ( in_array( $offset, $this->get_field_map(), true ) ) {
+			$this->{ $offset } = null;
+		}
+	}
+}

--- a/projects/plugins/crm/tests/php/automation/class-automation-workflow-test.php
+++ b/projects/plugins/crm/tests/php/automation/class-automation-workflow-test.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
 use Automattic\Jetpack\CRM\Automation\Tests\Mocks\Dummy_Step;
 use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Updated;
 use Automattic\Jetpack\CRM\Automation\Workflow_Exception;
+use Automattic\Jetpack\CRM\Entities\Contact;
 use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Test_Case;
 
 require_once __DIR__ . '/tools/class-automation-faker.php';
@@ -75,7 +76,7 @@ class Automation_Workflow_Test extends JPCRM_Base_Test_Case {
 		);
 
 		$contact_data      = $this->automation_faker->contact_data();
-		$automation_result = $workflow->execute( new Contact_Updated(), $contact_data );
+		$automation_result = $workflow->execute( new Contact_Updated(), new Contact( $contact_data ) );
 
 		$this->assertTrue( $automation_result );
 	}

--- a/projects/plugins/crm/tests/php/automation/contacts/actions/class-update-contact-status-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/actions/class-update-contact-status-test.php
@@ -8,6 +8,7 @@ use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Field_Changed;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
 use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Created;
+use Automattic\Jetpack\CRM\Entities\Contact;
 use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 
 /**
@@ -42,8 +43,9 @@ class Update_Contact_Status_Test extends JPCRM_Base_Integration_Test_Case {
 		global $zbs;
 
 		$contact_id = $this->add_contact( array( 'status' => 'Lead' ) );
-		$contact    = $this->get_contact( $contact_id );
-		$this->assertSame( 'Lead', $contact['status'] );
+		/** @var Contact $contact */
+		$contact = $this->get_contact( $contact_id );
+		$this->assertSame( 'Lead', $contact->status );
 
 		$action_update_contact = new Update_Contact_Status(
 			array(
@@ -57,6 +59,7 @@ class Update_Contact_Status_Test extends JPCRM_Base_Integration_Test_Case {
 		$action_update_contact->execute( $contact );
 
 		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
 		$this->assertSame( 'Customer', $contact['status'] );
 	}
 

--- a/projects/plugins/crm/tests/php/automation/contacts/actions/class-update-contact-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/actions/class-update-contact-test.php
@@ -8,6 +8,7 @@ use Automattic\Jetpack\CRM\Automation\Automation_Workflow;
 use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Field_Changed;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
 use Automattic\Jetpack\CRM\Automation\Triggers\Contact_Created;
+use Automattic\Jetpack\CRM\Entities\Contact;
 use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_Test_Case;
 
 /**
@@ -47,8 +48,10 @@ class Update_Contact_Test extends JPCRM_Base_Integration_Test_Case {
 				'fname' => 'This is definitely not a real first name',
 			)
 		);
-		$contact    = $this->get_contact( $contact_id );
-		$this->assertSame( 'This is definitely not a real first name', $contact['fname'] );
+		/** @var Contact $contact */
+		$contact = $this->get_contact( $contact_id );
+
+		$this->assertSame( 'This is definitely not a real first name', $contact->fname );
 
 		// Define what happens when the action is executed.
 		$action = new Update_Contact(

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
@@ -5,6 +5,7 @@ namespace Automattic\Jetpack\CRM\Automation\Tests;
 use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Field_Changed;
 use Automattic\Jetpack\CRM\Automation\Conditions\Contact_Transitional_Status;
+use Automattic\Jetpack\CRM\Entities\Contact;
 use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Test_Case;
 
 require_once __DIR__ . '../../tools/class-automation-faker.php';
@@ -60,12 +61,12 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$contact_data                    = $contact_data_type->get_entity();
 
 		// Testing when the condition has been met.
-		$contact_data['status'] = 'customer';
+		$contact_data->status = 'customer';
 		$contact_field_changed_condition->execute( $contact_data );
 		$this->assertTrue( $contact_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
-		$contact_data['status'] = 'lead';
+		$contact_data->status = 'lead';
 		$contact_field_changed_condition->execute( $contact_data );
 		$this->assertFalse( $contact_field_changed_condition->condition_met() );
 	}
@@ -79,12 +80,12 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$contact_data                    = $contact_data_type->get_entity();
 
 		// Testing when the condition has been met.
-		$contact_data['status'] = 'lead';
+		$contact_data->status = 'lead';
 		$contact_field_changed_condition->execute( $contact_data );
 		$this->assertTrue( $contact_field_changed_condition->condition_met() );
 
 		// Testing when the condition has not been met.
-		$contact_data['status'] = 'customer';
+		$contact_data->status = 'customer';
 		$contact_field_changed_condition->execute( $contact_data );
 		$this->assertFalse( $contact_field_changed_condition->condition_met() );
 	}
@@ -111,10 +112,10 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$this->expectException( Automation_Exception::class );
 		$this->expectExceptionCode( Automation_Exception::CONDITION_INVALID_OPERATOR );
 
-		$contact_data_type               = $this->automation_faker->contact_data( true );
-		$contact_data                    = $contact_data_type->get_entity();
-		$previous_contact_data           = $contact_data;
-		$previous_contact_data['status'] = 'old_status';
+		$contact_data_type             = $this->automation_faker->contact_data( true );
+		$contact_data                  = $contact_data_type->get_entity();
+		$previous_contact_data         = $contact_data;
+		$previous_contact_data->status = 'old_status';
 
 		$contact_transitional_status_condition->execute( $contact_data, $previous_contact_data );
 	}
@@ -128,22 +129,23 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$contact_data                          = $contact_data_type->get_entity();
 
 		// Create a previous state of a contact.
-		$previous_contact           = $contact_data;
-		$previous_contact['status'] = 'old_status';
+		$previous_contact         = new Contact( $contact_data->get_contact_array() );
+		$previous_contact->status = 'old_status';
 
 		// Testing when the condition has been met.
-		$contact_data['status'] = 'new_status';
+		$contact_data->status = 'new_status';
+
 		$contact_transitional_status_condition->execute( $contact_data, $previous_contact );
 		$this->assertTrue( $contact_transitional_status_condition->condition_met() );
 
 		// Testing when the condition has been not been met for the to field.
-		$contact_data['status'] = 'wrong_to';
+		$contact_data->status = 'wrong_to';
 		$contact_transitional_status_condition->execute( $contact_data, $previous_contact );
 		$this->assertFalse( $contact_transitional_status_condition->condition_met() );
 
 		// Testing when the condition has been not been met for the from field
-		$contact_data['status']     = 'new_status';
-		$previous_contact['status'] = 'wrong_from';
+		$contact_data->status     = 'new_status';
+		$previous_contact->status = 'wrong_from';
 		$contact_transitional_status_condition->execute( $contact_data, $previous_contact );
 		$this->assertFalse( $contact_transitional_status_condition->condition_met() );
 	}

--- a/projects/plugins/crm/tests/php/automation/mocks/mock-class-contact-condition.php
+++ b/projects/plugins/crm/tests/php/automation/mocks/mock-class-contact-condition.php
@@ -5,6 +5,7 @@ namespace Automattic\Jetpack\CRM\Automation\Tests\Mocks;
 use Automattic\Jetpack\CRM\Automation\Automation_Exception;
 use Automattic\Jetpack\CRM\Automation\Base_Condition;
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
+use Automattic\Jetpack\CRM\Entities\Contact;
 
 class Contact_Condition extends Base_Condition {
 
@@ -97,7 +98,7 @@ class Contact_Condition extends Base_Condition {
 	 * @throws Automation_Exception
 	 */
 	public function execute( $data, $previous_data = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( ! $this->is_valid_contact_data( $data ) ) {
+		if ( ! $data instanceof Contact ) {
 			$this->logger->log( 'Invalid contact data' );
 			$this->condition_met = false;
 			return;

--- a/projects/plugins/crm/tests/php/automation/mocks/mock-class-dummy-step.php
+++ b/projects/plugins/crm/tests/php/automation/mocks/mock-class-dummy-step.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack\CRM\Automation\Tests\Mocks;
 
 use Automattic\Jetpack\CRM\Automation\Automation_Logger;
 use Automattic\Jetpack\CRM\Automation\Base_Step;
+use Automattic\Jetpack\CRM\Entities\Contact;
 
 class Dummy_Step extends Base_Step {
 
@@ -31,7 +32,7 @@ class Dummy_Step extends Base_Step {
 	}
 
 	public static function get_data_type(): string {
-		return 'contact';
+		return Contact::class;
 	}
 
 	public static function get_category(): ?string {

--- a/projects/plugins/crm/tests/php/class-jpcrm-base-integration-test-case.php
+++ b/projects/plugins/crm/tests/php/class-jpcrm-base-integration-test-case.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\CRM\Tests;
 
 use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
+use Automattic\Jetpack\CRM\Entities\Contact;
 
 /**
  * Test case that ensures we have a clean and functioning Jetpack CRM instance.
@@ -40,9 +41,9 @@ class JPCRM_Base_Integration_Test_Case extends JPCRM_Base_Test_Case {
 	 *
 	 * @param int|string $id The ID of the contact we want to get.
 	 * @param array $args (Optional) A list of arguments we should use for the contact.
-	 * @return array|false
+	 * @return Contact The contact object
 	 */
-	public function get_contact( $id, array $args = array() ) {
+	public function get_contact( $id, array $args = array() ): Contact {
 		global $zbs;
 
 		$contact = $zbs->DAL->contacts->getContact( $id, $args );


### PR DESCRIPTION
Fixes: https://github.com/Automattic/zero-bs-crm/issues/3291

## Proposed changes:

This is a proof of concept/proposal to use entities as a way to manage well-known data, unified in one place. The current DAL implementation handles many data formats when we are going to add or update data, or when we retrieve the data from the database, we get different structures. 

For example, for the contact entity:

- `tidy_contact`, used by the Data_Type_Contact, expects data from the database, with the typical prefix `zbsc_`, like this `$contact->zbsc_status`. 
- When a contact is added/updated the expected format is different, is like:
   - `$contact = [ 'id' => -1, 'owner' => -1, 'data' => array( 'status' => 'lead') );`
   - And the old data has the same format returned from `tidy_contact` method (`get_contact` use it to tidy up)
- `tidy_contact` expects data from the database, so we cannot use it for managing data that is not from the database.

So we are managing different data structures. This proposal PR (draft) introduces the first concept of entity, it just adds a Contact class that holds the Contact information along with two methods that transform the data. Probably those methods will be the same for the rest of the entities so we could extract them to a `trait` file or parent class, or even into a Factory layer to make the transformation. I'd keep it as simple as we can, and then in the future, we could move to better entities and DAL system.

That is the idea of this change. It doesn't require too much time because the entities only have the properties and the mapping, which is super easy to implement after this PR, it will require one day more to adapt the rest of the entities and remove the Data_Type if we don't need it. The Contact entity in this PR has more fields that we really need for now, but I left it here to see how it'd look for a future full implementation of the entity, the right way. If the simple implementation is okay, I'll remove those methods and fields not needed.

In this first approach I didn't remove Data_Type classes, but probably using entities we don't need this middle layer.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

