### PR TITLE
Boost: Update image CDN quality label

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ImageCdnQualityControl.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/ImageCdnQualityControl.svelte
@@ -17,10 +17,10 @@
 	<div class="jb-image-cdn-quality-control__label">
 		{label}
 	</div>
-	<div class="jb-image-cdn-quality-control__lossless">
+	<label class="jb-image-cdn-quality-control__lossless">
 		<input type="checkbox" bind:checked={config.lossless} />
 		{__( 'Lossless', 'jetpack-boost' )}
-	</div>
+	</label>
 	{#if ! config.lossless}
 		<div class="jb-image-cdn-quality-control__slider">
 			<NumberSlider bind:currentValue={config.quality} {minValue} {maxValue} />

--- a/projects/plugins/boost/changelog/update-image-cdn-quality
+++ b/projects/plugins/boost/changelog/update-image-cdn-quality
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+


### PR DESCRIPTION
Fixes Automattic/boost-cloud#368

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* pc9hqz-26I-p2#comment-1650

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to boost settings on a premium boost site.
* Try clicking on the text "Lossless" beside the checkbox in image CDN quality settings.