### PR TITLE
AI Excerpt: stop and reset suggestions request once the panel gets hidden

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-excerpt-avoid-multiple-requests
+++ b/projects/plugins/jetpack/changelog/update-ai-excerpt-avoid-multiple-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Excerpt: stop and reset suggestions request once the panel gets hidden

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -9,7 +9,7 @@ import {
 import { TextareaControl, ExternalLink, Button, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { count } from '@wordpress/wordcount';
 import React from 'react';
@@ -49,7 +49,17 @@ function AiPostExcerpt() {
 	// Re enable the AI Excerpt component
 	const [ reenable, setReenable ] = useState( false );
 
-	const { request, suggestion, requestingState, error, reset } = useAiSuggestions( {} );
+	const { request, stopSuggestion, suggestion, requestingState, error, reset } = useAiSuggestions(
+		{}
+	);
+
+	// Cancel and reset AI suggestion when the component is unmounted
+	useEffect( () => {
+		return () => {
+			stopSuggestion();
+			reset();
+		};
+	}, [ stopSuggestion, reset ] );
 
 	// Pick raw post content
 	const postContent = useSelect(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When the user requests a post excerpt and then, in some way, hides the AI Excerpt panel, the requesting process continues in the background. This PR stops and resets the process when the panel is not shown, avoiding multiple requests.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Excerpt: stop and reset suggestions request once the panel gets hidden

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the post sidebar
* Request an excerpt
* Close the panel
* Request a again, and so on
* **Before( trunk)** Confirm performers a new request every time you click on the `Generate` button:

https://github.com/Automattic/jetpack/assets/77539/07512f6c-2c6f-4ced-8a7a-c992b84d2565

* **After (This PR)** Confirm the app stops the current requests

https://github.com/Automattic/jetpack/assets/77539/d56f0113-d781-4b61-95c8-ea57d0cd0666