### PR TITLE
AI Client: check media record ref before removing the listeners

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-create-with-voice-removeing-block-bug
+++ b/projects/js-packages/ai-client/changelog/update-create-with-voice-removeing-block-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Client: check media record ref of the useMediaRecording() hook before to remove the listeners

--- a/projects/js-packages/ai-client/src/hooks/use-media-recording/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-media-recording/index.ts
@@ -189,6 +189,15 @@ export default function useMediaRecording( {
 				throw err;
 			} );
 		return () => {
+			/*
+			 * mediaRecordRef is not defined when
+			 * the getUserMedia API is not supported,
+			 * or when the user has not granted access
+			 */
+			if ( ! mediaRecordRef?.current ) {
+				return;
+			}
+
 			mediaRecordRef.current.removeEventListener( 'start', onStartListener );
 			mediaRecordRef.current.removeEventListener( 'stop', onStopListener );
 			mediaRecordRef.current.removeEventListener( 'pause', onPauseListener );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Before removing the function listener, we need to ensure that the media recorder instance has been established. There are various reasons why the instance may be undefined, such as the user failing to provide recording permissions. Failing to make these adjustments will result in the application malfunctioning.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  AI Client: check media record ref of the useMediaRecording() hook before removing the listeners

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with Jetpack plugin 
* Enable `beta` extensions
* Go to the block editor
* Create a Create With Voice block instance
* Start to record an audio
* Ensure the browser asks for permission to record (you can use a new incognito browser instance)
* Confirm you see the browser prompt asking you to record the voice

<img width="673" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/08038a90-c21e-4fc7-b45c-b10656b03dec">

* Before accepting (or not) the permissions, try to delete the block

<img width="673" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/ea66760e-e634-41c7-9383-583e503084ce">

* Before (trunk), confirm the app breaks 

<img width="952" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/016bc349-3f77-484d-b05f-ff01ed967aa5">

<img width="777" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/0cd270d7-c0ec-4e62-9b14-dd6c7ddb9cd9">


* After (this PR) confirm the block is removed without any issue.

<img width="673" alt="image" src="https://github.com/Automattic/jetpack/assets/77539/9e81bc21-a49f-4af4-8216-dc61fcfc57a9">
