### PR TITLE
Change priority of load_map_block_settings action

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-not-loading-map-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-not-loading-map-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make map block settings load after registering the script

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -45,7 +45,7 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );
 
 		// Load the Map block settings.
-		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_map_block_settings' ) );
+		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_map_block_settings', 999 ) );
 
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -45,7 +45,7 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );
 
 		// Load the Map block settings.
-		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_map_block_settings', 999 ) );
+		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_map_block_settings' ), 999 );
 
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.


### PR DESCRIPTION
Fixes #32991

## Proposed changes:
The map block settings were not being loaded because the action ran before the script was registered. This PR changes the priority of the action, so the script is registered for sure.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this PR
2. Test using the instructions in FG: PCYsg-Osp-p2 
3. Mapkit should load on both WPCOM & Atomic 