### PR TITLE
Paywall Block: Fix Autosave before redirecting to Earn

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-link-to-earn
+++ b/projects/plugins/jetpack/changelog/update-paywall-link-to-earn
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Paywall Block: fix autosave

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -11,7 +11,7 @@ import {
 	ToolbarDropdownMenu,
 } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -23,6 +23,7 @@ import {
 import { useAccessLevel } from '../../shared/memberships/edit';
 import { getReachForAccessLevelKey } from '../../shared/memberships/settings';
 import { getPaidPlanLink } from '../../shared/memberships/utils';
+import useAutosaveAndRedirect from '../../shared/use-autosave-and-redirect';
 import { store as membershipProductsStore } from '../../store/membership-products';
 
 function PaywallEdit( { className } ) {
@@ -38,9 +39,10 @@ function PaywallEdit( { className } ) {
 		};
 	} );
 	const paidLink = getPaidPlanLink( hasNewsletterPlans );
+	const { autosaveAndRedirect } = useAutosaveAndRedirect( paidLink );
+
 	const [ showDialog, setShowDialog ] = useState( false );
 	const closeDialog = () => setShowDialog( false );
-	const { savePost } = useDispatch( 'core/editor' );
 
 	useEffect( () => {
 		if ( ! accessLevel || accessLevel === accessOptions.everybody.key ) {
@@ -148,10 +150,7 @@ function PaywallEdit( { className } ) {
 				confirmButtonText={ __( 'Get started', 'jetpack' ) }
 				isOpen={ showDialog }
 				onCancel={ closeDialog }
-				onConfirm={ () => {
-					savePost();
-					window.location.href = paidLink;
-				} }
+				onConfirm={ autosaveAndRedirect }
 			>
 				<h2>{ __( 'Enable payments', 'jetpack' ) }</h2>
 				<p style={ { maxWidth: 340 } }>


### PR DESCRIPTION
This message:

![image](https://github.com/Automattic/jetpack/assets/104869/f1b60708-e896-4c58-ac0d-ccd1f9b93fa1)


shouldn't show up when clicking:

<img width="510" alt="Screenshot 2023-09-13 at 08 51 13" src="https://github.com/Automattic/jetpack/assets/104869/bdfd9f00-afa2-4e09-995a-d46ded489ef7">

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `autosaveAndRedirect`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

