### PR TITLE
My Jetpack: Add AI Assistant Monthly to required plan check

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-ai-assistant-monthly
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-ai-assistant-monthly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Add AI Assistant Monthly to required plan check

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -132,6 +132,15 @@ class Jetpack_Ai extends Product {
 	}
 
 	/**
+	 * Get the WPCOM monthly product slug used to make the purchase
+	 *
+	 * @return ?string
+	 */
+	public static function get_wpcom_monthly_product_slug() {
+		return 'jetpack_ai_monthly';
+	}
+
+	/**
 	 * Checks whether the current plan (or purchases) of the site already supports the product
 	 *
 	 * @return boolean
@@ -143,9 +152,10 @@ class Jetpack_Ai extends Product {
 		}
 		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
 			foreach ( $purchases_data as $purchase ) {
-				if (
-					0 === strpos( $purchase->product_slug, static::get_wpcom_product_slug() )
-				) {
+				if ( 0 === strpos( $purchase->product_slug, static::get_wpcom_product_slug() ) ) {
+					return true;
+				}
+				if ( 0 === strpos( $purchase->product_slug, static::get_wpcom_monthly_product_slug() ) ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #32888

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `jetpack_ai_monthly` to the possible plans

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get the AI Assistant Monthly plan
* Go to My Jetpack
* On `trunk`: The AI Assistant card shows the `purchase` button and an `Inactive` state.
* On this branch: Check that the AI Assistant card shows as active, with the `Manage` button instead (disabled, as there is no management page)

| Before | After
| - | -
| ![2023-09-14_11-39-42](https://github.com/Automattic/jetpack/assets/8486249/166f7c43-f81b-4a73-934f-d0c6b00f64f1) | ![2023-09-14_11-40-45](https://github.com/Automattic/jetpack/assets/8486249/15224c5d-73c3-4fff-8aed-ace1cd4f30f1)