### PR TITLE
Add meta to subscription form GET parameters.

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -19,6 +19,12 @@ domReady( function () {
 		form.payments_attached = true;
 		form.addEventListener( 'submit', function ( event ) {
 			const email = form.querySelector( 'input[type=email]' ).value;
+			const email_clause = email ? `&email=${ encodeURIComponent( email ) }` : '';
+			const post_id = form.querySelector( 'input[name=post_id]' )?.value;
+			const post_id_clause = post_id ? `&post_id=${ post_id }` : '';
+			const tier_id = form.querySelector( 'input[name=tier_id]' )?.value;
+			const tier_id_clause = tier_id ? `&tier_id=${ tier_id }` : '';
+
 			if ( form.resubmitted || ! email ) {
 				return;
 			}
@@ -31,9 +37,10 @@ domReady( function () {
 				'&source=jetpack_subscribe' +
 				'&post_access_level=' +
 				form.dataset.post_access_level +
-				'&display=alternate&' +
-				'email=' +
-				encodeURIComponent( email );
+				'&display=alternate' +
+				post_id_clause +
+				tier_id_clause +
+				email_clause;
 			window.scrollTo( 0, 0 );
 			tb_show( null, url + '&TB_iframe=true', null );
 


### PR DESCRIPTION
Required by https://github.com/Automattic/gold/issues/143.

## Proposed changes:
* Adds the post metadata added in #32869 to the iframe GET parameters.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On clicking "subscribe" you can check the developer tools iframe loaded that it has the post_id and tier_id GET params.

