### PR TITLE
AI Excerpt: show upgrade banner

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-show-upgrade-banner
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-show-upgrade-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: show upgracde banner when site achieves requests limit

--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-show-upgrade-banner
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-show-upgrade-banner
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI Excerpt: show upgracde banner when site achieves requests limit
+AI Excerpt: show upgrade banner when site achieves requests limit

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
@@ -43,7 +43,6 @@ export function AiExcerptControl( {
 }: AiExcerptControlProps ) {
 	return (
 		<RangeControl
-			className="jetpack-generated-excerpt__words-number"
 			label={ __( 'Generate', 'jetpack' ) }
 			value={ words }
 			onChange={ onWordsNumberChange }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/components/ai-excerpt-control/index.tsx
@@ -43,6 +43,7 @@ export function AiExcerptControl( {
 }: AiExcerptControlProps ) {
 	return (
 		<RangeControl
+			className="jetpack-generated-excerpt__words-number"
 			label={ __( 'Generate', 'jetpack' ) }
 			value={ words }
 			onChange={ onWordsNumberChange }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -125,6 +125,15 @@ ${ postContent }
 				disabled={ isTextAreaDisabled }
 			/>
 
+			<ExternalLink
+				href={ __(
+					'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt',
+					'jetpack'
+				) }
+			>
+				{ __( 'Learn more about manual excerpts', 'jetpack' ) }
+			</ExternalLink>
+
 			{ error?.code && error.code !== 'error_quota_exceeded' && (
 				<Notice
 					status={ error.severity }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -119,6 +119,8 @@ ${ postContent }
 		reset();
 	}
 
+	const isQuotaExceeded = error?.code === ERROR_QUOTA_EXCEEDED;
+
 	return (
 		<div className="jetpack-ai-post-excerpt">
 			<TextareaControl
@@ -149,12 +151,12 @@ ${ postContent }
 				</Notice>
 			) }
 
-			{ error?.code === ERROR_QUOTA_EXCEEDED && <UpgradePrompt /> }
+			{ isQuotaExceeded && <UpgradePrompt /> }
 
 			<AiExcerptControl
 				words={ excerptWordsNumber }
 				onWordsNumberChange={ setExcerptWordsNumber }
-				disabled={ isBusy }
+				disabled={ isBusy || isQuotaExceeded }
 			/>
 
 			<div className="jetpack-generated-excerpt__generate-buttons-container">
@@ -162,12 +164,16 @@ ${ postContent }
 					onClick={ discardExpert }
 					variant="secondary"
 					isDestructive
-					disabled={ requestingState !== 'done' }
+					disabled={ requestingState !== 'done' || isQuotaExceeded }
 				>
 					{ __( 'Discard', 'jetpack' ) }
 				</Button>
 
-				<Button onClick={ setExpert } variant="secondary" disabled={ requestingState !== 'done' }>
+				<Button
+					onClick={ setExpert }
+					variant="secondary"
+					disabled={ requestingState !== 'done' || isQuotaExceeded }
+				>
 					{ __( 'Accept', 'jetpack' ) }
 				</Button>
 
@@ -175,7 +181,7 @@ ${ postContent }
 					onClick={ () => requestExcerpt() }
 					variant="secondary"
 					isBusy={ isBusy }
-					disabled={ isGenerateButtonDisabled }
+					disabled={ isGenerateButtonDisabled || isQuotaExceeded }
 				>
 					{ __( 'Generate', 'jetpack' ) }
 				</Button>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -141,60 +141,53 @@ ${ postContent }
 				{ __( 'Learn more about manual excerpts', 'jetpack' ) }
 			</ExternalLink>
 
-			{ error?.code && error.code !== 'error_quota_exceeded' && (
-				<Notice
-					status={ error.severity }
-					isDismissible={ false }
-					className="jetpack-ai-assistant__error"
-				>
-					{ error.message }
-				</Notice>
-			) }
-
-			{ isQuotaExceeded && <UpgradePrompt /> }
-
-			<AiExcerptControl
-				words={ excerptWordsNumber }
-				onWordsNumberChange={ setExcerptWordsNumber }
-				disabled={ isBusy || isQuotaExceeded }
-			/>
-
-			<div className="jetpack-generated-excerpt__generate-buttons-container">
-				<Button
-					onClick={ discardExpert }
-					variant="secondary"
-					isDestructive
-					disabled={ requestingState !== 'done' || isQuotaExceeded }
-				>
-					{ __( 'Discard', 'jetpack' ) }
-				</Button>
-
-				<Button
-					onClick={ setExpert }
-					variant="secondary"
-					disabled={ requestingState !== 'done' || isQuotaExceeded }
-				>
-					{ __( 'Accept', 'jetpack' ) }
-				</Button>
-
-				<Button
-					onClick={ () => requestExcerpt() }
-					variant="secondary"
-					isBusy={ isBusy }
-					disabled={ isGenerateButtonDisabled || isQuotaExceeded }
-				>
-					{ __( 'Generate', 'jetpack' ) }
-				</Button>
-			</div>
-
-			<ExternalLink
-				href={ __(
-					'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt',
-					'jetpack'
+			<div className="jetpack-generated-excerpt__ai-container">
+				{ error?.code && error.code !== 'error_quota_exceeded' && (
+					<Notice
+						status={ error.severity }
+						isDismissible={ false }
+						className="jetpack-ai-assistant__error"
+					>
+						{ error.message }
+					</Notice>
 				) }
-			>
-				{ __( 'Learn more about manual excerpts', 'jetpack' ) }
-			</ExternalLink>
+
+				{ isQuotaExceeded && <UpgradePrompt /> }
+
+				<AiExcerptControl
+					words={ excerptWordsNumber }
+					onWordsNumberChange={ setExcerptWordsNumber }
+					disabled={ isBusy || isQuotaExceeded }
+				/>
+
+				<div className="jetpack-generated-excerpt__generate-buttons-container">
+					<Button
+						onClick={ discardExpert }
+						variant="secondary"
+						isDestructive
+						disabled={ requestingState !== 'done' || isQuotaExceeded }
+					>
+						{ __( 'Discard', 'jetpack' ) }
+					</Button>
+
+					<Button
+						onClick={ setExpert }
+						variant="secondary"
+						disabled={ requestingState !== 'done' || isQuotaExceeded }
+					>
+						{ __( 'Accept', 'jetpack' ) }
+					</Button>
+
+					<Button
+						onClick={ () => requestExcerpt() }
+						variant="secondary"
+						isBusy={ isBusy }
+						disabled={ isGenerateButtonDisabled || isQuotaExceeded }
+					>
+						{ __( 'Generate', 'jetpack' ) }
+					</Button>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { aiAssistantIcon, useAiSuggestions } from '@automattic/jetpack-ai-client';
+import {
+	ERROR_QUOTA_EXCEEDED,
+	aiAssistantIcon,
+	useAiSuggestions,
+} from '@automattic/jetpack-ai-client';
 import { TextareaControl, ExternalLink, Button, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
@@ -13,6 +17,7 @@ import TurndownService from 'turndown';
  * Internal dependencies
  */
 import './style.scss';
+import UpgradePrompt from '../../../../components/upgrade-prompt';
 import { AiExcerptControl } from '../../components/ai-excerpt-control';
 /**
  * Types and constants
@@ -143,6 +148,8 @@ ${ postContent }
 					{ error.message }
 				</Notice>
 			) }
+
+			{ error?.code === ERROR_QUOTA_EXCEEDED && <UpgradePrompt /> }
 
 			<AiExcerptControl
 				words={ excerptWordsNumber }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
@@ -3,7 +3,8 @@
 	margin-bottom: 10px;
 }
 
-.jetpack-ai-post-excerpt .components-base-control__help {
+// Learn more link
+.jetpack-ai-post-excerpt .components-external-link {
 	margin-bottom: 12px;
 }
 
@@ -19,7 +20,7 @@
 // Upgrade banner
 .jetpack-ai-post-excerpt .jetpack-upgrade-plan-banner__wrapper {
 	flex-direction: column;
-	margin: 20px 0 10px;
+	margin: 20px 0 0;
 	padding: 0 10px;
 
 	.jetpack-ai-upgrade-banner__description {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
@@ -7,10 +7,22 @@
 	margin-bottom: 12px;
 }
 
+
 .jetpack-generated-excerpt__generate-buttons-container {
 	display: flex;
 	justify-content: end;
 	margin-bottom: 10px;
 	gap: 12px;
 	justify-content:space-around;
+}
+
+// Upgrade banner
+.jetpack-ai-post-excerpt .jetpack-upgrade-plan-banner__wrapper {
+	flex-direction: column;
+	margin: 20px 0 10px;
+	padding: 0 10px;
+
+	.jetpack-ai-upgrade-banner__description {
+		margin: 10px 0 0;
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/style.scss
@@ -3,11 +3,13 @@
 	margin-bottom: 10px;
 }
 
-// Learn more link
-.jetpack-ai-post-excerpt .components-external-link {
-	margin-bottom: 12px;
-}
+.jetpack-generated-excerpt__ai-container {
+	margin-top: 12px;
 
+	.jetpack-ai-assistant__error {
+		margin: 0 0 12px;
+	}
+}
 
 .jetpack-generated-excerpt__generate-buttons-container {
 	display: flex;
@@ -20,7 +22,7 @@
 // Upgrade banner
 .jetpack-ai-post-excerpt .jetpack-upgrade-plan-banner__wrapper {
 	flex-direction: column;
-	margin: 20px 0 0;
+	margin: 0 0 12px;
 	padding: 0 10px;
 
 	.jetpack-ai-upgrade-banner__description {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR shows the upgrade banner in the AI Excerpt panel when the site archives the request limit

Fixes https://github.com/Automattic/jetpack/issues/32883

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: show upgrade banner

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a site that requires AI upgrades
* Go to the block editor
* Open the block sidebar
* Look at the AI Excerpt panel
* Request an excerpt suggestion
* Confirm you see the upgrade banner

<img width="395" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/3ea74ec8-1783-4f6a-b238-51f077863aa2">