### PR TITLE
AI Assistant: Remove upgrade button when user is not administrator

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-upgrade-author
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-upgrade-author
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Remove upgrade button when user is not administrator

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { Nudge } from '../../../../shared/components/upgrade-nudge';
 import useAICheckout from '../../hooks/use-ai-checkout';
 import useAIFeature from '../../hooks/use-ai-feature';
+import { canUserPurchasePlan } from '../../lib/connection';
 
 /**
  * The default upgrade prompt for the AI Assistant block, containing the Upgrade button and linking
@@ -19,6 +20,30 @@ import useAIFeature from '../../hooks/use-ai-feature';
  */
 const DefaultUpgradePrompt = (): React.ReactNode => {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
+	const canUpgrade = canUserPurchasePlan();
+
+	if ( ! canUpgrade ) {
+		return (
+			<Nudge
+				showButton={ false }
+				className={ 'jetpack-ai-upgrade-banner' }
+				description={ createInterpolateElement(
+					__(
+						'Congratulations on exploring Jetpack AI and reaching the free requests limit!<br /><strong>Reach out to the site administrator to upgrade and keep using Jetpack AI.</strong>',
+						'jetpack'
+					),
+					{
+						br: <br />,
+						strong: <strong />,
+					}
+				) }
+				visible={ true }
+				align={ null }
+				title={ null }
+				context={ null }
+			/>
+		);
+	}
 
 	return (
 		<Nudge

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -520,7 +520,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 			) }
 			<AIControl
 				ref={ aiControlRef }
-				disabled={ requireUpgrade }
+				disabled={ requireUpgrade || ! connected }
 				value={ userPrompt }
 				placeholder={ __( 'Ask Jetpack AI', 'jetpack' ) }
 				onChange={ handleChange }
@@ -528,7 +528,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId }
 				onStop={ handleStopSuggestion }
 				onAccept={ handleAccept }
 				state={ requestingState }
-				isTransparent={ requireUpgrade }
+				isTransparent={ requireUpgrade || ! connected }
 				showButtonLabels={ ! isMobileViewport }
 				showAccept={ contentIsLoaded && ! isWaitingState }
 				acceptLabel={ acceptLabel }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/connection/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/connection/index.ts
@@ -39,3 +39,16 @@ export function isUserConnected(): boolean {
 	debugOnce( 'User is not connected ❌' );
 	return false;
 }
+
+export function canUserPurchasePlan(): boolean {
+	if ( isSimpleSite() ) {
+		// Roles on simple sites can't be inferred from the connection status.
+		return true;
+	}
+
+	const permissions =
+		initialState?.userConnectionData?.currentUser?.permissions ??
+		( {} as { manage_options?: boolean } );
+
+	return ! permissions.manage_options === false;
+}

--- a/projects/plugins/jetpack/extensions/global.d.ts
+++ b/projects/plugins/jetpack/extensions/global.d.ts
@@ -41,9 +41,18 @@ declare global {
 					};
 					gravatar: string;
 					permissions: {
+						admin_page?: boolean;
 						connect: boolean;
 						connect_user: boolean;
 						disconnect: boolean;
+						edit_posts?: boolean;
+						manage_modules?: boolean;
+						manage_options?: boolean;
+						manage_plugins?: boolean;
+						network_admin?: boolean;
+						network_sites_page?: boolean;
+						publish_posts?: boolean;
+						view_stats?: boolean;
 					};
 				};
 				connectionOwner: null;

--- a/projects/plugins/jetpack/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/upgrade-nudge/index.jsx
@@ -9,12 +9,13 @@ export const Nudge = ( {
 	className,
 	title,
 	description,
-	buttonText,
+	buttonText = null,
 	visible = true,
 	context,
-	checkoutUrl,
-	goToCheckoutPage,
+	checkoutUrl = null,
+	goToCheckoutPage = null,
 	isRedirecting = false,
+	showButton = true,
 } ) => {
 	const cssClasses = classNames( className, 'jetpack-upgrade-plan-banner', {
 		'wp-block': context === 'editor-canvas',
@@ -39,7 +40,7 @@ export const Nudge = ( {
 						{ description }
 					</span>
 				) }
-				{
+				{ showButton && (
 					<Button
 						href={ isRedirecting ? null : checkoutUrl } // Only for server-side rendering, since onClick doesn't work there.
 						onClick={ goToCheckoutPage }
@@ -51,7 +52,7 @@ export const Nudge = ( {
 					>
 						{ isRedirecting ? redirectingText : buttonText }
 					</Button>
-				}
+				) }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #31165

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disables the input when the user is not connected
* Change the upgrade nudge for users that are not administrators, removing the upgrade button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a non-admin user, like an Author
* Use the AI Assistant block to spend the 20 free requests
* As the non-admin user, check that the message does not include the upgrade button
* As the admin user, check that the button is displayed

| Before | After
| - | -
| ![2023-09-12_18-13-44-before-reconnect](https://github.com/Automattic/jetpack/assets/8486249/50939bf3-fe9b-4d8a-ac0a-be1de081fc7f) | ![2023-09-12_18-13-19-after-reconnect](https://github.com/Automattic/jetpack/assets/8486249/6473cdc5-9a60-40f0-ab5e-8e534af08a1a)
| ![2023-09-12_18-12-54-before-author](https://github.com/Automattic/jetpack/assets/8486249/7bdee694-b767-4d5b-9694-53dd82faef96) | ![2023-09-12_18-11-28-after-author](https://github.com/Automattic/jetpack/assets/8486249/937ab17e-216f-470c-a503-011c1236f903)



