### PR TITLE
CRM: Resolves #3306 - fix unit test deprecation notices

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3306-fix_unit_test_deprecation_notices
+++ b/projects/plugins/crm/changelog/fix-crm-3306-fix_unit_test_deprecation_notices
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Removed dynamic properties for unit test compatibility for PHP 8.2
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -55,6 +55,13 @@ final class ZeroBSCRM {
 	public $db_version = '3.0';
 
 	/**
+	 * Database details.
+	 *
+	 * @var array
+	 */
+	public $database_server_info = array();
+
+	/**
 	 * ZeroBSCRM DAL version.
 	 *
 	 * @var string
@@ -778,7 +785,7 @@ final class ZeroBSCRM {
 	 */
 	public function get_database_server_info() {
 
-		if ( ! isset( $this->database_server_info ) ) {
+		if ( empty( $this->database_server_info ) ) {
 			global $wpdb;
 			$raw_version                = $wpdb->get_var( 'SELECT VERSION()' );
 			$version                    = preg_replace( '/[^0-9.].*/', '', $raw_version );

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -134,6 +134,7 @@ class zbsDAL {
     public $transactions = false;
     public $forms = false;
     public $events = false;
+		public $eventreminders = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
     public $logs = false;
     public $lineitems = false;
     public $quotetemplates = false;

--- a/projects/plugins/crm/includes/class-crm-modules.php
+++ b/projects/plugins/crm/includes/class-crm-modules.php
@@ -11,6 +11,8 @@ namespace Automattic\JetpackCRM;
 // block direct access
 defined( 'ZEROBSCRM_PATH' ) || exit;
 
+// Prevent PHP 8.2 deprecation notices, as we currently add each module as a dynamic property
+#[\AllowDynamicProperties]
 class CRM_Modules {
 
 	/**

--- a/projects/plugins/crm/includes/jpcrm-dependency-checker.php
+++ b/projects/plugins/crm/includes/jpcrm-dependency-checker.php
@@ -10,8 +10,26 @@ if ( ! defined( 'ZEROBSCRM_PATH' ) ) exit;
 
 class JPCRM_DependencyChecker {
 
-  protected $core_ver;
-  protected $dal_ver;
+	/**
+	 * An array of plugins installed.
+	 *
+	 * @var array
+	 */
+	public $all_plugins = array();
+
+	/**
+	 * The current version of core.
+	 *
+	 * @var string
+	 */
+	protected $core_ver;
+
+	/**
+	 * The current version of DAL.
+	 *
+	 * @var string
+	 */
+	protected $dal_ver;
 
   public function __construct( ) {
     if ( ! function_exists( 'get_plugins' ) ) {

--- a/projects/plugins/crm/includes/jpcrm-feature-sniffer.php
+++ b/projects/plugins/crm/includes/jpcrm-feature-sniffer.php
@@ -9,12 +9,25 @@ if ( !defined( 'ZEROBSCRM_PATH' ) ) exit;
  */
 class JPCRM_FeatureSniffer {
 
+	/**
+	 * An array of plugins installed.
+	 *
+	 * @var array
+	 */
+	public $all_plugins = array();
+
+	/**
+	 * An array of alerts to display to user.
+	 *
+	 * @var array
+	 */
+	public $alerts = array();
+
 	public function __construct() {
 		if ( !function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 		$this->all_plugins = get_plugins();
-		$this->alerts = array();
 	}
 
 	/**

--- a/projects/plugins/crm/phpunit.xml.dist
+++ b/projects/plugins/crm/phpunit.xml.dist
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
-	<testsuites>
-		<testsuite name="rest-api">
-			<directory suffix="test.php">tests/php/rest-api</directory>
-		</testsuite>
-		<testsuite name="automation">
-			<directory suffix="test.php">tests/php/automation</directory>
-		</testsuite>
-		<testsuite name="event-manager">
-			<directory suffix="test.php">tests/php/event-manager</directory>
-		</testsuite>
-	</testsuites>
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="false">
-			<file>ZeroBSCRM.php</file>
-			<directory suffix=".php">api</directory>
-			<directory suffix=".php">includes</directory>
-			<directory suffix=".php">modules</directory>
-			<directory suffix=".php">src</directory>
-		</whitelist>
-	</filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="false">
+    <include>
+      <file>ZeroBSCRM.php</file>
+      <directory suffix=".php">api</directory>
+      <directory suffix=".php">includes</directory>
+      <directory suffix=".php">modules</directory>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="rest-api">
+      <directory suffix="test.php">tests/php/rest-api</directory>
+    </testsuite>
+    <testsuite name="automation">
+      <directory suffix="test.php">tests/php/automation</directory>
+    </testsuite>
+    <testsuite name="event-manager">
+      <directory suffix="test.php">tests/php/event-manager</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/projects/plugins/crm/tests/php/bootstrap.php
+++ b/projects/plugins/crm/tests/php/bootstrap.php
@@ -49,6 +49,7 @@ Failed to automatically locate WordPress or wordpress-develop to run tests.
 
 Set the WP_DEVELOP_DIR environment variable to point to a copy of WordPress
 or wordpress-develop.
+
 EOF
 	);
 	exit( 1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

CRM: Resolves Automattic/zero-bs-crm#3306 - fix unit test deprecation notices

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Due to the use of dynamic properties in some of our classes, we get several deprecation notices when running unit tests on PHP 8.2. This PR makes most of the properties static. The `CRM_Modules` class uses an exception ([`#[\AllowDynamicProperties]`](https://www.php.net/manual/en/class.allowdynamicproperties.php)), as the current setup adds arbitrary modules as properties and refactoring is out of scope.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Run `composer run phpunit` in PHP 8.2

In `trunk`, one will see lots of deprecation messages.

In the `fix/crm/3306-fix_unit_test_deprecation_notices` branch, the deprecation notices are no more.