### PR TITLE
AI Extension: extend only Jetpack Form blocks with AI Data

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-form-extend-with-ai-data
+++ b/projects/plugins/jetpack/changelog/update-jetpack-form-extend-with-ai-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Extension: extened only Jetpack Form blocks with AI Data

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -1,7 +1,7 @@
 /*
  * External dependencies
  */
-import { useAiContext, withAiDataProvider } from '@automattic/jetpack-ai-client';
+import { useAiContext, blockListBlockWithAiDataProvider } from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -191,4 +191,9 @@ addFilter(
 	100
 );
 
-addFilter( 'editor.BlockListBlock', 'jetpack/ai-assistant-block-list', withAiDataProvider, 110 );
+addFilter(
+	'editor.BlockListBlock',
+	'jetpack/ai-assistant-block-list',
+	blockListBlockWithAiDataProvider( { blocks: 'jetpack/contact-form' } ),
+	110
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

~# depends on https://github.com/Automattic/jetpack/pull/33025~

This PR populates only the Jetpack From block instances by using the [blockListBlockWithAiDataProvider()](https://github.com/Automattic/jetpack/blob/trunk/projects/js-packages/ai-client/src/data-flow/Readme.md#block-list-block-with-ai-data-provider) function. 

This function accepts an options object where it's possible to set the blocks that the app should extend with the AI data:

```jsx
import { blockListBlockWithAiDataProvider } from '@automattic/jetpack-ai-client';

// Example usage with WordPress filters
const enhancedBlockListBlock = blockListBlockWithAiDataProvider( {
  blocks: [ 'core/paragraph', 'core/heading' ]
} );

wp.hooks.addFilter( 'editor.BlockListBlock', 'my-plugin/with-ai-data', enhancedBlockListBlock );
```

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* AI Client: Introduce blockListBlockWithAiDataProvider() function

### Other information:

- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Create a few block instances, including the Jetpack Form one.
* Open the React dev tool of your browser
* Search by `blockListBlockWithAi`
* Confirm that, although all blocks get extended, only the Jetpack form contains the AI Data. For instance:

Paragraph block | Jetpack Form block
-------------|----------------
<img width="833" alt="Screenshot 2023-09-13 at 17 23 43" src="https://github.com/Automattic/jetpack/assets/77539/49a39fc0-e000-4368-abce-1f6e192dc2d5"> | <img width="839" alt="Screenshot 2023-09-13 at 17 24 26" src="https://github.com/Automattic/jetpack/assets/77539/0b50e424-16e3-4a2d-94a8-180a26eb17a1">




