### PR TITLE
CRM: Fix/revert the === issue introduced on the Invoice button to send email

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3308-revert-the-===-issue-introduced-on-invoice-section
+++ b/projects/plugins/crm/changelog/fix-crm-3308-revert-the-===-issue-introduced-on-invoice-section
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor issue introduced in a previous PR before releasing it.
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.MailTracking.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MailTracking.php
@@ -455,7 +455,7 @@ function zeroBSCRM_get_email_status($ID){
 	$sql = $wpdb->prepare("SELECT zbsmail_active FROM " . $ZBSCRM_t['system_mail_templates'] . " WHERE zbsmail_id = %d", $ID);
 	$r = $wpdb->get_results($sql);
 
-	if ( isset( $r[0] ) && $r[0]->zbsmail_active === 1 ) {
+	if ( isset( $r[0] ) && $r[0]->zbsmail_active == 1 ) { // phpcs:ignore
 		return true;
 	}else{
 		return false;

--- a/projects/plugins/crm/includes/ZeroBSCRM.MailTracking.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MailTracking.php
@@ -455,7 +455,7 @@ function zeroBSCRM_get_email_status($ID){
 	$sql = $wpdb->prepare("SELECT zbsmail_active FROM " . $ZBSCRM_t['system_mail_templates'] . " WHERE zbsmail_id = %d", $ID);
 	$r = $wpdb->get_results($sql);
 
-	if ( isset( $r[0] ) && $r[0]->zbsmail_active == 1 ) { // phpcs:ignore
+	if ( isset( $r[0] ) && $r[0]->zbsmail_active == 1 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- strict comparison breaks functionality.
 		return true;
 	}else{
 		return false;


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3308

## Proposed changes:

This PR simply fixes/reverts an issue we introduced on this PR https://github.com/Automattic/jetpack/pull/32738. This returns an invalid condition, so the users cannot email invoices. The issue is not released, so this PR just reverts it before hitting the final users.

![image](https://github.com/Automattic/jetpack/assets/9832440/0ba5cbfc-c839-4b6d-8f24-71652c625253)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Check the code
- Create a contact and an invoice
- Try to send the invoice by email
- In trunk, you won't see the button for it
- In this branch, you will see the button and can send it.

