### PR TITLE
My Jetpack: Fix disconnection confirmation module white space

### DIFF
--- a/projects/js-packages/connection/changelog/fix-my-jetpack-disconnect-confirmation-white-space
+++ b/projects/js-packages/connection/changelog/fix-my-jetpack-disconnect-confirmation-white-space
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: remove unnecessary whitespace on disconnection confirmation modal
+
+

--- a/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect-confirm.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect-confirm.jsx
@@ -17,7 +17,7 @@ const StepDisconnectConfirm = props => {
 	const { onExit, canProvideFeedback, onProvideFeedback } = props;
 
 	return (
-		<div className="jp-connection__disconnect-dialog__content">
+		<div className="jp-connection__disconnect-dialog__content jp-connection__disconnect-dialog__content__confirmation">
 			<DecorativeCard icon="unlink" imageUrl={ disconnectImage } />
 
 			<div className="jp-connection__disconnect-dialog__step-copy jp-connection__disconnect-dialog__step-copy--narrow">

--- a/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect-confirm.jsx
+++ b/projects/js-packages/connection/components/disconnect-dialog/steps/step-disconnect-confirm.jsx
@@ -17,7 +17,7 @@ const StepDisconnectConfirm = props => {
 	const { onExit, canProvideFeedback, onProvideFeedback } = props;
 
 	return (
-		<div className="jp-connection__disconnect-dialog__content jp-connection__disconnect-dialog__content__confirmation">
+		<div className="jp-connection__disconnect-dialog__content">
 			<DecorativeCard icon="unlink" imageUrl={ disconnectImage } />
 
 			<div className="jp-connection__disconnect-dialog__step-copy jp-connection__disconnect-dialog__step-copy--narrow">

--- a/projects/js-packages/connection/components/disconnect-dialog/style.scss
+++ b/projects/js-packages/connection/components/disconnect-dialog/style.scss
@@ -188,7 +188,6 @@
 	.jp-connection__disconnect-dialog,
 	.jp-connection__disconnect-dialog.components-modal__frame {
 		width: 1200px;
-		height: 900px;
 		display: flex;
 		flex-direction: column;
 	}
@@ -205,13 +204,6 @@
 
 		&__content {
 			padding: 80px;
-
-			&__confirmation {
-				position:absolute;
-				width: 100%;
-				height: 100%;
-				padding: 0;
-			}
 		}
 
 		&__actions {

--- a/projects/js-packages/connection/components/disconnect-dialog/style.scss
+++ b/projects/js-packages/connection/components/disconnect-dialog/style.scss
@@ -205,6 +205,13 @@
 
 		&__content {
 			padding: 80px;
+
+			&__confirmation {
+				position:absolute;
+				width: 100%;
+				height: 100%;
+				padding: 0;
+			}
 		}
 
 		&__actions {

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.29.8",
+	"version": "0.29.9-alpha",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes unintended whitespace at the bottom of the disconnection confirmation modal.
Discussed here:
p1693251258887639-slack-C02TQF5VAJD

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Before:
![image](https://github.com/Automattic/jetpack/assets/16329583/60d3e6a3-3b48-409e-b011-525fe67e4294)

After:
![Screenshot 2023-08-29 at 13 57 57](https://github.com/Automattic/jetpack/assets/16329583/38055433-0cbe-4a6a-ab73-faad3883c1ff)


### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect a Jetpack site 
* Go to My Jetpack
* Disconnect the site from My Jetpack and confirm that the Modal containing the successfully disconnected message works as expected.looks fine