### PR TITLE
Social: Update FB image restriction size limit

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-facebook-image-size-limit
+++ b/projects/js-packages/publicize-components/changelog/fix-facebook-image-size-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed FB image size limit for restrictions

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.js
@@ -91,7 +91,7 @@ export const RESTRICTIONS = {
 	facebook: {
 		allowedMediaTypes: facebookImageTypes.concat( [ VIDEOPRESS, ...facebookVideoTypes ] ),
 		image: {
-			maxSize: 4,
+			maxSize: 8,
 		},
 		video: {
 			maxSize: 10000,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This one-liner updates the image size requirement for FB images, to be 8Mb.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/orgs/Automattic/projects/733/views/2?pane=issue&itemId=36618444
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sanity check on code.
