### PR TITLE
Release mu-wpcom-plugin v1.6.18

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.0] - 2023-09-07
+### Added
+- Add HEIC/HEIF image upload support [#32900]
+- Add updater for WPCOM Marketplace plugins [#32872]
+
+### Changed
+- Update version numbers [#32902]
+
 ## [4.7.0] - 2023-09-06
 ### Added
 - Added Calypso paths for setup_free and domain_upsell tasks [#32851]
@@ -336,6 +344,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[4.8.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.7.0...v4.8.0
 [4.7.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.6.0...v4.7.0
 [4.6.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.5.1...v4.6.0
 [4.5.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v4.5.0...v4.5.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-marketplace-products-updater
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-marketplace-products-updater
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add updater for WPCOM Marketplace plugins

--- a/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
+++ b/projects/packages/jetpack-mu-wpcom/changelog/bump-jetpack-mu-wpcom-4-8-0-alpa
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update version numbers

--- a/projects/packages/jetpack-mu-wpcom/changelog/improve-jetpack-wpcom-heif-support
+++ b/projects/packages/jetpack-mu-wpcom/changelog/improve-jetpack-wpcom-heif-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add HEIC/HEIF image upload support

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "4.8.0-alpha",
+	"version": "4.8.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -14,7 +14,7 @@ namespace Automattic\Jetpack;
  */
 class Jetpack_Mu_Wpcom {
 
-	const PACKAGE_VERSION = '4.8.0-alpha';
+	const PACKAGE_VERSION = '4.8.0';
 	const PKG_DIR         = __DIR__ . '/../';
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.6.18 - 2023-09-07
+
 ## 1.6.17 - 2023-09-06
 
 ## 1.6.16 - 2023-09-04

--- a/projects/plugins/mu-wpcom-plugin/changelog/2023-09-06-18-07-19-807253
+++ b/projects/plugins/mu-wpcom-plugin/changelog/2023-09-06-18-07-19-807253
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_18_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ1_6_18"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 1.6.18-alpha
+ * Version: 1.6.18
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "1.6.18-alpha",
+	"version": "1.6.18",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
See p1694088128823839-slack-C01U2KGS2PQ

## Proposed changes:

Releases mu-wpcom-plugin v1.6.18

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

N/A