### PR TITLE
CRM: Resolves #3317 - prevent tag slug duplication and better fallback support

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3317-better_generic_tag_fallback_handling
+++ b/projects/plugins/crm/changelog/fix-crm-3317-better_generic_tag_fallback_handling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+
+Tags: prevent duplicate slugs
+Tags: more robust slug fallback support

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -3746,7 +3746,7 @@ class zbsDAL {
 		$slug_exists = $this->tag_slug_exists( $obj_type_id, $slug );
 
 		// slug as provided doesn't exist, so use that
-		if ( ! $slug_exists ) {
+		if ( ! $slug_exists && $slug !== 'tag' ) {
 			return $slug;
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -3753,7 +3753,7 @@ class zbsDAL {
 		$slug_base = $slug . '-';
 
 		// get last iteration of tag slug
-		$sql_query = 'SELECT CAST(TRIM(LEADING %s FROM zbstag_slug) AS SIGNED) AS next_slug_id FROM ' . $ZBSCRM_t['tags'] . ' WHERE zbstag_slug LIKE CONCAT(%s,"%") AND zbstag_objtype = %d ORDER BY next_slug_id DESC LIMIT 1000'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$sql_query = 'SELECT CAST(TRIM(LEADING %s FROM zbstag_slug) AS SIGNED) AS slug_iteration FROM ' . $ZBSCRM_t['tags'] . ' WHERE zbstag_slug LIKE CONCAT(%s,"%") AND zbstag_objtype = %d ORDER BY slug_iteration DESC LIMIT 1'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		$cur_slug_iteration = $wpdb->get_var( $wpdb->prepare( $sql_query, $slug_base, $slug_base, $obj_type_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -3197,19 +3197,22 @@ class zbsDAL {
 
             // check name present + legit
             if (!isset($data['name']) || empty($data['name'])) return false;
-            if (!isset($data['slug']) || empty($data['slug'])) {
+		if ( empty( $data['slug'] ) ) {
 
-                // generate one
-                $data['slug'] = $this->makeSlug($data['name']);
+			$potential_slug = $this->makeSlug( $data['name'] ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 			// catch empty slugs as per gh-462, chinese characters, for example
-			if ( empty( $data['slug'] ) ) {
-				$data['slug'] = $this->get_new_tag_slug( $data['objtype'], 'tag' ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+			if ( empty( $potential_slug ) ) {
+				$potential_slug = 'tag';
 			}
 
-                // if slug STILL empty, return false for now..
-                if (empty($data['slug'])) return false;
-            }
+			$data['slug'] = $this->get_new_tag_slug( $data['objtype'], $potential_slug ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+			// if slug STILL empty, return false for now..
+			if ( empty( $data['slug'] ) ) {
+				return false;
+			}
+		}
 
             // tag ID finder - if obj name provided, check tag not already present (if so overwrite)    
             // keeps unique...  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves Automattic/zero-bs-crm#3317 - prevent tag slug duplication and better fallback support

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This cleans up two fairly big issues:

1. Tags with different labels could be normalised to the same slug. We now make sure tags get a unique slug (incremented as needed).
2. The fallback tag schema (`tag-X`) capped at 1024, and looped through each iteration with a database call. We now make a single DB call to determine what X should be.

This does not address Automattic/zero-bs-crm#3316, which when resolved will contain a migration to resurface the duplicates.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to any object's tag manager (e.g. Quotes): `/wp-admin/admin.php?page=tag-manager&tagtype=quote`
2. Add the following four tags: `cat` `Cat` `ПРОМО` `ПРОМО ПАКЕТ`

In `trunk`, you'll see the following slugs: `cat`, `cat`, `tag-1`, `tag-2`. Not easy to verify, but each subsequent `tag-X` will result in more database calls (e.g. `tag-8` will have 7 more database calls than `tag-1`).

In the `fix/crm/3317-better_generic_tag_fallback_handling` branch, you'll see the following slugs: `cat`, `cat-1`, `tag-1`, `tag-2`. Not easy to verify, but each `tag-X` will have the same amount of database calls.