### PR TITLE
Reduce api calls for launchpad modal

### DIFF
--- a/projects/plugins/jetpack/changelog/reduce-api-calls-for-launchpad-modal
+++ b/projects/plugins/jetpack/changelog/reduce-api-calls-for-launchpad-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Launchpad modal: reduce API calls for modal dismiss flag

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -69,13 +69,16 @@ export const settings = {
 			siteIntentOption,
 		} = window?.Jetpack_LaunchpadSaveModal || {};
 
+		const hideFSENextStepsModalBool = !! hideFSENextStepsModal;
+
 		const [ isModalOpen, setIsModalOpen ] = useState( false );
-		const [ dontShowAgain, setDontShowAgain ] = useState( !! hideFSENextStepsModal );
-		const [ isChecked, setIsChecked ] = useState( !! hideFSENextStepsModal );
+		const [ dontShowAgain, setDontShowAgain ] = useState( hideFSENextStepsModalBool );
+		const [ isChecked, setIsChecked ] = useState( hideFSENextStepsModalBool );
 
 		const isInsideSiteEditor = document.getElementById( 'site-editor' ) !== null;
 		const isInsidePostEditor = document.querySelector( '.block-editor' ) !== null;
 		const prevHasNeverPublishedPostOption = useRef( hasNeverPublishedPostOption );
+		const initialHideFSENextStepsModal = useRef( hideFSENextStepsModalBool );
 
 		const siteFragment = getSiteFragment();
 		const launchPadUrl = getRedirectUrl( 'wpcom-launchpad-setup', {
@@ -177,7 +180,9 @@ export const settings = {
 		const handleDontShowAgainSetting = shouldHide => {
 			setDontShowAgain( shouldHide );
 			updateLaunchpadSaveModalBrowserConfig( { hideFSENextStepsModal: shouldHide } );
-			updateHideFSENextStepsModal( shouldHide );
+			if ( shouldHide !== initialHideFSENextStepsModal.current ) {
+				updateHideFSENextStepsModal( shouldHide );
+			}
 		};
 
 		return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/32567

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds some additional logic to the launchpad post publish modal to avoid making API calls when the setting hasn't actually changed. There were two situations where we were making API calls that we shouldn't:
   1. If the _Don't show this again_ checkbox was not checked, but the user clicked on a button or closed the modal, we'd send a redundant API call
   2. In some cases, we close the modal in favour of showing another modal, but then re-open our modal after that modal has been closed, which can also trigger an unnecessary API call. That modal juggling is handled via the following `useEffect()` code block: https://github.com/Automattic/jetpack/blob/abce9f2b0fda88238e65a2a2aca14c7b44758195/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js#L128-L159

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This changes a WordPress.com specific modal, so no discussion was involved.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to tracking or data.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure that you have an unlaunched WordPress.com site that is still showing the fullscreen modal -- if you don't have one, you can create a new site with the "Write & Publish" intent via https://wordpress.com/start - make sure you pause when you get to the fullscreen launchpad
* Apply this change to your WordPress.com development sandbox
* Ensure that `public-api.wordpress.com` _and_ the `*.wordpress.com` subdomain for your site are both pointing at your development sandbox
* Click on a task to publish or write a new post, or navigate directly to `https://wordpress.com/post/:siteSlug`
* Open your browser's development tools, and ensure that they retain data across navigation events
* Write some content for the post
* Publish the post
* Verify that you see the "Great progress" modal (you may see another "Post published!" modal first)
* Verify that there isn't a `POST` call to the `launchpad` REST API
* Click on the "Back to edit" button
* Verify that there still isn't a `POST` call to the `launchpad` REST API
* Navigate to `https://wordpress.com/post/:siteSlug`
* Write some content in the post, and publish the post
* Verify that you see the "Great progress" modal (again, it may be preceded by the "Post published!" modal)
* Check the _Don't show this again_ checkbox
* Click on the "Next steps" button
* Verify that there is a `POST` API call to the `launchpad` REST API

The basic idea here is that we want to limit calls to those that actually change the value.