### PR TITLE
Launchpad: New behaviour for navigator checklists

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/launchpad-empty-array-for-navigator-checklists
+++ b/projects/packages/jetpack-mu-wpcom/changelog/launchpad-empty-array-for-navigator-checklists
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Change the way the navigator checklists are handled

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -692,7 +692,14 @@ function wpcom_launchpad_navigator_get_checklists() {
 		return array();
 	}
 
-	return $wpcom_launchpad_config['navigator_checklists'];
+	$checklist_slugs = $wpcom_launchpad_config['navigator_checklists'];
+
+	$results = array();
+	foreach ( $checklist_slugs as $slug ) {
+		$results[ $slug ] = wpcom_get_launchpad_checklist_by_checklist_slug( $slug );
+	}
+
+	return $results;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -736,9 +736,7 @@ function wpcom_launchpad_navigator_add_checklist( $new_checklist_slug ) {
 	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
 	$checklists             = array();
 
-	if ( ! isset( $wpcom_launchpad_config['navigator_checklists'] ) ) {
-		$checklists = array();
-	} else {
+	if ( isset( $wpcom_launchpad_config['navigator_checklists'] ) ) {
 		$checklists = $wpcom_launchpad_config['navigator_checklists'];
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -691,12 +691,19 @@ function wpcom_launchpad_navigator_get_checklists() {
 	if ( ! isset( $wpcom_launchpad_config['navigator_checklists'] ) ) {
 		return array();
 	}
-
+	$all_checklists  = wpcom_launchpad_checklists()->get_all_task_lists();
 	$checklist_slugs = $wpcom_launchpad_config['navigator_checklists'];
 
 	$results = array();
 	foreach ( $checklist_slugs as $slug ) {
-		$results[ $slug ] = wpcom_get_launchpad_checklist_by_checklist_slug( $slug );
+		if ( ! isset( $all_checklists[ $slug ] ) ) {
+			continue;
+		}
+
+		$results[ $slug ] = array(
+			'slug'  => $slug,
+			'title' => $all_checklists[ $slug ]['title'],
+		);
 	}
 
 	return $results;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -681,6 +681,69 @@ function wpcom_launchpad_set_fse_next_steps_modal_hidden( $should_hide ) {
 }
 
 /**
+ * Returns a list of all the checklists that are currently available for the navigator.
+ *
+ * @return array Array of strings representing the checklist slugs.
+ */
+function wpcom_launchpad_navigator_get_checklists() {
+	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config' );
+	if ( ! $wpcom_launchpad_config || ! is_array( $wpcom_launchpad_config ) ) {
+		return array();
+	}
+
+	if ( ! isset( $wpcom_launchpad_config['navigator_checklists'] ) ) {
+		return array();
+	}
+
+	return $wpcom_launchpad_config['navigator_checklists'];
+}
+
+/**
+ * Updates the list of checklists that are currently available for the navigator.
+ *
+ * @param array $new_checklists Array of strings representing the checklist slugs.
+ * @return bool Whether the option update succeeded.
+ */
+function wpcom_launchpad_navigator_update_checklists( $new_checklists ) {
+	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config' );
+
+	if ( ! $wpcom_launchpad_config || ! is_array( $wpcom_launchpad_config ) ) {
+		$wpcom_launchpad_config = array();
+	}
+
+	$wpcom_launchpad_config['navigator_checklists'] = $new_checklists;
+
+	return update_option( 'wpcom_launchpad_config', $wpcom_launchpad_config );
+}
+
+/**
+ * Adds a new checklist to the list of checklists that are currently available for the navigator.
+ *
+ * @param string $new_checklist_slug The slug of the launchpad task list to add.
+ */
+function wpcom_launchpad_navigator_add_checklist( $new_checklist_slug ) {
+	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config' );
+	$checklists             = array();
+
+	if ( ! $wpcom_launchpad_config || ! is_array( $wpcom_launchpad_config ) ) {
+		$checklists = array();
+	}
+
+	if ( ! isset( $wpcom_launchpad_config['navigator_checklists'] ) ) {
+		$checklists = array();
+	} else {
+		$checklists = $wpcom_launchpad_config['navigator_checklists'];
+	}
+
+	// add the new_checklist_slug to the checklists array if it's not already there.
+	if ( ! in_array( $new_checklist_slug, $checklists, true ) ) {
+		$checklists[] = $new_checklist_slug;
+	}
+
+	wpcom_launchpad_navigator_update_checklists( $checklists );
+}
+
+/**
  * Helper function to indicate what's the current active checklist
  * in the context of the navigator.
  * It will try to read the key 'active_checklist_slug' from the 'wpcom_launchpad_config' option.
@@ -733,7 +796,13 @@ function wpcom_launchpad_set_current_active_checklist( $checklist_slug ) {
 		$wpcom_launchpad_config['active_checklist_slug'] = $checklist_slug;
 	}
 
-	return update_option( 'wpcom_launchpad_config', $wpcom_launchpad_config );
+	$return_value = update_option( 'wpcom_launchpad_config', $wpcom_launchpad_config );
+	// add to available checklists if not null
+	if ( $checklist_slug !== null ) {
+		wpcom_launchpad_navigator_add_checklist( $checklist_slug );
+	}
+
+	return $return_value;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -686,10 +686,7 @@ function wpcom_launchpad_set_fse_next_steps_modal_hidden( $should_hide ) {
  * @return array Array of strings representing the checklist slugs.
  */
 function wpcom_launchpad_navigator_get_checklists() {
-	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config' );
-	if ( ! $wpcom_launchpad_config || ! is_array( $wpcom_launchpad_config ) ) {
-		return array();
-	}
+	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
 
 	if ( ! isset( $wpcom_launchpad_config['navigator_checklists'] ) ) {
 		return array();
@@ -705,11 +702,7 @@ function wpcom_launchpad_navigator_get_checklists() {
  * @return bool Whether the option update succeeded.
  */
 function wpcom_launchpad_navigator_update_checklists( $new_checklists ) {
-	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config' );
-
-	if ( ! $wpcom_launchpad_config || ! is_array( $wpcom_launchpad_config ) ) {
-		$wpcom_launchpad_config = array();
-	}
+	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
 
 	$wpcom_launchpad_config['navigator_checklists'] = $new_checklists;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -702,6 +702,10 @@ function wpcom_launchpad_navigator_get_checklists() {
  * @return bool Whether the option update succeeded.
  */
 function wpcom_launchpad_navigator_update_checklists( $new_checklists ) {
+	if ( ! is_array( $new_checklists ) ) {
+		return false;
+	}
+
 	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
 
 	$wpcom_launchpad_config['navigator_checklists'] = $new_checklists;
@@ -715,12 +719,8 @@ function wpcom_launchpad_navigator_update_checklists( $new_checklists ) {
  * @param string $new_checklist_slug The slug of the launchpad task list to add.
  */
 function wpcom_launchpad_navigator_add_checklist( $new_checklist_slug ) {
-	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config' );
+	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
 	$checklists             = array();
-
-	if ( ! $wpcom_launchpad_config || ! is_array( $wpcom_launchpad_config ) ) {
-		$checklists = array();
-	}
 
 	if ( ! isset( $wpcom_launchpad_config['navigator_checklists'] ) ) {
 		$checklists = array();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-navigator.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-navigator.php
@@ -105,17 +105,8 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Navigator extends WP_REST_Controller 
 	 * @return array Array with two keys: `checklists` and `active_checklist`.
 	 */
 	public function get_navigator_data() {
-		$raw_checklists = wpcom_launchpad_checklists()->get_all_task_lists();
-		$checklists     = array();
-		foreach ( $raw_checklists as $slug => $checklist ) {
-			$checklists[] = array(
-				'slug'  => $slug,
-				'title' => $checklist['title'],
-			);
-		}
-
 		return array(
-			'available_checklists' => $checklists,
+			'available_checklists' => wpcom_launchpad_navigator_get_checklists(),
 			'current_checklist'    => wpcom_launchpad_get_active_checklist(),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Applies this behaviour:
* The checklists available for the navigator are stored in `wpcom_launchpad_config > navigator_checklists`.
* That array is the one being returned when a GET request to `/sites/[SITE]/launchpad/navigator` is made in the `available_checklists` return key.
* When the `active_checklist_slug` is updated via PUT/POST, the list is updated with that new checklist slug

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a GET request to `/sites/[SITE]/launchpad/navigator`
* Set the current active checklist using a POST/PUT to `/sites/[SITE]/launchpad/navigator`
* Try to remove the active checklist by following instructions in the testing section on https://github.com/Automattic/jetpack/pull/32964