### PR TITLE
jetpack: Restore some WP Requests library v1 back-compat code

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -1651,17 +1651,25 @@ class Jetpack_Tweetstorm_Helper {
 
 		$requests = array_filter( $requests );
 
-		$hooks = new \WpOrg\Requests\Hooks();
+		// @todo Remove this check when wpcom finally finishes updating to WP 6.2 (apparently they only mostly did so as of yet).
+		if ( ! class_exists( '\WpOrg\Requests\Hooks' ) ) {
+			$hooks = new Requests_Hooks();
+		} else {
+			$hooks = new \WpOrg\Requests\Hooks();
+		}
 
 		$hooks->register(
 			'requests.before_redirect',
 			array( self::class, 'validate_redirect_url' )
 		);
 
-		$results = \WpOrg\Requests\Requests::request_multiple( $requests, array( 'hooks' => $hooks ) );
+		// @todo Remove this check when wpcom finally finishes updating to WP 6.2 (apparently they only mostly did so as of yet).
+		$results = class_exists( '\WpOrg\Requests\Requests' )
+			? \WpOrg\Requests\Requests::request_multiple( $requests, array( 'hooks' => $hooks ) )
+			: Requests::request_multiple( $requests, array( 'hooks' => $hooks ) );
 
 		foreach ( $results as $result ) {
-			if ( $result instanceof \WpOrg\Requests\Exception ) {
+			if ( $result instanceof Requests_Exception || $result instanceof \WpOrg\Requests\Exception ) {
 				return new WP_Error(
 					'invalid_url',
 					__( 'Sorry, something is wrong with the requested URL.', 'jetpack' ),
@@ -1730,11 +1738,16 @@ class Jetpack_Tweetstorm_Helper {
 	 * Filters the redirect URLs that can appear when requesting passed URLs.
 	 *
 	 * @param String $redirect_url the URL to which a redirect is requested.
-	 * @throws \WpOrg\Requests\Exception In case the URL is not validated.
+	 * @throws Requests_Exception        In case the URL is not validated, if WP version is less than 6.2.
+	 * @throws \WpOrg\Requests\Exception In case the URL is not validated, if WP version is 6.2 or greater.
 	 * @return void
 	 */
 	public static function validate_redirect_url( $redirect_url ) {
 		if ( ! wp_http_validate_url( $redirect_url ) ) {
+			// @todo Remove this check when wpcom finally finishes updating to WP 6.2 (apparently they only mostly did so as of yet).
+			if ( ! class_exists( '\WpOrg\Requests\Exception' ) ) {
+				throw new Requests_Exception( __( 'A valid URL was not provided.', 'jetpack' ), 'wp_http.redirect_failed_validation' );
+			}
 			throw new \WpOrg\Requests\Exception( __( 'A valid URL was not provided.', 'jetpack' ), 'wp_http.redirect_failed_validation' );
 		}
 	}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -1651,7 +1651,7 @@ class Jetpack_Tweetstorm_Helper {
 
 		$requests = array_filter( $requests );
 
-		// @todo Remove this check when wpcom finally finishes updating to WP 6.2 (apparently they only mostly did so as of yet).
+		// @todo Remove this check when wpcom picks up the new Requests lib (it seems it was skipped during their update to 6.2)
 		if ( ! class_exists( '\WpOrg\Requests\Hooks' ) ) {
 			$hooks = new Requests_Hooks();
 		} else {
@@ -1663,7 +1663,7 @@ class Jetpack_Tweetstorm_Helper {
 			array( self::class, 'validate_redirect_url' )
 		);
 
-		// @todo Remove this check when wpcom finally finishes updating to WP 6.2 (apparently they only mostly did so as of yet).
+		// @todo Remove this check when wpcom picks up the new Requests lib (it seems it was skipped during their update to 6.2)
 		$results = class_exists( '\WpOrg\Requests\Requests' )
 			? \WpOrg\Requests\Requests::request_multiple( $requests, array( 'hooks' => $hooks ) )
 			: Requests::request_multiple( $requests, array( 'hooks' => $hooks ) );
@@ -1744,7 +1744,7 @@ class Jetpack_Tweetstorm_Helper {
 	 */
 	public static function validate_redirect_url( $redirect_url ) {
 		if ( ! wp_http_validate_url( $redirect_url ) ) {
-			// @todo Remove this check when wpcom finally finishes updating to WP 6.2 (apparently they only mostly did so as of yet).
+			// @todo Remove this check when wpcom picks up the new Requests lib (it seems it was skipped during their update to 6.2)
 			if ( ! class_exists( '\WpOrg\Requests\Exception' ) ) {
 				throw new Requests_Exception( __( 'A valid URL was not provided.', 'jetpack' ), 'wp_http.redirect_failed_validation' );
 			}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
@@ -113,10 +113,12 @@ class WPCOM_REST_API_V2_Endpoint_Resolve_Redirect extends WP_REST_Controller {
 	/**
 	 * Finds the destination url from an http response.
 	 *
-	 * @param \WpOrg\Requests\Response $response Response object.
-	 * @return string                  Final url of the response.
+	 * @todo Add WpOrg\Requests\Response type hint to method when wpcom finally finishes updating to WP 6.2 (apparently they only mostly did so as of yet).
+	 *
+	 * @param \WpOrg\Requests\Response|Requests_Response $response Response object.
+	 * @return string                                    Final url of the response.
 	 */
-	protected function get_response_url( WpOrg\Requests\Response $response ) {
+	protected function get_response_url( $response ) {
 		$history = $response->history;
 		if ( ! $history ) {
 			return $response->url;

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
@@ -113,7 +113,7 @@ class WPCOM_REST_API_V2_Endpoint_Resolve_Redirect extends WP_REST_Controller {
 	/**
 	 * Finds the destination url from an http response.
 	 *
-	 * @todo Add WpOrg\Requests\Response type hint to method when wpcom finally finishes updating to WP 6.2 (apparently they only mostly did so as of yet).
+	 * @todo Add WpOrg\Requests\Response type hint to method when wpcom picks up the new Requests lib (it seems it was skipped during their update to 6.2)
 	 *
 	 * @param \WpOrg\Requests\Response|Requests_Response $response Response object.
 	 * @return string                                    Final url of the response.

--- a/projects/plugins/jetpack/changelog/fix-wpcom-isnt-fully-on-WP-6.2-yet-despite-claiming-theyre-on-6.3.1
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-isnt-fully-on-WP-6.2-yet-despite-claiming-theyre-on-6.3.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Restore some Requests library v1 back-compat code, apparently WordPress.com Simple skipped that part of their update to WP 6.2.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It seems WordPress.com Simple skipped that part of their upgrade to WordPress 6.2, so despite their saying they're on 6.3.1 now the new Requests library classes are missing there.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1694008147802019/1693971459.257519-slack-C4N88L95W

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this on a Simple sandbox and hit these code paths, see that they work now.