### PR TITLE
Stats: Add blog stickers to override `is_commercial`

### DIFF
--- a/projects/plugins/jetpack/changelog/add-blog_sticker_override_is_commercial
+++ b/projects/plugins/jetpack/changelog/add-blog_sticker_override_is_commercial
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Stats: add sticker tests to override `is_commercial`

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1525,11 +1525,11 @@ abstract class SAL_Site {
 	public function is_commercial() {
 		// Override if blog has the commercial stickers.
 		if ( function_exists( 'has_blog_sticker' ) ) {
-			$has_not_commercial_sticker = has_blog_sticker( 'jetpack-site-is-not-commercial', $this->blog_id );
+			$has_not_commercial_sticker = has_blog_sticker( 'jetpack-site-is-not-commercial-override', $this->blog_id );
 			if ( $has_not_commercial_sticker ) {
 				return false;
 			}
-			$has_commercial_sticker = has_blog_sticker( 'jetpack-site-is-commercial', $this->blog_id );
+			$has_commercial_sticker = has_blog_sticker( 'jetpack-site-is-commercial-override', $this->blog_id );
 			if ( $has_commercial_sticker ) {
 				return true;
 			}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1523,6 +1523,18 @@ abstract class SAL_Site {
 	 * - `null`: the commercial status is not yet determined
 	 */
 	public function is_commercial() {
+		// Override if blog has the commercial stickers.
+		if ( function_exists( 'has_blog_sticker' ) ) {
+			$has_not_commercial_sticker = has_blog_sticker( 'jetpack-site-is-not-commercial', $this->blog_id );
+			if ( $has_not_commercial_sticker ) {
+				return false;
+			}
+			$has_commercial_sticker = has_blog_sticker( 'jetpack-site-is-commercial', $this->blog_id );
+			if ( $has_commercial_sticker ) {
+				return true;
+			}
+		}
+
 		$is_commercial = get_option( '_jetpack_site_is_commercial', null );
 		return $is_commercial === null ? null : (bool) $is_commercial;
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/80882

## Proposed changes:

* If blog has sticker `jetpack-site-is-not-commercial-override`, then `is_commercial` will be forced to be `false`
* If blog has sticker `jetpack-site-is-commercial-override`, then `is_commercial` will be forced to be `true`

The first sticker has higher priority. The stickers are intended for HEs to manually override the `is_commercial` status.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Pull changes to sandbox `bin/jetpack-downloader test jetpack add/blog_sticker_override_is_commercial`
* Sandbox `public-api.wordpress.com`
* Open dev console: `https://developer.wordpress.com/docs/api/console/`
* WP.COM API, v1.1, GET, `/sites/:blog_id`
* Connect to you sandbox
  * `cd ~/public_html && wpsh`
  * `switch_to_blog(___blog_id__);`
  * `add_blog_sticker('jetpack-site-is-commercial-override', __blog__id__);` 
* Ensure options->is_commercial is `true`
* Connect to you sandbox
  * `cd ~/public_html && wpsh`
  * `switch_to_blog(___blog_id__);`
  * `add_blog_sticker('jetpack-site-is-not-commercial-override', ___blog_id__);` 
* Ensure options->is_commercial is `false`
* Remove both stickers to clean up
  * `remove_blog_sticker('jetpack-site-is-commercial-override',  __blog__id__)`
  * `remove_blog_sticker('jetpack-site-is-not-commercial-override',  __blog__id__)`

