### PR TITLE
Add Users menu items for wpcom domain only sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-users-domain-menu
+++ b/projects/plugins/jetpack/changelog/update-add-users-domain-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Adds the User menu items to the sidebar for wpcom domain only sites.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
@@ -64,5 +64,29 @@ class Domain_Only_Admin_Menu extends Base_Admin_Menu {
 
 		add_menu_page( esc_attr__( 'Manage Purchases', 'jetpack' ), __( 'Manage Purchases', 'jetpack' ), 'manage_options', 'https://wordpress.com/purchases/subscriptions/' . $this->domain, null, 'dashicons-cart' );
 		add_menu_page( esc_attr__( 'Inbox', 'jetpack' ), __( 'Inbox', 'jetpack' ), 'manage_options', 'https://wordpress.com/inbox/' . $this->domain, null, 'dashicons-email' );
+
+		$this->add_users_menu();
+	}
+
+	/**
+	 * Add users menu
+	 */
+	public function add_users_menu() {
+		add_menu_page( esc_attr__( 'Users', 'jetpack' ), __( 'Users', 'jetpack' ), 'list_users', 'https://wordpress.com/people/team/' . $this->domain, null, 'dashicons-admin-users' );
+
+		$submenus_to_update = array(
+			'profile.php' => 'https://wordpress.com/me',
+		);
+
+		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'users.php' ) ) {
+			$submenus_to_update['users.php']    = 'https://wordpress.com/people/team/' . $this->domain;
+			$submenus_to_update['user-new.php'] = 'https://wordpress.com/people/new/' . $this->domain;
+		}
+
+		$slug = current_user_can( 'list_users' ) ? 'users.php' : 'profile.php';
+		$this->update_submenus( $slug, $submenus_to_update );
+
+		add_submenu_page( 'users.php', esc_attr__( 'Add New', 'jetpack' ), __( 'Add New', 'jetpack' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
+		add_submenu_page( 'users.php', esc_attr__( 'Users', 'jetpack' ), __( 'Users', 'jetpack' ), 'list_users', 'https://wordpress.com/people/team' . $this->domain, null, 3 );
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3606
Context: pb5gDS-3jS-p2

WordPress.com is enabling user management for domain only sites. We need the User menu items added into the sidebar. The sidebar for domain only sites is based on the Base_Admin_Menu class but has [all menu items wiped out](https://github.com/automattic/jetpack/blob/trunk/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php#L56) before adding back exactly what menu items we want available.
 
The `/people/*` routes were previously disabled in calypso for domain only sites but are now generally available with this change deployed: https://github.com/Automattic/wp-calypso/pull/81385

## Proposed changes:
* Adds User menu items for WordPress.com domain only sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Requires a test user with a domain only site, feel free to SU into the test user `testingtesterson51`
* Visit the domain only site management page e.g. https://wordpress.com/domains/manage/all/test345678.blog/edit/test345678.blog
* The user menu items should not be visible until sandboxed.
* Sandbox this change `bin/jetpack-downloader test jetpack update/add-users-domain-menu`
* The user menu items should now be visible on wordpress.com domain only site domain management pages.