### PR TITLE
ci: On the prerelease branch, don't build/test plugins

### DIFF
--- a/.github/files/list-changed-projects.sh
+++ b/.github/files/list-changed-projects.sh
@@ -34,7 +34,7 @@ elif [[ "${GITHUB_EVENT_NAME:?}" == "push" ]]; then
 			done <<<"$TMP"
 			DEPENDENTS=false
 			if [[ "$EXTRA" == "test" ]]; then
-				debug "Also considering depndencies of those as changed for running tests"
+				debug "Also considering dependencies of those as changed for running tests"
 				DEPENDENCIES=true
 			fi
 		else
@@ -49,7 +49,7 @@ elif [[ "${GITHUB_EVENT_NAME:?}" == "push" ]]; then
 				ARGS+=( "$LINE" )
 			done <<<"$TMP"
 			if [[ "$EXTRA" == "test" ]]; then
-				debug "Also considering depndencies of those as changed for running tests"
+				debug "Also considering dependencies of those as changed for running tests"
 				DEPENDENCIES=true
 			fi
 		else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When we're running CI builds and tests on pushes to the prerelease branch, we're mainly doing that to build Composer packages for use in an upcoming plugin release branch. There's no point in building the plugins as they'll be released later when the release branch is created instead. So let's only consider projects without a release-branch-prefix set as being "changed".

There is a slight risk that something in the prerelease branch might break a plugin build, which we'd now not discover until after the package releases are pushed to packagist and the plugin release branch is created. But that's probably ok, as the intent of the prerelease branch is that the only difference between it and trunk (or an existing release branch if we're doing a point release) are changelog file updates and version bump, which should not cause that sort of problem.

This is something of a followup to #32775, which has release branches build only the stuff for the release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1693493834412569-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/trunk .github/files/list-changed-projects.sh`, should output all projects.
* Run `GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/crm/branch-6.1.0 .github/files/list-changed-projects.sh`, should output only plugins/crm.
* Run `GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/prerelease .github/files/list-changed-projects.sh`, should output all non-plugins plus plugins/debug-helper.
* Create a prerelease branch based on this PR. It should only build the non-plugins (plus plugins/debug-helper). Maybe do that on a fork to avoid blocking releases.