### PR TITLE
AI Excerpt: remove core Excerpt panel when registering the AI Excerpt one

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-extend-when-registering-plugin
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-extend-when-registering-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: remove core Excerpt panel when registering the AI Excerpt one

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/editor.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
+import { dispatch } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
@@ -35,6 +36,9 @@ function extendAiContentLensFeatures( settings, name ) {
 
 	// Register AI Excerpt plugin.
 	registerJetpackPlugin( aiExcerptPluginName, aiExcerptPluginSettings );
+
+	// Remove the excerpt panel by dispatching an action.
+	dispatch( 'core/edit-post' )?.removeEditorPanel( 'post-excerpt' );
 
 	return settings;
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -9,7 +9,7 @@ import {
 import { TextareaControl, ExternalLink, Button, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { count } from '@wordpress/wordcount';
 import React from 'react';
@@ -49,14 +49,7 @@ function AiPostExcerpt() {
 	// Re enable the AI Excerpt component
 	const [ reenable, setReenable ] = useState( false );
 
-	// Remove core excerpt panel
-	const { removeEditorPanel } = useDispatch( 'core/edit-post' );
-
 	const { request, suggestion, requestingState, error, reset } = useAiSuggestions( {} );
-
-	useEffect( () => {
-		removeEditorPanel( 'post-excerpt' );
-	}, [ removeEditorPanel ] );
 
 	// Pick raw post content
 	const postContent = useSelect(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This pull request moves the code that removes the core Excerpt panel out of the AI Excerpt panel component, ensuring that both panels are not present at the same time.

Fixes https://github.com/Automattic/jetpack/issues/32996

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: remove core Excerpt panel when registering the AI Excerpt one

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Confirm you see the `AI Excerpt` panel and the core one gets removed when the `beta` extensions are enabled
* Confirm you never see both panels at the same time