### PR TITLE
Launchpad: remove checklist from navigator

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-remove-checklist-nav
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-remove-checklist-nav
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add removal capability for navigator available checklists

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -731,32 +731,43 @@ function wpcom_launchpad_navigator_update_checklists( $new_checklists ) {
  * Removes a checklist from the list of checklists that are currently available for the navigator.
  *
  * @param string $checklist_slug The slug of the checklist to remove.
- * @return bool Whether the option update succeeded.
+ * @return array Array with two values: whether the option update succeeded, and the new active checklist slug.
  */
 function wpcom_launchpad_navigator_remove_checklist( $checklist_slug ) {
 	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
 
 	if ( ! isset( $wpcom_launchpad_config['navigator_checklists'] ) ) {
-		return false;
+		return array(
+			'updated'              => false,
+			'new_active_checklist' => null,
+		);
 	}
+
+	$current_active_checklist = wpcom_launchpad_get_active_checklist();
 
 	$checklists = $wpcom_launchpad_config['navigator_checklists'];
 	// Find if $checklist_slug is in the checklists array. If it is, remove it.
 	$key = array_search( $checklist_slug, $checklists, true );
 	if ( $key === false ) {
-		return true;
+		return array(
+			'updated'              => false,
+			'new_active_checklist' => $current_active_checklist,
+		);
 	}
 
 	unset( $checklists[ $key ] );
 
-	$current_active_checklist = wpcom_launchpad_get_active_checklist();
+	$new_active_checklist = $current_active_checklist;
 	if ( $current_active_checklist === $checklist_slug ) {
 		// get last item on $checklists array, if there is one; otherwise set to null
 		$new_active_checklist = end( $checklists ) ? end( $checklists ) : null;
 		wpcom_launchpad_set_current_active_checklist( $new_active_checklist );
 	}
 
-	return wpcom_launchpad_navigator_update_checklists( $checklists );
+	return array(
+		'updated'              => wpcom_launchpad_navigator_update_checklists( $checklists ),
+		'new_active_checklist' => $new_active_checklist,
+	);
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -728,6 +728,30 @@ function wpcom_launchpad_navigator_update_checklists( $new_checklists ) {
 }
 
 /**
+ * Removes a checklist from the list of checklists that are currently available for the navigator.
+ *
+ * @param string $checklist_slug The slug of the checklist to remove.
+ * @return bool Whether the option update succeeded.
+ */
+function wpcom_launchpad_navigator_remove_checklist( $checklist_slug ) {
+	$wpcom_launchpad_config = get_option( 'wpcom_launchpad_config', array() );
+
+	if ( ! isset( $wpcom_launchpad_config['navigator_checklists'] ) ) {
+		return false;
+	}
+
+	$checklists = $wpcom_launchpad_config['navigator_checklists'];
+	// Find if $checklist_slug is in the checklists array. If it is, remove it.
+	$key = array_search( $checklist_slug, $checklists, true );
+	if ( $key === false ) {
+		return true;
+	}
+
+	unset( $checklists[ $key ] );
+	return wpcom_launchpad_navigator_update_checklists( $checklists );
+}
+
+/**
  * Adds a new checklist to the list of checklists that are currently available for the navigator.
  *
  * @param string $new_checklist_slug The slug of the launchpad task list to add.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -748,6 +748,14 @@ function wpcom_launchpad_navigator_remove_checklist( $checklist_slug ) {
 	}
 
 	unset( $checklists[ $key ] );
+
+	$current_active_checklist = wpcom_launchpad_get_active_checklist();
+	if ( $current_active_checklist === $checklist_slug ) {
+		// get last item on $checklists array, if there is one; otherwise set to null
+		$new_active_checklist = end( $checklists ) ? end( $checklists ) : null;
+		wpcom_launchpad_set_current_active_checklist( $new_active_checklist );
+	}
+
 	return wpcom_launchpad_navigator_update_checklists( $checklists );
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-navigator.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-navigator.php
@@ -89,8 +89,9 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Navigator extends WP_REST_Controller 
 	 * @param WP_REST_Request $request Request object.
 	 */
 	public function update_navigator_options( $request ) {
-		$updated = array();
-		$input   = $request->get_json_params();
+		$updated               = array();
+		$input                 = $request->get_json_params();
+		$extra_response_params = array();
 
 		foreach ( $input as $key => $value ) {
 			switch ( $key ) {
@@ -98,13 +99,19 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Navigator extends WP_REST_Controller 
 					$updated[ $key ] = wpcom_launchpad_set_current_active_checklist( $input['active_checklist_slug'] );
 					break;
 				case 'remove_checklist_slug':
-					$updated[ $key ] = wpcom_launchpad_navigator_remove_checklist( $input['remove_checklist_slug'] );
+					$removal_result  = wpcom_launchpad_navigator_remove_checklist( $input['remove_checklist_slug'] );
+					$updated[ $key ] = $removal_result['updated'];
+
+					$extra_response_params['new_active_checklist'] = $removal_result['new_active_checklist'];
 					break;
 			}
 		}
 
-		return array(
-			'updated' => $updated,
+		return array_merge(
+			array(
+				'updated' => $updated,
+			),
+			$extra_response_params
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-navigator.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-navigator.php
@@ -47,6 +47,11 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Navigator extends WP_REST_Controller 
 							'type'              => array( 'null', 'string' ),
 							'validate_callback' => array( $this, 'validate_checklist_slug_param' ),
 						),
+						'remove_checklist_slug' => array(
+							'description' => 'The slug of the checklist to set as active.',
+							'type'        => 'string',
+							'enum'        => $this->get_checklist_slug_enums(),
+						),
 					),
 				),
 			)
@@ -92,8 +97,12 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Navigator extends WP_REST_Controller 
 				case 'active_checklist_slug':
 					$updated[ $key ] = wpcom_launchpad_set_current_active_checklist( $input['active_checklist_slug'] );
 					break;
+				case 'remove_checklist_slug':
+					$updated[ $key ] = wpcom_launchpad_navigator_remove_checklist( $input['remove_checklist_slug'] );
+					break;
 			}
 		}
+
 		return array(
 			'updated' => $updated,
 		);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-navigator.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad-navigator.php
@@ -48,7 +48,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Navigator extends WP_REST_Controller 
 							'validate_callback' => array( $this, 'validate_checklist_slug_param' ),
 						),
 						'remove_checklist_slug' => array(
-							'description' => 'The slug of the checklist to set as active.',
+							'description' => 'The slug of the checklist to remove from the active list.',
 							'type'        => 'string',
 							'enum'        => $this->get_checklist_slug_enums(),
 						),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Removes a checklist from the navigator checklist list

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open API console
* Run a PUT/POST on `wpcom/v2` > `/sites/[SITE]/launchpad/navigator`
* Add a slug to the `remove_checklist_slug` body param
* Verify it removes it from the list
* Verify that the correct value is returned in the `new_active_checklist` response parameter.
<img width="388" alt="image" src="https://github.com/Automattic/jetpack/assets/375980/ea1bb77f-3811-422c-b056-748a714b0350">

This is what the response should look like:
<img width="400" alt="image" src="https://github.com/Automattic/jetpack/assets/375980/10a149ac-278c-476e-bc15-bba19411711b">

