### PR TITLE
Admin Menu: Display Newsletter settings submenu item for jetpack connected sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-admin-menu-display-newsletter-and-podcast-settings
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-display-newsletter-and-podcast-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Admin Menu: Display Newsletter settings submenu item for jetpack connected sites

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -371,34 +371,8 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		$this->update_submenus( 'options-general.php', $submenus_to_update );
 
-		if (
-			/**
-			 * Filter to enable the Newsletter Settings section in Calypso UI.
-			 *
-			 * @since 12.5
-			 * @module masterbar
-			 *
-			 * @param bool false Enable newsletter setting section? Default to false.
-			 */
-			apply_filters( 'calypso_use_newsletter_settings', false )
-		) {
-			add_submenu_page( 'options-general.php', esc_attr__( 'Newsletter', 'jetpack' ), __( 'Newsletter', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/newsletter/' . $this->domain, null, 7 );
-		}
-
-		if (
-			/**
-			 * Filter to enable the Podcasting Settings section in Calypso UI.
-			 *
-			 * @since 12.5
-			 * @module masterbar
-			 *
-			 * @param bool false Enable podcasting setting section? Default to false.
-			 */
-			apply_filters( 'calypso_use_podcasting_settings', false )
-		) {
-			add_submenu_page( 'options-general.php', esc_attr__( 'Podcasting', 'jetpack' ), __( 'Podcasting', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, 8 );
-		}
-
+		add_submenu_page( 'options-general.php', esc_attr__( 'Newsletter', 'jetpack' ), __( 'Newsletter', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/newsletter/' . $this->domain, null, 7 );
+		add_submenu_page( 'options-general.php', esc_attr__( 'Podcasting', 'jetpack' ), __( 'Podcasting', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, 8 );
 		add_submenu_page( 'options-general.php', esc_attr__( 'Performance', 'jetpack' ), __( 'Performance', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain, null, 9 );
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -270,6 +270,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		add_submenu_page( $slug, esc_attr__( 'Writing', 'jetpack' ), __( 'Writing', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/writing/' . $this->domain );
 		add_submenu_page( $slug, esc_attr__( 'Reading', 'jetpack' ), __( 'Reading', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/reading/' . $this->domain );
 		add_submenu_page( $slug, esc_attr__( 'Discussion', 'jetpack' ), __( 'Discussion', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/discussion/' . $this->domain );
+		add_submenu_page( $slug, esc_attr__( 'Newsletter', 'jetpack' ), __( 'Newsletter', 'jetpack' ), 'manage_options', 'https://wordpress.com/settings/newsletter/' . $this->domain );
 
 		$plan_supports_scan = Jetpack_Plan::supports( 'scan' );
 		$products           = Jetpack_Plan::get_products();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add "Newsletter" submenu option to "Settings" menu item in jetpack connected sites
* Remove the "Newsletter" and "Podcasting" feature flag checks. They are not required anymore. Both of the features are released to PROD.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1694683896468089-slack-C02TCEHP3HA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up an instance of a non-WPCOM hosted site with the jetpack plugin installed (you may use jurassic.tube)
* Apply the PR code to your test site
* Jetpack-connect your test site with your WPCOM account.
* Access the calypso portal for the site (you can do so by searching for the site at https://wordpress.com/sites)
* Ensure that the "Newsletter" settings submenu item is visible