### PR TITLE
AI Client: create blob audio data. Introduce onDone() callback 

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-client-generate-audio-data
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-generate-audio-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: creste blob audio data. Introduce onDone() callback

--- a/projects/js-packages/ai-client/changelog/update-ai-client-generate-audio-data
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-generate-audio-data
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-AI Client: creste blob audio data. Introduce onDone() callback
+AI Client: create blob audio data. Introduce onDone() callback

--- a/projects/js-packages/ai-client/src/hooks/use-media-recording/Readme.md
+++ b/projects/js-packages/ai-client/src/hooks/use-media-recording/Readme.md
@@ -39,7 +39,7 @@ const MediaRecorderComponent = () => {
 			<button onClick={ resume } disabled={ state !== 'paused' }>
 				Resume
 			</button>
-			<button onClick={ stop } disabled={ state === 'recording' }>
+			<button onClick={ stop } disabled={ state === 'inactive' }>
 				Stop
 			</button>
 		</div>

--- a/projects/js-packages/ai-client/src/hooks/use-media-recording/Readme.md
+++ b/projects/js-packages/ai-client/src/hooks/use-media-recording/Readme.md
@@ -10,7 +10,7 @@ Based on [MediaRecorder](https://developer.mozilla.org/en-US/docs/Web/API/MediaR
 
 The hook returns an object with the following properties and methods:
 
-- `start: () => void`: Start the media recording
+- `start: ( timeslice ) => void`: Start the media recording
 - `pause: () => void`: Pause the current media recording
 - `resume: () => void`: Resume a paused recording
 - `stop: () => void`: Stop the current recording

--- a/projects/js-packages/ai-client/src/hooks/use-media-recording/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-media-recording/index.ts
@@ -11,7 +11,7 @@ type UseMediaRecordingReturn = {
 	/**
 	 * `start` recording handler
 	 */
-	start: () => void;
+	start: ( timeslice?: number ) => void;
 
 	/**
 	 * `pause` recording handler
@@ -47,8 +47,8 @@ export default function useMediaRecording(): UseMediaRecordingReturn {
 	const [ state, setState ] = useState< RecordingStateProp >( 'inactive' );
 
 	// `start` recording handler
-	const start = useCallback( () => {
-		mediaRecordRef?.current?.start();
+	const start = useCallback( ( timeslice: number ) => {
+		mediaRecordRef?.current?.start( timeslice );
 	}, [] );
 
 	// `pause` recording handler

--- a/projects/js-packages/ai-client/src/hooks/use-media-recording/stories/index.stories.tsx
+++ b/projects/js-packages/ai-client/src/hooks/use-media-recording/stories/index.stories.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { Button } from '@wordpress/components';
+import React from 'react';
+/**
+ * Internal dependencies
+ */
+import useMediaRecording from '../';
+/**
+ * Types
+ */
+import type { Meta } from '@storybook/react';
+
+const RecorderComponent = () => {
+	const { start, pause, resume, stop, state } = useMediaRecording( {
+		onDone: ( blob: Blob ) => action( 'onDone' )( { size: blob.size, type: blob.type } ),
+	} );
+
+	return (
+		<div style={ { display: 'flex', flexDirection: 'row', gap: '1px' } }>
+			<Button variant="primary" onClick={ start } disabled={ state !== 'inactive' }>
+				Begin recording
+			</Button>
+
+			<Button variant="primary" onClick={ pause } disabled={ state !== 'recording' }>
+				Pause
+			</Button>
+
+			<Button variant="primary" onClick={ resume } disabled={ state !== 'paused' }>
+				Resume
+			</Button>
+
+			<Button variant="primary" onClick={ stop } disabled={ state === 'inactive' }>
+				Stop
+			</Button>
+		</div>
+	);
+};
+
+export default {
+	title: 'JS Packages/AI Client/useMediaRecording',
+	component: RecorderComponent,
+} as Meta< typeof RecorderComponent >;
+
+const Template = () => <RecorderComponent />;
+
+const DefaultArgs = {};
+
+export const Default = Template.bind( {} );
+Default.args = DefaultArgs;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR collects and stores the recording chunks to be able to generate a `blob` instance that will be provided to the hook consumer via the onDone() callback.

Fixes AI Client: creste blob audio data. Introduce onDone() callback 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: creste blob audio data. Introduce onDone() callback

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This PR introduces an useMediaRecordsing() story to test the hook

* Use Storybook

```
cd projects/js-packages/storybook/
```

```
pnpm run storybook:dev
```
* Load the default useMediaRecordsing story: http://localhost:50240/?path=/story/js-packages-ai-client-usemediarecording--default
* Open the addons panel
* Confirm that you can start recording, pause, and resume, and when you click on stop, the story shows the blob data:

https://github.com/Automattic/jetpack/assets/77539/897426be-6fe1-4c06-8d84-a585dfddadef

