### PR TITLE
Add Calypso paths for newsletter tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-calypso-paths-for-launchpad-newsletter-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-calypso-paths-for-launchpad-newsletter-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: added Calypso paths for newsletter tasks

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -139,7 +139,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_visible_callback' => 'wpcom_launchpad_has_goal_paid_subscribers',
 			'get_calypso_path'    => function ( $task, $default, $data ) {
-				return 'earn/payments-plans/' . $data['site_slug_encoded'] . '#add-newsletter-payment-plan';
+				return '/earn/payments-plans/' . $data['site_slug_encoded'] . '#add-newsletter-payment-plan';
 			},
 		),
 		'setup_newsletter'                => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -149,7 +149,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/settings/newsletter/' . $data['site_slug_encoded'];
+				return '/settings/general/' . $data['site_slug_encoded'];
 			},
 		),
 		'set_up_payments'                 => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -138,6 +138,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Create paid Newsletter', 'jetpack-mu-wpcom' );
 			},
 			'is_visible_callback' => 'wpcom_launchpad_has_goal_paid_subscribers',
+			'get_calypso_path'    => function ( $task, $default, $data ) {
+				return 'earn/payments-plans/' . $data['site_slug_encoded'] . '#add-newsletter-payment-plan';
+			},
 		),
 		'setup_newsletter'                => array(
 			'id'                   => 'setup_newsletter',
@@ -145,6 +148,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Personalize newsletter', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => '__return_true',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/settings/newsletter/' . $data['site_slug_encoded'];
+			},
 		),
 		'set_up_payments'                 => array(
 			'get_title'           => function () {
@@ -167,6 +173,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/subscribers/' . $data['site_slug_encoded'];
+			},
 		),
 		'migrate_content'                 => array(
 			'get_title'            => function () {
@@ -174,6 +183,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/import/' . $data['site_slug_encoded'];
+			},
 		),
 
 		// Link in bio tasks.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:
 * https://github.com/Automattic/wp-calypso/pull/81433
 * D120759-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR ensures that we have Calypso paths for a number of tasks that appear in the `newsletter` task list, as the changes in https://github.com/Automattic/wp-calypso/pull/81433 and D120759-code will result in those tasks appearing in Customer Home, where this data becomes important for correct handling of the tasks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This change is specific to WordPress.com, so no Jetpack product discussion was needed.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to data or activity tracking.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This change needs to be tested in conjunction with D120759-code and https://github.com/Automattic/wp-calypso/pull/81433.

* Apply D120759-code to your development sandbox
* Also apply the changes from this PR to your development sandbox
* Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/81433 to get your test site into the right status so you can see the initial set of newsletter tasks in Customer Home - select the "Import an existing newsletter" option when you're shown an option for getting started  -- don't complete any further steps once those tasks appear in Customer Home
* Click on the "Personalize newsletter" task
* Verify that you're taken to `/settings/general/:siteSlug`
  - Note that this could take users to `/settings/newsletter/:siteSlug` instead, but I think we have other tasks that take users there
* Navigate back to Customer Home
* Click on the "Add subscribers" task
* Verify that you're taken to `/subscribers/:siteSlug`
* Navigate back to Customer Home
* Click on the "Migrate content" task
* Verify that you're taken to `/import/:siteSlug`
* On the back end for your site, run the following command to add the `site_goals` option:
```
update_option( 'site_goals', array( 'paid-subscribers', 'import-subscribers' ) );
```
* Navigate back to Customer Home
* From Customer Home, click on the "Create paid Newsletter" task (which should now be visible)
* Verify that you're taken to `/earn/payments-plans/:siteSlug#add-newsletter-payment-plan`