### PR TITLE
Paywall Block: Improve toolbar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-block-toolbar
+++ b/projects/plugins/jetpack/changelog/update-paywall-block-toolbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Paywall Block: Improved toolbar

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -14,6 +14,7 @@ import {
 } from '../../shared/memberships/constants';
 import { useAccessLevel } from '../../shared/memberships/edit';
 import { Link, PaywallBlockSettings } from '../../shared/memberships/settings';
+import { getPaidPlanLink } from '../../shared/memberships/utils';
 
 function PaywallEdit( { className } ) {
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
@@ -27,6 +28,7 @@ function PaywallEdit( { className } ) {
 			hasNewsletterPlans: getNewsletterProducts()?.length !== 0,
 		};
 	} );
+	const paidLink = getPaidPlanLink( hasNewsletterPlans );
 
 	useEffect( () => {
 		if ( ! accessLevel || accessLevel === accessOptions.everybody.key ) {
@@ -113,15 +115,22 @@ function PaywallEdit( { className } ) {
 									{ getLabel( accessOptions.paid_subscribers.key ) }
 								</MenuItem>
 							</MenuGroup>
-							{ accessLevel === accessOptions.paid_subscribers.key && (
-								<MenuGroup>
-									<Link href={ stripeConnectUrl }>
-										<MenuItem info={ __( 'Enable paid subscribers', 'jetpack' ) }>
-											{ __( 'Connect to Stripe', 'jetpack' ) }
-										</MenuItem>
-									</Link>
-								</MenuGroup>
-							) }
+							{ accessLevel === accessOptions.paid_subscribers.key &&
+								( stripeConnectUrl || ! hasNewsletterPlans ) && (
+									<MenuGroup>
+										<MenuItem info={ __( 'Enable paid subscribers', 'jetpack' ) }></MenuItem>
+										{ stripeConnectUrl && (
+											<Link href={ stripeConnectUrl }>
+												<MenuItem>{ __( 'Connect to Stripe', 'jetpack' ) }</MenuItem>
+											</Link>
+										) }
+										{ ! stripeConnectUrl && ! hasNewsletterPlans && (
+											<Link href={ paidLink }>
+												<MenuItem>{ __( 'Add a paid plan', 'jetpack' ) }</MenuItem>
+											</Link>
+										) }
+									</MenuGroup>
+								) }
 						</>
 					) }
 				</ToolbarDropdownMenu>

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -124,7 +124,7 @@ function PaywallEdit( { className } ) {
 												<MenuItem>{ __( 'Connect to Stripe', 'jetpack' ) }</MenuItem>
 											</Link>
 										) }
-										{ ! stripeConnectUrl && ! hasNewsletterPlans && (
+										{ ! hasNewsletterPlans && (
 											<Link href={ paidLink }>
 												<MenuItem>{ __( 'Add a paid plan', 'jetpack' ) }</MenuItem>
 											</Link>

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -136,7 +136,7 @@ function PaywallEdit( { className } ) {
 			</BlockControls>
 			<ConfirmDialog
 				onRequestClose={ closeModal }
-				cancelButtonText={ __( 'I am not ready', 'jetpack' ) }
+				cancelButtonText={ __( 'Not now', 'jetpack' ) }
 				confirmButtonText={ __( 'Get started', 'jetpack' ) }
 				isOpen={ showModal }
 				onCancel={ closeModal }
@@ -145,26 +145,13 @@ function PaywallEdit( { className } ) {
 					window.location.href = paidLink;
 				} }
 			>
-				<h2>{ __( 'Enable payment collection', 'jetpack' ) }</h2>
-				<p>{ __( "You'll need to take the following steps:", 'jetpack' ) }</p>
-				<ul>
-					{ ! hasNewsletterPlans && (
-						<li>
-							{ __(
-								'Add a paid plan – Set up how much your user will have to pay in order to access your paid content.',
-								'jetpack'
-							) }
-						</li>
+				<h2>{ __( 'Enable payments', 'jetpack' ) }</h2>
+				<p>
+					{ __(
+						'To choose this option, you’ll need first to create a payment offer, setting up how much your subscribers should pay to access your paid content, and then connect your Stripe account, which is our payments’ processor.',
+						'jetpack'
 					) }
-					{ stripeConnectUrl && (
-						<li>
-							{ __(
-								'Connect to Stripe – Set up a Stripe account to securely handle payments.',
-								'jetpack'
-							) }
-						</li>
-					) }
-				</ul>
+				</p>
 			</ConfirmDialog>
 			<InspectorControls>
 				<PanelBody


### PR DESCRIPTION
## Proposed changes:

#### Before

<img width="736" alt="Screenshot 2023-08-30 at 12 31 12" src="https://github.com/Automattic/jetpack/assets/104869/1c43eb90-fac8-48cd-b0c4-b802f4739ab1">


#### After

<img width="712" alt="Screenshot 2023-08-31 at 13 14 44" src="https://github.com/Automattic/jetpack/assets/104869/0aa29012-97f4-4bd9-9349-048de0518b28">

<img width="1011" alt="Screenshot 2023-08-31 at 13 14 52" src="https://github.com/Automattic/jetpack/assets/104869/a844ba09-b76a-4cce-8c52-1e87d6531a5f">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Paywall block and play with the toolbar. 
