### PR TITLE
Repo gardening: update stats label name

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-stats-module-label-name
+++ b/projects/github-actions/repo-gardening/changelog/update-stats-module-label-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Labels: update Stats's label name.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -24,6 +24,11 @@ function cleanName( name ) {
 		name = 'Shortcodes / Embeds';
 	}
 
+	// We customize the Stats module's name to differentiate from the Stats UI (Stats dashboard).
+	if ( name === 'stats' ) {
+		name = 'Stats Data';
+	}
+
 	// We name our CPTs "Custom Content Types" to avoid confusion with WordPress's CPT.
 	if ( name === 'custom-post-types' ) {
 		name = 'Custom Content Types';


### PR DESCRIPTION
## Proposed changes:

We're updating the label name used for the Stats module, to differenciate it from the Stats app (the dashboard in wp-admin)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related discussion: p1693361697830399-slack-CQD1HH4MA

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test until this PR gets merged. Then, when making a change to `modules/stats.php`, the "Stats Data" label should be added instead of the "Stats" label.

