### PR TITLE
SAL: Defenseive coding for optionally returned item

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-undefined-key
+++ b/projects/plugins/jetpack/changelog/fix-undefined-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Resolves an undefined key error on sites with uploaded media without file extensions.

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -915,7 +915,7 @@ abstract class SAL_Post {
 
 		$file      = basename( wp_get_attachment_url( $media_item->ID ) );
 		$file_info = pathinfo( $file );
-		$ext       = $file_info['extension'];
+		$ext       = isset( $file_info['extension'] ) ? $file_info['extension'] : '';
 
 		$response = array(
 			'ID'          => $media_item->ID,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://wordpress.org/support/topic/php-warning-undefined-array-key-extension-in-jetpack-sal-c/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `extension` is optionally returned from `pathinfo` if PHP detects an extension. Let's set it to an empty string if it has not been returned.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
n/a

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unsure. I think it would be related to uploading a file without an extension to the media library, then perhaps try to retrieve it via the WP.com API (e.g. Calypso). Didn't trace the actual code path to duplicate.

