### PR TITLE
Add videopress and complete bi-yearly constants

### DIFF
--- a/projects/packages/videopress/changelog/add-bi-yearly-constants-to-videopress-plugin
+++ b/projects/packages/videopress/changelog/add-bi-yearly-constants-to-videopress-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add bi-yearly constants for complete and videopress in config

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -50,8 +50,10 @@ export const usePlan = (): usePlanProps => {
 	}
 
 	const hasVideoPressPurchase = [
+		'jetpack_videopress_bi_yearly',
 		'jetpack_videopress',
 		'jetpack_videopress_monthly',
+		'jetpack_complete_bi_yearly',
 		'jetpack_complete',
 		'jetpack_complete_monthly',
 		'jetpack_business',


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/8481

## Proposed changes:

 * Add complete and videopress bi-yearly constants to videopress config array

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

I could not reproduce the error on an ephemeral site that was reported in the issues, however these constants should still be added so these instructions are just testing to make sure the videopress plugin works as expected with a Complete or VideoPress plan

1. Checkout this branch locally or use the beta tester on an ephemeral site
2. Purchase a VideoPress bi-yearly plans
3. Install the VideoPress plugin and go to /wp-admin/admin.php?page=jetpack-videopress#/
4. Make sure the page behaves correctly to show the active plan
![image](https://github.com/Automattic/jetpack/assets/65001528/43d117d5-dafc-4050-a8c6-41f333395fc1)
5. Purchase a Complete plan and check the same thing