### PR TITLE
AI Assistant: Use backend prompts

### DIFF
--- a/projects/plugins/jetpack/changelog/udapte-ai-assistant-use-backend-prompts
+++ b/projects/plugins/jetpack/changelog/udapte-ai-assistant-use-backend-prompts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: start using backend prompts.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/prompt-templates-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/prompt-templates-control/index.tsx
@@ -4,7 +4,17 @@
 import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { title, postContent, postExcerpt, termDescription, post, pencil } from '@wordpress/icons';
-import React from 'react';
+/*
+ * Internal dependencies
+ */
+import {
+	PROMPT_TYPE_SUMMARY_BY_TITLE,
+	PROMPT_TYPE_CONTINUE,
+	PROMPT_TYPE_SIMPLIFY,
+	PROMPT_TYPE_CORRECT_SPELLING,
+	PROMPT_TYPE_GENERATE_TITLE,
+	PROMPT_TYPE_SUMMARIZE,
+} from '../../lib/prompt';
 
 type PromptTemplatesControlProps = {
 	hasContentBefore: boolean;
@@ -121,21 +131,21 @@ export default function PromptTemplatesControl( {
 								<MenuItem
 									icon={ postContent }
 									iconPosition="left"
-									onClick={ () => onSuggestionSelect( 'continue' ) }
+									onClick={ () => onSuggestionSelect( PROMPT_TYPE_CONTINUE ) }
 								>
 									{ __( 'Continue writing', 'jetpack' ) }
 								</MenuItem>
 								<MenuItem
 									icon={ termDescription }
 									iconPosition="left"
-									onClick={ () => onSuggestionSelect( 'correctSpelling' ) }
+									onClick={ () => onSuggestionSelect( PROMPT_TYPE_CORRECT_SPELLING ) }
 								>
 									{ __( 'Correct spelling and grammar', 'jetpack' ) }
 								</MenuItem>
 								<MenuItem
 									icon={ post }
 									iconPosition="left"
-									onClick={ () => onSuggestionSelect( 'simplify' ) }
+									onClick={ () => onSuggestionSelect( PROMPT_TYPE_SIMPLIFY ) }
 								>
 									{ __( 'Simplify', 'jetpack' ) }
 								</MenuItem>
@@ -147,7 +157,7 @@ export default function PromptTemplatesControl( {
 									<MenuItem
 										icon={ postExcerpt }
 										iconPosition="left"
-										onClick={ () => onSuggestionSelect( 'summarize' ) }
+										onClick={ () => onSuggestionSelect( PROMPT_TYPE_SUMMARIZE ) }
 									>
 										{ __( 'Summarize', 'jetpack' ) }
 									</MenuItem>
@@ -156,7 +166,7 @@ export default function PromptTemplatesControl( {
 									<MenuItem
 										icon={ title }
 										iconPosition="left"
-										onClick={ () => onSuggestionSelect( 'generateTitle' ) }
+										onClick={ () => onSuggestionSelect( PROMPT_TYPE_GENERATE_TITLE ) }
 									>
 										{ __( 'Generate a post title', 'jetpack' ) }
 									</MenuItem>
@@ -168,7 +178,7 @@ export default function PromptTemplatesControl( {
 								<MenuItem
 									icon={ pencil }
 									iconPosition="left"
-									onClick={ () => onSuggestionSelect( 'titleSummary' ) }
+									onClick={ () => onSuggestionSelect( PROMPT_TYPE_SUMMARY_BY_TITLE ) }
 								>
 									{ __( 'Summary based on title', 'jetpack' ) }
 								</MenuItem>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -35,7 +35,11 @@ import useAIFeature from './hooks/use-ai-feature';
 import useSuggestionsFromOpenAI from './hooks/use-suggestions-from-openai';
 import { isUserConnected } from './lib/connection';
 import { getImagesFromOpenAI } from './lib/image';
-import { getInitialSystemPrompt } from './lib/prompt';
+import {
+	getInitialSystemPrompt,
+	PROMPT_TYPE_GENERATE_TITLE,
+	PROMPT_TYPE_USER_PROMPT,
+} from './lib/prompt';
 import './editor.scss';
 
 const markdownConverter = new MarkdownIt( {
@@ -263,7 +267,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 		return lastEditableElement;
 	};
 
-	const isGeneratingTitle = attributes.promptType === 'generateTitle';
+	const isGeneratingTitle = attributes.promptType === PROMPT_TYPE_GENERATE_TITLE;
 
 	const acceptContentLabel = __( 'Accept', 'jetpack' );
 	const acceptTitleLabel = __( 'Accept title', 'jetpack' );
@@ -288,7 +292,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 	};
 
 	const handleSend = () => {
-		handleGetSuggestion( 'userPrompt' );
+		handleGetSuggestion( PROMPT_TYPE_USER_PROMPT );
 	};
 
 	const handleAccept = () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -9,17 +9,17 @@ import { ToneProp } from '../../components/tone-dropdown-control';
 /**
  * Types & consts
  */
-export const PROMPT_TYPE_SUMMARY_BY_TITLE = 'titleSummary' as const;
-export const PROMPT_TYPE_CONTINUE = 'continue' as const;
-export const PROMPT_TYPE_SIMPLIFY = 'simplify' as const;
-export const PROMPT_TYPE_CORRECT_SPELLING = 'correctSpelling' as const;
-export const PROMPT_TYPE_GENERATE_TITLE = 'generateTitle' as const;
-export const PROMPT_TYPE_MAKE_LONGER = 'makeLonger' as const;
-export const PROMPT_TYPE_MAKE_SHORTER = 'makeShorter' as const;
-export const PROMPT_TYPE_CHANGE_TONE = 'changeTone' as const;
-export const PROMPT_TYPE_SUMMARIZE = 'summarize' as const;
-export const PROMPT_TYPE_CHANGE_LANGUAGE = 'changeLanguage' as const;
-export const PROMPT_TYPE_USER_PROMPT = 'userPrompt' as const;
+export const PROMPT_TYPE_SUMMARY_BY_TITLE = 'ai-assistant-summary-by-title' as const;
+export const PROMPT_TYPE_CONTINUE = 'ai-assistant-continue-writing' as const;
+export const PROMPT_TYPE_SIMPLIFY = 'ai-assistant-simplify' as const;
+export const PROMPT_TYPE_CORRECT_SPELLING = 'ai-assistant-correct-spelling' as const;
+export const PROMPT_TYPE_GENERATE_TITLE = 'ai-assistant-generate-title' as const;
+export const PROMPT_TYPE_MAKE_LONGER = 'ai-assistant-make-longer' as const;
+export const PROMPT_TYPE_MAKE_SHORTER = 'ai-assistant-make-shorter' as const;
+export const PROMPT_TYPE_CHANGE_TONE = 'ai-assistant-change-tone' as const;
+export const PROMPT_TYPE_SUMMARIZE = 'ai-assistant-summarize' as const;
+export const PROMPT_TYPE_CHANGE_LANGUAGE = 'ai-assistant-change-language' as const;
+export const PROMPT_TYPE_USER_PROMPT = 'ai-assistant-user-prompt' as const;
 export const PROMPT_TYPE_JETPACK_FORM_CUSTOM_PROMPT = 'jetpackFormCustomPrompt' as const;
 
 export const PROMPT_TYPE_LIST = [

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/index.ts
@@ -566,6 +566,40 @@ function buildMessagesForBackendPrompt( {
 	userPrompt,
 	isGeneratingTitle,
 }: BuildPromptProps ): Array< PromptItemProps > {
+	return [
+		{
+			role: 'jetpack-ai',
+			context: buildMessageContextForBackendPrompt( {
+				generatedContent,
+				allPostContent,
+				postContentAbove,
+				currentPostTitle,
+				options,
+				type,
+				userPrompt,
+				isGeneratingTitle,
+			} ),
+		},
+	];
+}
+
+/**
+ * Builds backend message context based on the type
+ * and the options of the prompt.
+ *
+ * @param {BuildPromptProps} options - The prompt options.
+ * @returns {object} The context.
+ */
+function buildMessageContextForBackendPrompt( {
+	generatedContent,
+	allPostContent,
+	postContentAbove,
+	currentPostTitle,
+	options,
+	type,
+	userPrompt,
+	isGeneratingTitle,
+}: BuildPromptProps ): object {
 	const isContentGenerated = options?.contentType === 'generated';
 
 	// Determine the subject of the action
@@ -583,143 +617,88 @@ function buildMessagesForBackendPrompt( {
 	 */
 
 	if ( type === PROMPT_TYPE_SUMMARY_BY_TITLE ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-summary-by-title',
-					content: currentPostTitle,
-				},
-			},
-		];
+		return {
+			type,
+			content: currentPostTitle,
+		};
 	}
 
 	if ( type === PROMPT_TYPE_CONTINUE ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-continue-writing',
-					content: postContentAbove,
-				},
-			},
-		];
+		return {
+			type,
+			content: postContentAbove,
+		};
 	}
 
 	if ( type === PROMPT_TYPE_SIMPLIFY ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-simplify',
-					content: postContentAbove,
-					subject,
-				},
-			},
-		];
+		return {
+			type,
+			content: postContentAbove,
+			subject,
+		};
 	}
 
 	if ( type === PROMPT_TYPE_CORRECT_SPELLING ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-correct-spelling',
-					content: postContentAbove,
-					subject,
-				},
-			},
-		];
+		return {
+			type,
+			content: postContentAbove,
+			subject,
+		};
 	}
 
 	if ( type === PROMPT_TYPE_GENERATE_TITLE ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-generate-title',
-					content: allPostContent,
-				},
-			},
-		];
+		return {
+			type,
+			content: allPostContent,
+		};
 	}
 
 	if ( type === PROMPT_TYPE_MAKE_LONGER ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-make-longer',
-					content: generatedContent,
-					subject,
-				},
-			},
-		];
+		return {
+			type,
+			content: generatedContent,
+			subject,
+		};
 	}
 
 	if ( type === PROMPT_TYPE_MAKE_SHORTER ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-make-shorter',
-					content: generatedContent,
-					subject,
-				},
-			},
-		];
+		return {
+			type,
+			content: generatedContent,
+			subject,
+		};
 	}
 
 	if ( type === PROMPT_TYPE_CHANGE_TONE ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-change-tone',
-					content: isContentGenerated ? generatedContent : allPostContent,
-					tone: options?.tone,
-					subject,
-				},
-			},
-		];
+		return {
+			type,
+			content: isContentGenerated ? generatedContent : allPostContent,
+			tone: options?.tone,
+			subject,
+		};
 	}
 
 	if ( type === PROMPT_TYPE_SUMMARIZE ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-summarize',
-					content: isContentGenerated ? generatedContent : allPostContent,
-					subject,
-				},
-			},
-		];
+		return {
+			type,
+			content: isContentGenerated ? generatedContent : allPostContent,
+			subject,
+		};
 	}
 
 	if ( type === PROMPT_TYPE_CHANGE_LANGUAGE ) {
-		return [
-			{
-				role: 'jetpack-ai',
-				context: {
-					type: 'ai-assistant-change-language',
-					content: isContentGenerated ? generatedContent : allPostContent,
-					language: options?.language,
-					subject,
-				},
-			},
-		];
+		return {
+			type,
+			content: isContentGenerated ? generatedContent : allPostContent,
+			language: options?.language,
+			subject,
+		};
 	}
 
 	// default to the user prompt
-	return [
-		{
-			role: 'jetpack-ai',
-			context: {
-				type: 'ai-assistant-user-prompt',
-				request: userPrompt,
-				content: generatedContent || allPostContent,
-			},
-		},
-	];
+	return {
+		type: PROMPT_TYPE_USER_PROMPT,
+		request: userPrompt,
+		content: generatedContent || allPostContent,
+	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -38,17 +38,8 @@ export function transformToAIAssistantBlock( blockType: ExtendedBlockProp, attrs
 	// Convert the content to markdown.
 	const aiAssistantBlockcontent = turndownService.turndown( htmlContent );
 
-	// Create a pair of user/assistant messages.
-	const messages: Array< PromptItemProps > = [
-		{
-			role: 'user',
-			content: 'Tell me some content for this block, please.',
-		},
-		{
-			role: 'assistant',
-			content: aiAssistantBlockcontent,
-		},
-	];
+	// Start the list of messages with an empty list.
+	const messages: Array< PromptItemProps > = [];
 
 	return createBlock( blockName, {
 		...restAttrs,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #28569.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When building the prompt a given assistant request, use the new `role=jetpack-ai` messages following this strucutre:

```
{
   role: 'jetpack-ai',
   context: {
      type: 'the-type-of-the-operation-being-triggered',
      content?: 'relevant content for the request, when applicable',
      subject?: 'the subject of the operation, being the title, the content or the last anwser'
      request?: 'the user typed request/prompt',
      tone?: 'the target tone, when changing tone',
      language?: 'the target language, when changing language'
   }
}
```

* Multiple messages can be present on the list sent to the backend, usually alternating between `role=jetpack-ai` and `role=assistant`; only the Jetpack AI ones will be touched

Still missing:

- handle playground system prompts
- ...

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD

