### PR TITLE
My Jetpack: Show correct CTA and status for Stats card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -11,6 +11,7 @@ export const PRODUCT_STATUSES = {
 	ABSENT_WITH_PLAN: 'plugin_absent_with_plan',
 	NEEDS_PURCHASE: 'needs_purchase',
 	NEEDS_PURCHASE_OR_FREE: 'needs_purchase_or_free',
+	CAN_UPGRADE: 'can_upgrade',
 };
 
 const ActionButton = ( {
@@ -75,7 +76,8 @@ const ActionButton = ( {
 						) }
 				</Button>
 			);
-		case PRODUCT_STATUSES.NEEDS_PURCHASE: {
+		case PRODUCT_STATUSES.NEEDS_PURCHASE:
+		case PRODUCT_STATUSES.CAN_UPGRADE: {
 			const upgradeText = __( 'Upgrade', 'jetpack-my-jetpack' );
 			const purchaseText = __( 'Purchase', 'jetpack-my-jetpack' );
 			const buttonText = purchaseUrl ? upgradeText : purchaseText;

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -15,6 +15,7 @@ const PRODUCT_STATUSES_LABELS = {
 	[ PRODUCT_STATUSES.NEEDS_PURCHASE ]: __( 'Inactive', 'jetpack-my-jetpack' ),
 	[ PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE ]: __( 'Inactive', 'jetpack-my-jetpack' ),
 	[ PRODUCT_STATUSES.ERROR ]: __( 'Error', 'jetpack-my-jetpack' ),
+	[ PRODUCT_STATUSES.CAN_UPGRADE ]: __( 'Active', 'jetpack-my-jetpack' ),
 };
 
 /* eslint-disable react/jsx-no-bind */
@@ -148,7 +149,7 @@ const ProductCard = props => {
 		onDeactivateStandalone,
 	} = props;
 
-	const isActive = status === PRODUCT_STATUSES.ACTIVE;
+	const isActive = status === PRODUCT_STATUSES.ACTIVE || status === PRODUCT_STATUSES.CAN_UPGRADE;
 	const isError = status === PRODUCT_STATUSES.ERROR;
 	const isInactive = status === PRODUCT_STATUSES.INACTIVE;
 	const isAbsent =
@@ -323,6 +324,7 @@ ProductCard.propTypes = {
 		PRODUCT_STATUSES.ABSENT_WITH_PLAN,
 		PRODUCT_STATUSES.NEEDS_PURCHASE,
 		PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE,
+		PRODUCT_STATUSES.CAN_UPGRADE,
 	] ).isRequired,
 };
 

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added support for upgradable products. Updated the Stats card  to handle upgradeable products.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -74,7 +74,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.4.x-dev"
+			"dev-trunk": "3.5.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.4.5",
+	"version": "3.5.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.4.5';
+	const PACKAGE_VERSION = '3.5.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -237,6 +237,7 @@ class Wpcom_Products {
 	 * @return Object|WP_Error
 	 */
 	public static function get_site_current_purchases() {
+		// TODO: Add a short-lived cache (less than a minute) to accommodate repeated invocation of this function.
 		static $purchases = null;
 
 		if ( $purchases !== null ) {

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -312,6 +312,15 @@ abstract class Product {
 	}
 
 	/**
+	 * Checks whether the product can be upgraded to a different product.
+	 *
+	 * @return boolean
+	 */
+	public static function is_upgradable() {
+		return false;
+	}
+
+	/**
 	 * Checks whether product is a bundle.
 	 *
 	 * @return boolean True if product is a bundle. Otherwise, False.
@@ -357,6 +366,9 @@ abstract class Product {
 			// We only consider missing user connection an error when the Product is active.
 			if ( static::$requires_user_connection && ! ( new Connection_Manager() )->has_connected_owner() ) {
 				$status = 'error';
+			} elseif ( static::is_upgradable() ) {
+				// Upgradable plans should ignore whether or not they have the required plan.
+				$status = 'can_upgrade';
 			} elseif ( ! static::has_required_plan() ) { // We need needs_purchase here as well because some products we consider active without the required plan.
 				if ( static::has_trial_support() ) {
 					$status = 'needs_purchase_or_free';

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -152,6 +152,46 @@ class Stats extends Module_Product {
 	}
 
 	/**
+	 * Checks whether the product can be upgraded to a different product.
+	 * Only Jetpack Stats Commercial plan is not upgradable.
+	 *
+	 * @return boolean
+	 */
+	public static function is_upgradable() {
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
+			return false;
+		}
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				if (
+					// Purchase is Jetpack Stats...
+					0 === strpos( $purchase->product_slug, 'jetpack_stats' ) &&
+					// but not Jetpack Stats Free...
+					false === strpos( $purchase->product_slug, 'free' ) &&
+					// and not Pay What You Want.
+					false === strpos( $purchase->product_slug, 'pwyw' )
+				) {
+					// Only Jetpack Stats Commercial should be eligible for this conditional.
+					// Sample product slugs: jetpack_stats_monthly
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Checks whether the product supports trial or not.
+	 * Since Jetpack Stats has been widely available as a free product in the past, it "supports" a trial.
+	 *
+	 * @return boolean
+	 */
+	public static function has_trial_support() {
+		return true;
+	}
+
+	/**
 	 * Get the WordPress.com URL for purchasing Jetpack Stats for the current site.
 	 *
 	 * @return ?string

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -162,13 +162,15 @@ class Stats extends Module_Product {
 		if ( is_wp_error( $purchases_data ) ) {
 			return false;
 		}
-		$has_required_plan = static::has_required_plan();
 		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
 			foreach ( $purchases_data as $purchase ) {
 				if (
-					$has_required_plan &&
-					// but not Jetpack Stats Free...
-					false === strpos( $purchase->product_slug, 'free' )
+					(
+						// Purchase is Jetpack Stats...
+						0 === strpos( $purchase->product_slug, 'jetpack_stats' ) &&
+						// but not Jetpack Stats Free...
+						false === strpos( $purchase->product_slug, 'free' )
+					) || 0 === strpos( $purchase->product_slug, 'jetpack_complete' )
 				) {
 					// Only Jetpack Stats Commercial should be eligible for this conditional.
 					// Sample product slugs: jetpack_stats_monthly

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -162,15 +162,13 @@ class Stats extends Module_Product {
 		if ( is_wp_error( $purchases_data ) ) {
 			return false;
 		}
+		$has_required_plan = static::has_required_plan();
 		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
 			foreach ( $purchases_data as $purchase ) {
 				if (
-					// Purchase is Jetpack Stats...
-					0 === strpos( $purchase->product_slug, 'jetpack_stats' ) &&
+					$has_required_plan &&
 					// but not Jetpack Stats Free...
-					false === strpos( $purchase->product_slug, 'free' ) &&
-					// and not Pay What You Want.
-					false === strpos( $purchase->product_slug, 'pwyw' )
+					false === strpos( $purchase->product_slug, 'free' )
 				) {
 					// Only Jetpack Stats Commercial should be eligible for this conditional.
 					// Sample product slugs: jetpack_stats_monthly

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -172,7 +172,7 @@ class Stats extends Module_Product {
 						false === strpos( $purchase->product_slug, 'free' )
 					) || 0 === strpos( $purchase->product_slug, 'jetpack_complete' )
 				) {
-					// Only Jetpack Stats Commercial should be eligible for this conditional.
+					// Only Jetpack Stats paid plans should be eligible for this conditional.
 					// Sample product slugs: jetpack_stats_monthly
 					return false;
 				}

--- a/projects/plugins/backup/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/backup/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -896,7 +896,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8c7e56e6c97632cf8fff1285acff16362892e0ac"
+                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -926,7 +926,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/boost/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -950,7 +950,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8c7e56e6c97632cf8fff1285acff16362892e0ac"
+                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -980,7 +980,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1696,7 +1696,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8c7e56e6c97632cf8fff1285acff16362892e0ac"
+                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1726,7 +1726,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/migration/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -896,7 +896,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8c7e56e6c97632cf8fff1285acff16362892e0ac"
+                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -926,7 +926,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/protect/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8c7e56e6c97632cf8fff1285acff16362892e0ac"
+                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/search/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8c7e56e6c97632cf8fff1285acff16362892e0ac"
+                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/social/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8c7e56e6c97632cf8fff1285acff16362892e0ac"
+                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8c7e56e6c97632cf8fff1285acff16362892e0ac"
+                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-stats-active-status-and-upgrade-paths
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "8c7e56e6c97632cf8fff1285acff16362892e0ac"
+                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.4.x-dev"
+                    "dev-trunk": "3.5.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #33053

## Proposed changes:
* Enables marking certain Jetpack products as "upgradeable" via the `can_upgrade` status.
* Updates the Stats card to handle these scenarios:
    * Site has no stats plan: Show an upgrade button; activity status should equal stats module status.
    * Site has a free/PWYW plan: Show an upgrade button; activity status should equal stats module status.
    * Site has a commercial plan: Show a view button; activity status should equal stats module status.

![SCR-20230913-ler](https://github.com/Automattic/jetpack/assets/4044428/494bd641-c9e6-4bff-896f-6f4f7cef85d5)|![SCR-20230913-lm2](https://github.com/Automattic/jetpack/assets/4044428/6e3bf6bf-7d0d-4f4d-bb87-708de237c9d3)
-|-
![SCR-20230913-lte](https://github.com/Automattic/jetpack/assets/4044428/5e3418c8-b3da-4ea4-b7fc-95c4aa1903f4)|![SCR-20230913-mb1](https://github.com/Automattic/jetpack/assets/4044428/556bb444-0cd9-4f50-bda1-15bb7f159c82)
![image](https://github.com/Automattic/jetpack/assets/4044428/76052afc-bc68-408f-9f0e-b7537028943e)|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply this feature branch to your site.
2. Without any Jetpack Stats plan, navigate to My Jetpack.
3. Ensure that you see an "Upgrade" button alongside an "Active" status indicator for the Stats card.
4. Click on the upgrade button and purchase a free Jetpack Stats plan.
5. Return to the My Jetpack page.
6. Repeat steps 3 and 4, upgrading to a PWYW Stats plan this time.
7. Repeat steps 5 and 6, upgrading to a Commercial Stats plan this time.
8. Return to the My Jetpack page.
9. Ensure that you see a "View" button alongside an "Active" status indicator for the Stats card.
10. Try disabling the Stats module or the Jetpack plugin.
11. Ensure you see an "Activate" button alongside an "Inactive" status indicator for the Stats card.