### PR TITLE
Launchpad: Fixes the task path property

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-use-get-calypso-path-prop
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-use-get-calypso-path-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update the unused get_task_url prop on the task definition to the get_calypso_path

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -57,9 +57,6 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_domain_upsell_completed',
 			'badge_text_callback'  => 'wpcom_launchpad_get_domain_upsell_badge_text',
 			'is_visible_callback'  => 'wpcom_launchpad_is_domain_upsell_task_visible',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/domains/add/' . $data['site_slug_encoded'];
-			},
 		),
 		'first_post_published'            => array(
 			'get_title'             => function () {

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -45,7 +45,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_domain_claim_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_domain_claim_is_visible_callback',
-			'get_task_url'         => function ( $task, $default, $data ) {
+			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/domains/add/' . $data['site_slug_encoded'];
 			},
 		),
@@ -57,7 +57,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_domain_upsell_completed',
 			'badge_text_callback'  => 'wpcom_launchpad_get_domain_upsell_badge_text',
 			'is_visible_callback'  => 'wpcom_launchpad_is_domain_upsell_task_visible',
-			'get_task_url'         => function ( $task, $default, $data ) {
+			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/domains/add/' . $data['site_slug_encoded'];
 			},
 		),
@@ -99,7 +99,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'isLaunchTask'          => true,
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
-			'get_task_url'          => function ( $task, $default, $data ) {
+			'get_calypso_path'      => function ( $task, $default, $data ) {
 				return '/settings/general/' . $data['site_slug_encoded'] . '#site-privacy-settings';
 			},
 		),
@@ -108,7 +108,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Verify email address', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback' => 'wpcom_launchpad_is_email_unverified',
-			'get_task_url'        => function () {
+			'get_calypso_path'    => function () {
 				return '/me/account';
 			},
 		),

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -99,9 +99,6 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'isLaunchTask'          => true,
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
-			'get_calypso_path'      => function ( $task, $default, $data ) {
-				return '/settings/general/' . $data['site_slug_encoded'] . '#site-privacy-settings';
-			},
 		),
 		'verify_email'                    => array(
 			'get_title'           => function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Some tasks used the `get_task_url` key to define the path that Calypso interprets, but this key was not being used. The correct key is `get_calypso_path`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox the public API and use the command below to apply this diff to your sandbox
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/use-get-calypso-path-prop
```
* Create a new account and a new site with the "build" intent by selecting 'Promote myself or business' on the goals page.
* Go through the flow until you land on the Customer Home.
* On your sandbox, update the `is_visible_callback` callback value to `__return_true` in the `domain_claim` task definition:
```
> wp-content/mu-plugins/jetpack-mu-wpcom-plugin/production/vendor/automattic/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php

'domain_claim'                    => array(
	'get_title'            => function () {
		return __( 'Claim your free one-year domain', 'jetpack-mu-wpcom' );
	},
	'is_complete_callback' => 'wpcom_launchpad_is_domain_claim_completed',
	'is_visible_callback'  => '__return_true',
	'get_calypso_path'     => function ( $task, $default, $data ) {
		return '/domains/add/' . $data['site_slug_encoded'];
	},
),
```
* Open the Network tab on the dev console, and look for the `/wpcom/v2/sites/:siteSlug/launchpad?_locale=user&checklist_slug=intent-build&_envelope=1` URL.
* Verify that you can see the `calypso_path` on the `verify_email` and `claim_domain` tasks
![Screen Shot 2023-08-31 at 10 23 49](https://github.com/Automattic/jetpack/assets/1234758/bc278b70-5d61-4291-a62f-e6043f691530)

For the `domain_upsell` & `site_launched` task, since we are not using it on the Customer Home launchpad, I decided to remove the path definition.

