### PR TITLE
ContentLens: Add AI control to the Excerpt panel

### DIFF
--- a/projects/plugins/jetpack/changelog/udpate-content-lens-add-AI-controls
+++ b/projects/plugins/jetpack/changelog/udpate-content-lens-add-AI-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Content Lens: connect excerpt pannel with AI Assistant

--- a/projects/plugins/jetpack/changelog/udpate-content-lens-add-AI-controls
+++ b/projects/plugins/jetpack/changelog/udpate-content-lens-add-AI-controls
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Content Lens: connect excerpt pannel with AI Assistant
+Content Lens: connect excerpt panel with AI Assistant

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
@@ -1,0 +1,90 @@
+/*
+ * External dependencies
+ */
+import { Button, RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+/**
+ * Types and constants
+ */
+
+export type AiAssistantExcerptControlProps = {
+	/*
+	 * Whether the component is disabled.
+	 */
+	disabled?: boolean;
+
+	/*
+	 * The length of the generated excerpt.
+	 */
+	length?: number;
+
+	/*
+	 * The minimum length of the generated excerpt.
+	 */
+	minLength?: number;
+
+	/*
+	 * The maximum length of the generated excerpt.
+	 */
+	maxLength?: number;
+
+	/*
+	 * Whether the component is busy.
+	 */
+	isBusy?: boolean;
+
+	/*
+	 * Callback to generate suggestions from AI.
+	 */
+	onGenerate?: () => void;
+
+	/*
+	 * Callback to change the length of the generated excerpt.
+	 */
+	onLengthChange?: ( length: number ) => void;
+};
+
+export function AiAssistantExcerptControl( {
+	minLength = 10,
+	maxLength = 100,
+	disabled,
+	length,
+
+	isBusy,
+	onGenerate,
+	onLengthChange,
+}: AiAssistantExcerptControlProps ) {
+	return (
+		<>
+			<RangeControl
+				label={ __( 'Excerpt Length (in words)', 'jetpack' ) }
+				value={ length }
+				onChange={ onLengthChange }
+				min={ minLength }
+				max={ maxLength }
+				help={ __(
+					'Sets the limit for words in auto-generated excerpts. The final count may vary slightly due to sentence structure.',
+					'jetpack'
+				) }
+				showTooltip={ false }
+				disabled={ disabled }
+			/>
+
+			<div className="jetpack-generated-excerpt__generate-buttons-container">
+				<Button
+					onClick={ () => onGenerate() }
+					variant="secondary"
+					isBusy={ isBusy }
+					disabled={ disabled }
+				>
+					{ __( 'Generate', 'jetpack' ) }
+				</Button>
+			</div>
+		</>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
@@ -19,19 +19,19 @@ export type AiAssistantExcerptControlProps = {
 	disabled?: boolean;
 
 	/*
-	 * The length of the generated excerpt.
+	 * The number of words in the generated excerpt.
 	 */
-	length?: number;
+	words?: number;
 
 	/*
-	 * The minimum length of the generated excerpt.
+	 * The minimum number of words in the generated excerpt.
 	 */
-	minLength?: number;
+	minWords?: number;
 
 	/*
-	 * The maximum length of the generated excerpt.
+	 * The maximum number of words in the generated excerpt.
 	 */
-	maxLength?: number;
+	maxWords?: number;
 
 	/*
 	 * Whether the component is busy.
@@ -44,29 +44,29 @@ export type AiAssistantExcerptControlProps = {
 	onGenerate?: () => void;
 
 	/*
-	 * Callback to change the length of the generated excerpt.
+	 * Callback to change the number of words in the generated excerpt.
 	 */
-	onLengthChange?: ( length: number ) => void;
+	onWordsNumberChange?: ( words: number ) => void;
 };
 
 export function AiAssistantExcerptControl( {
-	minLength = 10,
-	maxLength = 100,
+	minWords = 10,
+	maxWords = 100,
 	disabled,
-	length,
+	words,
 
 	isBusy,
 	onGenerate,
-	onLengthChange,
+	onWordsNumberChange,
 }: AiAssistantExcerptControlProps ) {
 	return (
 		<>
 			<RangeControl
 				label={ __( 'Excerpt Length (in words)', 'jetpack' ) }
-				value={ length }
-				onChange={ onLengthChange }
-				min={ minLength }
-				max={ maxLength }
+				value={ words }
+				onChange={ onWordsNumberChange }
+				min={ minWords }
+				max={ maxWords }
 				help={ __(
 					'Sets the limit for words in auto-generated excerpts. The final count may vary slightly due to sentence structure.',
 					'jetpack'

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
@@ -12,7 +12,7 @@ import './style.scss';
  * Types and constants
  */
 
-export type AiAssistantExcerptControlProps = {
+export type AiExcerptControlProps = {
 	/*
 	 * Whether the component is disabled.
 	 */
@@ -49,7 +49,7 @@ export type AiAssistantExcerptControlProps = {
 	onWordsNumberChange?: ( words: number ) => void;
 };
 
-export function AiAssistantExcerptControl( {
+export function AiExcerptControl( {
 	minWords = 10,
 	maxWords = 100,
 	disabled,
@@ -58,7 +58,7 @@ export function AiAssistantExcerptControl( {
 	isBusy,
 	onGenerate,
 	onWordsNumberChange,
-}: AiAssistantExcerptControlProps ) {
+}: AiExcerptControlProps ) {
 	return (
 		<>
 			<RangeControl

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
@@ -62,7 +62,7 @@ export function AiAssistantExcerptControl( {
 	return (
 		<>
 			<RangeControl
-				label={ __( 'Excerpt Length (in words)', 'jetpack' ) }
+				label={ __( 'Length (in words)', 'jetpack' ) }
 				value={ words }
 				onChange={ onWordsNumberChange }
 				min={ minWords }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/style.scss
@@ -1,0 +1,5 @@
+.jetpack-generated-excerpt__generate-buttons-container {
+	display: flex;
+	justify-content: end;
+	margin-bottom: 10px;
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './style.scss';
+import { AiAssistantExcerptControl } from '../../components/ai-excerpt-control';
 
 function AiPostExcerpt() {
 	const excerpt = useSelect(
@@ -25,6 +26,10 @@ function AiPostExcerpt() {
 		removeEditorPanel( 'post-excerpt' );
 	}, [ removeEditorPanel ] );
 
+	function updatePostExcerpt() {
+		console.log( 'updatePostExcerpt' ); // eslint-disable-line no-console
+	}
+
 	return (
 		<div className="jetpack-ai-post-excerpt">
 			<TextareaControl
@@ -33,6 +38,8 @@ function AiPostExcerpt() {
 				onChange={ value => editPost( { excerpt: value } ) }
 				value={ excerpt }
 			/>
+
+			<AiAssistantExcerptControl onGenerate={ updatePostExcerpt } />
 
 			<ExternalLink
 				href={ __(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -5,7 +5,7 @@ import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
 import { TextareaControl, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -19,6 +19,9 @@ function AiPostExcerpt() {
 		[]
 	);
 	const { editPost } = useDispatch( 'core/editor' );
+
+	// Post excerpt words number
+	const [ excerptWordsNumber, setExcerptWordsNumber ] = useState( 50 );
 
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
@@ -39,7 +42,11 @@ function AiPostExcerpt() {
 				value={ excerpt }
 			/>
 
-			<AiAssistantExcerptControl onGenerate={ updatePostExcerpt } />
+			<AiAssistantExcerptControl
+				words={ excerptWordsNumber }
+				onWordsNumberChange={ setExcerptWordsNumber }
+				onGenerate={ updatePostExcerpt }
+			/>
 
 			<ExternalLink
 				href={ __(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
+import { aiAssistantIcon, useAiSuggestions } from '@automattic/jetpack-ai-client';
 import { TextareaControl, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
@@ -18,6 +18,8 @@ function AiPostExcerpt() {
 		select => select( 'core/editor' ).getEditedPostAttribute( 'excerpt' ),
 		[]
 	);
+
+	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId(), [] );
 	const { editPost } = useDispatch( 'core/editor' );
 
 	// Post excerpt words number
@@ -25,12 +27,27 @@ function AiPostExcerpt() {
 
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
+
+	const { request, suggestion } = useAiSuggestions();
+
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
 	}, [ removeEditorPanel ] );
 
 	function updatePostExcerpt() {
-		console.log( 'updatePostExcerpt' ); // eslint-disable-line no-console
+		const prompt = [
+			{
+				role: 'jetpack-ai',
+				context: {
+					type: 'ai-content-lens',
+					content: '',
+					words: excerptWordsNumber,
+					postId,
+				},
+			},
+		];
+
+		request( prompt );
 	}
 
 	return (
@@ -39,7 +56,7 @@ function AiPostExcerpt() {
 				__nextHasNoMarginBottom
 				label={ __( 'Write an excerpt (optional)', 'jetpack' ) }
 				onChange={ value => editPost( { excerpt: value } ) }
-				value={ excerpt }
+				value={ excerpt || suggestion }
 			/>
 
 			<AiAssistantExcerptControl

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './style.scss';
-import { AiAssistantExcerptControl } from '../../components/ai-excerpt-control';
+import { AiExcerptControl } from '../../components/ai-excerpt-control';
 
 function AiPostExcerpt() {
 	const excerpt = useSelect(
@@ -40,7 +40,7 @@ function AiPostExcerpt() {
 				role: 'jetpack-ai',
 				context: {
 					type: 'ai-content-lens',
-					content: '',
+					request: 'excerpt',
 					words: excerptWordsNumber,
 					postId,
 				},
@@ -59,7 +59,7 @@ function AiPostExcerpt() {
 				value={ excerpt || suggestion }
 			/>
 
-			<AiAssistantExcerptControl
+			<AiExcerptControl
 				words={ excerptWordsNumber }
 				onWordsNumberChange={ setExcerptWordsNumber }
 				onGenerate={ updatePostExcerpt }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { aiAssistantIcon, useAiSuggestions } from '@automattic/jetpack-ai-client';
+import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
 import { TextareaControl, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
@@ -19,7 +19,6 @@ function AiPostExcerpt() {
 		[]
 	);
 
-	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId(), [] );
 	const { editPost } = useDispatch( 'core/editor' );
 
 	// Post excerpt words number
@@ -28,26 +27,12 @@ function AiPostExcerpt() {
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
-	const { request, suggestion } = useAiSuggestions();
-
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
 	}, [ removeEditorPanel ] );
 
 	function updatePostExcerpt() {
-		const prompt = [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-content-lens',
-					request: 'excerpt',
-					words: excerptWordsNumber,
-					postId,
-				},
-			},
-		];
-
-		request( prompt );
+		console.log( 'request excerpt suggestion' ); // eslint-disable-line no-console
 	}
 
 	return (
@@ -56,7 +41,7 @@ function AiPostExcerpt() {
 				__nextHasNoMarginBottom
 				label={ __( 'Write an excerpt (optional)', 'jetpack' ) }
 				onChange={ value => editPost( { excerpt: value } ) }
-				value={ excerpt || suggestion }
+				value={ excerpt }
 			/>
 
 			<AiExcerptControl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On this PR introduce and use the AiExcert control

<img width="436" alt="Screenshot 2023-09-05 at 13 14 05" src="https://github.com/Automattic/jetpack/assets/77539/5869aac1-e301-48b3-82a0-0842b6961465">

Part of https://github.com/Automattic/jetpack/issues/32873

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* ContentLens: Add AI control to the Excerpt panel #32846

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Ensure `beta` extensions are enabled
* Open the Post sidebar
* Confirm you see the Jetpack Excerpt panel.
* Confirm when you can move the Length (words) range

<img width="382" alt="Screenshot 2023-09-06 at 07 44 30" src="https://github.com/Automattic/jetpack/assets/77539/d39faef7-f9d1-4c8d-834d-f87d54964384">

* Confirm you see the log line when clicking on the `Generate` button

<img width="245" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/8fbb57fb-e03b-4b55-9273-eb69ce6e7a04">

