### PR TITLE
Boost: Fix performance history

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/components/performance-history.scss
+++ b/projects/plugins/boost/app/assets/src/css/components/performance-history.scss
@@ -10,5 +10,13 @@
 
     &__dummy {
         position: relative;
+        min-height: 300px;
+
+        .jp-components-spinner {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
     }
 }

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumTooltip.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/PremiumTooltip.svelte
@@ -16,29 +16,29 @@
 <Tooltip title={__( 'Manual Critical CSS regeneration', 'jetpack-boost' )}>
 	<p>
 		{__(
-			'Actions that could change your CSS or HTML structure included but are not limited to:',
+			'Actions that could change your CSS or HTML structure include, but are not limited to:',
 			'jetpack-boost'
 		)}
 	</p>
 	<ul>
-		<li>{__( 'Make theme changes.', 'jetpack-boost' )}</li>
-		<li>{__( 'Write a new post/page.', 'jetpack-boost' )}</li>
-		<li>{__( 'Edit a post/page.', 'jetpack-boost' )}</li>
+		<li>{__( 'Making theme changes.', 'jetpack-boost' )}</li>
+		<li>{__( 'Writing a new post/page.', 'jetpack-boost' )}</li>
+		<li>{__( 'Editing a post/page.', 'jetpack-boost' )}</li>
 		<li>
 			{__(
-				'Activate, deactivate, or update plugins that impact your site layout or HTML structure.',
+				'Activating, deactivating, or updating plugins that will be impacting your site layout or HTML structure.',
 				'jetpack-boost'
 			)}
 		</li>
 		<li>
 			{__(
-				'Change settings of plugins that impact your site layout or HTML structure.',
+				'Changing settings of plugins that will be impacting your site layout or HTML structure.',
 				'jetpack-boost'
 			)}
 		</li>
 		<li>
 			{__(
-				'Upgrade your WordPress version if the new release includes core CSS changes.',
+				'Upgrading your WordPress version if the new release will be including core CSS changes.',
 				'jetpack-boost'
 			)}
 		</li>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/History.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/History.svelte
@@ -13,7 +13,7 @@
 	const siteIsOnline = Jetpack_Boost.site.online;
 
 	let loadError;
-	let isLoading = false;
+	let isLoading = true;
 	let periods = [];
 	let startDate;
 	let endDate;
@@ -80,5 +80,6 @@
 		{periods}
 		{startDate}
 		{endDate}
+		{isLoading}
 	/>
 </div>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/sections/Modules.svelte
@@ -103,7 +103,7 @@
 		<svelte:fragment slot="cta">
 			<UpgradeCTA
 				description={__(
-					'Save time by upgrading to Automatic Critical CSS generation',
+					'Save time by upgrading to Automatic Critical CSS generation.',
 					'jetpack-boost'
 				)}
 			/>

--- a/projects/plugins/boost/app/assets/src/js/react-components/PerformanceHistory.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/PerformanceHistory.tsx
@@ -1,9 +1,15 @@
-import { BoostScoreGraph, Button, Gridicon, Popover } from '@automattic/jetpack-components';
+import {
+	BoostScoreGraph,
+	Button,
+	Gridicon,
+	Popover,
+	Spinner,
+} from '@automattic/jetpack-components';
 import { useState } from 'react';
 import { Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const DummyWithPopover = ( { children } ) => {
+const DummyGraph = ( { children } ) => {
 	return (
 		<div className="jb-performance-history__dummy">
 			{ children }
@@ -12,27 +18,28 @@ const DummyWithPopover = ( { children } ) => {
 		</div>
 	);
 };
-  
-export const PerformanceHistory = ( {
+
+const GraphComponent = ( {
 	periods,
-	onToggle,
-	isOpen,
 	startDate,
 	endDate,
-	needsUpgrade = false,
-	handleUpgrade = () => {
-		/* noop */
-	},
+	needsUpgrade,
+	handleUpgrade,
+	isLoading,
 } ) => {
+	if ( isLoading ) {
+		return (
+			<div className="jb-performance-history__dummy">
+				<Spinner color="#000000" />
+			</div>
+		);
+	}
+
 	const [ showFreshStartPopover, setFreshStartPopover ] = useState( periods.length === 0 );
 
-	let graphComponent = (
-		<BoostScoreGraph periods={ periods } startDate={ startDate } endDate={ endDate } />
-	);
-
 	if ( needsUpgrade ) {
-		graphComponent = (
-			<DummyWithPopover>
+		return (
+			<DummyGraph>
 				<Popover
 					icon={ <Gridicon icon="lock" /> }
 					action={
@@ -46,11 +53,13 @@ export const PerformanceHistory = ( {
 						) }
 					</p>
 				</Popover>
-			</DummyWithPopover>
+			</DummyGraph>
 		);
-	} else if ( showFreshStartPopover ) {
-		graphComponent = (
-			<DummyWithPopover>
+	}
+
+	if ( showFreshStartPopover ) {
+		return (
+			<DummyGraph>
 				<Popover
 					icon={ <Gridicon icon="checkmark" /> }
 					action={
@@ -65,10 +74,25 @@ export const PerformanceHistory = ( {
 						{ __( 'Your scores will be recorded from now on.', 'jetpack-boost' ) }
 					</p>
 				</Popover>
-			</DummyWithPopover>
+			</DummyGraph>
 		);
 	}
 
+	return <BoostScoreGraph periods={ periods } startDate={ startDate } endDate={ endDate } />;
+};
+
+export const PerformanceHistory = ( {
+	periods,
+	onToggle,
+	isOpen,
+	startDate,
+	endDate,
+	isLoading,
+	needsUpgrade = false,
+	handleUpgrade = () => {
+		/* noop */
+	},
+} ) => {
 	return (
 		<Panel>
 			<PanelBody
@@ -78,7 +102,16 @@ export const PerformanceHistory = ( {
 				className="jb-performance-history__panel"
 			>
 				<PanelRow>
-					<div style={ { flexGrow: 1, minHeight: '300px' } }>{ graphComponent }</div>
+					<div style={ { flexGrow: 1, minHeight: '300px' } }>
+						<GraphComponent
+							periods={ periods }
+							startDate={ startDate }
+							endDate={ endDate }
+							needsUpgrade={ needsUpgrade }
+							handleUpgrade={ handleUpgrade }
+							isLoading={ isLoading }
+						/>
+					</div>
 				</PanelRow>
 			</PanelBody>
 		</Panel>

--- a/projects/plugins/boost/app/assets/src/js/react-components/PerformanceHistory.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/PerformanceHistory.tsx
@@ -43,12 +43,12 @@ const GraphComponent = ( {
 				<Popover
 					icon={ <Gridicon icon="lock" /> }
 					action={
-						<Button onClick={ handleUpgrade }>{ __( 'Okay, got it!', 'jetpack-boost' ) }</Button>
+						<Button onClick={ handleUpgrade }>{ __( 'Upgrade now!', 'jetpack-boost' ) }</Button>
 					}
 				>
 					<p>
 						{ __(
-							'Upgrade and learn more about your site performance over time',
+							'Upgrade and learn more about your site performance over time.',
 							'jetpack-boost'
 						) }
 					</p>

--- a/projects/plugins/boost/app/assets/src/js/react-components/stories/performance-history.stories.tsx
+++ b/projects/plugins/boost/app/assets/src/js/react-components/stories/performance-history.stories.tsx
@@ -165,6 +165,7 @@ const meta: Meta< typeof PerformanceHistory > = {
 		periods: { control: 'object' },
 		onToggle: { action: 'toggled' },
 		isOpen: { control: 'boolean' },
+		isLoading: { control: 'boolean' },
 		needsUpgrade: { control: 'boolean' },
 	},
 	decorators: [
@@ -181,6 +182,7 @@ const defaultValues = {
 	endDate: exampleRawResponse.data._meta.end,
 	periods: exampleRawResponse.data.periods,
 	isOpen: true,
+	isLoading: false,
 	needsUpgrade: false,
 };
 

--- a/projects/plugins/boost/changelog/fix-performance-history
+++ b/projects/plugins/boost/changelog/fix-performance-history
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Grammar and punctuation fixes
+
+


### PR DESCRIPTION
Fixes Automattic/boost-cloud#369
Fixes Automattic/boost-cloud#370
## Proposed changes:
* Show a spinner while loading performance history
* Fix grammar and punctuation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-26I-p2#comment-1652
pc9hqz-26I-p2#comment-1658
pc9hqz-26I-p2#comment-1660

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to boost dashboard with premium on an existing site
* Throttle your network to a slower mode (e.g. fast 3g)
* Reload and see if you see the spinner instead of a popover saying boost will record performance from now on.