### PR TITLE
AI Excerpt: pick and pass raw post content to the server side

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-pass-raw-content
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-pass-raw-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: pick and pass raw post content to the server side

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -13,7 +13,6 @@ import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { count } from '@wordpress/wordcount';
 import React from 'react';
-import TurndownService from 'turndown';
 /**
  * Internal dependencies
  */
@@ -31,9 +30,6 @@ type ContentLensMessageContextProps = {
 	content?: string;
 	words?: number;
 };
-
-// Turndown instance
-const turndownService = new TurndownService();
 
 function AiPostExcerpt() {
 	const excerpt = useSelect(
@@ -59,6 +55,7 @@ function AiPostExcerpt() {
 		removeEditorPanel( 'post-excerpt' );
 	}, [ removeEditorPanel ] );
 
+	// Pick raw post content
 	const postContent = useSelect(
 		select => {
 			const content = select( 'core/editor' ).getEditedPostContent();
@@ -66,7 +63,13 @@ function AiPostExcerpt() {
 				return '';
 			}
 
-			return turndownService.turndown( content );
+			// return turndownService.turndown( content );
+			const document = new window.DOMParser().parseFromString( content, 'text/html' );
+
+			const documentRawText = document.body.textContent || document.body.innerText || '';
+
+			// Keep only one break line (\n) between blocks.
+			return documentRawText.replace( /\n{2,}/g, '\n' ).trim();
 		},
 		[ postId ]
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR picks and passes raw post content to the server side, instead of markdown format. Excerpt doesn't require enriched text at least for this implementation.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: pick and pass raw post content to the server side

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the block sidebar
* Ensure the post has unsaved changes
* Look at the AI Excerpt panel
* Request an excerpt suggestion
* Take a look at the request payload. Confirm it's raw text:

Before (trunk) | After (This PR)
--------|---------
<img width="621" alt="Screenshot 2023-09-08 at 11 32 11" src="https://github.com/Automattic/jetpack/assets/77539/afc8fd9f-8f88-416f-a719-36874e82184c"> | <img width="619" alt="Screenshot 2023-09-08 at 11 31 16" src="https://github.com/Automattic/jetpack/assets/77539/ec19410c-2379-4971-b316-6d74984b7685">

