### PR TITLE
CRM: Automations get workflows api endpoint

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-3226-automations-get-workflows-api-endpoint
+++ b/projects/plugins/crm/changelog/add-crm-3226-automations-get-workflows-api-endpoint
@@ -1,0 +1,3 @@
+Significance: patch
+Type: added
+Comment: Add initial rest controller for automations with the workflows get endpoint

--- a/projects/plugins/crm/includes/ZeroBSCRM.REST.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.REST.php
@@ -108,6 +108,9 @@ add_action( 'rest_api_init', function () {
 	if ( apply_filters( 'jetpack_crm_feature_flag_api_v4', false ) ) {
 		$controller = new Automattic\Jetpack\CRM\REST_API\V4\REST_Contacts_Controller();
 		$controller->register_routes();
+
+		$automation_controller = new Automattic\Jetpack\CRM\REST_API\V4\REST_Automation_Controller();
+		$automation_controller->register_routes();
 	}
 });
 

--- a/projects/plugins/crm/src/rest-api/v4/class-rest-automation-controller.php
+++ b/projects/plugins/crm/src/rest-api/v4/class-rest-automation-controller.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Automation REST controller.
+ *
+ * @package Automattic\Jetpack\CRM
+ */
+
+namespace Automattic\Jetpack\CRM\REST_API\V4;
+
+use Exception;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST automation controller.
+ *
+ * @package Automattic\Jetpack\CRM
+ * @since $$next-version$$
+ */
+final class REST_Automation_Controller extends REST_Base_Objects_Controller {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->rest_base = 'automation';
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @since $$next-version$$
+	 * @see register_rest_route()
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		// Register REST collection resource endpoints.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/workflows',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_workflows' ),
+					'permission_callback' => array( $this, 'get_workflows_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get all workflows.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_workflows( $request ) {
+		try {
+			// TODO: Get the Workflows from the DB.
+			$workflows = array( 'Get Workflows from DB' );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'rest_unknown_error',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
+
+		$data = $this->prepare_workflows_for_response( $workflows, $request );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Checks if a given request has access to the workflows.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the workflows, WP_Error object otherwise.
+	 */
+	public function get_workflows_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$can_user_manage_workflows = zeroBSCRM_isZBSAdmin();
+
+		if ( is_wp_error( $can_user_manage_workflows ) ) {
+			return $can_user_manage_workflows;
+		}
+
+		if ( $can_user_manage_workflows ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_cannot_view',
+			__( 'Sorry, you cannot view this resource.', 'zero-bs-crm' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Prepares the workflow for the REST response.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array           $workflows WordPress' representation of the item.
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function prepare_workflows_for_response( $workflows, $request ) {
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $workflows );
+
+		/**
+		 * Filters the REST API response for workflows.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array $workflows The raw workflow array.
+		 * @param WP_REST_Request $request The request object.
+		 */
+		return apply_filters( 'jpcrm_rest_prepare_workflows_array', $response, $workflows, $request );
+	}
+}

--- a/projects/plugins/crm/tests/php/rest-api/class-rest-base-test-case.php
+++ b/projects/plugins/crm/tests/php/rest-api/class-rest-base-test-case.php
@@ -33,4 +33,22 @@ abstract class REST_Base_Test_Case extends JPCRM_Base_Integration_Test_Case {
 		);
 	}
 
+	/**
+	 * Create WordPress user with the 'zerobs_admin' role.
+	 *
+	 * @param array $args A list of arguments to create the WP user from.
+	 *
+	 * @return int
+	 */
+	public function create_wp_jpcrm_admin( $args = array() ) {
+		$user_id = $this->create_wp_user( $args );
+
+		if ( ! is_wp_error( $user_id ) ) {
+			$user = get_userdata( $user_id );
+			$user->add_role( 'zerobs_admin' );
+		}
+
+		return $user_id;
+	}
+
 }

--- a/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-controller-test.php
+++ b/projects/plugins/crm/tests/php/rest-api/v4/class-rest-automation-controller-test.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Automattic\Jetpack\CRM\Tests;
+
+use WP_REST_Request;
+use WP_REST_Server;
+
+require_once __DIR__ . '/../class-rest-base-test-case.php';
+
+/**
+ * REST_Automation_Controller_Test class.
+ *
+ * @covers \Automattic\Jetpack\CRM\REST_API\V4\REST_Automation_Controller
+ */
+class REST_Automation_Controller_Test extends REST_Base_Test_Case {
+
+	/**
+	 * GET Workflows: Test that we can successfully access the endpoint.
+	 *
+	 * @return void
+	 */
+	public function test_get_workflows_success() {
+		// Create and set authenticated user.
+		$jpcrm_admin_id = $this->create_wp_jpcrm_admin();
+		wp_set_current_user( $jpcrm_admin_id );
+
+		// Make request.
+		$request  = new WP_REST_Request(
+			WP_REST_Server::READABLE,
+			'/jetpack-crm/v4/automation/workflows'
+		);
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$workflows = $response->get_data();
+		$this->assertIsArray( $workflows );
+		// TODO: add more tests to ensure the workflows were returned correctly.
+	}
+}


### PR DESCRIPTION
This PR adds the initial endpoint for the automations get endpoint for workflows.
It still lacks the method to retrieve the workflows from the database, so instead of calling a proper method this PR uses `$workflows = array( 'Get Workflows from DB' );` as a stub that should be replaced once we have something to get workflows from.

This PR uses the `jetpack_crm_feature_flag_api_v4` feature flag.

Fixes https://github.com/Automattic/zero-bs-crm/issues/3301

## Proposed changes:
* This PR adds the initial endpoint for the automations get endpoint for workflows
  * `[GET] /automations/workflows`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3226

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Run: jetpack install plugins/crm
* Go to the CRM directory: projects/plugins/crm
* Run composer run-script phpunit

Check if the code is correct.

