### PR TITLE
SAL: prevent a potential undefined function error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-undefined-function-code
+++ b/projects/plugins/jetpack/changelog/fix-undefined-function-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+SAL: prevent a potential undefined function error

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -823,10 +823,12 @@ abstract class SAL_Post {
 	 * @param string $email The user's email.
 	 * @param int    $avatar_size The size of the avatar in pixels.
 	 *
+	 * @todo Provide a non-WP.com option.
+	 *
 	 * @return string
 	 */
 	protected function get_avatar_url( $email, $avatar_size = 96 ) {
-		$avatar_url = wpcom_get_avatar_url( $email, $avatar_size, '', true );
+		$avatar_url = function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $email, $avatar_size ) : '';
 		if ( ! $avatar_url || is_wp_error( $avatar_url ) ) {
 			return '';
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Just looking at the code while patching something else and I see this unguarded WP.com function in Jetpack. Let's handle it nicely just to be safe.

I'm not sure if this code ever actually gets hit in Jetpack based on the lack of previous reports, but rather prevent the fatal than assume no one ever hits it. I'm guessing our SAL never hits it, going for the similar function in Jetpack child class.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a function_exists check on a WP.com function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None. This should be extracted to the WP.com SAL layer and have this function just be an abstract, but that's for another day.

