### PR TITLE
AI Client: add and expose reset() from useAiSuggestions() hook

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-client-add-reset-suggestion-helper
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-add-reset-suggestion-helper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: add and expose reset() from useAiSuggestions() hook

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/Readme.md
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/Readme.md
@@ -36,6 +36,7 @@ An object with the following properties:
 - `requestingState: RequestingStateProp`: The state of the request.
 - `eventSource: SuggestionsEventSource | undefined`: The event source of the request.
 - `request: ( prompt: Array< PromptItemProps >, options: AskQuestionOptionsArgProps ) => Promise< void >`: The request handler.
+- `reset`: `() => void`: Reset the request state.
 
 ### `PromptItemProps`
 

--- a/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-suggestions/index.ts
@@ -99,6 +99,11 @@ type useAiSuggestionsProps = {
 	request: ( prompt: PromptProp, options?: AskQuestionOptionsArgProps ) => Promise< void >;
 
 	/*
+	 * Reset the request state.
+	 */
+	reset: () => void;
+
+	/*
 	 * The handler to stop a suggestion.
 	 */
 	stopSuggestion: () => void;
@@ -295,6 +300,17 @@ export default function useAiSuggestions( {
 	);
 
 	/**
+	 * Reset the request state.
+	 *
+	 * @returns {void}
+	 */
+	const reset = useCallback( () => {
+		setRequestingState( 'init' );
+		setSuggestion( '' );
+		setError( undefined );
+	}, [] );
+
+	/**
 	 * Stop suggestion handler.
 	 *
 	 * @returns {void}
@@ -358,9 +374,10 @@ export default function useAiSuggestions( {
 		error,
 		requestingState,
 
-		// Request/stop handlers
+		// Requests handlers
 		request,
 		stopSuggestion,
+		reset,
 
 		// SuggestionsEventSource
 		eventSource: eventSourceRef.current,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds and exposes the `reset()` helper function to/from the useAiSuggestions() react custom hook. It's used when the consumer needs to reset the current state of the requesting process.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: add and expose reset() from useAiSuggestions() hook

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Since the `reset()` is not used yet (follow-up PR coming on), a visual review and checking the compilation is oaky will be enough for now

