### PR TITLE
Launchpad: Remove is launched check for the Build intent

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-remove-launchpad-launched-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-remove-launchpad-launched-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove the is launched check for the build intent

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -686,14 +686,10 @@ function wpcom_launchpad_set_fse_next_steps_modal_hidden( $should_hide ) {
  * @return bool True if the task list is enabled, false otherwise.
  */
 function wpcom_launchpad_is_keep_building_enabled() {
-	$intent                  = get_option( 'site_intent', false );
-	$launchpad_task_statuses = get_option( 'launchpad_checklist_tasks_statuses', array() );
+	$intent  = get_option( 'site_intent', false );
+	$blog_id = get_current_blog_id();
 
-	// We don't care about the other *_launched tasks, since this is specific to the Build flow.
-	$launched = isset( $launchpad_task_statuses['site_launched'] ) && $launchpad_task_statuses['site_launched'];
-	$blog_id  = get_current_blog_id();
-
-	if ( 'build' === $intent && $blog_id > 220443356 && $launched ) {
+	if ( 'build' === $intent && $blog_id > 220443356 ) {
 		return true;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:
* https://github.com/Automattic/wp-calypso/pull/80661
 
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the checks that verify whether the site was launched for the build intent. This would prevent the skip feature from working properly for this intent.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this diff to your sandbox using the command below:
```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/remove-launchpad-launched-check
```
* Create a new site, and go through the flow until you reach the Goal step.
* Select the `Promote myself or business` option
* Go through the flow until you reach the Customer Home
* Make sure you can see the post-launch Launchpad on the Customer Home page.

