### PR TITLE
[CRM] Correct typo in Automation_Bootstrap class name

### DIFF
--- a/projects/plugins/crm/changelog/crm-update-automation-fix-bootstrap-class-name
+++ b/projects/plugins/crm/changelog/crm-update-automation-fix-bootstrap-class-name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix automation bootstrap class name. We do not need to inform the user about this change since automations are behind a feature flag.
+
+

--- a/projects/plugins/crm/modules/automations/jpcrm-automations-init.php
+++ b/projects/plugins/crm/modules/automations/jpcrm-automations-init.php
@@ -10,7 +10,7 @@
 
 namespace Automattic\Jetpack_CRM\Modules\Automations;
 
-use Automattic\Jetpack\CRM\Automation\Automation_Boostrap;
+use Automattic\Jetpack\CRM\Automation\Automation_Bootstrap;
 
 if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
 	exit;
@@ -51,7 +51,7 @@ function load_module() {
 
 	/* @todo Refactor this to be part of a separate initialisation process. */
 	if ( is_admin() ) {
-		$bootstrap = new Automation_Boostrap();
+		$bootstrap = new Automation_Bootstrap();
 		$bootstrap->init();
 	}
 }

--- a/projects/plugins/crm/src/automation/class-automation-bootstrap.php
+++ b/projects/plugins/crm/src/automation/class-automation-bootstrap.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\CRM\Automation;
  *
  * @since $$next-version$$
  */
-final class Automation_Boostrap {
+final class Automation_Bootstrap {
 
 	/**
 	 * The automation engine we want to bootstrap.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/zero-bs-crm/issues/3311

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change class name from `Automation_Boostrap` to `Automation_Bootstrap`
* Replace the one location it was being used.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

If our automated tests still pass, then this change is already approved as A-OK 👍 
