### PR TITLE
Add/paid newsletter subscriber count

### DIFF
--- a/projects/plugins/jetpack/changelog/add-paid-newsletter-subscriber-count
+++ b/projects/plugins/jetpack/changelog/add-paid-newsletter-subscriber-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add paid newsletter subscriber count.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -167,7 +167,7 @@ function NewsletterPrePublishSettingsPanel( {
 }
 
 function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
-	const { emailSubscribers, paidSubscribers } = useSelect( select =>
+	const { emailSubscribers, paidNewsletterSubscribers } = useSelect( select =>
 		select( membershipProductsStore ).getSubscriberCounts()
 	);
 
@@ -191,7 +191,7 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 	const reachCount = getReachForAccessLevelKey(
 		accessLevel,
 		emailSubscribers,
-		paidSubscribers
+		paidNewsletterSubscribers
 	).toLocaleString();
 
 	let subscriberType = __( 'subscribers', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -177,7 +177,7 @@ function render_newsletter_access_rows( $column_id, $post_id ) {
 /**
  * Determine the amount of folks currently subscribed to the blog, splitted out in email_subscribers & social_followers & paid_subscribers
  *
- * @return array containing ['value' => ['email_subscribers' => 0, 'paid_subscribers' => 0, 'social_followers' => 0]]
+ * @return array containing ['value' => ['email_subscribers' => 0, 'paid_subscribers' => 0, 'social_followers' => 0, 'paid_newsletter_subscribers' => 0]]
  */
 function fetch_subscriber_counts() {
 	$subs_count = 0;
@@ -198,9 +198,10 @@ function fetch_subscriber_counts() {
 					'code'    => $xml->getErrorCode(),
 					'message' => $xml->getErrorMessage(),
 					'value'   => ( isset( $subs_count['value'] ) ) ? $subs_count['value'] : array(
-						'email_subscribers' => 0,
-						'social_followers'  => 0,
-						'paid_subscribers'  => 0,
+						'email_subscribers'           => 0,
+						'social_followers'            => 0,
+						'paid_subscribers'            => 0,
+						'paid_newsletter_subscribers' => 0,
 					),
 				);
 			} else {

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -95,7 +95,7 @@ export function NewsletterAccessRadioButtons( {
 } ) {
 	const isStripeConnected = stripeConnectUrl === null;
 	const instanceId = useInstanceId( NewsletterAccessRadioButtons );
-	const { emailSubscribers, paidSubscribers } = useSelect( select =>
+	const { emailSubscribers, paidNewsletterSubscribers } = useSelect( select =>
 		select( membershipProductsStore ).getSubscriberCounts()
 	);
 
@@ -109,7 +109,11 @@ export function NewsletterAccessRadioButtons( {
 				const accessLabel = accessOptions[ key ].label;
 				const reach =
 					key !== accessOptions.everybody.key
-						? ` (${ getReachForAccessLevelKey( key, emailSubscribers, paidSubscribers ) })`
+						? ` (${ getReachForAccessLevelKey(
+								key,
+								emailSubscribers,
+								paidNewsletterSubscribers
+						  ) })`
 						: '';
 				return (
 					<div className="editor-post-visibility__choice" key={ key }>

--- a/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
@@ -10,6 +10,7 @@ export const DEFAULT_STATE = {
 		socialFollowers: null,
 		emailSubscribers: null,
 		paidSubscribers: null,
+		paidNewsletterSubscribers: null,
 	},
 };
 

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -184,6 +184,7 @@ export const getSubscriberCounts =
 					socialFollowers: response.counts.social_followers,
 					emailSubscribers: response.counts.email_subscribers,
 					paidSubscribers: response.counts.paid_subscribers,
+					paidNewsletterSubscribers: response.counts.paid_newsletter_subscribers,
 				} )
 			);
 		} catch ( error ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 120-gh-automattic/gold
Related to D120180-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds new `paid_newsletter_subscribers` count from API

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow instructions on D120180-code but download this patch to your sandbox, on top of D120180-code (not trunk) after patching D120180-code.
* Either build this branch locally and view in localhost or use JN/WoA and the Jetpack Beta plugin to test this branch.
* Set `JETPACK__SANDBOX_DOMAIN` to point to your sandbox's domain.
* Start editing a new or existing post and click over to the Jetpack panel. You should see a non-zero number for paid subscribers.
* If you aren't seeing the correct response, try setting `$subs_count` to `false` so that the transient containing the old counts is not used.

