### PR TITLE
Classic Editor Markdown: support double-tilde strikethrough

### DIFF
--- a/projects/plugins/jetpack/changelog/add-markdown-strikethrough-classic-editor
+++ b/projects/plugins/jetpack/changelog/add-markdown-strikethrough-classic-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Classic Editor Markdown: add support for double-tilde strikethrough, e.g. ~~strikethrough~~

--- a/projects/plugins/jetpack/phpunit.xml.dist
+++ b/projects/plugins/jetpack/phpunit.xml.dist
@@ -24,6 +24,9 @@
 		<testsuite name="likes">
 			<directory prefix="test_" suffix=".php">tests/php/modules/likes</directory>
 		</testsuite>
+		<testsuite name="markdown">
+			<directory prefix="test_" suffix=".php">tests/php/modules/markdown</directory>
+		</testsuite>
 		<testsuite name="publicize">
 			<directory prefix="test_" suffix=".php">tests/php/modules/publicize</directory>
 		</testsuite>

--- a/projects/plugins/jetpack/tests/php/modules/markdown/test_class-markdown.php
+++ b/projects/plugins/jetpack/tests/php/modules/markdown/test_class-markdown.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Class WP_Test_GFM_Markdown for unit testing special classic editor markdown features.
+ */
+
+/**
+ * Include the module to ensure we're loading everything even though we're only testing the Markdown parser itself.
+ */
+require_once JETPACK__PLUGIN_DIR . 'modules/markdown/easy-markdown.php';
+
+/**
+ * @group markdown
+ * @covers WPCom_GHF_Markdown_Parser
+ */
+class WP_Test_GFM_Markdown extends WP_UnitTestCase {
+
+	/**
+	 * Test verifying that ~~strikethrough~~ works.
+	 */
+	public function test_strikethrough() {
+		$markdown = '~~strikethrough~~';
+		$expected = '<del>strikethrough</del>';
+		$this->assertEquals( $expected, trim( ( new WPCom_GHF_Markdown_Parser() )->transform( $markdown ) ) );
+	}
+
+	/**
+	 * Test verifying that ~strikethrough~ does not convert.
+	 */
+	public function test_strikethrough_single() {
+		$markdown = '~strikethrough~';
+		$expected = '~strikethrough~';
+		$this->assertEquals( $expected, trim( ( new WPCom_GHF_Markdown_Parser() )->transform( $markdown ) ) );
+	}
+
+}

--- a/projects/plugins/jetpack/tests/php/modules/markdown/test_class-markdown.php
+++ b/projects/plugins/jetpack/tests/php/modules/markdown/test_class-markdown.php
@@ -32,4 +32,13 @@ class WP_Test_GFM_Markdown extends WP_UnitTestCase {
 		$this->assertEquals( $expected, trim( ( new WPCom_GHF_Markdown_Parser() )->transform( $markdown ) ) );
 	}
 
+	/**
+	 * Test verifying that ~~strikethrough~~ does not convert within backticks.
+	 */
+	public function test_strikethrough_in_backticks() {
+		$markdown = '`~~strikethrough~~`';
+		$expected = '<code>~~strikethrough~~</code>';
+		$this->assertEquals( $expected, trim( ( new WPCom_GHF_Markdown_Parser() )->transform( $markdown ) ) );
+	}
+
 }

--- a/projects/plugins/jetpack/tests/php/modules/markdown/test_class-markdown.php
+++ b/projects/plugins/jetpack/tests/php/modules/markdown/test_class-markdown.php
@@ -13,32 +13,49 @@ require_once JETPACK__PLUGIN_DIR . 'modules/markdown/easy-markdown.php';
  * @covers WPCom_GHF_Markdown_Parser
  */
 class WP_Test_GFM_Markdown extends WP_UnitTestCase {
-
 	/**
 	 * Test verifying that ~~strikethrough~~ works.
+	 *
+	 * @dataProvider data_strikethrough
+	 *
+	 * @param string $markdown Markdown to test.
+	 * @param string $expected Expected HTML.
 	 */
-	public function test_strikethrough() {
-		$markdown = '~~strikethrough~~';
-		$expected = '<del>strikethrough</del>';
+	public function test_strikethrough( $markdown, $expected ) {
 		$this->assertEquals( $expected, trim( ( new WPCom_GHF_Markdown_Parser() )->transform( $markdown ) ) );
 	}
 
 	/**
-	 * Test verifying that ~strikethrough~ does not convert.
+	 * Data provider for test_strikethrough.
+	 *
+	 * @return array
 	 */
-	public function test_strikethrough_single() {
-		$markdown = '~strikethrough~';
-		$expected = '~strikethrough~';
-		$this->assertEquals( $expected, trim( ( new WPCom_GHF_Markdown_Parser() )->transform( $markdown ) ) );
+	public function data_strikethrough() {
+		return array(
+			'double strikethrough'           => array(
+				'~~strikethrough~~',
+				'<del>strikethrough</del>',
+			),
+			'single strikethrough'           => array(
+				'~strikethrough~',
+				'~strikethrough~',
+			),
+			'strikethrough within backticks' => array(
+				'`~~strikethrough~~`',
+				'<code>~~strikethrough~~</code>',
+			),
+			'non closing strikthrough'       => array(
+				'~~strikethrough',
+				'~~strikethrough',
+			),
+			'strikethrough multiple words'   => array(
+				'~~strike through~~',
+				'<del>strike through</del>',
+			),
+			'strikthrough on multiple lines' => array(
+				"~~strike\nthrough~~",
+				"<del>strike\nthrough</del>",
+			),
+		);
 	}
-
-	/**
-	 * Test verifying that ~~strikethrough~~ does not convert within backticks.
-	 */
-	public function test_strikethrough_in_backticks() {
-		$markdown = '`~~strikethrough~~`';
-		$expected = '<code>~~strikethrough~~</code>';
-		$this->assertEquals( $expected, trim( ( new WPCom_GHF_Markdown_Parser() )->transform( $markdown ) ) );
-	}
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #3752

When we moved to the Markdown block for the Block Editor, we used Markdown-It, which natively supports ~~strikethrough~~ (`~~` for strikethrough). The Classic Editor used markdown-php which does not support that.

This adds GPL code to the Jetpack flavor of Markdown Extra to support the double-tilde sequence.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds support for double-tilde strikethrough

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. Just pinged on an old issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Jetpack + Connection
* `wp plugin install classic-editor --activate`
* `wp jetpack module activate markdown`
* `wp post create --post_title="Test" --post_content="~~strikethrough~~" --post_status=public`
* View the post on the front end. With patch, it will be a strikethrough. Without it, it won't.

Please note that the markdown is rendered on save, so you'll want to re-save any testing post between applying/removing the patch.
