### PR TITLE
WPCOM Media: Add HEIC/HEIF image upload support

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/improve-jetpack-wpcom-heif-support
+++ b/projects/packages/jetpack-mu-wpcom/changelog/improve-jetpack-wpcom-heif-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add HEIC/HEIF image upload support

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -36,6 +36,7 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_launchpad' ), 0 );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_block_theme_previews' ) );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_media' ) );
 
 		// Unified navigation fix for changes in WordPress 6.2.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );
@@ -80,6 +81,13 @@ class Jetpack_Mu_Wpcom {
 	 */
 	public static function load_launchpad() {
 		require_once __DIR__ . '/features/launchpad/launchpad.php';
+	}
+
+	/**
+	 * Load media features.
+	 */
+	public static function load_media() {
+		require_once __DIR__ . '/features/media/heif-support.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * HEIF/HEIF support for WordPress.com sites.
+ *
+ * @package automattic/jetpack-mu-plugins
+ */
+
+/**
+ * Convert HEIF/HEIC uploads to JPEG.
+ *
+ * @param string $filename Path to the file.
+ * @return bool True if the file was converted, false otherwise.
+ */
+function jetpack_wpcom_maybe_convert_heif_to_jpg( $filename ) {
+	if ( ! class_exists( 'Photon_OpenCV' ) ) {
+		return false;
+	}
+	$valid_magic_bytes = array(
+		'ftypheic',
+		'ftypheix',
+		'ftyphevc',
+		'ftypheim',
+		'ftypheis',
+		'ftyphevm',
+		'ftyphevs',
+		'ftypmif1',
+		'ftypmsf1',
+	);
+
+	// Read the first 8 bytes of the file.
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	$magic_bytes = file_get_contents( $filename, false, null, 4, 8 );
+	if ( false === in_array( $magic_bytes, $valid_magic_bytes, true ) ) {
+		return false;
+	}
+
+	$img = new Photon_OpenCV();
+	try {
+		$img->readimage( $filename );
+	} catch ( Exception $e ) {
+		// Bad detection or malformed image
+		/** This action is documented in modules/widgets/social-media-icons.php */
+		do_action( 'jetpack_bump_stats_extras', 'heif2jpg', 'failed-to-read' );
+		return false;
+	}
+
+	$img->setimageformat( 'jpg' );
+	// This should never fail
+	$img->writeimage( $filename );
+
+	return true;
+}
+
+/**
+ * Attempts to convert HEIF/HEIC uploads to JPEG.
+ *
+ * @param array $file The file array.
+ * @return array The file array.
+ */
+function jetpack_wpcom_transparently_convert_heif_upload_to_jpg( $file ) {
+
+	if ( ! class_exists( 'Photon_OpenCV' ) ) {
+		return $file;
+	}
+
+	// $file only has `name` and `tmp_name` when sideloading
+	$original_size = filesize( $file['tmp_name'] );
+
+	if ( false === jetpack_wpcom_maybe_convert_heif_to_jpg( $file['tmp_name'] ) ) {
+		return $file;
+	}
+
+	// tmp_name is reused, cache needs to be cleared
+	clearstatcache();
+	$new_file = array(
+		'name'     => pathinfo( $file['name'], PATHINFO_FILENAME ) . '.jpg',
+		'type'     => 'image/jpeg',
+		'tmp_name' => $file['tmp_name'],
+		'error'    => 0,
+		'size'     => filesize( $file['tmp_name'] ),
+	);
+
+	/** This action is documented in modules/widgets/social-media-icons.php */
+	do_action( 'jetpack_bump_stats_extras', 'heif2jpg', 'conversions' );
+	/** This action is documented in modules/widgets/social-media-icons.php */
+	do_action( 'jetpack_bump_stats_extras', 'heif2jpg', 'bytes-added', $new_file['size'] - $original_size );
+
+	return $new_file;
+}
+add_filter( 'wp_handle_upload_prefilter', 'jetpack_wpcom_transparently_convert_heif_upload_to_jpg' );
+add_filter( 'wp_handle_sideload_prefilter', 'jetpack_wpcom_transparently_convert_heif_upload_to_jpg' );
+
+/**
+ * Add HEIF/HEIC to the list of supported mime types for sideloading.
+ *
+ * @param array $mimes The list of supported mime types.
+ * @return array The list of supported mime types.
+ */
+function jetpack_wpcom_add_heif_mimes_to_supported_sideload_types( $mimes ) {
+	if ( ! class_exists( 'Photon_OpenCV' ) ) {
+		return $mimes;
+	}
+	$mimes[] = 'image/heif';
+	$mimes[] = 'image/heic';
+	return $mimes;
+}
+add_filter( 'jetpack_supported_media_sideload_types', 'jetpack_wpcom_add_heif_mimes_to_supported_sideload_types' );
+
+/**
+ * Add HEIF/HEIC to the list of supported mime types for uploads.
+ *
+ * @param array $mimes The list of supported mime types.
+ * @return array The list of supported mime types.
+ */
+function jetpack_wpcom_add_heif_mimes_to_supported_upload_types( $mimes ) {
+	if ( ! class_exists( 'Photon_OpenCV' ) ) {
+		return $mimes;
+	}
+	// Only need to modify 'upload_mimes' on Atomic.
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		$mimes['heif'] = 'image/heif';
+		$mimes['heic'] = 'image/heic';
+	}
+	return $mimes;
+}
+add_filter( 'upload_mimes', 'jetpack_wpcom_add_heif_mimes_to_supported_upload_types' );


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/55102
Originally https://github.com/Automattic/jetpack/pull/31719

## Proposed changes:

Ports the existing WordPress.com HEIC/HEIF support to the `jetpack-mu-wpcom` package so it can be used on both Simple and Atomic sites.

This PR only impacts the Media Library upload experience. It doesn't affect images uploaded via the Block Editor.

<img width="1491" alt="image" src="https://github.com/Automattic/jetpack/assets/36432/f34d93bb-c082-46a9-afbc-db19e907db05">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Here's an image you can test with if needed: https://danielbachhuber.com/wp-content/uploads/2023/07/IMG_3634.heif_.zip

### Simple

1. Create a new Premium Simple site and sandbox it.
2. Apply D120861-code to your sandbox.
3. Navigate to `/wp-admin/upload.php` on your Simple site.
4. Attempt to upload a HEIC image and verify you seen an error.
5.  Inside of your sandbox, run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin improve/jetpack-wpcom-heif-support-v2`
6. Attempt to upload a HEIC image and verify it uploads as expected.

### Atomic

1. Create a new Business site, mark it as a WoA dev site, and take it Atomic.
2. Install the [Jetpack Beta Tester plugin](https://jetpack.com/download-jetpack-beta/) and add `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` to your `wp-config.php` file.
3. Navigate to `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack-mu-wpcom-plugin` to switch to the `improve/jetpack-wpcom-heif-support-v2` branch.
4. Navigate to `/wp-admin/upload.php` on your Atomic site.
5. Attempt to upload a HEIC image and verify it uploads as expected.