### PR TITLE
Jetpack: Newsletter - make the next steps easier

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/newsletter-card/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/components/newsletter-card/index.tsx
@@ -1,0 +1,122 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+import Button from 'components/button';
+import Card from 'components/card';
+import analytics from 'lib/analytics';
+import { FC, useCallback } from 'react';
+import { connect } from 'react-redux';
+import { isCurrentUserLinked, isConnectionOwner, connectUser } from 'state/connection';
+import { newsletterLearnMoreDismissed, updateSettings } from 'state/settings';
+import { isFetchingSiteData } from 'state/site';
+import Gridicon from '../gridicon';
+
+interface Props {
+	isDismissed: boolean;
+	dismiss: () => void;
+	path: string;
+	isUserLinked: boolean;
+	isOwner: boolean;
+	isFetchingData: boolean;
+	className?: string;
+}
+
+const NewsletterCard: FC< Props > = ( {
+	isDismissed,
+	dismiss,
+	path,
+	isUserLinked,
+	isOwner,
+	isFetchingData,
+	className,
+} ) => {
+	const trackEvent = useCallback(
+		( target: string ) => {
+			analytics.tracks.recordJetpackClick( {
+				target: target,
+				feature: 'newsletter',
+				page: path,
+				is_user_wpcom_connected: isUserLinked ? 'yes' : 'no',
+				is_connection_owner: isOwner ? 'yes' : 'no',
+			} );
+		},
+		[ path, isUserLinked, isOwner ]
+	);
+
+	const handleClick = useCallback( () => {
+		trackEvent( 'learn-more-click' );
+	}, [ trackEvent ] );
+
+	const handleDismiss = useCallback( () => {
+		dismiss();
+		trackEvent( 'learn-more-dismiss' );
+	}, [ dismiss, trackEvent ] );
+
+	if ( isDismissed ) {
+		return null;
+	} else if ( isFetchingData ) {
+		return <div />;
+	}
+
+	const classes = classNames( className, 'jp-newsletter-card' );
+
+	return (
+		<div className={ classes }>
+			<Card className="jp-newsletter-card__wrapper">
+				<div className="jp-newsletter-card__contact">
+					<div className="jp-newsletter-card__content">
+						<div className="jp-newsletter-card-text">
+							<h3 className="jp-newsletter-card__header">
+								{ __( 'Get started with Jetpack Newsletter', 'jetpack' ) }
+							</h3>
+							<p className="jp-newsletter-card__description">
+								{ __(
+									'Ready to grow your subscribers? Begin by adding a subscribe form to your site.',
+									'jetpack'
+								) }
+							</p>
+						</div>
+						<div className="jp-newsletter-card__link-button">
+							<Button
+								onClick={ handleClick }
+								primary
+								href={ getRedirectUrl( 'jetpack-support-subscriptions' ) }
+								target="_blank"
+								rel="noreferrer"
+							>
+								{ __( 'Learn More', 'jetpack' ) }
+								<Gridicon className="dops-card__link-indicator" icon="external" />
+							</Button>
+						</div>
+					</div>
+					<Button
+						borderless
+						compact
+						className="jp-newsletter-card__dismiss"
+						onClick={ handleDismiss }
+					>
+						<span className="dashicons dashicons-no" />
+					</Button>
+				</div>
+			</Card>
+		</div>
+	);
+};
+
+export default connect(
+	state => ( {
+		isFetchingData: isFetchingSiteData( state ),
+		isUserLinked: isCurrentUserLinked( state ),
+		isOwner: isConnectionOwner( state ),
+		isDismissed: newsletterLearnMoreDismissed( state ),
+	} ),
+	dispatch => ( {
+		dismiss: () =>
+			dispatch(
+				updateSettings( {
+					dismiss_dash_newsletter_learn_more: true,
+				} )
+			),
+		connectUser: () => dispatch( connectUser() ),
+	} )
+)( NewsletterCard );

--- a/projects/plugins/jetpack/_inc/client/components/newsletter-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/newsletter-card/style.scss
@@ -36,7 +36,7 @@
 	margin-bottom: 0;
 	display: flex;
 	flex-flow: row nowrap;
-	background: rgb(249, 249, 246);
+	background: white;
 
 	@include dashboard-card-shadow;
 

--- a/projects/plugins/jetpack/_inc/client/components/newsletter-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/newsletter-card/style.scss
@@ -1,0 +1,99 @@
+.jp-newsletter-card {
+	margin-top: rem( 16px );
+	margin-bottom: 0;
+}
+
+.jp-newsletter-card__dismiss {
+	width: 20px;
+	margin-left: 21px;
+	flex-grow: 0;
+	flex-shrink: 0;
+}
+
+.jp-newsletter-card__description,
+.jp-newsletter-card__link-button {
+	font-size: $font-body-small;
+	line-height: 1.65;
+
+	&:first-of-type {
+		margin-top: 4px;
+	}
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
+
+	.dops-button {
+		margin: 0 16px 0 0;
+
+		@include breakpoint( "<960px" ) {
+			margin: 0 16px 8px 0;
+		}
+	}
+}
+
+.jp-newsletter-card__wrapper {
+	margin-bottom: 0;
+	display: flex;
+	flex-flow: row nowrap;
+	background: rgb(249, 249, 246);
+
+	@include dashboard-card-shadow;
+
+	@include breakpoint( '<782px' ) {
+		.jp-newsletter-card__description:first-of-type {
+			margin-bottom: rem( 16px );
+		}
+	}
+}
+
+.jp-newsletter-card__header {
+	font-weight: 500;
+	font-size: $font-title-small;
+	line-height: 30px;
+	color: $black;
+	margin: 0;
+
+	@include breakpoint( "<660px" ) {
+		margin: 1.5rem 0 0 0;
+	}
+}
+
+.jp-newsletter-card__description {
+	font-size: $font-body-small;
+	line-height: 24px;
+	letter-spacing: -0.02em;
+}
+
+.jp-newsletter-card__link-button {
+	flex-grow: 0;
+
+	.dops-button {
+		margin-right: 0;
+
+		.svg {
+			margin-left: 10px;
+		}
+	}
+	a:visited{
+		color:white !important; //to override the other styles
+	}
+}
+
+.jp-newsletter-card-text {
+	flex-grow: 1;
+}
+
+.jp-newsletter-card__contact {
+	flex-shrink: 1;
+	flex-grow: 1;
+	display: flex;
+	align-items: center;
+
+	.jp-newsletter-card__content {
+		display: flex;
+		flex-grow: 1;
+		align-items: center;
+		flex-wrap: wrap;
+	}
+}

--- a/projects/plugins/jetpack/_inc/client/components/newsletter-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/newsletter-card/style.scss
@@ -36,7 +36,8 @@
 	margin-bottom: 0;
 	display: flex;
 	flex-flow: row nowrap;
-	background: white;
+	background: rgb(249, 249, 246);
+	background: linear-gradient(133deg, rgb(206, 217, 242) 0%, rgb(249, 249, 246) 10%, rgb(249, 249, 246) 80%, rgb(245, 230, 179) 100%);
 
 	@include dashboard-card-shadow;
 

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -98,6 +98,7 @@ const recommendationsRoutes = [
 	'/recommendations/monitor',
 	'/recommendations/newsletter',
 	'/recommendations/newsletter-activated',
+	'/recommendations/paid-newsletter',
 	'/recommendations/related-posts',
 	'/recommendations/creative-mail',
 	'/recommendations/site-accelerator',
@@ -585,6 +586,7 @@ class Main extends React.Component {
 			case '/recommendations/monitor':
 			case '/recommendations/newsletter':
 			case '/recommendations/newsletter-activated':
+			case '/recommendations/paid-newsletter':
 			case '/recommendations/related-posts':
 			case '/recommendations/creative-mail':
 			case '/recommendations/site-accelerator':

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -97,6 +97,7 @@ const recommendationsRoutes = [
 	'/recommendations/woocommerce',
 	'/recommendations/monitor',
 	'/recommendations/newsletter',
+	'/recommendations/newsletter-activated',
 	'/recommendations/related-posts',
 	'/recommendations/creative-mail',
 	'/recommendations/site-accelerator',
@@ -583,6 +584,7 @@ class Main extends React.Component {
 			case '/recommendations/woocommerce':
 			case '/recommendations/monitor':
 			case '/recommendations/newsletter':
+			case '/recommendations/newsletter-activated':
 			case '/recommendations/related-posts':
 			case '/recommendations/creative-mail':
 			case '/recommendations/site-accelerator':

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -98,7 +98,6 @@ const recommendationsRoutes = [
 	'/recommendations/monitor',
 	'/recommendations/newsletter',
 	'/recommendations/newsletter-activated',
-	'/recommendations/paid-newsletter',
 	'/recommendations/related-posts',
 	'/recommendations/creative-mail',
 	'/recommendations/site-accelerator',
@@ -586,7 +585,6 @@ class Main extends React.Component {
 			case '/recommendations/monitor':
 			case '/recommendations/newsletter':
 			case '/recommendations/newsletter-activated':
-			case '/recommendations/paid-newsletter':
 			case '/recommendations/related-posts':
 			case '/recommendations/creative-mail':
 			case '/recommendations/site-accelerator':

--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { getModule } from 'state/modules';
 import { isModuleFound as isModuleFoundSelector } from 'state/search';
+import NewsletterCard from '../components/newsletter-card';
 import SubscriptionsSettings from './subscriptions-settings';
 
 /**
@@ -28,6 +29,7 @@ function Subscriptions( props ) {
 	return (
 		<div>
 			<QuerySite />
+			<NewsletterCard />
 			<h1 className="screen-reader-text">{ __( 'Jetpack Newsletter Settings', 'jetpack' ) }</h1>
 			<h2 className="jp-settings__section-title">
 				{ searchTerm
@@ -38,6 +40,7 @@ function Subscriptions( props ) {
 							/* dummy arg to avoid bad minification */ 0
 					  ) }
 			</h2>
+
 			{ foundSubscriptions && <SubscriptionsSettings siteRawUrl={ siteRawUrl } /> }
 		</div>
 	);

--- a/projects/plugins/jetpack/_inc/client/recommendations/constants.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/constants.js
@@ -44,6 +44,7 @@ export const RECOMMENDATION_WIZARD_STEP = {
 	ANTISPAM_ACTIVATED: 'antispam-activated',
 	VIDEOPRESS_ACTIVATED: 'videopress-activated',
 	SEARCH_ACTIVATED: 'search-activated',
+	NEWSLETTER_ACTIVATED: 'newsletter-activated',
 	SERVER_CREDENTIALS: 'server-credentials',
 	BOOST: 'boost',
 	SUMMARY: 'summary',
@@ -60,6 +61,7 @@ export const ONBOARDING_JETPACK_VIDEOPRESS = 'JETPACK_VIDEOPRESS';
 export const ONBOARDING_JETPACK_SEARCH = 'JETPACK_SEARCH';
 export const ONBOARDING_JETPACK_SCAN = 'JETPACK_SCAN';
 export const ONBOARDING_JETPACK_GOLDEN_TOKEN = 'JETPACK_GOLDEN_TOKEN';
+export const ONBOARDING_JETPACK_NEWSLETTER = 'JETPACK_NEWSLETTER';
 
 export const ONBOARDING_SUPPORT_START_TIMESTAMP = 1664323200000; // 2022-09-28
 
@@ -121,6 +123,10 @@ export const SUMMARY_SECTION_BY_ONBOARDING_NAME = {
 	[ ONBOARDING_JETPACK_SEARCH ]: {
 		name: 'Search',
 		slugs: [ 'search-activated' ],
+	},
+	[ ONBOARDING_JETPACK_NEWSLETTER ]: {
+		name: 'Newsletter',
+		slugs: [ 'newsletter-activated' ],
 	},
 	[ ONBOARDING_JETPACK_SCAN ]: {
 		name: 'Scan',

--- a/projects/plugins/jetpack/_inc/client/recommendations/constants.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/constants.js
@@ -44,7 +44,6 @@ export const RECOMMENDATION_WIZARD_STEP = {
 	ANTISPAM_ACTIVATED: 'antispam-activated',
 	VIDEOPRESS_ACTIVATED: 'videopress-activated',
 	SEARCH_ACTIVATED: 'search-activated',
-	NEWSLETTER_ACTIVATED: 'newsletter-activated',
 	SERVER_CREDENTIALS: 'server-credentials',
 	BOOST: 'boost',
 	SUMMARY: 'summary',
@@ -61,7 +60,6 @@ export const ONBOARDING_JETPACK_VIDEOPRESS = 'JETPACK_VIDEOPRESS';
 export const ONBOARDING_JETPACK_SEARCH = 'JETPACK_SEARCH';
 export const ONBOARDING_JETPACK_SCAN = 'JETPACK_SCAN';
 export const ONBOARDING_JETPACK_GOLDEN_TOKEN = 'JETPACK_GOLDEN_TOKEN';
-export const ONBOARDING_JETPACK_NEWSLETTER = 'JETPACK_NEWSLETTER';
 
 export const ONBOARDING_SUPPORT_START_TIMESTAMP = 1664323200000; // 2022-09-28
 
@@ -123,10 +121,6 @@ export const SUMMARY_SECTION_BY_ONBOARDING_NAME = {
 	[ ONBOARDING_JETPACK_SEARCH ]: {
 		name: 'Search',
 		slugs: [ 'search-activated' ],
-	},
-	[ ONBOARDING_JETPACK_NEWSLETTER ]: {
-		name: 'Newsletter',
-		slugs: [ 'newsletter-activated' ],
 	},
 	[ ONBOARDING_JETPACK_SCAN ]: {
 		name: 'Scan',

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -175,6 +175,12 @@ export const getSummaryPrimaryProps = ( state, primarySlug ) => {
 				ctaLabel: __( 'Customize', 'jetpack' ),
 				ctaLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-search-configure',
 			};
+		case 'newsletter-activated':
+			return {
+				displayName: __( 'Newsletter', 'jetpack' ),
+				ctaLabel: __( 'Customize', 'jetpack' ),
+				ctaLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-newsletter-configure',
+			};
 	}
 };
 
@@ -595,6 +601,24 @@ export const getStepContent = ( state, stepSlug ) => {
 				ctaText: __( 'Customize Search', 'jetpack' ),
 				ctaLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-search-configure',
 				illustration: 'assistant-search',
+				skipText: __( 'Next', 'jetpack' ),
+			};
+		case 'newsletter-activated':
+			return {
+				question: __( 'Jetpack Newsletter Activated', 'jetpack' ),
+				description: __(
+					'Jetpack Newsletter is now active. Grow your subscriber list and deliver your content to subscribers inboxes.',
+					'jetpack'
+				),
+				descriptionList: [
+					__( 'Simple Subscriber sign up form', 'jetpack' ),
+					__( 'Lock posts for subscribers only', 'jetpack' ),
+					__( 'Build your audience of loyal fans', 'jetpack' ),
+				],
+				ctaText: __( 'Create Newsletter Sign Up Page', 'jetpack' ),
+				ctaLink: getSiteAdminUrl( state ) + 'post-new.php?post_type=page',
+				illustration: 'assistant-newsletter',
+				summaryViewed: false,
 				skipText: __( 'Next', 'jetpack' ),
 			};
 		case 'server-credentials':

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -28,56 +28,56 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 	switch ( featureSlug ) {
 		case 'boost':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'Jetpack Boost', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-boost',
 			};
 		case 'creative-mail':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'Creative Mail', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=creativemail',
 			};
 		case 'monitor':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'Downtime Monitoring', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: '#/settings?term=monitor',
 			};
 		case 'newsletter':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'Newsletter', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
-				configLink: '#/settings?term=subscriptions',
+				configLink: '#/recommendations/newsletter-activated',
 			};
 		case 'related-posts':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'Related Posts', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: '#/settings?term=related%20posts',
 			};
 		case 'protect':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'Jetpack Protect', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-protect',
 			};
 		case 'site-accelerator':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'Site Accelerator', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: '#/settings?term=cdn',
 			};
 		case 'publicize':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'Social Media Sharing', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: getRedirectUrl( 'calypso-marketing-connections', {
@@ -86,14 +86,14 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 			};
 		case 'videopress':
 			return {
-				configureButtonLabel: __( 'How To', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'VideoPress', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: getRedirectUrl( 'jetpack-support-videopress-block-editor' ),
 			};
 		case 'woocommerce':
 			return {
-				configureButtonLabel: __( 'Settings', 'jetpack' ),
+				configureButtonLabel: __( 'Get Started', 'jetpack' ),
 				displayName: __( 'WooCommerce', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=wc-admin&path=%2Fsetup-wizard',
@@ -179,7 +179,7 @@ export const getSummaryPrimaryProps = ( state, primarySlug ) => {
 			return {
 				displayName: __( 'Newsletter', 'jetpack' ),
 				ctaLabel: __( 'Customize', 'jetpack' ),
-				ctaLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-newsletter-configure',
+				ctaLink: getSiteAdminUrl( state ) + 'post-new.php?post_type=page',
 			};
 	}
 };
@@ -607,19 +607,36 @@ export const getStepContent = ( state, stepSlug ) => {
 			return {
 				question: __( 'Jetpack Newsletter Activated', 'jetpack' ),
 				description: __(
-					'Jetpack Newsletter is now active. Grow your subscriber list and deliver your content to subscribers inboxes.',
+					'Jetpack Newsletter is now active. You are one step closer to growing your subscribers. Start by adding a subscribe form.',
 					'jetpack'
 				),
 				descriptionList: [
-					__( 'Simple Subscriber sign up form', 'jetpack' ),
-					__( 'Lock posts for subscribers only', 'jetpack' ),
-					__( 'Build your audience of loyal fans', 'jetpack' ),
+					__( 'Create a new post or page.', 'jetpack' ),
+					__( 'Add the subscribe block by typing /subscribe', 'jetpack' ),
+					__( 'Publish and start promoting your site.', 'jetpack' ),
 				],
 				ctaText: __( 'Create Newsletter Sign Up Page', 'jetpack' ),
 				ctaLink: getSiteAdminUrl( state ) + 'post-new.php?post_type=page',
 				illustration: 'assistant-newsletter',
-				summaryViewed: false,
-				skipText: __( 'Next', 'jetpack' ),
+			};
+		case 'paid-newsletter':
+			return {
+				question: __( 'Start a Paid Newsletter', 'jetpack' ),
+				description: __(
+					'Monetize your Newsletter by offering premium content to paid subscribers.',
+					'jetpack'
+				),
+				descriptionList: [
+					__( 'Set up paid newsletter subscriptions.', 'jetpack' ),
+					__( 'Publish premium content.', 'jetpack' ),
+					__( 'Earn money through your Newsletter.', 'jetpack' ),
+				],
+				ctaText: __( 'Create a Paid Newsletter', 'jetpack' ),
+				ctaLink:
+					'https://wordpress.com/earn/payments-plans/' +
+					location.hostname +
+					'#add-newsletter-payment-plan',
+				illustration: 'assistant-newsletter',
 			};
 		case 'server-credentials':
 			return {

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -615,8 +615,8 @@ export const getStepContent = ( state, stepSlug ) => {
 					__( 'Add the subscribe block by typing /subscribe', 'jetpack' ),
 					__( 'Publish and start promoting your site.', 'jetpack' ),
 				],
-				ctaText: __( 'Create Newsletter Sign Up Page', 'jetpack' ),
-				ctaLink: getSiteAdminUrl( state ) + 'post-new.php?post_type=page',
+				ctaText: __( 'Read the Guide', 'jetpack' ),
+				ctaLink: 'https://jetpack.com/support/newsletter/',
 				illustration: 'assistant-newsletter',
 			};
 		case 'paid-newsletter':

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -52,7 +52,7 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Newsletter', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
-				configLink: '#/recommendations/newsletter-activated',
+				configLink: '#/newsletter',
 			};
 		case 'related-posts':
 			return {

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -619,25 +619,6 @@ export const getStepContent = ( state, stepSlug ) => {
 				ctaLink: 'https://jetpack.com/support/newsletter/',
 				illustration: 'assistant-newsletter',
 			};
-		case 'paid-newsletter':
-			return {
-				question: __( 'Start a Paid Newsletter', 'jetpack' ),
-				description: __(
-					'Monetize your Newsletter by offering premium content to paid subscribers.',
-					'jetpack'
-				),
-				descriptionList: [
-					__( 'Set up paid newsletter subscriptions.', 'jetpack' ),
-					__( 'Publish premium content.', 'jetpack' ),
-					__( 'Earn money through your Newsletter.', 'jetpack' ),
-				],
-				ctaText: __( 'Create a Paid Newsletter', 'jetpack' ),
-				ctaLink:
-					'https://wordpress.com/earn/payments-plans/' +
-					location.hostname +
-					'#add-newsletter-payment-plan',
-				illustration: 'assistant-newsletter',
-			};
 		case 'server-credentials':
 			return {
 				question: __( 'Setup one-click restores', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -607,13 +607,13 @@ export const getStepContent = ( state, stepSlug ) => {
 			return {
 				question: __( 'Jetpack Newsletter Activated', 'jetpack' ),
 				description: __(
-					'Jetpack Newsletter is now active. You are one step closer to growing your subscribers. Start by adding a subscribe form.',
+					'Jetpack Newsletter is now active. You are one step closer to growing your subscribers. Start by adding a subscribe form to your site.',
 					'jetpack'
 				),
 				descriptionList: [
 					__( 'Create a new post or page.', 'jetpack' ),
 					__( 'Add the subscribe block by typing /subscribe', 'jetpack' ),
-					__( 'Publish and start promoting your site.', 'jetpack' ),
+					__( 'Start promoting your site.', 'jetpack' ),
 				],
 				ctaText: __( 'Read the Guide', 'jetpack' ),
 				ctaLink: 'https://jetpack.com/support/newsletter/',

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -178,8 +178,8 @@ export const getSummaryPrimaryProps = ( state, primarySlug ) => {
 		case 'newsletter-activated':
 			return {
 				displayName: __( 'Newsletter', 'jetpack' ),
-				ctaLabel: __( 'Customize', 'jetpack' ),
-				ctaLink: getSiteAdminUrl( state ) + 'post-new.php?post_type=page',
+				ctaLabel: __( 'Read the Guide', 'jetpack' ),
+				ctaLink: getRedirectUrl( 'jetpack-support-subscriptions' ),
 			};
 	}
 };
@@ -616,7 +616,7 @@ export const getStepContent = ( state, stepSlug ) => {
 					__( 'Start promoting your site.', 'jetpack' ),
 				],
 				ctaText: __( 'Read the Guide', 'jetpack' ),
-				ctaLink: 'https://jetpack.com/support/newsletter/',
+				ctaLink: getRedirectUrl( 'jetpack-support-subscriptions' ),
 				illustration: 'assistant-newsletter',
 			};
 		case 'server-credentials':

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-utils.js
@@ -28,56 +28,56 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 	switch ( featureSlug ) {
 		case 'boost':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Jetpack Boost', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-boost',
 			};
 		case 'creative-mail':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Creative Mail', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=creativemail',
 			};
 		case 'monitor':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Downtime Monitoring', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: '#/settings?term=monitor',
 			};
 		case 'newsletter':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Newsletter', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: '#/recommendations/newsletter-activated',
 			};
 		case 'related-posts':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Related Posts', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: '#/settings?term=related%20posts',
 			};
 		case 'protect':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Jetpack Protect', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=jetpack-protect',
 			};
 		case 'site-accelerator':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Site Accelerator', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: '#/settings?term=cdn',
 			};
 		case 'publicize':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'Social Media Sharing', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: getRedirectUrl( 'calypso-marketing-connections', {
@@ -86,14 +86,14 @@ export const mapStateToSummaryFeatureProps = ( state, featureSlug ) => {
 			};
 		case 'videopress':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'How To', 'jetpack' ),
 				displayName: __( 'VideoPress', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Enable', 'jetpack' ),
 				configLink: getRedirectUrl( 'jetpack-support-videopress-block-editor' ),
 			};
 		case 'woocommerce':
 			return {
-				configureButtonLabel: __( 'Get Started', 'jetpack' ),
+				configureButtonLabel: __( 'Settings', 'jetpack' ),
 				displayName: __( 'WooCommerce', 'jetpack' ),
 				summaryActivateButtonLabel: __( 'Install', 'jetpack' ),
 				configLink: getSiteAdminUrl( state ) + 'admin.php?page=wc-admin&path=%2Fsetup-wizard',

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -305,7 +305,7 @@ const RecommendationsComponent = props => {
 						<ResourcePrompt stepSlug="newsletter-activated" />
 					</Route>
 					<Route path="/recommendations/paid-newsletter">
-						<ResourcePrompt stepSlug="paid-newsletter" />
+						<ResourcePrompt stepSlug="paid-newsletter" isNew={ isNew( 'paid-newsletter' ) } />
 					</Route>
 					<Route path="/recommendations/summary">
 						<Summary newRecommendations={ newRecommendations } />

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -166,6 +166,9 @@ const RecommendationsComponent = props => {
 		case RECOMMENDATION_WIZARD_STEP.SEARCH_ACTIVATED:
 			redirectPath = '/search-activated';
 			break;
+		case RECOMMENDATION_WIZARD_STEP.NEWSLETTER_ACTIVATED:
+			redirectPath = '/newsletter-activated';
+			break;
 		default:
 			redirectPath = '/summary';
 			break;
@@ -297,6 +300,9 @@ const RecommendationsComponent = props => {
 					</Route>
 					<Route path="/recommendations/server-credentials">
 						<ResourcePrompt stepSlug="server-credentials" />
+					</Route>
+					<Route path="/recommendations/newsletter-activated">
+						<ResourcePrompt stepSlug="newsletter-activated" isNew={ isNew( 'newsletter' ) } />
 					</Route>
 					<Route path="/recommendations/summary">
 						<Summary newRecommendations={ newRecommendations } />

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -302,7 +302,10 @@ const RecommendationsComponent = props => {
 						<ResourcePrompt stepSlug="server-credentials" />
 					</Route>
 					<Route path="/recommendations/newsletter-activated">
-						<ResourcePrompt stepSlug="newsletter-activated" isNew={ isNew( 'newsletter' ) } />
+						<ResourcePrompt stepSlug="newsletter-activated" />
+					</Route>
+					<Route path="/recommendations/paid-newsletter">
+						<ResourcePrompt stepSlug="paid-newsletter" />
 					</Route>
 					<Route path="/recommendations/summary">
 						<Summary newRecommendations={ newRecommendations } />

--- a/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/index.jsx
@@ -304,9 +304,6 @@ const RecommendationsComponent = props => {
 					<Route path="/recommendations/newsletter-activated">
 						<ResourcePrompt stepSlug="newsletter-activated" />
 					</Route>
-					<Route path="/recommendations/paid-newsletter">
-						<ResourcePrompt stepSlug="paid-newsletter" isNew={ isNew( 'paid-newsletter' ) } />
-					</Route>
 					<Route path="/recommendations/summary">
 						<Summary newRecommendations={ newRecommendations } />
 					</Route>

--- a/projects/plugins/jetpack/_inc/client/scss/style.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/style.scss
@@ -40,6 +40,7 @@
 @import '../components/masthead/style';
 @import '../components/module-settings/style';
 @import '../components/agencies-card/style';
+@import '../components/newsletter-card/style';
 @import '../components/support-card/style';
 @import '../components/forms/styles';
 @import '../components/admin-notices/style';

--- a/projects/plugins/jetpack/_inc/client/state/settings/actions.js
+++ b/projects/plugins/jetpack/_inc/client/state/settings/actions.js
@@ -114,6 +114,7 @@ export const updateSettings = ( newOptionValues, noticeMessages = {} ) => {
 			'dismiss_empty_stats_card',
 			'dismiss_dash_backup_getting_started',
 			'dismiss_dash_agencies_learn_more',
+			'dismiss_dash_newsletter_learn_more',
 		];
 		if (
 			'object' === typeof newOptionValues &&

--- a/projects/plugins/jetpack/_inc/client/state/settings/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/settings/reducer.js
@@ -212,3 +212,13 @@ export function backupGettingStartedDismissed( state ) {
 export function agenciesLearnMoreDismissed( state ) {
 	return get( state.jetpack.settings.items, 'dismiss_dash_agencies_learn_more', false );
 }
+
+/**
+ * Returns true if Newsletter Learn More card has been dismissed.
+ *
+ * @param {object} state - Global state tree
+ * @returns {boolean} Whether the card has been dismissed
+ */
+export function newsletterLearnMoreDismissed( state ) {
+	return get( state.jetpack.settings.items, 'dismiss_dash_newsletter_learn_more', false );
+}

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2906,6 +2906,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 
+			// Newsletter Learn More card on settings.
+			'dismiss_dash_newsletter_learn_more'   => array(
+				'description'       => '',
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'settings',
+			),
+
 			'lang_id'                              => array(
 				'description' => esc_html__( 'Primary language for the site.', 'jetpack' ),
 				'type'        => 'string',

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -957,6 +957,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'dismiss_empty_stats_card':
 				case 'dismiss_dash_backup_getting_started':
 				case 'dismiss_dash_agencies_learn_more':
+				case 'dismiss_dash_newsletter_learn_more':
 					// If option value was the same, consider it done.
 					$updated = get_option( $option ) != $value // phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual -- ensure we support bools or strings saved by update_option.
 						? update_option( $option, (bool) $value )

--- a/projects/plugins/jetpack/changelog/welcome-to-newsletter
+++ b/projects/plugins/jetpack/changelog/welcome-to-newsletter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adds two new recommendation cards to help with Newsletter onboarding


### PR DESCRIPTION
## Proposed changes:

Working through the best place to guide next steps. Currently the link to the guide is hidden behind a tool-tip on the settings page.

<img width="1161" alt="Screenshot 2023-09-01 at 17 01 05" src="https://github.com/Automattic/jetpack/assets/4077604/29780c13-9a67-4011-b6de-76f1c47db23b">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
to follow

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `wp-admin/admin.php?page=jetpack#/recommendations/newsletter-activated` to view the Newsletter activated "Recommendation" if we decide to go that route
* Go to `wp-admin/admin.php?page=jetpack#/newsletter` to see the new card (not a JITM)

