### PR TITLE
Social: Do not show upsells on Atomic sites

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-dont-show-editor-upsell-on-atomic
+++ b/projects/js-packages/publicize-components/changelog/fix-dont-show-editor-upsell-on-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed issue where we showed upsell on Atomic sites

--- a/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
@@ -3,6 +3,8 @@ import {
 	isUpgradable,
 	getJetpackData,
 	getSiteFragment,
+	isAtomicSite,
+	isSimpleSite,
 } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -30,6 +32,7 @@ export default function usePublicizeConfig() {
 	const connectionsRootUrl =
 		getJetpackData()?.social?.publicizeConnectionsUrl ??
 		'https://wordpress.com/marketing/connections/';
+	const isPureJetpackSite = ! isAtomicSite() && ! isSimpleSite();
 
 	/*
 	 * isPublicizeEnabledMeta:
@@ -100,6 +103,9 @@ export default function usePublicizeConfig() {
 	 */
 	const isAutoConversionEnabled = !! getJetpackData()?.social?.isAutoConversionEnabled;
 
+	const shouldShowAdvancedPlanNudge =
+		sharesData.show_advanced_plan_upgrade_nudge && isPureJetpackSite;
+
 	return {
 		isPublicizeEnabledMeta,
 		isPublicizeEnabled,
@@ -111,7 +117,7 @@ export default function usePublicizeConfig() {
 		isShareLimitEnabled,
 		isPostAlreadyShared,
 		numberOfSharesRemaining: sharesData.shares_remaining,
-		shouldShowAdvancedPlanNudge: sharesData.show_advanced_plan_upgrade_nudge,
+		shouldShowAdvancedPlanNudge,
 		hasPaidPlan,
 		isEnhancedPublishingEnabled,
 		isSocialImageGeneratorAvailable: !! getJetpackData()?.social?.isSocialImageGeneratorAvailable,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We want to make sure we do not show upsells on Atomic sites. The notice in the editor could appear technically appear if the site has a paid plan but does not have the enchanced publishing feature. With this patch it should not appear ever.


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

