### PR TITLE
Launchpad: Reset the screen status when completing the Newsletter task list

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-reset-luanchpad-screen-skipped
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-reset-luanchpad-screen-skipped
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Reset the launchpad_screen status after completing the skipped newsletter task list

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -805,6 +805,13 @@ function wpcom_launchpad_track_publish_first_post_task() {
 	// Since we share the same callback for generic first post and newsletter-specific, we mark both.
 	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'first_post_published' );
 	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'first_post_published_newsletter' );
+
+	$site_intent      = get_option( 'site_intent', false );
+	$launchpad_screen = get_option( 'launchpad_screen', false );
+	if ( 'newsletter' === $site_intent && 'skipped' === $launchpad_screen ) {
+		// First publishing a post should make the pre-launch disappear in case it's a Newsletter.
+		update_option( 'launchpad_screen', 'full' );
+	}
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:
* https://github.com/Automattic/wp-calypso/pull/81433
* D120759-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The behavior for the newsletter is slightly different from the Build and Write intent. The Newsletter is completed when the user first publishes a post, so we can't leave the `launchpad_screen` as skipped after completing the first publish task. We need to reset the `launchpad_screen` to prevent users from falling into the condition added on D120759-code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* To test this PR, please follow the instructions on: https://github.com/Automattic/wp-calypso/pull/81433