### PR TITLE
WPCOM Marketplace: Add ability of updating theme in updater

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/src/features/marketplace-products-updater/class-marketplace-products-updater.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/marketplace-products-updater/class-marketplace-products-updater.php
@@ -121,7 +121,7 @@ class Marketplace_Products_Updater {
 			return array();
 		}
 
-		$cache_key = '_wpcom_marketplace_product_updates';
+		$cache_key = sprintf( '_wpcom_marketplace_%s_updates', $type );
 		$updates   = get_transient( $cache_key );
 
 		if ( false !== $updates ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/marketplace-products-updater/class-marketplace-products-updater.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/marketplace-products-updater/class-marketplace-products-updater.php
@@ -23,6 +23,7 @@ class Marketplace_Products_Updater {
 	 */
 	public static function init() {
 		add_filter( 'pre_set_site_transient_update_plugins', array( __CLASS__, 'transient_update_plugins' ), 100 );
+		add_filter( 'pre_set_site_transient_update_themes', array( __CLASS__, 'transient_update_themes' ), 100 );
 	}
 
 	/**
@@ -63,6 +64,45 @@ class Marketplace_Products_Updater {
 				$transient->no_update[ $update->plugin ] = $update;
 
 				unset( $transient->response[ $filename ] );
+			}
+		}
+
+		return $transient;
+	}
+
+	/**
+	 * Fetch and process themes updates.
+	 *
+	 * @param object $transient The update_themes transient object.
+	 *
+	 * @return object.
+	 */
+	public static function transient_update_themes( $transient ) {
+		$updates = self::fetch_updates( 'themes' );
+
+		foreach ( $updates as $remote_theme_info ) {
+			$slug = $remote_theme_info['slug'];
+
+			$local_theme_info = wp_get_theme( $slug );
+
+			// Do not attempt to add update if theme info is not found. Maybe theme does not exists on the site.
+			if ( ! $local_theme_info->exists() ) {
+				continue;
+			}
+
+			$update = array(
+				'theme'       => $slug,
+				'package'     => $remote_theme_info['download_link'],
+				'new_version' => $remote_theme_info['version'],
+			);
+
+			if ( version_compare( $local_theme_info->get( 'Version' ), $update['new_version'], '<' ) ) {
+				$transient->response[ $slug ] = $update;
+			} else {
+				// Clear package since we don't want to store download link under current version.
+				$update['package'] = '';
+
+				$transient->no_update[ $slug ] = $update;
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/3228

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR is follow up PR for #32872, the previous PR added functionality for updating plugins. This PR adds ability to provide updates for WPCOM marketplace themes. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use WoA Dev blog for testing. 
* Purchase Blissful theme from WPCOM Marketplace.
* SSH into your dev blog.
* Manually update version of Blissful theme to mark it outdated. ie change version to `1.0.1` from `1.0.2`. 
```
vim ~/htdocs/wp-content/themes/blissful/style.css
```
* Visit `/wp-admin/update-core.php` page of test site. You should be able to see update related to Blissful theme. Don't update the theme yet.
* SSH into your dev blog.
* Run `wp shell` and then run following command. The output would look something like one below.
```
get_site_transient( 'update_themes', 'site-transient' )->response
```
<img width="483" alt="Screenshot 2023-09-06 at 5 18 13 PM" src="https://github.com/Automattic/jetpack/assets/86406124/2c29252e-5767-4676-925f-61c7c9f29526">


* This update is provided by WooCommerce plugin for Woo themes. We want to overide this update if exists else push new update for WPCOM marketplace themes. 
* Install, and activate [the Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/). Once the plugin is active, go to Jetpack > Jetpack Beta > WordPress.com Features and enable the `add/marketplace-theme-updater` branch.
* Add following constant in `wp-config.php` file. This would allow you to test feature branches using jetpack beta. 
```
define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', 1 );
```
* Run `wp shell` and then run following command. This would force updates check to run again. 
```
delete_site_transient( 'update_themes' )
```
* Go to `/wp-admin/update-core.php` on test site. 
* Close all existing session of `wp shell`, start new session `wp shell` and then run following command. The output would look something like one below.
```
get_site_transient( 'update_themes', 'site-transient' )->response
```
<img width="604" alt="Screenshot 2023-09-06 at 5 18 24 PM" src="https://github.com/Automattic/jetpack/assets/86406124/f9d7b5a4-659b-47b0-830c-223271ab9046">


* As you can see in above image that update object doesn't have `url` property and has correct `package` property. This means that the updates was provided by this PR. 
