### PR TITLE
Lazy Images: disable when Gutenberg 16.6.0+ is active

### DIFF
--- a/projects/packages/lazy-images/changelog/remove-lazyloading-with-gutenberg
+++ b/projects/packages/lazy-images/changelog/remove-lazyloading-with-gutenberg
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Deprecated: The lazy-images functionality is not compatible with Gutenberg 16.6+ so it will be disabled when that version is present.

--- a/projects/packages/lazy-images/composer.json
+++ b/projects/packages/lazy-images/composer.json
@@ -55,7 +55,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-lazy-images/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.1.x-dev"
+			"dev-trunk": "2.2.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/lazy-images/src/lazy-images.php
+++ b/projects/packages/lazy-images/src/lazy-images.php
@@ -48,9 +48,15 @@ class Jetpack_Lazy_Images {
 	 * @since 1.0.0
 	 * @since-jetpack 5.6.0
 	 *
-	 * @return object The class instance.
+	 * @return object|void The class instance or void if Gutenberg is active.
 	 */
 	public static function instance() {
+		// Gutenberg's Interactivity API, starting in 16.6,  conflicts with our lazy images implementation.
+		if ( Constants::is_true( 'IS_GUTENBERG_PLUGIN' )
+				&& Constants::get_constant( 'GUTENBERG_VERSION' )
+				&& version_compare( Constants::get_constant( 'GUTENBERG_VERSION' ), '16.6.0', '>=' ) ) {
+			return;
+		}
 		if ( self::$instance === null ) {
 			self::$instance = new Jetpack_Lazy_Images();
 		}

--- a/projects/packages/lazy-images/tests/php/test_class.lazy-images.php
+++ b/projects/packages/lazy-images/tests/php/test_class.lazy-images.php
@@ -2,6 +2,7 @@
 
 require __DIR__ . '/../../src/lazy-images.php';
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Lazy_Images;
 use WorDBless\BaseTestCase;
 
@@ -599,5 +600,23 @@ class WP_Test_Lazy_Images extends BaseTestCase {
 	public function add_skip_lazy_class_to_attributes( $attributes ) {
 		$attributes['class'] .= ' skip-lazy';
 		return $attributes;
+	}
+
+	/**
+	 * Confirms that the lazy images module is not loaded with Gutenberg 16.6.
+	 */
+	public function test_lazy_images_not_loaded_with_gutenberg_16_6() {
+		// Verify without the constant set that the instance is returned.
+		$this->assertInstanceOf( 'Automattic\\Jetpack\\Jetpack_Lazy_Images', Jetpack_Lazy_Images::instance() );
+
+		// Verify loading on old versions of Gutenberg.
+		Constants::set_constant( 'IS_GUTENBERG_PLUGIN', true );
+		Constants::set_constant( 'GUTENBERG_VERSION', '16.5.0' );
+		$this->assertInstanceOf( 'Automattic\\Jetpack\\Jetpack_Lazy_Images', Jetpack_Lazy_Images::instance() );
+
+		// Set the Gutenberg constants and test instance.
+		Constants::set_constant( 'GUTENBERG_VERSION', '16.6.0' );
+		$this->assertNull( Jetpack_Lazy_Images::instance() );
+		Constants::clear_constants();
 	}
 }

--- a/projects/packages/lazy-images/tests/php/test_class.lazy-images.php
+++ b/projects/packages/lazy-images/tests/php/test_class.lazy-images.php
@@ -607,12 +607,12 @@ class WP_Test_Lazy_Images extends BaseTestCase {
 	 */
 	public function test_lazy_images_not_loaded_with_gutenberg_16_6() {
 		// Verify without the constant set that the instance is returned.
-		$this->assertInstanceOf( 'Automattic\\Jetpack\\Jetpack_Lazy_Images', Jetpack_Lazy_Images::instance() );
+		$this->assertInstanceOf( Jetpack_Lazy_Images::class, Jetpack_Lazy_Images::instance() );
 
 		// Verify loading on old versions of Gutenberg.
 		Constants::set_constant( 'IS_GUTENBERG_PLUGIN', true );
 		Constants::set_constant( 'GUTENBERG_VERSION', '16.5.0' );
-		$this->assertInstanceOf( 'Automattic\\Jetpack\\Jetpack_Lazy_Images', Jetpack_Lazy_Images::instance() );
+		$this->assertInstanceOf( Jetpack_Lazy_Images::class, Jetpack_Lazy_Images::instance() );
 
 		// Set the Gutenberg constants and test instance.
 		Constants::set_constant( 'GUTENBERG_VERSION', '16.6.0' );

--- a/projects/plugins/boost/changelog/remove-lazyloading-with-gutenberg
+++ b/projects/plugins/boost/changelog/remove-lazyloading-with-gutenberg
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -780,7 +780,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/lazy-images",
-                "reference": "e6b79362f4856459234f1fe50fb8e560ef586b3e"
+                "reference": "6ae6bbba80d1153fe109d7b718adc68daebfc3ac"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -803,7 +803,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-lazy-images/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/remove-lazyloading-with-gutenberg
+++ b/projects/plugins/jetpack/changelog/remove-lazyloading-with-gutenberg
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1526,7 +1526,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/lazy-images",
-                "reference": "e6b79362f4856459234f1fe50fb8e560ef586b3e"
+                "reference": "6ae6bbba80d1153fe109d7b718adc68daebfc3ac"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1549,7 +1549,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-lazy-images/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.1.x-dev"
+                    "dev-trunk": "2.2.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/WordPress/gutenberg/issues/54396
Related https://github.com/Automattic/jetpack/issues/24290

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Gutenberg's new Interactivity API and Lazy Images conflict, so aborting out when the instance is init.
* Lazy images is not needed with the vast majority of browsers having native support. Intent is to deprecation functionality completely.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdWQjU-wV-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The unit tests should be enough, but Jetpack + Lazy Images + Gutenberg 16.6
* Ensure that lazy images from Jetpack is not being used.