### PR TITLE
CRM: Resolves #3303 - handle invoice status dropdown mismatches

### DIFF
--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -588,7 +588,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 										$invoice_val = $invoice['total'];
 
-										$invoice_status = $invoice['status'];
+										$invoice_status = $invoice['status_label'];
 
 										echo '<tr>';
 										echo '<td><a href="' . esc_url( $invoice_url ) . '">' . esc_html( $id_ref_str ) . '</a></td>';

--- a/projects/plugins/crm/admin/contact/view.page.php
+++ b/projects/plugins/crm/admin/contact/view.page.php
@@ -876,7 +876,7 @@ item"><?php esc_html_e( 'Tasks', 'zero-bs-crm' ); ?></div><?php } ?>
 
 									$invoice_val = $invoice['total'];
 
-									$invoice_status = $invoice['status'];
+									$invoice_status = $invoice['status_label'];
 
 									echo '<tr>';
 									echo '<td><a href="' . esc_url( $invoice_url ) . '">' . esc_html( $id_ref_str ) . '</a></td>';

--- a/projects/plugins/crm/changelog/fix-crm-3303-fix_object_status_dropdown_mismatches
+++ b/projects/plugins/crm/changelog/fix-crm-3303-fix_object_status_dropdown_mismatches
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Invoices: Handle status translations consistently

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5427,9 +5427,9 @@ function zeroBSCRM_AJAX_sendInvoiceEmail_v3( $email = '', $invoiceID = -1, $atta
 
 			// once the invoice is sent it will mark it as unpaid (automatically)
 			// (if is draft)
-			if ( isset( $invoice['status'] ) && $invoice['status'] == __( 'Draft', 'zero-bs-crm' ) ) {
+			if ( isset( $invoice['status'] ) && $invoice['status'] === 'Draft' ) {
 
-				$zbs->DAL->invoices->setInvoiceStatus( $invoiceID, __( 'Unpaid', 'zero-bs-crm' ) );
+				$zbs->DAL->invoices->setInvoiceStatus( $invoiceID, 'Unpaid' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 			}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -7994,15 +7994,14 @@ function zeroBSCRM_GenerateTempHash($str=-1,$length=20){
 
 		// retrieves statuses from object :)
 		function zeroBSCRM_getInvoicesStatuses(){
-		    
-		    // for DAL3+ these are hard typed, probably need to sit in the obj:
-		    return array(
-		    	__( 'Draft', 'zero-bs-crm' ),
-		    	__( 'Unpaid', 'zero-bs-crm' ),
-		    	__( 'Paid', 'zero-bs-crm' ),
-		    	__( 'Overdue', 'zero-bs-crm' ),
-		    	__( 'Deleted', 'zero-bs-crm' )
-		    );
+			// for DAL3+ these are hard typed, probably need to sit in the obj:
+			return array(
+				'Draft',
+				'Unpaid',
+				'Paid',
+				'Overdue',
+				'Deleted',
+			);
 		}
 
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -5270,11 +5270,11 @@ function zeroBSCRM_invoicing_getInvoiceData( $invID = -1 ) {
 			// got balance?
 			if ($outstandingBalance <= 0 && $outstandingBalance !== false){
 
-				// simple status update
-				$statusStr = __('Paid','zero-bs-crm');
-				$invUpdate = $zbs->DAL->invoices->setInvoiceStatus($invoice_id,$statusStr);
+				// mark invoice as paid
+				$status_str     = 'Paid';
+				$invoice_update = $zbs->DAL->invoices->setInvoiceStatus( $invoice_id, $status_str ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-			    return $statusStr;
+				return $invoice_update;
 
 			}
 
@@ -5296,7 +5296,7 @@ function jpcrm_deleted_invoice_counts( $all_invoices = null ) {
 	}
 	$count_deleted = 0;
 	foreach ( $all_invoices as $invoice ) {
-		if ( $invoice['status'] === __( 'Deleted', 'zero-bs-crm' ) ) {
+		if ( $invoice['status'] === 'Deleted' ) {
 			++$count_deleted;
 		}
 	}

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
@@ -2120,6 +2120,7 @@ class zbsDAL_invoices extends zbsDAL_ObjectLayer {
             $res['id_override'] = $this->stripSlashes($obj->zbsi_id_override);
             $res['parent'] = (int)$obj->zbsi_parent;
             $res['status'] = $this->stripSlashes($obj->zbsi_status);
+					$res['status_label'] = __( $res['status'], 'zero-bs-crm' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
             $res['hash'] = $this->stripSlashes($obj->zbsi_hash);
             $res['pdf_template'] = $this->stripSlashes($obj->zbsi_pdf_template);
             $res['portal_template'] = $this->stripSlashes($obj->zbsi_portal_template);

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -609,7 +609,7 @@ function zeroBSCRM_invoicing_generateStatementHTML_v3( $contact_id = -1, $return
 
 				// 2 ways here - if marked 'paid', then assume balance
 				// ... if not, then trans allocation check
-				if ( isset( $invoice['status'] ) && $invoice['status'] === __( 'Paid', 'zero-bs-crm' ) ) {
+				if ( isset( $invoice['status'] ) && $invoice['status'] === 'Paid' ) {
 
 					// assume fully paid
 					$balance  = 0.00;
@@ -771,11 +771,12 @@ function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 
 	// Custom fields
 	$invoice_custom_fields_html = jpcrm_invoicing_generate_invoice_custom_fields_lines( $invoice, $template );
 
-	// status
+	// default status and status label
 	if ( ! isset( $invoice['status'] ) ) {
-		$zbs_stat = __( 'Draft', 'zero-bs-crm' );
-	} else {
-		$zbs_stat = $invoice['status_label'];
+		$invoice['status'] = 'Draft';
+	}
+	if ( ! isset( $invoice['status_label'] ) ) {
+		$invoice['status_label'] = __( 'Draft', 'zero-bs-crm' );
 	}
 
 	// status html:
@@ -783,7 +784,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 
 
 		// portal version: Includes status label and amount (shown at top of portal invoice)
 		$top_status  = '<div class="zbs-portal-label">';
-		$top_status .= esc_html( $zbs_stat );
+		$top_status .= esc_html( $invoice['status_label'] );
 		$top_status .= '</div>';
 		// WH added quickly to get around fact this is sometimes empty, please tidy when you address currency formatting :)
 		$inv_g_total = '';
@@ -791,38 +792,28 @@ function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 
 			$inv_g_total = zeroBSCRM_formatCurrency( $invoice['total'] );
 		}
 		$top_status .= '<h1 class="zbs-portal-value">' . esc_html( $inv_g_total ) . '</h1>';
-		if ( $zbs_stat === __( 'Paid', 'zero-bs-crm' ) ) {
-			$top_status .= '<div class="zbs-invoice-paid"><i class="fa fa-check"></i>' . esc_html__( 'Paid', 'zero-bs-crm' ) . '</div>';
+		if ( $invoice['status'] === 'Paid' ) {
+			$top_status .= '<div class="zbs-invoice-paid"><i class="fa fa-check"></i>' . esc_html( $invoice['status_label'] ) . '</div>';
 		}
 	} elseif ( $template === 'pdf' ) {
 
 		// pdf status
-		if ( $zbs_stat === __( 'Paid', 'zero-bs-crm' ) ) {
+		if ( $invoice['status'] === 'Paid' ) {
 
-			$top_status = '<div class="jpcrm-invoice-status jpcrm-invoice-paid">' . esc_html__( 'Paid', 'zero-bs-crm' ) . '</div>';
+			$top_status = '<div class="jpcrm-invoice-status jpcrm-invoice-paid">' . esc_html( $invoice['status_label'] ) . '</div>';
 
 		} else {
 
-			$top_status = '<div class="jpcrm-invoice-status">' . esc_html( $zbs_stat ) . '</div>';
+			$top_status = '<div class="jpcrm-invoice-status">' . esc_html( $invoice['status_label'] ) . '</div>';
 
 		}
 	} elseif ( $template === 'notification' ) {
 		// sent to contact via email
-		$top_status = esc_html( $zbs_stat );
+		$top_status = esc_html( $invoice['status_label'] );
 	}
 
 	// inv lines
 	$invlines = $invoice['lineitems'];
-
-	// SET all new invoices to unpaid
-	if (
-		// Not set, but inv exists
-		( isset( $invoice ) && is_array( $invoice ) && ( ! isset( $invoice['status'] ) || empty( $invoice['status'] ) ) ) ||
-		// No inv exists
-		( ! isset( $invoice ) || ! is_array( $invoice ) )
-	) {
-		$invoice['status'] = __( 'Draft', 'zero-bs-crm' ); //moved to draft. Unpaid will be set once the invoice has been sent.
-	}
 
 	// switch for Company if set...
 	if ( $zbs_company_id > 0 ) {
@@ -1128,11 +1119,11 @@ function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 
 	$partials_table .= '</table>';
 
 	// generate a templated paybutton (depends on template :))
-	$potential_pay_button = zeroBSCRM_invoicing_generateInvPart_payButton( $invoice_id, $zbs_stat, $template );
+	$potential_pay_button = zeroBSCRM_invoicing_generateInvPart_payButton( $invoice_id, $invoice['status_label'], $template );
 
 	// == Payment terms, thanks etc. will only replace when present in template, so safe to generically check
 	$pay_thanks = '';
-	if ( $zbs_stat === __( 'Paid', 'zero-bs-crm' ) ) {
+	if ( $invoice['status'] === 'Paid' ) {
 		$pay_thanks  = '<div class="deets"><h3>' . esc_html__( 'Thank You', 'zero-bs-crm' ) . '</h3>';
 		$pay_thanks .= '<div>' . nl2br( esc_html( zeroBSCRM_getSetting( 'paythanks' ) ) ) . '</div>';
 		$pay_thanks .= '</div>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -775,7 +775,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 
 	if ( ! isset( $invoice['status'] ) ) {
 		$zbs_stat = __( 'Draft', 'zero-bs-crm' );
 	} else {
-		$zbs_stat = $invoice['status'];
+		$zbs_stat = $invoice['status_label'];
 	}
 
 	// status html:

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Columns.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Columns.php
@@ -519,26 +519,22 @@
       ======================== Invoice filters
       ===================================================================================================== */
 
-    global $zeroBSCRM_filterbuttons_invoice;
+		global $zeroBSCRM_filterbuttons_invoice; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
-    $zeroBSCRM_filterbuttons_invoice['default'] = array(
+		$zeroBSCRM_filterbuttons_invoice['default'] = array( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			'status_draft'   => array( __( 'Draft', 'zero-bs-crm' ) ),
+			'status_unpaid'  => array( __( 'Unpaid', 'zero-bs-crm' ) ),
+			'status_paid'    => array( __( 'Paid', 'zero-bs-crm' ) ),
+			'status_overdue' => array( __( 'Overdue', 'zero-bs-crm' ) ),
+		);
 
-              'status_draft'    => array( __( 'Draft', 'zero-bs-crm' ) ),
-              'status_unpaid'   => array( __( 'Unpaid', 'zero-bs-crm' ) ),
-              'status_paid'     => array( __( 'Paid', 'zero-bs-crm' ) ),
-              'status_overdue'  => array( __( 'Overdue', 'zero-bs-crm' ) )
-
-      );
-
-    $zeroBSCRM_filterbuttons_invoice['all'] = array(
-
-              'status_draft'    => array( __( 'Draft', 'zero-bs-crm' ) ),
-              'status_unpaid'   => array( __( 'Unpaid', 'zero-bs-crm' ) ),
-              'status_paid'     => array( __( 'Paid', 'zero-bs-crm' ) ),
-              'status_overdue'  => array( __( 'Overdue', 'zero-bs-crm' ) ),
-              'status_deleted'  => array( __( 'Overdue', 'zero-bs-crm' ) )
-
-      );
+		$zeroBSCRM_filterbuttons_invoice['all'] = array( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			'status_draft'   => array( __( 'Draft', 'zero-bs-crm' ) ),
+			'status_unpaid'  => array( __( 'Unpaid', 'zero-bs-crm' ) ),
+			'status_paid'    => array( __( 'Paid', 'zero-bs-crm' ) ),
+			'status_overdue' => array( __( 'Overdue', 'zero-bs-crm' ) ),
+			'status_deleted' => array( __( 'Deleted', 'zero-bs-crm' ) ),
+		);
 
 
    /* ======================================================================================================

--- a/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
@@ -972,9 +972,9 @@ function jpcrm_can_wp_user_view_object( $wp_user, $obj_id, $obj_type_id ) {
       $is_invoice_admin = $wp_user->has_cap( 'admin_zerobs_invoices' );
       $obj_data = zeroBS_getInvoice( $obj_id );
       // draft invoice
-      if ( is_array($obj_data) && $obj_data['status'] == __( 'Draft', 'zero-bs-crm' ) && !$is_invoice_admin ) {
-        return false;
-      }
+			if ( is_array( $obj_data ) && $obj_data['status'] === 'Draft' && ! $is_invoice_admin ) {
+				return false;
+			}
       $assigned_contact_id = zeroBSCRM_invoice_getContactAssigned( $obj_id );
       break;
   }

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -529,20 +529,30 @@ function zbscrm_JS_draw_invoice_top_right_form( res ) {
  */
 function generateInvoiceStatusHtml( res ) {
 	let html = '<select id="invoice-status" name="invoice_status">';
-	const currentStatus = res.invoiceObj.status;
-	const allStatuses = [ 
-		[ 'Draft', 'status_draft' ],
-		[ 'Unpaid', 'status_unpaid' ],
-		[ 'Paid', 'status_paid' ],
-		[ 'Overdue', 'status_overdue'],
-		[ 'Deleted', 'status_deleted']
+	const current_status = res.invoiceObj.status;
+
+	// Status (value) is always stored in the database in English; key is used for lang lookup
+	const all_statuses = [
+		{value: 'Draft', key: 'status_draft'},
+		{value: 'Unpaid', key: 'status_unpaid'},
+		{value: 'Paid', key: 'status_paid'},
+		{value: 'Overdue', key: 'status_overdue'},
+		{value: 'Deleted', key: 'status_deleted'}
 	];
-	for ( const statusItem of allStatuses ) {
-		html += '<option value=' + statusItem[0];
-		if ( currentStatus === statusItem[0] ) {
+
+	is_selected = false;
+	for ( const status of all_statuses ) {
+		html += '<option value=' + status.value;
+		if ( current_status === status.value ) {
 			html += ' selected';
+			is_selected = true;
 		}
-		html += '>' + zbscrm_JS_invoice_lang( statusItem[1] ) + '</option>';
+		html += '>' + zbscrm_JS_invoice_lang( status.key ) + '</option>';
+	}
+
+	// if set to some odd status, append it to the dropdown and select it
+	if (!is_selected && current_status !== '') {
+		html += '<option value="' + jpcrm.esc_attr(current_status) + '" selected>' + jpcrm.esc_html(current_status) + '</option>';
 	}
 	html += '</select>';
 	return html;

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -216,7 +216,7 @@ function zbscrm_JS_draw_invoice_actions_html( res ) {
 	html += '<div id="zbs_invoice_actions">';
 
 	html += '<div class="zbs-invoice-status">';
-	html += '<span class="' + res.invoiceObj.status + ' statty">' + res.invoiceObj.status + '</span>';
+	html += '<span class="' + jpcrm.esc_attr(res.invoiceObj.status) + ' statty">' + jpcrm.esc_html(res.invoiceObj.status_label) + '</span>';
 	html += '</div>';
 
 	//now the preview, download pdf, and send buttons controlled by the data output (not via complex PHP ifs on page)

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -3977,8 +3977,8 @@ function zeroBSCRMJS_listView_invoice_value( dataLine ) {
  */
 function zeroBSCRMJS_listView_invoice_status( dataLine ) {
 	var stat = '';
-	if ( typeof dataLine.status !== 'undefined' ) {
-		stat = dataLine.status;
+	if ( typeof dataLine.status_label !== 'undefined' ) {
+		stat = dataLine.status_label;
 	}
 	var color = '';
 	switch ( stat ) {

--- a/projects/plugins/crm/modules/portal/endpoints/class-invoices-endpoint.php
+++ b/projects/plugins/crm/modules/portal/endpoints/class-invoices-endpoint.php
@@ -91,7 +91,7 @@ class Invoices_Endpoint extends Client_Portal_Endpoint {
 					if (isset($cinv['id_override']) && !empty($cinv['id_override'])) $idStr = $cinv['id_override'];
 
 					// skip drafts if not an admin with invoice access
-					if ( $inv_status == __( 'Draft', 'zero-bs-crm' ) && !$is_invoice_admin ){
+					if ( $inv_status === 'Draft' && ! $is_invoice_admin ) { // phpcs:ignore Generic.WhiteSpace.ScopeIndent.IncorrectExact
 						continue;
 					}
 

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -360,7 +360,7 @@ function jpcrm_settings_page_html_woosync_main() {
 													?>
 													<?php
 													foreach ( $map_type_value['statuses'] as $status ) {
-														printf( '<option value="%s" %s>%s</option>', esc_attr( $status ), ( $selected === $status ? 'selected' : '' ), esc_html( $status ) );
+														printf( '<option value="%s" %s>%s</option>', esc_attr( $status ), ( $selected === $status ? 'selected' : '' ), esc_html( $obj_type_id === ZBS_TYPE_INVOICE ? __( $status, 'zero-bs-crm' ) : $status ) ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
 													}
 													?>
 												</select>

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -265,11 +265,11 @@ class Woo_Sync {
 			);
 
 			if ( in_array( $order_status, $paid_statuses, true ) ) {
-				$status = __( 'Paid', 'zero-bs-crm' );
+				$status = 'Paid';
 			} elseif ( $order_status === 'checkout-draft' ) {
-				$status = __( 'Draft', 'zero-bs-crm' );
+				$status = 'Draft';
 			} else {
-				$status = __( 'Unpaid', 'zero-bs-crm' );
+				$status = 'Unpaid';
 			}
 		} elseif ( $obj_type_id === ZBS_TYPE_TRANSACTION ) {
 			// note that transaction statuses aren't translated, as they're user-configurable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3303 - handle invoice status dropdown mismatches

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the invoice status in the database doesn't match an available status, the edit page dropdown defaults to the first item on the list, making it appear to be selected.

Quotes don't have real statuses, and contact statuses are not translated. This was already solved for transactions (#30644), but we need to the same for invoices.

This PR does the following:

* If the status is an unexpected one, it appends the status as a dropdown option and selects it.
* WooSync was translating some statuses before saving, and now it should properly save the status in English.
* Along with the above, the invoice object now has a `status_label` key that can be used to output the translated status (e.g. listviews, edit page, client portal, and contact/company profiles).

The larger issue involves the fact that we store labels instead of keys in the database (#1497), which hopefully will be addressed at a future date. This PR begins to lay the groundwork for invoice status keys, though the "key" stored in the database is just the English name for the status at this stage.

Note also that this won't fix any existing errant saves in the database. We haven't had any complaints on this to date, but if it comes up after this is released, the easiest fix is to do a full Woo resync.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Change the WP language to Spanish.
2. Create a Woo order and sync it to the CRM.

In `trunk`:
* 👍 It will show as expected in Spanish in the listview and Client Portal.
* 👍 It will show as expected in Spanish in the assigned contact or company profile.
* 👎  The status will save in the database in Spanish.
* 👎  Listview quickfilters don't match statuses.
* 👎 When editing the invoice, the status dropdown will look like it's set to the first status in the dropdown (`Borrador`), whereas it just wasn't able to find a match, so the dropdown defaults to the first item.
* 👎 If you set the invoice to a non-existent status via the database, the above point applies; the dropdown seems to have the first item selected.
* 👎 If you change the WP language back to English, the status shows in Spanish for the first two points.

In the `fix/crm/3303-fix_invoice_status_dropdown_mismatches` branch:
* 👍 It will show as expected in Spanish in the listview and Client Portal.
* 👍 It will show as expected in Spanish in the assigned contact or company profile.
* 👍 The status will save in the database in English.
* 👍  Listview quickfilters match statuses.
* 👍 When editing the invoice, the status dropdown will properly select the current status.
* 👍 If you set the invoice to a non-existent status via the database, the dropdown shows said status as selected.
* 👍 If you change the WP language back to English, the status shows in English everywhere.

