### PR TITLE
Paid Newsletter: Detect subscription tier upgrade

### DIFF
--- a/projects/plugins/jetpack/changelog/add-detect-tier-upgrade
+++ b/projects/plugins/jetpack/changelog/add-detect-tier-upgrade
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adds newsletter tier upgrade detection

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -27,6 +27,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	const POST_ACCESS_LEVEL_EVERYBODY                  = 'everybody';
 	const POST_ACCESS_LEVEL_SUBSCRIBERS                = 'subscribers';
 	const POST_ACCESS_LEVEL_PAID_SUBSCRIBERS           = 'paid_subscribers';
+	const POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS = 'paid_subscribers_all_tiers';
 
 	/**
 	 * Initialize the token subscription service.
@@ -126,6 +127,10 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 
 		if ( $access_level === self::POST_ACCESS_LEVEL_SUBSCRIBERS ) {
 			return $is_blog_subscriber || $is_paid_subscriber;
+		}
+
+		if ( $access_level === self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS ) {
+			return $is_paid_subscriber;
 		}
 
 		if ( $access_level === self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS ) {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-token-subscription-service.php
@@ -18,15 +18,15 @@ use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID
  */
 abstract class Token_Subscription_Service implements Subscription_Service {
 
-	const JWT_AUTH_TOKEN_COOKIE_NAME         = 'jp-premium-content-session';
-	const DECODE_EXCEPTION_FEATURE           = 'memberships';
-	const DECODE_EXCEPTION_MESSAGE           = 'Problem decoding provided token';
-	const REST_URL_ORIGIN                    = 'https://subscribe.wordpress.com/';
-	const BLOG_SUB_ACTIVE                    = 'active';
-	const BLOG_SUB_PENDING                   = 'pending';
-	const POST_ACCESS_LEVEL_EVERYBODY        = 'everybody';
-	const POST_ACCESS_LEVEL_SUBSCRIBERS      = 'subscribers';
-	const POST_ACCESS_LEVEL_PAID_SUBSCRIBERS = 'paid_subscribers';
+	const JWT_AUTH_TOKEN_COOKIE_NAME                   = 'jp-premium-content-session';
+	const DECODE_EXCEPTION_FEATURE                     = 'memberships';
+	const DECODE_EXCEPTION_MESSAGE                     = 'Problem decoding provided token';
+	const REST_URL_ORIGIN                              = 'https://subscribe.wordpress.com/';
+	const BLOG_SUB_ACTIVE                              = 'active';
+	const BLOG_SUB_PENDING                             = 'pending';
+	const POST_ACCESS_LEVEL_EVERYBODY                  = 'everybody';
+	const POST_ACCESS_LEVEL_SUBSCRIBERS                = 'subscribers';
+	const POST_ACCESS_LEVEL_PAID_SUBSCRIBERS           = 'paid_subscribers';
 
 	/**
 	 * Initialize the token subscription service.
@@ -129,7 +129,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 		}
 
 		if ( $access_level === self::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS ) {
-			return $is_paid_subscriber && ! $this->maybe_gate_access_for_user_if_tier( $post_id, $user_abbreviated_subscriptions );
+			return $is_paid_subscriber && ! $this->maybe_gate_access_for_user_if_post_tier( $post_id, $user_abbreviated_subscriptions );
 		}
 
 		// This should not be a use case
@@ -144,7 +144,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	 *
 	 * @return bool
 	 */
-	private function maybe_gate_access_for_user_if_tier( $post_id, $user_abbreviated_subscriptions ) {
+	private function maybe_gate_access_for_user_if_post_tier( $post_id, $user_abbreviated_subscriptions ) {
 		$tier_id = intval(
 			get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true )
 		);
@@ -153,6 +153,18 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 			return false;
 		}
 
+		return $this->maybe_gate_access_for_user_if_tier( $tier_id, $user_abbreviated_subscriptions );
+	}
+
+	/**
+	 * Check access for tier.
+	 *
+	 * @param int   $tier_id Tier id.
+	 * @param array $user_abbreviated_subscriptions User subscription abbreviated.
+	 *
+	 * @return bool
+	 */
+	public function maybe_gate_access_for_user_if_tier( $tier_id, $user_abbreviated_subscriptions ) {
 		$plan_ids = \Jetpack_Memberships::get_all_newsletter_plan_ids();
 
 		if ( ! in_array( $tier_id, $plan_ids, true ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -51,12 +51,11 @@ function register_block() {
 			array(
 				'render_callback' => __NAMESPACE__ . '\render_block',
 				'supports'        => array(
-					'spacing'          => array(
+					'spacing' => array(
 						'margin'  => true,
 						'padding' => true,
 					),
-					'align'            => array( 'wide', 'full' ),
-					'isPaidSubscriber' => true,
+					'align'   => array( 'wide', 'full' ),
 				),
 			)
 		);
@@ -1130,7 +1129,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 <p class="has-text-align-center" style="margin-top:10px;margin-bottom:10px;font-size:14px">' . $subscribe_text . '</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact","isPaidSubscriber":' . $is_paid_subscriber . '} /-->
+<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact","isPaidSubscriber":' . ( $is_paid_subscriber ? 'true' : 'false' ) . '} /-->
 ' . $sign_in . '
 </div>
 <!-- /wp:group -->

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -590,6 +590,7 @@ function render_block( $attributes ) {
 	$styles  = get_element_styles_from_attributes( $attributes );
 
 	$include_social_followers = isset( $attributes['includeSocialFollowers'] ) ? (bool) get_attribute( $attributes, 'includeSocialFollowers' ) : true;
+	$is_paid_subscriber       = get_attribute( $attributes, 'isPaidSubscriber', false );
 
 	$data = array(
 		'widget_id'              => Jetpack_Subscriptions_Widget::$instance_count,
@@ -601,7 +602,7 @@ function render_block( $attributes ) {
 			)
 		),
 		'subscribe_placeholder'  => get_attribute( $attributes, 'subscribePlaceholder', esc_html__( 'Type your email…', 'jetpack' ) ),
-		'submit_button_text'     => get_attribute( $attributes, 'submitButtonText', esc_html__( 'Subscribe', 'jetpack' ) ),
+		'submit_button_text'     => get_attribute( $attributes, 'submitButtonText', $is_paid_subscriber ? esc_html__( 'Upgrade', 'jetpack' ) : esc_html__( 'Subscribe', 'jetpack' ) ),
 		'success_message'        => get_attribute(
 			$attributes,
 			'successMessage',
@@ -1084,13 +1085,18 @@ function get_paywall_content( $post_access_level, $email_confirmation_pending = 
 function get_paywall_blocks( $newsletter_access_level ) {
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	// Only display paid texts when Stripe is connected and the post is marked for paid subscribers
-	$is_paid_post = $newsletter_access_level === 'paid_subscribers' && Jetpack_Memberships::has_connected_account();
+	$is_paid_post       = $newsletter_access_level === 'paid_subscribers' && Jetpack_Memberships::has_connected_account();
+	$is_paid_subscriber = Jetpack_Memberships::user_is_paid_subscriber();
 
-	$access_heading = esc_html__( 'Subscribe to continue reading', 'jetpack' );
+	$access_heading = $is_paid_subscriber
+		? esc_html__( 'Upgrade to continue reading', 'jetpack' )
+		: esc_html__( 'Subscribe to continue reading', 'jetpack' );
 
 	$subscribe_text = $is_paid_post
 		// translators: %s is the name of the site.
-		? esc_html__( 'Become a paid subscriber to get access to the rest of this post and other exclusive content.', 'jetpack' )
+		? $is_paid_subscriber
+		? esc_html__( 'Upgrade to get access to the rest of this post and other exclusive content.', 'jetpack' )
+		: esc_html__( 'Become a paid subscriber to get access to the rest of this post and other exclusive content.', 'jetpack' )
 		// translators: %s is the name of the site.
 		: esc_html__( 'Subscribe to get access to the rest of this post and other subscriber-only content.', 'jetpack' );
 
@@ -1123,7 +1129,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 <p class="has-text-align-center" style="margin-top:10px;margin-bottom:10px;font-size:14px">' . $subscribe_text . '</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact"} /-->
+<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact","isPaidSubscriber":' . $is_paid_subscriber . '} /-->
 ' . $sign_in . '
 </div>
 <!-- /wp:group -->

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -51,11 +51,12 @@ function register_block() {
 			array(
 				'render_callback' => __NAMESPACE__ . '\render_block',
 				'supports'        => array(
-					'spacing' => array(
+					'spacing'          => array(
 						'margin'  => true,
 						'padding' => true,
 					),
-					'align'   => array( 'wide', 'full' ),
+					'align'            => array( 'wide', 'full' ),
+					'isPaidSubscriber' => true,
 				),
 			)
 		);

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -97,6 +97,13 @@ class Jetpack_Memberships {
 	private static $user_can_view_post_cache = array();
 
 	/**
+	 * Cached results of user_is_paid_subscriber() method.
+	 *
+	 * @var array
+	 */
+	private static $user_is_paid_subscriber_cache = array();
+
+	/**
 	 * Currencies we support and Stripe's minimum amount for a transaction in that currency.
 	 *
 	 * @link https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
@@ -488,6 +495,23 @@ class Jetpack_Memberships {
 		$user = wp_get_current_user();
 		// phpcs:ignore ImportDetection.Imports.RequireImports.Symbol
 		return 0 !== $user->ID && current_user_can( 'edit_post', get_the_ID() );
+	}
+
+	/**
+	 * Determines whether the current user can view the post based on the newsletter access level
+	 * and caches the result.
+	 *
+	 * @return bool Whether the post can be viewed
+	 */
+	public static function user_is_paid_subscriber() {
+		$user_id = get_current_user_id();
+
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+		$paywall            = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+		$is_paid_subscriber = $paywall->visitor_can_view_content( self::get_all_newsletter_plan_ids(), Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS );
+
+		self::$user_is_paid_subscriber_cache[ $user_id ] = $is_paid_subscriber;
+		return $is_paid_subscriber;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 142-gh-Automattic/gold

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the ability to check for a paid subscriber at any tier level
* Exposes tier validation function
* Switches language between Subscribe/Upgrade depending on paid status

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Apply D121198-code on your sandbox
- Patch your sandbox, answering "N" when it asks to checkout trunk:
```
bin/jetpack-downloader test jetpack add/detect-tier-upgrade
```
- Follow the instructions provided by [the bot below](#issuecomment-1716111091) or [create a new Jurassic Ninja site](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=add/detect-subscription-upgrade&wp-debug-log) using this branch. 
- Connect Jetpack
- Make sure  to enable the newsletter options in the jetpack settings.
- Make sure to set `JETPACK__SANDBOX_DOMAIN` to your sandbox address (see `wp-admin/options-general.php?page=companion_settings` in JN)
- Enable global http in your sandbox
- Use store sandbox: PCYsg-IA-p2
- Sandbox `public-api.wordpress.com`, `subscribe.wordpress.com` and the test site (if testing on a simple site)
- From the Earn dashboard, connect Stripe if needed
- Create two "Paid newsletter tier" payment plans with one priced higher than the other
- <img width="648" alt="image" src="https://github.com/Automattic/jetpack/assets/38750/265cbfa1-7cd1-44df-8e0e-0e84f0025044">
- Create a new post with the lower-priced tier and publish it
- <img width="300" alt="image" src="https://github.com/Automattic/jetpack/assets/38750/ccd2d140-c4df-4aa7-9e67-1fb30e9f20c9">
- Open a new incognito and visit the post page
- Text should read "Subscribe..."
- <img width="706" alt="image" src="https://github.com/Automattic/jetpack/assets/38750/f4d60b79-0249-4003-b522-fb19f889d36d">
- Clicking the "Subscribe" button should launch a popup and show the plan picker
- Subscribe to the lowest tier with an email account not associated with the site owner
- Change access to the post to a higher tier
- Open a new incognito and visit the post page (don't reload, open it again, or delete the query string after `?`)
- Text should read "Upgrade..."
- <img width="692" alt="267157571-43a0319e-0473-4abb-987b-bf825a356ed8" src="https://github.com/Automattic/jetpack/assets/38750/47def813-97c7-49b8-be34-ab4f4cd98808">
- Clicking the "Upgrade" button should launch a popup and show the plan picker