### PR TITLE
reverts d5ca47d8de after finding out it was not working right with P2

### DIFF
--- a/projects/packages/videopress/changelog/revert-d5ca47d8de
+++ b/projects/packages/videopress/changelog/revert-d5ca47d8de
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+This reverts changes introduced by d5ca47d8de53df832e67ac8b9d6bda3663c3e8df as we discovered an issue with P2s

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -64,7 +64,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.16.x-dev"
+			"dev-trunk": "0.17.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.16.0",
+	"version": "0.17.0-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -348,33 +348,6 @@ class Initializer {
 			return;
 		}
 
-		// check current theme
-		$is_block_theme = wp_get_theme()->is_block_theme();
-
-		// for non block themes frontend, we defer the enqueuing to the frontend, so we're able to tell if we need the assets
-		if ( ! $is_block_theme && ! is_admin() ) {
-			add_action(
-				'wp_enqueue_scripts',
-				function () use ( $videopress_video_metadata_file ) {
-					$post_content = get_the_content();
-
-					if ( ! has_block( 'videopress/video', $post_content ) && ! has_shortcode( $post_content, 'videopress' ) ) {
-						return;
-					}
-					self::enqueue_block_assets( $videopress_video_metadata_file );
-				}
-			);
-			return;
-		}
-		self::enqueue_block_assets( $videopress_video_metadata_file );
-	}
-
-	/**
-	 * Enqueue scripts used by the VideoPress video block and register block type.
-	 *
-	 * @param string $videopress_video_metadata_file Path to the block metadata file.
-	 */
-	public static function enqueue_block_assets( $videopress_video_metadata_file ) {
 		// Register script used by the VideoPress video block in the editor.
 		Assets::register_script(
 			self::JETPACK_VIDEOPRESS_VIDEO_HANDLER,

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.16.0';
+	const PACKAGE_VERSION = '0.17.0-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/changelog/revert-d5ca47d8de
+++ b/projects/plugins/jetpack/changelog/revert-d5ca47d8de
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2580,7 +2580,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "083fb7a5c30886d3858d9f7a9854052f2fe785c1"
+                "reference": "72b82335c2bb4313f34a9d7501e55958939b8361"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2605,7 +2605,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.16.x-dev"
+                    "dev-trunk": "0.17.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/videopress/changelog/revert-d5ca47d8de
+++ b/projects/plugins/videopress/changelog/revert-d5ca47d8de
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1345,7 +1345,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "083fb7a5c30886d3858d9f7a9854052f2fe785c1"
+                "reference": "72b82335c2bb4313f34a9d7501e55958939b8361"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1370,7 +1370,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.16.x-dev"
+                    "dev-trunk": "0.17.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"


### PR DESCRIPTION
This PR reverts the change introduced in d5ca47d8de as we found out it was not working right on P2s

## Proposed changes:
This is a branch resulting from `git revert d5ca47d8de`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1694603935108069-slack-C03TA48NSUX

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply and test using a classic theme. Visit the frontend to see the `jetpack_vendor/automattic/jetpack-videopress/build/block-editor/blocks/video/view.css` is being loaded even if no video block is present.