### PR TITLE
Newsletter categegories: Remove color property from subscriptions block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-block-newsletter-categories-accent-color
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-block-newsletter-categories-accent-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Change the text color of selected newsletter categories to be more easily readable.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -140,7 +140,6 @@
 		input[type="checkbox"]:checked + div {
 			background: color-mix(in srgb, var(--wp--preset--color--primary) 5%, white);
 			border-color: var(--wp--preset--color--primary);
-			color: var(--wp--preset--color--primary);
 
 			svg {
 				display: block;


### PR DESCRIPTION
## Proposed changes:
Removed the color property from the subscriptions' checkbox in view.scss. This is to prevent the text color from changing when the checkbox is checked, maintaining the default color for better text visibility.

Discussion: pdDOJh-2jl-p2#comment-1797 

| Before | After |
|-|-|
| ![CleanShot 2023-09-15 at 13 10 03@2x](https://github.com/Automattic/jetpack/assets/528287/b8db2b3e-e76f-4ea8-a1eb-b49d41091329) | ![CleanShot 2023-09-15 at 13 08 08@2x](https://github.com/Automattic/jetpack/assets/528287/a807999e-91a6-4f10-ac3d-61934c1f6420) |
 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this PR to your local env
2. Spin up a Jurassic Tube site with this PR
3. Test with a site that has Newsletter Categories already defined (and the blog sticker set)
4. Add the Subscribe block to a post/page
5. Open the post/page and see if the categories are displayed, and the text color stays gray when selecting one.