### PR TITLE
CRM: Allow admin users to accept quotes

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-2862-allow-to-accept-quotes-by-admin
+++ b/projects/plugins/crm/changelog/fix-crm-2862-allow-to-accept-quotes-by-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Quotes could be accepted by admin users

--- a/projects/plugins/crm/changelog/fix-crm-2862-allow-to-accept-quotes-by-admin
+++ b/projects/plugins/crm/changelog/fix-crm-2862-allow-to-accept-quotes-by-admin
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Quotes could be accepted by admin users
+Quotes: could be accepted by admin users.

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -1104,8 +1104,7 @@ function ZeroBSCRM_accept_quote() {
 
 		// validate that this has been posted by the contact associated with the quote
 		if ( ! $uinfo->ID
-			|| zeroBS_getCustomerIDWithEmail( $uinfo->user_email ) !== zeroBSCRM_quote_getContactAssigned( $quoteID )
-			|| zeroBSCRM_permsQuotes()
+			|| zeroBS_getCustomerIDWithEmail( $uinfo->user_email ) !== zeroBSCRM_quote_getContactAssigned( $quoteID ) // phpcs:ignore
 		) {
 			zeroBSCRM_sendJSONError( array( 'access' => 1 ), 403 );
 		}

--- a/projects/plugins/crm/includes/ZeroBSCRM.MailTracking.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MailTracking.php
@@ -455,7 +455,7 @@ function zeroBSCRM_get_email_status($ID){
 	$sql = $wpdb->prepare("SELECT zbsmail_active FROM " . $ZBSCRM_t['system_mail_templates'] . " WHERE zbsmail_id = %d", $ID);
 	$r = $wpdb->get_results($sql);
 
-	if($r[0]->zbsmail_active == 1){
+	if ( isset( $r[0] ) && $r[0]->zbsmail_active === 1 ) {
 		return true;
 	}else{
 		return false;

--- a/projects/plugins/crm/modules/portal/endpoints/class-single-quote-endpoint.php
+++ b/projects/plugins/crm/modules/portal/endpoints/class-single-quote-endpoint.php
@@ -72,7 +72,7 @@ class Single_Quote_Endpoint extends Client_Portal_Endpoint {
 					// js-exposed success/failure messages
 					?>
 						<div id="zbs-quote-accepted-<?php echo esc_attr( $quote_id ) ?>" class="alert alert-success" style="display:none;margin-bottom:5em;">
-							<?php esc_html_e( 'Quote accepted, Thank you.', 'zero-bs-crm' ); ?>
+							<?php esc_html_e( 'Quote accepted. Thank you!', 'zero-bs-crm' ); ?>
 						</div>
 						<div id="zbs-quote-failed-<?php echo esc_attr( $quote_id ) ?>" class="alert alert-warning" style="display:none;margin-bottom:5em;">
 							<?php esc_html_e( 'Quote could not be accepted at this time.', 'zero-bs-crm' ); ?>


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/2862

## Proposed changes:

This PR fixes this issue that doesn't allow admin users to accept quotes if it were necessary.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Check the code
- Create a quote for an admin user
- Try to accept it by clicking on `Share the Link or [preview]` below the quote, after save it, it will send you to the Client Portal and you will see the Quote, click on accept:
   - In trunk, it will return an error.
   - In this branch, the quote will be accepted. 

