### PR TITLE
Subscription Block: Add newsletter categories to the content view

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-categories-content-view
+++ b/projects/plugins/jetpack/changelog/add-newsletter-categories-content-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add newsletter categories to the subscription block content view.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -293,18 +293,20 @@ export function SubscriptionEdit( props ) {
 			) }
 
 			<div className={ getBlockClassName() } style={ cssVars }>
-				<div className="wp-block-jetpack-subscriptions__newsletter-categories">
-					{ newsletterCategories.map( category => {
-						return (
-							<div
-								key={ `newsletter-category-${ category.id }` }
-								className="wp-block-jetpack-subscriptions__newsletter-category"
-							>
-								{ category.name }
-							</div>
-						);
-					} ) }
-				</div>
+				{ newsletterCategoriesEnabled ? (
+					<div className="wp-block-jetpack-subscriptions__newsletter-categories">
+						{ newsletterCategories.map( category => {
+							return (
+								<div
+									key={ `newsletter-category-${ category.id }` }
+									className="wp-block-jetpack-subscriptions__newsletter-category"
+								>
+									<div>{ category.name }</div>
+								</div>
+							);
+						} ) }
+					</div>
+				) : null }
 
 				<div className="wp-block-jetpack-subscriptions__form" role="form">
 					<TextControl

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -443,6 +443,8 @@ function get_element_styles_from_attributes( $attributes ) {
 	$submit_button_styles .= $style;
 	$email_field_styles   .= $style;
 
+	$categories_styles = sprintf( '--subscribe-block-border-radius: %dpx;', get_attribute( $attributes, 'borderRadius', DEFAULT_BORDER_RADIUS_VALUE ) );
+
 	if ( has_attribute( $attributes, 'customBorderColor' ) ) {
 		$style = sprintf( 'border-color: %s; border-style: solid;', get_attribute( $attributes, 'customBorderColor' ) );
 
@@ -460,6 +462,7 @@ function get_element_styles_from_attributes( $attributes ) {
 		'email_field'           => $email_field_styles,
 		'submit_button'         => $submit_button_styles,
 		'submit_button_wrapper' => $submit_button_wrapper_styles,
+		'categories'            => $categories_styles,
 	);
 }
 
@@ -655,6 +658,19 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 	?>
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
 		<div class="wp-block-jetpack-subscriptions__container">
+			<?php if ( count( $newsletter_categories ) ) : ?>
+				<div
+					className="wp-block-jetpack-subscriptions__newsletter-categories"
+					style="<?php echo esc_attr( $styles['categories'] ); ?>"
+				>
+					<?php foreach ( $newsletter_categories as $category ) : ?>
+						<div class="wp-block-jetpack-subscriptions__newsletter-category">
+							<?php echo esc_html( $category['name'] ); ?>
+						</div>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
+
 			<form
 				action="<?php echo esc_url( $url ); ?>"
 				method="post"
@@ -663,16 +679,6 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 				data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
 				id="<?php echo esc_attr( $form_id ); ?>"
 			>
-				<?php if ( count( $newsletter_categories ) ) : ?>
-					<div className="wp-block-jetpack-subscriptions__newsletter-categories">
-						<?php foreach ( $newsletter_categories as $category ) : ?>
-							<div class="wp-block-jetpack-subscriptions__newsletter-category">
-								<?php echo esc_html( $category['name'] ); ?>
-							</div>
-						<?php endforeach; ?>
-					</div>
-				<?php endif; ?>
-
 				<?php
 				$email_field_id  = 'subscribe-field';
 				$email_field_id .= Jetpack_Subscriptions_Widget::$instance_count > 1
@@ -788,6 +794,19 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
 		<div class="jetpack_subscription_widget">
 			<div class="wp-block-jetpack-subscriptions__container">
+				<?php if ( count( $newsletter_categories ) ) : ?>
+					<div
+						className="wp-block-jetpack-subscriptions__newsletter-categories"
+						style="<?php echo esc_attr( $styles['categories'] ); ?>"
+					>
+						<?php foreach ( $newsletter_categories as $category ) : ?>
+							<div class="wp-block-jetpack-subscriptions__newsletter-category">
+								<?php echo esc_html( $category['name'] ); ?>
+							</div>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
+
 				<form
 					action="#"
 					method="post"
@@ -796,16 +815,6 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 					data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
-					<?php if ( count( $newsletter_categories ) ) : ?>
-						<div className="wp-block-jetpack-subscriptions__newsletter-categories">
-							<?php foreach ( $newsletter_categories as $category ) : ?>
-								<div class="wp-block-jetpack-subscriptions__newsletter-category">
-									<?php echo esc_html( $category['name'] ); ?>
-								</div>
-							<?php endforeach; ?>
-						</div>
-					<?php endif; ?>
-
 					<p id="subscribe-email">
 						<label id="jetpack-subscribe-label"
 							class="screen-reader-text"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -703,78 +703,76 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 			>
 				<?php render_newsletter_categories( $newsletter_categories, $styles ); ?>
 
-				<div class="wp-block-jetpack-subscriptions__hbox">
+				<?php
+				$email_field_id  = 'subscribe-field';
+				$email_field_id .= Jetpack_Subscriptions_Widget::$instance_count > 1
+					? '-' . Jetpack_Subscriptions_Widget::$instance_count
+					: '';
+				$label_field_id  = $email_field_id . '-label';
+				?>
+				<p id="subscribe-email">
+					<label
+						id="<?php echo esc_attr( $label_field_id ); ?>"
+						for="<?php echo esc_attr( $email_field_id ); ?>"
+						class="screen-reader-text"
+					>
+						<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
+					</label>
+
 					<?php
-					$email_field_id  = 'subscribe-field';
-					$email_field_id .= Jetpack_Subscriptions_Widget::$instance_count > 1
-						? '-' . Jetpack_Subscriptions_Widget::$instance_count
-						: '';
-					$label_field_id  = $email_field_id . '-label';
+					printf(
+						'<input
+							required="required"
+							type="email"
+							name="email"
+							%1$s
+							style="%2$s"
+							placeholder="%3$s"
+							value="%4$s"
+							id="%5$s"
+						/>',
+						( ! empty( $classes['email_field'] )
+							? 'class="' . esc_attr( $classes['email_field'] ) . '"'
+							: ''
+						),
+						( ! empty( $styles['email_field'] )
+							? esc_attr( $styles['email_field'] )
+							: 'width: 95%; padding: 1px 10px'
+						),
+						esc_attr( $data['subscribe_placeholder'] ),
+						esc_attr( $data['subscribe_email'] ),
+						esc_attr( $email_field_id )
+					);
 					?>
-					<p id="subscribe-email">
-						<label
-							id="<?php echo esc_attr( $label_field_id ); ?>"
-							for="<?php echo esc_attr( $email_field_id ); ?>"
-							class="screen-reader-text"
-						>
-							<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
-						</label>
+				</p>
 
-						<?php
-						printf(
-							'<input
-								required="required"
-								type="email"
-								name="email"
-								%1$s
-								style="%2$s"
-								placeholder="%3$s"
-								value="%4$s"
-								id="%5$s"
-							/>',
-							( ! empty( $classes['email_field'] )
-								? 'class="' . esc_attr( $classes['email_field'] ) . '"'
-								: ''
-							),
-							( ! empty( $styles['email_field'] )
-								? esc_attr( $styles['email_field'] )
-								: 'width: 95%; padding: 1px 10px'
-							),
-							esc_attr( $data['subscribe_placeholder'] ),
-							esc_attr( $data['subscribe_email'] ),
-							esc_attr( $email_field_id )
-						);
-						?>
-					</p>
-
-					<p id="subscribe-submit"
-						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+				<p id="subscribe-submit"
+					<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+						style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+					<?php endif; ?>
+				>
+					<input type="hidden" name="action" value="subscribe"/>
+					<input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
+					<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
+					<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
+					<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
+					<button type="submit"
+						<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+							class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
+						<?php endif; ?>
+						<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+							style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
 						<?php endif; ?>
 					>
-						<input type="hidden" name="action" value="subscribe"/>
-						<input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
-						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
-						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
-						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
-						<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-						<button type="submit"
-							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
-							<?php endif; ?>
-							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
-							<?php endif; ?>
-						>
-							<?php
-							echo wp_kses(
-								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
-							);
-							?>
-						</button>
-					</p>
-				</div>
+						<?php
+						echo wp_kses(
+							html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+							Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+						);
+						?>
+					</button>
+				</p>
 			</form>
 			<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
@@ -831,60 +829,58 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 				>
 					<?php render_newsletter_categories( $newsletter_categories, $styles ); ?>
 
-					<div class="wp-block-jetpack-subscriptions__hbox">
-						<p id="subscribe-email">
-							<label id="jetpack-subscribe-label"
-								class="screen-reader-text"
-								for="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>">
-								<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
-							</label>
-							<input type="email" name="email" required="required"
-								<?php if ( ! empty( $classes['email_field'] ) ) : ?>
-									class="<?php echo esc_attr( $classes['email_field'] ); ?> required"
-								<?php endif; ?>
-								<?php if ( ! empty( $styles['email_field'] ) ) : ?>
-									style="<?php echo esc_attr( $styles['email_field'] ); ?>"
-								<?php endif; ?>
-								value="<?php echo esc_attr( $data['subscribe_email'] ); ?>"
-								id="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>"
-								placeholder="<?php echo esc_attr( $data['subscribe_placeholder'] ); ?>"
-							/>
-						</p>
-
-
-						<p id="subscribe-submit"
-							<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-								style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+					<p id="subscribe-email">
+						<label id="jetpack-subscribe-label"
+							class="screen-reader-text"
+							for="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>">
+							<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
+						</label>
+						<input type="email" name="email" required="required"
+							<?php if ( ! empty( $classes['email_field'] ) ) : ?>
+								class="<?php echo esc_attr( $classes['email_field'] ); ?> required"
 							<?php endif; ?>
+							<?php if ( ! empty( $styles['email_field'] ) ) : ?>
+								style="<?php echo esc_attr( $styles['email_field'] ); ?>"
+							<?php endif; ?>
+							value="<?php echo esc_attr( $data['subscribe_email'] ); ?>"
+							id="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>"
+							placeholder="<?php echo esc_attr( $data['subscribe_placeholder'] ); ?>"
+						/>
+					</p>
+
+
+					<p id="subscribe-submit"
+						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+						<?php endif; ?>
+					>
+						<input type="hidden" name="action" value="subscribe"/>
+						<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
+						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
+						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
+						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+						<?php
+						if ( is_user_logged_in() ) {
+							wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
+						}
+						?>
+						<button type="submit"
+							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
+							<?php endif; ?>
+							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
+							<?php endif; ?>
+							name="jetpack_subscriptions_widget"
 						>
-							<input type="hidden" name="action" value="subscribe"/>
-							<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
-							<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
-							<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
-							<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 							<?php
-							if ( is_user_logged_in() ) {
-								wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
-							}
+							echo wp_kses(
+								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+							);
 							?>
-							<button type="submit"
-								<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-									class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
-								<?php endif; ?>
-								<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-									style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
-								<?php endif; ?>
-								name="jetpack_subscriptions_widget"
-							>
-								<?php
-								echo wp_kses(
-									html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-									Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
-								);
-								?>
-							</button>
-						</p>
-					</div>
+						</button>
+					</p>
 				</form>
 
 				<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -658,19 +658,6 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 	?>
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
 		<div class="wp-block-jetpack-subscriptions__container">
-			<?php if ( count( $newsletter_categories ) ) : ?>
-				<div
-					className="wp-block-jetpack-subscriptions__newsletter-categories"
-					style="<?php echo esc_attr( $styles['categories'] ); ?>"
-				>
-					<?php foreach ( $newsletter_categories as $category ) : ?>
-						<div class="wp-block-jetpack-subscriptions__newsletter-category">
-							<?php echo esc_html( $category['name'] ); ?>
-						</div>
-					<?php endforeach; ?>
-				</div>
-			<?php endif; ?>
-
 			<form
 				action="<?php echo esc_url( $url ); ?>"
 				method="post"
@@ -679,76 +666,91 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 				data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
 				id="<?php echo esc_attr( $form_id ); ?>"
 			>
-				<?php
-				$email_field_id  = 'subscribe-field';
-				$email_field_id .= Jetpack_Subscriptions_Widget::$instance_count > 1
-					? '-' . Jetpack_Subscriptions_Widget::$instance_count
-					: '';
-				$label_field_id  = $email_field_id . '-label';
-				?>
-				<p id="subscribe-email">
-					<label
-						id="<?php echo esc_attr( $label_field_id ); ?>"
-						for="<?php echo esc_attr( $email_field_id ); ?>"
-						class="screen-reader-text"
+				<?php if ( count( $newsletter_categories ) ) : ?>
+					<div
+						class="wp-block-jetpack-subscriptions__newsletter-categories"
+						style="<?php echo esc_attr( $styles['categories'] ); ?>"
 					>
-						<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
-					</label>
-
+						<?php foreach ( $newsletter_categories as $category ) : ?>
+							<label class="wp-block-jetpack-subscriptions__newsletter-category">
+								<input type="checkbox" value="<?php echo esc_html( $category['id'] ); ?>" />
+								<span><?php echo esc_html( $category['name'] ); ?></span>
+							</label>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
+				<div class="wp-block-jetpack-subscriptions__hbox">
 					<?php
-					printf(
-						'<input
-							required="required"
-							type="email"
-							name="email"
-							%1$s
-							style="%2$s"
-							placeholder="%3$s"
-							value="%4$s"
-							id="%5$s"
-						/>',
-						( ! empty( $classes['email_field'] )
-							? 'class="' . esc_attr( $classes['email_field'] ) . '"'
-							: ''
-						),
-						( ! empty( $styles['email_field'] )
-							? esc_attr( $styles['email_field'] )
-							: 'width: 95%; padding: 1px 10px'
-						),
-						esc_attr( $data['subscribe_placeholder'] ),
-						esc_attr( $data['subscribe_email'] ),
-						esc_attr( $email_field_id )
-					);
+					$email_field_id  = 'subscribe-field';
+					$email_field_id .= Jetpack_Subscriptions_Widget::$instance_count > 1
+						? '-' . Jetpack_Subscriptions_Widget::$instance_count
+						: '';
+					$label_field_id  = $email_field_id . '-label';
 					?>
-				</p>
+					<p id="subscribe-email">
+						<label
+							id="<?php echo esc_attr( $label_field_id ); ?>"
+							for="<?php echo esc_attr( $email_field_id ); ?>"
+							class="screen-reader-text"
+						>
+							<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
+						</label>
 
-				<p id="subscribe-submit"
-					<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-						style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
-					<?php endif; ?>
-				>
-					<input type="hidden" name="action" value="subscribe"/>
-					<input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
-					<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
-					<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
-					<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
-					<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
-					<button type="submit"
-						<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-							class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
-						<?php endif; ?>
-						<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-							style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
-						<?php endif; ?>
-					>
 						<?php
-						echo wp_kses(
-							html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-							Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+						printf(
+							'<input
+								required="required"
+								type="email"
+								name="email"
+								%1$s
+								style="%2$s"
+								placeholder="%3$s"
+								value="%4$s"
+								id="%5$s"
+							/>',
+							( ! empty( $classes['email_field'] )
+								? 'class="' . esc_attr( $classes['email_field'] ) . '"'
+								: ''
+							),
+							( ! empty( $styles['email_field'] )
+								? esc_attr( $styles['email_field'] )
+								: 'width: 95%; padding: 1px 10px'
+							),
+							esc_attr( $data['subscribe_placeholder'] ),
+							esc_attr( $data['subscribe_email'] ),
+							esc_attr( $email_field_id )
 						);
 						?>
-					</button>
-				</p>
+					</p>
+
+					<p id="subscribe-submit"
+						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+						<?php endif; ?>
+					>
+						<input type="hidden" name="action" value="subscribe"/>
+						<input type="hidden" name="blog_id" value="<?php echo (int) $current_blog->blog_id; ?>"/>
+						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
+						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
+						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
+						<?php wp_nonce_field( 'blogsub_subscribe_' . $current_blog->blog_id, '_wpnonce', false ); ?>
+						<button type="submit"
+							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
+							<?php endif; ?>
+							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
+							<?php endif; ?>
+						>
+							<?php
+							echo wp_kses(
+								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+							);
+							?>
+						</button>
+					</p>
+				</div>
 			</form>
 			<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
@@ -794,18 +796,6 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 	<div <?php echo wp_kses_data( $data['wrapper_attributes'] ); ?>>
 		<div class="jetpack_subscription_widget">
 			<div class="wp-block-jetpack-subscriptions__container">
-				<?php if ( count( $newsletter_categories ) ) : ?>
-					<div
-						className="wp-block-jetpack-subscriptions__newsletter-categories"
-						style="<?php echo esc_attr( $styles['categories'] ); ?>"
-					>
-						<?php foreach ( $newsletter_categories as $category ) : ?>
-							<div class="wp-block-jetpack-subscriptions__newsletter-category">
-								<?php echo esc_html( $category['name'] ); ?>
-							</div>
-						<?php endforeach; ?>
-					</div>
-				<?php endif; ?>
 
 				<form
 					action="#"
@@ -815,57 +805,73 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 					data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
-					<p id="subscribe-email">
-						<label id="jetpack-subscribe-label"
-							class="screen-reader-text"
-							for="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>">
-							<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
-						</label>
-						<input type="email" name="email" required="required"
-							<?php if ( ! empty( $classes['email_field'] ) ) : ?>
-								class="<?php echo esc_attr( $classes['email_field'] ); ?> required"
-							<?php endif; ?>
-							<?php if ( ! empty( $styles['email_field'] ) ) : ?>
-								style="<?php echo esc_attr( $styles['email_field'] ); ?>"
-							<?php endif; ?>
-							value="<?php echo esc_attr( $data['subscribe_email'] ); ?>"
-							id="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>"
-							placeholder="<?php echo esc_attr( $data['subscribe_placeholder'] ); ?>"
-						/>
-					</p>
-
-					<p id="subscribe-submit"
-						<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
-							style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
-						<?php endif; ?>
-					>
-						<input type="hidden" name="action" value="subscribe"/>
-						<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
-						<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
-						<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
-						<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
-						<?php
-						if ( is_user_logged_in() ) {
-							wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
-						}
-						?>
-						<button type="submit"
-							<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
-								class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
-							<?php endif; ?>
-							<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
-								style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
-							<?php endif; ?>
-							name="jetpack_subscriptions_widget"
+					<?php if ( count( $newsletter_categories ) ) : ?>
+						<div
+							class="wp-block-jetpack-subscriptions__newsletter-categories"
+							style="<?php echo esc_attr( $styles['categories'] ); ?>"
 						>
+							<?php foreach ( $newsletter_categories as $category ) : ?>
+								<label class="wp-block-jetpack-subscriptions__newsletter-category">
+									<input type="checkbox" value="<?php echo esc_html( $category['id'] ); ?>" />
+									<span><?php echo esc_html( $category['name'] ); ?></span>
+								</label>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+					<div class="wp-block-jetpack-subscriptions__hbox">
+						<p id="subscribe-email">
+							<label id="jetpack-subscribe-label"
+								class="screen-reader-text"
+								for="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>">
+								<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
+							</label>
+							<input type="email" name="email" required="required"
+								<?php if ( ! empty( $classes['email_field'] ) ) : ?>
+									class="<?php echo esc_attr( $classes['email_field'] ); ?> required"
+								<?php endif; ?>
+								<?php if ( ! empty( $styles['email_field'] ) ) : ?>
+									style="<?php echo esc_attr( $styles['email_field'] ); ?>"
+								<?php endif; ?>
+								value="<?php echo esc_attr( $data['subscribe_email'] ); ?>"
+								id="<?php echo esc_attr( $subscribe_field_id . '-' . $data['widget_id'] ); ?>"
+								placeholder="<?php echo esc_attr( $data['subscribe_placeholder'] ); ?>"
+							/>
+						</p>
+
+
+						<p id="subscribe-submit"
+							<?php if ( ! empty( $styles['submit_button_wrapper'] ) ) : ?>
+								style="<?php echo esc_attr( $styles['submit_button_wrapper'] ); ?>"
+							<?php endif; ?>
+						>
+							<input type="hidden" name="action" value="subscribe"/>
+							<input type="hidden" name="blog_id" value="<?php echo (int) $blog_id; ?>"/>
+							<input type="hidden" name="source" value="<?php echo esc_url( $data['referer'] ); ?>"/>
+							<input type="hidden" name="sub-type" value="<?php echo esc_attr( $data['source'] ); ?>"/>
+							<input type="hidden" name="redirect_fragment" value="<?php echo esc_attr( $form_id ); ?>"/>
 							<?php
-							echo wp_kses(
-								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
-								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
-							);
+							if ( is_user_logged_in() ) {
+								wp_nonce_field( 'blogsub_subscribe_' . get_current_blog_id(), '_wpnonce', false );
+							}
 							?>
-						</button>
-					</p>
+							<button type="submit"
+								<?php if ( ! empty( $classes['submit_button'] ) ) : ?>
+									class="<?php echo esc_attr( $classes['submit_button'] ); ?>"
+								<?php endif; ?>
+								<?php if ( ! empty( $styles['submit_button'] ) ) : ?>
+									style="<?php echo esc_attr( $styles['submit_button'] ); ?>"
+								<?php endif; ?>
+								name="jetpack_subscriptions_widget"
+							>
+								<?php
+								echo wp_kses(
+									html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+									Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
+								);
+								?>
+							</button>
+						</p>
+					</div>
 				</form>
 
 				<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -263,7 +263,12 @@ function fetch_newsletter_categories() {
 function get_newsletter_categories() {
 	$response = fetch_newsletter_categories();
 
-	if ( isset( $response['enabled'] ) && $response['enabled'] ) {
+	if (
+		isset( $response['enabled'] )
+		&& (bool) $response['enabled']
+		&& isset( $response['newsletter_categories'] )
+		&& is_array( $response['newsletter_categories'] )
+	) {
 		return $response['newsletter_categories'];
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -858,12 +858,12 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 							<?php endif; ?>
 							name="jetpack_subscriptions_widget"
 						>
-						<?php
+							<?php
 							echo wp_kses(
 								html_entity_decode( $data['submit_button_text'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 								Jetpack_Subscriptions_Widget::$allowed_html_tags_for_submit_button
 							);
-						?>
+							?>
 						</button>
 					</p>
 				</form>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -629,6 +629,41 @@ function get_post_access_level_for_current_post() {
 }
 
 /**
+ * Renders the newsletter categories in checkbox form.
+ *
+ * This function outputs a div containing labels and checkboxes for each newsletter category.
+ * Each checkbox represents a category, allowing users to select multiple newsletter categories.
+ *
+ * @param array $newsletter_categories An array of newsletter categories where each category is an associative array
+ *                                     with keys 'id' and 'name' representing the category's ID and display name, respectively.
+ * @param array $styles                An associative array of style settings. Default is an empty array.
+ *
+ * @return void Outputs HTML directly.
+ */
+function render_newsletter_categories( $newsletter_categories, $styles = array() ) {
+	if ( count( $newsletter_categories ) ) :
+		?>
+		<div
+			class="wp-block-jetpack-subscriptions__newsletter-categories"
+			style="<?php echo esc_attr( $styles['categories'] ); ?>"
+		>
+			<?php foreach ( $newsletter_categories as $category ) : ?>
+				<label class="wp-block-jetpack-subscriptions__newsletter-category">
+					<input type="checkbox" value="<?php echo esc_html( $category['id'] ); ?>" />
+					<div>
+						<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<path fill-rule="evenodd" clip-rule="evenodd" d="M14.9406 6.6485L8.94211 14.7159L5.1785 11.9174L5.92436 10.9143L8.68487 12.9669L13.9375 5.90264L14.9406 6.6485Z" fill="#1D39EB"/>
+						</svg>
+						<?php echo esc_html( $category['name'] ); ?>
+					</div>
+				</label>
+			<?php endforeach; ?>
+		</div>
+		<?php
+	endif;
+}
+
+/**
  * Renders the WP.com version of the subscriptions block.
  *
  * @param array $data    Array containing block view data.
@@ -666,19 +701,8 @@ function render_wpcom_subscribe_form( $data, $classes, $styles ) {
 				data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
 				id="<?php echo esc_attr( $form_id ); ?>"
 			>
-				<?php if ( count( $newsletter_categories ) ) : ?>
-					<div
-						class="wp-block-jetpack-subscriptions__newsletter-categories"
-						style="<?php echo esc_attr( $styles['categories'] ); ?>"
-					>
-						<?php foreach ( $newsletter_categories as $category ) : ?>
-							<label class="wp-block-jetpack-subscriptions__newsletter-category">
-								<input type="checkbox" value="<?php echo esc_html( $category['id'] ); ?>" />
-								<span><?php echo esc_html( $category['name'] ); ?></span>
-							</label>
-						<?php endforeach; ?>
-					</div>
-				<?php endif; ?>
+				<?php render_newsletter_categories( $newsletter_categories, $styles ); ?>
+
 				<div class="wp-block-jetpack-subscriptions__hbox">
 					<?php
 					$email_field_id  = 'subscribe-field';
@@ -805,19 +829,8 @@ function render_jetpack_subscribe_form( $data, $classes, $styles ) {
 					data-post_access_level="<?php echo esc_attr( $post_access_level ); ?>"
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
-					<?php if ( count( $newsletter_categories ) ) : ?>
-						<div
-							class="wp-block-jetpack-subscriptions__newsletter-categories"
-							style="<?php echo esc_attr( $styles['categories'] ); ?>"
-						>
-							<?php foreach ( $newsletter_categories as $category ) : ?>
-								<label class="wp-block-jetpack-subscriptions__newsletter-category">
-									<input type="checkbox" value="<?php echo esc_html( $category['id'] ); ?>" />
-									<span><?php echo esc_html( $category['name'] ); ?></span>
-								</label>
-							<?php endforeach; ?>
-						</div>
-					<?php endif; ?>
+					<?php render_newsletter_categories( $newsletter_categories, $styles ); ?>
+
 					<div class="wp-block-jetpack-subscriptions__hbox">
 						<p id="subscribe-email">
 							<label id="jetpack-subscribe-label"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -23,6 +23,16 @@ domReady( function () {
 				return;
 			}
 			event.preventDefault();
+
+			// get all unchecked categories
+			const excluded_newsletter_categories = Array.from(
+				form.querySelectorAll(
+					'.wp-block-jetpack-subscriptions__newsletter-category input[type=checkbox]'
+				)
+			)
+				.filter( checkbox => ! checkbox.checked )
+				.map( checkbox => checkbox.value );
+
 			const url =
 				'https://subscribe.wordpress.com/memberships/?' +
 				'blog=' +
@@ -31,9 +41,12 @@ domReady( function () {
 				'&source=jetpack_subscribe' +
 				'&post_access_level=' +
 				form.dataset.post_access_level +
-				'&display=alternate&' +
-				'email=' +
-				encodeURIComponent( email );
+				'&display=alternate' +
+				'&email=' +
+				encodeURIComponent( email ) +
+				'&excluded_newsletter_categories=' +
+				excluded_newsletter_categories.join( ',' );
+
 			window.scrollTo( 0, 0 );
 			tb_show( null, url + '&TB_iframe=true', null );
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -25,7 +25,7 @@
 	}
 
 	.wp-block-jetpack-subscriptions__form,
-	form {
+	form .wp-block-jetpack-subscriptions__hbox {
 		display: flex;
 		align-items: flex-start;
 
@@ -108,18 +108,35 @@
 	gap: 8px;
 
 	.wp-block-jetpack-subscriptions__newsletter-category {
-		padding: 6px 10px;
-		font-family: $default-font;
-		font-size: $default-font-size;
-		font-weight: 500;
-		line-height: 20px;
-		color: $gray-600;
-		border: 1px solid $gray-200;
-		border-radius: var(--subscribe-block-border-radius);
+		display: inline-flex;
+		align-items: center;
+		cursor: pointer;
+
+		input[type="checkbox"] {
+			display: none;
+		}
+
+		span {
+			padding: 6px 10px;
+			font-family: $default-font;
+			font-size: $default-font-size;
+			font-weight: 500;
+			line-height: 20px;
+			color: $gray-600;
+			border: 1px solid $gray-200;
+			border-radius: var(--subscribe-block-border-radius);
+			background: $white;
+			transition: background 0.3s;
+			user-select: none;
+		}
+
+		input[type="checkbox"]:checked + span {
+			background: var(--wp--preset--color--primary);
+			color: var(--wp--preset--color--contrast);
+		}
 	}
 }
 
-// make the form less wide when there are categories
 .wp-block-jetpack-subscriptions__newsletter-categories-enabled {
 	.wp-block-jetpack-subscriptions__form {
 		width: 80%;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -116,23 +116,37 @@
 			display: none;
 		}
 
-		span {
+		div {
+			display: flex;
 			padding: 6px 10px;
 			font-family: $default-font;
 			font-size: $default-font-size;
 			font-weight: 500;
 			line-height: 20px;
-			color: $gray-600;
+			color: #3c434a; // $studio-gray-70
 			border: 1px solid $gray-200;
 			border-radius: var(--subscribe-block-border-radius);
 			background: $white;
 			transition: background 0.1s;
 			user-select: none;
+
+			svg {
+				display: none;
+			}
 		}
 
-		input[type="checkbox"]:checked + span {
-			background: var( --wp--preset--color--primary );
-			color: var( --wp--preset--color--contrast, --wp--preset--color--white );
+		input[type="checkbox"]:checked + div {
+			background: color-mix(in srgb, var(--wp--preset--color--primary) 5%, white);
+			border-color: var(--wp--preset--color--primary);
+			color: var(--wp--preset--color--primary);
+
+			svg {
+				display: block;
+
+				path {
+					fill: var( --wp--preset--color--primary );
+				}
+			}
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -126,13 +126,13 @@
 			border: 1px solid $gray-200;
 			border-radius: var(--subscribe-block-border-radius);
 			background: $white;
-			transition: background 0.3s;
+			transition: background 0.1s;
 			user-select: none;
 		}
 
 		input[type="checkbox"]:checked + span {
-			background: var(--wp--preset--color--primary);
-			color: var(--wp--preset--color--contrast);
+			background: var( --wp--preset--color--primary );
+			color: var( --wp--preset--color--contrast, --wp--preset--color--white );
 		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -25,9 +25,10 @@
 	}
 
 	.wp-block-jetpack-subscriptions__form,
-	form .wp-block-jetpack-subscriptions__hbox {
+	form  {
 		display: flex;
 		align-items: flex-start;
+		flex-wrap: wrap;
 
 		.wp-block-jetpack-subscriptions__textfield .components-text-control__input,
 		.wp-block-jetpack-subscriptions__button,
@@ -100,6 +101,7 @@
 }
 
 .wp-block-jetpack-subscriptions__newsletter-categories {
+	flex: 1 0 100%;
 	margin-top: 8px;
 	margin-bottom: 24px;
 	display: flex;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/80905
Depends on https://github.com/Automattic/jetpack/pull/32666

## Proposed changes:

* Add newsletter categories to the Subscription Block content view
* Make the border-radius option of the Subscribe block affect the category pills on the content view https://github.com/Automattic/wp-calypso/issues/80908

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pdDOJh-2jl-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Apply this PR to your local env
2. Spin up a Jurassic Tube site with this PR
3. Test with a site that has Newsletter Categories already defined
4. Add the Subscribe block to a post/page
5. Open the post/page and see if the categories are displayed