### PR TITLE
Subscribe Block: Add optional login button

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paywall-login
+++ b/projects/plugins/jetpack/changelog/update-paywall-login
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Paywall: Add link to switch accounts when user is logged in.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/attributes.js
@@ -78,6 +78,10 @@ export default {
 	spacing: {
 		type: 'number',
 	},
+	showLogin: {
+		type: 'boolean',
+		default: false,
+	},
 	successMessage: {
 		type: 'string',
 		default: __(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1061,7 +1061,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		: __( 'Already a subscriber?', 'jetpack' );
 
 	$sign_in = '';
-	if ( ( new Host() )->is_wpcom_simple() || true ) {
+	if ( ( new Host() )->is_wpcom_simple() ) {
 		$sign_in_link = add_query_arg( 'redirect_to', rawurlencode( get_post_permalink() ), 'https://wordpress.com/log-in/link' );
 
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1057,7 +1057,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		: esc_html__( 'Subscribe to get access to the rest of this post and other subscriber-only content.', 'jetpack' );
 
 	$sign_in = '';
-	if ( ( new Host() )->is_wpcom_simple() || true ) {
+	if ( ( new Host() )->is_wpcom_simple() ) {
 		$access_question = $is_paid_post
 			? __( 'Already a paid subscriber?', 'jetpack' )
 			: __( 'Already a subscriber?', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1056,25 +1056,19 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		// translators: %s is the name of the site.
 		: esc_html__( 'Subscribe to get access to the rest of this post and other subscriber-only content.', 'jetpack' );
 
-	$access_question = $is_paid_post
-		? __( 'Already a paid subscriber?', 'jetpack' )
-		: __( 'Already a subscriber?', 'jetpack' );
-
 	$sign_in = '';
-	if ( ( new Host() )->is_wpcom_simple() ) {
-		$sign_in_link = add_query_arg( 'redirect_to', rawurlencode( get_post_permalink() ), 'https://wordpress.com/log-in/link' );
-
+	if ( ( new Host() )->is_wpcom_simple() || true ) {
+		$access_question = $is_paid_post
+			? __( 'Already a paid subscriber?', 'jetpack' )
+			: __( 'Already a subscriber?', 'jetpack' );
+		$sign_in_link    = add_query_arg( 'redirect_to', rawurlencode( get_post_permalink() ), 'https://wordpress.com/log-in/link' );
 		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
-		if ( ! is_user_logged_in() && empty( $subscription_service->get_token_payload() ) ) {
-			$sign_in = '<!-- wp:paragraph {"align":"center", "typography":{"fontSize":"14px","fontWeight":"400";"color":"#646970"}} -->
-	<p class="has-text-align-center" style="font-size:14px;font-weight:400;color:#646970">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '" class="jetpack-subscriber-paywall-login" style="font-size:14px;font-weight:400;color:#646970">' . esc_html__( 'Log in', 'jetpack' ) . '</a></p>
-	<!-- /wp:paragraph -->';
-		} else {
-			$sign_in = '<!-- wp:paragraph {"align":"center", "typography":{"fontSize":"14px","fontWeight":"400";"color":"#646970"}} -->
-	<p class="has-text-align-center" style="font-size:14px;font-weight:400;color:#646970">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '" class="jetpack-subscriber-paywall-login" style="font-size:14px;font-weight:400;color:#646970">' . esc_html__( 'Switch accounts', 'jetpack' ) . '</a></p>
-	<!-- /wp:paragraph -->';
-		}
+		$action_text          = ( ! is_user_logged_in() && empty( $subscription_service->get_token_payload() ) ) ? __( 'Log in', 'jetpack' ) : __( 'Switch accounts', 'jetpack' );
+
+		$sign_in = '<!-- wp:paragraph {"align":"center", "typography":{"fontSize":"14px","fontWeight":"400";"color":"#646970"}} -->
+<p class="has-text-align-center" style="font-size:14px;font-weight:400;color:#646970">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '" class="jetpack-subscriber-paywall-login" style="font-size:14px;font-weight:400;color:#646970">' . esc_html( $action_text ) . '</a></p>
+<!-- /wp:paragraph -->';
 	}
 
 	$lock_svg = plugins_url( 'images/lock-paywall.svg', JETPACK__PLUGIN_FILE );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1061,17 +1061,25 @@ function get_paywall_blocks( $newsletter_access_level ) {
 		: __( 'Already a subscriber?', 'jetpack' );
 
 	$sign_in = '';
-	if ( ! is_user_logged_in() && ( new Host() )->is_wpcom_simple() ) {
+	if ( ( new Host() )->is_wpcom_simple() || true ) {
 		$sign_in_link = add_query_arg( 'redirect_to', rawurlencode( get_post_permalink() ), 'https://wordpress.com/log-in/link' );
-		$sign_in      = '<!-- wp:paragraph {"align":"center", "typography":{"fontSize":"14px","fontWeight":"400";"color":"#646970"}} -->
-<p class="has-text-align-center" style="font-size:14px;font-weight:400;color:#646970">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '" class="jetpack-subscriber-paywall-login" style="font-size:14px;font-weight:400;color:#646970">' . esc_html__( 'Log in', 'jetpack' ) . '</a></p>
-<!-- /wp:paragraph -->';
+
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+		if ( ! is_user_logged_in() && empty( $subscription_service->get_token_payload() ) ) {
+			$sign_in = '<!-- wp:paragraph {"align":"center", "typography":{"fontSize":"14px","fontWeight":"400";"color":"#646970"}} -->
+	<p class="has-text-align-center" style="font-size:14px;font-weight:400;color:#646970">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '" class="jetpack-subscriber-paywall-login" style="font-size:14px;font-weight:400;color:#646970">' . esc_html__( 'Log in', 'jetpack' ) . '</a></p>
+	<!-- /wp:paragraph -->';
+		} else {
+			$sign_in = '<!-- wp:paragraph {"align":"center", "typography":{"fontSize":"14px","fontWeight":"400";"color":"#646970"}} -->
+	<p class="has-text-align-center" style="font-size:14px;font-weight:400;color:#646970">' . esc_html( $access_question ) . ' <a href="' . $sign_in_link . '" class="jetpack-subscriber-paywall-login" style="font-size:14px;font-weight:400;color:#646970">' . esc_html__( 'Switch accounts', 'jetpack' ) . '</a></p>
+	<!-- /wp:paragraph -->';
+		}
 	}
 
 	$lock_svg = plugins_url( 'images/lock-paywall.svg', JETPACK__PLUGIN_FILE );
 
-	return '
-<!-- wp:group {"style":{"border":{"width":"1px","radius":"4px"},"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"32px","right":"32px"}}},"borderColor":"primary","className":"jetpack-subscribe-paywall","layout":{"type":"constrained","contentSize":"400px"}} -->
+	return '<!-- wp:group {"style":{"border":{"width":"1px","radius":"4px"},"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"32px","right":"32px"}}},"borderColor":"primary","className":"jetpack-subscribe-paywall","layout":{"type":"constrained","contentSize":"400px"}} -->
 <div class="wp-block-group jetpack-subscribe-paywall has-border-color has-primary-border-color" style="border-width:1px;border-radius:4px;padding-top:var(--wp--preset--spacing--70);padding-right:32px;padding-bottom:var(--wp--preset--spacing--70);padding-left:32px">
 <!-- wp:image {"align":"center","width":24,"height":24,"sizeSlug":"large","linkDestination":"none"} -->
 <figure class="wp-block-image aligncenter size-large is-resized"><img src="' . $lock_svg . '" alt="" width="24" height="24"/></figure>


### PR DESCRIPTION
## Proposed changes:

<img width="715" alt="Screenshot 2023-09-13 at 15 05 10" src="https://github.com/Automattic/jetpack/assets/104869/3579233a-f25a-4fb3-819d-8d8b73c6a16a">

See p1694613846242699-slack-C052XEUUBL4

* Adds "Switch Account" when user is already logged and the post is paid.
* Moves the login link to the subscribe block to simplify the paywall template logic.
* You should be able to show login buttons by adding the showLogin attribute to the jetpack/subscribe block

```
<!-- wp:jetpack/subscriptions {"borderRadius":50,"borderColor":"primary","className":"is-style-compact","showLogin": true} /-->
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the paywall while logged in as a free subscriber on a paid post.