### PR TITLE
Content Lens: connect Excerpt UI with data layer

### DIFF
--- a/projects/plugins/jetpack/changelog/update-content-lens-connect-with-data-layer
+++ b/projects/plugins/jetpack/changelog/update-content-lens-connect-with-data-layer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: connect UI with data layer

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -61,7 +61,7 @@ function AiPostExcerpt() {
 				role: 'jetpack-ai',
 				context: {
 					type: 'ai-content-lens',
-					content: '',
+					request: 'excerpt',
 					words: excerptWordsNumber,
 					postId,
 				},

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -29,12 +29,23 @@ function AiPostExcerpt() {
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
-	const { request } = useAiSuggestions();
+	const { request, suggestion } = useAiSuggestions();
 
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
 	}, [ removeEditorPanel ] );
 
+	// Show custom prompt number of words
+	const numberOfWords = count( excerpt, 'words' );
+	const helpNumberOfWords = sprintf(
+		// Translators: %1$s is the number of words in the excerpt.
+		_n( '%1$s word', '%1$s words', numberOfWords, 'jetpack' ),
+		numberOfWords
+	);
+
+	/**
+	 * Request AI for a new excerpt.
+	 */
 	function updatePostExcerpt() {
 		const prompt = [
 			{
@@ -51,22 +62,14 @@ function AiPostExcerpt() {
 		request( prompt );
 	}
 
-	// Show custom prompt number of words
-	const numberOfWords = count( excerpt, 'words' );
-	const helpNumberOfWords = sprintf(
-		// Translators: %1$s is the number of words in the excerpt.
-		_n( '%1$s word', '%1$s words', numberOfWords, 'jetpack' ),
-		numberOfWords
-	);
-
 	return (
 		<div className="jetpack-ai-post-excerpt">
 			<TextareaControl
 				__nextHasNoMarginBottom
 				label={ __( 'Write an excerpt (optional)', 'jetpack' ) }
 				onChange={ value => editPost( { excerpt: value } ) }
-				value={ excerpt }
 				help={ numberOfWords ? helpNumberOfWords : null }
+				value={ excerpt || suggestion }
 			/>
 
 			<AiExcerptControl

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -29,7 +29,7 @@ function AiPostExcerpt() {
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
-	const { request, suggestion } = useAiSuggestions();
+	const { request, suggestion, requestingState } = useAiSuggestions();
 
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
@@ -42,6 +42,9 @@ function AiPostExcerpt() {
 		_n( '%1$s word', '%1$s words', numberOfWords, 'jetpack' ),
 		numberOfWords
 	);
+
+	const isGenerateButtonDisabled = requestingState === 'requesting';
+	const isBusy = requestingState === 'requesting' || requestingState === 'suggesting';
 
 	/**
 	 * Request AI for a new excerpt.
@@ -76,6 +79,8 @@ function AiPostExcerpt() {
 				words={ excerptWordsNumber }
 				onWordsNumberChange={ setExcerptWordsNumber }
 				onGenerate={ updatePostExcerpt }
+				disabled={ isGenerateButtonDisabled }
+				isBusy={ isBusy }
 			/>
 
 			<ExternalLink

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -13,6 +13,15 @@ import { count } from '@wordpress/wordcount';
  */
 import './style.scss';
 import { AiExcerptControl } from '../../components/ai-excerpt-control';
+/**
+ * Types and constants
+ */
+type ContentLensMessageContextProps = {
+	type: 'ai-content-lens';
+	contentType: 'post-excerpt';
+	postId: number;
+	words?: number;
+};
 
 function AiPostExcerpt() {
 	const excerpt = useSelect(
@@ -49,16 +58,18 @@ function AiPostExcerpt() {
 	/**
 	 * Request AI for a new excerpt.
 	 */
-	function updatePostExcerpt() {
+	function requestExcerpt() {
+		const messageContext: ContentLensMessageContextProps = {
+			type: 'ai-content-lens',
+			contentType: 'post-excerpt',
+			words: excerptWordsNumber,
+			postId,
+		};
+
 		const prompt = [
 			{
 				role: 'jetpack-ai',
-				context: {
-					type: 'ai-content-lens',
-					request: 'excerpt',
-					words: excerptWordsNumber,
-					postId,
-				},
+				context: messageContext,
 			},
 		];
 
@@ -78,7 +89,7 @@ function AiPostExcerpt() {
 			<AiExcerptControl
 				words={ excerptWordsNumber }
 				onWordsNumberChange={ setExcerptWordsNumber }
-				onGenerate={ updatePostExcerpt }
+				onGenerate={ requestExcerpt }
 				disabled={ isGenerateButtonDisabled }
 				isBusy={ isBusy }
 			/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -20,10 +20,7 @@ function AiPostExcerpt() {
 		[]
 	);
 
-<<<<<<< HEAD
-=======
 	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId(), [] );
->>>>>>> a5796b31ff ([not verified] start to request suggestion)
 	const { editPost } = useDispatch( 'core/editor' );
 
 	// Post excerpt words number
@@ -32,29 +29,12 @@ function AiPostExcerpt() {
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
-<<<<<<< HEAD
-=======
-	const { request, suggestion } = useAiSuggestions();
+	const { request } = useAiSuggestions();
 
->>>>>>> a5796b31ff ([not verified] start to request suggestion)
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
 	}, [ removeEditorPanel ] );
 
-	function updatePostExcerpt() {
-		console.log( 'request excerpt suggestion' ); // eslint-disable-line no-console
-	}
-
-	// Show custom prompt number of words
-	const numberOfWords = count( excerpt, 'words' );
-	const helpNumberOfWords = sprintf(
-		// Translators: %1$s is the number of words in the excerpt.
-		_n( '%1$s word', '%1$s words', numberOfWords, 'jetpack' ),
-		numberOfWords
-	);
-
-<<<<<<< HEAD
-=======
 	function updatePostExcerpt() {
 		const prompt = [
 			{
@@ -71,14 +51,21 @@ function AiPostExcerpt() {
 		request( prompt );
 	}
 
->>>>>>> a5796b31ff ([not verified] start to request suggestion)
+	// Show custom prompt number of words
+	const numberOfWords = count( excerpt, 'words' );
+	const helpNumberOfWords = sprintf(
+		// Translators: %1$s is the number of words in the excerpt.
+		_n( '%1$s word', '%1$s words', numberOfWords, 'jetpack' ),
+		numberOfWords
+	);
+
 	return (
 		<div className="jetpack-ai-post-excerpt">
 			<TextareaControl
 				__nextHasNoMarginBottom
 				label={ __( 'Write an excerpt (optional)', 'jetpack' ) }
 				onChange={ value => editPost( { excerpt: value } ) }
-				value={ excerpt || suggestion }
+				value={ excerpt }
 				help={ numberOfWords ? helpNumberOfWords : null }
 			/>
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
+import { aiAssistantIcon, useAiSuggestions } from '@automattic/jetpack-ai-client';
 import { TextareaControl, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
@@ -20,6 +20,10 @@ function AiPostExcerpt() {
 		[]
 	);
 
+<<<<<<< HEAD
+=======
+	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId(), [] );
+>>>>>>> a5796b31ff ([not verified] start to request suggestion)
 	const { editPost } = useDispatch( 'core/editor' );
 
 	// Post excerpt words number
@@ -28,6 +32,11 @@ function AiPostExcerpt() {
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
+<<<<<<< HEAD
+=======
+	const { request, suggestion } = useAiSuggestions();
+
+>>>>>>> a5796b31ff ([not verified] start to request suggestion)
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
 	}, [ removeEditorPanel ] );
@@ -44,13 +53,32 @@ function AiPostExcerpt() {
 		numberOfWords
 	);
 
+<<<<<<< HEAD
+=======
+	function updatePostExcerpt() {
+		const prompt = [
+			{
+				role: 'jetpack-ai',
+				context: {
+					type: 'ai-content-lens',
+					content: '',
+					words: excerptWordsNumber,
+					postId,
+				},
+			},
+		];
+
+		request( prompt );
+	}
+
+>>>>>>> a5796b31ff ([not verified] start to request suggestion)
 	return (
 		<div className="jetpack-ai-post-excerpt">
 			<TextareaControl
 				__nextHasNoMarginBottom
 				label={ __( 'Write an excerpt (optional)', 'jetpack' ) }
 				onChange={ value => editPost( { excerpt: value } ) }
-				value={ excerpt }
+				value={ excerpt || suggestion }
 				help={ numberOfWords ? helpNumberOfWords : null }
 			/>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Content Lens: connect Excerpt UI with data layer

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the post sidebar
* Look at the AI Excerpt panel
* Click on the `Generate` button
* Confirm the client performs a request to AI

<img width="817" alt="Screenshot 2023-09-06 at 07 56 32" src="https://github.com/Automattic/jetpack/assets/77539/617c7f3b-fc12-4d3a-8311-bb391f9eb8ba">

Disclaimer: you may get a `400` response error:

<img width="499" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/1ed270de-9bd1-4404-b1ce-c181c37e55bc">

It's expected. It's going to be addressed once D120777-code ships. Feel free to apply the patch to test the feature.