### PR TITLE
CRM: Resolves #3307 - increase minimum PHP version to 7.3

### DIFF
--- a/projects/plugins/crm/.phpcs.dir.phpcompatibility.xml
+++ b/projects/plugins/crm/.phpcs.dir.phpcompatibility.xml
@@ -1,10 +1,4 @@
 <?xml version="1.0"?>
 <ruleset>
-	<rule ref="Jetpack-Compat-72" />
-
-	<!-- WordPress core polyfills this. -->
-	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.array_key_lastFound">
-		<severity>0</severity>
-	</rule>
-
+	<rule ref="Jetpack-Compat-73" />
 </ruleset>

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -8,7 +8,7 @@
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm
  * Requires at least: 5.0
- * Requires PHP: 7.2
+ * Requires PHP: 7.3
  * License: GPLv2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
@@ -99,7 +99,7 @@ add_action( 'activate_plugin', 'jpcrm_activation_checks', 10, 2 );
  * @return bool
  */
 function jpcrm_check_min_php_version() {
-	$min_php_version = '7.2';
+	$min_php_version = '7.3';
 
 	if ( version_compare( PHP_VERSION, $min_php_version, '<' ) ) {
 

--- a/projects/plugins/crm/changelog/fix-crm-increase_min_php_to_7.3
+++ b/projects/plugins/crm/changelog/fix-crm-increase_min_php_to_7.3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Requires PHP 7.3 or higher

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -4,7 +4,7 @@ Tags: CRM, Invoice, Woocommerce CRM, Clients, Lead Generation, contacts, custome
 Tested up to: 6.3
 Stable tag: 6.0.0
 Requires at least: 5.0
-Requires PHP: 7.2
+Requires PHP: 7.3
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/projects/plugins/crm/tests/action-skip-test-php.sh
+++ b/projects/plugins/crm/tests/action-skip-test-php.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if php -r 'exit( version_compare( PHP_VERSION, "7.2.0", "<" ) ? 0 : 1 );'; then
-	echo "PHP version is too old to run tests. 7.2 is required, but $(php -r 'echo PHP_VERSION;') is installed. Skipping.";
+if php -r 'exit( version_compare( PHP_VERSION, "7.3.0", "<" ) ? 0 : 1 );'; then
+	echo "PHP version is too old to run tests. 7.3 is required, but $(php -r 'echo PHP_VERSION;') is installed. Skipping.";
 	exit 3
 fi
 

--- a/tools/parallel-lint.sh
+++ b/tools/parallel-lint.sh
@@ -26,13 +26,16 @@ if $ALL; then
 	SKIPS=()
 	if php -r 'exit( PHP_VERSION_ID < 70000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php7 )
-	elif php -r 'exit( PHP_VERSION_ID < 70300 ? 0 : 1 );'; then
+	fi
+	if php -r 'exit( PHP_VERSION_ID < 70300 ? 0 : 1 );'; then
 		# Plugin requires PHP 7.3 or later.
 		SKIPS+=( -o -path ./projects/plugins/crm )
-	elif php -r 'exit( PHP_VERSION_ID < 70400 ? 0 : 1 );'; then
+	fi
+	if php -r 'exit( PHP_VERSION_ID < 70400 ? 0 : 1 );'; then
 		# Plugin requires PHP 7.4 or later.
 		SKIPS+=( -o -path ./projects/plugins/inspect )
-	elif php -r 'exit( PHP_VERSION_ID < 80000 ? 0 : 1 );'; then
+	fi
+	if php -r 'exit( PHP_VERSION_ID < 80000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php8 )
 	fi
 

--- a/tools/parallel-lint.sh
+++ b/tools/parallel-lint.sh
@@ -26,16 +26,13 @@ if $ALL; then
 	SKIPS=()
 	if php -r 'exit( PHP_VERSION_ID < 70000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php7 )
-	fi
-	if php -r 'exit( PHP_VERSION_ID < 70300 ? 0 : 1 );'; then
+	elif php -r 'exit( PHP_VERSION_ID < 70300 ? 0 : 1 );'; then
 		# Plugin requires PHP 7.3 or later.
 		SKIPS+=( -o -path ./projects/plugins/crm )
-	fi
-	if php -r 'exit( PHP_VERSION_ID < 70400 ? 0 : 1 );'; then
+	elif php -r 'exit( PHP_VERSION_ID < 70400 ? 0 : 1 );'; then
 		# Plugin requires PHP 7.4 or later.
 		SKIPS+=( -o -path ./projects/plugins/inspect )
-	fi
-	if php -r 'exit( PHP_VERSION_ID < 80000 ? 0 : 1 );'; then
+	elif php -r 'exit( PHP_VERSION_ID < 80000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php8 )
 	fi
 

--- a/tools/parallel-lint.sh
+++ b/tools/parallel-lint.sh
@@ -27,8 +27,8 @@ if $ALL; then
 	if php -r 'exit( PHP_VERSION_ID < 70000 ? 0 : 1 );'; then
 		SKIPS+=( -o -name php7 )
 	fi
-	if php -r 'exit( PHP_VERSION_ID < 70200 ? 0 : 1 );'; then
-		# Plugin requires PHP 7.2 or later.
+	if php -r 'exit( PHP_VERSION_ID < 70300 ? 0 : 1 );'; then
+		# Plugin requires PHP 7.3 or later.
 		SKIPS+=( -o -path ./projects/plugins/crm )
 	fi
 	if php -r 'exit( PHP_VERSION_ID < 70400 ? 0 : 1 );'; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3307 - increase minimum PHP version to 7.3

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
See title.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In `trunk`, the extension can be activated on PHP 7.2.

In the `fix/crm/increase_min_php_to_7.3` branch, the extension cannot be activated on PHP 7.2 and one will see a notice:

![image](https://github.com/Automattic/jetpack/assets/32492176/27c62079-cf9e-4ba1-84bf-01752ab76eb4)
