### PR TITLE
Boost: Fix invalid html ID for concatenated stylesheets

### DIFF
--- a/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
+++ b/projects/plugins/boost/app/lib/minify/Concatenate_CSS.php
@@ -185,7 +185,7 @@ class Concatenate_CSS extends WP_Styles {
 				}
 
 				$handles = array_keys( $css );
-				$css_id  = "$media-css-" . md5( $href );
+				$css_id  = sanitize_title_with_dashes( $media ) . '-css-' . md5( $href );
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					$style_tag = "<link data-handles='" . esc_attr( implode( ',', $handles ) ) . "' rel='stylesheet' id='$css_id' href='$href' type='text/css' media='$media' />";
 				} else {

--- a/projects/plugins/boost/changelog/fix-css-concat-invalid-html-id
+++ b/projects/plugins/boost/changelog/fix-css-concat-invalid-html-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed generating invalid html ID values for concatenated stylesheets.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/29041

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes invalid HTML IDs for stylesheets when the media query is resolution specific.

Before patch:
`id='only screen and (max-width: 768px)-css-ac63dff77c72fffa799551ed1ab3537f'`

After patch:
`id='only-screen-and-max-width-768px-css-ac63dff77c72fffa799551ed1ab3537f'`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Pre-requisites:**
WooCommerce with test pages (the shop page for example) and Boost with CSS Concatenation.

### Test that the ID is invalid:
* Check out Boost trunk;
* Open the shop page and check the id for the `woocommerce-smallscreen` stylesheet;
* It should be invalid.

### Test that the ID is valid:
* Apply the patch;
* Open the shop page and check the id for the `woocommerce-smallscreen` stylesheet;
* It should valid.