### PR TITLE
Subscriptions: Hide modal when paywall block exists

### DIFF
--- a/projects/plugins/jetpack/changelog/update-hide-subscribe-modal-if-paywall
+++ b/projects/plugins/jetpack/changelog/update-hide-subscribe-modal-if-paywall
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Hide modal if paywall block exists.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -188,6 +188,11 @@ HTML;
 			return false;
 		}
 
+		// Don't show if post is for subscribers only or has paywall block
+		if ( has_block( 'jetpack/paywall' ) ) {
+			return false;
+		}
+
 		// Dont show if user is member of site.
 		if ( is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
 			return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/81101

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Do not show subscribe modal on posts that have a paywall block. The paywall block already shows the subscribe form, so showing the modal is redundant for readers.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Testing in Jetpack dev environment: 
1) Add add_filter( 'jetpack_subscriptions_modal_enabled', '__return_true', 20 ); to tools/dockers/mu-plugins/0-sandbox.php. Without this, the modal will not load at all on self hosted sites.
2) Go to Jetpack > Settings > Newsletter and enable the Enable subscriber popup setting.
3) Test the modal.  
   - Test the frontend modal in a browser where you are not logged in to WordPress.com as an admin.
   - Go to a single post without a paywall, scroll, and confirm the modal still loads. 
   - Add a paywall block to a post, go to the frontend, and confirm the modal does not load. 
   - Note that if at any point, you dismiss the modal by clicking Continue reading or clicking outside of the modal to close it, you will need to delete the dismiss modal cookie to get the modal to show again. 


