### PR TITLE
AI Client: fix mic icon visual issue in Safari

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-client-player-icons
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-player-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Client: fix mic icon visual issue in Safari

--- a/projects/js-packages/ai-client/src/icons/mic.tsx
+++ b/projects/js-packages/ai-client/src/icons/mic.tsx
@@ -5,14 +5,7 @@ import { SVG, Rect, Line, Path } from '@wordpress/components';
 import React from 'react';
 
 const mic = (
-	<SVG
-		width="24"
-		height="24"
-		viewBox="0 0 24 24"
-		fill="none"
-		color="currentColor"
-		xmlns="http://www.w3.org/2000/SVG"
-	>
+	<SVG width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/SVG">
 		<Rect
 			x="8.75"
 			y="2.75"
@@ -21,12 +14,14 @@ const mic = (
 			rx="3.25"
 			stroke="currentColor"
 			strokeWidth="1.5"
+			fill="none"
 		/>
-		<Line x1="12" y1="17" x2="12" y2="21" stroke="currentColor" strokeWidth="1.5" />
+		<Line x1="12" y1="17" x2="12" y2="21" stroke="currentColor" strokeWidth="1.5" fill="none" />
 		<Path
 			d="M18 11C18 11.7879 17.8448 12.5681 17.5433 13.2961C17.2417 14.0241 16.7998 14.6855 16.2426 15.2426C15.6855 15.7998 15.0241 16.2418 14.2961 16.5433C13.5681 16.8448 12.7879 17 12 17C11.2121 17 10.4319 16.8448 9.7039 16.5433C8.97595 16.2417 8.31451 15.7998 7.75736 15.2426C7.20021 14.6855 6.75825 14.0241 6.45672 13.2961C6.15519 12.5681 6 11.7879 6 11"
 			stroke="currentColor"
 			strokeWidth="1.5"
+			fill="none"
 		/>
 	</SVG>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #https://github.com/Automattic/jetpack/issues/32786

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: fix mic icon visual issue in Safari

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Create with voice block instance
* Test in Safari
* Confirm the mic icon is visually fixed 

before (trunk) | after 
------|------
<img width="664" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/f9238c1d-6a0b-471c-a5d6-4e4f0de01c1e"> | <img width="665" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/a372c60a-1130-4c77-8bb2-ea07955acb58">