### PR TITLE
Boost: Update critical CSS URL parameter

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/utils/generate-critical-css.ts
@@ -38,7 +38,7 @@ export default async function generateCriticalCss(
 
 		// Prepare GET parameters to include with each request.
 		const requestGetParameters = {
-			'jb-generate-critical-css': '1',
+			'jb-generate-critical-css': Date.now().toString(),
 		};
 
 		logPreCriticalCSSGeneration();

--- a/projects/plugins/boost/changelog/update-critical-css-param
+++ b/projects/plugins/boost/changelog/update-critical-css-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Critical CSS: Updated critical CSS url parameter to avoid redirect caching


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Update critical CSS generation parameter from `"1"` to the current timestamp to avoid cached redirects. Even after #32627 is merged, users may still find their critical CSS to be broken because of cached 301 redirects. This PR works around that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Generate critical CSS manually and make sure it works
* Use an old version of Boost with one of the SEO plugins to reproduce the issue fixed by #32627, upgrade boost to this PR and make sure the critical CSS generation goes smoothly.

