### PR TITLE
AI Excerpt: re-enable generate button when options change

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-escerpt-re-enable-when-options-change
+++ b/projects/plugins/jetpack/changelog/update-ai-escerpt-re-enable-when-options-change
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: re enable generate button when options change

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/content-lens/plugins/ai-post-excerpt/index.tsx
@@ -50,10 +50,13 @@ function AiPostExcerpt() {
 	// Post excerpt words number
 	const [ excerptWordsNumber, setExcerptWordsNumber ] = useState( 50 );
 
+	// Re enable the AI Excerpt component
+	const [ reenable, setReenable ] = useState( false );
+
 	// Remove core excerpt panel
 	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
 
-	const { request, suggestion, requestingState, error, reset } = useAiSuggestions();
+	const { request, suggestion, requestingState, error, reset } = useAiSuggestions( {} );
 
 	useEffect( () => {
 		removeEditorPanel( 'post-excerpt' );
@@ -83,7 +86,8 @@ function AiPostExcerpt() {
 	const isGenerateButtonDisabled =
 		requestingState === 'requesting' ||
 		requestingState === 'suggesting' ||
-		requestingState === 'done';
+		( requestingState === 'done' && ! reenable );
+
 	const isBusy = requestingState === 'requesting' || requestingState === 'suggesting';
 	const isTextAreaDisabled = isBusy || requestingState === 'done';
 
@@ -95,6 +99,12 @@ function AiPostExcerpt() {
 	 */
 	async function requestExcerpt( ev: React.MouseEvent ): Promise< void > {
 		await autosave( ev );
+
+		// Enable Generate button
+		setReenable( false );
+
+		// Reset suggestion state
+		reset();
 
 		const messageContext: ContentLensMessageContextProps = {
 			type: 'ai-content-lens',
@@ -163,7 +173,10 @@ ${ postContent }
 
 				<AiExcerptControl
 					words={ excerptWordsNumber }
-					onWordsNumberChange={ setExcerptWordsNumber }
+					onWordsNumberChange={ wordsNumber => {
+						setExcerptWordsNumber( wordsNumber );
+						setReenable( true );
+					} }
 					disabled={ isBusy || isQuotaExceeded }
 				/>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR re-enables the Generate button when the user changes the AI Excerpt options. For now, it means when it changes the _Number of words_ through the range control

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: re-enable generate button when options change

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the block sidebar
* Look at the AI Excerpt panel
* Request an excerpt suggestion
* Confirm the `Generate` button gets disabled from the requests until the response is onde.
* Confirm that, after change the number or words, the Generate button gets enabled again

https://github.com/Automattic/jetpack/assets/77539/85118264-612a-4494-859b-ac148f5bb616


