### PR TITLE
Lazy loading images: Update description on settings toggle to discourage enabling it

### DIFF
--- a/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
@@ -297,7 +297,7 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 						>
 							<p>
 								{ __(
-									'Lazy-loading images will improve your site’s speed and create a smoother viewing experience. Images will load as visitors scroll down the screen, instead of all at once.',
+									'Most modern browsers already support lazy loading. With over 90% of current browsers offering native support, enabling this feature may be unnecessary',
 									'jetpack'
 								) }
 							</p>

--- a/projects/plugins/jetpack/changelog/update-lazy-loading-feature-description
+++ b/projects/plugins/jetpack/changelog/update-lazy-loading-feature-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Discourage enabling of Lazy loading images as now 90% of browser support the feature natively and this version in Jetpack can conflict with the upcoming WordPress interactivity API'

--- a/projects/plugins/jetpack/modules/lazy-images.php
+++ b/projects/plugins/jetpack/modules/lazy-images.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Lazy Images
- * Module Description: Speed up your site and create a smoother viewing experience by loading images as visitors scroll down the screen, instead of all at once.
+ * Module Description: Most modern browsers already support lazy loading. With over 90% of current browsers offering native support, enabling this feature may be unnecessary.
  * Sort Order: 24
  * Recommendation Order: 14
  * First Introduced: 5.6.0


### PR DESCRIPTION
See #24290 

## Proposed changes:

This pull request aims to discourage the activation of the JavaScript-based image lazy loading feature from the Performance settings panel. Given that over 90% of modern browsers now support native lazy loading, this feature is no longer a necessary optimization.

The new description will be

_Most modern browsers already support lazy loading. With over 90% of current browsers offering native support, enabling this feature may be unnecessary._

This feature is interfering with the work being done on the Interactivity API

See https://github.com/WordPress/gutenberg/issues/54396

Related https://github.com/Automattic/wp-calypso/pull/81679
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-wV-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Performance
* Check the feature description.