### PR TITLE
Add tier logic for premium content

### DIFF
--- a/projects/plugins/jetpack/changelog/add-tier-logic-for-premium-content
+++ b/projects/plugins/jetpack/changelog/add-tier-logic-for-premium-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use tier logic to get premium content block


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See this discussion: p1694698889470569-slack-C01B6KEJ5GE
Part of https://github.com/Automattic/gold/issues/151
Prevent this use case to happen: p1694700121016389/1694698889.470569-slack-C01B6KEJ5GE
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  If the Premium content is a "tier", use the tier logic (higher tier gives access), to prveent issue when upgrading (and therefore cancelling a lower subscription that could be used by the premium content.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Create 2 tiers Silver and Gold
* Create a Premium content block and use Silver plan~
* Subscribe to the Silver plan : you should have access to Premium content 
* Subscribe to the Gold plan : you should STILL have access to Premium content 