### PR TITLE
Comments: remove mention of Twitter since it is no longer an option

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wording-comments-twitter
+++ b/projects/plugins/jetpack/changelog/update-wording-comments-twitter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Comments: remove mention of Twitter as a log in option since it is no longer available.

--- a/projects/plugins/jetpack/modules/comments.php
+++ b/projects/plugins/jetpack/modules/comments.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * Module Name: Comments
- * Module Description: Let visitors use a WordPress.com, Twitter, or Facebook account to comment
+ * Module Description: Let visitors use a WordPress.com or Facebook account to comment
  * First Introduced: 1.4
  * Sort Order: 20
  * Requires Connection: Yes
  * Auto Activate: No
  * Module Tags: Social
  * Feature: Engagement
- * Additional Search Queries: comments, comment, facebook, twitter, social
+ * Additional Search Queries: comments, comment, facebook, social
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/modules/module-info.php
+++ b/projects/plugins/jetpack/modules/module-info.php
@@ -335,7 +335,7 @@ add_action( 'jetpack_learn_more_button_comments', 'jetpack_comments_learn_more_b
  */
 function jetpack_comments_more_info() {
 	esc_html_e(
-		'Allow visitors to use their WordPress.com, Twitter, or Facebook accounts when commenting on
+		'Allow visitors to use their WordPress.com or Facebook accounts when commenting on
 		your site. Jetpack will match your site\'s color scheme automatically (but you can adjust that).',
 		'jetpack'
 	);


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/80972

## Proposed changes:

One can no longer use Twitter to log in when using Jetpack Comments, so let's remove it from our settings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Discussion
* You should not see a mention of Twitter in the UI anymore.
