### PR TITLE
Create with voice: connect block with useMediaRecording() hook

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-create-with-mic-use-custom-hook
+++ b/projects/js-packages/ai-client/changelog/update-create-with-mic-use-custom-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: minor change in useMediaRecording() hook example

--- a/projects/js-packages/ai-client/src/hooks/use-media-recording/Readme.md
+++ b/projects/js-packages/ai-client/src/hooks/use-media-recording/Readme.md
@@ -30,7 +30,7 @@ const MediaRecorderComponent = () => {
 		<div>
 			<h1>Media Recorder</h1>
 			<p>Current State: { state }</p>
-			<button onClick={ start } disabled={ state === 'recording' }>
+			<button onClick={ start } disabled={ state !== 'inactive' }>
 				Start
 			</button>
 			<button onClick={ pause } disabled={ state !== 'recording' }>
@@ -39,7 +39,7 @@ const MediaRecorderComponent = () => {
 			<button onClick={ resume } disabled={ state !== 'paused' }>
 				Resume
 			</button>
-			<button onClick={ stop } disabled={ state === 'inactive' }>
+			<button onClick={ stop } disabled={ state === 'recording' }>
 				Stop
 			</button>
 		</div>

--- a/projects/plugins/jetpack/changelog/update-create-with-mic-use-custom-hook
+++ b/projects/plugins/jetpack/changelog/update-create-with-mic-use-custom-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Create with voice: connect block with useMediaRecording() hook

--- a/projects/plugins/jetpack/extensions/blocks/create-with-voice/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/create-with-voice/edit.tsx
@@ -1,14 +1,30 @@
 /**
  * External dependencies
  */
-import { micIcon } from '@automattic/jetpack-ai-client';
+import { micIcon, playerStopIcon, useMediaRecording } from '@automattic/jetpack-ai-client';
 import { Placeholder, Button } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 export default function CreateWithVoiceEdit() {
-	const startToRecord = () => {
-		console.log( 'recording...' ); // eslint-disable-line no-console
-	};
+	const { state, start, pause, resume } = useMediaRecording();
+
+	const recordingHandler = useCallback( () => {
+		if ( state === 'inactive' ) {
+			start();
+		} else if ( state === 'recording' ) {
+			pause();
+		} else if ( state === 'paused' ) {
+			resume();
+		}
+	}, [ state, start, pause, resume ] );
+
+	let buttoneLabel = __( 'Start recording', 'jetpack' );
+	if ( state === 'recording' ) {
+		buttoneLabel = __( 'Pause recording', 'jetpack' );
+	} else if ( state === 'paused' ) {
+		buttoneLabel = __( 'Resume recording', 'jetpack' );
+	}
 
 	return (
 		<Placeholder
@@ -21,11 +37,11 @@ export default function CreateWithVoiceEdit() {
 		>
 			<Button
 				className="jetpack-ai-create-with-voice__record-button"
-				icon={ micIcon }
+				icon={ state === 'recording' ? playerStopIcon : micIcon }
 				variant="primary"
-				onClick={ startToRecord }
+				onClick={ recordingHandler }
 			>
-				{ __( 'Start recording', 'jetpack' ) }
+				{ buttoneLabel }
 			</Button>
 		</Placeholder>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR connects the Create with voice block with the `useMediaRecording()` custom hook to start recording audio. 
It opens the mic and gets the recording state, updating the recording block button state.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create with voice: connect block with useMediaRecording() hook

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Create with voice block instance
* Start to record/pause /resume.
* Confirm how the block button changes according to the recording status,

https://github.com/Automattic/jetpack/assets/77539/69631cbd-101c-4918-9ec6-95fa304251cb


