### PR TITLE
AI Excerpt: save the post before to request excerpt

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-save-post-before-to-ask
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-save-post-before-to-ask
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: ensure to save the post before to ask a suggestion

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -139,18 +139,6 @@ ${ postContent }
 				disabled={ isTextAreaDisabled }
 			/>
 
-			{ isQuotaExceeded && <UpgradePrompt /> }
-
-			{ error?.code && error.code !== 'error_quota_exceeded' && (
-				<Notice
-					status={ error.severity }
-					isDismissible={ false }
-					className="jetpack-ai-assistant__error"
-				>
-					{ error.message }
-				</Notice>
-			) }
-
 			<ExternalLink
 				href={ __(
 					'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt',
@@ -161,6 +149,18 @@ ${ postContent }
 			</ExternalLink>
 
 			<div className="jetpack-generated-excerpt__ai-container">
+				{ isQuotaExceeded && <UpgradePrompt /> }
+
+				{ error?.code && error.code !== 'error_quota_exceeded' && (
+					<Notice
+						status={ error.severity }
+						isDismissible={ false }
+						className="jetpack-ai-assistant__error"
+					>
+						{ error.message }
+					</Notice>
+				) }
+
 				<AiExcerptControl
 					words={ excerptWordsNumber }
 					onWordsNumberChange={ setExcerptWordsNumber }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -93,7 +93,7 @@ function AiPostExcerpt() {
 	 * @param {React.MouseEvent} ev - The click event.
 	 * @returns {void}
 	 */
-	async function requestExcerpt( ev ) {
+	async function requestExcerpt( ev: React.MouseEvent ): Promise< void > {
 		await autosave( ev );
 
 		const messageContext: ContentLensMessageContextProps = {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -149,8 +149,6 @@ ${ postContent }
 			</ExternalLink>
 
 			<div className="jetpack-generated-excerpt__ai-container">
-				{ isQuotaExceeded && <UpgradePrompt /> }
-
 				{ error?.code && error.code !== 'error_quota_exceeded' && (
 					<Notice
 						status={ error.severity }
@@ -160,6 +158,8 @@ ${ postContent }
 						{ error.message }
 					</Notice>
 				) }
+
+				{ isQuotaExceeded && <UpgradePrompt /> }
 
 				<AiExcerptControl
 					words={ excerptWordsNumber }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Since the post content is obtained in the server-side, we'd like to ensure the post is saved before to request the excerpt.

Fixes https://github.com/Automattic/jetpack/issues/32877

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ai Excerpt: save the post before to request excerpt

### Other information:


- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the block sidebar
* Ensure the post has unsaved changes
* Look at the AI Excerpt panel
* Request an excerpt suggestion
* Confirm it requests the except 
* Add post changes 
* Request a new suggestion
* Confirm, now, the editor saves the post before performing a new request


https://github.com/Automattic/jetpack/assets/77539/30cce10c-e466-4c3e-aa1f-4589e2a30ed2

