### PR TITLE
Fix AI Chat block styles not loading

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-chat-block-styles-not-loading
+++ b/projects/plugins/jetpack/changelog/fix-ai-chat-block-styles-not-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix AI Chat block styles not loading

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
@@ -68,7 +68,7 @@ function load_assets( $attr ) {
 
 	return sprintf(
 		'<div class="%1$s" data-ask-button-label="%2$s" id="jetpack-ai-chat" data-blog-id="%3$d" data-blog-type="%4$s"></div>',
-		esc_attr( Blocks::classes( FEATURE_NAME, $attr ) ),
+		esc_attr( Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) ),
 		esc_attr( $ask_button_label ),
 		esc_attr( $blog_id ),
 		esc_attr( $type )

--- a/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
+++ b/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
@@ -70,6 +70,7 @@ export default function registerJetpackBlock( name, settings, childBlocks = [], 
  */
 export function registerJetpackBlockFromMetadata( metadata, settings, childBlocks, prefix ) {
 	const clientSettings = {
+		...metadata,
 		...settings,
 		icon: getBlockIconProp( metadata ),
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
#32815 refactored how beta blocks were registered, but broke the loading of _AI Chat_ styles in both WPadmin and the site. This PR fixes it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site
- Enable beta blocks in the Jetpack constants section if you're using a JN site, or by adding `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );` to your wp-config.php otherwise.
- You may need to enable AI features
- Create a new post and add the _AI Chat_ block
<img width="348" alt="Screenshot 2023-09-14 at 2 32 14 PM" src="https://github.com/Automattic/jetpack/assets/1620183/cf3e1401-df23-484f-87fc-0965516ff9d0">

- It should look like this:
<img width="500" alt="Screenshot 2023-09-14 at 2 24 05 PM" src="https://github.com/Automattic/jetpack/assets/1620183/0adeca5b-f743-46a9-97db-72bcf56dc2ea">

__In WPadmin__

<img width="500" alt="Screenshot 2023-09-14 at 2 24 54 PM" src="https://github.com/Automattic/jetpack/assets/1620183/9b76153b-e61c-4b4b-9bda-b2dacba69161">

__In the site__

