### PR TITLE
CRM: Resolves CSV importer #450 - Transaction import does not assign to company name

### DIFF
--- a/projects/plugins/crm/changelog/fix-csv-importer-450-transaction-import-does-not-assign-to-company-name
+++ b/projects/plugins/crm/changelog/fix-csv-importer-450-transaction-import-does-not-assign-to-company-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CSV Importer: Fixed assignment to companies by name

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -3472,23 +3472,19 @@ function zeroBS___________DAL30Helpers(){return;}
 
 	}
 
-	// get co with name? legacy shiz
-	function zeroBS_getCompanyIDWithName($coName=''){
-
-		#} No empties, no validation, either.
-		if (!empty($coName)){
-
-			global $zbs; 
-			return $zbs->DAL->companies->getCompany(-1,array(
-					'name'=>$coName,
-					'onlyID'=>true,
-					'ignoreowner'		=> zeroBSCRM_DAL2_ignoreOwnership(ZBS_TYPE_COMPANY)));
-		
-		}
-
-		return false;
-
+/**
+ * Retrieves the company ID based on its name.
+ *
+ * @param  string $company_name  The name of the company for which the ID is required.
+ * @return int|bool              Returns the ID of the company if found, false otherwise.
+ */
+function zeroBS_getCompanyIDWithName( $company_name = '' ) {
+	if ( ! empty( $company_name ) ) {
+		global $zbs;
+		return $zbs->DAL->companies->get_company_id_by_name( $company_name ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
+	return false;
+}
 
 	#} ExternalID is name in this case :)
 	function zeroBS_getCompanyIDWithExternalSource($externalSource='',$externalID=''){

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
@@ -334,6 +334,33 @@ class zbsDAL_companies extends zbsDAL_ObjectLayer {
 
     }
 
+	/**
+	 * Retrieves the company ID by its name.
+	 *
+	 * @param  string $name  The name of the company whose ID is to be retrieved.
+	 * @return int|bool      Returns the ID of the company if found, false otherwise.
+	 *
+	 * @throws Exception     Catches and handles exceptions, logging SQL errors.
+	 *
+	 * @since  $$next-version$$
+	 */
+	public function get_company_id_by_name( $name ) {
+		global $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		global $wpdb;
+
+		try {
+			$query  = $this->prepare( 'SELECT ID FROM ' . $ZBSCRM_t['companies'] . ' WHERE zbsco_name LIKE %s', $name ); // phpcs:ignore
+			$result = $wpdb->get_row( $query, OBJECT ); // phpcs:ignore
+
+			if ( isset( $result ) && ( $result->ID ) ) {
+				return $result->ID;
+			}
+		} catch ( Exception $e ) {
+			$this->catchSQLError( $e );
+		}
+		return false;
+	}
+
     /**
      * returns full company line +- details
      *

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
@@ -349,8 +349,8 @@ class zbsDAL_companies extends zbsDAL_ObjectLayer {
 		global $wpdb;
 
 		try {
-			$query  = $this->prepare( 'SELECT ID FROM ' . $ZBSCRM_t['companies'] . ' WHERE zbsco_name LIKE %s', $name ); // phpcs:ignore
-			$result = $wpdb->get_row( $query, OBJECT ); // phpcs:ignore
+			$query  = $this->prepare( 'SELECT ID FROM ' . $ZBSCRM_t['companies'] . ' WHERE zbsco_name LIKE %s', $name ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$result = $wpdb->get_row( $query, OBJECT ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery,WordPress.DB.PreparedSQL.NotPrepared
 
 			if ( isset( $result ) && ( $result->ID ) ) {
 				return $result->ID;


### PR DESCRIPTION
This PR fixes a problem with our paid plugin CSV Importer.
When importing transactions companies weren't getting assigned when using the company name.
This proved to be a bug in core with the function `zeroBS_getCompanyIDWithName`, which no matter the parameter would always return false.

## Proposed changes:
* Reimplement `zeroBS_getCompanyIDWithName`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack-crm-extensions/issues/450

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the plugin CSV Importer PRO
* Create a company (e.g. `MyCompany`)
* Create a CSV with the following data:
```
MyCompany,123456,100
MyCompany,123457,101
MyCompany,123458,102

```
![image](https://github.com/Automattic/jetpack/assets/37049295/3d0562f2-1c5e-4d1f-b426-5914c3eda719)

![image](https://github.com/Automattic/jetpack/assets/37049295/fbed8f76-2d51-480b-8b27-6e3d1727dda3)



Those 3 transactions should be imported and assigned successfully to `MyCompany`