### PR TITLE
Boost: Remove global store from Notice component

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/elements/Notice.svelte
+++ b/projects/plugins/boost/app/assets/src/js/elements/Notice.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { Button, Notice } from '@automattic/jetpack-components';
 	import React from 'react';
+	import { createEventDispatcher } from 'svelte';
 	import { slide } from 'svelte/transition';
-	import { dismissedPopOuts } from '../stores/config';
 	import ReactComponent from './ReactComponent.svelte';
 
 	type ActionButton = {
@@ -16,41 +16,35 @@
 	export let title: string;
 	export let message: string;
 	export let actions: ActionButton[] | undefined;
-	export let dismissalKey: string | undefined;
+	export let hideCloseButton = true;
 
-	$: isDismissed = dismissalKey && $dismissedPopOuts.includes( dismissalKey );
+	const dispatch = createEventDispatcher();
 
-	$: actionComponents =
-		! isDismissed &&
-		actions?.map( ( action, index ) =>
-			React.createElement(
-				Button,
-				{
-					isPrimary: true,
-					onClick: action.onClick,
-					key: index,
-					isLoading: !! action.isLoading,
-					disabled: !! action.disabled,
-				},
-				action.label
-			)
-		);
-
-	function dismiss() {
-		dismissedPopOuts.dismiss( dismissalKey );
-	}
+	const actionComponents = actions?.map( ( action, index ) =>
+		React.createElement(
+			Button,
+			{
+				isPrimary: true,
+				onClick: action.onClick,
+				key: index,
+				isLoading: !! action.isLoading,
+				disabled: !! action.disabled,
+			},
+			action.label
+		)
+	);
 </script>
 
-{#if ! isDismissed}
-	<div transition:slide|local>
-		<ReactComponent
-			this={Notice}
-			{level}
-			{title}
-			children={message}
-			actions={actionComponents}
-			onClose={dismissalKey ? dismiss : undefined}
-			hideCloseButton={! dismissalKey}
-		/>
-	</div>
-{/if}
+<div transition:slide|local>
+	<ReactComponent
+		this={Notice}
+		{level}
+		{title}
+		children={message}
+		actions={actionComponents}
+		onClose={() => {
+			dispatch( 'onClose' );
+		}}
+		{hideCloseButton}
+	/>
+</div>

--- a/projects/plugins/boost/app/assets/src/js/pages/settings/elements/SuperCacheInfo.svelte
+++ b/projects/plugins/boost/app/assets/src/js/pages/settings/elements/SuperCacheInfo.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { __, sprintf } from '@wordpress/i18n';
 	import Notice from '../../../elements/Notice.svelte';
+	import { superCacheNoticeDisabledClientStore } from '../../../stores/notice';
 	import { measureSuperCacheSaving } from '../../../utils/measure-super-cache-saving';
 	import { isSuperCachePluginActive, isSuperCacheEnabled } from '../../../utils/super-cache';
 
@@ -57,12 +58,15 @@
 			actions={[ { label: runLabel, onClick: runTest } ]}
 		/>
 	{/if}
-{:else if isSuperCachePluginActive()}
+{:else if isSuperCachePluginActive() && ! $superCacheNoticeDisabledClientStore}
 	<Notice
 		level="warning"
 		title={__( 'Super Cache is installed but not enabled', 'jetpack-boost' )}
 		message={__( 'Enable Super Cache to speed your site up further.', 'jetpack-boost' )}
 		actions={[ { label: __( 'Set up', 'jetpack-boost' ), onClick: navToSuperCacheSettings } ]}
-		dismissalKey={'super-cache-not-enabled'}
+		hideCloseButton={false}
+		on:onClose={() => {
+			$superCacheNoticeDisabledClientStore = true;
+		}}
 	/>
 {/if}

--- a/projects/plugins/boost/app/assets/src/js/stores/notice.ts
+++ b/projects/plugins/boost/app/assets/src/js/stores/notice.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { jetpack_boost_ds } from './data-sync-client';
+
+export const superCacheNoticeDisabledClient = jetpack_boost_ds.createAsyncStore(
+	'super_cache_notice_disabled',
+	z.boolean()
+);
+
+export const superCacheNoticeDisabledClientStore = superCacheNoticeDisabledClient.store;

--- a/projects/plugins/boost/changelog/remove-store-super-cache-notice
+++ b/projects/plugins/boost/changelog/remove-store-super-cache-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Removed global store from notice component in favor of data sync.
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -209,3 +209,8 @@ jetpack_boost_register_option(
 jetpack_boost_register_option( 'premium_features', $premium_features_schema, new Premium_Features_Entry() );
 
 jetpack_boost_register_option( 'performance_history_toggle', Schema::as_boolean()->fallback( false ) );
+
+/**
+ * Register Super Cache Notice Disabled store.
+ */
+jetpack_boost_register_option( 'super_cache_notice_disabled', Schema::as_boolean()->fallback( false ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the global store from the Notice component, in favor of Data Sync, handled in the parent component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-286-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the Super Cache notice works as expected.

![CleanShot 2023-09-13 at 15 32 59](https://github.com/Automattic/jetpack/assets/11799079/17a3bd8a-6b62-4e4a-8799-eb243b49792a)
