### PR TITLE
AI Excerpt: show excerpt number of words

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-count-words
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-count-words
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: show excerpt number of words

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
@@ -62,7 +62,7 @@ export function AiExcerptControl( {
 	return (
 		<>
 			<RangeControl
-				label={ __( 'Length (in words)', 'jetpack' ) }
+				label={ __( 'Generate', 'jetpack' ) }
 				value={ words }
 				onChange={ onWordsNumberChange }
 				min={ minWords }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -6,7 +6,8 @@ import { TextareaControl, ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { useEffect, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf, _n } from '@wordpress/i18n';
+import { count } from '@wordpress/wordcount';
 /**
  * Internal dependencies
  */
@@ -35,6 +36,14 @@ function AiPostExcerpt() {
 		console.log( 'request excerpt suggestion' ); // eslint-disable-line no-console
 	}
 
+	// Show custom prompt number of words
+	const numberOfWords = count( excerpt, 'words' );
+	const helpNumberOfWords = sprintf(
+		// Translators: %1$s is the number of words in the excerpt.
+		_n( '%1$s word', '%1$s words', numberOfWords, 'jetpack' ),
+		numberOfWords
+	);
+
 	return (
 		<div className="jetpack-ai-post-excerpt">
 			<TextareaControl
@@ -42,6 +51,7 @@ function AiPostExcerpt() {
 				label={ __( 'Write an excerpt (optional)', 'jetpack' ) }
 				onChange={ value => editPost( { excerpt: value } ) }
 				value={ excerpt }
+				help={ numberOfWords ? helpNumberOfWords : null }
 			/>
 
 			<AiExcerptControl

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
@@ -2,3 +2,7 @@
 	width: 100%;
 	margin-bottom: 10px;
 }
+
+.jetpack-ai-post-excerpt .components-base-control__help {
+	margin-bottom: 12px;
+}


### PR DESCRIPTION

This pull request displays the word count of the input in the textarea. This feature is useful for generating an excerpt using AI since the desired word count may vary.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: show excerpt number of words

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the post sidebar
* Start to type custom excerpt
* Confirm it shows number of words in the textarea help

https://github.com/Automattic/jetpack/assets/77539/908244a1-0d93-45f2-9801-b758b13ea531
