### PR TITLE
AI Extension: Remove HTML fragments from AI-generated forms on site editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-site-editor-html
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-site-editor-html
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Extension: Remove HTML fragments from AI-generated forms on site editor

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -167,7 +167,10 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 
 				// Check if the generated blocks are valid.
 				const validBlocks = newContentBlocks.filter( block => {
-					return block.isValid && block.name !== 'core/freeform' && block.name !== 'core/missing';
+					return (
+						block.isValid &&
+						! [ 'core/freeform', 'core/missing', 'core/html' ].includes( block.name )
+					);
 				} );
 
 				let lastBlockUpdated = false;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -10,6 +10,7 @@ import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import React from 'react';
 /**
  * Internal dependencies
  */
@@ -20,6 +21,7 @@ import { AiAssistantUiContextProvider } from './context';
 /**
  * Types
  */
+import type { Block } from '../../../lib/utils/compare-blocks';
 import type { RequestingErrorProps } from '@automattic/jetpack-ai-client';
 
 // An identifier to use on the extension error notices,
@@ -54,7 +56,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 		const [ assistantAnchor, setAssistantAnchor ] = useState< HTMLElement | null >( null );
 
 		// Keep track of the current list of valid blocks between renders.
-		const currentListOfValidBlocks = useRef( [] );
+		const currentListOfValidBlocks = useRef< Array< Block > >( [] );
 
 		const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 		const coreEditorSelect = useSelect( select => select( 'core/editor' ), [] ) as {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -156,7 +156,7 @@ const withUiHandlerDataProvider = createHigherOrderComponent( BlockListBlock => 
 			( newContent: string, isRequestDone = false ) => {
 				// Remove the Jetpack Form block from the content.
 				const processedContent = newContent.replace(
-					/<!-- (\/)*wp:jetpack\/(contact-)*form ({.*} )*(\/)*-->/g,
+					/<!-- (\/)*wp:jetpack\/(contact-)*form ({[^}]*} )*(\/)*-->/g,
 					''
 				);
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/compare-blocks.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/compare-blocks.ts
@@ -1,4 +1,4 @@
-type Block = {
+export type Block = {
 	attributes?: object;
 	clientId?: string;
 	innerBlocks?: Block[];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32561

Turns out that the site editor parses invalid content differently, creating a valid `core:html` block.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes core:html from the list of valid blocks
* Fixes a regex used to remove form blocks from the response
* Fixes some typescript issues

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the site editor
* Add a form outside of a query loop
* Ask for a form
* Check that there are no HTML fragments and there are no regressions

Note: There is an unrelated bug in the site editor currently where the initial state is not injected for Jetpack sites, so the form extension will not show up on Jetpack sites. It possibly is intermittent, but it happens every time for me. ref p1693495835507849-slack-CDLH4C1UZ