### PR TITLE
Launchpad: Adapt the pre launch tasks to work on the Customer Home

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-pre-launch-write-customer-home
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-pre-launch-write-customer-home
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adapt the pre launch tasks to work on the Customer Home

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -38,6 +38,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => '__return_true',
 			'is_disabled_callback' => 'wpcom_launchpad_is_design_step_enabled',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/setup/update-design/designSetup?siteSlug=' . $data['site_slug_encoded'];
+			},
 		),
 		'domain_claim'                    => array(
 			'get_title'            => function () {
@@ -82,6 +85,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'subtitle'             => 'wpcom_launchpad_get_plan_selected_subtitle',
 			'is_complete_callback' => '__return_true',
 			'badge_text_callback'  => 'wpcom_launchpad_get_plan_selected_badge_text',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/plans/' . $data['site_slug_encoded'];
+			},
 		),
 		'setup_general'                   => array(
 			'get_title'            => function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/81186

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adapts the pre-launch tasks for the Write intent to be compatible with the Customer Home launchpad. I added the `get_calypso_path` to several tasks that are in the write intent task list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this diff in your sandbox with the following command
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/pre-launch-write-customer-home
```
* Use the Calypso Live link on the following PR: https://github.com/Automattic/wp-calypso/pull/80661
* Create a new site and select the `Write & Publish` option on the Goal step
* Go through the setup flow until you reach the pre-launch launchpad
* Skip the pre-launch launchpad
* You should land on the Customer Home
* Click on the tasks to ensure the click event works.

