### PR TITLE
Social Change/move auto conversion notice up

### DIFF
--- a/projects/js-packages/publicize-components/changelog/change-move-auto-conversion-notice-up
+++ b/projects/js-packages/publicize-components/changelog/change-move-auto-conversion-notice-up
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Move auto-conversion notice near the Instagram one

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.37.1-alpha",
+	"version": "0.38.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -182,7 +182,7 @@ export default function PublicizeForm( {
 						] }
 					>
 						{ __(
-							'When your post is published, this image will be converted for maximum compatibility across your connected social networks.',
+							'When your post is published, the selected image will be converted for maximum compatibility across your connected social networks.',
 							'jetpack'
 						) }
 					</Notice>

--- a/projects/js-packages/publicize-components/src/components/form/index.js
+++ b/projects/js-packages/publicize-components/src/components/form/index.js
@@ -160,6 +160,33 @@ export default function PublicizeForm( {
 					) }
 				</Notice>
 			) }
+			{ shouldAutoConvert &&
+				showValidationNotice &&
+				mediaId &&
+				shouldShowNotice( NOTICES.autoConversion ) && (
+					<Notice
+						type={ 'warning' }
+						actions={ [
+							<Button onClick={ onAutoConversionNoticeDismiss } key="dismiss" variant="primary">
+								{ __( 'Got it', 'jetpack' ) }
+							</Button>,
+							<Button
+								className={ styles[ 'change-settings-button' ] }
+								key="change-settings"
+								href={ adminUrl || jetpackSharingSettingsUrl }
+								target="_blank"
+								rel="noreferrer noopener"
+							>
+								{ __( 'Change settings', 'jetpack' ) }
+							</Button>,
+						] }
+					>
+						{ __(
+							'When your post is published, this image will be converted for maximum compatibility across your connected social networks.',
+							'jetpack'
+						) }
+					</Notice>
+				) }
 		</>
 	);
 
@@ -417,39 +444,6 @@ export default function PublicizeForm( {
 											'jetpack'
 									  )
 									: null
-							}
-							CustomNotice={
-								shouldAutoConvert &&
-								showValidationNotice &&
-								mediaId &&
-								shouldShowNotice( NOTICES.autoConversion ) && (
-									<Notice
-										type={ 'warning' }
-										actions={ [
-											<Button
-												onClick={ onAutoConversionNoticeDismiss }
-												key="dismiss"
-												variant="primary"
-											>
-												{ __( 'Got it', 'jetpack' ) }
-											</Button>,
-											<Button
-												className={ styles[ 'change-settings-button' ] }
-												key="change-settings"
-												href={ adminUrl || jetpackSharingSettingsUrl }
-												target="_blank"
-												rel="noreferrer noopener"
-											>
-												{ __( 'Change settings', 'jetpack' ) }
-											</Button>,
-										] }
-									>
-										{ __(
-											'When your post is published, this image will be converted for maximum compatibility across your connected social networks.',
-											'jetpack'
-										) }
-									</Notice>
-								)
 							}
 						/>
 					) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This changes moves our auto-conversion notice near the other Instagram notice so it makes more sense for the featured image validation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/orgs/Automattic/projects/733/views/2?pane=issue&itemId=38718952
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Select a media that is convertible and not valid

| Before  | After |
| ------------- | ------------- |
| <img width="310" alt="CleanShot 2023-09-15 at 14 29 51 png" src="https://github.com/Automattic/jetpack/assets/36671565/7b40b595-d610-427f-9975-d72153bf833a"> | <img width="306" alt="CleanShot 2023-09-15 at 14 28 17 png" src="https://github.com/Automattic/jetpack/assets/36671565/c55d9cb4-b39f-4e70-b6d3-c6ec6a9d062d"> |
