### PR TITLE
CRM: Add crm webpack alias

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-webpack-alias
+++ b/projects/plugins/crm/changelog/add-crm-webpack-alias
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add crm alias to webpack config
+
+

--- a/projects/plugins/crm/webpack.config.js
+++ b/projects/plugins/crm/webpack.config.js
@@ -120,6 +120,9 @@ const crmWebpackConfig = {
 	},
 	resolve: {
 		...jetpackWebpackConfig.resolve,
+		alias: {
+			"crm": path.resolve(__dirname, "src/js/")	
+		}
 	},
 	node: false,
 	plugins: [

--- a/projects/plugins/crm/webpack.config.js
+++ b/projects/plugins/crm/webpack.config.js
@@ -122,7 +122,7 @@ const crmWebpackConfig = {
 		...jetpackWebpackConfig.resolve,
 		alias: {
 			...jetpackWebpackConfig.resolve.alias,
-			"crm": path.resolve(__dirname, "src/js/")	
+			crm: path.resolve( __dirname, 'src/js/' ),
 		}
 	},
 	node: false,

--- a/projects/plugins/crm/webpack.config.js
+++ b/projects/plugins/crm/webpack.config.js
@@ -121,6 +121,7 @@ const crmWebpackConfig = {
 	resolve: {
 		...jetpackWebpackConfig.resolve,
 		alias: {
+			...jetpackWebpackConfig.resolve.alias,
 			"crm": path.resolve(__dirname, "src/js/")	
 		}
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/zero-bs-crm/issues/3305

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

In tsconfig.json there is a "crm/*" path which allows the reference of JS code by direct paths instead of relative paths. e.g. "crm/components/*" instead of "../../*" for component files.

This allowed the TS compiler to understand these paths, but Webpack was not correctly understanding these paths. This PR adds a Webpack alias so that it will understand these paths.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Build the JavaScript with `pnpm build` and make sure everything compiles. The actual error only happened at runtime and there is no code in trunk that will currently exhibit this, so there is no functionality to test. This was found and fixed in https://github.com/Automattic/jetpack/pull/32907 so you may run that if you really want to test it.