### PR TITLE
AI Assistant: Use backend prompts on Proofread/Generate feedback feature

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-assistant-use-backend-prompts-on-proofread-feature
+++ b/projects/js-packages/ai-client/changelog/update-ai-assistant-use-backend-prompts-on-proofread-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: Add support for the jetpack-ai role on the prompt messages.

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -17,7 +17,7 @@ export type SuggestionErrorCode =
  * Prompt types
  */
 export type PromptItemProps = {
-	role: 'system' | 'user' | 'assistant';
+	role: 'system' | 'user' | 'assistant' | 'jetpack-ai';
 	content?: string;
 	context?: object;
 };

--- a/projects/plugins/jetpack/changelog/update-ai-assistant-use-backend-prompts-on-proofread-feature
+++ b/projects/plugins/jetpack/changelog/update-ai-assistant-use-backend-prompts-on-proofread-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Use backend prompts for the "Generate feedback" feature.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
@@ -81,6 +81,7 @@ export default function Proofread( {
 	} );
 
 	const handleRequest = () => {
+		// Message to request a backend prompt for this feature
 		const messages = [
 			{
 				role: 'jetpack-ai',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/proofread/index.tsx
@@ -13,11 +13,6 @@ import TurndownService from 'turndown';
 /**
  * Internal dependencies
  */
-import {
-	delimiter,
-	getDelimitedContent,
-	getInitialSystemPrompt,
-} from '../../../../blocks/ai-assistant/lib/prompt';
 import './style.scss';
 
 // Turndown instance
@@ -87,26 +82,14 @@ export default function Proofread( {
 
 	const handleRequest = () => {
 		const messages = [
-			getInitialSystemPrompt( {
-				context:
-					'You are an advanced polyglot ghostwriter. Your task is to review blog content and provide reasonable actions and feedback about the content, without suggesting to rewrite it. This functionality is integrated into the Jetpack product developed by Automattic. Users interact with you through a Gutenberg sidebar. You are inside the WordPress editor',
-				rules: [
-					'Format your response in plain text only including line breaks',
-					'Focus on feedback and do not summarize the content',
-					"Be concise and direct, don't repeat the content and avoid repeating the request. Ex. 'The content delimited ...'",
-					'Do not ask to assist with anything else',
-					'Answer in the same language as the content',
-				],
-				useGutenbergSyntax: false,
-				useMarkdown: false,
-			} ),
+			{
+				role: 'jetpack-ai',
+				context: {
+					type: 'proofread-plugin',
+					content: postContent,
+				},
+			},
 		];
-		messages.push( {
-			role: 'user',
-			content: `Provide a short feedback about the post content delimited with ${ delimiter }. If it could be improved, provide a list of actions on how to do it. ${ getDelimitedContent(
-				postContent
-			) }`,
-		} );
 
 		request( messages );
 		toggleProofreadModal();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #28569.

Depends on D121683-code.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add support for messages with the `jetpack-ai` role on the `ai-client` package
* Start sending a `role=jetpack-ai` message for the proofread completions, following this format:

```
{
  "role": "jetpack-ai",
  "context": {
    "type": "proofread-plugin",
    "content": "the post content"
  }
}

```

* This message will be mapped on the backend to the full prompt that we will send to OpenAI

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D121683-code to your sandbox and sandbox the `public-api`
* Go to the block editor and add some content to the post (you can use the assistant to generate some paragraphs for testing purposes)
* Open the browser development console and make sure you have the debug messages enabled
* On the editor, open the Jetpack pre-publish sidebar:

<img width="400" alt="Screenshot 2023-09-13 at 17 39 48" src="https://github.com/Automattic/jetpack/assets/6760046/d3a09b93-247f-4b06-9748-a46c26311e52">

* On the Jetpack pre-publish sidebar, look for the "AI Assistant" section and click the "Generate feedback" button:

<img width="400" alt="Screenshot 2023-09-13 at 17 40 20" src="https://github.com/Automattic/jetpack/assets/6760046/fd5f54a4-4a83-48f3-a3a8-198af4ed5ca7">

* Notice the `jetpack-ai-client:ask-question` log message containing the list of messages sent to the completion endpoint
* Confirm that the message follows the new format:

<img width="600" alt="Screenshot 2023-09-13 at 17 23 23" src="https://github.com/Automattic/jetpack/assets/6760046/4b3f2f13-7aee-4378-be21-89ed8779d04c">

* Confirm that the popup with the content feedback will show as expected:

<img width="600" alt="Screenshot 2023-09-13 at 17 23 28" src="https://github.com/Automattic/jetpack/assets/6760046/09432fbb-18f8-4eae-b729-3ae832ca0457">

* Head to the logstash logs and confirm that the prompt that was sent to OpenAI is the same this feature would send before this change:

<img width="700" alt="Screenshot 2023-09-13 at 17 46 10" src="https://github.com/Automattic/jetpack/assets/6760046/fb877ef0-ecbf-4e81-a648-995d9639824b">

<img width="700" alt="Screenshot 2023-09-13 at 17 46 36" src="https://github.com/Automattic/jetpack/assets/6760046/048648c8-1cc6-4bdb-a4bf-e69b4cfdcbeb">
