### PR TITLE
Import: import attachment improvement

### DIFF
--- a/projects/packages/import/changelog/update-import-attachment-improvement
+++ b/projects/packages/import/changelog/update-import-attachment-improvement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Handles scaled images for attachments

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-import",
-	"version": "0.7.2",
+	"version": "0.7.3-alpha",
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
 	"bugs": {

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.7.2';
+	const PACKAGE_VERSION = '0.7.3-alpha';
 
 	/**
 	 * A list of all the routes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/dotcom-forge#3640

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the `post_date_gmt` check when looking for an existing attachment.
* Disable big image handling when uploading attachment via unified importer to match the behavior as simple site.
* Checking `-scaled` image filename to prevent duplication, and for backward compatibility

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site and apply this PR or test it locally. Your site needs to be connected to WordPress.com.
* Navigate to `https://wordpress.com/import/:site_slug` and select WordPress importer.
* Get the `substack-small.xml` sample file from D120640-code and performs an import.
* Review the results in media and perform another import using the same file.
* Go to media and make sure the attachments aren't created twice, and there's no images with `-scaled` append to the filename. `9713ae89-a4d3-4c2d-abe5-ade9ed291462_3929x1953.jpeg` will be the one you're looking for.