### PR TITLE
Update/hide subscribe modal on post access

### DIFF
--- a/projects/plugins/jetpack/changelog/update-hide-subscribe-modal-on-post-access
+++ b/projects/plugins/jetpack/changelog/update-hide-subscribe-modal-on-post-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Hide modal if post is subscribers-onnl

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -194,7 +194,7 @@ HTML;
 		global $post;
 		$access_level              = get_post_meta( $post->ID, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 		$is_accessible_by_everyone = Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY === $access_level;
-		if ( has_block( 'jetpack/paywall' ) || ! $is_accessible_by_everyone ) {
+		if ( ! $is_accessible_by_everyone ) {
 			return false;
 		}
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -191,7 +191,6 @@ HTML;
 		}
 
 		// Don't show if post is for subscribers only or has paywall block
-		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/subscriptions/constants.php';
 		global $post;
 		$access_level              = get_post_meta( $post->ID, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 		$is_accessible_by_everyone = Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY === $access_level;

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -6,7 +6,9 @@
  * @since 12.4
  */
 
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Token_Subscription_Service;
 use Automattic\Jetpack\Status\Host;
+use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
 
 /**
  * Jetpack_Subscribe_Modal class.
@@ -189,7 +191,11 @@ HTML;
 		}
 
 		// Don't show if post is for subscribers only or has paywall block
-		if ( has_block( 'jetpack/paywall' ) ) {
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/subscriptions/constants.php';
+		global $post;
+		$access_level              = get_post_meta( $post->ID, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
+		$is_accessible_by_everyone = Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY === $access_level;
+		if ( has_block( 'jetpack/paywall' ) || ! $is_accessible_by_everyone ) {
 			return false;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

Hide the subscribe modal if the entire post is set to be visible only to subscribers or paid subscribers. In such cases, the post content itself already has a subscribe block, so showing the modal is redundant.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Setup: In your local Jetpack test environment, publish a post and set Access to subscribers only or paid subscribers only. Do not add paywall block to the post. You'll also want to be sure the subscribe modal is enabled at Jetpack > Settings > Newsletters. 
2) In a browser where you are not logged in, open that post, scroll, and confirm the modal does not load. 
   - Extra check: If you previously dismissed the modal, there may be a cookie in your browser that prevents it from showing. To avoid that, you may want to check storage/cookies in your browser dev tools, search for 'dismiss' and if a cookie for dismissing the modal shows delete it.  
3) Test that he modal still does load on a post that is accessible to everyone. 
