### PR TITLE
VideoPress: improve asset enqueuing for P2 and Classic themes

### DIFF
--- a/projects/packages/videopress/changelog/change-vp-asset-enqueuing
+++ b/projects/packages/videopress/changelog/change-vp-asset-enqueuing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add VideoPress assets enqueuing logic after the revert c9fa94de7886af75b65b8c75e642fb529144eb31 (reverted d5ca47d8de53df832e67ac8b9d6bda3663c3e8df). This time P2s should not be affected.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -348,6 +348,37 @@ class Initializer {
 			return;
 		}
 
+		// check current theme
+		$is_block_theme = wp_get_theme()->is_block_theme();
+
+		// Check if the site is a P2 site
+		$is_p2_site = function_exists( '\WPForTeams\is_wpforteams_site' ) && \WPForTeams\is_wpforteams_site( get_current_blog_id() );
+
+		// for non block themes frontend, we defer the enqueuing to the frontend, so we're able to tell if we need the assets
+		// If site is p2, load the assets in the frontend
+		if ( ! $is_block_theme && ! is_admin() && ! $is_p2_site ) {
+			add_action(
+				'wp_enqueue_scripts',
+				function () use ( $videopress_video_metadata_file ) {
+					$post_content = get_the_content();
+
+					if ( ! has_block( 'videopress/video', $post_content ) && ! has_shortcode( $post_content, 'videopress' ) ) {
+						return;
+					}
+					self::enqueue_block_assets( $videopress_video_metadata_file );
+				}
+			);
+			return;
+		}
+		self::enqueue_block_assets( $videopress_video_metadata_file );
+	}
+
+	/**
+	 * Enqueue scripts used by the VideoPress video block and register block type.
+	 *
+	 * @param string $videopress_video_metadata_file Path to the block metadata file.
+	 */
+	public static function enqueue_block_assets( $videopress_video_metadata_file ) {
 		// Register script used by the VideoPress video block in the editor.
 		Assets::register_script(
 			self::JETPACK_VIDEOPRESS_VIDEO_HANDLER,


### PR DESCRIPTION
This PR is a re-add for a better VideoPress assets enqueuing mechanism.

The issue was solved on #32680 (d5ca47d8de53df832e67ac8b9d6bda3663c3e8df), but then reverted on #33038 (c9fa94de7886af75b65b8c75e642fb529144eb31) as we discovered an issue where P2s wouldn't load the block.

@nunyvega Added extra logic to the original change on #33036 and this PR is the result of that change.

Fixes #32235 

## Proposed changes:
The change adds an extra check to see if
- the theme is a block theme
- the site is a P2

When the theme is NOT a block theme and NOT a P2, the enqueuing process is deferred to `wp_enqueue_scripts` hook, where the content of the post can be parsed and checked for a VP block and, only then, enqueue the needed assets.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1694603935108069-slack-C03TA48NSUX

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

- [ ] Create a site and connect it to Jetpack. Don't enable VideoPress yet. Visit the site's homepage (or any page), check on the sources to verify jetpack_vendor/automattic/jetpack-videopress/build/block-editor/blocks/video/view.css is NOT being loaded.

- [ ] Change theme to a classic theme, like 2020. Visit a page/post on frontend where NO video blocks are present. See that the mentioned file above is not being loaded. Then visit a page WITH a video block to see the file is being loaded properly.

- [ ] Apply the patch on .com and check on a P2 site. Load some site which holds no videoblock, start a new post (or new comment) and try and add a VideoPress block. Block should be available and working correctly.
