### PR TITLE
Add jetpack endpoint for jetpack product data

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6084,6 +6084,11 @@ packages:
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
+  /@eslint-community/regexpp@4.8.1:
+    resolution: {integrity: sha512-PWiOzLIUAjN/w5K17PoF4n6sKBw0gqLHPhywmYHP4t1VFQQVYeb1yWsJwnMVEMl3tUHME7X/SJPZLmtG7XBDxQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
   /@eslint/eslintrc@2.1.2:
     resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -14471,7 +14476,7 @@ packages:
     hasBin: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.48.0)
-      '@eslint-community/regexpp': 4.8.0
+      '@eslint-community/regexpp': 4.8.1
       '@eslint/eslintrc': 2.1.2
       '@eslint/js': 8.48.0
       '@humanwhocodes/config-array': 0.11.11
@@ -14935,13 +14940,13 @@ packages:
     resolution: {integrity: sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      flatted: 3.2.7
+      flatted: 3.2.9
       keyv: 4.5.3
       rimraf: 3.0.2
     dev: true
 
-  /flatted@3.2.7:
-    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
+  /flatted@3.2.9:
+    resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
   /flow-parser@0.216.1:
@@ -15293,6 +15298,16 @@ packages:
 
   /glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  /glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -20718,7 +20733,7 @@ packages:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
     dependencies:
-      glob: 7.1.6
+      glob: 7.2.3
 
   /rollup-plugin-copy@3.4.0:
     resolution: {integrity: sha512-rGUmYYsYsceRJRqLVlE9FivJMxJ7X6jDlP79fmFkL8sJs7VVMSVyA2yfyL+PGyO/vJs4A87hwhgVfz61njI+uQ==}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -24,6 +24,7 @@ import useChatAuthentication from '../../hooks/use-chat-authentication';
 import useChatAvailability from '../../hooks/use-chat-availability';
 import useConnectionWatcher from '../../hooks/use-connection-watcher';
 import useGlobalNotice from '../../hooks/use-notice';
+import useProductData from '../../hooks/use-product-data';
 import ConnectionsSection from '../connections-section';
 import IDCModal from '../idc-modal';
 import PlansSection from '../plans-section';
@@ -89,6 +90,8 @@ export default function MyJetpackScreen() {
 	const { jwt, isFetchingChatAuthentication } = useChatAuthentication();
 	const shouldShowZendeskChatWidget =
 		! isFetchingChatAuthentication && ! isFetchingChatAvailability && isAvailable && jwt;
+	// eslint-disable-next-line no-unused-vars
+	const { productData, isQueryingProductData } = useProductData();
 
 	const { recordEvent } = useAnalytics();
 	const [ reloading, setReloading ] = useState( false );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -24,7 +24,6 @@ import useChatAuthentication from '../../hooks/use-chat-authentication';
 import useChatAvailability from '../../hooks/use-chat-availability';
 import useConnectionWatcher from '../../hooks/use-connection-watcher';
 import useGlobalNotice from '../../hooks/use-notice';
-import useProductData from '../../hooks/use-product-data';
 import ConnectionsSection from '../connections-section';
 import IDCModal from '../idc-modal';
 import PlansSection from '../plans-section';
@@ -90,8 +89,6 @@ export default function MyJetpackScreen() {
 	const { jwt, isFetchingChatAuthentication } = useChatAuthentication();
 	const shouldShowZendeskChatWidget =
 		! isFetchingChatAuthentication && ! isFetchingChatAvailability && isAvailable && jwt;
-	// eslint-disable-next-line no-unused-vars
-	const { productData, fetchingProductData } = useProductData();
 
 	const { recordEvent } = useAnalytics();
 	const [ reloading, setReloading ] = useState( false );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -91,7 +91,7 @@ export default function MyJetpackScreen() {
 	const shouldShowZendeskChatWidget =
 		! isFetchingChatAuthentication && ! isFetchingChatAvailability && isAvailable && jwt;
 	// eslint-disable-next-line no-unused-vars
-	const { productData, isQueryingProductData } = useProductData();
+	const { productData, fetchingProductData } = useProductData();
 
 	const { recordEvent } = useAnalytics();
 	const [ reloading, setReloading ] = useState( false );

--- a/projects/packages/my-jetpack/_inc/hooks/use-product-data/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product-data/index.js
@@ -13,17 +13,8 @@ import { STORE_ID } from '../../state/store';
  * @returns {object} product data
  */
 export default function useProductData() {
-	const { productData, isQueryingProductData } = useSelect( select => {
-		const { getProductData, isFetchingProductData } = select( STORE_ID );
-
-		return {
-			productData: getProductData(),
-			isQueryingProductData: isFetchingProductData(),
-		};
-	} );
-
 	return {
-		productData,
-		isQueryingProductData,
+		productData: useSelect( select => select( STORE_ID ).getProductData() ),
+		fetchingProductData: useSelect( select => select( STORE_ID ).isFetchingProductData() ),
 	};
 }

--- a/projects/packages/my-jetpack/_inc/hooks/use-product-data/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product-data/index.js
@@ -6,12 +6,6 @@ import { STORE_ID } from '../../state/store';
  *
  * @returns {object} product data
  */
-
-/**
- * React custom hook to get the product data
- *
- * @returns {object} product data
- */
 export default function useProductData() {
 	return {
 		productData: useSelect( select => select( STORE_ID ).getProductData() ),

--- a/projects/packages/my-jetpack/_inc/hooks/use-product-data/index.js
+++ b/projects/packages/my-jetpack/_inc/hooks/use-product-data/index.js
@@ -1,0 +1,29 @@
+import { useSelect } from '@wordpress/data';
+import { STORE_ID } from '../../state/store';
+
+/**
+ * React custom hook to get the product data
+ *
+ * @returns {object} product data
+ */
+
+/**
+ * React custom hook to get the product data
+ *
+ * @returns {object} product data
+ */
+export default function useProductData() {
+	const { productData, isQueryingProductData } = useSelect( select => {
+		const { getProductData, isFetchingProductData } = select( STORE_ID );
+
+		return {
+			productData: getProductData(),
+			isQueryingProductData: isFetchingProductData(),
+		};
+	} );
+
+	return {
+		productData,
+		isQueryingProductData,
+	};
+}

--- a/projects/packages/my-jetpack/_inc/state/actions.js
+++ b/projects/packages/my-jetpack/_inc/state/actions.js
@@ -21,6 +21,8 @@ const SET_CHAT_AVAILABILITY_IS_FETCHING = 'SET_CHAT_AVAILABILITY_IS_FETCHING';
 const SET_CHAT_AVAILABILITY = 'SET_CHAT_AVAILABILITY';
 const SET_CHAT_AUTHENTICATION_IS_FETCHING = 'SET_CHAT_AUTHENTICATION_IS_FETCHING';
 const SET_CHAT_AUTHENTICATION = 'SET_CHAT_AUTHENTICATION';
+const SET_PRODUCT_DATA_IS_FETCHING = 'SET_PRODUCT_DATA_IS_FETCHING';
+const SET_PRODUCT_DATA = 'SET_PRODUCT_DATA';
 
 const SET_GLOBAL_NOTICE = 'SET_GLOBAL_NOTICE';
 const CLEAN_GLOBAL_NOTICE = 'CLEAN_GLOBAL_NOTICE';
@@ -38,6 +40,10 @@ const setChatAvailabilityIsFetching = isFetching => {
 
 const setChatAuthenticationIsFetching = isFetching => {
 	return { type: SET_CHAT_AUTHENTICATION_IS_FETCHING, isFetching };
+};
+
+const setProductDataIsFetching = isFetching => {
+	return { type: SET_PRODUCT_DATA_IS_FETCHING, isFetching };
 };
 
 const fetchPurchases = () => {
@@ -69,6 +75,8 @@ const setAvailableLicenses = availableLicenses => {
 };
 
 const setProduct = product => ( { type: SET_PRODUCT, product } );
+
+const setProductData = productData => ( { type: SET_PRODUCT_DATA, productData } );
 
 const setRequestProductError = ( productId, error ) => ( {
 	type: SET_PRODUCT_REQUEST_ERROR,
@@ -271,6 +279,8 @@ const actions = {
 	setPurchases,
 	setChatAvailability,
 	setChatAuthentication,
+	setProductDataIsFetching,
+	setProductData,
 	setAvailableLicensesIsFetching,
 	fetchAvailableLicenses,
 	setAvailableLicenses,
@@ -300,5 +310,7 @@ export {
 	SET_CHAT_AVAILABILITY_IS_FETCHING,
 	SET_CHAT_AUTHENTICATION,
 	SET_CHAT_AUTHENTICATION_IS_FETCHING,
+	SET_PRODUCT_DATA_IS_FETCHING,
+	SET_PRODUCT_DATA,
 	actions as default,
 };

--- a/projects/packages/my-jetpack/_inc/state/constants.js
+++ b/projects/packages/my-jetpack/_inc/state/constants.js
@@ -1,6 +1,7 @@
 const REST_API_NAMESPACE = 'my-jetpack/v1';
 export const REST_API_SITE_PURCHASES_ENDPOINT = `${ REST_API_NAMESPACE }/site/purchases`;
 export const REST_API_SITE_PRODUCTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/products`;
+export const REST_API_SITE_PRODUCT_DATA_ENDPOINT = `${ REST_API_NAMESPACE }/site/product-data`;
 export const REST_API_CHAT_AVAILABILITY_ENDPOINT = `${ REST_API_NAMESPACE }/chat/availability`;
 export const REST_API_CHAT_AUTHENTICATION_ENDPOINT = `${ REST_API_NAMESPACE }/chat/authentication`;
 export const PRODUCTS_THAT_NEEDS_INITIAL_FETCH = [ 'scan' ];

--- a/projects/packages/my-jetpack/_inc/state/reducers.js
+++ b/projects/packages/my-jetpack/_inc/state/reducers.js
@@ -16,6 +16,8 @@ import {
 	CLEAN_GLOBAL_NOTICE,
 	SET_PRODUCT_STATS,
 	SET_IS_FETCHING_PRODUCT_STATS,
+	SET_PRODUCT_DATA_IS_FETCHING,
+	SET_PRODUCT_DATA,
 } from './actions';
 
 const products = ( state = {}, action ) => {
@@ -71,6 +73,25 @@ const products = ( state = {}, action ) => {
 				},
 			};
 		}
+
+		default:
+			return state;
+	}
+};
+
+const productData = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case SET_PRODUCT_DATA_IS_FETCHING:
+			return {
+				...state,
+				isFetching: action.isFetching,
+			};
+
+		case SET_PRODUCT_DATA:
+			return {
+				...state,
+				items: action?.productData || {},
+			};
 
 		default:
 			return state;
@@ -213,6 +234,7 @@ const stats = ( state = {}, action ) => {
 
 const reducers = combineReducers( {
 	products,
+	productData,
 	purchases,
 	chatAvailability,
 	chatAuthentication,

--- a/projects/packages/my-jetpack/_inc/state/resolvers.js
+++ b/projects/packages/my-jetpack/_inc/state/resolvers.js
@@ -13,6 +13,7 @@ import {
 	REST_API_SITE_PRODUCTS_ENDPOINT,
 	REST_API_CHAT_AVAILABILITY_ENDPOINT,
 	REST_API_CHAT_AUTHENTICATION_ENDPOINT,
+	REST_API_SITE_PRODUCT_DATA_ENDPOINT,
 	PRODUCTS_THAT_NEEDS_INITIAL_FETCH,
 } from './constants';
 import resolveProductStatsRequest from './stats-resolvers';
@@ -129,6 +130,19 @@ const myJetpackResolvers = {
 				dispatch.setAvailableLicensesIsFetching( false );
 			}
 		},
+
+	getProductData: () => {
+		async ( { dispatch } ) => {
+			dispatch.setProductDataIsFetching( true );
+
+			try {
+				dispatch.setProductData( await apiFetch( { path: REST_API_SITE_PRODUCT_DATA_ENDPOINT } ) );
+				dispatch.setProductDataIsFetching( false );
+			} catch ( error ) {
+				dispatch.setProductDataIsFetching( false );
+			}
+		};
+	},
 };
 
 const getProductStats = {

--- a/projects/packages/my-jetpack/_inc/state/resolvers.js
+++ b/projects/packages/my-jetpack/_inc/state/resolvers.js
@@ -132,7 +132,7 @@ const myJetpackResolvers = {
 		},
 
 	getProductData: () => {
-		async ( { dispatch } ) => {
+		return async ( { dispatch } ) => {
 			dispatch.setProductDataIsFetching( true );
 
 			try {

--- a/projects/packages/my-jetpack/_inc/state/selectors.js
+++ b/projects/packages/my-jetpack/_inc/state/selectors.js
@@ -77,6 +77,11 @@ const productSelectors = {
 	getProductsThatRequiresUserConnection,
 };
 
+const productDataSelectors = {
+	getProductData: state => state.productData?.items || {},
+	isFetchingProductData: state => state.productData?.isFetching || false,
+};
+
 const purchasesSelectors = {
 	getPurchases: state => state.purchases?.items || [],
 	isRequestingPurchases: state => state.purchases?.isFetching || false,
@@ -134,6 +139,7 @@ const selectors = {
 	...purchasesSelectors,
 	...chatAvailabilitySelectors,
 	...chatAuthenticationSelectors,
+	...productDataSelectors,
 	...availableLicensesSelectors,
 	...noticeSelectors,
 	...pluginSelectors,

--- a/projects/packages/my-jetpack/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add barebones infrastructure for querying jetpack product data

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -74,7 +74,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.5.x-dev"
+			"dev-trunk": "3.6.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "3.5.0",
+	"version": "3.6.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -31,7 +31,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '3.5.0';
+	const PACKAGE_VERSION = '3.6.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -231,6 +231,7 @@ class Initializer {
 		new REST_Products();
 		new REST_Purchases();
 		new REST_Zendesk_Chat();
+		new REST_Product_Data();
 		new REST_AI();
 
 		register_rest_route(

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -45,12 +45,12 @@ class REST_Product_Data {
 	 * @return array|WP_Error
 	 */
 	public static function get_all_product_data() {
-		$site_id           = \Jetpack_Options::get_option( 'id' );
-		$wpcom_endpoint    = sprintf( 'sites/%d/jetpack-product-data?locale=%2$s', $site_id, get_user_locale() );
-		$wpcom_api_version = '1.1';
-		$response          = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $wpcom_api_version );
-		$response_code     = wp_remote_retrieve_response_code( $response );
-		$body              = json_decode( wp_remote_retrieve_body( $response ) );
+		$site_id        = \Jetpack_Options::get_option( 'id' );
+		$wpcom_endpoint = sprintf( 'sites/%d/jetpack-product-data?locale=%2$s', $site_id, get_user_locale() );
+		$api_version    = '1.2';
+		$response       = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $api_version );
+		$response_code  = wp_remote_retrieve_response_code( $response );
+		$body           = json_decode( wp_remote_retrieve_body( $response ) );
 
 		l( $response );
 		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -47,8 +47,8 @@ class REST_Product_Data {
 	public static function get_all_product_data() {
 		$site_id        = \Jetpack_Options::get_option( 'id' );
 		$wpcom_endpoint = sprintf( 'sites/%d/jetpack-product-data?locale=%2$s', $site_id, get_user_locale() );
-		$api_version    = '1.2';
-		$response       = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $api_version );
+		$api_version    = '2';
+		$response       = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $api_version, array(), null, 'wpcom' );
 		$response_code  = wp_remote_retrieve_response_code( $response );
 		$body           = json_decode( wp_remote_retrieve_body( $response ) );
 

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -47,11 +47,12 @@ class REST_Product_Data {
 	public static function get_all_product_data() {
 		$site_id           = \Jetpack_Options::get_option( 'id' );
 		$wpcom_endpoint    = sprintf( 'sites/%d/jetpack-product-data?locale=%2$s', $site_id, get_user_locale() );
-		$wpcom_api_version = '2';
+		$wpcom_api_version = '1.1';
 		$response          = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $wpcom_api_version );
 		$response_code     = wp_remote_retrieve_response_code( $response );
 		$body              = json_decode( wp_remote_retrieve_body( $response ) );
 
+		l( $response );
 		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {
 			return new WP_Error( 'site_products_data_fetch_failed', 'Site products data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
 		}

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -43,7 +43,7 @@ class REST_Product_Data {
 	 */
 	public static function get_all_product_data() {
 		$site_id        = \Jetpack_Options::get_option( 'id' );
-		$wpcom_endpoint = sprintf( 'sites/%d/jetpack-product-data/backup?locale=%2$s&force=wpcom', $site_id, get_user_locale() );
+		$wpcom_endpoint = sprintf( 'sites/%d/jetpack-product-data?locale=%2$s&force=wpcom', $site_id, get_user_locale() );
 		$api_version    = '2';
 		$response       = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $api_version, array(), null, 'wpcom' );
 		$response_code  = wp_remote_retrieve_response_code( $response );

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -24,7 +24,7 @@ class REST_Product_Data {
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => __CLASS__ . '::get_product_data',
+					'callback'            => __CLASS__ . '::get_all_product_data',
 					'permission_callback' => __CLASS__ . '::permissions_callback',
 				),
 				'schema' => array( $this, 'get_product_data_schema' ),

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\My_Jetpack;
 
-use Automattic\Jetpack\Connection\Client as Client;
+use Automattic\Jetpack\Connection\Client;
 use WP_Error;
 
 /**

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Sets up the Product Data REST API endpoints.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Client as Client;
+use WP_Error;
+
+/**
+ * Registers the REST routes for Product Data
+ */
+class REST_Product_Data {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		register_rest_route(
+			'my-jetpack/v1',
+			'site/product-data',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => __CLASS__ . '::get_product_data',
+					'permission_callback' => __CLASS__ . '::permissions_callback',
+				),
+				'schema' => array( $this, 'get_product_data_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks if the user has the correct permissions
+	 */
+	public static function permissions_callback() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Gets the product data for all products
+	 *
+	 * @return array|WP_Error
+	 */
+	public static function get_all_product_data() {
+		$site_id           = \Jetpack_Options::get_option( 'id' );
+		$wpcom_endpoint    = sprintf( 'sites/%d/jetpack-product-data?locale=%2$s', $site_id, get_user_locale() );
+		$wpcom_api_version = '2';
+		$response          = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $wpcom_api_version );
+		$response_code     = wp_remote_retrieve_response_code( $response );
+		$body              = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {
+			return new WP_Error( 'site_products_data_fetch_failed', 'Site products data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
+		}
+
+		return rest_ensure_response( $body, 200 );
+	}
+}

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -22,12 +22,9 @@ class REST_Product_Data {
 			'my-jetpack/v1',
 			'site/product-data',
 			array(
-				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => __CLASS__ . '::get_all_product_data',
-					'permission_callback' => __CLASS__ . '::permissions_callback',
-				),
-				'schema' => array( $this, 'get_product_data_schema' ),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::get_all_product_data',
+				'permission_callback' => __CLASS__ . '::permissions_callback',
 			)
 		);
 	}
@@ -46,7 +43,7 @@ class REST_Product_Data {
 	 */
 	public static function get_all_product_data() {
 		$site_id        = \Jetpack_Options::get_option( 'id' );
-		$wpcom_endpoint = sprintf( 'sites/%d/jetpack-product-data?locale=%2$s', $site_id, get_user_locale() );
+		$wpcom_endpoint = sprintf( 'sites/%d/jetpack-product-data?locale=%2$s&force=wpcom', $site_id, get_user_locale() );
 		$api_version    = '2';
 		$response       = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $api_version, array(), null, 'wpcom' );
 		$response_code  = wp_remote_retrieve_response_code( $response );

--- a/projects/packages/my-jetpack/src/class-rest-product-data.php
+++ b/projects/packages/my-jetpack/src/class-rest-product-data.php
@@ -43,13 +43,12 @@ class REST_Product_Data {
 	 */
 	public static function get_all_product_data() {
 		$site_id        = \Jetpack_Options::get_option( 'id' );
-		$wpcom_endpoint = sprintf( 'sites/%d/jetpack-product-data?locale=%2$s&force=wpcom', $site_id, get_user_locale() );
+		$wpcom_endpoint = sprintf( 'sites/%d/jetpack-product-data/backup?locale=%2$s&force=wpcom', $site_id, get_user_locale() );
 		$api_version    = '2';
 		$response       = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $api_version, array(), null, 'wpcom' );
 		$response_code  = wp_remote_retrieve_response_code( $response );
 		$body           = json_decode( wp_remote_retrieve_body( $response ) );
 
-		l( $response );
 		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {
 			return new WP_Error( 'site_products_data_fetch_failed', 'Site products data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
 		}

--- a/projects/packages/videopress/changelog/add-bi-yearly-constants-to-videopress-plugin
+++ b/projects/packages/videopress/changelog/add-bi-yearly-constants-to-videopress-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add bi-yearly constants for complete and videopress in config

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.17.0",
+	"version": "0.17.1-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.17.0';
+	const PACKAGE_VERSION = '0.17.1-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/backup/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/backup/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -896,7 +896,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
+                "reference": "0215fe042f7bc5ee5df1f131b612dbbc3c48a690"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -926,7 +926,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/boost/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -950,7 +950,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
+                "reference": "0215fe042f7bc5ee5df1f131b612dbbc3c48a690"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -980,7 +980,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/jetpack/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1699,7 +1699,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
+                "reference": "0215fe042f7bc5ee5df1f131b612dbbc3c48a690"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1729,7 +1729,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/migration/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -896,7 +896,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
+                "reference": "0215fe042f7bc5ee5df1f131b612dbbc3c48a690"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -926,7 +926,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/protect/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
+                "reference": "0215fe042f7bc5ee5df1f131b612dbbc3c48a690"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/search/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
+                "reference": "0215fe042f7bc5ee5df1f131b612dbbc3c48a690"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/social/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
+                "reference": "0215fe042f7bc5ee5df1f131b612dbbc3c48a690"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/starter-plugin/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
+                "reference": "0215fe042f7bc5ee5df1f131b612dbbc3c48a690"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/add-jetpack-endpoint-for-jetpack-product-data
+++ b/projects/plugins/videopress/changelog/add-jetpack-endpoint-for-jetpack-product-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -811,7 +811,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "be10267234d5655d40cce53aa72f8efac4eaa477"
+                "reference": "0215fe042f7bc5ee5df1f131b612dbbc3c48a690"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -841,7 +841,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.5.x-dev"
+                    "dev-trunk": "3.6.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
## Proposed changes:

Add infrastructure to query and store product data into state. Right now it will not be used anywhere

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pbNhbs-80w-p2

## Does this pull request change what data or activity we track or use?

We are pulling data from WPCOM to store Jetpack product data into state. Right now that data will not be used and this PR does not add any tracking

## Testing instructions:

This has to be tested in tandem with D121691-code

1. Checkout this branch locally
2. Go to `projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx` and add the following import
```jsx
import useProductData from '../../hooks/use-product-data';
```
and add the hook to line 94
```
const { productData, fetchingProductData } = useProductData();
```
This will call the API so it can be viewed in the Network panel

3. Checkout this diff: D121691-code and follow the instructions on that diff to finish testing this PR