### PR TITLE
Subscribers: Add edit link for subscribe modal

### DIFF
--- a/projects/plugins/jetpack/changelog/add-subsribe-modal-edit-link
+++ b/projects/plugins/jetpack/changelog/add-subsribe-modal-edit-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribers: Add edit link for subscribe modal.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/jetpack/issues/31865
## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Adds link to edit subscribe modal in site editor. I also adjusted the wording of the explanation by the setting to shorten it and avoid wrapping.

Note that the subscribe modal is still behind a filter/feature flag for self hosted jetpack sites. So the only way to see this to is to add a specific filter (see testing instructions below). 

<img width="1062" alt="subscribe-modal-edit" src="https://github.com/Automattic/jetpack/assets/21228350/24818622-9777-4816-88a2-5311fe4aa8ed">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Checkout this branch in your local jetpack dev environment. 
2) Add `add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 );` to tools/dockers/mu-plugins/0-sandbox.php: 
3) Go to Jetpack > Settings > Newsletter and find the Enable subscriber popup setting.
4) Confirm updated text looks like screenshot above, and that link takes you to the correct place in the site editor where you can see and edit the content of the subscribe modal. 

