### PR TITLE
Widgets Save Snackbar:  Notice overlaps admin menu

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-edit-widget-snackbar-notice-overlaps-admin-menu
+++ b/projects/plugins/jetpack/changelog/fix-edit-widget-snackbar-notice-overlaps-admin-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed an issue that caused the notice displayed when updating widgets to overlap the admin menu

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/admin-menu.css
@@ -39,6 +39,7 @@
 @media (min-width: 961px) {
 	body:not(.folded).auto-fold .interface-interface-skeleton,
 	.auto-fold .edit-post-layout .components-editor-notices__snackbar,
+	.components-snackbar-list.edit-widgets-notices__snackbar,
 	.jp-dialogue-modern-full__container {
 		left: 272px;
 	}


### PR DESCRIPTION
Fixes #https://github.com/Automattic/wp-calypso/issues/56461

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added the widgets editor notice class to the list of notices and other components that get shifted with the Masterbar's Admin menu

|Before|After|
|-----|-----|
|![Captura de Pantalla 2023-09-07 a las 13 27 02](https://github.com/Automattic/jetpack/assets/1989914/d06becfa-0d30-489f-9268-6eec394a87dd)|![Captura de Pantalla 2023-09-07 a las 13 27 47](https://github.com/Automattic/jetpack/assets/1989914/04f608ea-625f-4510-a38d-518dffaa4967)|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No product discussion.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Apply the changes made in this PR.
* Open {your site}/wp-admin/widgets.php
* Make some random changes and press save.
* The notice at the bottom left shouldn't overlap the Admin Menu anymore.

