### PR TITLE
 ContentLens: add `ai-content-lens` beta extension

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-ai-content-lens-feature
+++ b/projects/plugins/jetpack/changelog/update-add-ai-content-lens-feature
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-ContentLends: add `ai-content-lens` beta extension
+ContentLens: add `ai-content-lens` beta extension

--- a/projects/plugins/jetpack/changelog/update-add-ai-content-lens-feature
+++ b/projects/plugins/jetpack/changelog/update-add-ai-content-lens-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+ContentLends: add `ai-content-lens` beta extension

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -68,3 +68,14 @@ add_action(
 		\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-form-support' );
 	}
 );
+
+/**
+ * Register the `ai-content-lens` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		\Jetpack_Gutenberg::set_extension_available( 'ai-content-lens' );
+	}
+);
+

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -64,7 +64,8 @@
 		"recipe",
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
-		"create-with-voice"
+		"create-with-voice",
+		"ai-content-lens"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],
 	"no-post-editor": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  ContentLens: add `ai-content-lens` beta extension

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/32739

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Extension: add ai-content-lens beta extension

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test switching between `production` and [beta](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/jetpack/extensions#beta-extensions) extension.
* Confirm that when `production` extension is enabled, the `ai-content-lens` extension is not available. You can do that easily:
  *  Go to the block editor
  *  Open the dev console of your browser
  * Type `Jetpack_Editor_Initial_State.available_blocks?.[ 'ai-content-lens' ]`


* Confirm that when `beta` extension enabled, the `ai-content-lens` extension is available:

<img width="331" alt="Screenshot 2023-09-05 at 13 20 38" src="https://github.com/Automattic/jetpack/assets/77539/b63eb8d5-277a-432f-b965-539d9efd9289">

* Confirm the extension is not available in `production`


Test in Jetpack, Atomic, and Simple sites

