### PR TITLE
skip git internals with rsync

### DIFF
--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -228,6 +228,9 @@ async function addVendorFilesToFilter( source, filters ) {
  */
 async function rsyncToDest( source, dest, pluginDestPath ) {
 	const filters = new Set();
+
+	// Exclude git internals
+	filters.add( '- .git' );
 	// To catch files required in dev builds.
 	await addVendorFilesToFilter( `${ source }/vendor/`, filters );
 	await buildFilterRules( source, '', filters );

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -229,7 +229,7 @@ async function addVendorFilesToFilter( source, filters ) {
 async function rsyncToDest( source, dest, pluginDestPath ) {
 	const filters = new Set();
 
-	// Exclude git internals
+	// Exclude any `.git` dirs, mostly in case someone ran composer with --prefer-source (or composer fell back to that).
 	filters.add( '- .git' );
 	// To catch files required in dev builds.
 	await addVendorFilesToFilter( `${ source }/vendor/`, filters );


### PR DESCRIPTION
I noticed running rsync, it was uploading .git internal files to my sandbox, I added a simple line to skip this:
## Does this pull request change what data or activity we track or use?
No

### Testing instructions 

I was using this on my wpcom sandbox.
```
jetpack build plugins/jetpack

jetpack rsync jetpack <SANDBOX_USER>@<SANDBOX_SERVER>:~/public_html/wp-content/mu-plugins/jetpack-plugin/production
```

With this change , `.git/**` blobs should no longer be uploaded, speeding up the rsync
