### PR TITLE
Add Calypso paths for free intent tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-calypso-paths-for-free-intent-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-calypso-paths-for-free-intent-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added Calypso paths for setup_free and domain_upsell tasks

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "4.6.x-dev"
+			"dev-trunk": "4.7.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.6.0",
+	"version": "4.7.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.6.0';
+	const PACKAGE_VERSION = '4.7.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -61,7 +61,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'badge_text_callback'  => 'wpcom_launchpad_get_domain_upsell_badge_text',
 			'is_visible_callback'  => 'wpcom_launchpad_is_domain_upsell_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( $task['completed'] ) {
+				if ( wpcom_launchpad_checklists()->is_task_complete( $task ) ) {
 						return '/domains/manage/' . $data['site_slug_encoded'];
 				}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -60,6 +60,13 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_domain_upsell_completed',
 			'badge_text_callback'  => 'wpcom_launchpad_get_domain_upsell_badge_text',
 			'is_visible_callback'  => 'wpcom_launchpad_is_domain_upsell_task_visible',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( $task['completed'] ) {
+						return '/domains/manage/' . $data['site_slug_encoded'];
+				}
+
+				return '/setup/domain-upsell/domains?siteSlug=' . $data['site_slug_encoded'];
+			},
 		),
 		'first_post_published'            => array(
 			'get_title'             => function () {
@@ -244,6 +251,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Personalize your site', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/settings/general/' . $data['site_slug_encoded'];
+			},
 		),
 
 		// Write tasks.

--- a/projects/plugins/mu-wpcom-plugin/changelog/bump-mu-wpcom-plugin-version
+++ b/projects/plugins/mu-wpcom-plugin/changelog/bump-mu-wpcom-plugin-version
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_16"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_17_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "f1164839dd9eedb045e902ab712a4001b51732a8"
+                "reference": "c4203608e592e2bb82a1398b744eec9db95c893b"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.6.x-dev"
+                    "dev-trunk": "4.7.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.16
+ * Version: 1.6.17-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.16",
+	"version": "1.6.17-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:
* https://github.com/Automattic/wp-calypso/pull/81363
* https://github.com/Automattic/wp-calypso/pull/81402

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds Calypso path data to the `setup_free` and `domain_upsell` tasks so that they will work correctly from launchpads that we show in Calypso.
  - The `setup_free` task will send users to `/settings/general/:siteSlug`
  - The `domain_upsell` task will send users to `/setup/domain-upsell/domains?siteSlug=:siteSlug` if they haven't completed the task, and `/domains/manage/:siteSlug` if they have completed the task
    * Note that the completion logic is replicated from the full-screen launchpad logic in Calypso, so "completion" includes deferring the domain selection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
These changes are to a WordPress.com-specific feature, so no discussion needed.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to data collection or tracking.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D120621-code to your sandbox
* Also apply this change to your sandbox
* Follow the testing instructions for https://github.com/Automattic/wp-calypso/pull/81363 to show the task list for the `free` flow in Customer Home
* Click on the "Choose a domain" task
* Verify that you're taken to `/setup/domain-upsell/domains?siteSlug=:siteSlug`
* Click on the "Choose a domain later" link towards the right of the screen
* You should be returned to Customer Home (though you may see the fullscreen launchpad briefly)
* Verify that the "Choose a domain" task is marked as complete
* Click on the "Choose a domain" task again
* Verify that you're taken to `/domains/manage/:siteSlug`
* Navigate back to Customer Home
* Click on the "Personalise your site" task
* Verify that you're taken to `/settings/general/:siteSlug`
