### PR TITLE
Subscriptions: Tweak subscribe modal text/spacing

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-text
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Tweak subscribe modal text/spacing.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -132,7 +132,7 @@ class Jetpack_Subscribe_Modal {
 		// translators: %s is the name of the site.
 		$discover_more_from = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
 		$continue_reading   = __( 'Continue Reading', 'jetpack' );
-		$subscribe_text     = __( 'Subscribe now to keep reading and gain access to the full archive.', 'jetpack' );
+		$subscribe_text     = __( 'Subscribe now to keep reading and get access to the full archive.', 'jetpack' );
 
 		return <<<HTML
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|70","right":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -132,14 +132,14 @@ class Jetpack_Subscribe_Modal {
 		// translators: %s is the name of the site.
 		$discover_more_from = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
 		$continue_reading   = __( 'Continue Reading', 'jetpack' );
-		$subscribe_text     = __( 'Subscribe to the newsletter to keep reading and get access to the full archive.', 'jetpack' );
+		$subscribe_text     = __( 'Subscribe now to have great new content delivered to your inbox.', 'jetpack' );
 
 		return <<<HTML
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|70","right":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
 	<div class="wp-block-group has-border-color" style="border-color:#dddddd;border-width:1px;margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)">
 
 	<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"600","fontSize":"26px"},"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"4px"}}}} -->
-		<h2 class="wp-block-heading has-text-align-center" style="margin-top:4px;margin-bottom:4px;font-size:26px;font-style:normal;font-weight:600">$discover_more_from</h2>
+		<h2 class="wp-block-heading has-text-align-center" style="margin-top:4px;margin-bottom:10px;font-size:26px;font-style:normal;font-weight:600">$discover_more_from</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"15px"},"spacing":{"margin":{"top":"4px","bottom":"0px"}}}} -->
@@ -149,7 +149,7 @@ class Jetpack_Subscribe_Modal {
 		<!-- wp:jetpack/subscriptions {"buttonBackgroundColor":"primary","textColor":"secondary","borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->
 
 		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"14px"}},"className":"jetpack-subscribe-modal__close"} -->
-		<p class="has-text-align-center jetpack-subscribe-modal__close" style="font-size:14px"><a href="#">$continue_reading</a></p>
+		<p class="has-text-align-center jetpack-subscribe-modal__close" style="margin-top:20px;font-size:14px"><a href="#">$continue_reading</a></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -132,7 +132,7 @@ class Jetpack_Subscribe_Modal {
 		// translators: %s is the name of the site.
 		$discover_more_from = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
 		$continue_reading   = __( 'Continue Reading', 'jetpack' );
-		$subscribe_text     = __( 'Subscribe now to have great new content delivered to your inbox.', 'jetpack' );
+		$subscribe_text     = __( 'Subscribe now to keep reading and gain access to the full archive.', 'jetpack' );
 
 		return <<<HTML
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|70","right":"var:preset|spacing|70"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
@@ -35,6 +35,16 @@
 	visibility: visible;
 }
 
+/*
+ * These text-wrap properties still have limited browser
+ * support, but based on feedback still adding them for when
+ * they are supported.
+ */
+.jetpack-subscribe-modal__modal-content p {
+	text-wrap: balance;
+	text-wrap: pretty;
+}
+
 @media screen and (max-width: 640px) {
 	.jetpack-subscribe-modal__modal-content {
 		width: 94%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Adds a a bit more vertical spacing between some elements in subscribe modal. 
- Updates the paragraph text to be shorter. There were several considerations here. 
   - First, the current text suggests that a user needs to subscribe to gain access to content. This is not the case with the subscribe modal, which does not block content. So I've updated the wording to be more reflective of that fact. 
   - Second, the current text was frequently wrapping just 1-2 words as orphans on the second line. I shorten the text to avoid line wrapping. I considered adjusting left/right padding, but (a) the impact varies by theme and (b) there's no way in the site editor to have different padding on a paragraph between desktop and mobile. Any padding that was enough for desktop was too much for mobile. And we didn't want to use custom css, which would be hard to edit.
   
**Before (on Lettre)**
<img width="613" alt="lettre-before" src="https://github.com/Automattic/jetpack/assets/21228350/b796eefc-d294-4f6a-ad06-005ae63dbcc2">

**After (Lettre)**
<img width="613" alt="lettre" src="https://github.com/Automattic/jetpack/assets/21228350/a8e7b487-8294-499b-a289-9f6bcfb88299">

**After (Lettre - Mobile)**
<img width="378" alt="lettre-mobile" src="https://github.com/Automattic/jetpack/assets/21228350/927fe689-5763-4ff4-b072-5bb6dc0144b4">

**After (Twenty Twenty-Three)**
<img width="608" alt="2023" src="https://github.com/Automattic/jetpack/assets/21228350/64199839-b0a6-487f-aba2-649de60d4bbe">

**After (Twenty Twenty-Two)**
<img width="609" alt="2022" src="https://github.com/Automattic/jetpack/assets/21228350/5272dfcd-78e2-428e-bf54-e79ffc10d605">

**After (Astra)**
<img width="621" alt="astra" src="https://github.com/Automattic/jetpack/assets/21228350/0fbdad06-907c-47a1-a050-14a472a6c47e">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Checkout this branch in your local jetpack dev environment.
2) Add add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 ); to tools/dockers/mu-plugins/0-sandbox.php.
3) Go to Jetpack > Settings > Newsletter and enable the Enable subscriber popup setting.
4) In a non-logged-in browser or private tab, open a single post on your test site, and scroll. The modal should open. confirm the new text looks like above and spacing looks reasonable. 

