### PR TITLE
Add Enhanced Ownership

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/100-year-plan-enhanced-ownership
+++ b/projects/packages/jetpack-mu-wpcom/changelog/100-year-plan-enhanced-ownership
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adds 100 Year Plan features, including the ability to set a legacy contact and enable locked mode.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -57,8 +57,8 @@ class Jetpack_Mu_Wpcom {
 	 * Load features that don't need any special loading considerations.
 	 */
 	public static function load_features() {
-		require_once __DIR__ . '/features/100-year-plan/locked-mode.php';
 		require_once __DIR__ . '/features/100-year-plan/enhanced-ownership.php';
+		require_once __DIR__ . '/features/100-year-plan/locked-mode.php';
 
 		require_once __DIR__ . '/features/media/heif-support.php';
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -19,25 +19,23 @@ class Jetpack_Mu_Wpcom {
 
 	/**
 	 * Initialize the class.
-	 *
-	 * @return void
 	 */
 	public static function init() {
 		if ( did_action( 'jetpack_mu_wpcom_initialized' ) ) {
 			return;
 		}
 
-		// Shared code for src/features
+		// Shared code for src/features.
 		require_once self::PKG_DIR . 'src/common/index.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 
 		// Coming Soon feature.
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_coming_soon' ) );
 
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_features' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_launchpad' ), 0 );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_block_theme_previews' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_site_editor_dashboard_link' ) );
-		add_action( 'plugins_loaded', array( __CLASS__, 'load_media' ) );
 
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_marketplace_products_updater' ) );
 
@@ -53,6 +51,16 @@ class Jetpack_Mu_Wpcom {
 		 * @since 0.1.2
 		 */
 		do_action( 'jetpack_mu_wpcom_initialized' );
+	}
+
+	/**
+	 * Load features that don't need any special loading considerations.
+	 */
+	public static function load_features() {
+		require_once __DIR__ . '/features/100-year-plan/locked-mode.php';
+		require_once __DIR__ . '/features/100-year-plan/enhanced-ownership.php';
+
+		require_once __DIR__ . '/features/media/heif-support.php';
 	}
 
 	/**
@@ -87,14 +95,7 @@ class Jetpack_Mu_Wpcom {
 	}
 
 	/**
-	 * Load media features.
-	 */
-	public static function load_media() {
-		require_once __DIR__ . '/features/media/heif-support.php';
-	}
-
-	/**
-	 * Load WP REST API plugins for wpcom
+	 * Load WP REST API plugins for wpcom.
 	 */
 	public static function load_wpcom_rest_api_endpoints() {
 		if ( ! function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
@@ -114,9 +115,7 @@ class Jetpack_Mu_Wpcom {
 	}
 
 	/**
-	 * Adds a global variable containing the map provider in a map_block_settings object to the window object
-	 *
-	 * @return void
+	 * Adds a global variable containing the map provider in a map_block_settings object to the window object.
 	 */
 	public static function load_map_block_settings() {
 		if (

--- a/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/enhanced-ownership.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/enhanced-ownership.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Enhanced Ownership
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Registers Enhanced Ownership settings.
+ */
+function wpcom_eo_register_settings() {
+	if ( ! wpcom_site_has_feature( WPCOM_Features::LEGACY_CONTACT ) ) {
+		return;
+	}
+
+	register_setting(
+		'general',
+		'wpcom_legacy_contact',
+		array(
+			'type'         => 'string',
+			'description'  => 'The legacy contact for this site.',
+			'show_in_rest' => true,
+			'default'      => '',
+		)
+	);
+}
+add_action( 'admin_init', 'wpcom_eo_register_settings' );
+add_action( 'rest_api_init', 'wpcom_eo_register_settings' );
+
+/**
+ * Adds settings to the v1 API site settings endpoint.
+ *
+ * @param array $settings A single site's settings.
+ * @return array
+ */
+function wpcom_eo_get_options_v1_api( $settings ) {
+	if ( wpcom_site_has_feature( WPCOM_Features::LEGACY_CONTACT ) ) {
+		$settings['wpcom_legacy_contact'] = get_option( 'wpcom_legacy_contact' );
+	}
+
+	return $settings;
+}
+add_filter( 'site_settings_endpoint_get', 'wpcom_eo_get_options_v1_api' );
+
+/**
+ * Updates settings via public-api.wordpress.com.
+ *
+ * @param array $input             Associative array of site settings to be updated.
+ *                                 Cast and filtered based on documentation.
+ * @param array $unfiltered_input  Associative array of site settings to be updated.
+ *                                 Neither cast nor filtered. Contains raw input.
+ * @return array
+ */
+function wpcom_eo_update_options_v1_api( $input, $unfiltered_input ) {
+	if ( isset( $unfiltered_input['wpcom_legacy_contact'] ) ) {
+		$input['wpcom_legacy_contact'] = sanitize_text_field( $unfiltered_input['wpcom_legacy_contact'] );
+	}
+
+	return $input;
+}
+add_filter( 'rest_api_update_site_settings', 'wpcom_eo_update_options_v1_api', 10, 2 );
+
+/**
+ * Registers the settings section and fields.
+ */
+function wpcom_eo_settings_page_init() {
+	if ( ! wpcom_site_has_feature( WPCOM_Features::LEGACY_CONTACT ) ) {
+		return;
+	}
+
+	add_settings_section(
+		'wpcom_enhanced_ownership_section',
+		__( 'Enhanced Ownership', 'jetpack-mu-wpcom' ),
+		'', // No callback needed.
+		'general'
+	);
+
+	add_settings_field(
+		'wpcom_legacy_contact',
+		__( 'Legacy Contact', 'jetpack-mu-wpcom' ),
+		'wpcom_legacy_contact_render',
+		'general',
+		'wpcom_enhanced_ownership_section',
+		array(
+			'label_for' => 'wpcom_legacy_contact',
+		)
+	);
+}
+add_action( 'admin_init', 'wpcom_eo_settings_page_init' );
+
+/**
+ * Renders the Legacy Contact settings markup.
+ */
+function wpcom_legacy_contact_render() {
+	?>
+	<input type="text" id="wpcom_legacy_contact" class="regular-text" name="wpcom_legacy_contact" value="<?php echo esc_attr( get_option( 'wpcom_legacy_contact' ) ); ?>">
+	<p class="description"><?php esc_html_e( 'Choose someone to look after your site when you pass away.', 'jetpack-mu-wpcom' ); ?></p>
+	<p class="description">
+		<?php
+		printf(
+			/* translators: link to the help page: https://wordpress.com/help */
+			esc_html__( 'To take ownership of the site, we ask that the person you designate contacts us at %s with a copy of the death certificate.', 'jetpack-mu-wpcom' ),
+			'<a href="https://wordpress.com/help">wordpress.com/help</a>'
+		);
+		?>
+	</p>
+	<?php
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
@@ -110,10 +110,6 @@ function wpcom_locked_mode_render() {
  * @return array
  */
 function wpcom_lm_remove_post_capabilities( $caps, $cap ) {
-	if ( ! wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) ) {
-		return $caps;
-	}
-
 	// Return if option is not set.
 	if ( ! get_option( 'wpcom_locked_mode' ) ) {
 		return $caps;

--- a/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Locked Mode.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Registers Locked Mode settings.
+ */
+function wpcom_lm_register_settings() {
+	if ( ! wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) ) {
+		return;
+	}
+
+	register_setting(
+		'general',
+		'wpcom_locked_mode',
+		array(
+			'type'              => 'boolean',
+			'description'       => 'Whether the site is in locked mode.',
+			'show_in_rest'      => true,
+			'default'           => false,
+			'sanitize_callback' => function ( $value ) {
+				return (bool) $value;
+			},
+		)
+	);
+}
+add_action( 'admin_init', 'wpcom_lm_register_settings' );
+add_action( 'rest_api_init', 'wpcom_lm_register_settings' );
+
+/**
+ * Adds settings to the v1 API site settings endpoint.
+ *
+ * @param array $settings A single site's settings.
+ * @return array
+ */
+function wpcom_lm_get_options_v1_api( $settings ) {
+	if ( wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) ) {
+		$settings['wpcom_locked_mode'] = (bool) get_option( 'wpcom_locked_mode' );
+	}
+
+	return $settings;
+}
+add_filter( 'site_settings_endpoint_get', 'wpcom_lm_get_options_v1_api' );
+
+/**
+ * Updates settings via public-api.wordpress.com.
+ *
+ * @param array $input             Associative array of site settings to be updated.
+ *                                 Cast and filtered based on documentation.
+ * @param array $unfiltered_input  Associative array of site settings to be updated.
+ *                                 Neither cast nor filtered. Contains raw input.
+ * @return array
+ */
+function wpcom_lm_update_options_v1_api( $input, $unfiltered_input ) {
+	if ( isset( $unfiltered_input['wpcom_locked_mode'] ) ) {
+		$input['wpcom_locked_mode'] = (bool) $unfiltered_input['wpcom_locked_mode'];
+	}
+
+	return $input;
+}
+add_filter( 'rest_api_update_site_settings', 'wpcom_lm_update_options_v1_api', 10, 2 );
+
+/**
+ * Registers the settings section and fields.
+ */
+function wpcom_lm_settings_page_init() {
+	if ( ! wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) ) {
+		return;
+	}
+
+	add_settings_section(
+		'wpcom_enhanced_ownership_section',
+		__( 'Enhanced Ownership', 'jetpack-mu-wpcom' ),
+		'', // No callback needed.
+		'general'
+	);
+
+	add_settings_field(
+		'wpcom_locked_mode',
+		__( 'Locked Mode', 'jetpack-mu-wpcom' ),
+		'wpcom_locked_mode_render',
+		'general',
+		'wpcom_enhanced_ownership_section',
+		array(
+			'label_for' => 'wpcom_locked_mode',
+		)
+	);
+}
+add_action( 'admin_init', 'wpcom_lm_settings_page_init' );
+
+/**
+ * Renders the Locked Mode settings markup.
+ */
+function wpcom_locked_mode_render() {
+	?>
+	<input type="checkbox" id="wpcom_locked_mode" name="wpcom_locked_mode" <?php checked( get_option( 'wpcom_locked_mode' ) ); ?>>
+	<label for="wpcom_locked_mode"><?php esc_html_e( 'Enable Locked Mode', 'jetpack-mu-wpcom' ); ?></label>
+	<p class="description"><?php esc_html_e( 'Prevents new post and page from being created as well as existing posts and pages from being edited, and closes comments site wide.', 'jetpack-mu-wpcom' ); ?></p>
+	<?php
+}
+
+/**
+ * Removes post and page creation/editing capabilities for locked mode sites.
+ *
+ * @param array  $caps The user's capabilities.
+ * @param string $cap  The capability name.
+ * @return array
+ */
+function wpcom_lm_remove_post_capabilities( $caps, $cap ) {
+	if ( ! wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) ) {
+		return $caps;
+	}
+
+	// Return if option is not set.
+	if ( ! get_option( 'wpcom_locked_mode' ) ) {
+		return $caps;
+	}
+
+	switch ( $cap ) {
+		case 'edit_posts':
+			if ( ! defined( 'REST_API_REQUEST' ) || ! REST_API_REQUEST ) {
+				$caps = array( 'do_not_allow' );
+				break;
+			}
+
+			// This is only called on REST API requests on sites that have the Locked Mode feature, where Locked Mode is enabled.
+			$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 8 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions
+
+			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
+			if ( isset( $trace[7]['class'] ) && 'WPCOM_JSON_API_Site_Settings_Endpoint' === $trace[7]['class'] && 'get_settings_response' === $trace[7]['function'] ) {
+				/*
+				 * This targets the edit_posts check in WPCOM_JSON_API_Site_Settings_Endpoint::get_settings_response().
+				 * We still want to allow the endpoint to return the settings for the site, even if the site is in locked mode.
+				 * So in this case we don't change the capabilities, for all other cases we do.
+				 */
+			} else {
+				$caps = array( 'do_not_allow' );
+			}
+			break;
+
+		case 'install_themes':
+		case 'switch_themes':
+		case 'edit_themes':
+		case 'delete_themes':
+		case 'edit_theme_options':
+		case 'customize':
+		case 'install_plugins':
+		case 'activate_plugins':
+		case 'edit_plugins':
+		case 'delete_plugins':
+		case 'edit_files':
+		case 'upload_files':
+		case 'edit_comment':
+		case 'moderate_comments':
+		case 'manage_categories':
+		case 'manage_links':
+		case 'import':
+		case 'edit_posts':
+		case 'edit_others_posts':
+		case 'edit_published_posts':
+		case 'publish_posts':
+		case 'delete_posts':
+		case 'delete_others_posts':
+		case 'delete_published_posts':
+		case 'delete_private_posts':
+		case 'edit_private_posts':
+		case 'edit_pages':
+		case 'edit_others_pages':
+		case 'edit_published_pages':
+		case 'publish_pages':
+		case 'delete_pages':
+		case 'delete_others_pages':
+		case 'delete_published_pages':
+		case 'delete_private_pages':
+		case 'edit_private_pages':
+		case 'create_users':
+		case 'delete_users':
+			$caps = array( 'do_not_allow' );
+	}
+
+	return $caps;
+}
+add_filter( 'map_meta_cap', 'wpcom_lm_remove_post_capabilities', 10, 2 );
+
+/**
+ * Disables comments site-wide for locked mode sites.
+ *
+ * @param bool $comments_open Whether the current post is open for comments.
+ */
+function wpcom_lm_disable_comments( $comments_open ) {
+	if ( wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) && get_option( 'wpcom_locked_mode' ) ) {
+		return false;
+	}
+
+	return $comments_open;
+}
+add_filter( 'comments_open', 'wpcom_lm_disable_comments' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
@@ -14,7 +14,7 @@ function wpcom_lm_maybe_add_map_meta_cap_filter() {
 		add_filter( 'map_meta_cap', 'wpcom_lm_remove_post_capabilities', 10, 2 );
 	}
 }
-add_action( 'plugins_loaded', 'wpcom_lm_maybe_add_map_meta_cap_filter' );
+add_action( 'plugins_loaded', 'wpcom_lm_maybe_add_map_meta_cap_filter', 11 );
 
 /**
  * Registers Locked Mode settings.

--- a/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
@@ -6,6 +6,17 @@
  */
 
 /**
+ * Adds the action to limit capabilities for locked mode sites when the Locked Mode feature is available
+ * and the option enabled.
+ */
+function wpcom_lm_maybe_add_map_meta_cap_filter() {
+	if ( wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) && get_option( 'wpcom_locked_mode' ) ) {
+		add_filter( 'map_meta_cap', 'wpcom_lm_remove_post_capabilities', 10, 2 );
+	}
+}
+add_action( 'plugins_loaded', 'wpcom_lm_maybe_add_map_meta_cap_filter' );
+
+/**
  * Registers Locked Mode settings.
  */
 function wpcom_lm_register_settings() {
@@ -110,11 +121,6 @@ function wpcom_locked_mode_render() {
  * @return array
  */
 function wpcom_lm_remove_post_capabilities( $caps, $cap ) {
-	// Return if option is not set.
-	if ( ! get_option( 'wpcom_locked_mode' ) ) {
-		return $caps;
-	}
-
 	switch ( $cap ) {
 		case 'edit_posts':
 			if ( ! defined( 'REST_API_REQUEST' ) || ! REST_API_REQUEST ) {
@@ -154,7 +160,6 @@ function wpcom_lm_remove_post_capabilities( $caps, $cap ) {
 		case 'manage_categories':
 		case 'manage_links':
 		case 'import':
-		case 'edit_posts':
 		case 'edit_others_posts':
 		case 'edit_published_posts':
 		case 'publish_posts':
@@ -179,7 +184,6 @@ function wpcom_lm_remove_post_capabilities( $caps, $cap ) {
 
 	return $caps;
 }
-add_filter( 'map_meta_cap', 'wpcom_lm_remove_post_capabilities', 10, 2 );
 
 /**
  * Disables comments site-wide for locked mode sites.

--- a/projects/packages/sync/changelog/add-enhanced-ownership
+++ b/projects/packages/sync/changelog/add-enhanced-ownership
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds legacy contact and locked mode options for 100-year plan

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -163,6 +163,7 @@ class Defaults {
 		'uploads_use_yearmonth_folders',
 		'users_can_register',
 		'verification_services_codes',
+		'videopress_private_enabled_for_site',
 		'wordads_ccpa_enabled',
 		'wordads_ccpa_privacy_policy_url',
 		'wordads_custom_adstxt',
@@ -178,15 +179,16 @@ class Defaults {
 		'wp_mobile_featured_images',
 		'wp_page_for_privacy_policy',
 		'wpcom_featured_image_in_email',
-		'wpcom_newsletter_categories_enabled',
+		'wpcom_gifting_subscription',
 		'wpcom_is_fse_activated',
+		'wpcom_legacy_contact',
+		'wpcom_locked_mode',
+		'wpcom_newsletter_categories_enabled',
 		'wpcom_publish_comments_with_markdown',
 		'wpcom_publish_posts_with_markdown',
 		'wpcom_reader_views_enabled',
-		'wpcom_subscription_emails_use_excerpt',
-		'videopress_private_enabled_for_site',
-		'wpcom_gifting_subscription',
 		'wpcom_site_setup',
+		'wpcom_subscription_emails_use_excerpt',
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-enhanced-ownership
+++ b/projects/plugins/jetpack/changelog/add-enhanced-ownership
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Adds legacy contact and locked mode options for 100-year plan

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -237,6 +237,8 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_subscription_emails_use_excerpt'        => false,
 			'launchpad_checklist_tasks_statuses'           => array(),
 			'launchpad_screen'                             => 'full',
+			'wpcom_legacy_contact'                         => '',
+			'wpcom_locked_mode'                            => false,
 			'wpcom_reader_views_enabled'                   => true,
 			'wpcom_site_setup'                             => '',
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/3655 and https://github.com/Automattic/dotcom-forge/issues/3657

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a feature that allows users to designate a legacy contact, including settings in General Settings in wp-admin and callbacks to return and update the values in the 1.4 settings API endpoint
* Introduced Locked Mode, including settings in General Settings in wp-admin and callbacks to return and update the values in the 1.4 settings API endpoint, removing the ability to add/edit/delete content, plugins, themes, and disables comments side wide.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes. We log changes to the contents of the legacy contact and whether locked mode was enabled/disabled.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox public-api and a test site on Simple.
* Add a 100-year plan in your Store Admin to your test site.
* Visit /wp-admin/options-general.php on your test site and scroll to the end of the page.
* Check the Lock Mode option and Save Changes.
* Populate the Legacy Contact input field and Save Changes.
* Check the blog RC to make sure audit log entries appear as expected.
* Apply https://github.com/Automattic/wp-calypso/pull/81650 and spin up your local Calypso instance.
* Navigate to General Settings and look for Enhanced Ownership settings.
* The values you set in wp-admin should show up there. They should also update when you change them from Calypso.

