### PR TITLE
AI Extension: add create-with-voice beta extension

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-extension-add-create-with-voice-beta-extension
+++ b/projects/plugins/jetpack/changelog/update-ai-extension-add-create-with-voice-beta-extension
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: add create-with-voice beta extension

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -68,3 +68,13 @@ add_action(
 		\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-form-support' );
 	}
 );
+
+/**
+ * Register the `create-with-voice` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		\Jetpack_Gutenberg::set_extension_available( 'create-with-voice' );
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -62,7 +62,8 @@
 		"launchpad-save-modal",
 		"recipe",
 		"v6-video-frame-poster",
-		"videopress/video-chapters"
+		"videopress/video-chapters",
+		"create-with-voice"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],
 	"no-post-editor": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/32739

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: add create-with-voice beta extension

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test switching between `production` and [beta](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/jetpack/extensions#beta-extensions) extension.
* Confirm that when `production` extension is enabled, the `create-witth-voice` extension is not available. You can do that easily:
  *  Go to the block editor
  *  Open the dev console of your browser
  * Type `Jetpack_Editor_Initial_State.available_blocks?.[ 'create-with-voice' ]`

<img width="491" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/e6914b84-0eb5-49b2-866d-83971581ad1e">

* Confirm that when `beta` extension enabled, the `create-with-voice` extension is available:
<img width="502" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/bef9e10e-18b3-4eaa-93ed-85f31cb7de30">

Test in Jetpack, Atomic and Simple sites

