### PR TITLE
Fix: Exclude Pantheon domains starting with live- from known staging

### DIFF
--- a/projects/packages/status/changelog/fix-pantheon-staging-domain
+++ b/projects/packages/status/changelog/fix-pantheon-staging-domain
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Exclude domains starting with live from known Pantheon staging domains

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -227,18 +227,18 @@ class Status {
 
 		$known_staging = array(
 			'urls'      => array(
-				'#\.staging\.wpengine\.com$#i',                     // WP Engine. This is their legacy staging URL structure. Their new platform does not have a common URL. https://github.com/Automattic/jetpack/issues/21504
-				'#\.staging\.kinsta\.com$#i',                       // Kinsta.com.
-				'#\.kinsta\.cloud$#i',                              // Kinsta.com.
-				'#\.stage\.site$#i',                                // DreamPress.
-				'#\.newspackstaging\.com$#i',                       // Newspack.
+				'#\.staging\.wpengine\.com$#i',                    // WP Engine. This is their legacy staging URL structure. Their new platform does not have a common URL. https://github.com/Automattic/jetpack/issues/21504
+				'#\.staging\.kinsta\.com$#i',                      // Kinsta.com.
+				'#\.kinsta\.cloud$#i',                             // Kinsta.com.
+				'#\.stage\.site$#i',                               // DreamPress.
+				'#\.newspackstaging\.com$#i',                      // Newspack.
 				'#^(?!live-)([a-zA-Z0-9-]+)\.pantheonsite\.io$#i', // Pantheon.
-				'#\.flywheelsites\.com$#i',                         // Flywheel.
-				'#\.flywheelstaging\.com$#i',                       // Flywheel.
-				'#\.cloudwaysapps\.com$#i',                         // Cloudways.
-				'#\.azurewebsites\.net$#i',                         // Azure.
-				'#\.wpserveur\.net$#i',                             // WPServeur.
-				'#\-liquidwebsites\.com$#i',                        // Liquidweb.
+				'#\.flywheelsites\.com$#i',                        // Flywheel.
+				'#\.flywheelstaging\.com$#i',                      // Flywheel.
+				'#\.cloudwaysapps\.com$#i',                        // Cloudways.
+				'#\.azurewebsites\.net$#i',                        // Azure.
+				'#\.wpserveur\.net$#i',                            // WPServeur.
+				'#\-liquidwebsites\.com$#i',                       // Liquidweb.
 			),
 			'constants' => array(
 				'IS_WPE_SNAPSHOT',      // WP Engine. This is used on their legacy staging environment. Their new platform does not have a constant. https://github.com/Automattic/jetpack/issues/21504

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -232,7 +232,7 @@ class Status {
 				'#\.kinsta\.cloud$#i',                              // Kinsta.com.
 				'#\.stage\.site$#i',                                // DreamPress.
 				'#\.newspackstaging\.com$#i',                       // Newspack.
-				'#\^(?!live-)([a-zA-Z0-9-]+)\.pantheonsite\.io$#i', // Pantheon.
+				'#^(?!live-)([a-zA-Z0-9-]+)\.pantheonsite\.io$#i', // Pantheon.
 				'#\.flywheelsites\.com$#i',                         // Flywheel.
 				'#\.flywheelstaging\.com$#i',                       // Flywheel.
 				'#\.cloudwaysapps\.com$#i',                         // Cloudways.

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -227,18 +227,18 @@ class Status {
 
 		$known_staging = array(
 			'urls'      => array(
-				'#\.staging\.wpengine\.com$#i', // WP Engine. This is their legacy staging URL structure. Their new platform does not have a common URL. https://github.com/Automattic/jetpack/issues/21504
-				'#\.staging\.kinsta\.com$#i',   // Kinsta.com.
-				'#\.kinsta\.cloud$#i',          // Kinsta.com.
-				'#\.stage\.site$#i',            // DreamPress.
-				'#\.newspackstaging\.com$#i',   // Newspack.
-				'#\.pantheonsite\.io$#i',       // Pantheon.
-				'#\.flywheelsites\.com$#i',     // Flywheel.
-				'#\.flywheelstaging\.com$#i',   // Flywheel.
-				'#\.cloudwaysapps\.com$#i',     // Cloudways.
-				'#\.azurewebsites\.net$#i',     // Azure.
-				'#\.wpserveur\.net$#i',         // WPServeur.
-				'#\-liquidwebsites\.com$#i',    // Liquidweb.
+				'#\.staging\.wpengine\.com$#i',                     // WP Engine. This is their legacy staging URL structure. Their new platform does not have a common URL. https://github.com/Automattic/jetpack/issues/21504
+				'#\.staging\.kinsta\.com$#i',                       // Kinsta.com.
+				'#\.kinsta\.cloud$#i',                              // Kinsta.com.
+				'#\.stage\.site$#i',                                // DreamPress.
+				'#\.newspackstaging\.com$#i',                       // Newspack.
+				'#\^(?!live-)([a-zA-Z0-9-]+)\.pantheonsite\.io$#i', // Pantheon.
+				'#\.flywheelsites\.com$#i',                         // Flywheel.
+				'#\.flywheelstaging\.com$#i',                       // Flywheel.
+				'#\.cloudwaysapps\.com$#i',                         // Cloudways.
+				'#\.azurewebsites\.net$#i',                         // Azure.
+				'#\.wpserveur\.net$#i',                             // WPServeur.
+				'#\-liquidwebsites\.com$#i',                        // Liquidweb.
 			),
 			'constants' => array(
 				'IS_WPE_SNAPSHOT',      // WP Engine. This is used on their legacy staging environment. Their new platform does not have a constant. https://github.com/Automattic/jetpack/issues/21504

--- a/projects/packages/status/tests/php/test-status.php
+++ b/projects/packages/status/tests/php/test-status.php
@@ -388,6 +388,22 @@ class Test_Status extends TestCase {
 				'http://staging.wpengine.com.example.com/',
 				false,
 			),
+			'pantheon_dev'          => array(
+				'http://dev-site-name.pantheonsite.io',
+				true,
+			),
+			'pantheon_test'         => array(
+				'http://test-site-name.pantheonsite.io',
+				true,
+			),
+			'pantheon_multi'        => array(
+				'http://multidev-env-site-name.pantheonsite.io',
+				true,
+			),
+			'pantheon_live'         => array(
+				'http://live-site-name.pantheonsite.io',
+				false,
+			),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Pantheon live sites automatically get a domain like this: live-site-name.pantheonsite.io. Our checks for staging sites don't recognize this and place live sites in staging mode. 
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Edited regex so domains starting with live- will be ignored when performing staging check.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

