### PR TITLE
Create with voice: introduce Done button

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-client-generate-audio-data
+++ b/projects/plugins/jetpack/changelog/update-ai-client-generate-audio-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Create with voice: introduce Done button

--- a/projects/plugins/jetpack/extensions/blocks/create-with-voice/edit.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/create-with-voice/edit.tsx
@@ -1,14 +1,18 @@
 /**
  * External dependencies
  */
-import { micIcon, playerStopIcon, useMediaRecording } from '@automattic/jetpack-ai-client';
+import { micIcon, playerPauseIcon, useMediaRecording } from '@automattic/jetpack-ai-client';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder, Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 export default function CreateWithVoiceEdit() {
-	const { state, start, pause, resume } = useMediaRecording();
+	const { state, start, pause, stop, resume } = useMediaRecording( {
+		onDone: blob => {
+			console.log( 'Blob created: ', blob ); // eslint-disable-line no-console
+		},
+	} );
 
 	const recordingHandler = useCallback( () => {
 		if ( state === 'inactive' ) {
@@ -20,7 +24,7 @@ export default function CreateWithVoiceEdit() {
 		}
 	}, [ state, start, pause, resume ] );
 
-	let buttonLabel = __( 'Start recording', 'jetpack' );
+	let buttonLabel = __( 'Begin recording', 'jetpack' );
 	if ( state === 'recording' ) {
 		buttonLabel = __( 'Pause recording', 'jetpack' );
 	} else if ( state === 'paused' ) {
@@ -39,14 +43,26 @@ export default function CreateWithVoiceEdit() {
 					'jetpack'
 				) }
 			>
-				<Button
-					className="jetpack-ai-create-with-voice__record-button"
-					icon={ state === 'recording' ? playerStopIcon : micIcon }
-					variant="primary"
-					onClick={ recordingHandler }
-				>
-					{ buttonLabel }
-				</Button>
+				<div className="jetpack-ai-create-with-voice__recorder">
+					<Button
+						className="jetpack-ai-create-with-voice__record-button"
+						icon={ state === 'recording' ? playerPauseIcon : micIcon }
+						iconPosition="right"
+						variant="primary"
+						onClick={ recordingHandler }
+					>
+						{ buttonLabel }
+					</Button>
+
+					<Button
+						className="jetpack-ai-create-with-voice__done-button"
+						variant="primary"
+						onClick={ stop }
+						disabled={ state === 'inactive' }
+					>
+						{ __( 'Done', 'jetpack' ) }
+					</Button>
+				</div>
 			</Placeholder>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/create-with-voice/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/create-with-voice/editor.scss
@@ -1,9 +1,19 @@
 @import '@automattic/jetpack-base-styles/style';
 
-.jetpack-ai-create-with-voice__record-button {
-	&.components-button.has-icon {
-		> SVG {
-			fill: none;
+.jetpack-ai-create-with-voice__recorder {
+	display: flex;
+	flex-direction:row;
+	gap: 1px;
+
+	.components-button {
+		margin-right: 0;
+
+		&.jetpack-ai-create-with-voice__record-button {
+			border-radius: 4px 0 0 4px;
+		}
+
+		&.jetpack-ai-create-with-voice__done-button {
+			border-radius: 0 4px 4px 0;
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~Depends on https://github.com/Automattic/jetpack/pull/32791~

This PR adds the `Done` button to the block placeholder. Once the user clicks on it, the transformation process will start (follow-up).
~Although the changes are visually testable, it would be better to merge https://github.com/Automattic/jetpack/pull/32791 before.~
Edit: https://github.com/Automattic/jetpack/pull/32791 merged.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create with voice: introduce Done button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a Create with voice block instance
* Confirm the Done button is there, and the logic of start, pause, resume and done is okay

https://github.com/Automattic/jetpack/assets/77539/edd8a7d6-3c3c-44b0-b9b9-6d40ff6478bf

