### PR TITLE
AI Excerpt: show notice when request fails

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-show-notice-re-attemps-when-error
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-show-notice-re-attemps-when-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: show notice when request fails

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { aiAssistantIcon, useAiSuggestions } from '@automattic/jetpack-ai-client';
+<<<<<<< HEAD
 import { TextareaControl, ExternalLink, Button } from '@wordpress/components';
+=======
+import { TextareaControl, ExternalLink, Notice } from '@wordpress/components';
+>>>>>>> ed57a596a8 (show notive when request fails)
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { useEffect, useState } from '@wordpress/element';
@@ -38,7 +42,11 @@ function AiPostExcerpt() {
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
+<<<<<<< HEAD
 	const { request, reset, suggestion, requestingState } = useAiSuggestions();
+=======
+	const { request, suggestion, requestingState, error } = useAiSuggestions();
+>>>>>>> ed57a596a8 (show notive when request fails)
 
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
@@ -93,6 +101,16 @@ function AiPostExcerpt() {
 				value={ currentExcerpt }
 				disabled={ isTextAreaDisabled }
 			/>
+
+			{ error?.code && error.code !== 'error_quota_exceeded' && (
+				<Notice
+					status={ error.severity }
+					isDismissible={ false }
+					className="jetpack-ai-assistant__error"
+				>
+					{ error.message }
+				</Notice>
+			) }
 
 			<AiExcerptControl
 				words={ excerptWordsNumber }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import { aiAssistantIcon, useAiSuggestions } from '@automattic/jetpack-ai-client';
-<<<<<<< HEAD
-import { TextareaControl, ExternalLink, Button } from '@wordpress/components';
-=======
-import { TextareaControl, ExternalLink, Notice } from '@wordpress/components';
->>>>>>> ed57a596a8 (show notive when request fails)
+import { TextareaControl, ExternalLink, Button, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { useEffect, useState } from '@wordpress/element';
@@ -42,15 +38,7 @@ function AiPostExcerpt() {
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-	const { request, reset, suggestion, requestingState } = useAiSuggestions();
-=======
-	const { request, suggestion, requestingState, error } = useAiSuggestions();
->>>>>>> ed57a596a8 (show notive when request fails)
-=======
 	const { request, suggestion, requestingState, error, reset } = useAiSuggestions();
->>>>>>> 53c4920da2 (reset suggestion when requesting)
 
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -43,10 +43,14 @@ function AiPostExcerpt() {
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 	const { request, reset, suggestion, requestingState } = useAiSuggestions();
 =======
 	const { request, suggestion, requestingState, error } = useAiSuggestions();
 >>>>>>> ed57a596a8 (show notive when request fails)
+=======
+	const { request, suggestion, requestingState, error, reset } = useAiSuggestions();
+>>>>>>> 53c4920da2 (reset suggestion when requesting)
 
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
@@ -69,6 +73,9 @@ function AiPostExcerpt() {
 	 * Request AI for a new excerpt.
 	 */
 	function requestExcerpt() {
+		// Reset suggestion state
+		reset();
+
 		const messageContext: ContentLensMessageContextProps = {
 			type: 'ai-content-lens',
 			contentType: 'post-excerpt',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR shows a notice in the sidebar panel when the request fails. 
The upgrade banner part going to be tabled here https://github.com/Automattic/jetpack/pull/32895

Part of https://github.com/Automattic/jetpack/issues/32883

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: show notice when request fails

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the block sidebar
* Look at the AI Excerpt panel
* Request an excerpt suggestion
* Since the server-side part is not handled yet, it will response with a `400` error (network). Confirm you see the notice:

https://github.com/Automattic/jetpack/assets/77539/72d8bfe4-b653-4115-b4b2-3d8f4d6fa0f2