### PR TITLE
Jetpack Sync: Drop Sync custom queue table when Jetpack is disconnected

### DIFF
--- a/projects/packages/sync/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/packages/sync/changelog/update-sync-drop-table-on-disconnection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Sync: Drop Sync custom queue table when Jetpack is disconnected

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -57,7 +57,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "1.56.x-dev"
+			"dev-trunk": "1.57.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-main.php
+++ b/projects/packages/sync/src/class-main.php
@@ -34,6 +34,9 @@ class Main {
 		// Any hooks below are special cases that need to be declared even if Sync is not allowed.
 		add_action( 'jetpack_site_registered', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );
 
+		// Sync clean up, when Jetpack is disconnected.
+		add_action( 'jetpack_site_disconnected', array( __CLASS__, 'on_jetpack_site_disconnected' ), 1000 );
+
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
 	}
@@ -43,6 +46,24 @@ class Main {
 	 */
 	public static function on_jetpack_idc_disconnect() {
 		Sender::get_instance()->uninstall();
+	}
+
+	/**
+	 * Sync cleanup on shutdown.
+	 */
+	public static function on_jetpack_site_disconnected() {
+		add_action( 'shutdown', array( __CLASS__, 'sync_cleanup' ), 10000 );
+	}
+
+	/**
+	 * Delete all sync related data on Site disconnect / clean up custom table.
+	 * Needs to happen on shutdown to prevent fatals.
+	 */
+	public static function sync_cleanup() {
+		Sender::get_instance()->uninstall();
+
+		$table_storage = new Queue_Storage_Table( 'test_queue' );
+		$table_storage->drop_table();
 	}
 
 	/**

--- a/projects/packages/sync/src/class-main.php
+++ b/projects/packages/sync/src/class-main.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Sync\Actions as Sync_Actions;
+use Automattic\Jetpack\Sync\Queue\Queue_Storage_Table;
 
 /**
  * Jetpack Sync main class.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '1.56.0';
+	const PACKAGE_VERSION = '1.57.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/backup/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/plugins/backup/changelog/update-sync-drop-table-on-disconnection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1299,7 +1299,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "52f24108a1066efeb6d1a214fd2d40f286631539"
+                "reference": "13867202a8d95960f5afa3e16324d8e42eac735a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1330,7 +1330,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/plugins/jetpack/changelog/update-sync-drop-table-on-disconnection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2513,7 +2513,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "52f24108a1066efeb6d1a214fd2d40f286631539"
+                "reference": "13867202a8d95960f5afa3e16324d8e42eac735a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2544,7 +2544,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/migration/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/plugins/migration/changelog/update-sync-drop-table-on-disconnection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1299,7 +1299,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "52f24108a1066efeb6d1a214fd2d40f286631539"
+                "reference": "13867202a8d95960f5afa3e16324d8e42eac735a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1330,7 +1330,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/plugins/protect/changelog/update-sync-drop-table-on-disconnection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1278,7 +1278,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "52f24108a1066efeb6d1a214fd2d40f286631539"
+                "reference": "13867202a8d95960f5afa3e16324d8e42eac735a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1309,7 +1309,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/plugins/search/changelog/update-sync-drop-table-on-disconnection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1358,7 +1358,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "52f24108a1066efeb6d1a214fd2d40f286631539"
+                "reference": "13867202a8d95960f5afa3e16324d8e42eac735a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1389,7 +1389,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/plugins/social/changelog/update-sync-drop-table-on-disconnection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1354,7 +1354,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "52f24108a1066efeb6d1a214fd2d40f286631539"
+                "reference": "13867202a8d95960f5afa3e16324d8e42eac735a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1385,7 +1385,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/starter-plugin/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/plugins/starter-plugin/changelog/update-sync-drop-table-on-disconnection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1214,7 +1214,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "52f24108a1066efeb6d1a214fd2d40f286631539"
+                "reference": "13867202a8d95960f5afa3e16324d8e42eac735a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1245,7 +1245,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/update-sync-drop-table-on-disconnection
+++ b/projects/plugins/videopress/changelog/update-sync-drop-table-on-disconnection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1278,7 +1278,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "52f24108a1066efeb6d1a214fd2d40f286631539"
+                "reference": "13867202a8d95960f5afa3e16324d8e42eac735a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1309,7 +1309,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.56.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Drops Sync custom queue table when Jetpack is disconnected

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Sync\Main`: Add `jetpack_site_disconnected` hook, that will ensure Sync cleanup (drop custom table, reset Sync data etc) when Jetpack is disconnected. This needs to also happen on shutdown to prevent fatals.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-7e6-p2#comment-10025

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
Pre-requisites: A JP connected site with the Jetpack plugin active

- Go to Jetpack Debugger and enable the Sync custom queue table in the Sync settings section
- In cli run: `wp db tables --all-tables` and confirm `wp_jetpack_sync_queue` table is present
- Deactivate Jetpack
- In cli run: `wp db tables --all-tables` and confirm `wp_jetpack_sync_queue` table is NOT present
- Make sure no fatals occurred

**Repeat the above steps with at least 2 Jetpack plugins present.**

Note: There's an unhandled edge case when 2 Jetpack plugins are present (eg one on this branch - Protect, another on latest stable - Jetpack). In this case, if we first deactivate Protect and then Jetpack, the table will not be dropped. See linked Jetpack product discussion for details.