### PR TITLE
Create with voice: set block properties by using useBlockProps() custom hook

### DIFF
--- a/projects/plugins/jetpack/changelog/update-create-with-voice-fix-block-props-issue
+++ b/projects/plugins/jetpack/changelog/update-create-with-voice-fix-block-props-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Create with voice: set block properties by using useBlockProps() custom hook

--- a/projects/plugins/jetpack/extensions/blocks/create-with-voice/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/create-with-voice/edit.tsx
@@ -20,11 +20,11 @@ export default function CreateWithVoiceEdit() {
 		}
 	}, [ state, start, pause, resume ] );
 
-	let buttoneLabel = __( 'Start recording', 'jetpack' );
+	let buttonLabel = __( 'Start recording', 'jetpack' );
 	if ( state === 'recording' ) {
-		buttoneLabel = __( 'Pause recording', 'jetpack' );
+		buttonLabel = __( 'Pause recording', 'jetpack' );
 	} else if ( state === 'paused' ) {
-		buttoneLabel = __( 'Resume recording', 'jetpack' );
+		buttonLabel = __( 'Resume recording', 'jetpack' );
 	}
 
 	const blockProps = useBlockProps();
@@ -45,10 +45,9 @@ export default function CreateWithVoiceEdit() {
 					variant="primary"
 					onClick={ recordingHandler }
 				>
-					{ buttoneLabel }
+					{ buttonLabel }
 				</Button>
 			</Placeholder>
 		</div>
-
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/create-with-voice/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/create-with-voice/edit.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { micIcon, playerStopIcon, useMediaRecording } from '@automattic/jetpack-ai-client';
+import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder, Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -26,23 +27,28 @@ export default function CreateWithVoiceEdit() {
 		buttoneLabel = __( 'Resume recording', 'jetpack' );
 	}
 
+	const blockProps = useBlockProps();
+
 	return (
-		<Placeholder
-			icon="microphone"
-			label="AI: Create with voice"
-			instructions={ __(
-				'Transform your spoken words into publish-ready blocks with AI',
-				'jetpack'
-			) }
-		>
-			<Button
-				className="jetpack-ai-create-with-voice__record-button"
-				icon={ state === 'recording' ? playerStopIcon : micIcon }
-				variant="primary"
-				onClick={ recordingHandler }
+		<div { ...blockProps }>
+			<Placeholder
+				icon="microphone"
+				label="AI: Create with voice"
+				instructions={ __(
+					'Transform your spoken words into publish-ready blocks with AI',
+					'jetpack'
+				) }
 			>
-				{ buttoneLabel }
-			</Button>
-		</Placeholder>
+				<Button
+					className="jetpack-ai-create-with-voice__record-button"
+					icon={ state === 'recording' ? playerStopIcon : micIcon }
+					variant="primary"
+					onClick={ recordingHandler }
+				>
+					{ buttoneLabel }
+				</Button>
+			</Placeholder>
+		</div>
+
 	);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR sets the block props by using the proper hook which sets correctly its implementation.

This is a follow-up of https://github.com/Automattic/jetpack/pull/32750#pullrequestreview-1603046210


Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create with voice: set block properties by using useBlockProps() custom hook

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Create with voice block instance
* Confrm now, he block shows its toolbar
* Confirm the `beta` style
* Confirm now it's possible to remove the block

Before | after
------|-----
<img width="598" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/5173f0ac-aa8e-41b7-8cf0-1ce0ead8e970"> | <img width="603" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/730491da-f70a-4f59-990e-68c138cc33f2">



