### PR TITLE
AI Excerpt: do not disable Generate button when there is a request error

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-do-not-disable-when-error
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-do-not-disable-when-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: do not disable Genertate button when there is a request error

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -53,7 +53,10 @@ function AiPostExcerpt() {
 		numberOfWords
 	);
 
-	const isGenerateButtonDisabled = requestingState === 'requesting';
+	const isGenerateButtonDisabled =
+		requestingState === 'requesting' ||
+		requestingState === 'suggesting' ||
+		requestingState === 'done';
 	const isBusy = requestingState === 'requesting' || requestingState === 'suggesting';
 	const isTextAreaDisabled = isBusy || requestingState === 'done';
 
@@ -136,7 +139,7 @@ function AiPostExcerpt() {
 					onClick={ () => requestExcerpt() }
 					variant="secondary"
 					isBusy={ isBusy }
-					disabled={ isGenerateButtonDisabled || requestingState !== 'init' }
+					disabled={ isGenerateButtonDisabled }
 				>
 					{ __( 'Generate', 'jetpack' ) }
 				</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When there is an error in the suggestion response, the Generate button should not be disabled. This PR checks the request status and don't disable the button when it's `error`.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: do not disable Generate button when there is a request error

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Ensure your post has content
* Open the block sidebar
* Identify the AI Excerpt panel
* Try to generate bad conditions to generate a response error. For instance, disable the network 

<img width="335" alt="Screenshot 2023-09-07 at 17 35 41" src="https://github.com/Automattic/jetpack/assets/77539/0be1df9a-1d8a-43b1-b4ab-9a94f97380d8">

* Request an excerpt suggestion
* Take a look at the jetpack-ai-query request. Confirm content has the current content of the post

Before (trunk) | After (this PR)
------|------
<img width="287" alt="Screenshot 2023-09-07 at 17 36 59" src="https://github.com/Automattic/jetpack/assets/77539/d7eca8d2-039b-46cf-ae76-954813338303"> | <img width="297" alt="Screenshot 2023-09-07 at 17 36 08" src="https://github.com/Automattic/jetpack/assets/77539/679799ab-f6ac-4848-a381-18922196528c">


