### PR TITLE
ci: Fix e2e repository_dispatch run

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -195,9 +195,6 @@ jobs:
               echo "::error::Build job ran but result is not being used!"
               exit 1
             fi
-            echo "::group::Prepare build artefacts"
-            tar --xz -xf "$BUILD_DIR/jetpack-build/build.tar.xz" -C "$BUILD_DIR"
-            echo "::endgroup::"
 
             echo "::group::Update volume mapping"
             .github/files/e2e-tests/map-plugins-for-e2e-env.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
During all the code rearranging in #32686, a piece of code that was only for workflow_run wound up being incorrectly run for repository_dispatch as well.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/32686#issuecomment-1699050071

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Fork the repo, set necessary secrets, and trigger a repostory_dispatch.
  * Or look at https://github.com/anomiex/jetpack/actions/runs/6026033651 where I already did that. Note the jobs still failing there are an existing issue (e.g. see [this past run](https://github.com/Automattic/jetpack/actions/runs/6010764087) from before #32686).