### PR TITLE
General: update WordPress requirements to WP 6.2

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -74,11 +74,8 @@ $matrix[] = array(
 	'timeout' => 20, // 2022-01-25: 5.6 tests have started timing out at 15 minutes. Previously: Successful runs seem to take ~8 minutes for PHP 5.6 and for the 7.4 trunk run, ~5.5-6 for 7.x and 8.0.
 );
 
-foreach ( array( 'previous', 'trunk', 'special' ) as $wp ) {
-	$phpver = $versions['PHP_VERSION'];
-	if ( $wp === 'special' ) {
-		$phpver = '8.0'; // WordPress 6.1 is not ready for PHP 8.1+.
-	}
+foreach ( array( 'previous', 'trunk' ) as $wp ) {
+	$phpver   = $versions['PHP_VERSION'];
 	$matrix[] = array(
 		'name'    => "PHP tests: PHP {$phpver} WP $wp",
 		'script'  => 'test-php',
@@ -206,7 +203,7 @@ foreach ( $matrix as &$m ) {
 	}
 
 	// Only specific values allowed for `wp`.
-	$valid_wp = array( 'latest', 'previous', 'trunk', 'special', 'none' );
+	$valid_wp = array( 'latest', 'previous', 'trunk', 'none' );
 	if ( ! in_array( $m['wp'], $valid_wp, true ) ) {
 		$valid_wp = join_or(
 			array_map(

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -42,11 +42,6 @@ case "$WP_BRANCH" in
 		# we've dropped the old 'previous' but WP hasn't actually released the new 'latest'
 		TAG=6.2
 		;;
-	special)
-		# This is a special case for testing WP 6.1 as well as 6.2 in the interim between Jetpack 12.4 and WC US on 25th of August, 2023.
-		# TODO: Remove this after Jetpack 12.5 is released, more here: pdWQjU-r3-p2
-		TAG=6.1
-		;;
 	*)
 		echo "Unrecognized value for WP_BRANCH: $WP_BRANCH" >&2
 		exit 1

--- a/.phpcs.config.xml
+++ b/.phpcs.config.xml
@@ -2,7 +2,7 @@
 <!-- This file configures everything except the list of rules. -->
 <!-- The separation is so .github/files/phpcompatibility-dev-phpcs.xml can use the same config with a different rule set. -->
 <ruleset>
-	<config name="minimum_supported_wp_version" value="6.1" />
+	<config name="minimum_supported_wp_version" value="6.2" />
 	<config name="testVersion" value="5.6-"/>
 
 	<!-- Use our custom filter for `.phpcsignore` and `.phpcs.dir.xml` support. -->

--- a/projects/plugins/backup/changelog/update-wp-requirements-62
+++ b/projects/plugins/backup/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/backup/composer.json
+++ b/projects/plugins/backup/composer.json
@@ -34,7 +34,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"config": {
-		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ2_1",
+		"autoloader-suffix": "9559eef123208b7d1b9c15b978567267_backupⓥ2_2_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack VaultPress Backup
  * Plugin URI: https://jetpack.com/jetpack-backup
  * Description: Easily restore or download a backup of your site from a specific moment in time.
- * Version: 2.1
+ * Version: 2.2-alpha
  * Author: Automattic - Jetpack Backup team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack VaultPress Backup ===
 Contributors: automattic, bjorsch, fgiannar, initsogar, jeherve, jwebbdev, kraftbj, macbre, samiff, sermitr, williamvianas
 Tags: jetpack, backup, restore
-Requires at least: 6.1
+Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.3
 Stable tag: 2.1

--- a/projects/plugins/inspect/changelog/update-wp-requirements-62
+++ b/projects/plugins/inspect/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/inspect/readme.txt
+++ b/projects/plugins/inspect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack inspect ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.1
+Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.2
 Stable tag: 1.0.0-alpha
@@ -11,19 +11,19 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 A debugging plugin to inspect Jetpack interactions with WordPress.com.
 
 == Description ==
- 
+
 Longer description of the plugin.
- 
+
 == Installation ==
- 
+
 Installation instructions go here.
- 
+
 == Frequently Asked Questions ==
- 
+
 = A question that someone might have =
- 
+
 An answer to that question.
- 
+
 == Screenshots ==
 
 1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
@@ -31,38 +31,38 @@ the /assets directory or the directory that contains the stable readme.txt (tags
 directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png`
 (or jpg, jpeg, gif).
 2. This is the second screen shot
- 
+
 == Changelog ==
 
 <!-- When you do a release, use the monorepo script tools/plugin-changelog-to-readme.sh to copy from CHANGELOG.md to here. -->
- 
+
 == Arbitrary section ==
- 
+
 You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated
 plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
 "installation."  Arbitrary sections will be shown below the built-in sections outlined above.
- 
+
 == A brief Markdown Example ==
- 
+
 Ordered list:
- 
+
 1. Some feature
 1. Another feature
 1. Something else about the plugin
- 
+
 Unordered list:
- 
+
 * something
 * something else
 * third thing
- 
+
 Here's a link to [WordPress](https://wordpress.org/ "Your favorite software") and one to [Markdown's Syntax Documentation][markdown syntax].
 Titles are optional, naturally.
- 
+
 [markdown syntax]: http://daringfireball.net/projects/markdown/syntax
 "Markdown is what the parser uses to process much of the readme file"
- 
+
 Markdown uses email style notation for blockquotes and I've been told:
 > Asterisks for *emphasis*. Double it up  for **strong**.
- 
+
 `<?php code(); // goes in backticks ?>`

--- a/projects/plugins/jetpack/changelog/update-wp-requirements-62
+++ b/projects/plugins/jetpack/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+General: Jetpack now requires WordPress version 6.2.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -8,7 +8,7 @@
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
- * Requires at least: 6.1
+ * Requires at least: 6.2
  * Requires PHP: 5.6
  *
  * @package automattic/jetpack
@@ -32,7 +32,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '6.1' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '6.2' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
 define( 'JETPACK__VERSION', '12.6-a.2' );
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, batmoo, barry, beaulebens, bindlegirl, biskobe, blobaugh, bjorsch, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, robertbpugh, roccotripaldi, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, wpkaren, yoavf, zinigor
 Tags: Security, backup, Woo, malware, scan, spam, CDN, search, social
 Stable tag: 12.5
-Requires at least: 6.1
+Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.3
 

--- a/projects/plugins/migration/changelog/update-wp-requirements-62
+++ b/projects/plugins/migration/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/migration/readme.txt
+++ b/projects/plugins/migration/readme.txt
@@ -1,7 +1,7 @@
 === Move to WordPress.com ===
 Contributors: automattic
 Tags: migrate, migration, backup, restore, transfer, move, copy, wordpress.com, automattic, import, importer, hosting
-Requires at least: 6.1
+Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.3
 Stable tag: 0.1.0

--- a/projects/plugins/protect/changelog/update-wp-requirements-62
+++ b/projects/plugins/protect/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Protect ===
 Contributors: automattic, retrofox, leogermani, renatoagds, bjorsch, ebinnion, fgiannar, zinigor, miguelxavierpenha, dsmart, jeherve, manzoorwanijk, njweller, oskosk, samiff, siddarthan, wpkaren, arsihasi, kraftbj, kev, sermitr, kangzj, pabline, dkmyta
 Tags: jetpack, protect, security, malware, scan
-Requires at least: 6.1
+Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.3
 Stable tag: 1.4.0

--- a/projects/plugins/search/changelog/update-wp-requirements-62
+++ b/projects/plugins/search/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Search ===
 Contributors: automattic, annamcphee, bluefuton, kangzj, jsnmoon, robfelty, gibrown, trakos, dognose24, a8ck3n
 Tags: search, filter, woocommerce search, ajax search, product search, free cloud-based search
-Requires at least: 6.1
+Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.3
 Stable tag: 1.4.0

--- a/projects/plugins/social/changelog/update-wp-requirements-62
+++ b/projects/plugins/social/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -81,6 +81,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ2_2_0"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ2_2_1_alpha"
 	}
 }

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 2.2.0
+ * Version: 2.2.1-alpha
  * Author: Automattic - Jetpack Social team
  * Author URI: https://jetpack.com/social/
  * License: GPLv2 or later

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Social  ===
 Contributors: automattic, pabline, siddarthan, gmjuhasz, manzoorwanijk, danielpost
 Tags: social-media, publicize, social-media-manager, social-networking, social marketing, social, social share,  social media scheduling, social media automation, auto post, auto- publish, social share
-Requires at least: 6.1
+Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.3
 Stable tag: 2.2.0

--- a/projects/plugins/starter-plugin/changelog/update-wp-requirements-62
+++ b/projects/plugins/starter-plugin/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/starter-plugin/readme.txt
+++ b/projects/plugins/starter-plugin/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Starter Plugin ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.1
+Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.3
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/super-cache/changelog/update-wp-requirements-62
+++ b/projects/plugins/super-cache/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -1,7 +1,7 @@
 === WP Super Cache ===
 Contributors: donncha, automattic, adnan007, dilirity, mikemayhem3030, pyronaur, thingalon
 Tags: performance, caching, wp-cache, wp-super-cache, cache
-Requires at least: 6.1
+Requires at least: 6.2
 Requires PHP: 5.6
 Tested up to: 6.3
 Stable tag: 1.10.0

--- a/projects/plugins/videopress/changelog/update-wp-requirements-62
+++ b/projects/plugins/videopress/changelog/update-wp-requirements-62
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.2.

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski, nunyvega, leogermani
 Tags: video, video-hosting, video-player, cdn, vimeo, youtube, video-streaming, mobile-video, jetpack
 
-Requires at least: 6.1
+Requires at least: 6.2
 Tested up to: 6.3
 Stable tag: 1.5
 Requires PHP: 5.6
@@ -39,7 +39,7 @@ With the [Jetpack VideoPress Block](https://jetpack.com/support/jetpack-videopre
 * Optimized for mobile – Switch between mobile and desktop without missing a beat.
 * Picture-in-picture – Pop out the video from the web browser for easier viewing.
 * Unlimited Logins – Work with a team? We don’t charge per seat, so everyone that works on your site can have their own login.
-* High-Resolution Videos Up to 4K – Watch crisp images on any display and screen size. We’ve added video display for 1440p, 60 FPS, and full 4K resolution. 
+* High-Resolution Videos Up to 4K – Watch crisp images on any display and screen size. We’ve added video display for 1440p, 60 FPS, and full 4K resolution.
 * Ad-free video - Keep the spotlight on your content, not on ads you can’t control.
 
 = Your one-stop solution for video management =

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -750,7 +750,7 @@ function createReadMeTxt( answers ) {
 		`=== Jetpack ${ answers.name } ===\n` +
 		'Contributors: automattic,\n' +
 		'Tags: jetpack, stuff\n' +
-		'Requires at least: 6.1\n' +
+		'Requires at least: 6.2\n' +
 		'Requires PHP: 5.6\n' +
 		'Tested up to: 6.3\n' +
 		`Stable tag: ${ answers.version }\n` +


### PR DESCRIPTION
See #31638

## Proposed changes:

Now that WordPress 6.3 and folks have had some time to update to the most recent version of WordPress, let's start requiring WP 6.2 for everyone wanting to use our different plugins.

This also reverts #32366.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* #31638

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Is CI happy?
