### PR TITLE
Chat with a blog: Prompt config

### DIFF
--- a/projects/packages/search/changelog/prompt-config
+++ b/projects/packages/search/changelog/prompt-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/packages/search/src/class-settings.php
+++ b/projects/packages/search/src/class-settings.php
@@ -37,6 +37,7 @@ class Settings {
 		// NOTE: This contains significant code overlap with class-jetpack-search-customize.
 		$setting_prefix = Options::OPTION_PREFIX;
 		$settings       = array(
+			array( $setting_prefix . 'ai_prompt_override', 'string', '' ),
 			array( $setting_prefix . 'color_theme', 'string', 'light' ),
 			array( $setting_prefix . 'result_format', 'string', 'minimal' ),
 			array( $setting_prefix . 'default_sort', 'string', 'relevance' ),

--- a/projects/packages/search/src/class-settings.php
+++ b/projects/packages/search/src/class-settings.php
@@ -37,7 +37,6 @@ class Settings {
 		// NOTE: This contains significant code overlap with class-jetpack-search-customize.
 		$setting_prefix = Options::OPTION_PREFIX;
 		$settings       = array(
-			array( $setting_prefix . 'ai_prompt_override', 'string', '' ),
 			array( $setting_prefix . 'color_theme', 'string', 'light' ),
 			array( $setting_prefix . 'result_format', 'string', 'minimal' ),
 			array( $setting_prefix . 'default_sort', 'string', 'relevance' ),

--- a/projects/packages/sync/changelog/prompt-config
+++ b/projects/packages/sync/changelog/prompt-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -1740,6 +1740,7 @@ class Search extends Module {
 	 * @var array
 	 */
 	private static $options_to_sync = array(
+		'jetpack_search_ai_prompt_override',
 		'jetpack_search_color_theme',
 		'jetpack_search_result_format',
 		'jetpack_search_default_sort',

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -1740,7 +1740,6 @@ class Search extends Module {
 	 * @var array
 	 */
 	private static $options_to_sync = array(
-		'jetpack_search_ai_prompt_override',
 		'jetpack_search_color_theme',
 		'jetpack_search_result_format',
 		'jetpack_search_default_sort',

--- a/projects/plugins/jetpack/changelog/chat-with-blog-prompt-config
+++ b/projects/plugins/jetpack/changelog/chat-with-blog-prompt-config
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added prompt override for the chat-with-a-blog feature

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
@@ -29,6 +29,24 @@ function register_block() {
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
+ * Register the setting for the AI prompt override.
+ */
+function register_settings() {
+	register_setting(
+		'general',
+		'jetpack_search_ai_prompt_override',
+		array(
+			'type'         => 'string',
+			'show_in_rest' => true,
+			'description'  => __( 'Override for the Jetpack AI prompt in the Jetpack AI Search feature.', 'jetpack' ),
+			'defualt'      => '',
+		)
+	);
+}
+
+add_action( 'rest_api_init', __NAMESPACE__ . '\register_settings' );
+
+/**
  * Jetpack AI Paragraph block registration/dependency declaration.
  *
  * @param array $attr Array containing the Jetpack AI Chat block attributes.

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/controls.js
@@ -30,20 +30,13 @@ export function AiChatControls( { setAttributes, askButtonLabel } ) {
 			</InspectorControls>
 			<InspectorAdvancedControls>
 				<BaseControl
-					label={ __( 'Prompt override', 'jetpack' ) }
+					label={ __( 'Additional instructions', 'jetpack' ) }
 					help={ __(
-						'This will override the default prompt used in Jetpack AI Search. Relevant documents from your blog and the user question is passed to Jetpack AI to produce an answer. You can change the tone and behaviour of Jetpack AI Search by tweaking this prompt, but it requires caution and may result in unwanted behaviour.',
+						'This will instruct Jetpack AI to adjust the answer in a certain way. You can ask it to only provide one sentence response, or make it talk like a pirate, but please remember your instructions may have unintended consequences.',
 						'jetpack'
 					) }
 				>
-					<TextareaControl
-						placeholder={ __(
-							'Based on the content and relevant URLs provided below, all from a blog written by the same author, answer the following question…',
-							'jetpack'
-						) }
-						value={ promptOverride }
-						onChange={ setPromptOverride }
-					/>
+					<TextareaControl value={ promptOverride } onChange={ setPromptOverride } />
 				</BaseControl>
 			</InspectorAdvancedControls>
 		</>

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/controls.js
@@ -35,14 +35,14 @@ export function AiChatControls( { setAttributes, askButtonLabel } ) {
 						'This will override the default prompt used in Jetpack AI Search. Relevant documents from your blog and the user question is passed to Jetpack AI to produce an answer. You can change the tone and behaviour of Jetpack AI Search by tweaking this prompt, but it requires caution and may result in unwanted behaviour.',
 						'jetpack'
 					) }
-					value={ promptOverride }
-					onChange={ setPromptOverride }
 				>
 					<TextareaControl
 						placeholder={ __(
 							'Based on the content and relevant URLs provided below, all from a blog written by the same author, answer the following question…',
 							'jetpack'
 						) }
+						value={ promptOverride }
+						onChange={ setPromptOverride }
 					/>
 				</BaseControl>
 			</InspectorAdvancedControls>

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/controls.js
@@ -1,20 +1,51 @@
-import { BaseControl, PanelBody, TextControl } from '@wordpress/components';
+import { InspectorAdvancedControls, InspectorControls } from '@wordpress/block-editor';
+import { BaseControl, PanelBody, TextControl, TextareaControl } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 
 export function AiChatControls( { setAttributes, askButtonLabel } ) {
+	const [ promptOverride, setPromptOverride ] = useEntityProp(
+		'root',
+		'site',
+		'jetpack_search_ai_prompt_override'
+	);
 	return (
-		<PanelBody title={ __( 'Settings', 'jetpack' ) } initialOpen={ false }>
-			<BaseControl
-				label={ __( 'Ask button', 'jetpack' ) }
-				help={ __( 'What do you want the button to say?', 'jetpack' ) }
-				className="jetpack-ai-chat__ask-button-text"
-			>
-				<TextControl
-					placeholder={ __( 'Ask', 'jetpack' ) }
-					onChange={ newAskButtonLabel => setAttributes( { askButtonLabel: newAskButtonLabel } ) }
-					value={ askButtonLabel }
-				/>
-			</BaseControl>
-		</PanelBody>
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack' ) } initialOpen={ false }>
+					<BaseControl
+						label={ __( 'Ask button', 'jetpack' ) }
+						help={ __( 'What do you want the button to say?', 'jetpack' ) }
+						className="jetpack-ai-chat__ask-button-text"
+					>
+						<TextControl
+							placeholder={ __( 'Ask', 'jetpack' ) }
+							onChange={ newAskButtonLabel =>
+								setAttributes( { askButtonLabel: newAskButtonLabel } )
+							}
+							value={ askButtonLabel }
+						/>
+					</BaseControl>
+				</PanelBody>
+			</InspectorControls>
+			<InspectorAdvancedControls>
+				<BaseControl
+					label={ __( 'Prompt override', 'jetpack' ) }
+					help={ __(
+						'This will override the default prompt used in Jetpack AI Search. Relevant documents from your blog and the user question is passed to Jetpack AI to produce an answer. You can change the tone and behaviour of Jetpack AI Search by tweaking this prompt, but it requires caution and may result in unwanted behaviour.',
+						'jetpack'
+					) }
+					value={ promptOverride }
+					onChange={ setPromptOverride }
+				>
+					<TextareaControl
+						placeholder={ __(
+							'Based on the content and relevant URLs provided below, all from a blog written by the same author, answer the following question…',
+							'jetpack'
+						) }
+					/>
+				</BaseControl>
+			</InspectorAdvancedControls>
+		</>
 	);
 }


### PR DESCRIPTION
Addresses: #32949 

This adds the ability to override a prompt in Jetpack "Chat with a blog" feature. This allows for tweaking the prompt to change the behavior of the chat.


<img width="977" alt="Zrzut ekranu 2023-09-13 o 14 09 21" src="https://github.com/Automattic/jetpack/assets/3775068/0cdd19e7-1a4b-4365-a7fc-1bf7a526eaba">
<img width="721" alt="Zrzut ekranu 2023-09-13 o 14 09 00" src="https://github.com/Automattic/jetpack/assets/3775068/0f22ce63-2944-480c-b77c-3567d9421c1d">


## Does this pull request change what data or activity we track or use?
NO

## Testing instructions:

1. Check out D121589-code on wpcom sandbox
2. Do `sudo global-http enable` on sandbox
3. Get a Jetpack site, connect to WPCOM
4. Purchase / enable Jetpack Search
6. Point Jetpack sync to your sandbox in `/wp-admin/options-general.php?page=companion_settings`
7. Set JETPACK_BLOCKS_VARIATION to beta
8. Publish a few posts
9. Insert the block on a page
10. **Add additional instructions in the PROMPT OVERRIDE sidebar field (under Advanced)**
11. Publish/save
12. Open the page on the frontend
13. Ask a question relating to your published posts
14. Get a WPCOM site, sandbox public-api AND site domain, apply D121589-code
15. bin/jetpack-downloader test jetpack chat-with-site/wpcom
16. Get Jetpack search product ( click upgrade jetpack search on /wp-admin/admin.php?page=jetpack-search )
17. Publish a few posts
9. Insert the block on a page
10. **Add additional instructions in the PROMPT OVERRIDE sidebar field (under Advanced)**
11. Publish/save
12. Ask a question relating to your published posts