### PR TITLE
Link styles and scripts to block.json automatically

### DIFF
--- a/projects/plugins/jetpack/changelog/update-block-assets-build
+++ b/projects/plugins/jetpack/changelog/update-block-assets-build
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Link styles and scripts to block.json automatically

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -199,6 +199,48 @@ module.exports = [
 						to: '[path][name][ext]',
 						context: path.join( __dirname, '../extensions/blocks' ),
 						noErrorOnMissing: true,
+						// Automatically link scripts and styles
+						transform( content, absoluteFrom ) {
+							let metadata = {};
+
+							try {
+								metadata = JSON.parse( content.toString() );
+							} catch ( e ) {}
+
+							const name = metadata.name.replace( 'jetpack/', '' );
+
+							if ( ! name ) {
+								return metadata;
+							}
+
+							const metadataDir = path.dirname( absoluteFrom );
+							let scriptName = 'editor';
+
+							if ( presetIndex.beta.includes( name ) ) {
+								scriptName += '-beta';
+							} else if ( presetIndex.experimental.includes( name ) ) {
+								scriptName += '-experimental';
+							}
+
+							const result = {
+								...metadata,
+								editorScript: `file:../${ scriptName }.js`,
+								editorStyle: `file:../${ scriptName }.css`,
+							};
+
+							if ( fs.existsSync( path.join( metadataDir, 'view.js' ) ) ) {
+								result.viewScript = 'file:./view.js';
+							}
+
+							if (
+								fs.existsSync( path.join( metadataDir, 'style.scss' ) ) ||
+								fs.existsSync( path.join( metadataDir, 'view.scss' ) )
+							) {
+								result.style = 'file:./view.css';
+							}
+
+							return JSON.stringify( result, null, 4 );
+						},
 					},
 				],
 			} ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`block.json` metadata files require at least an `editorScript` field to be valid. This field was manually added to each `block.json` file, but generating it during the build makes more sense. This will prevent forgetting to update the value when moving a block from one mode to another (e.g., beta to production).

This PR adds the `editorScript`, `editorView`, `viewScript`, or `style` fields to `block.json` files at build time.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pedMtX-RS-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Run `cd projects/plugins/jetpack`
- Rebuild the blocks by running `rm -rf _inc/blocks && pnpm build-extensions`
- Choose a couple of blocks, and notice that the values for `editorScript`, `editorView`, `viewScript`, or `style` in `block.json` are correct.

_Note: blocks are currently not registered through their `block.json` file. This PR shouldn't impact the behaviour of blocks._
