### PR TITLE
ci: On release branches, build/test relevant plugins only

### DIFF
--- a/.github/files/list-changed-projects.sh
+++ b/.github/files/list-changed-projects.sh
@@ -15,7 +15,9 @@ function die {
 	exit 1
 }
 
-ARGS=( --add-dependents )
+DEPENDENTS=true
+DEPENDENCIES=false
+ARGS=()
 
 if [[ "${GITHUB_EVENT_NAME:?}" == "pull_request" ]]; then
 	[[ -f "${GITHUB_EVENT_PATH:?}" ]] || die "GITHUB_EVENT_PATH file $GITHUB_EVENT_PATH does not exist"
@@ -23,7 +25,24 @@ if [[ "${GITHUB_EVENT_NAME:?}" == "pull_request" ]]; then
 	debug "GITHUB_EVENT_NAME is pull_request, checking diff from $DIFF"
 	ARGS+=( --verbose "--git-changed=$DIFF" )
 elif [[ "${GITHUB_EVENT_NAME:?}" == "push" ]]; then
-	debug "GITHUB_EVENT_NAME is push, considering all projects changed."
+	if [[ "${GITHUB_REF:?}" == refs/heads/*/branch-* ]]; then
+		REF=${GITHUB_REF#refs/heads/}
+		TMP="$(jq -r --arg P "${REF%%/branch-*}" '.extra["release-branch-prefix"] | if type == "array" then . else [ . ] end | if index( $P ) then input_filename | match( "^projects/([^/]+/[^/]+)/composer.json$" ).captures[0].string else empty end' projects/*/*/composer.json)"
+		if [[ -n "$TMP" ]]; then
+			debug "GITHUB_EVENT_NAME is push and branch $REF seems to be a release branch, considering matching projects changed: ${TMP//$'\n'/ }"
+			while IFS= read -r LINE; do
+				ARGS+=( "$LINE" )
+			done <<<"$TMP"
+			if [[ "$EXTRA" == "test" ]]; then
+				debug "Also considering depndencies of those as changed for running tests"
+				DEPENDENCIES=true
+			fi
+		else
+			debug "GITHUB_EVENT_NAME is push and branch $REF does not seem to be a release branch (nothing uses that prefix), considering all projects changed."
+		fi
+	else
+		debug "GITHUB_EVENT_NAME is push and branch ${GITHUB_REF#refs/heads/} does not seem to be a release branch, considering all projects changed."
+	fi
 else
 	die "Unsupported GITHUB_EVENT_NAME \"$GITHUB_EVENT_NAME\""
 fi
@@ -35,4 +54,11 @@ if [[ -n "$EXTRA" ]]; then
 	fi
 fi
 
-pnpm jetpack dependencies list "${ARGS[@]}" | jq -ncR 'reduce inputs as $i ({}; .[$i] |= true)'
+{
+	if $DEPENDENTS; then
+		pnpm jetpack dependencies list --add-dependents "${ARGS[@]}"
+	fi
+	if $DEPENDENCIES; then
+		pnpm jetpack dependencies list --add-dependencies "${ARGS[@]}"
+	fi
+} | jq -ncR 'reduce inputs as $i ({}; .[$i] |= true)'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When we're running CI builds and tests on pushes to release branches, we only really care about the stuff that's being released on that branch. So only consider those projects as "changed" instead of building or testing everything in the monorepo.

Also, for tests, consider the dependencies of release branch stuff as changed since any cherry-picks that wind up in the release should also be tested.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None, but inspired by p1693410681377669-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/trunk .github/files/list-changed-projects.sh`, should output all projects.
* Run `GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/crm/branch-6.1.0 .github/files/list-changed-projects.sh`, should output only plugins/crm.
* Run `EXTRA=test GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/crm/branch-6.1.0 .github/files/list-changed-projects.sh`, should output plugins/crm and things it depends on (recursively), but not everything else.
* Run `GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/weekly/branch-2023-08-30 .github/files/list-changed-projects.sh`, should output only plugins/jetpack and plugins/mu-wpcom-plugin.
* Run `GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/bogus/branch-1.2 .github/files/list-changed-projects.sh`, should output all projects.
* If you really want to be ambitious, fork the monorepo and push this to some branch name that looks like a release branch, see that it actually builds/tests only the relevant stuff.