### PR TITLE
VideoPress: load VideoPress block on p2

### DIFF
--- a/projects/packages/videopress/changelog/fix-load-videopress-block-on-p2
+++ b/projects/packages/videopress/changelog/fix-load-videopress-block-on-p2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix to change not shipped to users
+
+

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -351,8 +351,12 @@ class Initializer {
 		// check current theme
 		$is_block_theme = wp_get_theme()->is_block_theme();
 
+		// Check if the site is a P2 site
+		$is_p2_site = function_exists( '\WPForTeams\is_wpforteams_site' ) && \WPForTeams\is_wpforteams_site( get_current_blog_id() );
+
 		// for non block themes frontend, we defer the enqueuing to the frontend, so we're able to tell if we need the assets
-		if ( ! $is_block_theme && ! is_admin() ) {
+		// If site is p2, load the assets in the frontend
+		if ( ! $is_block_theme && ! is_admin() && ! $is_p2_site ) {
 			add_action(
 				'wp_enqueue_scripts',
 				function () use ( $videopress_video_metadata_file ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes VideoPress block not loading in P2 front-end editor nor comments whenever there are no previous videos in the post or comments, introduced in [#32680](https://github.com/Automattic/jetpack/pull/32680)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check if the page loa

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR and use bin/jetpack-downloader to apply it on your dotcom sandbox
* Test it and verify that assets load on P2 but are still skipped in the cases proposed by the original PR

