### PR TITLE
Bump jetpack-mu-wpcom to 4.8.0-alpha

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
+++ b/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
@@ -1,3 +1,4 @@
 Significance: minor
 Type: changed
+
 Update version numbers

--- a/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
+++ b/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Bump jetpack-mu-wpcom to 4.8.0-alpha

--- a/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
+++ b/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: changed
 Comment: Bump jetpack-mu-wpcom to 4.7.1-alpha
 

--- a/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
+++ b/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
-Comment: Bump jetpack-mu-wpcom to 4.7.1-alpha
+Comment: Bump jetpack-mu-wpcom to 4.8-alpha
 

--- a/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
+++ b/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Bump jetpack-mu-wpcom to 4.7.1-alpha
 
-Bump jetpack-mu-wpcom to 4.8.0-alpha

--- a/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
+++ b/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
@@ -1,4 +1,3 @@
 Significance: minor
 Type: changed
-Comment: Bump jetpack-mu-wpcom to 4.8-alpha
-
+Update version numbers

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -47,7 +47,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "4.7.x-dev"
+			"dev-trunk": "4.8.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.7.0",
+	"version": "4.8.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.7.0';
+	const PACKAGE_VERSION = '4.8.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/changelog/2023-09-06-18-07-19-807253
+++ b/projects/plugins/mu-wpcom-plugin/changelog/2023-09-06-18-07-19-807253
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_17"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_18_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "c4203608e592e2bb82a1398b744eec9db95c893b"
+                "reference": "64834487d36221c54451490aea577b6da57dc83a"
             },
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "4.7.x-dev"
+                    "dev-trunk": "4.8.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.17
+ * Version: 1.6.18-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.17",
+	"version": "1.6.18-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
See p1694022596410069-slack-CDLH4C1UZ

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

N/A