### PR TITLE
AI Client: Introduce blockListBlockWithAiDataProvider() function

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-extension-introduce-block-with-ai-data-provider
+++ b/projects/js-packages/ai-client/changelog/update-ai-extension-introduce-block-with-ai-data-provider
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: Introduce blockListBlockWithAiDataProvider() function

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.1.7",
+	"version": "0.1.8-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -33,6 +33,7 @@ export default withAiAssistantData( MyComponent );
 
 * [AI Data Context](#ai-assistant-content)
 * [withAiDataProvider HOC](#with-ai-data-provider)
+* [blockListBlockWithAiDataProvider](#block-list-block-with-ai-data-provider)
 * [useAiContext Hook](#use-ai-context)
 
 <h2 id="ai-assistant-content">Ai Data Context</h2>
@@ -113,3 +114,40 @@ Optional options object:
 These callbacks will be invoked with the detail of the corresponding event emitted by SuggestionsEventSource.
 
 When called, the hook returns the Ai Data Context.
+
+
+<h2 id="block-list-block-with-ai-data-provider">blockListBlockWithAiDataProvider Function</h2>
+
+The `blockListBlockWithAiDataProvider` function returns a Higher Order Component (HOC) that wraps and provides the AI Assistant Data context to a specified set of blocks. Primarily designed for use with the `editor.BlockListBlock` filter in the WordPress Block Editor, it conditionally applies the data provider only to block types specified in the function options.
+
+### Usage
+
+To use the `blockListBlockWithAiDataProvider`, you'll need to specify which blocks should have access to the AI Assistant Data context:
+
+```jsx
+import { blockListBlockWithAiDataProvider } from '@automattic/jetpack-ai-client';
+
+// Example usage with WordPress filters
+const enhancedBlockListBlock = blockListBlockWithAiDataProvider( {
+  blocks: [ 'core/paragraph', 'core/heading' ]
+} );
+
+wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-ai-data', enhancedBlockListBlock );
+```
+
+### Parameters
+
+The function accepts an optional options object:
+
+#### `options.blocks`
+- Type: `string[]`
+- Default: `['']`
+
+An array of block names (e.g., `[ 'core/paragraph', 'core/image' ]`) to which the data provider should be applied. Only the blocks specified in this array will have access to the AI Assistant Data context.
+
+### Returned Wrapped Component
+
+When a block type matches one of the specified names in `options.blocks`, the returned component will be wrapped with the AI Assistant Data context, providing it with all the available data and functionalities. For other block types, the original component will be returned without any modifications.
+
+_Before using this function, ensure that the AI Assistant Data is available in the higher component hierarchy. The [Ai Data Context](#ai-assistant-content) should typically wrap the top-level component or application._
+

--- a/projects/js-packages/ai-client/src/data-flow/Readme.md
+++ b/projects/js-packages/ai-client/src/data-flow/Readme.md
@@ -143,11 +143,10 @@ The function accepts an optional options object:
 - Type: `string[]`
 - Default: `['']`
 
-An array of block names (e.g., `[ 'core/paragraph', 'core/image' ]`) to which the data provider should be applied. Only the blocks specified in this array will have access to the AI Assistant Data context.
+An array of block names (e.g., `[ 'core/paragraph', 'core/image' ]`) to which the data provider should be applied. Only the blocks specified in this array can access the AI Assistant Data context.
 
 ### Returned Wrapped Component
 
-When a block type matches one of the specified names in `options.blocks`, the returned component will be wrapped with the AI Assistant Data context, providing it with all the available data and functionalities. For other block types, the original component will be returned without any modifications.
+When a block type matches one of the specified names in `options.blocks`, the returned component will be wrapped with the AI Assistant Data context, providing all the available data and functionalities. The original component will be returned without any modifications for other block types.
 
-_Before using this function, ensure that the AI Assistant Data is available in the higher component hierarchy. The [Ai Data Context](#ai-assistant-content) should typically wrap the top-level component or application._
-
+_Before using this function, ensure the AI Assistant Data is available in the higher component hierarchy. The [Ai Data Context](#ai-assistant-content) should typically wrap the top-level component or application._

--- a/projects/js-packages/ai-client/src/data-flow/index.ts
+++ b/projects/js-packages/ai-client/src/data-flow/index.ts
@@ -1,3 +1,6 @@
 export { AiDataContext, AiDataContextProvider } from './context';
-export { default as withAiDataProvider } from './with-ai-assistant-data';
+export {
+	default as withAiDataProvider,
+	blockListBlockWithAiDataProvider,
+} from './with-ai-assistant-data';
 export { default as useAiContext } from './use-ai-context';

--- a/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
+++ b/projects/js-packages/ai-client/src/data-flow/with-ai-assistant-data.tsx
@@ -59,3 +59,82 @@ const withAiDataProvider = createHigherOrderComponent( ( WrappedComponent: React
 }, 'withAiDataProvider' );
 
 export default withAiDataProvider;
+
+type OptionsProps = {
+	/**
+	 * Array of block names to apply the data provider to.
+	 */
+	blocks: string[] | string;
+};
+
+/**
+ * Function that returns a High Order Component that provides the
+ * AI Assistant Data context to the wrapped component.
+ *
+ * Ideally though to use with the `editor.BlockListBlock` filter.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#editor-blocklistblock
+ * @param {OptionsProps} options - Options
+ * @param {string[]} options.blocks - Array of block names to apply the data provider to.
+ * @returns {ReactNode}          	  Wrapped component, populated with the AI Assistant Data context.
+ */
+export const blockListBlockWithAiDataProvider = ( options: OptionsProps = { blocks: [ '' ] } ) => {
+	return createHigherOrderComponent( ( WrappedComponent: ReactNode ) => {
+		return props => {
+			const blockName = props?.block?.name;
+			if ( ! blockName ) {
+				return <WrappedComponent { ...props } />;
+			}
+
+			/*
+			 * Extend only blocks that are specified in the blocks option.
+			 * `blocks` option accepts a string or an array of strings.
+			 */
+			const blockTypesToExtend = Array.isArray( options.blocks )
+				? options.blocks
+				: [ options.blocks ];
+
+			if ( ! blockTypesToExtend.includes( blockName ) ) {
+				return <WrappedComponent { ...props } />;
+			}
+
+			// Connect with the AI Assistant communication layer.
+			// @todo: this is a copy of the code above, we should refactor this.
+			const {
+				suggestion,
+				error: requestingError,
+				requestingState,
+				request: requestSuggestion,
+				stopSuggestion,
+				eventSource,
+			} = useAiSuggestions();
+
+			// Build the context value to pass to the ai assistant data provider.
+			const dataContextValue = useMemo(
+				() => ( {
+					suggestion,
+					requestingError,
+					requestingState,
+					eventSource,
+
+					requestSuggestion,
+					stopSuggestion,
+				} ),
+				[
+					suggestion,
+					requestingError,
+					requestingState,
+					eventSource,
+					requestSuggestion,
+					stopSuggestion,
+				]
+			);
+
+			return (
+				<AiDataContextProvider value={ dataContextValue }>
+					<WrappedComponent { ...props } />
+				</AiDataContextProvider>
+			);
+		};
+	}, 'blockListBlockWithAiDataProvider' );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR introduces a helper function that returns an HOC useful to provide the component with AI Data. Its primary purpose is to be used with the `editor.blockListBlock` filter.

_We will use this function to filter the blocks that need to be extended with AI data in another follow-up PR._

Pasted the [doc section](https://github.com/Automattic/jetpack/blob/5ac9580acf71b51c4911918864207def21162b37/projects/js-packages/ai-client/src/data-flow/Readme.md):

--------------------
<h2 id="block-list-block-with-ai-data-provider">blockListBlockWithAiDataProvider Function</h2>

The `blockListBlockWithAiDataProvider` function returns a Higher Order Component (HOC) that wraps and provides the AI Assistant Data context to a specified set of blocks. Primarily designed for use with the `editor.BlockListBlock` filter in the WordPress Block Editor, it conditionally applies the data provider only to block types specified in the function options.

### Usage

To use the `blockListBlockWithAiDataProvider`, you'll need to specify which blocks should have access to the AI Assistant Data context:

```jsx
import { blockListBlockWithAiDataProvider } from '@automattic/jetpack-ai-client';

// Example usage with WordPress filters
const enhancedBlockListBlock = blockListBlockWithAiDataProvider( {
  blocks: [ 'core/paragraph', 'core/heading' ]
} );

wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-ai-data', enhancedBlockListBlock );
```

### Parameters

The function accepts an optional options object:

#### `options.blocks`
- Type: `string[]`
- Default: `['']`

An array of block names (e.g., `[ 'core/paragraph', 'core/image' ]`) to which the data provider should be applied. Only the blocks specified in this array can access the AI Assistant Data context.

### Returned Wrapped Component

When a block type matches one of the specified names in `options.blocks`, the returned component will be wrapped with the AI Assistant Data context, providing all the available data and functionalities. The original component will be returned without any modifications for other block types.

_Before using this function, ensure the AI Assistant Data is available in the higher component hierarchy. The [Ai Data Context](#ai-assistant-content) should typically wrap the top-level component or application._

---------------

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: Introduce blockListBlockWithAiDataProvider() function

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Since the function is not used yet, it's a matter of
  * The function is currently unused. 
  * Confirm Jetpack Form with AI and app compile correctly. 
  * Visual review of documentation is welcome.


