### PR TITLE
launchpad: hide modal on first post for bloggers

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-launchpad-hide-modal-on-first-post
+++ b/projects/plugins/jetpack/changelog/fix-launchpad-hide-modal-on-first-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+hide launchpad modal on first post for bloggers

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -39,25 +39,18 @@ const updateLaunchpadSaveModalBrowserConfig = config => {
 
 export const settings = {
 	render: function LaunchpadSaveModal() {
-		const {
-			isSavingSite,
-			isSavingPost,
-			isPublishingPost,
-			isCurrentPostPublished,
-			postLink,
-			postType,
-		} = useSelect( selector => ( {
-			isSavingSite: selector( editorStore ).isSavingNonPostEntityChanges(),
-			isSavingPost: selector( editorStore ).isSavingPost(),
-			isPublishingPost: selector( editorStore ).isPublishingPost(),
-			isCurrentPostPublished: selector( editorStore ).isCurrentPostPublished(),
-			postLink: selector( editorStore ).getPermalink(),
-			postType: selector( editorStore ).getCurrentPostType(),
-		} ) );
+		const { isSavingSite, isSavingPost, isCurrentPostPublished, postLink, postType } = useSelect(
+			selector => ( {
+				isSavingSite: selector( editorStore ).isSavingNonPostEntityChanges(),
+				isSavingPost: selector( editorStore ).isSavingPost(),
+				isCurrentPostPublished: selector( editorStore ).isCurrentPostPublished(),
+				postLink: selector( editorStore ).getPermalink(),
+				postType: selector( editorStore ).getCurrentPostType(),
+			} )
+		);
 
 		const prevIsSavingSite = usePrevious( isSavingSite );
 		const prevIsSavingPost = usePrevious( isSavingPost );
-		const prevIsPublishingPost = usePrevious( isPublishingPost );
 
 		// We use this state as a flag to manually handle the modal close on first post publish
 		const [ isInitialPostPublish, setIsInitialPostPublish ] = useState( false );
@@ -77,7 +70,6 @@ export const settings = {
 
 		const isInsideSiteEditor = document.getElementById( 'site-editor' ) !== null;
 		const isInsidePostEditor = document.querySelector( '.block-editor' ) !== null;
-		const prevHasNeverPublishedPostOption = useRef( hasNeverPublishedPostOption );
 		const initialHideFSENextStepsModal = useRef( hideFSENextStepsModalBool );
 
 		const siteFragment = getSiteFragment();
@@ -135,14 +127,14 @@ export const settings = {
 			// to migrate the first post published modal logic into jetpack, abstract code from
 			// both modals and their rendering behavior, and remove this solution afterwards.
 			if (
-				prevIsPublishingPost === true &&
-				isPublishingPost === false &&
-				prevHasNeverPublishedPostOption.current &&
+				// Previously, we would check whether the post is publishing (as opposed to saving)
+				// but publish and isPublishingPost and isSavingPost were updated in different render cycles
+				// so we were unable to meaningfully compare them in an IF statement here.
+				hasNeverPublishedPostOption &&
 				siteIntentOption === 'write' &&
 				isInsidePostEditor
 			) {
 				setIsModalOpen( false );
-				prevHasNeverPublishedPostOption.current = '';
 				return;
 			} else if (
 				( prevIsSavingSite === true && isSavingSite === false ) ||
@@ -152,13 +144,12 @@ export const settings = {
 			}
 		}, [
 			isSavingSite,
+			hasNeverPublishedPostOption,
 			prevIsSavingSite,
 			isSavingPost,
 			prevIsSavingPost,
 			siteIntentOption,
 			isInsidePostEditor,
-			isPublishingPost,
-			prevIsPublishingPost,
 		] );
 
 		useEffect( () => {


### PR DESCRIPTION
Draft PR because we still need to decide whether this is the right approach:

For wpcom simple sites, we've found an issue where the "First post congratulations" modal and the launchpad modal are both shown at the same time.

p1694530274144539-slack-C057AH42XQD

We had code in the launchpad modal which was supposed to hide it on the first publish of the first post. Unfortunately, the logic checks for `isPublishingPost` which is true on the fist render cycle, but then there is another render cycle where `isPublishingPost` is now false, but `isSavingPost` is still true. This caused the modal to be shown anyway.

With this PR, we will check the original state of `hasNeverPublishedPostOption` instead. So any saves on the first load of the editor for a blog (`site_intent === 'write'`) will not trigger the launchpad modal.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Honestly, I haven't done jetpack development for a while, here is how I tested it.

`const { tracks } = useAnalytics();` [on line 88]( https://github.com/Automattic/jetpack/compare/fix/launchpad-hide-modal-on-first-post?expand=1#diff-13206839dd3315d528c316c3405fbf89039de38e648bc7b16ac786db91fbb37dL88) threw an error in my sandbox, so I had to comment it out for testing.
```
#build code: 
jetpack watch plugins/jetpack
#upload to sandbox
jetpack rsync jetpack <SANDBOX_USER>@<MY_SANDBOX>:~/public_html/wp-content/mu-plugins/jetpack-plugin/production
```

I then set `has_never_published_post` option to simulate a new site.
```
#in wpsh
update_blog_option(<SITE_ID>, 'has_never_published_post', true);
```