### PR TITLE
Content Lens: pass post content when requesting post excerpt

### DIFF
--- a/projects/plugins/jetpack/changelog/update-content-lens-send-post-content
+++ b/projects/plugins/jetpack/changelog/update-content-lens-send-post-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Content Lens: pass post content when requesting post excerpt

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -8,6 +8,7 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { count } from '@wordpress/wordcount';
+import TurndownService from 'turndown';
 /**
  * Internal dependencies
  */
@@ -20,8 +21,12 @@ type ContentLensMessageContextProps = {
 	type: 'ai-content-lens';
 	contentType: 'post-excerpt';
 	postId: number;
+	content?: string;
 	words?: number;
 };
+
+// Turndown instance
+const turndownService = new TurndownService();
 
 function AiPostExcerpt() {
 	const excerpt = useSelect(
@@ -44,6 +49,18 @@ function AiPostExcerpt() {
 		removeEditorPanel( 'post-excerpt' );
 	}, [ removeEditorPanel ] );
 
+	const postContent = useSelect(
+		select => {
+			const content = select( 'core/editor' ).getEditedPostContent();
+			if ( ! content ) {
+				return '';
+			}
+
+			return turndownService.turndown( content );
+		},
+		[ postId ]
+	);
+
 	// Show custom prompt number of words
 	const numberOfWords = count( excerpt, 'words' );
 	const helpNumberOfWords = sprintf(
@@ -62,8 +79,11 @@ function AiPostExcerpt() {
 		const messageContext: ContentLensMessageContextProps = {
 			type: 'ai-content-lens',
 			contentType: 'post-excerpt',
-			words: excerptWordsNumber,
 			postId,
+			words: excerptWordsNumber,
+			content: `Post content:
+${ postContent }
+`,
 		};
 
 		const prompt = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR gets and sends the post content when requesting a post excerpt. We'd like to try to pick the content from the server side, but we're getting cache issues with Jetpack sites.
Additionally, being able to set the `content` is a good idea since it will allow us to scale the feature in other contexts beyond the block post.

Fixes https://github.com/Automattic/jetpack/issues/32918

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Content Lens: pass post content when requesting post excerpt

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Ensure your post has content
* Open the block sidebar
* Identify the AI Excerpt panel
* Request an excerpt suggestion
* Take a look at the `jetpack-ai-query` request. Confirm `content` has the current content of the post

<img width="800" alt="Screenshot 2023-09-07 at 11 06 31" src="https://github.com/Automattic/jetpack/assets/77539/d87f5a5e-d5fc-472c-af14-41b5f25ffe6f">
