### PR TITLE
CRM: Automations conditions for contact tags

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-3236-3237-3247-automations-conditions-contact-tags
+++ b/projects/plugins/crm/changelog/add-crm-3236-3237-3247-automations-conditions-contact-tags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Automation: Added conditions for contact tags

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-tag.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-tag.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Jetpack CRM Automation Contact_Tag condition.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Automation\Conditions;
+
+use Automattic\Jetpack\CRM\Automation\Attribute_Definition;
+use Automattic\Jetpack\CRM\Automation\Automation_Exception;
+use Automattic\Jetpack\CRM\Automation\Base_Condition;
+use Automattic\Jetpack\CRM\Automation\Data_Types\Data_Type_Contact;
+
+/**
+ * Contact_Tag condition class.
+ *
+ * @since $$next-version$$
+ */
+class Contact_Tag extends Base_Condition {
+
+	/**
+	 * Contact_Tag constructor.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $step_data The step data.
+	 */
+	public function __construct( array $step_data ) {
+		parent::__construct( $step_data );
+
+		$this->valid_operators = array(
+			'tag_added'   => __( 'Tag was added', 'zero-bs-crm' ),
+			'tag_removed' => __( 'Tag was removed', 'zero-bs-crm' ),
+			'has_tag'     => __( 'Has tag', 'zero-bs-crm' ),
+		);
+
+		$this->set_attribute_definitions(
+			array(
+				new Attribute_Definition( 'operator', __( 'Operator', 'zero-bs-crm' ), __( 'Determines how the field is compared to the specified value.', 'zero-bs-crm' ), Attribute_Definition::SELECT, $this->valid_operators ),
+				new Attribute_Definition( 'tag', __( 'Tag', 'zero-bs-crm' ), __( 'Contact Tag to compare with.', 'zero-bs-crm' ), Attribute_Definition::TEXT ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given tag name exists in the tags array.
+	 *
+	 * @param array  $data     The data array containing the 'tags' key.
+	 * @param string $tag_name The name of the tag to check for.
+	 *
+	 * @return bool True if the tag name exists, false otherwise.
+	 */
+	private function has_tag_by_name( $data, $tag_name ) {
+		if ( ! isset( $data['tags'] ) || ! is_array( $data['tags'] ) ) {
+			return false;
+		}
+
+		foreach ( $data['tags'] as $tag ) {
+			if ( isset( $tag['name'] ) && $tag['name'] === $tag_name ) {
+					return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Executes the condition. If the condition is met, the value stored in the
+	 * attribute $condition_met is set to true; otherwise, it is set to false.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param mixed  $data Data passed from the trigger.
+	 * @param ?mixed $previous_data (Optional) The data before being changed.
+	 * @return void
+	 *
+	 * @throws Automation_Exception If an invalid operator is encountered.
+	 */
+	public function execute( $data, $previous_data = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( $previous_data === null ) {
+			$this->logger->log( 'Invalid previous contact tag data' );
+			$this->condition_met = false;
+
+			return;
+		}
+
+		if ( ! $this->is_valid_contact_tag_data( $data ) || ! $this->is_valid_contact_tag_data( $previous_data ) ) {
+			$this->logger->log( 'Invalid contact tag data' );
+			$this->condition_met = false;
+
+			return;
+		}
+
+		$operator = $this->get_attributes()['operator'];
+		$tag      = $this->get_attributes()['tag'];
+
+		$this->check_for_valid_operator( $operator );
+		$this->logger->log( 'Condition: Contact_Tag ' . $operator . ' => ' . $tag );
+
+		switch ( $operator ) {
+			case 'tag_added':
+				$this->condition_met = ( ! $this->has_tag_by_name( $previous_data, $tag ) && $this->has_tag_by_name( $data, $tag ) );
+				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
+
+				return;
+			case 'tag_removed':
+				$this->condition_met = ( $this->has_tag_by_name( $previous_data, $tag ) && ! $this->has_tag_by_name( $data, $tag ) );
+				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
+
+				return;
+			case 'has_tag':
+				$this->condition_met = $this->has_tag_by_name( $data, $tag );
+				$this->logger->log( 'Condition met?: ' . ( $this->condition_met ? 'true' : 'false' ) );
+
+				return;
+			default:
+				$this->condition_met = false;
+				throw new Automation_Exception(
+					/* Translators: %s is the unimplemented operator. */
+					sprintf( __( 'Valid but unimplemented operator: %s', 'zero-bs-crm' ), $operator ),
+					Automation_Exception::CONDITION_OPERATOR_NOT_IMPLEMENTED
+				);
+		}
+	}
+
+	/**
+	 * Checks if the contact has at least the necessary keys to detect a contact
+	 * tag condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $data The event data.
+	 * @return bool True if the data is valid to evaluate a contact tag condition, false otherwise.
+	 */
+	private function is_valid_contact_tag_data( array $data ): bool {
+		return is_array( $data ) && isset( $data['tags'] );
+	}
+
+	/**
+	 * Get the title for the contact tag condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The title.
+	 */
+	public static function get_title(): string {
+		return __( 'Contact Tag', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the slug for the contact tag condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The slug 'jpcrm/condition/contact_tag'.
+	 */
+	public static function get_slug(): string {
+		return 'jpcrm/condition/contact_tag';
+	}
+
+	/**
+	 * Get the description for the contact tag condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The description for the condition.
+	 */
+	public static function get_description(): string {
+		return __( 'Checks if a contact tag matches a specified condition', 'zero-bs-crm' );
+	}
+
+	/**
+	 * Get the category of the contact tag condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The category 'contact'.
+	 */
+	public static function get_category(): string {
+		return 'contact';
+	}
+
+	/**
+	 * Get the data type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The type of the step.
+	 */
+	public static function get_data_type(): string {
+		return Data_Type_Contact::get_slug();
+	}
+
+	/**
+	 * Get the allowed triggers for the contact tag condition.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string[] An array of allowed triggers:
+	 *               - 'jpcrm/contact_updated'
+	 */
+	public static function get_allowed_triggers(): array {
+		return array(
+			'jpcrm/contact_updated',
+		);
+	}
+
+}

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-tag.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-tag.php
@@ -203,10 +203,10 @@ class Contact_Tag extends Base_Condition {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string The category 'contact'.
+	 * @return string The translated string for 'Contact'.
 	 */
 	public static function get_category(): string {
-		return 'contact';
+		return __( 'Contact', 'zero-bs-crm' );
 	}
 
 	/**

--- a/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-tag.php
+++ b/projects/plugins/crm/src/automation/commons/conditions/contacts/class-contact-tag.php
@@ -66,6 +66,42 @@ class Contact_Tag extends Base_Condition {
 	}
 
 	/**
+	 * Check for valid parameters.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $operator The operator.
+	 * @param mixed  $data The data to validate.
+	 * @param mixed  $previous_data The previous data to validate.
+	 * @return bool True if parameters are valid, false otherwise.
+	 */
+	private function check_for_valid_parameters( $operator, $data, $previous_data ) {
+		switch ( $operator ) {
+			case 'tag_added':
+			case 'tag_removed':
+				if ( $previous_data === null || ! $this->is_valid_contact_tag_data( $data ) || ! $this->is_valid_contact_tag_data( $previous_data ) ) {
+					$this->logger->log( 'Invalid contact tag data' );
+
+					return false;
+				}
+				break;
+			case 'has_tag':
+				if ( ! $this->is_valid_contact_tag_data( $data ) ) {
+					$this->logger->log( 'Invalid contact tag data' );
+					$this->condition_met = false;
+
+					return false;
+				}
+				break;
+			default:
+				$this->logger->log( 'Unknown operator: ' . $operator );
+				return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Executes the condition. If the condition is met, the value stored in the
 	 * attribute $condition_met is set to true; otherwise, it is set to false.
 	 *
@@ -78,24 +114,16 @@ class Contact_Tag extends Base_Condition {
 	 * @throws Automation_Exception If an invalid operator is encountered.
 	 */
 	public function execute( $data, $previous_data = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( $previous_data === null ) {
-			$this->logger->log( 'Invalid previous contact tag data' );
-			$this->condition_met = false;
-
-			return;
-		}
-
-		if ( ! $this->is_valid_contact_tag_data( $data ) || ! $this->is_valid_contact_tag_data( $previous_data ) ) {
-			$this->logger->log( 'Invalid contact tag data' );
-			$this->condition_met = false;
-
-			return;
-		}
-
 		$operator = $this->get_attributes()['operator'];
 		$tag      = $this->get_attributes()['tag'];
 
 		$this->check_for_valid_operator( $operator );
+
+		if ( ! $this->check_for_valid_parameters( $operator, $data, $previous_data ) ) {
+			$this->condition_met = false;
+			return;
+		}
+
 		$this->logger->log( 'Condition: Contact_Tag ' . $operator . ' => ' . $tag );
 
 		switch ( $operator ) {

--- a/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
+++ b/projects/plugins/crm/tests/php/automation/contacts/class-contact-condition-test.php
@@ -169,6 +169,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$contact_tag_condition = $this->get_contact_tag_condition( 'tag_added', 'Tag Added' );
 		$contact_data_type     = $this->automation_faker->contact_data( true );
 		$contact_data          = $contact_data_type->get_entity();
+		$tag_id                = end( $contact_data['tags'] )['id'] + 1;
 
 		// Create a previous state of a contact.
 		$previous_contact = $contact_data;
@@ -179,8 +180,8 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$contact_data['tags'][] = array(
-			'id'          => 3,
-			'objtype'     => 1,
+			'id'          => $tag_id,
+			'objtype'     => ZBS_TYPE_CONTACT,
 			'name'        => 'Tag Added',
 			'slug'        => 'tag-added',
 			'created'     => 1692663412,
@@ -191,8 +192,8 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been not been met because the previous contact already had said tag.
 		$previous_contact['tags'][] = array(
-			'id'          => 3,
-			'objtype'     => 1,
+			'id'          => $tag_id,
+			'objtype'     => ZBS_TYPE_CONTACT,
 			'name'        => 'Tag Added',
 			'slug'        => 'tag-added',
 			'created'     => 1692663412,
@@ -210,6 +211,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$contact_tag_condition = $this->get_contact_tag_condition( 'tag_removed', 'Tag to be removed' );
 		$contact_data_type     = $this->automation_faker->contact_data( true );
 		$contact_data          = $contact_data_type->get_entity();
+		$tag_id                = end( $contact_data['tags'] )['id'] + 1;
 
 		// Create a previous state of a contact.
 		$previous_contact = $contact_data;
@@ -220,8 +222,8 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$previous_contact['tags'][] = array(
-			'id'          => 4,
-			'objtype'     => 1,
+			'id'          => $tag_id,
+			'objtype'     => ZBS_TYPE_CONTACT,
 			'name'        => 'Tag to be removed',
 			'slug'        => 'tag-to-be-removed',
 			'created'     => 1692663412,
@@ -232,8 +234,8 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been not been met because the current contact still has said tag.
 		$contact_data['tags'][] = array(
-			'id'          => 4,
-			'objtype'     => 1,
+			'id'          => $tag_id,
+			'objtype'     => ZBS_TYPE_CONTACT,
 			'name'        => 'Tag to be removed',
 			'slug'        => 'tag-to-be-removed',
 			'created'     => 1692663412,
@@ -250,6 +252,7 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 		$contact_tag_condition = $this->get_contact_tag_condition( 'has_tag', 'Some Tag' );
 		$contact_data_type     = $this->automation_faker->contact_data( true );
 		$contact_data          = $contact_data_type->get_entity();
+		$tag_id                = end( $contact_data['tags'] )['id'] + 1;
 
 		// Create a previous state of a contact.
 		$previous_contact = $contact_data;
@@ -260,8 +263,8 @@ class Contact_Condition_Test extends JPCRM_Base_Test_Case {
 
 		// Testing when the condition has been met.
 		$contact_data['tags'][] = array(
-			'id'          => 5,
-			'objtype'     => 1,
+			'id'          => $tag_id,
+			'objtype'     => ZBS_TYPE_CONTACT,
 			'name'        => 'Some Tag',
 			'slug'        => 'some-tag',
 			'created'     => 1692663412,

--- a/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
+++ b/projects/plugins/crm/tests/php/automation/tools/class-automation-faker.php
@@ -285,6 +285,24 @@ class Automation_Faker {
 			'lastcontacted'  => '',
 			'lastlog'        => '',
 			'lastcontactlog' => '',
+			'tags'           => array(
+				array(
+					'id'          => 1,
+					'objtype'     => 1,
+					'name'        => 'Name 1',
+					'slug'        => 'name-1',
+					'created'     => 1692663411,
+					'lastupdated' => 1692663411,
+				),
+				array(
+					'id'          => 2,
+					'objtype'     => 1,
+					'name'        => 'Name 2',
+					'slug'        => 'name-2',
+					'created'     => 1692663412,
+					'lastupdated' => 1692663412,
+				),
+			),
 		);
 
 		if ( $get_as_data_type ) {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds conditions for contact tags:
  * has_tag
  * tag_added
  * tag_removed

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3236
https://github.com/Automattic/zero-bs-crm/issues/3237
https://github.com/Automattic/zero-bs-crm/issues/3247

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Run tests by navigating to the CRM directory in your local installation after running `jetpack build plugins/crm`, and then run `composer phpunit -- --testdox --testsuite automation` (note this will currently run all tests as well with a new commit adding tests to this PR).

