### PR TITLE
paywall block: toolbar, improve dialog and copy

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-block-toolbar-2
+++ b/projects/plugins/jetpack/changelog/update-paywall-block-toolbar-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+minor copy change

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -14,7 +14,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { arrowDown, Icon, update, check } from '@wordpress/icons';
+import { arrowDown, Icon, people, check } from '@wordpress/icons';
 import {
 	accessOptions,
 	META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
@@ -84,6 +84,7 @@ function PaywallEdit( { className } ) {
 
 	const style = {
 		width: `${ text.length + 1.2 }em`,
+		userSelect: 'none',
 	};
 
 	return (
@@ -97,7 +98,7 @@ function PaywallEdit( { className } ) {
 			<BlockControls __experimentalShareWithChildBlocks group="block">
 				<ToolbarDropdownMenu
 					className="product-management-control-toolbar__dropdown-button"
-					icon={ update }
+					icon={ people }
 					text={ getLabel( accessLevel ) }
 				>
 					{ ( { onClose: closeDropdown } ) => (
@@ -146,9 +147,9 @@ function PaywallEdit( { className } ) {
 				} }
 			>
 				<h2>{ __( 'Enable payments', 'jetpack' ) }</h2>
-				<p>
+				<p style={ { maxWidth: 340 } }>
 					{ __(
-						'To choose this option, you’ll need first to create a payment offer, setting up how much your subscribers should pay to access your paid content, and then connect your Stripe account, which is our payments’ processor.',
+						'To choose this option, you need to create a payment plan, setting up how much your subscribers should pay to access your paid content, and then connect your Stripe account, which is our payments processor.',
 						'jetpack'
 					) }
 				</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

<img width="1015" alt="Screenshot 2023-08-31 at 18 34 07" src="https://github.com/Automattic/jetpack/assets/104869/9f5fb0b5-0d93-4f05-bfbc-5ad93a22cb84">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

