### PR TITLE
beta: Chain PHP error handlers

### DIFF
--- a/projects/plugins/beta/changelog/fix-beta-chain-error-handlers
+++ b/projects/plugins/beta/changelog/fix-beta-chain-error-handlers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+If another PHP error handler was set, chain to it insead of calling PHP's default handler.

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -99,7 +99,7 @@ if ( is_readable( $jetpack_beta_autoloader ) ) {
 
 add_action( 'init', array( Automattic\JetpackBeta\AutoupdateSelf::class, 'instance' ) );
 
-set_error_handler( array( Automattic\JetpackBeta\Hooks::class, 'custom_error_handler' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+Automattic\JetpackBeta\Hooks::setup();
 
 register_activation_hook( __FILE__, array( Automattic\JetpackBeta\Hooks::class, 'activate' ) );
 register_deactivation_hook( __FILE__, array( Automattic\JetpackBeta\Hooks::class, 'deactivate' ) );

--- a/projects/plugins/beta/src/class-hooks.php
+++ b/projects/plugins/beta/src/class-hooks.php
@@ -26,6 +26,13 @@ class Hooks {
 	protected static $instance = null;
 
 	/**
+	 * Previous error handler.
+	 *
+	 * @var callable
+	 */
+	protected static $prev_error_handler = null;
+
+	/**
 	 * Main Instance
 	 */
 	public static function instance() {
@@ -577,6 +584,13 @@ class Hooks {
 	}
 
 	/**
+	 * Set up at plugin load.
+	 */
+	public static function setup() {
+		self::$prev_error_handler = set_error_handler( array( self::class, 'custom_error_handler' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+	}
+
+	/**
 	 * Custom error handler to intercept errors and log them using Jetpack's own logger.
 	 *
 	 * @param int    $errno   - Error code.
@@ -595,7 +609,11 @@ class Hooks {
 			}
 		}
 
-		// Returning false makes the error go through the standard error handler as well.
-		return false;
+		if ( self::$prev_error_handler ) {
+			return call_user_func( self::$prev_error_handler, $errno, $errstr, $errfile, $errline );
+		} else {
+			// Returning false makes the error go through the standard error handler as well.
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We set an error handler to log certain messages to Jetpack. If there was another error handler registered before us, chain to that handler instead of calling PHP's own default handler.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Call `set_error_handler()` in wp-config.php, and make sure your handler still gets called when Jetpack Beta Tester is active.