### PR TITLE
Subscriptions: Add mobile padding to subscribe modal 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-modal-mobile-padding
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-modal-mobile-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Add subscribe modal mobile padding.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
@@ -34,3 +34,9 @@
 	top: 0;
 	visibility: visible;
 }
+
+@media screen and (max-width: 640px) {
+	.jetpack-subscribe-modal__modal-content {
+		width: 94%;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds a bit of left/right mobile padding for subscribe modal popup. 

**Before**
<img width="418" alt="mobile-before" src="https://github.com/Automattic/jetpack/assets/21228350/741588a1-0907-41e0-87d1-81e865aa9226">

**After**
<img width="442" alt="mobile-after" src="https://github.com/Automattic/jetpack/assets/21228350/30d1739d-f0ab-4177-9162-d12d25491cbb">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Checkout this branch in your local jetpack dev environment.
2) Add add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 ); to tools/dockers/mu-plugins/0-sandbox.php.
3) Go to Jetpack > Settings > Newsletter and enable the Enable subscriber popup setting.
4) In a non-logged-in browser or private tab, open a single post on your test site, and scroll. The modal should open. With your browser dev tools, adjust the view to a mobile device and confirm there is spacing on the left/right.
