### PR TITLE
AI Excerpt: Add `Accept` button

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-add-use-button
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-add-use-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: add `Use` button

--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-add-use-button
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-add-use-button
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI Excerpt: add `Use` button
+AI Excerpt: add `Accept` button

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
@@ -1,7 +1,7 @@
 /*
  * External dependencies
  */
-import { Button, RangeControl } from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 /**
@@ -34,16 +34,6 @@ export type AiExcerptControlProps = {
 	maxWords?: number;
 
 	/*
-	 * Whether the component is busy.
-	 */
-	isBusy?: boolean;
-
-	/*
-	 * Callback to generate suggestions from AI.
-	 */
-	onGenerate?: () => void;
-
-	/*
 	 * Callback to change the number of words in the generated excerpt.
 	 */
 	onWordsNumberChange?: ( words: number ) => void;
@@ -54,37 +44,21 @@ export function AiExcerptControl( {
 	maxWords = 100,
 	disabled,
 	words,
-
-	isBusy,
-	onGenerate,
 	onWordsNumberChange,
 }: AiExcerptControlProps ) {
 	return (
-		<>
-			<RangeControl
-				label={ __( 'Generate', 'jetpack' ) }
-				value={ words }
-				onChange={ onWordsNumberChange }
-				min={ minWords }
-				max={ maxWords }
-				help={ __(
-					'Sets the limit for words in auto-generated excerpts. The final count may vary slightly due to sentence structure.',
-					'jetpack'
-				) }
-				showTooltip={ false }
-				disabled={ disabled }
-			/>
-
-			<div className="jetpack-generated-excerpt__generate-buttons-container">
-				<Button
-					onClick={ () => onGenerate() }
-					variant="secondary"
-					isBusy={ isBusy }
-					disabled={ disabled }
-				>
-					{ __( 'Generate', 'jetpack' ) }
-				</Button>
-			</div>
-		</>
+		<RangeControl
+			label={ __( 'Generate', 'jetpack' ) }
+			value={ words }
+			onChange={ onWordsNumberChange }
+			min={ minWords }
+			max={ maxWords }
+			help={ __(
+				'Sets the limit for words in auto-generated excerpts. The final count may vary slightly due to sentence structure.',
+				'jetpack'
+			) }
+			showTooltip={ false }
+			disabled={ disabled }
+		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
@@ -5,10 +5,6 @@ import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 /**
- * Internal dependencies
- */
-import './style.scss';
-/**
  * Types and constants
  */
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/style.scss
@@ -1,5 +1,0 @@
-.jetpack-generated-excerpt__generate-buttons-container {
-	display: flex;
-	justify-content: end;
-	margin-bottom: 10px;
-}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -102,7 +102,7 @@ function AiPostExcerpt() {
 
 			<div className="jetpack-generated-excerpt__generate-buttons-container">
 				<Button onClick={ setExpert } variant="secondary" disabled={ requestingState !== 'done' }>
-					{ __( 'Use', 'jetpack' ) }
+					{ __( 'Accept', 'jetpack' ) }
 				</Button>
 
 				<Button

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -55,6 +55,7 @@ function AiPostExcerpt() {
 
 	const isGenerateButtonDisabled = requestingState === 'requesting';
 	const isBusy = requestingState === 'requesting' || requestingState === 'suggesting';
+	const isTextAreaDisabled = isBusy || requestingState === 'done';
 
 	/**
 	 * Request AI for a new excerpt.
@@ -85,6 +86,7 @@ function AiPostExcerpt() {
 				onChange={ value => editPost( { excerpt: value } ) }
 				help={ numberOfWords ? helpNumberOfWords : null }
 				value={ currentExcerpt }
+				disabled={ isTextAreaDisabled }
 			/>
 
 			<AiExcerptControl

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -38,7 +38,7 @@ function AiPostExcerpt() {
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
-	const { request, suggestion, requestingState } = useAiSuggestions();
+	const { request, reset, suggestion, requestingState } = useAiSuggestions();
 
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
@@ -78,6 +78,11 @@ function AiPostExcerpt() {
 		request( prompt, { feature: 'jetpack-ai-content-lens' } );
 	}
 
+	function setExpert() {
+		editPost( { excerpt: suggestion } );
+		reset();
+	}
+
 	return (
 		<div className="jetpack-ai-post-excerpt">
 			<TextareaControl
@@ -96,6 +101,10 @@ function AiPostExcerpt() {
 			/>
 
 			<div className="jetpack-generated-excerpt__generate-buttons-container">
+				<Button onClick={ setExpert } variant="secondary" disabled={ requestingState !== 'done' }>
+					{ __( 'Use', 'jetpack' ) }
+				</Button>
+
 				<Button
 					onClick={ () => requestExcerpt() }
 					variant="secondary"

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -45,7 +45,8 @@ function AiPostExcerpt() {
 	}, [ removeEditorPanel ] );
 
 	// Show custom prompt number of words
-	const numberOfWords = count( excerpt, 'words' );
+	const currentExcerpt = suggestion || excerpt;
+	const numberOfWords = count( currentExcerpt, 'words' );
 	const helpNumberOfWords = sprintf(
 		// Translators: %1$s is the number of words in the excerpt.
 		_n( '%1$s word', '%1$s words', numberOfWords, 'jetpack' ),
@@ -83,7 +84,7 @@ function AiPostExcerpt() {
 				label={ __( 'Write an excerpt (optional)', 'jetpack' ) }
 				onChange={ value => editPost( { excerpt: value } ) }
 				help={ numberOfWords ? helpNumberOfWords : null }
-				value={ excerpt || suggestion }
+				value={ currentExcerpt }
 			/>
 
 			<AiExcerptControl

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { aiAssistantIcon, useAiSuggestions } from '@automattic/jetpack-ai-client';
-import { TextareaControl, ExternalLink } from '@wordpress/components';
+import { TextareaControl, ExternalLink, Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { useEffect, useState } from '@wordpress/element';
@@ -75,7 +75,7 @@ function AiPostExcerpt() {
 			},
 		];
 
-		request( prompt );
+		request( prompt, { feature: 'jetpack-ai-content-lens' } );
 	}
 
 	return (
@@ -92,10 +92,19 @@ function AiPostExcerpt() {
 			<AiExcerptControl
 				words={ excerptWordsNumber }
 				onWordsNumberChange={ setExcerptWordsNumber }
-				onGenerate={ requestExcerpt }
-				disabled={ isGenerateButtonDisabled }
-				isBusy={ isBusy }
+				disabled={ isBusy }
 			/>
+
+			<div className="jetpack-generated-excerpt__generate-buttons-container">
+				<Button
+					onClick={ () => requestExcerpt() }
+					variant="secondary"
+					isBusy={ isBusy }
+					disabled={ isGenerateButtonDisabled }
+				>
+					{ __( 'Generate', 'jetpack' ) }
+				</Button>
+			</div>
 
 			<ExternalLink
 				href={ __(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
@@ -6,3 +6,11 @@
 .jetpack-ai-post-excerpt .components-base-control__help {
 	margin-bottom: 12px;
 }
+
+.jetpack-generated-excerpt__generate-buttons-container {
+	display: flex;
+	justify-content: end;
+	margin-bottom: 10px;
+	gap: 12px;
+	justify-content:flex-end;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds the `Accept` button to let the users accept the except suggestion provided by the AI. Additionally, it moves the `Generate` button out of the AI Excerpt control.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: Add `Accept` button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editod
* Open the block sidebar
* Look at the AI Excerpt panel 
* Confirm you see, initially the `Accept` button disable
* Request an excerpt
* Confirm that `Accept` button gets enabled once the requests finishes
* Confirm you can _use_ the suggestion by clicking on the button

Init | Done
-----|-----
<img width="321" alt="Screenshot 2023-09-06 at 13 26 20" src="https://github.com/Automattic/jetpack/assets/77539/ac51343b-5722-4dd5-af00-86d48673ea8f"> | <img width="314" alt="Screenshot 2023-09-06 at 13 27 00" src="https://github.com/Automattic/jetpack/assets/77539/22eedf70-7b57-436b-ba2b-97e4fdfdadff">

You should apply D120777-code to get the excerpt suggestion:


https://github.com/Automattic/jetpack/assets/77539/9fff11c5-51cb-4ced-bb5d-21b9bb3af2f3
