### PR TITLE
Admin page: rely on initial state passed from PHP for theme data

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -1,6 +1,5 @@
 import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import Card from 'components/card';
@@ -17,6 +16,7 @@ import { isCurrentUserLinked, isUnavailableInOfflineMode, isOfflineMode } from '
 import {
 	isSubscriptionModalEnabled,
 	currentThemeIsBlockTheme,
+	currentThemeStylesheet,
 	getSiteAdminUrl,
 } from 'state/initial-state';
 import { getModule } from 'state/modules';
@@ -48,16 +48,14 @@ function SubscriptionsSettings( props ) {
 		updateFormStateModuleOption,
 		isBlockTheme,
 		siteAdminUrl,
+		themeStylesheet,
 	} = props;
 
-	const theme = useSelect( select => select( 'core' ).getCurrentTheme() );
-	const themeSlug = theme?.stylesheet;
-
 	const subscribeModalEditorUrl =
-		siteAdminUrl && themeSlug
+		siteAdminUrl && themeStylesheet
 			? addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
 					postType: 'wp_template_part',
-					postId: `${ themeSlug }//jetpack-subscribe-modal`,
+					postId: `${ themeStylesheet }//jetpack-subscribe-modal`,
 					canvas: 'edit',
 			  } )
 			: null;
@@ -211,6 +209,7 @@ export default withModuleSettingsFormHelpers(
 			isSmEnabled: ownProps.getOptionValue( 'sm_enabled' ),
 			isBlockTheme: currentThemeIsBlockTheme( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
+			themeStylesheet: currentThemeStylesheet( state ),
 		};
 	} )( SubscriptionsSettings )
 );

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -361,6 +361,16 @@ export function isAtomicPlatform( state ) {
 }
 
 /**
+ * Get the current theme's stylesheet (slug).
+ *
+ * @param {object} state - Global state tree.
+ * @returns {string} theme stylesheet, e.g. twentytwentythree.
+ */
+export function currentThemeStylesheet( state ) {
+	return get( state.jetpack.initialState.themeData, 'stylesheet' );
+}
+
+/**
  * Check that theme supports a certain feature
  *
  * @param {Object} state   Global state tree.

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -199,6 +199,7 @@ class Jetpack_Redux_State_Helper {
 			),
 			'themeData'                   => array(
 				'name'         => $current_theme->get( 'Name' ),
+				'stylesheet'   => $current_theme->get_stylesheet(),
 				'hasUpdate'    => (bool) get_theme_update_available( $current_theme ),
 				'isBlockTheme' => (bool) $current_theme->is_block_theme(),
 				'support'      => array(

--- a/projects/plugins/jetpack/changelog/update-fetching-stylesheet-client
+++ b/projects/plugins/jetpack/changelog/update-fetching-stylesheet-client
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: update the way we fetch the current theme's stylesheet to build site editor link.


### PR DESCRIPTION
Follow-up to #32722

## Proposed changes:

This is a bit of refactoring that came to my mind as I was looking at #32722. @edanzer Let me know what you think about it, this is just an idea :)
Since we already query for information about the theme when we first load the dashboard, maybe we can use that directly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Follow the instructions in #32722.
