### PR TITLE
My Jetpack: Hide Stats upgrade button when site has Complete plans

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-treat-complete-as-upgraded
+++ b/projects/packages/my-jetpack/changelog/update-treat-complete-as-upgraded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: stop showing upgrade button for sites with Complete plan

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -143,6 +143,9 @@ class Stats extends Module_Product {
 				if ( 0 === strpos( $purchase->product_slug, 'jetpack_stats' ) ) {
 					return true;
 				}
+				if ( 0 === strpos( $purchase->product_slug, 'jetpack_complete' ) ) {
+					return true;
+				}
 			}
 		}
 		return false;


### PR DESCRIPTION
## Proposed changes:

* Hide Stats upgrade button when site has Complete plans

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1693938134503299-slack-GQK64C7B4

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Spin up a new JN site with Jetpack of the current branch
* Connect the site and purchase a Complete plan
* Open `/wp-admin/admin.php?page=my-jetpack`
* Ensure the Stats card is like the screenshot below

<img width="375" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/250b6437-ee34-475f-aa3b-96a1dfb1e388">
