### PR TITLE
Paywall: Add custom filter

### DIFF
--- a/projects/plugins/jetpack/changelog/add-paywall-filter
+++ b/projects/plugins/jetpack/changelog/add-paywall-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Paywall: Add a filter to define a custom paywall

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1064,9 +1064,6 @@ function get_paywall_content( $post_access_level, $email_confirmation_pending = 
 	if ( $email_confirmation_pending ) {
 		return get_paywall_blocks_subscribe_pending();
 	}
-	if ( ! jetpack_is_frontend() ) { // emails
-		return get_paywall_simple();
-	}
 	if ( doing_filter( 'get_the_excerpt' ) ) {
 		return '';
 	}
@@ -1080,6 +1077,13 @@ function get_paywall_content( $post_access_level, $email_confirmation_pending = 
  * @return string
  */
 function get_paywall_blocks( $newsletter_access_level ) {
+	$custom_paywall = apply_filters( 'jetpack_custom_paywall_blocks', false );
+	if ( ! empty( $custom_paywall ) ) {
+		return $custom_paywall;
+	}
+	if ( ! jetpack_is_frontend() ) { // emails
+		return get_paywall_simple();
+	}
 	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	// Only display paid texts when Stripe is connected and the post is marked for paid subscribers
 	$is_paid_post = $newsletter_access_level === 'paid_subscribers' && Jetpack_Memberships::has_connected_account();


### PR DESCRIPTION
See: p1694638019596869/1694628745.600779-slack-C053A0D3WGK

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new filter `'jetpack_custom_paywall_blocks' so plugins can define their own default paywall.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a plugin add a filter for `'jetpack_custom_paywall_blocks'` and return some custom content.
* Verify it replaces paywalls.