### PR TITLE
Add/allow premium to use subcribe as site subscriber

### DIFF
--- a/projects/plugins/jetpack/changelog/add-allow-premium-to-use-subcribe_as_site_subscriber
+++ b/projects/plugins/jetpack/changelog/add-allow-premium-to-use-subcribe_as_site_subscriber
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Revert change where newsletter plans could not be used on Premium content

--- a/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
+++ b/projects/plugins/jetpack/extensions/shared/components/product-management-controls/index.js
@@ -17,10 +17,14 @@ export default function ProductManagementControls( {
 	selectedProductId = 0,
 	setSelectedProductId = () => {},
 } ) {
-	const products = useSelect( select =>
-		select( membershipProductsStore )
-			?.getProducts( productType, selectedProductId, setSelectedProductId )
-			.filter( product => ! product.subscribe_as_site_subscriber )
+	const products = useSelect(
+		select =>
+			select( membershipProductsStore ).getProducts(
+				productType,
+				selectedProductId,
+				setSelectedProductId
+			),
+		[]
 	);
 
 	const { connectUrl, isApiConnected, isSelectedProductInvalid } = useSelect( select => {


### PR DESCRIPTION
After some discussion we realised that preventing users to use "newsletter" plans for Premium content and payment button is actually not a proper behaviour. 

This PR reverts https://github.com/Automattic/jetpack/pull/31200

 
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reverting https://github.com/Automattic/jetpack/pull/31200

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*